### PR TITLE
fix: unblock pm-mcp-server Render Docker build

### DIFF
--- a/ctf/packages/pm-mcp-server/Dockerfile
+++ b/ctf/packages/pm-mcp-server/Dockerfile
@@ -5,9 +5,10 @@
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS builder
 WORKDIR /app
-# Install all deps (including devDeps for tsc)
+# Install all deps (including devDeps for tsc). No package-lock.json is committed
+# (pnpm monorepo gitignores npm lockfiles), so use npm install.
 COPY package.json ./
-RUN npm ci
+RUN npm install
 # Compile TypeScript
 COPY tsconfig.json ./
 COPY src ./src
@@ -19,7 +20,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 # Install only production deps
 COPY package.json ./
-RUN npm ci --omit=dev
+RUN npm install --omit=dev
 # Copy compiled output
 COPY --from=builder /app/dist ./dist
 CMD ["node", "dist/index.js"]

--- a/ctf/packages/pm-mcp-server/package.json
+++ b/ctf/packages/pm-mcp-server/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "pnpm run clean && tsc",
+    "build": "rm -rf dist && tsc",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
## Summary

Fixes the `ctf-pm-mcp-server` Render deployment build, which had **two** failures.

### Root causes

1. **`npm ci` without a lockfile** — same as agent-mcp-server (#92). `npm ci` requires a committed `package-lock.json`, but this pnpm monorepo gitignores npm lockfiles. Reverted to `npm install` in both build stages.
2. **`pnpm` invoked inside the alpine image** — the build script was `"build": "pnpm run clean && tsc"`, but `pnpm` isn't installed in `node:24-alpine`, so `npm run build` would fail even after fixing #1. Inlined the clean step as `"build": "rm -rf dist && tsc"` so the build is package-manager agnostic. The standalone `clean` script is kept for local use.

### Verification

Simulated the exact Dockerfile steps in a clean dir (Docker daemon unavailable here):
- builder: `npm install` ✓
- `npm run build` (`rm -rf dist && tsc`) → produces `dist/index.js` ✓
- runner: `npm install --omit=dev` ✓
- EOF format check ✓

### Context

`ctf-pm-mcp-server` is the second of the two MCP workers powering the 100% agentic infrastructure. With agent-mcp (#92, merged) this completes the MCP worker builds. Remaining Render services to verify after this: web, infisical, formance, ollama.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_