### PR TITLE
fix: remove ctf-agent-mcp-server from Render (stdio transport crash-loops)

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -163,6 +163,18 @@ else
   echo "Add RAILWAY_API_TOKEN as a Codespaces secret (Settings > Secrets > Codespaces) and re-open the Codespace."
 fi
 
+# Verify Render API key for MCP server access (.mcp.json uses RENDER_API_KEY to
+# authenticate against https://mcp.render.com/mcp — lets agents pull logs, trigger
+# deploys, and inspect services without copy-pasting from the dashboard).
+echo "Verifying Render MCP access..."
+if [ -n "$RENDER_API_KEY" ]; then
+  echo "Render MCP: RENDER_API_KEY is set — Render MCP server will be authenticated."
+else
+  echo "Warning: RENDER_API_KEY not set. Render MCP server will not work."
+  echo "Add RENDER_API_KEY as a Codespaces secret (Settings > Secrets > Codespaces) and re-open the Codespace."
+  echo "Generate an API key at: https://dashboard.render.com/u/settings#api-keys"
+fi
+
 # Prompt for any remaining manual logins
 echo "If you need to log in to GitHub or Vercel, run:"
 echo "  gh auth login"

--- a/render.yaml
+++ b/render.yaml
@@ -47,21 +47,6 @@ services:
       # CRON_SECRET, INFISICAL_CLIENT_ID/SECRET, FORMANCE_POSTGRES_URI) are synced
       # automatically by Infisical via the Render Sync integration.
 
-  # ── Agent MCP Server ─────────────────────────────────────────────
-  # Background worker — stdio MCP transport for agentic build/deploy/debug.
-  # Part of 100% agentic infrastructure orchestration.
-  # Secrets injected by Infisical → Render Sync.
-  - type: worker
-    name: ctf-agent-mcp-server
-    runtime: docker
-    dockerfilePath: ctf/packages/agent-mcp-server/Dockerfile
-    # Context is ctf/ (same proven pattern as ctf-web) so COPY can reach
-    # ctf/agents and ctf/scripts, which live outside the package directory.
-    dockerContext: ctf
-    region: ohio
-    plan: starter
-    envVars: []
-
   # ── PM MCP Server ────────────────────────────────────────────────
   # Background worker — stdio MCP transport for PM feedback workflows.
   # Part of 100% agentic infrastructure orchestration.


### PR DESCRIPTION
## Summary

The `ctf-agent-mcp-server` was crash-looping on Render ("Instance failed: qn5nh" → "Service recovered" → repeat). Root cause: the server uses `StdioServerTransport` which exits immediately when stdin closes — which always happens on a Render worker where no MCP client is connected via stdin.

**The fix**: Remove the service from `render.yaml` entirely. The agent-mcp-server is designed for local use by Claude Code / Codespaces where an MCP client connects via stdio. It cannot function as a Render PaaS worker.

The only practical use case that required it on Render (running `formanceBootstrap.sh` from inside the private network) is tracked for proper automation in issue #106 (automate bootstrap inside the Formance Dockerfile).

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment setup with authentication verification and configuration guidance
  * Removed background worker service from deployment configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->