### PR TITLE
feat: directory web pixel pass + modularity refactor

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -100,7 +100,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 |---|---|---|---|---|---|---|
 | chyme | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | skills-taxonomy | ⏳ | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
-| directory | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| directory | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | feed-announcements | 🎨 | 🟡 | ⬜ | ⬜ | ⬜ | ⬜ |
 | workforce | 🎨 | 🟡 | ⬜ | ⬜ | ⬜ | ⬜ |
 | skills-hunt | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
@@ -374,3 +374,13 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   in the backend pass). Loading/empty states render inline; no public state by design (Chyme is
   auth-only per #102). API wiring untouched; typecheck/EOF/parity/schema-drift gates green. Marked
   chyme Web px ✅ in the table above; Android pixel parity (`MobileChyme.tsx` → RN feature) remains ⬜.
+- 2026-05-29: UI circle-back — directory web pixel pass + modularity refactor. Aligned `DirectoryShell`
+  to `design/.../survivor-hub/Directory.tsx` and its Loading/Empty mockups: corrected the app-surface
+  background to `#0F1117` (the shell had used the mockup's dead `BG` constant `#0C1A3D`), added the
+  skeleton loading state, rebuilt the empty state to the mockup's category-grid + Browse All / Clear
+  Filters treatment (real sector data, no dummy counts), and restored the `📇` heading glyphs. The
+  oversized single-function shell (382 lines / complexity 16, a pre-existing rule-116 violation) was
+  decomposed into modular sub-components so every unit is within the 200-line / complexity-10 limits;
+  also removed the unused `userId`/`isAdmin` props. API wiring untouched; typecheck, lint, modularity,
+  build:ci, EOF, parity, and schema-drift gates green. Marked directory Web px ✅; Android pixel parity
+  (`MobileDirectory.tsx` → RN feature) remains ⬜.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-feature-inventory.md
@@ -95,6 +95,8 @@ Web and Android implementations:
 - Admin role-gated controls reach parity (same policy outcomes and deny taxonomy across platforms).
 - Unified UI contract governs both clients, with platform-specific presentation only.
 
+Web pixel pass: the `DirectoryShell` is aligned to `design/.../survivor-hub/Directory.tsx` and its Loading/Empty states (`DirectoryLoading.tsx`, `DirectoryEmpty.tsx`). The app surface background was corrected to `#0F1117` (the mockup's rendered surface), the loading state now renders the skeleton layout, and the empty state matches the mockup's category-grid + "Browse All / Clear Filters" treatment (driven by real sector data). The shell was decomposed into modular sub-components (`directory-profile-detail`, `directory-browse`, `directory-chat-tab`, `directory-right-panel`, `directory-loading-skeleton`, `directory-empty-state`, `shared`) so each unit stays within the rule-116 complexity/length limits. API wiring is unchanged. The Android pixel pass to `MobileDirectory.tsx` remains tracked in `PRODUCTION_READINESS_PLAN.md`.
+
 ## Seed Coverage Status
 
 Deterministic Directory seed script exists: `ctf/scripts/seedDirectory.mjs`.
@@ -111,6 +113,7 @@ Seeded content:
 
 ## Change Log
 
+- 2026-05-29: Web UI circle-back. Aligned `DirectoryShell` to the `Directory.tsx` mockup and its Loading/Empty states; corrected the app surface background to `#0F1117`, added the skeleton loading state and the mockup's empty-state category grid (real sector data), and restored the `📇` heading glyphs. Decomposed the previously oversized shell into modular sub-components to satisfy rule-116 limits and removed the unused `userId`/`isAdmin` props (cleared a lint error). API wiring unchanged.
 - 2026-05-17: Updated inventory to enforce Rule 120 living-snapshot model. Removed Phase language, Planned section headers, and planning-phase ambiguities list. Confirmed web+android complete delivery status. Clarified technical debt (skills compatibility, route ownership codification) as known limitations, not unimplemented features.
 - 2026-03-02: Implemented backend and unified web surface (user/admin role-gated sections) with resolved list/pagination/claimed-delete decisions.
 - 2026-02-25: Created initial unified Directory CTF rewrite inventory merging user and admin flows into one planned UI surface.

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -176,7 +176,7 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (selectedPlugin.slug === 'directory') {
-    return <DirectoryShell userId={decision.userId} isAdmin={decision.isAdmin} />;
+    return <DirectoryShell />;
   }
 
   if (selectedPlugin.slug === 'feed-announcements') {

--- a/ctf/packages/web/components/directory/directory-browse.tsx
+++ b/ctf/packages/web/components/directory/directory-browse.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { ArrowUpRight, CheckCircle, ChevronRight, MessageSquare, Search } from "lucide-react";
+import { COLOR, SKILLS_HUNT_COLOR, initials, type Member, type SkillsHuntRewardCard } from "./shared";
+import { DirectoryEmptyState } from "./directory-empty-state";
+
+export function DirectoryBrowse({
+  rewardCard,
+  loadingMembers,
+  members,
+  categories,
+  filtered,
+  onSelect,
+  onClearFilters,
+}: {
+  rewardCard: SkillsHuntRewardCard | null;
+  loadingMembers: boolean;
+  members: Member[];
+  categories: string[];
+  filtered: boolean;
+  onSelect: (member: Member) => void;
+  onClearFilters: () => void;
+}) {
+  if (!loadingMembers && members.length === 0) {
+    return <DirectoryEmptyState categories={categories} filtered={filtered} onClearFilters={onClearFilters} />;
+  }
+
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ padding: "24px" }}>
+        {rewardCard && rewardCard.isActive && (
+          <a href={rewardCard.ctaUrl} style={{ display: "block", marginBottom: 16, padding: "18px 22px", borderRadius: 14, background: `${SKILLS_HUNT_COLOR}10`, border: `1px solid ${SKILLS_HUNT_COLOR}30`, textDecoration: "none", color: "inherit" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+              <div style={{ width: 44, height: 44, borderRadius: 12, background: `${SKILLS_HUNT_COLOR}25`, border: `1px solid ${SKILLS_HUNT_COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+                <Search size={20} style={{ color: SKILLS_HUNT_COLOR }} />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 700, color: SKILLS_HUNT_COLOR, marginBottom: 2 }}>{rewardCard.title}</div>
+                <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.5 }}>{rewardCard.description}</div>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 14px", borderRadius: 10, background: SKILLS_HUNT_COLOR, color: "#fff", fontSize: 13, fontWeight: 700, flexShrink: 0 }}>
+                {rewardCard.ctaLabel} <ArrowUpRight size={14} />
+              </div>
+            </div>
+          </a>
+        )}
+        <div style={{ marginBottom: 20, padding: "20px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}20 0%,rgba(14,165,233,0.1) 100%)`, border: `1px solid ${COLOR}25` }}>
+          <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Find Your Support Network</div>
+          <div style={{ fontSize: 14, color: "#9CA3AF" }}>Verified trauma-informed providers · Trusted · Privacy-first</div>
+        </div>
+
+        {loadingMembers ? (
+          <div style={{ padding: "48px", textAlign: "center", color: "#6B7280", fontSize: 14 }}>Loading providers…</div>
+        ) : (
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(2,1fr)", gap: 14 }}>
+            {members.map((p) => (
+              <div key={p.id} onClick={() => onSelect(p)} style={{ padding: "20px", borderRadius: 16, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}20`, cursor: "pointer" }}>
+                <div style={{ display: "flex", gap: 14, marginBottom: 14, alignItems: "flex-start" }}>
+                  <Avatar style={{ width: 48, height: 48, flexShrink: 0 }}>
+                    <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 18, fontWeight: 800 }}>{initials(p.name)}</AvatarFallback>
+                  </Avatar>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+                      <div style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
+                      <CheckCircle size={14} style={{ color: COLOR, flexShrink: 0 }} />
+                    </div>
+                    <div style={{ fontSize: 12, color: "#9CA3AF", marginBottom: 4 }}>{p.jobTitle}</div>
+                    <Badge style={{ background: `${COLOR}10`, color: COLOR, border: `1px solid ${COLOR}25`, fontSize: 11 }}>{p.sector}</Badge>
+                  </div>
+                </div>
+                {p.skills.length > 0 && (
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 14 }}>
+                    {p.skills.slice(0, 3).map((s) => (
+                      <Badge key={s} style={{ background: `${COLOR}10`, color: COLOR, border: `1px solid ${COLOR}25`, fontSize: 11 }}>{s}</Badge>
+                    ))}
+                  </div>
+                )}
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button style={{ flex: 1, padding: "8px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 4 }}>
+                    View Profile <ChevronRight size={12} />
+                  </button>
+                  <button style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", color: "#9CA3AF", fontSize: 12, cursor: "pointer", display: "flex", alignItems: "center", gap: 4 }}>
+                    <MessageSquare size={12} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/ctf/packages/web/components/directory/directory-chat-tab.tsx
+++ b/ctf/packages/web/components/directory/directory-chat-tab.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ArrowUpRight, BookOpen, Plus, Send } from "lucide-react";
+import { COLOR } from "./shared";
+
+const INFO_MSGS = [
+  { id: 1, text: "Directory connects you with verified providers across the Survivor Hub. Who are you looking for?" },
+  { id: 2, text: "Search by name, sector, or skill. Use the filters on the left to narrow results. All interactions are privacy-first and trauma-informed.", action: "Browse Providers" },
+];
+
+export function DirectoryChatTab({
+  chatInput,
+  onChatInputChange,
+  onBrowse,
+}: {
+  chatInput: string;
+  onChatInputChange: (value: string) => void;
+  onBrowse: () => void;
+}) {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+      <ScrollArea style={{ flex: 1, padding: "16px 24px" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {INFO_MSGS.map((msg) => (
+            <div key={msg.id} style={{ display: "flex", gap: 10, alignItems: "flex-end" }}>
+              <div style={{ width: 32, height: 32, borderRadius: 10, background: `${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+                <BookOpen size={14} style={{ color: COLOR }} />
+              </div>
+              <div style={{ maxWidth: "70%", display: "flex", flexDirection: "column", gap: 6 }}>
+                <div style={{ padding: "12px 16px", borderRadius: "16px 16px 16px 4px", background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.06)", fontSize: 14, lineHeight: 1.6, color: "#E8EAF0" }}>
+                  {msg.text}
+                </div>
+                {msg.action && (
+                  <button onClick={onBrowse} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", alignSelf: "flex-start" }}>
+                    {msg.action} <ArrowUpRight size={13} />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+      <div style={{ padding: "8px 24px 20px", flexShrink: 0, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 14 }}>
+          <Plus size={18} style={{ color: "#4B5563", flexShrink: 0 }} />
+          <input
+            value={chatInput}
+            onChange={(e) => onChatInputChange(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") onChatInputChange(""); }}
+            placeholder="Find providers, ask questions…"
+            style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: "#E8EAF0" }}
+          />
+          <button onClick={() => onChatInputChange("")} style={{ width: 32, height: 32, borderRadius: 8, background: chatInput.trim() ? COLOR : "rgba(255,255,255,0.06)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0 }}>
+            <Send size={14} style={{ color: chatInput.trim() ? "#fff" : "#4B5563" }} />
+          </button>
+        </div>
+        <div style={{ textAlign: "center", fontSize: 11, color: "#374151", marginTop: 8 }}>Privacy-first · Trauma-informed design</div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/directory/directory-empty-state.tsx
+++ b/ctf/packages/web/components/directory/directory-empty-state.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+// STATE: Empty — no providers match the active filter. Ported from the
+// emptyMode block in design/.../survivor-hub/Directory.tsx.
+import { Briefcase, Globe, Users } from "lucide-react";
+import { COLOR } from "./shared";
+
+export function DirectoryEmptyState({
+  categories,
+  filtered,
+  onClearFilters,
+}: {
+  categories: string[];
+  filtered: boolean;
+  onClearFilters: () => void;
+}) {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "40px 24px", gap: 16 }}>
+      <div style={{ width: 72, height: 72, borderRadius: 20, background: "rgba(59,130,246,0.1)", border: "1px solid rgba(59,130,246,0.2)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Users size={32} style={{ color: COLOR, opacity: 0.5 }} />
+      </div>
+      <div style={{ textAlign: "center", maxWidth: 400 }}>
+        <div style={{ fontSize: 20, fontWeight: 700, color: "#F9FAFB", marginBottom: 8 }}>No providers found</div>
+        <div style={{ fontSize: 14, color: "#6B7280", lineHeight: 1.7, marginBottom: 24 }}>
+          No trauma-informed providers match your current filter. Try broadening your search, or check back as new providers join the network. All providers are background-verified before listing.
+        </div>
+      </div>
+      {categories.length > 0 && (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 10, width: "100%", maxWidth: 540 }}>
+          {categories.slice(0, 6).map((cat) => (
+            <div key={cat} style={{ padding: "12px", borderRadius: 10, background: "rgba(59,130,246,0.04)", border: "1px dashed rgba(59,130,246,0.2)", textAlign: "center" }}>
+              <div style={{ width: 32, height: 32, borderRadius: 8, background: "rgba(59,130,246,0.08)", margin: "0 auto 6px", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <Briefcase size={14} style={{ color: COLOR, opacity: 0.4 }} />
+              </div>
+              <div style={{ fontSize: 12, color: "#4B5563" }}>{cat}</div>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ display: "flex", gap: 12 }}>
+        <button onClick={onClearFilters} style={{ padding: "12px 24px", borderRadius: 12, background: COLOR, border: "none", color: "#fff", fontSize: 14, fontWeight: 700, cursor: "pointer", display: "flex", alignItems: "center", gap: 8 }}>
+          <Globe size={16} /> Browse All Providers
+        </button>
+        {filtered && (
+          <button onClick={onClearFilters} style={{ padding: "12px 24px", borderRadius: 12, background: "rgba(59,130,246,0.12)", border: "1px solid rgba(59,130,246,0.3)", color: COLOR, fontSize: 14, fontWeight: 600, cursor: "pointer" }}>
+            Clear Filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/directory/directory-loading-skeleton.tsx
+++ b/ctf/packages/web/components/directory/directory-loading-skeleton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+// STATE: Loading — data fetch in progress. Ported from
+// design/.../survivor-hub/DirectoryLoading.tsx.
+import { BookOpen } from "lucide-react";
+import { BG, COLOR } from "./shared";
+
+const surface = "#161B27";
+const border = "#1E2A3A";
+
+function Sk({ w = "100%", h = 14, r = 6 }: { w?: string | number; h?: number; r?: number }) {
+  return <div style={{ width: w, height: h, borderRadius: r, background: "rgba(255,255,255,0.06)", flexShrink: 0 }} />;
+}
+
+export function DirectoryLoadingSkeleton() {
+  return (
+    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, fontFamily: "'Inter',system-ui", color: "#F9FAFB", overflow: "hidden" }}>
+      {/* Sidebar */}
+      <aside style={{ width: 320, borderRight: `1px solid ${border}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
+        <div style={{ padding: "16px 16px 12px", borderBottom: `1px solid ${border}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+            <BookOpen size={16} color={COLOR} /><Sk w={90} h={16} r={6} />
+          </div>
+          <Sk h={36} r={8} />
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 10 }}>
+            {[60, 80, 55, 70, 65, 75, 50].map((w, i) => <Sk key={i} w={w} h={24} r={12} />)}
+          </div>
+        </div>
+        <div style={{ padding: "10px 12px", borderBottom: `1px solid ${border}`, display: "flex", gap: 6 }}>
+          <Sk w={90} h={32} r={8} /><Sk w={90} h={32} r={8} />
+        </div>
+        <div style={{ flex: 1, padding: "12px", display: "flex", flexDirection: "column", gap: 10 }}>
+          {[{ from: "hub", w: 200 }, { from: "me", w: 160 }, { from: "hub", w: 220 }].map(({ from, w }, i) => (
+            <div key={i} style={{ display: "flex", justifyContent: from === "me" ? "flex-end" : "flex-start" }}>
+              <Sk w={w} h={44} r={10} />
+            </div>
+          ))}
+        </div>
+        <div style={{ padding: "12px", borderTop: `1px solid ${border}` }}>
+          <div style={{ display: "flex", gap: 8 }}><Sk h={40} r={8} /><Sk w={40} h={40} r={8} /></div>
+        </div>
+      </aside>
+
+      {/* Main — profile list */}
+      <main style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", background: surface }}>
+        <div style={{ height: 56, borderBottom: `1px solid ${border}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 12, flexShrink: 0 }}>
+          <Sk w={120} h={16} r={6} />
+          <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}><Sk w={100} h={32} r={8} /><Sk w={80} h={32} r={8} /></div>
+        </div>
+        <div style={{ flex: 1, overflowY: "auto", padding: "20px 24px", display: "flex", flexDirection: "column", gap: 12 }}>
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} style={{ borderRadius: 14, border: `1px solid ${border}`, padding: "16px 20px", display: "flex", gap: 16 }}>
+              <Sk w={56} h={56} r={28} />
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+                  <Sk w={130} h={15} r={5} /><Sk w={70} h={20} r={10} />
+                </div>
+                <Sk w={160} h={12} r={4} />
+                <div style={{ display: "flex", gap: 6 }}>
+                  {[55, 45, 65].map((w, j) => <Sk key={j} w={w} h={22} r={11} />)}
+                </div>
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+                <Sk w={50} h={14} r={5} /><Sk w={80} h={32} r={8} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/directory/directory-profile-detail.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-detail.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { BG, COLOR, initials, type Member } from "./shared";
+
+export function DirectoryProfileDetail({ member, onBack }: { member: Member; onBack: () => void }) {
+  const p = member;
+  return (
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex", flexDirection: "column" }}>
+      <div style={{ height: 56, borderBottom: `1px solid ${COLOR}25`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+        <button onClick={onBack} style={{ color: COLOR, background: "none", border: "none", cursor: "pointer", fontSize: 14, display: "flex", alignItems: "center", gap: 6 }}>
+          ← Back
+        </button>
+        <div style={{ flex: 1, fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>📇 Provider Profile</div>
+        <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}40`, fontSize: 11 }}>GetStream ⚡</Badge>
+      </div>
+      <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+        <div style={{ flex: 1, padding: "32px 40px", overflow: "auto" }}>
+          <div style={{ display: "flex", gap: 24, marginBottom: 32 }}>
+            <Avatar style={{ width: 80, height: 80 }}>
+              <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 28, fontWeight: 800 }}>{initials(p.name)}</AvatarFallback>
+            </Avatar>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 24, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>{p.name}</div>
+              <div style={{ fontSize: 15, color: "#9CA3AF", marginBottom: 8 }}>{p.jobTitle}</div>
+              <Badge style={{ background: `${COLOR}15`, color: COLOR, border: `1px solid ${COLOR}30`, fontSize: 12 }}>{p.sector}</Badge>
+            </div>
+            <div style={{ display: "flex", gap: 10 }}>
+              <button style={{ padding: "10px 20px", borderRadius: 10, background: COLOR, border: "none", color: "#fff", fontWeight: 700, fontSize: 14, cursor: "pointer" }}>Book Session</button>
+              <button style={{ padding: "10px 20px", borderRadius: 10, background: "rgba(255,255,255,0.05)", border: `1px solid ${COLOR}35`, color: COLOR, fontWeight: 600, fontSize: 14, cursor: "pointer" }}>Message</button>
+            </div>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr", gap: 20 }}>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 12 }}>Specializations</div>
+              {p.skills.length > 0 ? (
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 24 }}>
+                  {p.skills.map((s) => (
+                    <Badge key={s} style={{ background: `${COLOR}15`, color: COLOR, border: `1px solid ${COLOR}30`, fontSize: 13, padding: "5px 12px" }}>{s}</Badge>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ fontSize: 13, color: "#4B5563", marginBottom: 24 }}>No skills listed yet.</div>
+              )}
+              <div style={{ fontSize: 14, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 12 }}>Reviews</div>
+              <div style={{ padding: "20px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)", color: "#4B5563", fontSize: 13, textAlign: "center" }}>
+                No reviews yet.
+              </div>
+            </div>
+            <div>
+              <div style={{ padding: "20px", borderRadius: 16, background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)", marginBottom: 16 }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: "#9CA3AF", marginBottom: 12, textTransform: "uppercase", letterSpacing: "0.08em" }}>Availability</div>
+                {["Mon – Fri", "By appointment", "Accepts Service Credits ✓"].map((line) => (
+                  <div key={line} style={{ fontSize: 13, color: "#E8EAF0", marginBottom: 6 }}>{line}</div>
+                ))}
+              </div>
+              <div style={{ padding: "20px", borderRadius: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, marginBottom: 8 }}>GetStream Chat</div>
+                <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>All messages are end-to-end encrypted and trauma-informed by design.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/directory/directory-right-panel.tsx
+++ b/ctf/packages/web/components/directory/directory-right-panel.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { CheckCircle, Shield } from "lucide-react";
+import { COLOR, initials, type Member, type Sector } from "./shared";
+
+export function DirectoryRightPanel({
+  members,
+  sectors,
+  activeFilter,
+  loadingMembers,
+  onSelect,
+  onFilter,
+}: {
+  members: Member[];
+  sectors: Sector[];
+  activeFilter: string;
+  loadingMembers: boolean;
+  onSelect: (member: Member) => void;
+  onFilter: (sector: string) => void;
+}) {
+  return (
+    <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", display: "flex", flexDirection: "column", padding: "20px 16px", flexShrink: 0 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Top Providers</div>
+      {members.slice(0, 4).map((p) => (
+        <div key={p.id} onClick={() => onSelect(p)} style={{ display: "flex", gap: 10, alignItems: "center", padding: "10px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}15`, marginBottom: 8, cursor: "pointer" }}>
+          <Avatar style={{ width: 36, height: 36 }}>
+            <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 14, fontWeight: 700 }}>{initials(p.name)}</AvatarFallback>
+          </Avatar>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
+            <div style={{ fontSize: 11, color: "#6B7280", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.jobTitle}</div>
+          </div>
+          <CheckCircle size={12} style={{ color: COLOR, flexShrink: 0 }} />
+        </div>
+      ))}
+      {members.length === 0 && !loadingMembers && (
+        <div style={{ fontSize: 12, color: "#4B5563", textAlign: "center", padding: "16px 0" }}>No providers loaded yet.</div>
+      )}
+
+      <div style={{ marginTop: 16, padding: "16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+          <Shield size={14} style={{ color: COLOR }} />
+          <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Privacy Guarantee</span>
+        </div>
+        <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Your identity is protected. All interactions use encrypted channels.</div>
+      </div>
+
+      {sectors.length > 0 && (
+        <div style={{ marginTop: 12, padding: "16px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Sectors</div>
+          {sectors.slice(0, 5).map((s) => (
+            <div key={s.id} onClick={() => onFilter(s.name)} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "6px 0", cursor: "pointer" }}>
+              <span style={{ fontSize: 12, color: activeFilter === s.name ? COLOR : "#9CA3AF" }}>{s.name}</span>
+              {activeFilter === s.name && <CheckCircle size={11} style={{ color: COLOR }} />}
+            </div>
+          ))}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -4,21 +4,13 @@ import { useEffect, useRef, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import {
-  BookOpen, Search, MessageSquare, Users, ChevronRight,
-  CheckCircle, Shield, Bell, Settings, Send, Plus, ArrowUpRight,
-} from "lucide-react";
-
-const COLOR = "#3B82F6";
-const SKILLS_HUNT_COLOR = "#A855F7";
-
-type SkillsHuntRewardCard = {
-  title: string;
-  description: string;
-  ctaLabel: string;
-  ctaUrl: string;
-  isActive: boolean;
-};
+import { BookOpen, Search, MessageSquare, Users, Bell, Settings } from "lucide-react";
+import { BG, COLOR, type Member, type Sector, type SkillsHuntRewardCard } from "./shared";
+import { DirectoryProfileDetail } from "./directory-profile-detail";
+import { DirectoryLoadingSkeleton } from "./directory-loading-skeleton";
+import { DirectoryBrowse } from "./directory-browse";
+import { DirectoryChatTab } from "./directory-chat-tab";
+import { DirectoryRightPanel } from "./directory-right-panel";
 
 const DEFAULT_REWARD_CARD: SkillsHuntRewardCard = {
   title: "Help grow the Directory",
@@ -28,31 +20,9 @@ const DEFAULT_REWARD_CARD: SkillsHuntRewardCard = {
   isActive: true,
 };
 
-interface Member {
-  id: string;
-  name: string;
-  sector: string;
-  jobTitle: string;
-  skills: string[];
-}
-
-interface Sector {
-  id: string;
-  name: string;
-}
-
 type Tab = "browse" | "chat";
 
-const INFO_MSGS = [
-  { id: 1, text: "Directory connects you with verified providers across the Survivor Hub. Who are you looking for?" },
-  { id: 2, text: "Search by name, sector, or skill. Use the filters on the left to narrow results. All interactions are privacy-first and trauma-informed.", action: "Browse Providers" },
-];
-
-function initials(name: string) {
-  return name.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase();
-}
-
-export function DirectoryShell(_props: { userId?: string; isAdmin?: boolean }) {
+export function DirectoryShell() {
   const [loadingMeta, setLoadingMeta] = useState(true);
   const [loadingMembers, setLoadingMembers] = useState(false);
   const [metaError, setMetaError] = useState<string | null>(null);
@@ -140,88 +110,31 @@ export function DirectoryShell(_props: { userId?: string; isAdmin?: boolean }) {
   ];
 
   const sectorFilters = ["All", ...sectors.map((s) => s.name)];
+  const isFiltered = activeFilter !== "All" || query.trim().length > 0;
+
+  function clearFilters() {
+    setActiveFilter("All");
+    setQuery("");
+  }
 
   if (loadingMeta) {
-    return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0C1A3D", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#6B7280" }}>
-        Loading directory…
-      </div>
-    );
+    return <DirectoryLoadingSkeleton />;
   }
 
   if (metaError) {
     return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0C1A3D", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
+      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
         {metaError}
       </div>
     );
   }
 
   if (selected) {
-    const p = selected;
-    return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0C1A3D", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex", flexDirection: "column" }}>
-        <div style={{ height: 56, borderBottom: `1px solid ${COLOR}25`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <button onClick={() => setSelected(null)} style={{ color: COLOR, background: "none", border: "none", cursor: "pointer", fontSize: 14, display: "flex", alignItems: "center", gap: 6 }}>
-            ← Back
-          </button>
-          <div style={{ flex: 1, fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>Provider Profile</div>
-          <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}40`, fontSize: 11 }}>GetStream ⚡</Badge>
-        </div>
-        <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
-          <div style={{ flex: 1, padding: "32px 40px", overflow: "auto" }}>
-            <div style={{ display: "flex", gap: 24, marginBottom: 32 }}>
-              <Avatar style={{ width: 80, height: 80 }}>
-                <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 28, fontWeight: 800 }}>{initials(p.name)}</AvatarFallback>
-              </Avatar>
-              <div style={{ flex: 1 }}>
-                <div style={{ fontSize: 24, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>{p.name}</div>
-                <div style={{ fontSize: 15, color: "#9CA3AF", marginBottom: 8 }}>{p.jobTitle}</div>
-                <Badge style={{ background: `${COLOR}15`, color: COLOR, border: `1px solid ${COLOR}30`, fontSize: 12 }}>{p.sector}</Badge>
-              </div>
-              <div style={{ display: "flex", gap: 10 }}>
-                <button style={{ padding: "10px 20px", borderRadius: 10, background: COLOR, border: "none", color: "#fff", fontWeight: 700, fontSize: 14, cursor: "pointer" }}>Book Session</button>
-                <button style={{ padding: "10px 20px", borderRadius: 10, background: "rgba(255,255,255,0.05)", border: `1px solid ${COLOR}35`, color: COLOR, fontWeight: 600, fontSize: 14, cursor: "pointer" }}>Message</button>
-              </div>
-            </div>
-            <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr", gap: 20 }}>
-              <div>
-                <div style={{ fontSize: 14, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 12 }}>Specializations</div>
-                {p.skills.length > 0 ? (
-                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 24 }}>
-                    {p.skills.map((s) => (
-                      <Badge key={s} style={{ background: `${COLOR}15`, color: COLOR, border: `1px solid ${COLOR}30`, fontSize: 13, padding: "5px 12px" }}>{s}</Badge>
-                    ))}
-                  </div>
-                ) : (
-                  <div style={{ fontSize: 13, color: "#4B5563", marginBottom: 24 }}>No skills listed yet.</div>
-                )}
-                <div style={{ fontSize: 14, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 12 }}>Reviews</div>
-                <div style={{ padding: "20px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)", color: "#4B5563", fontSize: 13, textAlign: "center" }}>
-                  No reviews yet.
-                </div>
-              </div>
-              <div>
-                <div style={{ padding: "20px", borderRadius: 16, background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)", marginBottom: 16 }}>
-                  <div style={{ fontSize: 13, fontWeight: 700, color: "#9CA3AF", marginBottom: 12, textTransform: "uppercase", letterSpacing: "0.08em" }}>Availability</div>
-                  {["Mon – Fri", "By appointment", "Accepts Service Credits ✓"].map((line) => (
-                    <div key={line} style={{ fontSize: 13, color: "#E8EAF0", marginBottom: 6 }}>{line}</div>
-                  ))}
-                </div>
-                <div style={{ padding: "20px", borderRadius: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-                  <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, marginBottom: 8 }}>GetStream Chat</div>
-                  <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>All messages are end-to-end encrypted and trauma-informed by design.</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
+    return <DirectoryProfileDetail member={selected} onBack={() => setSelected(null)} />;
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0C1A3D", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       {/* Icon rail */}
       <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
         <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
@@ -247,7 +160,7 @@ export function DirectoryShell(_props: { userId?: string; isAdmin?: boolean }) {
       {/* Sidebar */}
       <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
         <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>Directory</div>
+          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>📇 Directory</div>
           <div style={{ position: "relative", marginBottom: 12 }}>
             <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
             <input
@@ -286,7 +199,7 @@ export function DirectoryShell(_props: { userId?: string; isAdmin?: boolean }) {
         <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
           <BookOpen size={18} style={{ color: COLOR }} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Directory</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>📇 Directory</div>
             <div style={{ fontSize: 12, color: "#6B7280" }}>Verified providers · Trauma-informed · Safe</div>
           </div>
           <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
@@ -294,162 +207,34 @@ export function DirectoryShell(_props: { userId?: string; isAdmin?: boolean }) {
           </Badge>
         </header>
 
-        {tab === "browse" && (
-          <ScrollArea style={{ flex: 1 }}>
-            <div style={{ padding: "24px" }}>
-              {rewardCard && rewardCard.isActive && (
-                <a href={rewardCard.ctaUrl} style={{ display: "block", marginBottom: 16, padding: "18px 22px", borderRadius: 14, background: `${SKILLS_HUNT_COLOR}10`, border: `1px solid ${SKILLS_HUNT_COLOR}30`, textDecoration: "none", color: "inherit" }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-                    <div style={{ width: 44, height: 44, borderRadius: 12, background: `${SKILLS_HUNT_COLOR}25`, border: `1px solid ${SKILLS_HUNT_COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-                      <Search size={20} style={{ color: SKILLS_HUNT_COLOR }} />
-                    </div>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: 14, fontWeight: 700, color: SKILLS_HUNT_COLOR, marginBottom: 2 }}>{rewardCard.title}</div>
-                      <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.5 }}>{rewardCard.description}</div>
-                    </div>
-                    <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 14px", borderRadius: 10, background: SKILLS_HUNT_COLOR, color: "#fff", fontSize: 13, fontWeight: 700, flexShrink: 0 }}>
-                      {rewardCard.ctaLabel} <ArrowUpRight size={14} />
-                    </div>
-                  </div>
-                </a>
-              )}
-              <div style={{ marginBottom: 20, padding: "20px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}20 0%,rgba(14,165,233,0.1) 100%)`, border: `1px solid ${COLOR}25` }}>
-                <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Find Your Support Network</div>
-                <div style={{ fontSize: 14, color: "#9CA3AF" }}>Verified trauma-informed providers · Trusted · Privacy-first</div>
-              </div>
-
-              {loadingMembers ? (
-                <div style={{ padding: "48px", textAlign: "center", color: "#6B7280", fontSize: 14 }}>Loading providers…</div>
-              ) : members.length === 0 ? (
-                <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-                  <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(59,130,246,0.3)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                    <Users size={20} style={{ color: "rgba(59,130,246,0.4)" }} />
-                  </div>
-                  <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No providers found</div>
-                  <div style={{ fontSize: 13, color: "#4B5563" }}>Try adjusting your search or filters.</div>
-                </div>
-              ) : (
-                <div style={{ display: "grid", gridTemplateColumns: "repeat(2,1fr)", gap: 14 }}>
-                  {members.map((p) => (
-                    <div key={p.id} onClick={() => setSelected(p)} style={{ padding: "20px", borderRadius: 16, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}20`, cursor: "pointer" }}>
-                      <div style={{ display: "flex", gap: 14, marginBottom: 14, alignItems: "flex-start" }}>
-                        <Avatar style={{ width: 48, height: 48, flexShrink: 0 }}>
-                          <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 18, fontWeight: 800 }}>{initials(p.name)}</AvatarFallback>
-                        </Avatar>
-                        <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
-                            <div style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
-                            <CheckCircle size={14} style={{ color: COLOR, flexShrink: 0 }} />
-                          </div>
-                          <div style={{ fontSize: 12, color: "#9CA3AF", marginBottom: 4 }}>{p.jobTitle}</div>
-                          <Badge style={{ background: `${COLOR}10`, color: COLOR, border: `1px solid ${COLOR}25`, fontSize: 11 }}>{p.sector}</Badge>
-                        </div>
-                      </div>
-                      {p.skills.length > 0 && (
-                        <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 14 }}>
-                          {p.skills.slice(0, 3).map((s) => (
-                            <Badge key={s} style={{ background: `${COLOR}10`, color: COLOR, border: `1px solid ${COLOR}25`, fontSize: 11 }}>{s}</Badge>
-                          ))}
-                        </div>
-                      )}
-                      <div style={{ display: "flex", gap: 8 }}>
-                        <button style={{ flex: 1, padding: "8px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 4 }}>
-                          View Profile <ChevronRight size={12} />
-                        </button>
-                        <button style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", color: "#9CA3AF", fontSize: 12, cursor: "pointer", display: "flex", alignItems: "center", gap: 4 }}>
-                          <MessageSquare size={12} />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </ScrollArea>
-        )}
-
-        {tab === "chat" && (
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
-            <ScrollArea style={{ flex: 1, padding: "16px 24px" }}>
-              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                {INFO_MSGS.map((msg) => (
-                  <div key={msg.id} style={{ display: "flex", gap: 10, alignItems: "flex-end" }}>
-                    <div style={{ width: 32, height: 32, borderRadius: 10, background: `${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-                      <BookOpen size={14} style={{ color: COLOR }} />
-                    </div>
-                    <div style={{ maxWidth: "70%", display: "flex", flexDirection: "column", gap: 6 }}>
-                      <div style={{ padding: "12px 16px", borderRadius: "16px 16px 16px 4px", background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.06)", fontSize: 14, lineHeight: 1.6, color: "#E8EAF0" }}>
-                        {msg.text}
-                      </div>
-                      {msg.action && (
-                        <button onClick={() => setTab("browse")} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", alignSelf: "flex-start" }}>
-                          {msg.action} <ArrowUpRight size={13} />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </ScrollArea>
-            <div style={{ padding: "8px 24px 20px", flexShrink: 0, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 14 }}>
-                <Plus size={18} style={{ color: "#4B5563", flexShrink: 0 }} />
-                <input
-                  value={chatInput}
-                  onChange={(e) => setChatInput(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") setChatInput(""); }}
-                  placeholder="Find providers, ask questions…"
-                  style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: "#E8EAF0" }}
-                />
-                <button onClick={() => setChatInput("")} style={{ width: 32, height: 32, borderRadius: 8, background: chatInput.trim() ? COLOR : "rgba(255,255,255,0.06)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0 }}>
-                  <Send size={14} style={{ color: chatInput.trim() ? "#fff" : "#4B5563" }} />
-                </button>
-              </div>
-              <div style={{ textAlign: "center", fontSize: 11, color: "#374151", marginTop: 8 }}>Privacy-first · Trauma-informed design</div>
-            </div>
-          </div>
+        {tab === "browse" ? (
+          <DirectoryBrowse
+            rewardCard={rewardCard}
+            loadingMembers={loadingMembers}
+            members={members}
+            categories={sectors.map((s) => s.name)}
+            filtered={isFiltered}
+            onSelect={setSelected}
+            onClearFilters={clearFilters}
+          />
+        ) : (
+          <DirectoryChatTab
+            chatInput={chatInput}
+            onChatInputChange={setChatInput}
+            onBrowse={() => setTab("browse")}
+          />
         )}
       </div>
 
       {/* Right panel */}
-      <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", display: "flex", flexDirection: "column", padding: "20px 16px", flexShrink: 0 }}>
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Top Providers</div>
-        {members.slice(0, 4).map((p) => (
-          <div key={p.id} onClick={() => setSelected(p)} style={{ display: "flex", gap: 10, alignItems: "center", padding: "10px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}15`, marginBottom: 8, cursor: "pointer" }}>
-            <Avatar style={{ width: 36, height: 36 }}>
-              <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 14, fontWeight: 700 }}>{initials(p.name)}</AvatarFallback>
-            </Avatar>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
-              <div style={{ fontSize: 11, color: "#6B7280", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.jobTitle}</div>
-            </div>
-            <CheckCircle size={12} style={{ color: COLOR, flexShrink: 0 }} />
-          </div>
-        ))}
-        {members.length === 0 && !loadingMembers && (
-          <div style={{ fontSize: 12, color: "#4B5563", textAlign: "center", padding: "16px 0" }}>No providers loaded yet.</div>
-        )}
-
-        <div style={{ marginTop: 16, padding: "16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
-            <Shield size={14} style={{ color: COLOR }} />
-            <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Privacy Guarantee</span>
-          </div>
-          <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Your identity is protected. All interactions use encrypted channels.</div>
-        </div>
-
-        {sectors.length > 0 && (
-          <div style={{ marginTop: 12, padding: "16px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
-            <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Sectors</div>
-            {sectors.slice(0, 5).map((s) => (
-              <div key={s.id} onClick={() => setActiveFilter(s.name)} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "6px 0", cursor: "pointer" }}>
-                <span style={{ fontSize: 12, color: activeFilter === s.name ? COLOR : "#9CA3AF" }}>{s.name}</span>
-                {activeFilter === s.name && <CheckCircle size={11} style={{ color: COLOR }} />}
-              </div>
-            ))}
-          </div>
-        )}
-      </aside>
+      <DirectoryRightPanel
+        members={members}
+        sectors={sectors}
+        activeFilter={activeFilter}
+        loadingMembers={loadingMembers}
+        onSelect={setSelected}
+        onFilter={setActiveFilter}
+      />
     </div>
   );
 }

--- a/ctf/packages/web/components/directory/shared.ts
+++ b/ctf/packages/web/components/directory/shared.ts
@@ -1,0 +1,38 @@
+// Shared constants, types, and helpers for the Directory web shell.
+// Palette and layout derive from design/.../survivor-hub/Directory.tsx.
+
+export const COLOR = "#3B82F6";
+export const SKILLS_HUNT_COLOR = "#A855F7";
+// App surface background as rendered by the mockup (the mockup's `BG`
+// constant is dead code; every rendered surface uses #0F1117).
+export const BG = "#0F1117";
+
+export interface Member {
+  id: string;
+  name: string;
+  sector: string;
+  jobTitle: string;
+  skills: string[];
+}
+
+export interface Sector {
+  id: string;
+  name: string;
+}
+
+export interface SkillsHuntRewardCard {
+  title: string;
+  description: string;
+  ctaLabel: string;
+  ctaUrl: string;
+  isActive: boolean;
+}
+
+export function initials(name: string): string {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}


### PR DESCRIPTION
## Summary

UI circle-back for the **directory** plugin (web), continuing the per-plugin pixel-perfect pass tracked in [PRODUCTION_READINESS_PLAN.md](ctf/docs/developer/PRODUCTION_READINESS_PLAN.md) and umbrella PR #119.

`DirectoryShell` was already structurally faithful to `design/.../survivor-hub/Directory.tsx` (blue `#3B82F6` palette, icon rail + sidebar + browse grid + chat + right panel, lucide icons, profile detail). This pass closes the remaining fidelity gaps and resolves a pre-existing modularity violation.

## Changes

Pixel fidelity (vs. `Directory.tsx` / `DirectoryLoading.tsx` / `DirectoryEmpty.tsx`):
- **App-surface background → `#0F1117`.** The shell rendered `#0C1A3D` — the mockup's *dead* `BG` constant; every rendered surface in the mockup actually uses `#0F1117`.
- **Loading state** now renders the skeleton layout from `DirectoryLoading.tsx` (was a plain "Loading…" line).
- **Empty state** rebuilt to the mockup's category-grid + "Browse All Providers / Clear Filters" treatment, driven by **real sector data** (no dummy counts — per the project rule that mockup counts are dummy).
- Restored the `📇` heading glyphs the mockup uses.

Modularity (rule 116):
- The single-function shell was a pre-existing violation (**382 lines, complexity 16**; only uncaught because the gate runs on changed files). Decomposed into `directory-profile-detail`, `directory-browse`, `directory-chat-tab`, `directory-right-panel`, `directory-loading-skeleton`, `directory-empty-state`, and a `shared` module. Every unit now passes `max-lines-per-function:200` / `complexity:10`.
- Removed the unused `userId`/`isAdmin` props (cleared a `no-unused-vars` error) and updated the route call site.

API wiring (`/api/directory/sectors`, `/api/directory/list`, `/api/skills-hunt/feature-reward-card`) is unchanged.

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- `pnpm --filter @ctf/web lint components/directory/` — green
- Modularity gate (`complexity:10`, `max-lines-per-function:200`) on all new/changed directory files — green
- `pnpm --filter @ctf/web build:ci` — green (full route manifest built)
- `check-eof-format.sh`, `check-web-android-parity.mjs`, `check-schema-drift.sh` — green

Note: the modularity gate still reports a pre-existing complexity-23 violation in `app/apps/[pluginSlug]/page.tsx` (the plugin router); this PR only removed two props from one line and did not change its complexity. Refactoring that router is out of scope.

## Scope

Web-only pixel pass + refactor. Directory already ships functional web+android parity; the Android **pixel** pass (`MobileDirectory.tsx` → React Native feature) is deferred and tracked in the plan.

Parity Ticket: #119


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_