### PR TITLE
ci: build Docker images in GitHub Actions, push to GHCR — zero Render build minutes

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,263 @@
+name: Build and push Docker images
+
+# Builds each service image on push to main (with path filtering so Ollama
+# only rebuilds when its Dockerfile changes) and pushes to GHCR. Render is
+# then configured to pull pre-built images, consuming zero Render build minutes.
+#
+# FIRST-TIME SETUP (do once per service image):
+#   After the workflow runs for the first time, go to:
+#   github.com/orgs/chargingthefuture/packages → each ctf-* image →
+#   Package settings → Change visibility → Public.
+#   This lets Render pull images without registry credentials.
+#
+# REQUIRED GITHUB SECRETS:
+#   NEXT_PUBLIC_APP_URL               — production URL, e.g. https://chargingthefuture.com
+#   NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY  — Clerk publishable key (pk_live_…)
+#   NEXT_PUBLIC_AUTH_SIGN_IN_URL      — e.g. /sign-in
+#   NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL — e.g. /
+#   NEXT_PUBLIC_AUTH_PROVIDER         — clerk
+#
+# OPTIONAL GITHUB SECRETS (enables auto-deploy to Render after image push):
+#   RENDER_API_KEY                    — Render API key
+#   RENDER_SERVICE_ID_WEB             — Render service ID for ctf-web
+#   RENDER_SERVICE_ID_PM_MCP          — Render service ID for ctf-pm-mcp-server
+#   RENDER_SERVICE_ID_OLLAMA          — Render service ID for ctf-ollama
+#   RENDER_SERVICE_ID_FORMANCE        — Render service ID for ctf-formance-ledger
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ctf/**'
+      - 'render.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # ── Detect which services have changed ──────────────────────────
+  changes:
+    name: Detect changed services
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+      pm-mcp-server: ${{ steps.filter.outputs.pm-mcp-server }}
+      ollama: ${{ steps.filter.outputs.ollama }}
+      formance: ${{ steps.filter.outputs.formance }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'ctf/packages/web/**'
+              - 'ctf/packages/shared/**'
+              - 'ctf/pnpm-lock.yaml'
+              - 'ctf/package.json'
+              - 'ctf/tsconfig.base.json'
+              - 'ctf/pnpm-workspace.yaml'
+            pm-mcp-server:
+              - 'ctf/packages/pm-mcp-server/**'
+            ollama:
+              - 'ctf/ops/ollama/**'
+            formance:
+              - 'ctf/ops/formance/Dockerfile.ledger'
+
+  # ── ctf-web ─────────────────────────────────────────────────────
+  build-web:
+    name: Build ctf-web
+    needs: changes
+    if: needs.changes.outputs.web == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ctf-web
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ctf
+          file: ctf/packages/web/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ctf-web
+          cache-to: type=gha,scope=ctf-web,mode=max
+          build-args: |
+            NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }}
+            NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY }}
+            NEXT_PUBLIC_AUTH_SIGN_IN_URL=${{ secrets.NEXT_PUBLIC_AUTH_SIGN_IN_URL }}
+            NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL=${{ secrets.NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL }}
+            NEXT_PUBLIC_AUTH_PROVIDER=${{ secrets.NEXT_PUBLIC_AUTH_PROVIDER }}
+
+      - name: Trigger Render deploy
+        if: ${{ secrets.RENDER_API_KEY != '' && secrets.RENDER_SERVICE_ID_WEB != '' }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_WEB/deploys"
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID_WEB: ${{ secrets.RENDER_SERVICE_ID_WEB }}
+
+  # ── ctf-pm-mcp-server ───────────────────────────────────────────
+  build-pm-mcp-server:
+    name: Build ctf-pm-mcp-server
+    needs: changes
+    if: needs.changes.outputs.pm-mcp-server == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ctf-pm-mcp-server
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ctf/packages/pm-mcp-server
+          file: ctf/packages/pm-mcp-server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ctf-pm-mcp-server
+          cache-to: type=gha,scope=ctf-pm-mcp-server,mode=max
+
+      - name: Trigger Render deploy
+        if: ${{ secrets.RENDER_API_KEY != '' && secrets.RENDER_SERVICE_ID_PM_MCP != '' }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_PM_MCP/deploys"
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID_PM_MCP: ${{ secrets.RENDER_SERVICE_ID_PM_MCP }}
+
+  # ── ctf-ollama ──────────────────────────────────────────────────
+  # Only rebuilds when the Dockerfile changes — model bake takes ~1 hour.
+  build-ollama:
+    name: Build ctf-ollama
+    needs: changes
+    if: needs.changes.outputs.ollama == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ctf-ollama
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ctf/ops/ollama
+          file: ctf/ops/ollama/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ctf-ollama
+          cache-to: type=gha,scope=ctf-ollama,mode=max
+
+      - name: Trigger Render deploy
+        if: ${{ secrets.RENDER_API_KEY != '' && secrets.RENDER_SERVICE_ID_OLLAMA != '' }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_OLLAMA/deploys"
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID_OLLAMA: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
+
+  # ── ctf-formance-ledger ─────────────────────────────────────────
+  build-formance-ledger:
+    name: Build ctf-formance-ledger
+    needs: changes
+    if: needs.changes.outputs.formance == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ctf-formance-ledger
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ctf/ops/formance
+          file: ctf/ops/formance/Dockerfile.ledger
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ctf-formance-ledger
+          cache-to: type=gha,scope=ctf-formance-ledger,mode=max
+
+      - name: Trigger Render deploy
+        if: ${{ secrets.RENDER_API_KEY != '' && secrets.RENDER_SERVICE_ID_FORMANCE != '' }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_FORMANCE/deploys"
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID_FORMANCE: ${{ secrets.RENDER_SERVICE_ID_FORMANCE }}

--- a/ctf/packages/web/Dockerfile
+++ b/ctf/packages/web/Dockerfile
@@ -37,12 +37,24 @@ COPY packages/shared packages/shared
 COPY packages/web    packages/web
 # Build shared first — web depends on it
 RUN pnpm --filter @ctf/shared run build
+# Build-time public env vars — passed as --build-arg from GitHub Actions.
+# NEXT_PUBLIC_* vars are baked into the client bundle at build time by Next.js.
+ARG NEXT_PUBLIC_APP_URL
+ARG NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_AUTH_SIGN_IN_URL
+ARG NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL
+ARG NEXT_PUBLIC_AUTH_PROVIDER
 # Build web (CI mode: skips Sentry build plugin, increases heap)
 ENV NEXT_TELEMETRY_DISABLED=1 \
     CTF_SKIP_SENTRY_NEXTJS=1 \
     NODE_OPTIONS="--max-old-space-size=8192" \
     NEXT_PRIVATE_MAX_WORKER_THREADS=1 \
-    SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1
+    SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1 \
+    NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL} \
+    NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY=${NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY} \
+    NEXT_PUBLIC_AUTH_SIGN_IN_URL=${NEXT_PUBLIC_AUTH_SIGN_IN_URL} \
+    NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL=${NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL} \
+    NEXT_PUBLIC_AUTH_PROVIDER=${NEXT_PUBLIC_AUTH_PROVIDER}
 RUN pnpm --filter @ctf/web run build:ci
 
 # ── 3. Production runner ──────────────────────────────────────────

--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,17 @@
 # changes locally / in Codespaces before merging to `main`. To get ephemeral
 # per-PR previews later, upgrade the workspace and re-add a `previews:` block.
 #
+# IMAGE BUILD ARCHITECTURE
+# ───────────────────────────────
+# Docker images are built by GitHub Actions (build-images.yml) and pushed to
+# GHCR (ghcr.io/chargingthefuture/*:latest). Render pulls pre-built images —
+# zero Render build pipeline minutes consumed.
+#
+# FIRST-TIME SETUP: after build-images.yml runs for the first time, go to
+# github.com/orgs/chargingthefuture/packages → each ctf-* image →
+# Package settings → Change visibility → Public.
+# This lets Render pull images without registry credentials.
+#
 # SECRET MANAGEMENT ARCHITECTURE
 # ───────────────────────────────
 # Infisical (self-hosted on Railway) is the single source of truth for secrets.
@@ -22,13 +33,13 @@
 
 services:
   # ── Next.js web app ─────────────────────────────────────────────
+  # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-web:latest
   # All secrets injected by Infisical → Render Sync. No manual setup required
   # beyond configuring the Render Sync inside Infisical.
   - type: web
     name: ctf-web
-    runtime: docker
-    dockerfilePath: ctf/packages/web/Dockerfile
-    dockerContext: ctf
+    image:
+      url: ghcr.io/chargingthefuture/ctf-web:latest
     region: ohio
     # Standard (2GB/1CPU) — headroom for a production Next.js app (~159 routes).
     plan: standard
@@ -48,14 +59,14 @@ services:
       # automatically by Infisical via the Render Sync integration.
 
   # ── PM MCP Server ────────────────────────────────────────────────
-  # Background worker — stdio MCP transport for PM feedback workflows.
+  # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-pm-mcp-server:latest
+  # Background worker — HTTP MCP transport for PM feedback workflows.
   # Part of 100% agentic infrastructure orchestration.
   # Secrets injected by Infisical → Render Sync.
   - type: worker
     name: ctf-pm-mcp-server
-    runtime: docker
-    dockerfilePath: ctf/packages/pm-mcp-server/Dockerfile
-    dockerContext: ctf/packages/pm-mcp-server
+    image:
+      url: ghcr.io/chargingthefuture/ctf-pm-mcp-server:latest
     region: ohio
     plan: starter
     envVars:
@@ -63,17 +74,16 @@ services:
         value: production
 
   # ── Ollama ────────────────────────────────────────────────────────
+  # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-ollama:latest
   # Private service — reachable by other Render services via internal URL.
-  # Render has no persistent volumes; models are baked into the image at build time.
+  # Model (llama3.2) is baked into the image at build time. Image only rebuilt
+  # when ctf/ops/ollama/Dockerfile changes (path-filtered in build-images.yml).
   - type: pserv
     name: ctf-ollama
-    runtime: docker
-    dockerfilePath: ctf/ops/ollama/Dockerfile
-    dockerContext: ctf/ops/ollama
+    image:
+      url: ghcr.io/chargingthefuture/ctf-ollama:latest
     region: ohio
     plan: standard
-    # No fromGroup: ctf-ollama only serves a baked-in model and reads no app
-    # secrets, so it needs nothing from ctf-preview-secrets.
     envVars:
       - key: OLLAMA_MODEL
         value: llama3.2
@@ -87,9 +97,8 @@ services:
   #
   # - type: pserv
   #   name: ctf-infisical
-  #   runtime: docker
-  #   dockerfilePath: ctf/ops/infisical/Dockerfile
-  #   dockerContext: ctf/ops/infisical
+  #   image:
+  #     url: ghcr.io/chargingthefuture/ctf-infisical:latest
   #   region: ohio
   #   plan: starter
   #   envVars:
@@ -105,16 +114,16 @@ services:
   #       sync: false
 
   # ── Formance Ledger (financial ledger) ───────────────────────────
-  # Private service — pinned to ghcr.io/formancehq/ledger:v2.3.15-dev.1
+  # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-formance-ledger:latest
+  # Private service — wraps ghcr.io/formancehq/ledger with Render-compatible config.
   # All state lives in Neon Postgres (no persistent disk on Render).
   # AUTO_UPGRADE=true handles schema migrations on container start.
   # Backups: daily pg_dump → Supabase Storage via backup-formance-supabase.yml.
   # FORMANCE_POSTGRES_URI injected by Infisical → Render Sync.
   - type: pserv
     name: ctf-formance-ledger
-    runtime: docker
-    dockerfilePath: ctf/ops/formance/Dockerfile.ledger
-    dockerContext: ctf/ops/formance
+    image:
+      url: ghcr.io/chargingthefuture/ctf-formance-ledger:latest
     region: ohio
     plan: starter
     envVars: []


### PR DESCRIPTION
## Summary

- **New workflow** `build-images.yml` — builds all 4 service images on push to `main` and pushes to GHCR. `dorny/paths-filter` ensures Ollama (1h+ model bake) only rebuilds when `ctf/ops/ollama/Dockerfile` actually changes. GHA Docker layer cache (scope-keyed per service) keeps subsequent web builds fast. Optional Render API auto-deploy step fires after each image push if `RENDER_SERVICE_ID_*` secrets are set.
- **render.yaml** — all 4 services switched from `runtime: docker + dockerfilePath/dockerContext` to `image: url: ghcr.io/chargingthefuture/{service}:latest`. Render now just pulls and runs; zero Render build pipeline minutes consumed.
- **web Dockerfile** — added `ARG`/`ENV` for `NEXT_PUBLIC_*` vars in the builder stage so Clerk publishable key and app URLs are correctly baked into the client bundle when built in CI.

## Setup required after merge

1. **Add GitHub Actions secrets** (Settings → Secrets → Actions):
   - `NEXT_PUBLIC_APP_URL` — e.g. `https://chargingthefuture.com`
   - `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY` — Clerk publishable key (`pk_live_…`)
   - `NEXT_PUBLIC_AUTH_SIGN_IN_URL` — e.g. `/sign-in`
   - `NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL` — e.g. `/`
   - `NEXT_PUBLIC_AUTH_PROVIDER` — `clerk`

2. **Run the workflow once** via Actions → "Build and push Docker images" → Run workflow (or just merge to main). This creates the 4 GHCR packages.

3. **Make packages public** — go to `github.com/orgs/chargingthefuture/packages` → each `ctf-*` image → Package settings → Change visibility → Public. This lets Render pull without registry credentials.

4. **Optional auto-deploy secrets** (if you want Render to redeploy automatically after each image push):
   - `RENDER_API_KEY` (already set)
   - `RENDER_SERVICE_ID_WEB`, `RENDER_SERVICE_ID_PM_MCP`, `RENDER_SERVICE_ID_OLLAMA`, `RENDER_SERVICE_ID_FORMANCE` — copy each service ID from the Render dashboard URL (`/services/srv-xxxxx`)

5. **Blueprint sync** — Render will pick up the `render.yaml` change on next sync. Services will pull from GHCR instead of building locally.

## Test plan

- [ ] Merge triggers `build-images.yml`; all 4 jobs complete (Ollama skips if its Dockerfile unchanged)
- [ ] GHCR shows `ctf-web:latest`, `ctf-pm-mcp-server:latest`, `ctf-ollama:latest`, `ctf-formance-ledger:latest`
- [ ] Set packages to public
- [ ] Render Blueprint sync picks up `image:` references and deploys successfully
- [ ] `ctf-web` health check `/api/health` returns 200
- [ ] Subsequent code push only rebuilds web (not Ollama)

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_