### PR TITLE
refactor: make publish-product-update script feed-only

### DIFF
--- a/ctf/scripts/publish-product-update.mjs
+++ b/ctf/scripts/publish-product-update.mjs
@@ -1,40 +1,35 @@
 #!/usr/bin/env node
 /**
- * Posts the generated product update to:
- *   1. The in-app feed (via /api/internal/product-update)
- *   2. The wiki-site content-index.yaml (via GitHub Contents API)
+ * Posts the generated product update to the in-app feed
+ * (via POST {APP_URL}/api/internal/product-update).
  *
- * Wiki page creation happens via git in the workflow (generate-product-update.yml)
- * because GitHub has no REST API for wiki pages.
+ * Wiki page creation and the wiki-site content-index.yaml update are handled by
+ * dedicated steps in the workflow (generate-product-update.yml), not here.
  *
  * Required env vars:
  *   UPDATE_JSON              — JSON output from generate-update.mjs
- *   APP_URL                  — Deployed app base URL (e.g. https://app.chargingthefuture.org)
+ *   APP_URL                  — Deployed app base URL (e.g. https://the-comic.com)
  *   INTERNAL_SERVICE_SECRET  — Shared secret for /api/internal/* routes
- *   GH_PAT                   — GitHub PAT with contents:write on wiki-site repo
  */
 
 const json = JSON.parse(process.env.UPDATE_JSON ?? '{}');
-const { feedTitle, feedBody, wikiPageName, wikiSiteExcerpt } = json;
+const { feedTitle, feedBody } = json;
 
-if (!feedTitle || !feedBody || !wikiPageName || !wikiSiteExcerpt) {
-  console.error('UPDATE_JSON is missing required fields');
+if (!feedTitle || !feedBody) {
+  console.error('UPDATE_JSON is missing required fields (feedTitle, feedBody)');
   process.exit(1);
 }
 
 const appUrl = process.env.APP_URL;
 const secret = process.env.INTERNAL_SERVICE_SECRET;
-const ghPat = process.env.GH_PAT;
-const today = new Date().toISOString().split('T')[0];
 
 // Fail fast with an actionable message when required config is absent, rather
 // than letting fetch throw a cryptic "Failed to parse URL from undefined/...".
-// These are injected from Infisical (APP_URL, INTERNAL_SERVICE_SECRET) and the
-// GitHub Actions secret store (GH_PAT) by generate-product-update.yml.
+// Both are injected from the Infisical production environment by
+// generate-product-update.yml.
 const missing = [
   ['APP_URL', appUrl],
   ['INTERNAL_SERVICE_SECRET', secret],
-  ['GH_PAT', ghPat],
 ]
   .filter(([, value]) => !value)
   .map(([name]) => name);
@@ -42,13 +37,12 @@ const missing = [
 if (missing.length > 0) {
   console.error(
     `Missing required env var(s): ${missing.join(', ')}. ` +
-      'APP_URL and INTERNAL_SERVICE_SECRET must be defined in the Infisical ' +
-      'production environment; GH_PAT must be set as a GitHub Actions secret.',
+      'Both must be defined in the Infisical production environment.',
   );
   process.exit(1);
 }
 
-// ── 1. Post to in-app feed ────────────────────────────────────────────────────
+// ── Post to in-app feed ───────────────────────────────────────────────────────
 
 const feedRes = await fetch(`${appUrl}/api/internal/product-update`, {
   method: 'POST',
@@ -66,59 +60,3 @@ if (!feedRes.ok) {
 
 const feedData = await feedRes.json();
 console.log(`Feed announcement published (id: ${feedData.id})`);
-
-// ── 2. Update wiki-site content-index.yaml ───────────────────────────────────
-
-const WIKI_SITE_REPO = 'chargingthefuture/wiki-site';
-const INDEX_PATH = 'wiki-blog/content-index.yaml';
-const API_BASE = 'https://api.github.com';
-
-const ghHeaders = {
-  Authorization: `Bearer ${ghPat}`,
-  Accept: 'application/vnd.github.v3+json',
-  'Content-Type': 'application/json',
-};
-
-const fileRes = await fetch(`${API_BASE}/repos/${WIKI_SITE_REPO}/contents/${INDEX_PATH}`, {
-  headers: ghHeaders,
-});
-
-if (!fileRes.ok) {
-  console.error('Failed to read content-index.yaml:', fileRes.status, await fileRes.text());
-  process.exit(1);
-}
-
-const fileData = await fileRes.json();
-const currentContent = Buffer.from(fileData.content, 'base64').toString('utf-8');
-
-// Prepend so newest appears first; trailing newline is preserved from currentContent
-const safeTitle = feedTitle.replace(/"/g, '\\"');
-const safeExcerpt = wikiSiteExcerpt.replace(/"/g, '\\"');
-const newEntry = [
-  `- slug: ${wikiPageName}`,
-  `  title: "${safeTitle}"`,
-  `  repo: chargingthefuture/chargingthefuture`,
-  `  date: "${today}"`,
-  `  excerpt: "${safeExcerpt}"`,
-  `  category: Updates`,
-  '',
-].join('\n');
-
-const updatedContent = newEntry + currentContent;
-
-const updateRes = await fetch(`${API_BASE}/repos/${WIKI_SITE_REPO}/contents/${INDEX_PATH}`, {
-  method: 'PUT',
-  headers: ghHeaders,
-  body: JSON.stringify({
-    message: `chore: add product update ${today}`,
-    content: Buffer.from(updatedContent).toString('base64'),
-    sha: fileData.sha,
-  }),
-});
-
-if (!updateRes.ok) {
-  console.error('Failed to update content-index.yaml:', updateRes.status, await updateRes.text());
-  process.exit(1);
-}
-
-console.log('content-index.yaml updated in wiki-site repo.');


### PR DESCRIPTION
## What & Why

The `Post to in-app feed` step of `generate-product-update.yml` failed because `publish-product-update.mjs` had drifted out of sync with the workflow:

- The script did **two** things: (1) POST to the in-app feed, and (2) update `wiki-site/content-index.yaml` via the GitHub API using `GH_PAT`.
- Part 2 was **redundant** — the workflow already has a dedicated `Publish to wiki-site blog registry` step that maintains `content-index.yaml` with the current `.articles` schema (plus `pnpm wiki:validate` / `wiki:sync`). The script's copy used an outdated root-level `- slug:` format.
- Part 2 was the **only** reason the script required `GH_PAT` — and the `Post to in-app feed` step intentionally does **not** pass `GH_PAT` (only the wiki/blog steps do). So the old script aborted on its `GH_PAT` check even though the feed POST itself never needed it.

The Infisical injection was working correctly: the `Inject secrets from Infisical` step (`env-slug: production`) exports `APP_URL` and `INTERNAL_SERVICE_SECRET` into the job env, and both are available to the feed step. `GH_PAT` was the sole missing variable.

## Fix

Reduce the script to its sole live responsibility: posting the feed announcement. It now requires only `APP_URL` and `INTERNAL_SERVICE_SECRET` (both already injected from the Infisical `production` env). `GH_PAT` and all wiki-site code are removed. Wiki page creation and the content-index registry update remain handled by the workflow's dedicated steps. Net: 12 insertions, 74 deletions. No Infisical or workflow config changes are needed.

## Testing

- `node --check` passes.
- Ran with `APP_URL` unset → exits 1 with `Missing required env var(s): APP_URL ...`.
- Ran with both vars set → passes validation and proceeds to the feed POST.
- No lingering `GH_PAT` / wiki-site references; file ends with a single trailing newline.

Parity Status: web+android complete