### PR TITLE
chore(service-credits): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: service-credits
+
+In-progress: implement mobile parity items for service-credits. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for service-credits. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:29:05Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n