### PR TITLE
feat: automated product update pipeline (feed + wiki + Quora draft)

### DIFF
--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -61,11 +61,23 @@ jobs:
         with:
           node-version: '20'
 
+      # ── Secrets (Infisical → env) ─────────────────────────────────────────────
+      # Injects: ANTHROPIC_API_KEY, APP_URL, INTERNAL_SERVICE_SECRET
+      # GitHub-direct secrets (not in Infisical): GH_PAT, GITHUB_TOKEN
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: production
+          domain: ${{ secrets.INFISICAL_URL }}
+
       # ── Generate ─────────────────────────────────────────────────────────────
       - name: Generate update content via Claude
         id: content
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # ANTHROPIC_API_KEY is in env after Infisical step
           COMMITS: ${{ needs.check-changes.outputs.commits }}
         run: |
           OUTPUT=$(node ctf/scripts/generate-update.mjs)
@@ -77,8 +89,7 @@ jobs:
       - name: Post to in-app feed and update wiki-site index
         env:
           UPDATE_JSON: ${{ steps.content.outputs.json }}
-          APP_URL: ${{ secrets.APP_URL }}
-          INTERNAL_SERVICE_SECRET: ${{ secrets.INTERNAL_SERVICE_SECRET }}
+          # APP_URL and INTERNAL_SERVICE_SECRET are in env after Infisical step
           GH_PAT: ${{ secrets.GH_PAT }}
         run: node ctf/scripts/publish-product-update.mjs
 

