### PR TITLE
docs: add design-pass gating rule (127) + CLAUDE.md callout

### DIFF
--- a/.github/instructions/127-design-pass-gating-rules.mdc
+++ b/.github/instructions/127-design-pass-gating-rules.mdc
@@ -1,0 +1,119 @@
+# Design Pass Gating Rules
+
+## Intent
+
+Stop AI implementation agents from building UI against an unlocked design. Replit's design agent produces designs that are the **only** authoritative visual source for this codebase. Code agents that build UI before the design lands cause rework, drift, and product debt. This rule defines exactly when an agent must halt for a design pass, how to verify a pass exists, and how to resume.
+
+Companion rule: `126-design-mockup-implementation-rules.mdc` covers what to do *after* a design exists. This rule (`127-`) covers what to do *before* one does.
+
+## The Design Submodule Is The Only Source Of Truth
+
+- Authoritative design location: the `design/` submodule at the root of this repo (`/design`). Submodule URL: `https://github.com/chargingthefuture/design`.
+- The Replit design agent commits designs **directly into that submodule** and pushes to its remote. There is no Figma file, no screenshot folder, no Slack thread, no Notion page that supersedes it. If it isn't in the `design/` submodule, it is not the design.
+- The submodule pointer in this repo (`/design`) may lag the latest design-repo HEAD. Agents must `git -C design fetch && git -C design log --oneline -5` to see what's actually on the remote before claiming a design exists.
+- The design system reference (component path, CSS approach, breakpoints, typography, file→shell mapping) is in `ctf/agents/design.agent.md`. That file is the authoritative *index* into the design submodule — do not re-derive its facts from anywhere else.
+
+## When Stop-For-Design Is REQUIRED
+
+An agent must halt before writing any UI code if the change introduces or materially restructures:
+
+1. A new user-facing page, route, modal, drawer, or component family.
+2. A new plugin or major plugin rewrite (per the New Plugin Lifecycle Checklist in `CLAUDE.md`).
+3. A pinned, featured, or above-the-fold surface on a high-traffic page (Directory, Feed, Lighthouse, etc.).
+4. A change to existing user-facing UI that materially changes layout, information architecture, or interaction model (not just copy or color).
+5. Anything visible to the 5M-survivor audience that is not a copy-only or color-only tweak.
+6. Cross-plugin UI co-changes (e.g., Skills Hunt placing a reward card on Directory's public page).
+
+In any of these cases, the agent must follow the **Required Checkpoint Behavior** below.
+
+## When Stop-For-Design Is SKIPPABLE
+
+An agent may proceed end-to-end without waiting for a design pass if the change is limited to:
+
+1. Schema / database migration only.
+2. Library, utility, helper, or repository code with no UI surface.
+3. API routes whose only consumer is another agent, admin tooling the owner uses directly, or a server-side process.
+4. Internal admin tooling **only the owner uses**, with no risk of accidental exposure to the survivor audience.
+5. Infra, configuration, CI/CD, or devcontainer changes.
+6. Bug fixes that change behavior but not layout, copy, or interaction model.
+7. Pure refactors with no observable user-visible effect.
+8. Type, lint, or test-only changes.
+
+When in doubt, treat the change as REQUIRED. Cost of a false stop is one round-trip. Cost of a false start is rework.
+
+## Bypass Mechanism (User-Initiated)
+
+The owner may explicitly bypass the gate by including one of the following in their prompt:
+
+- `bypass design` — agent proceeds end-to-end without a design pass; document the bypass in the change-log entry and in the relevant `*-session-continuity.md` doc.
+- `design done` followed by a reference to the design submodule path or commit (e.g. `design done: design/skills-hunt/`) — agent treats the design as locked, reads the referenced design artifacts, and resumes.
+- `hotfix` — agent treats the change as a bug fix and applies the SKIPPABLE rules even if the surface is normally REQUIRED.
+
+If the prompt is ambiguous, the agent must ask before proceeding.
+
+## Required Checkpoint Behavior
+
+When stop-for-design is required, the agent must, in order:
+
+1. **Lock the spec.** Write or update a `*-session-continuity.md` doc next to the relevant plugin's inventory at `ctf/docs/developer/ctf-plugin-feature-inventories/`. The doc must include:
+   - The owner-locked decisions made in this session (verbatim where possible).
+   - The audit findings if this is a rewrite.
+   - The roadmap split into "foundation now" vs "UI after design pass."
+   - Open questions that still need owner input.
+   - A "How a future session should start" section.
+2. **Update the rewrite/feature checklist.** Mark off the foundation items being committed and leave the UI items unchecked, with a note that they are gated on the design pass.
+3. **Commit + push the foundation.** Schema, types, library helpers, API routes that don't render UI, contract YAMLs, inventory updates. **Do not build UI components against unlocked design.** Foundation commits go on the working feature branch.
+4. **Announce the stop.** End the session-or-turn with a short summary that ends with this exact pattern, with no extra prose after it:
+
+   ```
+   DESIGN PASS REQUIRED
+   branch: <feature-branch>
+   design path: design/<plugin-or-feature>/
+   resume command: continue against design/<plugin-or-feature>/ at commit <sha>
+   ```
+
+5. **Stop.** Do not proceed to UI components. Do not "scaffold" a component file with a placeholder. Do not "pre-stub" the JSX. The next code change against UI must come after the design pass.
+
+## Verifying A Design Pass Exists (Resume Protocol)
+
+When the owner asks the agent to resume, the agent must:
+
+1. Update the submodule: `git -C design fetch` (do not assume the in-tree submodule pointer is current; the Replit agent pushes to the remote independently).
+2. Check the relevant subfolder of the design submodule for files specific to this feature (e.g. `design/skills-hunt/`, `design/directory/`).
+3. Confirm the design covers the four states required by `126-design-mockup-implementation-rules.mdc`: Unauthenticated, Authenticated+Loading, Authenticated+Empty, Authenticated+Populated. Surface missing states to the owner; do not invent them.
+4. Reconcile the design against the locked decisions in the `*-session-continuity.md` doc. If the design contradicts a locked decision (wrong field, wrong copy, wrong placement), surface the conflict to the owner before writing any code. Do not silently re-shape the implementation to match a drifted design.
+5. Only after reconciliation, implement the UI per `126-design-mockup-implementation-rules.mdc` (no stub data, no UI for non-existent backend, etc.).
+
+## Anti-Patterns (do not do these)
+
+1. **Building a component "skeleton" or "shell" while waiting for design.** Even if the file is "just a placeholder," it becomes the design once it ships, and Replit will be forced to design around it. The right placeholder is `null`.
+2. **Treating screenshots, Figma exports, Slack messages, or chat descriptions as the design.** They are not. The submodule is.
+3. **Copying mockup stub data into production shells.** Forbidden by `126-`. Even more forbidden when there is no design pass at all.
+4. **Splitting a single user-facing feature across "foundation now, UI later" without a session-continuity doc.** The doc is what makes the split safe. Without it, the next session has to re-litigate the spec and the owner pays the documentation cost again.
+5. **Asking the owner "should I keep going?" instead of stopping.** The gate is the stop. If the surface is REQUIRED, stop without asking. Resume on explicit owner instruction.
+
+## Cross-References
+
+- `099-agent-scope-guardrails.mdc` — write-scope rules; this rule extends them with a design-scope concept.
+- `120-plugin-feature-inventory-lifecycle-rules.mdc` — inventory and continuity doc naming.
+- `122-schema-drift-predeployment-rules.mdc` — schema-side gate; this rule is the UI-side equivalent.
+- `126-design-mockup-implementation-rules.mdc` — what to do once a design exists.
+- `CLAUDE.md` "Plugin Feature Inventory Sync Policy" — every code change must update the inventory; the session-continuity doc is the lightweight form of that for in-flight design-gated work.
+
+## Examples
+
+### Example 1 — REQUIRED (Skills Hunt rewrite, 2026-05-11)
+
+Owner asks for a Skills Hunt audit + fix. Scope includes a new submission modal, admin panel UI, reward card placement on Directory, mobile rebuild. **Required stop.** Agent locked the spec in `ctf-skills-hunt-session-continuity.md`, committed schema + types + inventory updates as the foundation, and stopped with the `DESIGN PASS REQUIRED` block before writing any of the new UI components. Replit picks up next.
+
+### Example 2 — SKIPPABLE (Adding a database index)
+
+Owner asks for a Postgres index on `directory_profiles.unclaimed_handle`. No UI surface touched. Agent proceeds end-to-end without a design pass; documents the change in the relevant inventory.
+
+### Example 3 — BYPASS (Hotfix on existing screen)
+
+Production is showing an incorrect leaderboard rank for ties. Owner prompts: `hotfix — leaderboard tie-break broken in /apps/skills-hunt`. Agent applies the bug fix to the existing leaderboard component without waiting for a design pass; logs the bypass in the relevant change-log.
+
+### Example 4 — DRIFT (Design contradicts locked decision)
+
+Resume: design lands at `design/skills-hunt/submission-modal.tsx` showing skills as a free-text textarea rather than the taxonomy multi-select that was owner-locked in the continuity doc. Agent surfaces the conflict to the owner ("design shows free-text; continuity §2.1 locks taxonomy multi-select — which wins?") before writing any code. Does **not** silently match the implementation to the drifted design.

--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -49,6 +49,7 @@
 - [124-brand-voice-and-language-rules.mdc](124-brand-voice-and-language-rules.mdc)
 - [125-railway-mcp-debugging-rules.mdc](125-railway-mcp-debugging-rules.mdc)
 - [126-design-mockup-implementation-rules.mdc](126-design-mockup-implementation-rules.mdc)
+- [127-design-pass-gating-rules.mdc](127-design-pass-gating-rules.mdc)
 - [200-plugin-command-contract-templates.mdc](200-plugin-command-contract-templates.mdc)
 - [201-plugin-command-schema-template.mdc](201-plugin-command-schema-template.mdc)
 - [202-plugin-access-policy-schema-template.mdc](202-plugin-access-policy-schema-template.mdc)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,13 @@ Commit messages must end with the active session URL on its own line:
 ```
 https://claude.ai/code/session_<id>
 ```
+
+## Design Pass Gating (Critical — Read Before Touching UI)
+
+Before writing any user-facing UI for a new page, modal, plugin, featured surface, or material layout/IA change, you **must** verify a design exists in the `design/` submodule (canonical source; the only authoritative design location, remote: `https://github.com/chargingthefuture/design`). If no design exists for the feature, you **must** stop and announce `DESIGN PASS REQUIRED` per the protocol in `.github/instructions/127-design-pass-gating-rules.mdc`.
+
+Skippable: schema, libraries, API-only routes, admin-internal tooling, infra/CI, bug fixes, refactors, type/lint/test changes.
+
+Owner-issued bypass keywords (must appear in the user's prompt): `bypass design`, `design done`, `hotfix`.
+
+Full trigger conditions, checkpoint behavior, resume protocol, and worked examples: see `.github/instructions/127-design-pass-gating-rules.mdc`.


### PR DESCRIPTION
## Summary

- New standing rule `.github/instructions/127-design-pass-gating-rules.mdc` that halts AI implementation agents from building UI before the Replit design agent has pushed a corresponding design into the `design/` submodule (canonical source: `https://github.com/chargingthefuture/design`).
- Companion-rule split with `126-design-mockup-implementation-rules.mdc`: `126` governs what to do **after** a design exists; `127` governs what to do **before** one does.
- `CLAUDE.md` gets a top-level callout so every agent sees the gate at task start, not buried in a 30-item index.

## Why

Authored after the Skills Hunt rewrite on `claude/audit-skills-hunt-plugin-6yv3e` (commits `82fd92d`, `f3aeb3f`, `90d880c`) demonstrated the workflow value end-to-end: the agent stopped at a foundation commit, the owner pointed Replit at the branch, and the Replit pass can now design against locked spec without rework risk. Formalizing the pattern so future tasks default to it instead of re-discovering it.

The owner explicitly raised this as a workflow concern: re-explaining spec every session was a recurring cost across earlier Skills Hunt sessions. The gate + the mandatory `*-session-continuity.md` checkpoint doc together make the spec durable across sessions.

## What's in the rule

- **Authoritative design source is unambiguous:** the `design/` submodule. Not Figma, not screenshots, not Slack, not chat. Agents must `git -C design fetch` to see what Replit pushed — the in-tree submodule pointer can lag.
- **REQUIRED stop conditions:** new pages/modals/component families, new plugins, featured high-traffic surfaces (Directory, Feed, Lighthouse), cross-plugin UI co-changes, material layout/IA changes for the 5M-survivor audience.
- **SKIPPABLE conditions:** schema, libraries, API-only routes, admin-internal tooling, infra/CI, bug fixes, refactors, type/lint/test changes. When in doubt, treat as REQUIRED.
- **Owner bypass keywords** (must appear in user's prompt): `bypass design`, `design done`, `hotfix`.
- **Mandatory checkpoint behavior** when stopping: lock the spec in a `*-session-continuity.md` doc, update the rewrite checklist, commit foundation (schema/types/libs/contracts), and emit a deterministic announce block ending with `DESIGN PASS REQUIRED` + branch + design path + resume command.
- **Resume protocol:** fetch the design submodule remote, verify state completeness per `126-`, reconcile against locked decisions in the continuity doc, surface drift to the owner rather than silently re-shaping code.
- **Anti-patterns explicitly forbidden:** "skeleton" components against unlocked design, copying mockup stub data into production shells, treating non-submodule artifacts as authoritative, asking "should I keep going?" instead of stopping.
- **Worked examples:** Skills Hunt rewrite as REQUIRED, schema index as SKIPPABLE, leaderboard hotfix as BYPASS, and a drift scenario (design contradicts locked decision).

## Files

- `.github/instructions/127-design-pass-gating-rules.mdc` — new (120 lines).
- `.github/instructions/copilot-instructions.md` — one-line addition to the Product Rule Modules index.
- `CLAUDE.md` — new "Design Pass Gating (Critical)" section with inline trigger summary + bypass keywords + pointer to 127.

## Test plan

- [ ] Skim `127-design-pass-gating-rules.mdc` end-to-end; confirm trigger conditions match real product surfaces (Directory, Feed, Lighthouse, Skills Hunt).
- [ ] Confirm the `design/` submodule URL in the rule (`https://github.com/chargingthefuture/design`) matches the canonical remote.
- [ ] Confirm the bypass keywords (`bypass design`, `design done`, `hotfix`) are the ones the owner wants to use long-term.
- [ ] Confirm the rule's interaction with `126-design-mockup-implementation-rules.mdc` reads as complementary (126 = post-design, 127 = pre-design), not contradictory.
- [ ] Spot-check that the CLAUDE.md callout has every element a fast-skimming agent needs: trigger summary, skippable list, bypass keywords, pointer to full rule.
- [ ] After merge, the next agent task with a UI surface should trigger the gate organically — no further prompting needed. Test on the next Replit-design feature.

## Parity Status

Parity Status: web+android complete

(Documentation-only change; no product code, no user-facing UI, no schema, no API. Web/Android parity not applicable.)

## Related

- Rule `126-design-mockup-implementation-rules.mdc` — implementation-time companion.
- Skills Hunt rewrite branch `claude/audit-skills-hunt-plugin-6yv3e` — the case study that produced this rule. See `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-session-continuity.md` for the canonical session-continuity doc pattern this rule enforces.

https://claude.ai/code/session_01W9FxP1GgDY6f8AghrC87ri

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9FxP1GgDY6f8AghrC87ri)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design pass gating rules defining when design verification is required before UI changes
  * Documented conditions for skipping design reviews and approved bypass directives for specific scenarios
  * Updated team guides to reference the new design governance protocol
  * Includes checkpoint behavior and resume procedures for continued design work after interruptions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->