### PR TITLE
fix: address CodeRabbit review findings on Skills Hunt rewrite

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-feature-inventory.md
@@ -67,12 +67,12 @@ Implemented routes:
 
 1. `source TEXT NOT NULL DEFAULT 'admin' CHECK (source IN ('admin', 'self', 'community-generated'))` — drives the "Community generated profile" badge in the UI.
 2. `invited_by_username TEXT NULL` — denormalized from `skills_hunt_directory_profiles.invited_by_username` so the (auth-gated) profile page renders attribution without a join.
-3. `unclaimed_handle TEXT UNIQUE NULL` — auto-generated vanity handle for unclaimed profiles. Format: `community-<6char-hex>` (no leading `@` in storage; `@` is presentation only). Cleared/ignored once `claimed_by_user_id` is set.
+3. `unclaimed_handle TEXT NULL` — auto-generated vanity handle for unclaimed profiles. Format: `community-<6char-hex>` (no leading `@` in storage; `@` is presentation only). Cleared/ignored once `claimed_by_user_id` is set. Uniqueness is enforced by a case-insensitive partial unique index (`directory_profiles_unclaimed_handle_key` on `lower(unclaimed_handle)` WHERE `unclaimed_handle IS NOT NULL`), not an inline column constraint — so `Community-7F3A2B` and `community-7f3a2b` cannot coexist, and the migration block can drop/recreate the index without tripping over a constraint-backed index on the fresh-schema path.
 4. `deleted_at TIMESTAMPTZ NULL` — soft-delete for GDPR and moderation removals; `is_active` remains in place but `deleted_at` takes precedence for visibility filters.
 
 ### Backfill (one-shot, idempotent)
 
-For every `directory_profiles` row where `claimed_by_user_id IS NULL AND unclaimed_handle IS NULL`, assign `unclaimed_handle = 'community-' || encode(gen_random_bytes(3), 'hex')`. Retry on UNIQUE collision. Establishes consistent `@handle` URLs on day one.
+For every `directory_profiles` row where `claimed_by_user_id IS NULL AND unclaimed_handle IS NULL`, assign `unclaimed_handle = 'community-' || encode(gen_random_bytes(3), 'hex')`. Retry on case-insensitive unique-index collision. Establishes consistent `@handle` URLs on day one.
 
 ## Security, Privacy, and Compliance Controls
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-rewrite-checklist.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-rewrite-checklist.md
@@ -139,7 +139,7 @@
 - [x] Verify authz/deny conditions and audit integrity on existing endpoints.
 - [x] **Wave 2 — soft-delete + GDPR endpoint:**
   - [x] `deleted_at` columns already landed in Phase 1 (`f3aeb3f`); user-visible reads (`listSubmissions` and `rebuildLeaderboard` individual + team aggregates, all-time) now filter `AND deleted_at IS NULL`.
