### PR TITLE
fix: railway CLI self-install and token scope clarification

### DIFF
--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -11,6 +11,11 @@ tasks:
         exit 1
       fi
 
+      if ! command -v railway &> /dev/null; then
+        echo "Railway CLI not found. Installing..."
+        npm install -g @railway/cli
+      fi
+
       cd /workspaces/chargingthefuture/ctf
 
       echo "=== Railway Status ===" | tee /tmp/railway-debug.log
@@ -42,6 +47,11 @@ tasks:
         echo "ERROR: RAILWAY_TOKEN is not set."
         echo "Add RAILWAY_TOKEN to Ona project secrets. See ctf/docs/ona-secrets-inventory.md."
         exit 1
+      fi
+
+      if ! command -v railway &> /dev/null; then
+        echo "Railway CLI not found. Installing..."
+        npm install -g @railway/cli
       fi
 
       cd /workspaces/chargingthefuture/ctf

--- a/ctf/docs/ona-secrets-inventory.md
+++ b/ctf/docs/ona-secrets-inventory.md
@@ -120,10 +120,12 @@ These are personal tokens that should not be shared across team members.
 1. Go to [railway.app](https://railway.app) → Account Settings → Tokens
 2. Click **New Token**
 3. Name it `ona-agent` (or similar)
-4. Set scope to the `chargingthefuture` project
+4. Set scope to **Production** (Railway tokens are scoped to an environment — staging or production — not to a project)
 5. Copy the token value
 6. Add it as `RAILWAY_TOKEN` in Ona project secrets (above)
 7. Also add it to GitHub Actions secrets: repo Settings → Secrets and variables → Actions → `RAILWAY_TOKEN`
+
+> **Note:** Railway tokens are environment-scoped (staging or production), not project-scoped. Create separate tokens if you need to debug both environments. The token used in CI targets whichever Railway environment is connected to the service.
 
 > The Railway token must exist in **both** Ona (for agent CLI access) and GitHub Actions (for CI deploy). These are separate secret stores.
 


### PR DESCRIPTION
## Summary

- `railway-debug` and `railway-redeploy` Ona tasks now self-install the Railway CLI if not present, preventing `railway: command not found` failures when the `setup` task hasn't run
- Updated `ctf/docs/ona-secrets-inventory.md` to clarify Railway tokens are environment-scoped (staging or production), not project-scoped

## Diagnosis

The `railway-debug` task failed with `railway: command not found` because the Railway CLI was not installed in the environment. The `setup` task installs it on `postDevcontainerStart`, but tasks run in contexts where that may not have completed. Both tasks now install the CLI inline before use.

## Fix applied

Added a CLI presence check to both `railway-debug` and `railway-redeploy` in `.ona/automations.yaml`:

```bash
if ! command -v railway &> /dev/null; then
  echo "Railway CLI not found. Installing..."
  npm install -g @railway/cli
fi
```

Also corrected the Railway token creation instructions — Railway only offers staging/production environment scope, not project scope.

## Railway log excerpt

See the `railway-failure` issue for the full log link.

---

Pushing this branch triggers `deploy-backend-railway.yml` automatically.
Review and merge if the CI pipeline passes.

## Parity

- Parity Status: web+android complete

## Testing

- [ ] Web tested
- [ ] Android tested
- [ ] Accessibility checks completed

## Compliance

- [ ] Privacy/security impact reviewed
- [x] No sensitive data exposed in logs/telemetry

## Modularity Governance

- [x] Changed files respect responsibility boundaries
- [x] Complexity gates pass
- [x] No tightly-coupled private helpers introduced