### PR TITLE
fix: resolve ctf-web health-check timeout on Render

### DIFF
--- a/ctf/packages/web/app/api/health/route.ts
+++ b/ctf/packages/web/app/api/health/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return Response.json({ status: 'ok' }, { status: 200 });
+}

--- a/render.yaml
+++ b/render.yaml
@@ -46,8 +46,10 @@ services:
     plan: standard
     healthCheckPath: /api/health
     envVars:
-      - key: PORT
-        value: "3000"
+      # PORT is injected automatically by Render (default 10000) and consumed by
+      # the container's CMD (PORT=${PORT:-3000}). Do NOT hardcode PORT here — an
+      # explicit value makes the server bind to a port Render does not route to,
+      # causing health-check timeouts.
       - key: NODE_ENV
         value: production
       - key: NEXT_TELEMETRY_DISABLED


### PR DESCRIPTION
## Summary

Fixes the 3-hour `ctf-web` deploy timeout loop on Render. Two root causes:

1. **Port mismatch.** `render.yaml` hardcoded `PORT=3000`, so the standalone server bound to `0.0.0.0:3000` — but Render routes and health-checks on its own injected port (`10000`). The check at `:10000/api/health` never connected → `Timed Out`. Removed the `PORT` override so the container's `CMD` (`PORT=${PORT:-3000}`) picks up Render's injected value.

2. **Missing health route.** `healthCheckPath: /api/health` pointed at a route that did not exist in the codebase (would 404 even once the port aligned). Added a minimal liveness route returning `200 {"status":"ok"}`. Not protected by Clerk middleware (no `auth.protect()`), so the unauthenticated probe passes.

## Evidence

Render log showed the standalone server healthy but on the wrong port:
```
▲ Next.js 16.2.4
- Network:  http://0.0.0.0:3000      ← bound to 3000
...
==> Timed Out                        ← Render health-checked :10000
```

## Test plan

- [ ] `build-images.yml` rebuilds ctf-web with the health route
- [ ] Render deploy passes health check at `/api/health` on the injected port
- [ ] Service reaches "Live"

Parity Status: web+android complete

https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYSiDyAwGnMtPwFQi9Mq5i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoint to monitor and verify service status.

* **Chores**
  * Corrected deployment environment configuration to prevent health-check failures during service startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->