### PR TITLE
chore(non-plugin): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: non-plugin
+
+In-progress: implement mobile parity items for non-plugin. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for non-plugin. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:28:56Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n