### PR TITLE
fix: use empty list [] for envVars, not empty map {}

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -60,7 +60,7 @@ services:
     dockerContext: ctf
     region: ohio
     plan: starter
-    envVars: {}
+    envVars: []
 
   # ── PM MCP Server ────────────────────────────────────────────────
   # Background worker — stdio MCP transport for PM feedback workflows.
@@ -132,4 +132,4 @@ services:
     dockerContext: ctf/ops/formance
     region: ohio
     plan: starter
-    envVars: {}
+    envVars: []


### PR DESCRIPTION
## Summary

Render Blueprint YAML parser expects `envVars:` to be a **list**, not a map. Changed two instances:
- Line 63 (ctf-agent-mcp-server): `envVars: {}` → `envVars: []`
- Line 135 (ctf-formance-ledger): `envVars: {}` → `envVars: []`

This fixes the Blueprint validation error: `cannot unmarshal !map into []file.EnvVar`.

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_