### PR TITLE
fix: remove previews block so Blueprint syncs on Hobby workspace

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,38 +4,29 @@
 #
 # ENVIRONMENT MODEL
 # ───────────────────────────────
-# Production is the only persistent environment — it deploys from `main`.
-# Every pull request gets a full ephemeral preview environment (all services
-# below), which Render destroys automatically when the PR merges or closes.
-# There is no permanent staging environment; test branches via previews.
+# Production is the only environment — it deploys from `main`. Render preview
+# environments are NOT used: they require a paid (non-Hobby) workspace, and a
+# `previews:` block here blocks Blueprint sync on a Hobby workspace. Test
+# changes locally / in Codespaces before merging to `main`. To get ephemeral
+# per-PR previews later, upgrade the workspace and re-add a `previews:` block.
 #
 # SECRET MANAGEMENT ARCHITECTURE
 # ───────────────────────────────
 # Infisical (self-hosted on Railway) is the single source of truth for secrets.
 # Its Render Sync integration pushes secrets into each production service below.
 #
-# Preview environments get suffixed service names that Infisical's per-service
-# syncs do not target, so preview secrets come from the linked Render env group
-# `ctf-preview-secrets` (env groups are inherited by previews). Services that
-# need secrets reference it via `fromGroup` below.
-#
-# IMPORTANT — populating `ctf-preview-secrets`:
-#   * Add the staging values as ENV VARS (use the env group's "Add from .env"
-#     bulk paste), NOT as a secret file. Render secret files are mounted on disk
-#     only and are never loaded into process.env, so the app would not see them.
-#   * Production must have Infisical sync every key the group contains. Service-
-#     level vars (Infisical → Render Sync) override env-group vars, so any group
-#     key NOT synced by Infisical would leak its staging value into production.
+# The `ctf-preview-secrets` env group (linked via `fromGroup` below) is a base
+# secret layer for the Production services. Service-level vars synced by
+# Infisical override env-group vars, so Infisical stays authoritative.
+# IMPORTANT: Production must have Infisical sync every key the group contains —
+# any group key NOT synced by Infisical would otherwise serve its env-group
+# value in production.
+#   * Populate the group via the "Add from .env" bulk paste as ENV VARS, NOT a
+#     secret file (secret files are disk-mounted only, never in process.env).
 #
 # For GitHub Actions (backup workflow), add two GitHub secrets:
 # INFISICAL_CLIENT_ID + INFISICAL_CLIENT_SECRET; the workflow fetches the rest
 # from Infisical at runtime.
-
-# Ephemeral preview environment per PR; auto-destroyed on merge/close.
-# expireAfterDays cleans up previews on abandoned-but-open PRs.
-previews:
-  generation: automatic
-  expireAfterDays: 5
 
 services:
   # ── Next.js web app ─────────────────────────────────────────────
@@ -51,9 +42,8 @@ services:
     plan: standard
     healthCheckPath: /api/health
     envVars:
-      # PREVIEW SECRETS: previews inherit staging values from this env group.
-      # In production these are overridden by Infisical → Render Sync, since
-      # service-level vars take precedence over env-group vars.
+      # Base secret layer; Infisical → Render Sync overrides these in production
+      # (service-level vars take precedence over env-group vars).
       - fromGroup: ctf-preview-secrets
       - key: PORT
         value: "3000"
@@ -82,7 +72,7 @@ services:
     region: ohio
     plan: starter
     envVars:
-      # PREVIEW SECRETS (see ctf-web). Prod overridden by Infisical Render Sync.
+      # Base secret layer (see ctf-web). Infisical Render Sync overrides in prod.
       - fromGroup: ctf-preview-secrets
 
   # ── PM MCP Server ────────────────────────────────────────────────
@@ -97,7 +87,7 @@ services:
     region: ohio
     plan: starter
     envVars:
-      # PREVIEW SECRETS (see ctf-web). Prod overridden by Infisical Render Sync.
+      # Base secret layer (see ctf-web). Infisical Render Sync overrides in prod.
       - fromGroup: ctf-preview-secrets
       - key: NODE_ENV
         value: production
@@ -113,7 +103,7 @@ services:
     region: ohio
     plan: standard
     # No fromGroup: ctf-ollama only serves a baked-in model and reads no app
-    # secrets, so previews need nothing from ctf-preview-secrets.
+    # secrets, so it needs nothing from ctf-preview-secrets.
     envVars:
       - key: OLLAMA_MODEL
         value: llama3.2
@@ -158,6 +148,6 @@ services:
     region: ohio
     plan: starter
     envVars:
-      # PREVIEW SECRETS (see ctf-web): previews need FORMANCE_POSTGRES_URI from the
-      # staging env group. Prod overridden by Infisical Render Sync.
+      # Base secret layer (see ctf-web): provides FORMANCE_POSTGRES_URI.
+      # Infisical Render Sync overrides in prod.
       - fromGroup: ctf-preview-secrets


### PR DESCRIPTION
## Summary

The Render Blueprint stopped syncing on the Hobby workspace. Root cause: the `previews:` block. Render **preview environments require a paid (non-Hobby) workspace**, so the Blueprint validator rejected the block — and, as a knock-on, rejected the `fromGroup: ctf-preview-secrets` links (it was validating them for a preview environment that can't exist on Hobby).

### Fix

- **Removed the `previews:` block** — this is the blocker. With it gone, the Blueprint validates against the Production environment only, where `ctf-preview-secrets` lives, so the `fromGroup` links are valid again.
- **Reframed `ctf-preview-secrets`** in the comments: it is now a *base secret layer* for the Production services rather than a preview-inheritance mechanism. Infisical → Render Sync still overrides it at the service level, so Infisical remains the source of truth.
- Updated all "PREVIEW SECRETS" per-service comments to match.

No service definitions changed; only the previews block + comments.

## Alternative to preview environments (Hobby workspace)

Preview environments aren't available without upgrading the workspace. Recommended path for now:

- **Test locally / in Codespaces** before merging to `main` (fits the current cost-conscious setup; no extra always-on services).
- If per-PR previews become important later, **upgrade the workspace** and re-add a `previews:` block (the comment in `render.yaml` notes this).
- A persistent `staging` service is also possible but adds always-on cost.

## Operator follow-up after merge

1. **Manual sync** the Blueprint in Render — it should now succeed.
2. Recreate the deleted services (`ctf-web`, `ctf-agent-mcp-server`, `ctf-pm-mcp-server`) from the synced Blueprint.
3. Still pending from before: fix `FORMANCE_POSTGRES_URI` in Infisical (remove `-pooler` from the Neon host) and run `bash scripts/formanceBootstrap.sh` from the agent-mcp shell.

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified deployment infrastructure to production environment only, removing ephemeral preview environments previously created for pull requests.
  * Updated deployment secret management configuration to use a base layer approach with production-level overrides, improving clarity on service secret handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->