### PR TITLE
feat: reconcile chyme + directory copy to design-sync c5d83c0 (remove GetStream)

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -384,3 +384,11 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   also removed the unused `userId`/`isAdmin` props. API wiring untouched; typecheck, lint, modularity,
   build:ci, EOF, parity, and schema-drift gates green. Marked directory Web px ✅; Android pixel parity
   (`MobileDirectory.tsx` → RN feature) remains ⬜.
+- 2026-05-29: Design re-pin `dcaaf15` → `c5d83c0` (76 commits; separate design-sync PR) + copy
+  reconcile. The newer design removed all user-facing "GetStream" wording and added mockups for the
+  four previously design-gated plugins (skills-taxonomy, weekly-performance, clicklog, unlock). Began
+  reconciling the shipped shells to the new copy: chyme and directory (this PR) and lighthouse (folded
+  into its open PR) drop "GetStream" branding for "end-to-end encrypted" wording; Directory's detail
+  "Reviews" → "Endorsements". Copy-only; no structural/API changes. Follow-up: `ChymeLiveShell` remains
+  a pre-existing rule-116 violation (359 lines / complexity 40) not introduced here — a chyme
+  modularity decomposition (matching the directory/lighthouse pattern) is tracked next.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-feature-inventory.md
@@ -107,6 +107,7 @@ Current status:
 
 ## Change Log
 
+- 2026-05-29: Design-sync reconcile to `c5d83c0`. Removed user-facing "GetStream" wording from `chyme-live-shell`: "Social Audio · GetStream Powered" → "Social Audio · End-to-End Encrypted", the chat "GetStream" badge → "Encrypted", and "Audio via GetStream" → "Audio — encrypted". Copy-only.
 - 2026-05-29: Web UI circle-back. Aligned `chyme-live-shell` to the `Chyme.tsx` mockup by replacing emoji glyphs with the mockup's lucide-react icons (Radio, Mic/MicOff, Hand, Phone, MessageSquare, Hash, Send, Volume2, Users, Lock, RefreshCw); structure and palette already matched. API wiring unchanged.
 - 2026-05-17: Updated inventory to enforce Rule 120 living-snapshot model. Removed Phase language (Delivery Phasing section); confirmed implementation is complete across web and Android. Renamed section to "Gaps and Known Technical Debt" (Rule 120 format).
 - 2026-04-05: Completed Android parity on the real Chyme API surface, queued Service Credits reclaim dependency on full-account delete, and aligned Chyme docs to `ctf/schema.sql` plus shared Stream wrappers.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-directory-feature-inventory.md
@@ -113,6 +113,7 @@ Seeded content:
 
 ## Change Log
 
+- 2026-05-29: Design-sync reconcile to `c5d83c0`. Removed user-facing "GetStream" wording from the profile detail (dropped the badge; "GetStream Chat" → "Encrypted Chat") and right panel ("All interactions are end-to-end encrypted"); renamed the detail "Reviews" section to "Endorsements" per the revised mockup. Copy-only.
 - 2026-05-29: Web UI circle-back. Aligned `DirectoryShell` to the `Directory.tsx` mockup and its Loading/Empty states; corrected the app surface background to `#0F1117`, added the skeleton loading state and the mockup's empty-state category grid (real sector data), and restored the `📇` heading glyphs. Decomposed the previously oversized shell into modular sub-components to satisfy rule-116 limits and removed the unused `userId`/`isAdmin` props (cleared a lint error). API wiring unchanged.
 - 2026-05-17: Updated inventory to enforce Rule 120 living-snapshot model. Removed Phase language, Planned section headers, and planning-phase ambiguities list. Confirmed web+android complete delivery status. Clarified technical debt (skills compatibility, route ownership codification) as known limitations, not unimplemented features.
 - 2026-03-02: Implemented backend and unified web surface (user/admin role-gated sections) with resolved list/pagination/claimed-delete decisions.

--- a/ctf/packages/web/components/chyme/chyme-live-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-live-shell.tsx
@@ -180,7 +180,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
           </div>
           <div>
             <div style={{ fontSize: 17, fontWeight: 800, color: '#F0FDF4' }}>Chyme 🎙️</div>
-            <div style={{ fontSize: 12, color: '#16A34A' }}>Social Audio · GetStream Powered</div>
+            <div style={{ fontSize: 12, color: '#16A34A' }}>Social Audio · End-to-End Encrypted</div>
           </div>
         </div>
         <div style={{ flex: 1 }} />
