### PR TITLE
ci: add workflow_dispatch for cleanup-old-workflow-runs script

### DIFF
--- a/.github/workflows/cleanup-workflow-runs.yml
+++ b/.github/workflows/cleanup-workflow-runs.yml
@@ -1,0 +1,27 @@
+name: Cleanup deprecated workflow runs
+
+# One-shot cleanup: deletes all GitHub Actions runs for workflows whose .yml
+# files have been removed, removing them from the Actions sidebar.
+# Safe to re-run. Active workflows are preserved (see script ACTIVE_PATHS).
+#
+# Usage: Actions → "Cleanup deprecated workflow runs" → Run workflow
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  cleanup:
+    name: Delete deprecated workflow runs
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete deprecated workflow runs
+        run: |
+          chmod +x ctf/scripts/cleanup-old-workflow-runs.sh
+          ctf/scripts/cleanup-old-workflow-runs.sh


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cleanup-workflow-runs.yml` — a `workflow_dispatch`-only workflow that runs `ctf/scripts/cleanup-old-workflow-runs.sh` from the Actions UI (no local `gh` CLI required).
- Uses `GITHUB_TOKEN` with `actions: write` to delete runs for deprecated workflows (e.g. `deploy-infisical-render`, `blog-validate`, `deploy-backend-railway`, `expo-*`).
- Active workflows are preserved; only runs from removed `.yml` files are deleted.

## Usage

Actions → "Cleanup deprecated workflow runs" → Run workflow

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_