### PR TITLE
fix: restore missing RENDER_API and SERVICE_NAME in deploy script

### DIFF
--- a/ctf/scripts/deploy-infisical-render.sh
+++ b/ctf/scripts/deploy-infisical-render.sh
@@ -17,6 +17,9 @@ set -euo pipefail
 : "${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY is required — generate with: openssl rand -hex 16}"
 : "${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET is required — generate with: openssl rand -base64 32}"
 
+RENDER_API="https://api.render.com/v1"
+SERVICE_NAME="infisical"
+
 echo "==> Checking if Infisical service already exists on Render..."
 EXISTING=$(curl -sf "$RENDER_API/services?name=$SERVICE_NAME&ownerId=$RENDER_OWNER_ID&limit=1" \
   -H "Authorization: Bearer $RENDER_API_KEY" | jq -r '.[0].service.id // empty')


### PR DESCRIPTION
## Summary

Hotfix for deploy-infisical-render.sh which was missing `RENDER_API` and `SERVICE_NAME` variable definitions, causing "unbound variable" error on execution.

## Test plan

- [ ] Trigger `Deploy Infisical to Render` workflow with all six secrets set
- [ ] Verify script runs without "unbound variable" errors
- [ ] Confirm Infisical service deploys successfully to Render

Parity Status: web+android complete

https://claude.ai/code/session_01HspQng6ki5ap2ZusubsEti

---
_Generated by [Claude Code](https://claude.ai/code/session_01HspQng6ki5ap2ZusubsEti)_