### PR TITLE
fix: change agent-mcp build context to repository root

### DIFF
--- a/ctf/packages/agent-mcp-server/Dockerfile
+++ b/ctf/packages/agent-mcp-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # agent-mcp-server — standalone TypeScript MCP server (stdio transport)
-# Build context: ctf/  (needs access to ctf/agents — set dockerContext: ctf in render.yaml)
+# Build context: repository root (.)  (needs access to ctf/agents, ctf/scripts — set dockerContext: . in render.yaml)
 
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS builder
@@ -8,11 +8,11 @@ WORKDIR /app
 # Install deps. No package-lock.json is committed (pnpm monorepo gitignores npm
 # lockfiles), so use npm install. The single runtime dep is exactly pinned in
 # package.json, keeping the deployed artifact reproducible.
-COPY packages/agent-mcp-server/package.json ./
+COPY ctf/packages/agent-mcp-server/package.json ./
 RUN npm install
 # Copy source and compile
-COPY packages/agent-mcp-server/tsconfig.json ./
-COPY packages/agent-mcp-server/src ./src
+COPY ctf/packages/agent-mcp-server/tsconfig.json ./
+COPY ctf/packages/agent-mcp-server/src ./src
 RUN npm run build && chmod +x dist/index.js
 
 # ── Production image ──────────────────────────────────────────────
@@ -22,12 +22,12 @@ ENV NODE_ENV=production
 # Install curl for shell utilities (e.g. Formance ledger bootstrap script)
 RUN apk add --no-cache curl bash
 # Install only production deps
-COPY packages/agent-mcp-server/package.json ./
+COPY ctf/packages/agent-mcp-server/package.json ./
 RUN npm install --omit=dev
 # Copy compiled output
 COPY --from=builder /app/dist ./dist
 # Copy agent definitions (loaded at runtime by discoverAgents)
-COPY agents ./agents
+COPY ctf/agents ./agents
 # Copy scripts directory (includes formanceBootstrap.sh and other utilities)
-COPY scripts ./scripts
+COPY ctf/scripts ./scripts
 CMD ["node", "dist/index.js"]

--- a/render.yaml
+++ b/render.yaml
@@ -76,7 +76,7 @@ services:
     name: ctf-agent-mcp-server
     runtime: docker
     dockerfilePath: ctf/packages/agent-mcp-server/Dockerfile
-    dockerContext: ctf
+    dockerContext: .
     region: ohio
     plan: starter
     envVars:


### PR DESCRIPTION
## Summary

Fixes agent-mcp-server Docker build failure. The Dockerfile was failing with `"/agents": not found` because Render was not respecting the `dockerContext: ctf` directive in render.yaml.

## Root Cause

Render was sending a build context narrower than `ctf/`, making the `agents` directory inaccessible to the COPY command. This happened because:
1. Render may cache the service build configuration independently from `render.yaml` updates
2. The Dockerfile relied on a context that Render wasn't actually providing

## Fix

Changed the build context to the **repository root** (`.`) and made all COPY paths explicitly relative to it:
- `COPY ctf/packages/agent-mcp-server/package.json ./`
- `COPY ctf/packages/agent-mcp-server/tsconfig.json ./`
- `COPY ctf/packages/agent-mcp-server/src ./src`
- `COPY ctf/agents ./agents`
- `COPY ctf/scripts ./scripts`

This is more explicit and avoids context ambiguity. The repository root is the natural top-level boundary, and all relative paths are now unambiguous.

## Verification

- ✅ Dockerfile syntax valid
- ✅ All COPY paths resolve relative to repo root
- ✅ Pre-commit typecheck passed
- ✅ EOF format check passed

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_