### PR TITLE
fix: use npm install in agent-mcp-server Dockerfile for Render deploy

### DIFF
--- a/ctf/packages/agent-mcp-server/Dockerfile
+++ b/ctf/packages/agent-mcp-server/Dockerfile
@@ -5,9 +5,11 @@
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS builder
 WORKDIR /app
-# Install deps
+# Install deps. No package-lock.json is committed (pnpm monorepo gitignores npm
+# lockfiles), so use npm install. The single runtime dep is exactly pinned in
+# package.json, keeping the deployed artifact reproducible.
 COPY package.json ./
-RUN npm ci
+RUN npm install
 # Copy source and compile
 COPY tsconfig.json ./
 COPY src ./src
@@ -19,7 +21,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 # Install only production deps
 COPY package.json ./
-RUN npm ci --omit=dev
+RUN npm install --omit=dev
 # Copy compiled output
 COPY --from=builder /app/dist ./dist
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Fixes the `ctf-agent-mcp-server` Render deployment build failure (`RUN npm ci` exit code 1).

### Root cause

`npm ci` strictly requires a committed `package-lock.json`. This is a **pnpm monorepo** (`pnpm@9.12.0`, root `pnpm-lock.yaml`) that deliberately gitignores `package-lock.json` and `yarn.lock` — so no npm lockfile exists, and `npm ci` errored out during the Render Docker build.

### Fix

Revert `npm ci` → `npm install` in both build stages of `ctf/packages/agent-mcp-server/Dockerfile`. No lockfile is needed, and the single runtime dependency (`@modelcontextprotocol/sdk: 1.29.0`) is exactly pinned in `package.json`, so the deployed artifact stays reproducible.

Committing an npm lockfile instead would create a competing source of truth against `pnpm-lock.yaml` in the workspace, so `npm install` is the convention-respecting fix.

### Verification

Simulated the exact Dockerfile steps in a clean dir (Docker daemon unavailable in this environment):
- builder: `npm install` ✓
- `npm run build` (tsc) → produces `dist/index.js` ✓
- runner: `npm install --omit=dev` ✓
- EOF format check ✓

### Why this matters

`ctf-agent-mcp-server` is the worker that enables the 100% agentic build/deploy/debug workflow on Render. This unblocks it first; the sibling `ctf-pm-mcp-server` has a separate issue (its build script invokes `pnpm`, which isn't present in the alpine image) to be addressed next.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_