### PR TITLE
chore: cut Render Blueprint cost from $114 to $46/mo

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -31,9 +31,8 @@ services:
     dockerfilePath: ctf/packages/web/Dockerfile
     dockerContext: ctf
     region: ohio
-    # Starter (512MB/0.5CPU). Watch memory under real traffic — this is the
-    # most likely service to need a bump back to `standard`.
-    plan: starter
+    # Standard (2GB/1CPU) — headroom for a production Next.js app (~159 routes).
+    plan: standard
     healthCheckPath: /api/health
     envVars:
       - key: PORT

--- a/render.yaml
+++ b/render.yaml
@@ -31,7 +31,9 @@ services:
     dockerfilePath: ctf/packages/web/Dockerfile
     dockerContext: ctf
     region: ohio
-    plan: standard
+    # Starter (512MB/0.5CPU). Watch memory under real traffic — this is the
+    # most likely service to need a bump back to `standard`.
+    plan: starter
     healthCheckPath: /api/health
     envVars:
       - key: PORT
@@ -47,30 +49,12 @@ services:
       # CRON_SECRET, INFISICAL_CLIENT_ID/SECRET, FORMANCE_*) are synced
       # automatically by Infisical via the Render Sync integration.
 
-  # ── Agent MCP Server ─────────────────────────────────────────────
-  # Background worker — stdio MCP transport, no inbound HTTP port.
-  # Secrets injected by Infisical → Render Sync.
-  - type: worker
-    name: ctf-agent-mcp-server
-    runtime: docker
-    dockerfilePath: ctf/packages/agent-mcp-server/Dockerfile
-    dockerContext: ctf/packages/agent-mcp-server
-    region: ohio
-    plan: starter
-
-  # ── PM MCP Server ────────────────────────────────────────────────
-  # Background worker — stdio MCP transport, no inbound HTTP port.
-  # Secrets injected by Infisical → Render Sync.
-  - type: worker
-    name: ctf-pm-mcp-server
-    runtime: docker
-    dockerfilePath: ctf/packages/pm-mcp-server/Dockerfile
-    dockerContext: ctf/packages/pm-mcp-server
-    region: ohio
-    plan: starter
-    envVars:
-      - key: NODE_ENV
-        value: production
+  # NOTE: agent-mcp-server and pm-mcp-server are intentionally NOT deployed
+  # here. They are stdio-transport MCP servers (no inbound HTTP port) that
+  # are spawned on demand by local AI coding agents (Claude Code, Copilot)
+  # via `node dist/index.js` — see ctf/agents/AGENT-MCP-SETUP.md. Running
+  # them as always-on Render workers serves no purpose (no client is
+  # attached to stdin). Their Dockerfiles remain for local/CI builds only.
 
   # ── Ollama ────────────────────────────────────────────────────────
   # Private service — reachable by other Render services via internal URL.
@@ -104,7 +88,7 @@ services:
     dockerfilePath: ctf/ops/infisical/Dockerfile
     dockerContext: ctf/ops/infisical
     region: ohio
-    plan: standard
+    plan: starter
     envVars:
       - key: ENCRYPTION_KEY
         sync: false
@@ -127,4 +111,4 @@ services:
     dockerfilePath: ctf/ops/formance/Dockerfile.ledger
     dockerContext: ctf/ops/formance
     region: ohio
-    plan: standard
+    plan: starter


### PR DESCRIPTION
## Summary

The Render Blueprint preview showed **$114/month** for 6 services. Render bills a fixed price per instance 24/7 (unlike Railway's usage-based model), so the original config was structurally expensive. This trims it to **$64/month** without losing any real capability.

## Changes to `render.yaml`

| Service | Before | After | Note |
|---|---|---|---|
| ctf-web | standard $25 | standard $25 | Kept on standard for production headroom (~159 routes) |
| ctf-ollama | standard $25 | standard $25 | Kept — llama3.2 needs the RAM |
| ctf-infisical | standard $25 | **starter $7** | |
| ctf-formance-ledger | standard $25 | **starter $7** | Lightweight Go binary |
| ctf-agent-mcp-server | starter $7 | **removed** | stdio MCP server — see below |
| ctf-pm-mcp-server | starter $7 | **removed** | stdio MCP server — see below |
| **Total** | **$114/mo** | **$64/mo** | |

## Why the MCP servers were removed

Both `agent-mcp-server` and `pm-mcp-server` use `StdioServerTransport` exclusively — no inbound HTTP port. They are spawned on demand by local AI coding agents (Claude Code, Copilot) via `node dist/index.js` (see `ctf/agents/AGENT-MCP-SETUP.md`). Run as always-on Render workers they accomplish nothing — no client is attached to stdin. Their Dockerfiles are retained for local/CI builds.

## Verification

- ✅ Pre-commit `typecheck` gate passed.
- ✅ Pre-push build verification passed.
- ⚠️ No `docker build` / live deploy in this environment — the user deploys the Blueprint via the Render dashboard.

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i