### PR TITLE
fix: point Formance web client at bare ledger /v2 API (empty-DB cause)

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -51,6 +51,15 @@ else
   echo "Railway CLI already installed."
 fi
 
+# Install/update Render CLI (used to open a shell into Render services, e.g. to
+# run the one-time Formance ledger bootstrap from inside the private network).
+echo "Checking for Render CLI..."
+if ! command -v render &> /dev/null; then
+  curl -fsSL https://raw.githubusercontent.com/render-oss/cli/refs/heads/main/bin/install.sh | sh || echo "Warning: Render CLI install failed — run 'curl -fsSL https://raw.githubusercontent.com/render-oss/cli/refs/heads/main/bin/install.sh | sh' manually."
+else
+  echo "Render CLI already installed."
+fi
+
 
 echo "Checking for eas-cli..."
 if ! command -v eas &> /dev/null; then

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -43,14 +43,6 @@ else
   echo "Vercel CLI already installed."
 fi
 
-# Install/update Railway CLI (required by Railway MCP server)
-echo "Checking for Railway CLI..."
-if ! command -v railway &> /dev/null; then
-  npm install -g @railway/cli
-else
-  echo "Railway CLI already installed."
-fi
-
 # Install/update Render CLI (used to open a shell into Render services, e.g. to
 # run the one-time Formance ledger bootstrap from inside the private network).
 echo "Checking for Render CLI..."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,145 @@
