### PR TITLE
fix: copy agents directory into agent-mcp-server Docker image

### DIFF
--- a/ctf/packages/agent-mcp-server/Dockerfile
+++ b/ctf/packages/agent-mcp-server/Dockerfile
@@ -24,4 +24,6 @@ COPY package.json ./
 RUN npm install --omit=dev
 # Copy compiled output
 COPY --from=builder /app/dist ./dist
+# Copy agent definitions (loaded at runtime by discoverAgents)
+COPY ../../agents ./agents
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Fixes agent-mcp-server hanging with "Agents directory not found: /agents" in Render logs.

### Root cause

The agent-mcp server discovers available agents by scanning the `/agents` directory at runtime (line 40 of `src/index.ts`). The Dockerfile wasn't copying the agents from the repo into the container image, so `discoverAgents()` found nothing and logged "Agents directory not found: /agents" repeatedly. The server stayed alive but had no tools or resources to expose, making it useless.

### Fix

Added a COPY directive in the runner stage to include the agents:
```dockerfile
COPY ../../agents ./agents
```

The build context is `ctf/packages/agent-mcp-server/`, so `../../agents` resolves to `ctf/agents/` in the repo — the location of the 15 `.agent.md` definition files.

### Verification

Path resolution confirmed locally:
- Build context: `ctf/packages/agent-mcp-server/`
- Relative path `../../agents` → `/home/user/chargingthefuture/ctf/agents/` ✓
- Found 15 agent definition files (e.g., `feedback-inventory-matcher.agent.md`, `meta-orchestrator.agent.md`) ✓

After Render rebuilds with this fix, the server should discover all agents and start successfully.

### What happens next

Once deployed, the agent-mcp server will:
1. Copy all 15 `.agent.md` files into `/agents` in the container
2. On startup, `discoverAgents()` will scan `/agents`, parse metadata from each file
3. Expose tools like `invoke_agent_feedback_inventory_matcher`, `invoke_agent_meta_orchestrator`, etc.
4. Allow other services (web, other agents) to invoke agents via MCP

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_