### PR TITLE
fix: restore missing imports in ClicklogTabs.tsx

### DIFF
--- a/ctf/packages/mobile/src/features/clicklog/ClicklogTabs.tsx
+++ b/ctf/packages/mobile/src/features/clicklog/ClicklogTabs.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { ClicklogCounter } from './ClicklogCounter';
 import { ClicklogHistory } from './ClicklogHistory';
 


### PR DESCRIPTION
## Summary

- Restores `createBottomTabNavigator` (from `@react-navigation/bottom-tabs`) and `Ionicons` (from `@expo/vector-icons/Ionicons`) imports that were accidentally dropped in commit 2a0eb7f.
- Without these imports `pnpm --filter @ctf/mobile run typecheck` fails on `main` with three TS2304 errors, which blocks the pre-commit hook for every contributor (it runs the full workspace typecheck before allowing a commit).
- Smallest possible fix — just the two missing import lines, no behavior change.

Parity Status: web+android complete

## Test plan

- [x] `pnpm --filter @ctf/mobile run typecheck` passes (was failing on `main`).
- [x] `pnpm --filter @ctf/web run typecheck` still passes.
- [x] Pre-commit hook runs the full workspace typecheck cleanly.

https://claude.ai/code/session_01NJCwkNRyhY2qktHHWYKmcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJCwkNRyhY2qktHHWYKmcL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compilation issue in the mobile app that was preventing proper navigation and icon rendering initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->