+# Charging the Future
+
+World's first psyop-free economy.
+
+## Overview
+
+This repository contains the v3 rewrite of the Charging the Future platform — a full-stack application for building psyop-resistant economic systems. It includes:
+
+- **Web App** — Next.js frontend for the core user experience
+- **Mobile App** — React Native (Expo) Android client with feature parity to web
+- **Ledger** — Formance-backed financial ledger for Service Credits
+- **Agents** — AI-powered MCP servers for autonomous build, deployment, and operational workflows
+- **Schema** — PostgreSQL schema migrations and audit trails
+
+## Architecture
+
+The codebase is organized as a **monorepo** (pnpm workspaces) under `/ctf`:
+
+```
+ctf/
+├── packages/
+│   ├── web/                    # Next.js app (React, tRPC, Clerk auth)
+│   ├── mobile/                 # React Native app (Expo, EAS)
+│   ├── shared/                 # Shared TypeScript library
+│   ├── agent-mcp-server/       # Agentic MCP server (stdio transport)
+│   ├── pm-mcp-server/          # PM feedback MCP worker
+│   ├── economic-models/        # Economic modeling utilities
+│   ├── education/              # Educational content & materials
+│   ├── eol/                    # End-of-life/deprecation tooling
+├── ops/
+│   ├── formance/               # Formance ledger Docker configs
+│   ├── infisical/              # Secrets management Docker configs
+│   ├── ollama/                 # Local LLM inference
+├── scripts/                    # Utilities: seeding, backups, schema migration
+├── agents/                     # AI agent definitions (.agent.md files)
+├── schema.sql                  # PostgreSQL schema (CREATE TABLE + ALTER TABLE)
+├── render.yaml                 # Render Blueprint (production infrastructure)
+├── pnpm-workspace.yaml         # pnpm monorepo configuration
+```
+
+## Getting Started (Development)
+
+### Prerequisites
+
+- **Node.js 24+** (or use Codespaces)
+- **pnpm 9.12+**
+- **PostgreSQL** (for local schema testing)
+- **Docker** (for Formance, Infisical, Ollama)
+
+### Quick Start
+
+1. **Clone and install:**
+   ```bash
+   git clone https://github.com/chargingthefuture/chargingthefuture
+   cd chargingthefuture
+   pnpm install
+   ```
+
+2. **Set up environment:**
+   Create a `.env.local` file in `ctf/packages/web/` with required secrets:
+   ```bash
+   DATABASE_URL=postgresql://user:pass@localhost/ctf
+   CLERK_SECRET_KEY=your_clerk_key
+   STREAM_CHAT_API_KEY=your_stream_key
+   # See ctf/docs/developer/README.md for full list
+   ```
+
+3. **Apply schema and run dev server:**
+   ```bash
+   cd ctf
+   psql "$DATABASE_URL" -f schema.sql
+   pnpm --filter @ctf/web run dev
+   ```
+
+4. **Open http://localhost:3000**
+
+## GitHub Codespaces
+
+For a zero-setup experience, use GitHub Codespaces:
+
+1. Click **Code** → **Codespaces** → **Create codespace on main**
+2. Wait for container startup (~2 min in fast mode)
+3. `pnpm --filter @ctf/web run dev` starts the dev server
+4. Web and mobile development available immediately
+
+See `.devcontainer/README.md` for fast-mode options and database setup.
+
+## Infrastructure (Production)
+
+Production deployment uses:
+
+- **[Render](https://render.com)** — All services (web, workers, ledger, LLM inference)
+- **[Infisical](https://infisical.com)** (self-hosted on Railway) — Single source of truth for secrets
+- **[Neon](https://neon.tech)** — PostgreSQL database with connection pooling
+- **[Supabase Storage](https://supabase.com)** — Formance ledger backups
+
+See `render.yaml` for service definitions and `ctf/docs/developer/` for runbooks.
+
+## Key Documents
+
+| Document | Purpose |
+|---|---|
+| [`ctf/docs/spec.md`](ctf/docs/spec.md) | Archived v2 architecture (for reference) |
+| [`ctf/docs/developer/README.md`](ctf/docs/developer/README.md) | Developer guide (setup, API, plugin system) |
+| [`ctf/docs/developer/FORMANCE.md`](ctf/docs/developer/FORMANCE.md) | Formance ledger runtime contract and bootstrap |
+| [`ctf/docs/developer/FORMANCE_BACKUP_RUNBOOK.md`](ctf/docs/developer/FORMANCE_BACKUP_RUNBOOK.md) | Backup/restore procedures |
+| [`ctf/docs/contracts/`](ctf/docs/contracts/) | Plugin command contracts, access policies, audit schema |
+| [`ctf/AGENTS.md`](ctf/AGENTS.md) | Agent framework and MCP setup |
+| [`ctf/README.md`](ctf/README.md) | CTF monorepo overview |
+
+## Contributing
+
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) (if present) or open an issue to discuss changes.
+
+### Code Quality
+
+All commits run through:
+
+- **TypeScript** type checking (tsc)
+- **EOF format validation** (all files end with exactly one newline)
+- **Pre-commit hooks** (Husky) — runs tsc + linting
+- **CI workflow** (`rewrite-ci.yml`) — full test suite, schema drift checks, dependency audit
+
+To prepare a PR:
+
+```bash
+cd ctf
+pnpm typecheck              # TypeScript validation
+pnpm --filter @ctf/web run build  # Full Next.js build
+bash scripts/check-eof-format.sh  # EOF validation
+```
+
+## License
+
+[License information to be added]
+
+## Support
+
+- **Issues & bugs:** GitHub Issues
+- **Discussions:** GitHub Discussions
+- **Documentation:** See `ctf/docs/developer/` and inline code comments
+
+---
+
+**Last updated:** May 2026 | v3 rewrite (Render migration)

--- a/ctf/docs/developer/FORMANCE.md
+++ b/ctf/docs/developer/FORMANCE.md
@@ -14,7 +14,8 @@ contract, one-time ledger bootstrap, and backup/restore.
 
 State lives entirely in external Neon Postgres (Render has no persistent
 volumes). `AUTO_UPGRADE=true` runs schema migrations on container start.
-`POSTGRES_URI` is injected from Infisical → Render Sync.
+`FORMANCE_POSTGRES_URI` is injected from Infisical → Render Sync (the
+`Dockerfile.ledger` entrypoint maps it to the `POSTGRES_URI` the binary expects).
 
 To update the pinned image, change the digest in `Dockerfile.ledger` after
 verifying it: `docker buildx imagetools inspect ghcr.io/formancehq/ledger:<tag>`.

--- a/ctf/package.json
+++ b/ctf/package.json
@@ -32,7 +32,7 @@
     "formance:up:standalone": "pnpm run formance:fetch:standalone && docker compose -f ./ops/formance/upstream-standalone/docker-compose.yml up -d",
     "formance:down:standalone": "bash ./scripts/formanceStandaloneDown.sh",
     "formance:ps:standalone": "pnpm run formance:fetch:standalone && docker compose -f ./ops/formance/upstream-standalone/docker-compose.yml ps",
-    "formance:bootstrap:railway": "bash ./scripts/formanceRailwayBootstrap.sh",
+    "formance:bootstrap": "bash ./scripts/formanceBootstrap.sh",
     "ollama:list:railway": "infisical run -- bash ./scripts/ollamaModelManager.sh list",
     "format:check": "bash ./scripts/check-eof-format.sh",
     "governance:check": "bash ./scripts/check-modularity-governance.sh",

--- a/ctf/packages/agent-mcp-server/Dockerfile
+++ b/ctf/packages/agent-mcp-server/Dockerfile
@@ -19,6 +19,8 @@ RUN npm run build && chmod +x dist/index.js
 FROM node:${NODE_VERSION}-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+# Install curl for shell utilities (e.g. Formance ledger bootstrap script)
+RUN apk add --no-cache curl bash
 # Install only production deps
 COPY packages/agent-mcp-server/package.json ./
 RUN npm install --omit=dev
@@ -26,4 +28,6 @@ RUN npm install --omit=dev
 COPY --from=builder /app/dist ./dist
 # Copy agent definitions (loaded at runtime by discoverAgents)
 COPY agents ./agents
+# Copy scripts directory (includes formanceBootstrap.sh and other utilities)
+COPY scripts ./scripts
 CMD ["node", "dist/index.js"]

--- a/ctf/packages/web/Dockerfile
+++ b/ctf/packages/web/Dockerfile
@@ -11,7 +11,7 @@ FROM base AS deps
 COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 # Root manifest carries the pnpm `overrides`; without it --frozen-lockfile
 # reports an overrides mismatch against the lockfile.
-COPY package.json ./
+COPY package.json tsconfig.base.json ./
 # Copy every workspace member's package.json so pnpm can resolve the graph
 COPY packages/shared/package.json           packages/shared/package.json
 COPY packages/web/package.json              packages/web/package.json

--- a/ctf/packages/web/lib/service-credits/formance-ledger.ts
+++ b/ctf/packages/web/lib/service-credits/formance-ledger.ts
@@ -59,7 +59,7 @@ async function postTransactionToFormance(input: {
 }) {
   const config = getFormanceConfig();
 
-  const response = await fetch(`${config.apiUrl}/api/ledger/${encodeURIComponent(config.ledger)}/transactions`, {
+  const response = await fetch(`${config.apiUrl}/v2/${encodeURIComponent(config.ledger)}/transactions`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',

--- a/ctf/scripts/README.md
+++ b/ctf/scripts/README.md
@@ -11,7 +11,7 @@ Monorepo scripts for build, migration, seeding, and CI gates.
 | Schema/Migration | `runAllMigrations.mjs`, `runMigrationFile.mjs`, `audit_schema_drift.sh` | DB migrations and drift checks               |
 | Seeding          | `seedChymePhase0.mjs`, `seedClicklogPhase0.mjs`, ... | Seed data by phase                           |
 | Skills Taxonomy (Data)  | `skills-lock.json`                | Skills system lockfile                       |
-| Formance/Ledger  | `formance-backup.sh`, `formanceRailwayBootstrap.sh` | Formance ledger management                   |
+| Formance/Ledger  | `formance-backup.sh`, `formanceBootstrap.sh` | Formance ledger management                   |
 | Performance/Budget| `performanceBudgetAudit.mjs`, `githubActionsBudgetMonitor.mjs` | Performance and budget audits                |
 
 ## Environment Variables

--- a/ctf/scripts/formanceBootstrap.sh
+++ b/ctf/scripts/formanceBootstrap.sh
@@ -18,7 +18,8 @@ REQUEST_ID="$(date +%s)"
 
 # FORMANCE_API_URL is the Render internal address (e.g. http://ctf-formance-ledger:3068),
 # reachable only from inside the Render private network. Run this from a Render
-# service shell, not from a local machine.
+# service shell (Render dashboard > ctf-web > Shell > $) to create the ledger namespace.
+# It cannot run from a local machine — the URL is internal-only.
 
 echo "[1/4] Bootstrapping ledger namespace: ${LEDGER_NAME}"
 bootstrap_status="$(curl -sS -o /tmp/formance-bootstrap-response.json -w "%{http_code}" \

--- a/ctf/scripts/formanceBootstrap.sh
+++ b/ctf/scripts/formanceBootstrap.sh
@@ -6,7 +6,7 @@ required_env=("FORMANCE_API_URL" "FORMANCE_LEDGER" "FORMANCE_API_TOKEN")
 for key in "${required_env[@]}"; do
   if [[ -z "${!key:-}" ]]; then
     echo "Missing required env var: $key"
-    echo "Example: export FORMANCE_API_URL=http://ledger.railway.internal:8080"
+    echo "Example: export FORMANCE_API_URL=http://ctf-formance-ledger:3068"
     exit 1
   fi
 done
@@ -16,13 +16,9 @@ LEDGER_NAME="${FORMANCE_LEDGER}"
 AUTH_HEADER="Authorization: Bearer ${FORMANCE_API_TOKEN}"
 REQUEST_ID="$(date +%s)"
 
-if [[ "${BASE_URL}" == *".railway.internal"* ]]; then
-  if ! getent hosts "${BASE_URL#http://}" >/dev/null 2>&1 && ! getent hosts "${BASE_URL#https://}" >/dev/null 2>&1; then
-    echo "${BASE_URL} is a Railway private hostname and is not resolvable from this shell."
-    echo "Use https://<service>.up.railway.app when running bootstrap locally, or run this script inside Railway runtime."
-    exit 1
-  fi
-fi
+# FORMANCE_API_URL is the Render internal address (e.g. http://ctf-formance-ledger:3068),
+# reachable only from inside the Render private network. Run this from a Render
+# service shell, not from a local machine.
 
 echo "[1/4] Bootstrapping ledger namespace: ${LEDGER_NAME}"
 bootstrap_status="$(curl -sS -o /tmp/formance-bootstrap-response.json -w "%{http_code}" \
@@ -77,4 +73,4 @@ curl -sS \
   "${BASE_URL}/v2/${LEDGER_NAME}/transactions" || true
 echo
 
-echo "Formance Railway bootstrap + smoke completed successfully."
+echo "Formance bootstrap + smoke completed successfully."


### PR DESCRIPTION
## Summary

Fixes for the Render migration: **Formance empty-DB root cause**, missing web Dockerfile config, and operator tooling.

### 1. `fix` — Formance client API path points at gateway, not bare ledger

`FORMANCE_API_URL` points at the **bare ledger** (`http://ctf-formance-ledger:3068`) per docs. The bare ledger serves `/v2/{ledger}/transactions` (`/v2/` is Formance API versioning, not CTF v3).

But the web client posted to `/api/ledger/{ledger}/transactions` — the Formance *stack gateway* path (Caddy service in the standalone compose). Render runs only the ledger engine, no gateway, so every write 404'd → `external_ledger_unavailable` → empty DB.

**Fixed:** Changed path to `/v2/{ledger}/transactions`.

### 2. `fix` — web Dockerfile missing tsconfig.base.json

The builder stage failed: `Cannot read file '/repo/tsconfig.base.json'`. The Dockerfile copied root `package.json` but not `tsconfig.base.json`, which `packages/shared/tsconfig.json` extends.

**Fixed:** Added `tsconfig.base.json` to the deps stage COPY.

### 3. `chore` — Wire Formance bootstrap script into agent-mcp-server

The bootstrap script (`formanceBootstrap.sh`) runs curl commands to create the ledger namespace — a one-time setup required after Formance deploys.

Previously, there was no practical way to run it from inside the Render private network (the internal URL is unreachable from local machines).

**Fixed:** 
- Added `curl` + `bash` to agent-mcp runner image (required for HTTP calls and shell scripts)
- Copy `ctf/scripts/` into the container so the bootstrap script is available
- Operators can now run: `render ssh ctf-agent-mcp-server` → `bash scripts/formanceBootstrap.sh`

Also clarified the script docs: **must run from a Render service shell, not locally**.

### 4. `chore` — Remove Railway CLI from devcontainer

Post-migration cleanup: removed the Railway CLI install block from `.devcontainer/setup.sh`.

### 5. `chore` — Create root README.md

Added a visitor-facing README at the repo root with:
- Project overview and intent
- Monorepo structure and package layout
- Getting started (local + Codespaces)
- Key documents and architecture
- Contribution and CI workflow

Helps open-source visitors understand the project immediately.

## Operator Follow-Up Steps

### 1. Deploy & Redeploy Services

After this PR merges, manually redeploy affected services in Render dashboard:
- **ctf-web** — will build successfully (tsconfig.base.json now included)
- **ctf-agent-mcp-server** — force Render to pick up `dockerContext: ctf` from render.yaml + new scripts/ copy

### 2. One-Time Formance Bootstrap (from Render service shell)

From Render dashboard:
1. Navigate to **ctf-agent-mcp-server** > **Shell** (wait for service to be running)
2. Run:
   ```bash
   export FORMANCE_API_TOKEN="<token from Infisical>"
   export FORMANCE_LEDGER="ctf-service-credits"
   bash scripts/formanceBootstrap.sh
   ```

This creates the ledger namespace. After this, Service Credits writes will land in Formance.

### 3. Fix Neon Pooler Conflict (separate, from PR #96)

In Infisical, update `FORMANCE_POSTGRES_URI`:
- Current (wrong): `ep-xxx-pooler.us-east-2.aws.neon.tech`
- Correct: `ep-xxx.us-east-2.aws.neon.tech` (remove `-pooler`)

Formance's migrator uses prepared statements, which collide with Neon's transaction-mode pooler endpoint.

## Verification

- ✅ `tsc --noEmit` on all workspaces passes
- ✅ Pre-commit typecheck + pre-push build passed
- ✅ EOF format check passes
- ✅ Dockerfile syntax valid (curl + bash additions)
- ✅ README.md created (non-breaking, helps visitors)

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive platform overview and development setup guide.
  * Updated infrastructure and environment variable documentation for Render deployment.

* **Infrastructure**
  * Migrated cloud CLI tooling from Railway to Render.
  * Updated Formance API endpoints to v2 transaction paths.
  * Enhanced Docker build configurations with additional dependencies and resources.

* **Chores**
  * Updated bootstrap scripts and references for Render infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->