### PR TITLE
fix: web builder tsconfig.base.json + agent-mcp ctf build context

### DIFF
--- a/ctf/packages/agent-mcp-server/Dockerfile
+++ b/ctf/packages/agent-mcp-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # agent-mcp-server — standalone TypeScript MCP server (stdio transport)
-# Build context: repository root (.)  (needs access to ctf/agents, ctf/scripts — set dockerContext: . in render.yaml)
+# Build context: ctf/  (needs access to ctf/agents and ctf/scripts — set dockerContext: ctf in render.yaml)
 
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS builder
@@ -8,11 +8,11 @@ WORKDIR /app
 # Install deps. No package-lock.json is committed (pnpm monorepo gitignores npm
 # lockfiles), so use npm install. The single runtime dep is exactly pinned in
 # package.json, keeping the deployed artifact reproducible.
-COPY ctf/packages/agent-mcp-server/package.json ./
+COPY packages/agent-mcp-server/package.json ./
 RUN npm install
 # Copy source and compile
-COPY ctf/packages/agent-mcp-server/tsconfig.json ./
-COPY ctf/packages/agent-mcp-server/src ./src
+COPY packages/agent-mcp-server/tsconfig.json ./
+COPY packages/agent-mcp-server/src ./src
 RUN npm run build && chmod +x dist/index.js
 
 # ── Production image ──────────────────────────────────────────────
@@ -22,12 +22,12 @@ ENV NODE_ENV=production
 # Install curl for shell utilities (e.g. Formance ledger bootstrap script)
 RUN apk add --no-cache curl bash
 # Install only production deps
-COPY ctf/packages/agent-mcp-server/package.json ./
+COPY packages/agent-mcp-server/package.json ./
 RUN npm install --omit=dev
 # Copy compiled output
 COPY --from=builder /app/dist ./dist
 # Copy agent definitions (loaded at runtime by discoverAgents)
-COPY ctf/agents ./agents
+COPY agents ./agents
 # Copy scripts directory (includes formanceBootstrap.sh and other utilities)
-COPY ctf/scripts ./scripts
+COPY scripts ./scripts
 CMD ["node", "dist/index.js"]

--- a/ctf/packages/web/Dockerfile
+++ b/ctf/packages/web/Dockerfile
@@ -25,7 +25,9 @@ RUN pnpm install --frozen-lockfile
 # ── 2. Build @ctf/shared + @ctf/web ──────────────────────────────
 FROM base AS builder
 WORKDIR /repo
-COPY pnpm-workspace.yaml ./
+# Root manifest (workspace root + pnpm overrides) and tsconfig.base.json, which
+# every package's tsconfig.json extends via `../../tsconfig.base.json`.
+COPY pnpm-workspace.yaml package.json tsconfig.base.json ./
 # Bring in node_modules from deps stage
 COPY --from=deps /repo/node_modules                      ./node_modules
 COPY --from=deps /repo/packages/shared/node_modules      ./packages/shared/node_modules

--- a/render.yaml
+++ b/render.yaml
@@ -76,7 +76,9 @@ services:
     name: ctf-agent-mcp-server
     runtime: docker
     dockerfilePath: ctf/packages/agent-mcp-server/Dockerfile
-    dockerContext: .
+    # Context is ctf/ (same proven pattern as ctf-web) so COPY can reach
+    # ctf/agents and ctf/scripts, which live outside the package directory.
+    dockerContext: ctf
     region: ohio
     plan: starter
     envVars:


### PR DESCRIPTION
## Summary

Two more deploy fixes after live Render logs.

### 1. `fix` — web builder stage missing tsconfig.base.json (+ TS1259 cascade)

The web build still failed with `Cannot read file '/repo/tsconfig.base.json'` plus a cascade of `TS1259 ... can only be default-imported using the 'esModuleInterop' flag` errors.

PR #97 added `tsconfig.base.json` to the **deps** stage, but `tsc` runs in the **builder** stage — a separate stage that never received the file. `tsconfig.base.json` sets `esModuleInterop: true`; without it, tsc fell back to defaults, which is what produced the entire TS1259 cascade (not separate bugs — all one root cause).

**Fixed:** Copy root `package.json` (workspace root + pnpm overrides) and `tsconfig.base.json` into the builder stage. This resolves:
- `TS5083` (file not found)
- the full `TS1259` esModuleInterop cascade
- the `No projects matched the filters "/repo"` warning (root manifest now present)

### 2. `fix` — agent-mcp back to `dockerContext: ctf`

The repo-root (`.`) context from PR #98 did not resolve on Render — logs showed `ctf/packages/agent-mcp-server/package.json`, `ctf/agents`, and `ctf/scripts` all "not found", meaning Render's actual build context was **not** the repo root.

**Key evidence:** the **ctf-web** service uses `dockerContext: ctf` and Render *does* honor it (its build reaches the builder stage and copies `packages/shared`/`packages/web` relative to `ctf/`). So `dockerContext: ctf` is the proven pattern.

**Fixed:** Reverted agent-mcp to `dockerContext: ctf` with ctf-relative COPY paths (`packages/agent-mcp-server/*`, `agents`, `scripts`) — identical to the web service's working setup.

## ⚠️ Operator action likely required for agent-mcp

The repeated agent-mcp failures across PRs #94/#96/#98 — despite correct blueprint edits — strongly indicate the **existing ctf-agent-mcp-server service has a frozen/stale build context** that isn't updating from `render.yaml` changes (manual deploys + cache clears rebuild, but don't re-read the build-context setting).

After this merges, if agent-mcp still fails, do **one** of these in the Render dashboard:
- **Recommended:** Delete the `ctf-agent-mcp-server` service and re-sync the Blueprint so it's recreated with `dockerContext: ctf`, **or**
- In **Settings**, set the service's **Docker Build Context Directory** to `ctf` (matching ctf-web), then redeploy.

The web service's success with `dockerContext: ctf` confirms this is the right target context.

## Verification

- ✅ Pre-commit typecheck gate passed (web, shared, mobile)
- ✅ Pre-push build verification passed
- ✅ `tsconfig.base.json` confirmed to set `esModuleInterop: true` (root cause of TS1259)
- ✅ Dockerfile paths now match the proven ctf-web context pattern

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_