### PR TITLE
ci: init only wiki-site submodule for blog Pages deploy

### DIFF
--- a/.github/workflows/deploy-blog-gh-pages.yml
+++ b/.github/workflows/deploy-blog-gh-pages.yml
@@ -26,14 +26,20 @@ jobs:
         working-directory: wiki-site/wiki-blog
 
     steps:
-      # submodules: true fetches the wiki-site submodule (which contains the
-      # blog). It deliberately does NOT recurse: the blog build reads the
-      # already-committed articles.ts and fetches wiki markdown at runtime, so
-      # wiki-site's own nested submodules (wiki, design/mockups) are not needed.
+      # Check out WITHOUT submodules, then init only the wiki-site submodule.
+      # submodules: true would init every sibling submodule (ctf-v2-deprecated,
+      # landing-page, etc.) — unnecessary here, and some have broken/unreachable
+      # pinned refs that fail the whole checkout. We only need wiki-site, and not
+      # recursively: the blog build reads the committed articles.ts and fetches
+      # wiki markdown at runtime, so wiki-site's nested submodules aren't needed.
       # Content validation / articles.ts sync are enforced by wiki-site's own CI.
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
+
+      - name: Check out wiki-site submodule only
+        working-directory: ${{ github.workspace }}
+        run: git submodule update --init wiki-site
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Problem

After #138, the deploy ran but **failed at checkout**. `submodules: true` makes `actions/checkout` initialize **every** submodule in the repo (`ctf-v2-deprecated`, `design`, `landing-page`, `waitlist-landing-page`, `wiki`, `wiki-site`). That's both unnecessary — we only need `wiki-site` — and fatal, because a sibling submodule has an unreachable pinned ref:

```
fatal: remote error: upload-pack: not our ref c71b5c8...
Fetched in submodule path 'landing-page', but it did not contain c71b5c8...
The process '/usr/bin/git' failed with exit code 128
```

## Fix

- `actions/checkout` with **`submodules: false`**.
- A follow-up step inits **only** `wiki-site` (non-recursive), run at the workspace root: `git submodule update --init wiki-site`.

The blog build needs only `wiki-site/wiki-blog`'s committed `articles.ts` and fetches wiki markdown at runtime, so no other submodule — sibling or nested — is required.

## Testing

- `deploy-blog-gh-pages.yml` parses cleanly (`yaml.safe_load`).
- The build itself was already verified locally in #138 (`pnpm blog:build:pages` → `dist/public/index.html` + `404.html`, `BASE_PATH=/chargingthefuture/`); this PR only changes how the single submodule is fetched.

## After merge
Trigger **Actions → Deploy Blog to GitHub Pages → Run workflow** to publish immediately, or it auto-deploys on the next `main` push touching `wiki-site/**`.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_