### PR TITLE
ci: fix Infisical env-slug (prod) and make secret injection non-fatal

### DIFF
--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -71,18 +71,22 @@ jobs:
 
       # ── Secrets (Infisical → env) ─────────────────────────────────────────────
       # Intended to inject APP_URL and INTERNAL_SERVICE_SECRET into the job env
-      # for the "Post to in-app feed" step. recursive:true so secrets nested in
-      # a sub-folder of the production environment (not just the root path) are
-      # picked up. The feed step also falls back to same-named GitHub Actions
-      # secrets, so it still works if Infisical injection is unavailable.
+      # for the "Post to in-app feed" step. env-slug is the Infisical environment
+      # *slug* (not its display name) — the Production environment's default slug
+      # is "prod", so env-slug: production returns a 404. recursive:true picks up
+      # secrets nested in sub-folders, not just the root path.
+      # This step is non-fatal: if Infisical is unreachable or misconfigured, the
+      # job continues and downstream steps fall back to same-named GitHub Actions
+      # secrets (APP_URL, INTERNAL_SERVICE_SECRET — see the feed step below).
       # GitHub-direct secrets (not via Infisical): ANTHROPIC_API_KEY, GH_PAT, GITHUB_TOKEN
       - name: Inject secrets from Infisical
         uses: Infisical/secrets-action@v1.0.16
+        continue-on-error: true
         with:
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
-          env-slug: production
+          env-slug: prod
           domain: ${{ secrets.INFISICAL_URL }}
           secret-path: /
           recursive: true


### PR DESCRIPTION
## Root cause (finally definitive)

With `recursive: true` merged, the latest run failed at the Infisical step with a clear API error:

```
##[error]Environment with slug 'production' in project with ID
0cbee7c0-6f8b-4ce0-838b-5ce926be2d1b not found  (statusCode 404)
```

The **project** resolves correctly — the failure is that **no environment with the *slug* `production` exists** in it. In Infisical an environment's **slug** is distinct from its display name; the "Production" environment's default slug is **`prod`**. So `env-slug: production` has been 404-ing the whole time, and nothing was ever injected — which is exactly why `APP_URL`/`INTERNAL_SERVICE_SECRET` were "missing" in earlier runs.

Secondary problem: the Infisical step's 404 **aborts the entire job** before the feed step runs, so the GitHub-secrets fallback added in #130 never executed.

## Fix

- **`env-slug: prod`** — target the Production environment by its real slug.
- **`continue-on-error: true`** on the Infisical step — an Infisical outage or misconfig no longer kills the pipeline; downstream steps fall back to same-named GitHub Actions secrets (`APP_URL`, `INTERNAL_SERVICE_SECRET`), which are now configured.
- Updated the comment to explain the slug-vs-name distinction.

Together these mean the run goes green whether the values come from Infisical (`prod`) or the GitHub Actions secret fallback.

No secret values are printed anywhere — values flow only as masked env vars, per repo policy.

## Note on the slug

`prod` is Infisical's default slug for a Production environment and is almost certainly correct here. If your Production environment happens to use a different slug, you can confirm it in Infisical under Project Settings → Environments (the slug column). Even if it differs, `continue-on-error` + the GitHub-secrets fallback keep the run green.

## Testing

- Workflow YAML parses cleanly (`yaml.safe_load`).
- `continue-on-error` placement is at the step level (valid GitHub Actions schema).
- File ends with a single trailing newline.
- Full verification requires a manual `workflow_dispatch` run (this workflow doesn't run on PRs).

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_