-  - [x] `DELETE /api/account/skills-hunt-profile` GDPR erasure — soft-deletes every submission authored by the caller; emits audit log entry; rebuilt leaderboards automatically skip the deleted rows on the next review.
+  - [x] `DELETE /api/account/skills-hunt-profile` GDPR erasure — soft-deletes every submission authored by the caller; emits audit log entry; the delete runs in one transaction that immediately rebuilds affected leaderboards and recomputes mission progress, so the deleted rows drop out of standings and mission counts right away (not on the next review).
   - [x] Audit-log retention preserved (`skills_hunt_audit_log` is not soft-deleted; the delete endpoint *writes* an audit row with `skills-hunt.profile.delete`).
 - [x] **Wave 2 — moderation report flow:** `lib/skills-hunt/moderation.ts` (createReport, listOpenReports, resolveReport).
   - [x] `POST /api/skills-hunt/submissions/{id}/report` (auth required, CSRF, reason CHECK enforced).

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
@@ -185,7 +185,7 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
               <thead>
                 <tr style={{ textAlign: "left", color: "#6B7280", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em" }}>
                   <th style={{ padding: "8px 6px", width: 32 }}>
-                    <input type="checkbox" checked={selected.size > 0 && selected.size === submissions.length} onChange={toggleAllVisible} />
+                    <input type="checkbox" checked={selected.size > 0 && selected.size === submissions.filter(s => s.status === "pending").length} onChange={toggleAllVisible} />
                   </th>
                   <th style={{ padding: "8px 6px" }}>Submitter</th>
                   <th style={{ padding: "8px 6px" }}>Display Name</th>

--- a/ctf/packages/web/lib/directory/repository.ts
+++ b/ctf/packages/web/lib/directory/repository.ts
@@ -37,12 +37,14 @@ type DirectoryProfileRow = {
   source?: 'admin' | 'self' | 'community-generated' | null;
   invited_by_username?: string | null;
   unclaimed_handle?: string | null;
+  // Optional on the row type so SELECTs that don't pull the payment columns
+  // still typecheck; mapProfileRow defaults each to null.
+  venmo_address?: string | null;
+  monero_address?: string | null;
+  bitcoin_address?: string | null;
+  service_credits_address?: string | null;
   created_at: Date;
   updated_at: Date;
-    venmo_address: string | null;
-    monero_address: string | null;
-    bitcoin_address: string | null;
-    service_credits_address: string | null;
 };
 
 type DirectorySkillRow = {
@@ -145,10 +147,10 @@ async function mapProfileRow(client: PoolClient, row: DirectoryProfileRow): Prom
     unclaimedHandle: row.unclaimed_handle ?? null,
     createdAtIso: toIso(row.created_at),
     updatedAtIso: toIso(row.updated_at),
-      venmoAddress: row.venmo_address,
-      moneroAddress: row.monero_address,
-      bitcoinAddress: row.bitcoin_address,
-      serviceCreditsAddress: row.service_credits_address,
+    venmoAddress: row.venmo_address ?? null,
+    moneroAddress: row.monero_address ?? null,
+    bitcoinAddress: row.bitcoin_address ?? null,
+    serviceCreditsAddress: row.service_credits_address ?? null,
   };
 }
 
@@ -339,9 +341,9 @@ export async function upsertOwnProfile(userId: string, input: DirectoryProfileIn
       const inserted = await client.query<{ id: string }>(
         `
           INSERT INTO directory_profiles
-            (claimed_by_user_id, display_name, headline, bio, profile_url, sector_id, job_title_id, is_active)
+            (claimed_by_user_id, display_name, headline, bio, profile_url, sector_id, job_title_id, is_active, source)
           VALUES
-            ($1, $2, $3, $4, $5, $6::uuid, $7::uuid, true)
+            ($1, $2, $3, $4, $5, $6::uuid, $7::uuid, true, 'self')
           RETURNING id
         `,
         [userId, displayName, headline, bio, profileUrl, sectorId, jobTitleId],

--- a/ctf/packages/web/lib/directory/repository.ts
+++ b/ctf/packages/web/lib/directory/repository.ts
@@ -279,6 +279,9 @@ async function loadProfileByUser(client: PoolClient, userId: string): Promise<Di
         p.job_title_id,
         jt.name AS job_title_name,
         p.is_active,
+        p.source,
+        p.invited_by_username,
+        p.unclaimed_handle,
         p.created_at,
         p.updated_at
       FROM directory_profiles p
@@ -396,6 +399,9 @@ export async function upsertOwnProfile(userId: string, input: DirectoryProfileIn
           p.job_title_id,
           jt.name AS job_title_name,
           p.is_active,
+          p.source,
+          p.invited_by_username,
+          p.unclaimed_handle,
           p.created_at,
           p.updated_at
         FROM directory_profiles p

--- a/ctf/packages/web/lib/skills-hunt/repository.ts
+++ b/ctf/packages/web/lib/skills-hunt/repository.ts
@@ -1015,7 +1015,7 @@ export async function rebuildLeaderboard(client: PoolClient, roundId: string): P
 // can promote/dampen rewards mid-program without code change.
 // Explicit number-typed shape (not `typeof SKILLS_HUNT_SCORE_WEIGHTS_SPEC`)
 // because the spec object is `as const` and its literal types would reject
-// per-round overrides from scoring_config.
+// per-round overrides stored on the round.
 type ResolvedScoreWeights = {
   -readonly [K in keyof typeof SKILLS_HUNT_SCORE_WEIGHTS_SPEC]: number;
 };

--- a/ctf/packages/web/lib/skills-hunt/repository.ts
+++ b/ctf/packages/web/lib/skills-hunt/repository.ts
@@ -75,9 +75,7 @@ import {
   SKILLS_HUNT_REJECTION_GUARD_SAMPLE_SIZE,
   SKILLS_HUNT_REJECTION_GUARD_THRESHOLD,
   SKILLS_HUNT_REPUTATION,
-  SKILLS_HUNT_SCORE_WEIGHTS,
   SKILLS_HUNT_SCORE_WEIGHTS_SPEC,
-  SKILLS_HUNT_SUBMISSION_LIMIT_7D,
 } from './constants';
 import type {
   SkillsHuntAchievement,
@@ -787,6 +785,7 @@ async function awardNamedBadges(
       FROM skills_hunt_submissions
       WHERE submitter_user_id = $1
         AND status = 'accepted'
+        AND deleted_at IS NULL
         AND COALESCE((score_breakdown ->> 'rareSkillBonus')::int, 0) > 0
     `,
     [userId],
@@ -810,6 +809,7 @@ async function awardNamedBadges(
         FROM skills_hunt_submissions
         WHERE submitter_user_id = $1
           AND status = 'accepted'
+          AND deleted_at IS NULL
           AND jsonb_typeof(claimed_professions) = 'array'
       ) p
     `,
@@ -833,6 +833,7 @@ async function awardNamedBadges(
         COUNT(*) FILTER (WHERE status = 'rejected')::text AS rejected
       FROM skills_hunt_submissions
       WHERE submitter_user_id = $1
+        AND deleted_at IS NULL
     `,
     [userId],
   );
@@ -890,7 +891,7 @@ export async function rebuildLeaderboard(client: PoolClient, roundId: string): P
           submitter_user_id,
           (COUNT(*) * $2)::text AS pending_points
         FROM skills_hunt_submissions
-        WHERE round_id = $1::uuid AND status = 'pending'
+        WHERE round_id = $1::uuid AND status = 'pending' AND deleted_at IS NULL
         GROUP BY submitter_user_id
       ),
       activity AS (
@@ -902,7 +903,7 @@ export async function rebuildLeaderboard(client: PoolClient, roundId: string): P
           submitter_user_id,
           MIN(created_at) AS last_submission_at
         FROM skills_hunt_submissions
-        WHERE round_id = $1::uuid
+        WHERE round_id = $1::uuid AND deleted_at IS NULL
         GROUP BY submitter_user_id
       )
       SELECT
@@ -1546,6 +1547,9 @@ export async function listSubmissions(
       review_notes,
       reviewed_by_user_id,
       reviewed_at,
+      edit_history,
+      edited_at,
+      deleted_at,
       directory_profile_generated_at,
       created_at,
       updated_at
@@ -1690,6 +1694,9 @@ export async function reviewSubmission(
           review_notes,
           reviewed_by_user_id,
           reviewed_at,
+          edit_history,
+          edited_at,
+          deleted_at,
           directory_profile_generated_at,
           created_at,
           updated_at
@@ -1720,7 +1727,12 @@ export async function reviewSubmission(
     }
 
     if (status === 'accepted') {
-      await emitSubmissionAccepted(client, existing.submitter_user_id, submissionId, pointsAwarded);
+      // Only fan out the acceptance notification on an actual transition into
+      // `accepted` — re-reviewing an already-accepted submission (accept/edit)
+      // must not spam duplicate inbox entries for the same submission.
+      if (existing.status !== 'accepted') {
+        await emitSubmissionAccepted(client, existing.submitter_user_id, submissionId, pointsAwarded);
+      }
 
       await awardNamedBadges(client, existing.submitter_user_id, existing.round_id, scoreBreakdown);
 
@@ -1924,7 +1936,7 @@ export async function listAllTimeLeaderboard(
 export async function listAchievements(userId: string): Promise<SkillsHuntAchievement[]> {
   const result = await queryDb<SkillsHuntAchievementRow>(
     `
-      SELECT id, user_id, code, title, description, metadata, awarded_at
+      SELECT id, user_id, code, title, description, round_id, metadata, archived_at, awarded_at
       FROM skills_hunt_achievements
       WHERE user_id = $1
       ORDER BY awarded_at DESC

--- a/ctf/packages/web/lib/skills-hunt/url-validation.ts
+++ b/ctf/packages/web/lib/skills-hunt/url-validation.ts
@@ -11,22 +11,42 @@ export type UrlLivenessOutcome = {
 // when Quora rate-limits the worker or the network is briefly flaky.
 const DEAD_STATUSES = new Set<number>([404, 410]);
 
-function isPlausibleHttpUrl(value: string): boolean {
+// SSRF guard: this worker only ever pings Quora profile URLs. Restricting the
+// outbound host to the Quora apex (and its subdomains) before any fetch keeps
+// a user-supplied URL from steering the request at an internal address, even
+// if an upstream caller's allow-list is ever bypassed. Defaults are passed in
+// so the function stays the single sanitizer right before the network call.
+const DEFAULT_ALLOWED_HOST_SUFFIXES = ['quora.com'] as const;
+
+function isAllowedHost(hostname: string, allowedHostSuffixes: readonly string[]): boolean {
+  const host = hostname.toLowerCase();
+  return allowedHostSuffixes.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+}
+
+function parseAllowedHttpUrl(value: string, allowedHostSuffixes: readonly string[]): URL | null {
   try {
     const parsed = new URL(value);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null;
+    }
+    if (!isAllowedHost(parsed.hostname, allowedHostSuffixes)) {
+      return null;
+    }
+    return parsed;
   } catch {
-    return false;
+    return null;
   }
 }
 
 export async function checkUrlLiveness(
   rawUrl: string,
   timeoutMs: number = SKILLS_HUNT_URL_VALIDATION_TIMEOUT_MS,
+  allowedHostSuffixes: readonly string[] = DEFAULT_ALLOWED_HOST_SUFFIXES,
 ): Promise<UrlLivenessOutcome> {
   const checkedAtIso = new Date().toISOString();
 
-  if (!isPlausibleHttpUrl(rawUrl)) {
+  const allowedUrl = parseAllowedHttpUrl(rawUrl, allowedHostSuffixes);
+  if (!allowedUrl) {
     return { result: 'invalid', status: null, checkedAtIso };
   }
 
@@ -34,9 +54,12 @@ export async function checkUrlLiveness(
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(rawUrl, {
+    // redirect: 'manual' — never auto-follow a 3xx to an attacker-controlled
+    // host. A redirect still counts as live (status is in the 2xx-3xx range
+    // below), but we never issue a second request at a non-allow-listed host.
+    const response = await fetch(allowedUrl.toString(), {
       method: 'HEAD',
-      redirect: 'follow',
+      redirect: 'manual',
       signal: controller.signal,
     });
 

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1594,7 +1594,11 @@ CREATE TABLE IF NOT EXISTS directory_profiles (
   is_active BOOLEAN NOT NULL DEFAULT TRUE,
   source TEXT NOT NULL DEFAULT 'admin' CHECK (source IN ('admin', 'self', 'community-generated')),
   invited_by_username TEXT,
-  unclaimed_handle TEXT UNIQUE,
+  -- No inline UNIQUE: the case-insensitive unique index below owns uniqueness.
+  -- A constraint-backed index here cannot be dropped by the DROP INDEX in the
+  -- migration block (Postgres rejects it), which would break the fresh-schema
+  -- path. See the directory_profiles_unclaimed_handle_unique DO block.
+  unclaimed_handle TEXT,
   venmo_address TEXT,
   monero_address TEXT,
   bitcoin_address TEXT,
@@ -1655,6 +1659,12 @@ BEGIN
     WHERE indexname = 'directory_profiles_unclaimed_handle_key'
       AND indexdef NOT ILIKE '%lower(unclaimed_handle)%'
   ) THEN
+    -- A legacy DB may have created this name as a UNIQUE *constraint*
+    -- (constraint-backed index), which Postgres refuses to DROP INDEX. Drop
+    -- the constraint first (cascades to its index); the DROP INDEX then mops
+    -- up any standalone index left by an earlier migration run.
+    ALTER TABLE directory_profiles
+      DROP CONSTRAINT IF EXISTS directory_profiles_unclaimed_handle_key;
     EXECUTE 'DROP INDEX IF EXISTS directory_profiles_unclaimed_handle_key';
   END IF;
   IF NOT EXISTS (

--- a/ctf/scripts/seedDirectoryPhase0.mjs
+++ b/ctf/scripts/seedDirectoryPhase0.mjs
@@ -16,16 +16,18 @@ const pool = new Pool({
   ssl: { rejectUnauthorized: false },
 });
 
+// directory_profiles.id is UUID, so the deterministic seed ids must be valid
+// UUIDs. userId stays a free-form text key for directory_user_extension.
 const seedUsers = [
   {
-    profileId: 'seed-directory-profile-001',
+    profileId: 'd1100000-0000-4000-8000-000000000001',
     userId: 'seed-directory-user-001',
     displayName: 'Amina Johnson',
     headline: 'Community support navigator',
     bio: 'Deterministic seed profile for directory phase-0 validation.',
   },
   {
-    profileId: 'seed-directory-profile-002',
+    profileId: 'd1100000-0000-4000-8000-000000000002',
     userId: 'seed-directory-user-002',
     displayName: 'Luis Rivera',
     headline: 'Legal advocacy coordinator',
@@ -73,7 +75,7 @@ async function main() {
         `
           SELECT id
           FROM directory_profiles
-          WHERE id = $1
+          WHERE id = $1::uuid
           LIMIT 1
         `,
         [user.profileId],
@@ -85,19 +87,18 @@ async function main() {
           `
             UPDATE directory_profiles
             SET
-              user_id = NULL,
               claimed_by_user_id = NULL,
               display_name = $2,
               headline = $3,
               bio = $4,
-              description = $4,
               profile_url = NULL,
-              is_claimed = false,
+              source = 'admin',
               sector_id = $5::uuid,
               job_title_id = $6::uuid,
               is_active = true,
+              deleted_at = NULL,
               updated_at = NOW()
-            WHERE id = $1
+            WHERE id = $1::uuid
             RETURNING id
           `,
           [
@@ -113,9 +114,9 @@ async function main() {
         profileResult = await client.query(
           `
             INSERT INTO directory_profiles
-              (id, claimed_by_user_id, user_id, display_name, headline, bio, description, profile_url, is_claimed, sector_id, job_title_id, is_active)
+              (id, claimed_by_user_id, display_name, headline, bio, profile_url, source, sector_id, job_title_id, is_active)
             VALUES
-              ($1::text, NULL, NULL, $2::text, $3::text, $4::text, $4::text, NULL, false, $5::uuid, $6::uuid, true)
+              ($1::uuid, NULL, $2::text, $3::text, $4::text, NULL, 'admin', $5::uuid, $6::uuid, true)
             RETURNING id
           `,
           [

--- a/ctf/scripts/seedDirectoryPhase0.mjs
+++ b/ctf/scripts/seedDirectoryPhase0.mjs
@@ -155,7 +155,7 @@ async function main() {
             service_deleted_at = NULL,
             updated_at = NOW()
         `,
-        [user.profileId],
+        [user.userId],
       );
     }
 

--- a/ctf/scripts/seedSkillsHuntPhase1.mjs
+++ b/ctf/scripts/seedSkillsHuntPhase1.mjs
@@ -191,9 +191,13 @@ async function main() {
            NOW(), NOW())
         ON CONFLICT (id) DO UPDATE SET
           display_name = EXCLUDED.display_name,
+          headline = EXCLUDED.headline,
+          bio = EXCLUDED.bio,
+          is_active = TRUE,
           source = EXCLUDED.source,
           invited_by_username = EXCLUDED.invited_by_username,
           unclaimed_handle = EXCLUDED.unclaimed_handle,
+          deleted_at = NULL,
           updated_at = NOW()
       `,
       [directoryProfileId],


### PR DESCRIPTION
## Summary

Follow-up to PR #68 (merged Skills Hunt rewrite) addressing CodeRabbit review findings, rebased onto current `main` (picks up the schema-query-audit comment-stripping false-positive fix).

Parity Status: web+android complete

_(Backend/library/seed/schema only — no Android-facing surface is added or changed by this PR.)_

## Fixes Applied

### Core Repository Fixes (`skills-hunt/repository.ts`)
1. **Soft-delete visibility**: Added `deleted_at IS NULL` filters to badge qualification queries (rareCountResult, diversityResult, qualityResult) and pending/activity CTEs in rebuildLeaderboard so deleted submissions stop counting.
2. **Read projection completeness**: Submission projections now include `edit_history`, `edited_at`, `deleted_at`; achievement projections include `round_id`, `archived_at`.
3. **Acceptance notification idempotency**: Only emit `emitSubmissionAccepted` when `existing.status !== 'accepted'`, preventing duplicate inbox entries on re-review.
4. **Unused imports**: Removed `SKILLS_HUNT_SCORE_WEIGHTS` and `SKILLS_HUNT_SUBMISSION_LIMIT_7D`.

### SSRF Hardening (`url-validation.ts`)
5. **Hostname allow-list**: Replaced `isPlausibleHttpUrl()` with `parseAllowedHttpUrl()`, validating protocol and hostname against `DEFAULT_ALLOWED_HOST_SUFFIXES = ['quora.com']`.
6. **Redirect-based SSRF prevention**: fetch `redirect` changed from `'follow'` to `'manual'`.

### Directory Profile Fixes (`directory/repository.ts`)
7. **Optional payment fields**: `venmo_address`, `monero_address`, `bitcoin_address`, `service_credits_address` made optional on DirectoryProfileRow.
8. **Source classification**: `upsertOwnProfile` explicitly sets `source='self'` instead of relying on the `'admin'` column default.
9. **Read projection completeness**: by-user and upsert projections now select `source`, `invited_by_username`, `unclaimed_handle` so `mapProfileRow` returns persisted values.

### Schema Fixes (`schema.sql`)
10. **Constraint-backed index removal**: Dropped the inline `TEXT UNIQUE` on `unclaimed_handle`; the case-insensitive unique index owns uniqueness.
11. **Migration robustness**: Drop `directory_profiles_unclaimed_handle_key` constraint before `DROP INDEX`, so the fresh-schema path doesn't trip over a constraint-backed index.

### Admin UI Fix (`skills-hunt-admin-shell.tsx`)
12. **Select-all checkbox**: Compares `selected.size` against the pending-row count (toggleAllVisible only selects pending rows).

### Seed Script Fixes
13. **`seedDirectoryPhase0.mjs`**: Use valid UUID profile ids and `claimed_by_user_id`/`source`; drop references to columns that don't exist on `directory_profiles` (`user_id`, `description`, `is_claimed`).
14. **`seedSkillsHuntPhase1.mjs`**: Expanded ON CONFLICT to restore `is_active=TRUE`, clear `deleted_at`, and refresh `headline`/`bio` on rerun.

## Findings Deferred

Per PR #68 body, these are tracked as Wave 2 / follow-up work: per-round badge uniqueness, round-ending-soon service auth, missions COALESCE clearable nulls, and notification dedup under concurrency.

## Verification

- All modified files pass EOF formatting
- shared / mobile / web packages pass lint + typecheck
- Production web build succeeds (pre-push gate)
- Schema query audit clean (0 issues) after rebase
- No `any` assignments added

https://claude.ai/code/session_01W9FxP1GgDY6f8AghrC87ri

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9FxP1GgDY6f8AghrC87ri)_