### PR TITLE
fix: correct Docker build contexts for web and agent-mcp deploys

### DIFF
--- a/ctf/packages/agent-mcp-server/Dockerfile
+++ b/ctf/packages/agent-mcp-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # agent-mcp-server — standalone TypeScript MCP server (stdio transport)
-# Build context: ctf/packages/agent-mcp-server/
+# Build context: ctf/  (needs access to ctf/agents — set dockerContext: ctf in render.yaml)
 
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS builder
@@ -8,11 +8,11 @@ WORKDIR /app
 # Install deps. No package-lock.json is committed (pnpm monorepo gitignores npm
 # lockfiles), so use npm install. The single runtime dep is exactly pinned in
 # package.json, keeping the deployed artifact reproducible.
-COPY package.json ./
+COPY packages/agent-mcp-server/package.json ./
 RUN npm install
 # Copy source and compile
-COPY tsconfig.json ./
-COPY src ./src
+COPY packages/agent-mcp-server/tsconfig.json ./
+COPY packages/agent-mcp-server/src ./src
 RUN npm run build && chmod +x dist/index.js
 
 # ── Production image ──────────────────────────────────────────────
@@ -20,10 +20,10 @@ FROM node:${NODE_VERSION}-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 # Install only production deps
-COPY package.json ./
+COPY packages/agent-mcp-server/package.json ./
 RUN npm install --omit=dev
 # Copy compiled output
 COPY --from=builder /app/dist ./dist
 # Copy agent definitions (loaded at runtime by discoverAgents)
-COPY ../../agents ./agents
+COPY agents ./agents
 CMD ["node", "dist/index.js"]

--- a/ctf/packages/web/Dockerfile
+++ b/ctf/packages/web/Dockerfile
@@ -9,11 +9,15 @@ WORKDIR /repo
 # ── 1. Install all workspace deps ────────────────────────────────
 FROM base AS deps
 COPY pnpm-workspace.yaml pnpm-lock.yaml ./
+# Root manifest carries the pnpm `overrides`; without it --frozen-lockfile
+# reports an overrides mismatch against the lockfile.
+COPY package.json ./
 # Copy every workspace member's package.json so pnpm can resolve the graph
 COPY packages/shared/package.json           packages/shared/package.json
 COPY packages/web/package.json              packages/web/package.json
 COPY packages/pm-mcp-server/package.json    packages/pm-mcp-server/package.json
 COPY packages/economic-models/package.json  packages/economic-models/package.json
+COPY packages/education/package.json        packages/education/package.json
 COPY packages/eol/package.json              packages/eol/package.json
 COPY packages/mobile/package.json           packages/mobile/package.json
 RUN pnpm install --frozen-lockfile

--- a/render.yaml
+++ b/render.yaml
@@ -91,7 +91,7 @@ services:
     name: ctf-pm-mcp-server
     runtime: docker
     dockerfilePath: ctf/packages/pm-mcp-server/Dockerfile
-    dockerContext: ctf
+    dockerContext: ctf/packages/pm-mcp-server
     region: ohio
     plan: starter
     envVars:


### PR DESCRIPTION
## Summary

Follow-up Render deploy fixes discovered after PR #95 (env-group wiring) merged. Three of five services were still failing to build/deploy; this PR fixes the build-stage issues.

### 1. ctf-web — pnpm lockfile overrides mismatch (`fix`)
The web Dockerfile's deps stage copied `pnpm-lock.yaml` and 6 workspace `package.json` files but **never copied the root `ctf/package.json`** — which is where the pnpm `overrides` are declared. With overrides in the lockfile but absent from the manifests, `pnpm install --frozen-lockfile` aborted with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Also added the missing `packages/education/package.json` (a workspace member the lockfile expects). Now copies root manifest + all 7 workspace members.

### 2. ctf-agent-mcp-server — `COPY ../../agents` escapes build context (`fix`)
Docker forbids `COPY ../../agents` (paths cannot escape the build context), so the build failed at the agents copy step regardless of context. Rewrote all COPY paths to be relative to the `ctf/` build context (`packages/agent-mcp-server/*`) and copy `agents/` directly from the context root.

### 3. ctf-pm-mcp-server — reverted unnecessary context widening (`fix`)
pm-mcp-server reads nothing from `ctf/agents`, so it does not need the wide `ctf/` context. Reverted its `dockerContext` to `ctf/packages/pm-mcp-server` so its existing Dockerfile COPY paths stay valid.

## Status after this PR

| Service | Expected |
|---|---|
| ctf-web | Builds (lockfile validates) |
| ctf-agent-mcp-server | Builds (agents dir copied) |
| ctf-pm-mcp-server | Builds + boots (DATABASE_URL from env group) |
| ctf-ollama | Already deploying (model bake is slow, expected) |
| ctf-formance-ledger | **Still blocked** — see below |

## Known remaining issue (not in this PR — needs a secret change)

**ctf-formance-ledger** now connects to Postgres (the `FORMANCE_POSTGRES_URI` mapping from PR #95 worked) but fails migrations with:

```
FATAL: prepared statement name is already in use (SQLSTATE 08P01)
```

This is the classic **Neon connection-pooler + prepared statements** conflict. Formance's migrator uses prepared statements, which break against Neon's transaction-mode pooler endpoint. Fix is a secret change (no code): point `FORMANCE_POSTGRES_URI` at Neon's **direct (non-pooler)** endpoint — i.e. the host **without** `-pooler` in it.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_