@@ -362,7 +362,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
                     <div style={{ padding: '14px 16px', borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', gap: 8 }}>
                       <Hash size={14} style={{ color: PRIMARY }} />
                       <span style={{ fontSize: 14, fontWeight: 600, color: '#F0FDF4' }}>Room Chat</span>
-                      <span style={{ marginLeft: 'auto', background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}25`, fontSize: 10, padding: '2px 8px', borderRadius: 12 }}>GetStream</span>
+                      <span style={{ marginLeft: 'auto', background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}25`, fontSize: 10, padding: '2px 8px', borderRadius: 12 }}>Encrypted</span>
                     </div>
                     <div style={{ flex: 1, overflowY: 'auto', padding: '12px 14px' }}>
                       {messages.length === 0 ? (
@@ -420,7 +420,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
                 </button>
                 <div style={{ flex: 1 }} />
                 <div style={{ fontSize: 12, color: '#4B5563', display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <Volume2 size={14} /> Audio via GetStream
+                  <Volume2 size={14} /> Audio — encrypted
                 </div>
                 {joinState === 'ready' && (
                   <button

--- a/ctf/packages/web/components/directory/directory-profile-detail.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-detail.tsx
@@ -13,7 +13,6 @@ export function DirectoryProfileDetail({ member, onBack }: { member: Member; onB
           ← Back
         </button>
         <div style={{ flex: 1, fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>📇 Provider Profile</div>
-        <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}40`, fontSize: 11 }}>GetStream ⚡</Badge>
       </div>
       <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
         <div style={{ flex: 1, padding: "32px 40px", overflow: "auto" }}>
@@ -43,9 +42,9 @@ export function DirectoryProfileDetail({ member, onBack }: { member: Member; onB
               ) : (
                 <div style={{ fontSize: 13, color: "#4B5563", marginBottom: 24 }}>No skills listed yet.</div>
               )}
-              <div style={{ fontSize: 14, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 12 }}>Reviews</div>
+              <div style={{ fontSize: 14, fontWeight: 700, color: "#9CA3AF", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 12 }}>Endorsements</div>
               <div style={{ padding: "20px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)", color: "#4B5563", fontSize: 13, textAlign: "center" }}>
-                No reviews yet.
+                No endorsements yet.
               </div>
             </div>
             <div>
@@ -56,7 +55,7 @@ export function DirectoryProfileDetail({ member, onBack }: { member: Member; onB
                 ))}
               </div>
               <div style={{ padding: "20px", borderRadius: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, marginBottom: 8 }}>GetStream Chat</div>
+                <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, marginBottom: 8 }}>Encrypted Chat</div>
                 <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>All messages are end-to-end encrypted and trauma-informed by design.</div>
               </div>
             </div>

--- a/ctf/packages/web/components/directory/directory-right-panel.tsx
+++ b/ctf/packages/web/components/directory/directory-right-panel.tsx
@@ -43,7 +43,7 @@ export function DirectoryRightPanel({
           <Shield size={14} style={{ color: COLOR }} />
           <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Privacy Guarantee</span>
         </div>
-        <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Your identity is protected. All interactions use encrypted channels.</div>
+        <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Your identity is protected. All interactions are end-to-end encrypted.</div>
       </div>
 
       {sectors.length > 0 && (


### PR DESCRIPTION
## Summary

Reconciles the two already-shipped shells (**chyme**, **directory**) to the revised mockups at design SHA `c5d83c0` (the design sync in #137). The newer design removed all user-facing "GetStream" wording across the survivor-hub plugins; this PR brings the production copy in line. Copy-only — no structural or API changes.

(Lighthouse is reconciled on its own open PR #136; this PR covers the two plugins already on `main`.)

## Changes

**chyme** (`chyme-live-shell`):
- "Social Audio · GetStream Powered" → "Social Audio · End-to-End Encrypted"
- chat "GetStream" badge → "Encrypted"
- "Audio via GetStream" → "Audio — encrypted"

**directory**:
- profile detail: drop the "GetStream ⚡" badge; "GetStream Chat" → "Encrypted Chat"; rename the "Reviews" section → "Endorsements" (per the revised mockup).
- right panel: "All interactions use encrypted channels" → "All interactions are end-to-end encrypted".

Inventories (chyme, directory) and `PRODUCTION_READINESS_PLAN.md` updated.

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- Modularity gate on the touched directory files — green
- `check-eof-format.sh` — green

Note: `ChymeLiveShell` remains a **pre-existing** rule-116 violation (359 lines / complexity 40) from the backend pass. This 3-line copy change neither introduces nor worsens it; a chyme modularity decomposition (matching the directory/lighthouse pattern) is tracked as the next follow-up.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_