### PR TITLE
chore(trusttransport): Android parity - start

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-android-parity-note.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-android-parity-note.md
@@ -1,0 +1,5 @@
+Android parity: trusttransport
+
+In-progress: implement mobile parity items for trusttransport. Refer to checklist: ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-rewrite-checklist.md
+
+Work started by agent. Will add UI mocks and tests in follow-up commits.


### PR DESCRIPTION
Starts Android parity work for trusttransport. See checklist in ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-rewrite-checklist.md\n\n---\nAutomated: marked DRAFT (WIP) on 2026-03-28T18:28:23Z before suspend. Resume instructions: see ANDROID_PARITY_RESUME.md in repository root.\n