### PR TITLE
ci: source ANTHROPIC_API_KEY from GitHub secret in product-update workflow

### DIFF
--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -85,7 +85,8 @@ jobs:
       - name: Generate update content via Claude
         id: content
         env:
-          # ANTHROPIC_API_KEY is in env after Infisical step
+          # Sourced directly from the GitHub Actions repo secret (not Infisical)
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           COMMITS: ${{ needs.check-changes.outputs.commits }}
         run: |
           OUTPUT=$(node ctf/scripts/generate-update.mjs)


### PR DESCRIPTION
## Problem

The **Generate Product Update** workflow has failed on every run since it was created. The step **"Generate update content via Claude"** exits 1 with `ANTHROPIC_API_KEY is not set`.

The Infisical injection step reports ✓ ("Injected secrets as environment variables") but `ANTHROPIC_API_KEY` never lands in the environment for that step, so [generate-update.mjs](ctf/scripts/generate-update.mjs#L21-L24) hard-exits.

## Fix

`ANTHROPIC_API_KEY` now exists as a GitHub Actions repository secret. This wires it directly into the step's `env` instead of depending on Infisical to resolve it:

```yaml
env:
  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
  COMMITS: ${{ needs.check-changes.outputs.commits }}
```

All other secrets in the job (APP_URL, INTERNAL_SERVICE_SECRET) continue to come from Infisical, which is working for the rest of the pipeline.

## Verification

Trigger via **workflow_dispatch** (with `force: true` if there are no recent feat/fix/perf commits) after merge and confirm the Generate step succeeds.

Parity Status: web+android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)