### PR TITLE
ci: make product-update feed step resilient to Infisical injection gaps

### DIFF
--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -70,8 +70,12 @@ jobs:
           node-version: '22'
 
       # ── Secrets (Infisical → env) ─────────────────────────────────────────────
-      # Injects: ANTHROPIC_API_KEY, APP_URL, INTERNAL_SERVICE_SECRET
-      # GitHub-direct secrets (not in Infisical): GH_PAT, GITHUB_TOKEN
+      # Intended to inject APP_URL and INTERNAL_SERVICE_SECRET into the job env
+      # for the "Post to in-app feed" step. recursive:true so secrets nested in
+      # a sub-folder of the production environment (not just the root path) are
+      # picked up. The feed step also falls back to same-named GitHub Actions
+      # secrets, so it still works if Infisical injection is unavailable.
+      # GitHub-direct secrets (not via Infisical): ANTHROPIC_API_KEY, GH_PAT, GITHUB_TOKEN
       - name: Inject secrets from Infisical
         uses: Infisical/secrets-action@v1.0.16
         with:
@@ -80,6 +84,8 @@ jobs:
           project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
           env-slug: production
           domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
 
       # ── Generate ─────────────────────────────────────────────────────────────
       - name: Generate update content via Claude
@@ -98,7 +104,12 @@ jobs:
       - name: Post to in-app feed
         env:
           UPDATE_JSON: ${{ steps.content.outputs.json }}
-          # APP_URL and INTERNAL_SERVICE_SECRET are in env after Infisical step
+          # Prefer the Infisical-injected value (env context, populated by the
+          # step above); fall back to a same-named GitHub Actions repo secret.
+          # This mirrors how ANTHROPIC_API_KEY is sourced and unblocks the step
+          # when Infisical injection does not deliver these keys.
+          APP_URL: ${{ env.APP_URL || secrets.APP_URL }}
+          INTERNAL_SERVICE_SECRET: ${{ env.INTERNAL_SERVICE_SECRET || secrets.INTERNAL_SERVICE_SECRET }}
         run: node ctf/scripts/publish-product-update.mjs
 
       # ── GitHub wiki page ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What & Why

Even after #129 made `publish-product-update.mjs` feed-only, the `Post to in-app feed` step still failed:

```
Missing required env var(s): APP_URL, INTERNAL_SERVICE_SECRET.
```

The run log is the key evidence: the `Inject secrets from Infisical` step (`env-slug: production`, `secret-path: /`, `recursive: false`) reports **`Injected secrets as environment variables`**, yet neither `APP_URL` nor `INTERNAL_SERVICE_SECRET` is present in the subsequent step. So the Infisical injection is not delivering these two keys to the job env in this workflow.

This is the same situation that led to #124 ("source `ANTHROPIC_API_KEY` from GitHub secret in product-update workflow") — `ANTHROPIC_API_KEY` is already sourced directly from `${{ secrets.ANTHROPIC_API_KEY }}` rather than Infisical for exactly this reason.

## Fix

Make the feed step work regardless of which store holds the values:

- `APP_URL` / `INTERNAL_SERVICE_SECRET` now resolve as `${{ env.X || secrets.X }}` — **prefer** the Infisical-injected value (kept canonical), **fall back** to a same-named GitHub Actions repo secret. Mirrors how `ANTHROPIC_API_KEY` is handled.
- Set the Infisical step to `secret-path: /` with `recursive: true`, so secrets nested in a **sub-folder** of the `production` environment (a common reason root-path injection finds nothing) are also picked up.
- Corrected the stale comment that claimed Infisical injects `ANTHROPIC_API_KEY`.

No secret values are printed anywhere — values flow only as masked env vars, per the repo security policy.

## Action needed to guarantee green

The deterministic fix is to add the two values as **GitHub Actions repository secrets** (Settings → Secrets and variables → Actions), named exactly:

- `APP_URL` — e.g. the deployed app base URL
- `INTERNAL_SERVICE_SECRET` — the shared secret for `/api/internal/*`

This matches how `ANTHROPIC_API_KEY`, `GH_PAT`, and the `INFISICAL_*` secrets are already stored for this workflow. Alternatively, if these are meant to stay in Infisical only, the `recursive: true` change should pick them up if they live in a `production` sub-folder — if it still fails after this, the Infisical machine identity likely can't read them at the queried scope.

## Testing

- Workflow YAML parses cleanly (`yaml.safe_load`).
- Expression form `${{ env.X || secrets.X }}` is the standard GitHub Actions default-fallback pattern; undefined secrets resolve to empty and fall through without error.
- File ends with a single trailing newline.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to enhance reliability and robustness of the in-app feed posting process with improved fallback mechanisms for system variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->