### PR TITLE
chore(survivor-hub-chat): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: survivor-hub-chat
+
+In-progress: implement mobile parity items for survivor-hub-chat. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for survivor-hub-chat. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:29:12Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n