### PR TITLE
ci: disable in-app feed product-update step until announcements ship

### DIFF
--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -103,12 +103,14 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       # ── Feed (in-app) ─────────────────────────────────────────────────────────
-      - name: Post to in-app feed
-        env:
-          UPDATE_JSON: ${{ steps.content.outputs.json }}
-          # APP_URL and INTERNAL_SERVICE_SECRET are injected into the job env by
-          # the Infisical step above — Infisical is the single source of truth.
-        run: node ctf/scripts/publish-product-update.mjs
+      # DISABLED: the in-app feed/announcements feature is still in final
+      # validation and not ready to receive product updates. Re-enable this step
+      # once the announcements backend is live. (APP_URL and INTERNAL_SERVICE_SECRET
+      # are injected by the Infisical step above when this runs again.)
+      # - name: Post to in-app feed
+      #   env:
+      #     UPDATE_JSON: ${{ steps.content.outputs.json }}
+      #   run: node ctf/scripts/publish-product-update.mjs
 
       # ── GitHub wiki page ──────────────────────────────────────────────────────
       - name: Create GitHub wiki page


### PR DESCRIPTION
## What & Why

The `env-slug: prod` fix worked — the latest scheduled run injected all Infisical secrets and reached the in-app feed endpoint. It then failed with:

```
Feed post failed: 503 {"error":"Failed to publish",
"detail":"null value in column \"content\" of relation \"announcements\" violates not-null constraint"}
```

Per the owner, the in-app **feed/announcements** feature is still in final validation and not ready to receive product updates yet (hence the schema mid-change). So this is expected, not a bug to fix in this PR.

## Change

Comment out **only** the `Post to in-app feed` step. Everything else stays active:

- ✅ Generate update content via Claude
- ✅ Create GitHub wiki page
- ✅ Publish to wiki-site blog registry
- ✅ Create Quora draft issue
- ✅ Tag this update

No changes to `publish-product-update.mjs`, the API route, or `schema.sql`. The step is left as a commented block with a note so it can be re-enabled once the announcements backend ships.

## Testing

- Workflow YAML parses cleanly; confirmed the active step list no longer includes the feed step.
- Single trailing newline.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_