### PR TITLE
chore(chyme): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: chyme
+
+In-progress: implement mobile parity items for chyme. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for chyme. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:28:29Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n