### PR TITLE
chore(directory): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: directory
+
+In-progress: implement mobile parity items for directory. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for directory. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:28:50Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n