### PR TITLE
chore(feed): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: feed
+
+In-progress: implement mobile parity items for feed. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for feed. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:28:44Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n