### PR TITLE
fix: copy pnpm root node_modules into web runner stage; add workflow run cleanup script

### DIFF
--- a/ctf/packages/web/Dockerfile
+++ b/ctf/packages/web/Dockerfile
@@ -64,7 +64,11 @@ RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 RUN addgroup -S app && adduser -S -G app -h /home/app app
 WORKDIR /repo
 ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
-# Copy only what `next start` needs at runtime, owned by the non-root user
+# Copy what `next start` needs at runtime, owned by the non-root user.
+# The pnpm store lives in the workspace-root node_modules; packages/web's
+# node_modules are relative symlinks into it (../../../node_modules/.pnpm/…),
+# so the root store must be copied too or `next` resolves to a dangling symlink.
+COPY --from=deps    --chown=app:app /repo/node_modules                node_modules
 COPY --from=builder --chown=app:app /repo/packages/web/.next          packages/web/.next
 COPY --from=builder --chown=app:app /repo/packages/web/public         packages/web/public
 COPY --from=builder --chown=app:app /repo/packages/web/package.json   packages/web/package.json

--- a/ctf/scripts/cleanup-old-workflow-runs.sh
+++ b/ctf/scripts/cleanup-old-workflow-runs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# ctf/scripts/cleanup-old-workflow-runs.sh
+#
+# Deletes all GitHub Actions runs for workflows that no longer have an active
+# .yml file, removing them from the Actions sidebar.
+#
+# Requirements: gh CLI authenticated (`gh auth login`) with repo scope.
+# Usage: ./ctf/scripts/cleanup-old-workflow-runs.sh
+#
+# Safe to re-run. Does NOT delete any active workflow files.
+
+set -euo pipefail
+
+OWNER="chargingthefuture"
+REPO="chargingthefuture"
+
+# Active workflow paths — runs for these are preserved
+ACTIVE_PATHS=(
+  ".github/workflows/backup-formance-supabase.yml"
+  ".github/workflows/build-images.yml"
+  ".github/workflows/ci.yml"
+  ".github/workflows/cleanup-artifacts.yml"
+  ".github/workflows/coderabbit-review.yml"
+  ".github/workflows/generate-product-update.yml"
+  ".github/workflows/github-actions-billing-token-reminder.yml"
+  ".github/workflows/github-actions-budget-monitor.yml"
+  ".github/workflows/pr-title-semantic.yml"
+  ".github/workflows/render-debug-agent.yml"
+  ".github/workflows/security-compliance.yml"
+  ".github/workflows/update-neon-db.yml"
+)
+
+delete_runs_for_workflow() {
+  local wf_id="$1"
+  local wf_name="$2"
+  local page=1
+  local total=0
+
+  while true; do
+    run_ids=$(gh api \
+      "/repos/$OWNER/$REPO/actions/workflows/$wf_id/runs?per_page=100&page=$page" \
+      --jq '.workflow_runs[].id' 2>/dev/null || true)
+
+    [ -z "$run_ids" ] && break
+
+    while IFS= read -r run_id; do
+      [ -z "$run_id" ] && continue
+      if gh api --method DELETE \
+        "/repos/$OWNER/$REPO/actions/runs/$run_id" >/dev/null 2>&1; then
+        echo "    deleted run $run_id"
+        ((total++)) || true
+      fi
+    done <<< "$run_ids"
+
+    ((page++))
+  done
+
+  echo "  $total run(s) deleted for: $wf_name"
+}
+
+echo "Fetching all workflows for $OWNER/$REPO..."
+wf_list=$(gh api \
+  "/repos/$OWNER/$REPO/actions/workflows?per_page=100" \
+  --jq '.workflows[] | [(.id | tostring), .name, .path] | @tsv')
+
+while IFS=$'\t' read -r wf_id wf_name wf_path; do
+  if [[ -z "$wf_path" || "$wf_path" != .github/workflows/* ]]; then
+    echo "SKIP (managed): $wf_name"
+    continue
+  fi
+
+  keep=false
+  for active in "${ACTIVE_PATHS[@]}"; do
+    if [[ "$wf_path" == "$active" ]]; then
+      keep=true
+      break
+    fi
+  done
+
+  if $keep; then
+    echo "KEEP: $wf_name ($wf_path)"
+    continue
+  fi
+
+  echo "CLEAN: $wf_name ($wf_path, id=$wf_id)"
+  delete_runs_for_workflow "$wf_id" "$wf_name"
+
+done <<< "$wf_list"
+
+echo ""
+echo "Done. Workflows with all runs removed will no longer appear in the sidebar."


### PR DESCRIPTION
## Summary

- Fixes the Render `ctf-web` runtime crash: `Error: Cannot find module '/repo/packages/web/node_modules/next/dist/bin/next'`.
- Root cause: the production runner stage copied only `packages/web/node_modules`, but pnpm stores package contents in the **workspace-root** `node_modules/.pnpm` store and links to them via relative symlinks (`../../../node_modules/.pnpm/…`). Without the root store, `packages/web/node_modules/next` is a dangling symlink, so `next start` cannot resolve the `next` binary.
- Fix: copy `/repo/node_modules` (the pnpm store) from the `deps` stage into the runner so the relative symlinks resolve.
- Adds `ctf/scripts/cleanup-old-workflow-runs.sh` — a one-shot script (requires `gh` CLI) that bulk-deletes all GitHub Actions runs for deprecated workflows (e.g. `deploy-infisical-render`, `blog-validate`, `deploy-backend-railway`, `expo-*`), removing them from the Actions sidebar. Runs for the 12 active workflows are preserved.

## Test plan

- [ ] Re-run `build-images.yml` (workflow_dispatch) to rebuild & push `ctf-web` to GHCR
- [ ] Render `ctf-web` deploy starts the container without the `MODULE_NOT_FOUND` error and serves on `$PORT`
- [ ] Run `./ctf/scripts/cleanup-old-workflow-runs.sh` locally (`gh auth login` required) to clear deprecated workflow runs from the Actions sidebar

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i