### PR TITLE
ci: auto-generate Infisical secrets and support Render project ID

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -124,6 +124,29 @@ All `.ts`, `.tsx`, `.js`, `.json`, `.yml`, `.yaml`, `.css` files must end with e
 
 ## CTF Contract
 
+## Security and Secrets Policy (Critical)
+
+**This is an open source repository.** Everything committed to this codebase is publicly visible. Never expose secrets, credentials, API keys, encryption keys, tokens, or any sensitive information through:
+
+- **Code commits** — no secrets hardcoded or in examples
+- **GitHub Actions logs/stdout** — no auto-generated secrets printed to console
+- **Job summaries or outputs** — no sensitive values in workflow summaries
+- **Documentation or comments** — no example credentials or keys
+- **Error messages or debugging output** — scrub sensitive info from error handling
+
+**Correct pattern for secrets:**
+1. User generates secrets locally (e.g., `openssl rand -hex 16` in a terminal)
+2. User stores them securely as GitHub repository secrets
+3. Workflows pass them to scripts as masked environment variables
+4. Scripts consume them but never print or output them
+5. Error messages that fail validation refer users to the generation command, not the secret itself
+
+**If a secret is ever exposed** (even locally in logs or momentarily in a PR):
+- Rotate it immediately via the GitHub Actions secrets UI or service dashboard
+- Do not commit the exposed value to the repo
+
+This applies to all development: deploy scripts, CI/CD workflows, seed scripts, test fixtures, and any infrastructure code.
+
 ## Local Build and Error Checking Requirement
 
 - After every code change, always run the local build (e.g., `pnpm build` or project-specific build command) and check for errors.

--- a/.github/workflows/deploy-infisical-render.yml
+++ b/.github/workflows/deploy-infisical-render.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_OWNER_ID: ${{ secrets.RENDER_OWNER_ID }}
+          RENDER_PROJECT_ID: ${{ secrets.RENDER_PROJECT_ID }}
           INFISICAL_DB_URI: ${{ secrets.INFISICAL_DB_URI }}
           INFISICAL_ENCRYPTION_KEY: ${{ secrets.INFISICAL_ENCRYPTION_KEY }}
           INFISICAL_AUTH_SECRET: ${{ secrets.INFISICAL_AUTH_SECRET }}
@@ -30,3 +31,9 @@ jobs:
           echo "### Infisical Deployed" >> $GITHUB_STEP_SUMMARY
           echo "- Service ID: ${{ steps.deploy.outputs.SERVICE_ID }}" >> $GITHUB_STEP_SUMMARY
           echo "- URL: ${{ steps.deploy.outputs.SERVICE_URL }}" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ steps.deploy.outputs.INFISICAL_ENCRYPTION_KEY }}" ]; then
+            echo "- **Save this ENCRYPTION_KEY**: ${{ steps.deploy.outputs.INFISICAL_ENCRYPTION_KEY }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -n "${{ steps.deploy.outputs.INFISICAL_AUTH_SECRET }}" ]; then
+            echo "- **Save this AUTH_SECRET**: ${{ steps.deploy.outputs.INFISICAL_AUTH_SECRET }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/deploy-infisical-render.yml
+++ b/.github/workflows/deploy-infisical-render.yml
@@ -31,9 +31,3 @@ jobs:
           echo "### Infisical Deployed" >> $GITHUB_STEP_SUMMARY
           echo "- Service ID: ${{ steps.deploy.outputs.SERVICE_ID }}" >> $GITHUB_STEP_SUMMARY
           echo "- URL: ${{ steps.deploy.outputs.SERVICE_URL }}" >> $GITHUB_STEP_SUMMARY
-          if [ -n "${{ steps.deploy.outputs.INFISICAL_ENCRYPTION_KEY }}" ]; then
-            echo "- **Save this ENCRYPTION_KEY**: ${{ steps.deploy.outputs.INFISICAL_ENCRYPTION_KEY }}" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ -n "${{ steps.deploy.outputs.INFISICAL_AUTH_SECRET }}" ]; then
-            echo "- **Save this AUTH_SECRET**: ${{ steps.deploy.outputs.INFISICAL_AUTH_SECRET }}" >> $GITHUB_STEP_SUMMARY
-          fi

--- a/ctf/scripts/deploy-infisical-render.sh
+++ b/ctf/scripts/deploy-infisical-render.sh
@@ -4,19 +4,32 @@
 #   RENDER_API_KEY       - Render API key
 #   RENDER_OWNER_ID      - Render owner/user ID (e.g. usr-xxx)
 #   INFISICAL_DB_URI     - Postgres connection string (Neon)
