### PR TITLE
chore: document CLERK_ENCRYPTION_KEY requirement in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -57,6 +57,7 @@ services:
         value: sentry
       # All remaining secrets are synced automatically by Infisical → Render Sync:
       #   AUTH_SECRET_KEY               — Clerk secret key (sk_test_… / sk_live_…)
+      #   CLERK_ENCRYPTION_KEY          — random 32-char string (openssl rand -hex 16); required when secretKey is passed dynamically
       #   NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY — Clerk publishable key (pk_…)
       #   DATABASE_URL                  — Neon Postgres connection string
       #   STREAM_API_KEY / STREAM_API_SECRET — Stream Chat


### PR DESCRIPTION
## Summary

Documents `CLERK_ENCRYPTION_KEY` in render.yaml's required secrets list. This env var is mandatory when `secretKey` is passed dynamically to `clerkMiddleware()` (our pattern in `middleware.ts`). Without it the Edge runtime throws `encryption_key_missing` on every request.

## Required manual action

Generate and add to Render `ctf-web` environment (or Infisical Production for permanent sync):

```bash
openssl rand -hex 16
```

Add the output as `CLERK_ENCRYPTION_KEY`, then redeploy.

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment variable documentation clarifying requirements for encryption key configuration when dynamic settings are enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->