### PR TITLE
chore(skills-hunt): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: skills-hunt
+
+In-progress: implement mobile parity items for skills-hunt. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for skills-hunt. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:29:02Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n