-#   INFISICAL_ENCRYPTION_KEY - 32-char hex encryption key
-#   INFISICAL_AUTH_SECRET    - JWT auth secret
+# Optional env vars:
+#   RENDER_PROJECT_ID        - Render project ID (e.g. prj-xxx); places service in a project
+#   INFISICAL_ENCRYPTION_KEY - 32-char hex encryption key (auto-generated if not set)
+#   INFISICAL_AUTH_SECRET    - JWT auth secret (auto-generated if not set)
 
 set -euo pipefail
 
 : "${RENDER_API_KEY:?RENDER_API_KEY is required}"
 : "${RENDER_OWNER_ID:?RENDER_OWNER_ID is required}"
 : "${INFISICAL_DB_URI:?INFISICAL_DB_URI is required}"
-: "${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY is required}"
-: "${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET is required}"
 
 RENDER_API="https://api.render.com/v1"
 SERVICE_NAME="infisical"
+
+# Auto-generate secrets if not provided
+if [ -z "${INFISICAL_ENCRYPTION_KEY:-}" ]; then
+  INFISICAL_ENCRYPTION_KEY=$(openssl rand -hex 16)
+  echo "==> Generated INFISICAL_ENCRYPTION_KEY (save this): $INFISICAL_ENCRYPTION_KEY"
+  echo "INFISICAL_ENCRYPTION_KEY=$INFISICAL_ENCRYPTION_KEY" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true
+fi
+
+if [ -z "${INFISICAL_AUTH_SECRET:-}" ]; then
+  INFISICAL_AUTH_SECRET=$(openssl rand -base64 32)
+  echo "==> Generated INFISICAL_AUTH_SECRET (save this): $INFISICAL_AUTH_SECRET"
+  echo "INFISICAL_AUTH_SECRET=$INFISICAL_AUTH_SECRET" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true
+fi
 
 echo "==> Checking if Infisical service already exists on Render..."
 EXISTING=$(curl -sf "$RENDER_API/services?name=$SERVICE_NAME&ownerId=$RENDER_OWNER_ID&limit=1" \
@@ -44,40 +57,45 @@ if [ -n "$EXISTING" ]; then
   echo "==> Env vars updated."
 else
   echo "==> Creating Infisical service on Render..."
+
+  # Build the service payload, optionally including projectId
+  SERVICE_PAYLOAD=$(jq -n \
+    --arg name "$SERVICE_NAME" \
+    --arg owner "$RENDER_OWNER_ID" \
+    --arg project "${RENDER_PROJECT_ID:-}" \
+    --arg db "$INFISICAL_DB_URI" \
+    --arg enc "$INFISICAL_ENCRYPTION_KEY" \
+    --arg auth "$INFISICAL_AUTH_SECRET" \
+    '{
+      type: "web_service",
+      name: $name,
+      ownerId: $owner,
+      image: {
+        ownerId: $owner,
+        imagePath: "docker.io/infisical/infisical:latest-postgres"
+      },
+      serviceDetails: {
+        env: "image",
+        plan: "starter",
+        region: "ohio",
+        healthCheckPath: "/api/status",
+        numInstances: 1,
+        pullRequestPreviewsEnabled: "no"
+      },
+      envVars: [
+        {key: "DB_CONNECTION_URI", value: $db},
+        {key: "ENCRYPTION_KEY", value: $enc},
+        {key: "AUTH_SECRET", value: $auth},
+        {key: "NODE_ENV", value: "production"},
+        {key: "TELEMETRY_ENABLED", value: "false"},
+        {key: "PORT", value: "8080"}
+      ]
+    } | if $project != "" then . + {projectId: $project} else . end')
+
   RESPONSE=$(curl -sf -X POST "$RENDER_API/services" \
     -H "Authorization: Bearer $RENDER_API_KEY" \
     -H "Content-Type: application/json" \
-    -d "$(jq -n \
-      --arg name "$SERVICE_NAME" \
-      --arg owner "$RENDER_OWNER_ID" \
-      --arg db "$INFISICAL_DB_URI" \
-      --arg enc "$INFISICAL_ENCRYPTION_KEY" \
-      --arg auth "$INFISICAL_AUTH_SECRET" \
-      '{
-        type: "web_service",
-        name: $name,
-        ownerId: $owner,
-        image: {
-          ownerId: $owner,
-          imagePath: "docker.io/infisical/infisical:latest-postgres"
-        },
-        serviceDetails: {
-          env: "image",
-          plan: "starter",
-          region: "ohio",
-          healthCheckPath: "/api/status",
-          numInstances: 1,
-          pullRequestPreviewsEnabled: "no"
-        },
-        envVars: [
-          {key: "DB_CONNECTION_URI", value: $db},
-          {key: "ENCRYPTION_KEY", value: $enc},
-          {key: "AUTH_SECRET", value: $auth},
-          {key: "NODE_ENV", value: "production"},
-          {key: "TELEMETRY_ENABLED", value: "false"},
-          {key: "PORT", value: "8080"}
-        ]
-      }')")
+    -d "$SERVICE_PAYLOAD")
 
   SERVICE_ID=$(echo "$RESPONSE" | jq -r '.service.id')
   echo "==> Service created: $SERVICE_ID"

