### PR TITLE
fix: remove dead code in ClicklogTabs.tsx to unblock lint gate

### DIFF
--- a/ctf/packages/mobile/src/features/clicklog/ClicklogTabs.tsx
+++ b/ctf/packages/mobile/src/features/clicklog/ClicklogTabs.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { ClicklogCounter } from './ClicklogCounter';
@@ -18,8 +17,6 @@ const Tab = createBottomTabNavigator<ClicklogTabParamList>();
 const TabNavigator = Tab.Navigator as React.ComponentType<any>;
 
 export function ClicklogTabs() {
-  const [tab, setTab] = useState('counter');
-
   return (
     <TabNavigator>
       <Tab.Screen
@@ -41,11 +38,3 @@ export function ClicklogTabs() {
 }
 
 export default ClicklogTabs;
-
-const styles = StyleSheet.create({
-  tabBar: { flexDirection: 'row', backgroundColor: '#181A20', borderBottomWidth: 1, borderBottomColor: '#23262F' },
-  tab: { flex: 1, paddingVertical: 14, alignItems: 'center' },
-  tabActive: { borderBottomWidth: 3, borderBottomColor: '#EAB308' },
-  tabLabel: { color: '#9CA3AF', fontSize: 15, fontWeight: '600' },
-  tabLabelActive: { color: '#EAB308' },
-});


### PR DESCRIPTION
## Summary

Removes dead code from `ctf/packages/mobile/src/features/clicklog/ClicklogTabs.tsx` that was left over from the navigation refactor commits. The workspace lint gate fails on `main` with six `no-unused-vars` errors:

```
2:10  error  'View' is defined but never used
2:16  error  'Text' is defined but never used
2:34  error  'TouchableOpacity' is defined but never used
21:10 error  'tab' is assigned a value but never used
21:15 error  'setTab' is assigned a value but never used
45:7  error  'styles' is assigned a value but never used
```

This blocks the `Rewrite Quality Gates` aggregator job on every PR (lint is one of its gates), independently of the missing-imports fix in #78 and the EOF newline fix in #81.

Removes the unused imports, the unused `useState`, and the unused `StyleSheet.create` block. No behavior change — none of the removed declarations were read by the rendered `<TabNavigator>`.

Parity Status: web+android complete

## Test plan

- [x] `pnpm --filter @ctf/mobile run lint` passes (was failing on `main`).
- [x] `pnpm --filter @ctf/mobile run typecheck` still passes.
- [x] `pnpm run lint` (full workspace) passes.

https://claude.ai/code/session_01NJCwkNRyhY2qktHHWYKmcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJCwkNRyhY2qktHHWYKmcL)_