### PR TITLE
fix: fail fast with actionable error when product-update env vars missing

### DIFF
--- a/ctf/scripts/publish-product-update.mjs
+++ b/ctf/scripts/publish-product-update.mjs
@@ -27,6 +27,27 @@ const secret = process.env.INTERNAL_SERVICE_SECRET;
 const ghPat = process.env.GH_PAT;
 const today = new Date().toISOString().split('T')[0];
 
+// Fail fast with an actionable message when required config is absent, rather
+// than letting fetch throw a cryptic "Failed to parse URL from undefined/...".
+// These are injected from Infisical (APP_URL, INTERNAL_SERVICE_SECRET) and the
+// GitHub Actions secret store (GH_PAT) by generate-product-update.yml.
+const missing = [
+  ['APP_URL', appUrl],
+  ['INTERNAL_SERVICE_SECRET', secret],
+  ['GH_PAT', ghPat],
+]
+  .filter(([, value]) => !value)
+  .map(([name]) => name);
+
+if (missing.length > 0) {
+  console.error(
+    `Missing required env var(s): ${missing.join(', ')}. ` +
+      'APP_URL and INTERNAL_SERVICE_SECRET must be defined in the Infisical ' +
+      'production environment; GH_PAT must be set as a GitHub Actions secret.',
+  );
+  process.exit(1);
+}
+
 // ── 1. Post to in-app feed ────────────────────────────────────────────────────
 
 const feedRes = await fetch(`${appUrl}/api/internal/product-update`, {


### PR DESCRIPTION
## What & Why

A manual test run of the product-update workflow failed in `publish-product-update.mjs` with:

```
TypeError: Failed to parse URL from undefined/api/internal/product-update
  code: 'ERR_INVALID_URL',
  input: 'undefined/api/internal/product-update'
```

The script read `APP_URL` from the environment and interpolated it straight into a `fetch()` URL without checking it was set. When `APP_URL` is absent the result is `undefined/api/internal/...`, which surfaces as a cryptic undici parse error several frames deep instead of pointing at the actual problem (missing configuration).

## Fix

Validate the three required env vars up front and exit with a message naming the missing var(s) and where each is sourced from:

- `APP_URL`, `INTERNAL_SERVICE_SECRET` — injected from the **Infisical `production`** environment
- `GH_PAT` — a **GitHub Actions secret**

This mirrors the input-validation pattern already used in `generate-update.mjs`.

## Underlying cause of the reported run

This change makes the failure legible; it does **not** by itself make the run succeed. The reported failure means `APP_URL` is not present in the Infisical `production` environment (the workflow injects it there via the Infisical action). To get a green run, `APP_URL` (and `INTERNAL_SERVICE_SECRET`, if also unset) must be defined in Infisical's `production` env. After this fix, a missing var will say exactly that.

## Testing

- `node --check` passes.
- Ran the script with `APP_URL` unset → exits 1 with `Missing required env var(s): APP_URL ...` instead of the undici stack trace.
- File ends with a single trailing newline (EOF gate).

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_