--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -1,0 +1,138 @@
+name: Generate Product Update
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # ── Job 1: decide whether this push warrants a product update ───────────────
+  check-changes:
+    name: Check for meaningful commits
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+      commits: ${{ steps.check.outputs.commits }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find feat/fix/perf commits since last update tag
+        id: check
+        run: |
+          LAST_TAG=$(git tag -l "update/*" --sort=-version:refname | head -1)
+          if [ -z "$LAST_TAG" ]; then
+            RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"
+          else
+            RANGE="${LAST_TAG}..HEAD"
+          fi
+
+          COMMITS=$(git log "$RANGE" --pretty=format:"%h %s" | head -30)
+          COUNT=$(echo "$COMMITS" | grep -cE " (feat|fix|perf):" || true)
+
+          echo "commits<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$COMMITS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Found $COUNT meaningful commit(s) — will generate update."
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No feat/fix/perf commits found — skipping update."
+          fi
+
+  # ── Job 2: generate content and publish to all three destinations ───────────
+  generate-and-publish:
+    name: Generate and publish product update
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push update/* tag
+      issues: write     # create Quora draft issue
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # ── Generate ─────────────────────────────────────────────────────────────
+      - name: Generate update content via Claude
+        id: content
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          COMMITS: ${{ needs.check-changes.outputs.commits }}
+        run: |
+          OUTPUT=$(node ctf/scripts/generate-update.mjs)
+          echo "json<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      # ── Feed + wiki-site ─────────────────────────────────────────────────────
+      - name: Post to in-app feed and update wiki-site index
+        env:
+          UPDATE_JSON: ${{ steps.content.outputs.json }}
+          APP_URL: ${{ secrets.APP_URL }}
+          INTERNAL_SERVICE_SECRET: ${{ secrets.INTERNAL_SERVICE_SECRET }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: node ctf/scripts/publish-product-update.mjs
+
+      # ── GitHub wiki page ──────────────────────────────────────────────────────
+      - name: Create GitHub wiki page
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          UPDATE_JSON: ${{ steps.content.outputs.json }}
+        run: |
+          WIKI_PAGE_NAME=$(echo "$UPDATE_JSON" | jq -r '.wikiPageName')
+          echo "$UPDATE_JSON" | jq -r '.wikiContent' > /tmp/wiki-page.md
+
+          git clone \
+            "https://x-access-token:${GH_PAT}@github.com/chargingthefuture/chargingthefuture.wiki.git" \
+            /tmp/ctf-wiki
+
+          cd /tmp/ctf-wiki
+          git config user.email "ci@chargingthefuture.org"
+          git config user.name "CTF CI Bot"
+          cp /tmp/wiki-page.md "${WIKI_PAGE_NAME}.md"
+          git add "${WIKI_PAGE_NAME}.md"
+          git commit -m "Add product update: ${WIKI_PAGE_NAME}"
+          git push
+
+      # ── Quora draft issue ─────────────────────────────────────────────────────
+      - name: Create Quora draft issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_JSON: ${{ steps.content.outputs.json }}
+        run: |
+          TODAY=$(date +%Y-%m-%d)
+          FEED_TITLE=$(echo "$UPDATE_JSON" | jq -r '.feedTitle')
+          echo "$UPDATE_JSON" | jq -r '.quoraDraft' > /tmp/quora-draft.md
+
+          gh label create "quora-draft" \
+            --color "0075ca" \
+            --description "Auto-generated Quora post draft" \
+            --force 2>/dev/null || true
+
+          gh label create "posted" \
+            --color "0e8a16" \
+            --description "Posted to Quora" \
+            --force 2>/dev/null || true
+
+          gh issue create \
+            --title "Quora Draft: ${TODAY} — ${FEED_TITLE}" \
+            --body-file /tmp/quora-draft.md \
+            --label "quora-draft"
+
+      # ── Tag for next run's range ──────────────────────────────────────────────
+      - name: Tag this update
+        run: |
+          git config user.email "ci@chargingthefuture.org"
+          git config user.name "CTF CI Bot"
+          TAG="update/$(date +%Y-%m-%d-%H%M)"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/ctf/docs/developer/PRODUCT_UPDATE_PIPELINE_SECRETS_RUNBOOK.md
+++ b/ctf/docs/developer/PRODUCT_UPDATE_PIPELINE_SECRETS_RUNBOOK.md
@@ -1,0 +1,133 @@
+# Product Update Pipeline — Secrets Runbook
+
+Date: 2026-05-11
+Owner: platform/infra
+
+Documents every secret required by `.github/workflows/generate-product-update.yml`
+and `ctf/packages/web/app/api/internal/product-update/route.ts`.
+
+---
+
+## Secret tiers
+
+The pipeline uses a two-tier model:
+
+| Tier | Where stored | Why |
+|---|---|---|
+| **Infisical** | Infisical (synced at workflow runtime) | Source of truth for all app secrets |
+| **GitHub-direct** | GitHub org secrets only | Cannot come from Infisical due to bootstrapping constraints |
+
+---
+
+## Infisical secrets
+
+Add these to Infisical under the **production** environment.
+The workflow reads them automatically via `Infisical/secrets-action@v1.0.16`.
+
+| Key | Value | Notes |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Anthropic API key | Generate at console.anthropic.com → API Keys |
+| `APP_URL` | `https://<your-railway-domain>` | The Railway production URL for the deployed web app. No trailing slash. |
+| `INTERNAL_SERVICE_SECRET` | Random 32-byte hex string | See generation command below. Must also be set in Railway env vars so the Next.js app can verify the header. |
+
+Generate `INTERNAL_SERVICE_SECRET`:
+```bash
+openssl rand -hex 32
+```
+
+---
+
+## GitHub-direct secrets
+
+Set these at: **github.com → chargingthefuture org → Settings → Secrets and variables → Actions → New organization secret**
+
+These four already exist for other workflows. Verify they are present:
+
+| Key | Why GitHub-only |
+|---|---|
+| `INFISICAL_CLIENT_ID` | Authenticates to Infisical — cannot itself come from Infisical |
+| `INFISICAL_CLIENT_SECRET` | Same bootstrapping reason |
+| `INFISICAL_PROJECT_SLUG` | Same |
+| `INFISICAL_URL` | Same |
+| `GH_PAT` | GitHub Personal Access Token — a GitHub credential that cannot bootstrap from Infisical |
+
+---
+
+## Generating GH_PAT
+
+`GH_PAT` grants the workflow write access to the wiki-site repo and the
+main repo's GitHub wiki (used to push product update pages).
+
+### Step 1 — Open token creation
+
+In a browser, sign in as the account that should own the token (personal or
+a dedicated machine account), then navigate to:
+
+```
+Personal avatar → Settings → Developer Settings
+  → Personal access tokens → Fine-grained tokens → Generate new token
+```
+
+### Step 2 — Configure the token
+
+| Field | Value |
+|---|---|
+| Token name | `CTF CI Product Update` |
+| Expiration | 1 year (set a calendar reminder to rotate) |
+| Resource owner | `chargingthefuture` (the org, not your personal account) |
+| Repository access | **Only select repositories** → `chargingthefuture/wiki-site` and `chargingthefuture/chargingthefuture` |
+
+Under **Permissions → Repository permissions**:
+
+| Permission | Level |
+|---|---|
+| Contents | Read and write |
+
+All other permissions: No access.
+
+### Step 3 — Copy the token
+
+GitHub shows the token value **once** immediately after generation.
+Copy it before navigating away.
+
+### Step 4 — Store it as a GitHub org secret
+
+Navigate to:
+```
+github.com → chargingthefuture → Settings → Secrets and variables
+  → Actions → New organization secret
+```
+
+| Field | Value |
+|---|---|
+| Name | `GH_PAT` |
+| Value | Paste the token copied in Step 3 |
+| Repository access | All repositories (or restrict to this repo if preferred) |
+
+---
+
+## Rotating GH_PAT
+
+1. Generate a new fine-grained token following Step 1–3 above.
+2. Update the `GH_PAT` org secret value with the new token.
+3. Delete the old token at **Settings → Developer Settings → Fine-grained tokens**.
+4. Update the expiration reminder in your calendar.
+
+---
+
+## Verifying the pipeline end-to-end
+
+After all secrets are in place, push a commit to `main` with a message
+prefixed `feat:` or `fix:`. The workflow should:
+
+1. Detect the meaningful commit in the `check-changes` job.
+2. Call Claude Haiku and generate content.
+3. Post a published announcement to the in-app feed.
+4. Prepend an entry to `wiki-blog/content-index.yaml` in the `wiki-site` repo.
+5. Push a new `.md` page to `chargingthefuture/chargingthefuture.wiki`.
+6. Open a GitHub issue titled `Quora Draft: YYYY-MM-DD — <title>` with label `quora-draft`.
+7. Push an `update/YYYY-MM-DD-HHMM` tag to `main`.
+
+If step 3 fails with 401, `INTERNAL_SERVICE_SECRET` does not match between
+GitHub/Infisical and Railway. If step 4 fails with 404, verify `GH_PAT`
+has Contents write access on `chargingthefuture/wiki-site`.

--- a/ctf/packages/web/app/api/internal/product-update/route.ts
+++ b/ctf/packages/web/app/api/internal/product-update/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAnnouncementDraft, publishAnnouncement } from 'lib/feed/repository';
+import { logFeedAudit } from 'lib/feed/audit';
+
+const CI_ACTOR_ID = 'ci-product-update';
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.INTERNAL_SERVICE_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'Not configured' }, { status: 501 });
+  }
+
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let title: string, body: string;
+  try {
+    const data = (await request.json()) as { title?: unknown; body?: unknown };
+    title = typeof data.title === 'string' ? data.title.trim() : '';
+    body = typeof data.body === 'string' ? data.body.trim() : '';
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (!title || !body) {
+    return NextResponse.json({ error: 'title and body required' }, { status: 400 });
+  }
+
+  try {
+    const draft = await createAnnouncementDraft(CI_ACTOR_ID, { title, body });
+    const announcement = await publishAnnouncement(CI_ACTOR_ID, draft.id);
+
+    logFeedAudit({
+      actorId: CI_ACTOR_ID,
+      pluginId: 'feed',
+      command: 'feed.announcement.publish',
+      status: 'allow',
+      reason: 'ci_product_update',
+      targetType: 'announcement',
+      targetId: announcement.id,
+      result: 'success',
+      errorCategory: null,
+    });
+
+    return NextResponse.json({ id: announcement.id, status: 'published' }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown';
+    return NextResponse.json({ error: 'Failed to publish', detail: message }, { status: 503 });
+  }
+}

--- a/ctf/scripts/generate-update.mjs
+++ b/ctf/scripts/generate-update.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Calls the Anthropic API to generate a multi-format product update from recent commits.
+ * Reads: ANTHROPIC_API_KEY, COMMITS (env vars)
+ * Writes: JSON to stdout
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../..');
+
+const commits = process.env.COMMITS ?? '';
+if (!commits.trim()) {
+  console.error('COMMITS env var is empty — nothing to generate');
+  process.exit(1);
+}
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error('ANTHROPIC_API_KEY is not set');
+  process.exit(1);
+}
+
+const brandVoice = readFileSync(
+  join(repoRoot, 'ctf/docs/BRAND_VOICE_LEXICON.md'),
+  'utf-8',
+).slice(0, 3000);
+
+const today = new Date().toISOString().split('T')[0];
+
+const response = await fetch('https://api.anthropic.com/v1/messages', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'x-api-key': process.env.ANTHROPIC_API_KEY,
+    'anthropic-version': '2023-06-01',
+  },
+  body: JSON.stringify({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 2048,
+    system: `You write product updates for Charging the Future, an open-source platform built for survivors of Specterati harassment. Follow the brand voice guide carefully.\n\nBRAND VOICE:\n${brandVoice}\n\nToday: ${today}`,
+    messages: [
+      {
+        role: 'user',
+        content: `Recent commits merged to main:\n\n${commits}\n\nGenerate a product update. Return ONLY a JSON object with these exact keys:\n- feedTitle: In-app announcement title (max 80 chars, plain language)\n- feedBody: 2-3 sentence in-app announcement. Calm, empowering, no jargon.\n- wikiPageName: Wiki page filename. Format: Product-Update-${today}-Short-Title (hyphens only, no spaces, no special chars)\n- wikiContent: Full markdown page. Include ## What Shipped and ## Why It Matters sections.\n- wikiSiteExcerpt: One sentence summary for the content index (max 150 chars)\n- quoraDraft: 3-5 paragraph Quora post. Narrative style — explain what was built and why it matters to survivors. End with an invitation to follow the project's progress.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
+      },
+    ],
+  }),
+});
+
+if (!response.ok) {
+  console.error('Anthropic API error:', response.status, await response.text());
+  process.exit(1);
+}
+
+const result = await response.json();
+const content = result.content[0].text.trim();
+
+try {
+  JSON.parse(content);
+} catch {
+  console.error('Model returned invalid JSON:\n', content);
+  process.exit(1);
+}
+
+process.stdout.write(content + '\n');

--- a/ctf/scripts/publish-product-update.mjs
+++ b/ctf/scripts/publish-product-update.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Posts the generated product update to:
+ *   1. The in-app feed (via /api/internal/product-update)
+ *   2. The wiki-site content-index.yaml (via GitHub Contents API)
+ *
+ * Wiki page creation happens via git in the workflow (generate-product-update.yml)
+ * because GitHub has no REST API for wiki pages.
+ *
+ * Required env vars:
+ *   UPDATE_JSON              — JSON output from generate-update.mjs
+ *   APP_URL                  — Deployed app base URL (e.g. https://app.chargingthefuture.org)
+ *   INTERNAL_SERVICE_SECRET  — Shared secret for /api/internal/* routes
+ *   GH_PAT                   — GitHub PAT with contents:write on wiki-site repo
+ */
+
+const json = JSON.parse(process.env.UPDATE_JSON ?? '{}');
+const { feedTitle, feedBody, wikiPageName, wikiSiteExcerpt } = json;
+
+if (!feedTitle || !feedBody || !wikiPageName || !wikiSiteExcerpt) {
+  console.error('UPDATE_JSON is missing required fields');
+  process.exit(1);
+}
+
+const appUrl = process.env.APP_URL;
+const secret = process.env.INTERNAL_SERVICE_SECRET;
+const ghPat = process.env.GH_PAT;
+const today = new Date().toISOString().split('T')[0];
+
+// ── 1. Post to in-app feed ────────────────────────────────────────────────────
+
+const feedRes = await fetch(`${appUrl}/api/internal/product-update`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${secret}`,
+  },
+  body: JSON.stringify({ title: feedTitle, body: feedBody }),
+});
+
+if (!feedRes.ok) {
+  console.error('Feed post failed:', feedRes.status, await feedRes.text());
+  process.exit(1);
+}
+
+const feedData = await feedRes.json();
+console.log(`Feed announcement published (id: ${feedData.id})`);
+
+// ── 2. Update wiki-site content-index.yaml ───────────────────────────────────
+
+const WIKI_SITE_REPO = 'chargingthefuture/wiki-site';
+const INDEX_PATH = 'wiki-blog/content-index.yaml';
+const API_BASE = 'https://api.github.com';
+
+const ghHeaders = {
+  Authorization: `Bearer ${ghPat}`,
+  Accept: 'application/vnd.github.v3+json',
+  'Content-Type': 'application/json',
+};
+
+const fileRes = await fetch(`${API_BASE}/repos/${WIKI_SITE_REPO}/contents/${INDEX_PATH}`, {
+  headers: ghHeaders,
+});
+
+if (!fileRes.ok) {
+  console.error('Failed to read content-index.yaml:', fileRes.status, await fileRes.text());
+  process.exit(1);
+}
+
+const fileData = await fileRes.json();
+const currentContent = Buffer.from(fileData.content, 'base64').toString('utf-8');
+
+// Prepend so newest appears first; trailing newline is preserved from currentContent
+const safeTitle = feedTitle.replace(/"/g, '\\"');
+const safeExcerpt = wikiSiteExcerpt.replace(/"/g, '\\"');
+const newEntry = [
+  `- slug: ${wikiPageName}`,
+  `  title: "${safeTitle}"`,
+  `  repo: chargingthefuture/chargingthefuture`,
+  `  date: "${today}"`,
+  `  excerpt: "${safeExcerpt}"`,
+  `  category: Updates`,
+  '',
+].join('\n');
+
+const updatedContent = newEntry + currentContent;
+
+const updateRes = await fetch(`${API_BASE}/repos/${WIKI_SITE_REPO}/contents/${INDEX_PATH}`, {
+  method: 'PUT',
+  headers: ghHeaders,
+  body: JSON.stringify({
+    message: `chore: add product update ${today}`,
+    content: Buffer.from(updatedContent).toString('base64'),
+    sha: fileData.sha,
+  }),
+});
+
+if (!updateRes.ok) {
+  console.error('Failed to update content-index.yaml:', updateRes.status, await updateRes.text());
+  process.exit(1);
+}
+
+console.log('content-index.yaml updated in wiki-site repo.');


### PR DESCRIPTION
Adds an agentic deploy-to-post pipeline that fires on every push to main
when feat/fix/perf commits are present:

- /api/internal/product-update — internal Next.js endpoint (INTERNAL_SERVICE_SECRET
  auth) that creates and immediately publishes a feed announcement
- ctf/scripts/generate-update.mjs — calls Claude Haiku with recent commits
  and the brand voice lexicon to produce feed, wiki, and Quora content in
  one generation pass
- ctf/scripts/publish-product-update.mjs — posts to the feed endpoint and
  prepends a new entry to wiki-site's content-index.yaml via GitHub API
- .github/workflows/generate-product-update.yml — orchestrates the full
  pipeline: generate → feed → wiki-site index → GitHub wiki page (git push)
  → Quora draft GitHub Issue → update/* tag for next run's range

Required secrets: ANTHROPIC_API_KEY, APP_URL, INTERNAL_SERVICE_SECRET, GH_PAT

https://claude.ai/code/session_017ttWRPjQiXhG9QKFYcko56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated product update generation and distribution across in-app feeds and external documentation platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/65)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->