--- a/ctf/scripts/deploy-infisical-render.sh
+++ b/ctf/scripts/deploy-infisical-render.sh
@@ -1,35 +1,21 @@
 #!/usr/bin/env bash
 # Deploy Infisical to Render via API.
 # Required env vars:
-#   RENDER_API_KEY       - Render API key
-#   RENDER_OWNER_ID      - Render owner/user ID (e.g. usr-xxx)
-#   INFISICAL_DB_URI     - Postgres connection string (Neon)
+#   RENDER_API_KEY           - Render API key
+#   RENDER_OWNER_ID          - Render owner/user ID (e.g. usr-xxx)
+#   INFISICAL_DB_URI         - Postgres connection string (Neon)
+#   INFISICAL_ENCRYPTION_KEY - 32-char hex key: openssl rand -hex 16
+#   INFISICAL_AUTH_SECRET    - JWT secret: openssl rand -base64 32
 # Optional env vars:
 #   RENDER_PROJECT_ID        - Render project ID (e.g. prj-xxx); places service in a project
-#   INFISICAL_ENCRYPTION_KEY - 32-char hex encryption key (auto-generated if not set)
-#   INFISICAL_AUTH_SECRET    - JWT auth secret (auto-generated if not set)
 
 set -euo pipefail
 
 : "${RENDER_API_KEY:?RENDER_API_KEY is required}"
 : "${RENDER_OWNER_ID:?RENDER_OWNER_ID is required}"
 : "${INFISICAL_DB_URI:?INFISICAL_DB_URI is required}"
-
-RENDER_API="https://api.render.com/v1"
-SERVICE_NAME="infisical"
-
-# Auto-generate secrets if not provided
-if [ -z "${INFISICAL_ENCRYPTION_KEY:-}" ]; then
-  INFISICAL_ENCRYPTION_KEY=$(openssl rand -hex 16)
-  echo "==> Generated INFISICAL_ENCRYPTION_KEY (save this): $INFISICAL_ENCRYPTION_KEY"
-  echo "INFISICAL_ENCRYPTION_KEY=$INFISICAL_ENCRYPTION_KEY" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true
-fi
-
-if [ -z "${INFISICAL_AUTH_SECRET:-}" ]; then
-  INFISICAL_AUTH_SECRET=$(openssl rand -base64 32)
-  echo "==> Generated INFISICAL_AUTH_SECRET (save this): $INFISICAL_AUTH_SECRET"
-  echo "INFISICAL_AUTH_SECRET=$INFISICAL_AUTH_SECRET" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true
-fi
+: "${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY is required — generate with: openssl rand -hex 16}"
+: "${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET is required — generate with: openssl rand -base64 32}"
 
 echo "==> Checking if Infisical service already exists on Render..."
 EXISTING=$(curl -sf "$RENDER_API/services?name=$SERVICE_NAME&ownerId=$RENDER_OWNER_ID&limit=1" \


### PR DESCRIPTION
## Summary

- Added `RENDER_PROJECT_ID` (optional) to deploy script to place service in a Render project
- **Removed auto-generation of secrets** to prevent exposing them in public logs/summaries on this open source repo
- Both `INFISICAL_ENCRYPTION_KEY` and `INFISICAL_AUTH_SECRET` are now required as repository secrets (users generate locally with `openssl rand`, store securely)
- Added **Security and Secrets Policy** to copilot-instructions.md to prevent future accidental secret exposure

## Test plan

- [x] Generate secrets locally:
  - `openssl rand -hex 16` → `INFISICAL_ENCRYPTION_KEY`
  - `openssl rand -base64 32` → `INFISICAL_AUTH_SECRET`
- [x] Add as repository secrets: `RENDER_PROJECT_ID`, `RENDER_API_KEY`, `RENDER_OWNER_ID`, `INFISICAL_DB_URI`, `INFISICAL_ENCRYPTION_KEY`, `INFISICAL_AUTH_SECRET`
- [ ] Trigger `Deploy Infisical to Render` workflow via `workflow_dispatch`
- [ ] Confirm service appears in Render dashboard and is live
- [ ] Verify no secrets appear in job logs or summaries

Parity Status: web+android complete

https://claude.ai/code/session_01HspQng6ki5ap2ZusubsEti