### PR TITLE
ci: publish product updates to live wiki-site blog and auto-deploy

### DIFF
--- a/.github/workflows/deploy-blog-gh-pages.yml
+++ b/.github/workflows/deploy-blog-gh-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "wiki-site"          # submodule pointer bump (gitlink path)
       - "wiki-site/**"
       - ".github/workflows/deploy-blog-gh-pages.yml"
   workflow_dispatch:

--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -134,6 +134,9 @@ jobs:
           git push
 
       # ── Blog registry (wiki-site) ─────────────────────────────────────────────
+      # Adds the update to the wiki-site blog (category "Updates") and bumps the
+      # wiki-site submodule pointer in THIS repo so deploy-blog-gh-pages.yml
+      # rebuilds and publishes the post to the live site.
       - name: Publish to wiki-site blog registry
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -143,13 +146,17 @@ jobs:
 
           SLUG=$(echo "$UPDATE_JSON"     | jq -r '.wikiPageName')
           TITLE=$(echo "$UPDATE_JSON"    | jq -r '.feedTitle')
-          EXCERPT=$(echo "$UPDATE_JSON"  | jq -r '.excerpt // .feedTitle')
+          EXCERPT=$(echo "$UPDATE_JSON"  | jq -r '.wikiSiteExcerpt // .feedTitle')
           CATEGORY="Updates"
           DATE=$(date +%Y-%m-%d)
 
-          git clone "https://x-access-token:${GH_PAT}@github.com/chargingthefuture/wiki-site.git" /tmp/wiki-site
-          cd /tmp/wiki-site/wiki-site
+          # Clone wiki-site with its nested submodules: blog:sync infers extra
+          # "folder" articles from the nested wiki/ submodule, so it must be
+          # present or sync would drop them from articles.ts.
+          git clone --recurse-submodules \
+            "https://x-access-token:${GH_PAT}@github.com/chargingthefuture/wiki-site.git" /tmp/wiki-site
 
+          cd /tmp/wiki-site/wiki-blog
           SLUG="$SLUG" TITLE="$TITLE" EXCERPT="$EXCERPT" CATEGORY="$CATEGORY" DATE="$DATE" \
           yq -i '.articles += [{
             "slug": strenv(SLUG), "title": strenv(TITLE),
@@ -160,15 +167,38 @@ jobs:
 
           corepack enable
           pnpm install --frozen-lockfile
-          pnpm wiki:validate
-          pnpm wiki:sync
+          pnpm blog:validate
+          pnpm blog:sync
 
           cd /tmp/wiki-site
           git config user.name  "CTF CI Bot"
           git config user.email "ci@chargingthefuture.org"
-          git add wiki-site/content-index.yaml wiki-site/artifacts/wiki/src/lib/articles.ts
-          git commit -m "feat(blog): publish ${DATE} product update — ${SLUG}" || { echo "no changes"; exit 0; }
-          git push
+          git add wiki-blog/content-index.yaml wiki-blog/artifacts/blog/src/lib/articles.ts
+          if git commit -m "feat(blog): publish ${DATE} product update — ${SLUG}"; then
+            git push
+            WIKI_SITE_SHA=$(git rev-parse HEAD)
+          else
+            echo "No content-index changes; skipping wiki-site push."
+            WIKI_SITE_SHA=""
+          fi
+
+          # Bump the wiki-site submodule pointer in this repo so the Pages deploy
+          # rebuilds from the new content. deploy-blog-gh-pages.yml triggers on
+          # changes to the "wiki-site" gitlink (see its paths filter).
+          if [ -n "$WIKI_SITE_SHA" ]; then
+            cd "$GITHUB_WORKSPACE"
+            git submodule update --init wiki-site
+            git -C wiki-site fetch origin
+            git -C wiki-site checkout "$WIKI_SITE_SHA"
+            git config user.name  "CTF CI Bot"
+            git config user.email "ci@chargingthefuture.org"
+            git add wiki-site
+            git commit -m "chore(blog): bump wiki-site to publish ${DATE} update — ${SLUG}"
+            # Push with GH_PAT (not GITHUB_TOKEN) so deploy-blog-gh-pages.yml is
+            # triggered — pushes authored by GITHUB_TOKEN do not start workflows.
+            git push "https://x-access-token:${GH_PAT}@github.com/chargingthefuture/chargingthefuture.git" \
+              "HEAD:${GITHUB_REF_NAME}"
+          fi
 
       # ── Quora draft issue ─────────────────────────────────────────────────────
       - name: Create Quora draft issue


### PR DESCRIPTION
## Context

The Pages site is live (✅ both deploy runs succeeded). Two follow-ups from the owner:

1. Product-update posts should be labeled **"Updates"** on wiki-site → **already correct** (the step hardcodes `CATEGORY="Updates"`, and the live site shows posts under the UPDATES tab). No change needed for the label itself.
2. **New product updates don't reach the live site** → real bug, fixed here.
3. `blog-validate.yml` "needed?" → **No.** It was removed in #138 and won't run again; the Actions page just retains its history. (No change in this PR.)

## Root cause

The `Publish to wiki-site blog registry` step in `generate-product-update.yml` was written for an **old wiki-site layout** and is broken against the current repo (verified against the live `wiki-site` submodule):

| Step did | Reality today |
|---|---|
| `cd /tmp/wiki-site/wiki-site` + root `content-index.yaml` | No nested `wiki-site/` dir; content is at `wiki-blog/content-index.yaml` |
| `pnpm wiki:validate` / `pnpm wiki:sync` | Don't exist — real scripts are `blog:validate` / `blog:sync` in `wiki-blog/` |
| commits `wiki-site/artifacts/wiki/src/lib/articles.ts` | Real path: `wiki-blog/artifacts/blog/src/lib/articles.ts` |
| reads `.excerpt` | `generate-update.mjs` emits **`wikiSiteExcerpt`** → excerpts silently fell back to the title |
| (nothing) | Never bumped the **wiki-site submodule pointer** in this repo, so the Pages deploy (which builds from the pinned submodule) never saw new posts |

## Fix

In `generate-product-update.yml`:
- Target `wiki-blog/` and use the real `blog:validate` / `blog:sync` scripts.
- Use `wikiSiteExcerpt`; keep `category: "Updates"`.
- `git clone --recurse-submodules` for wiki-site — `blog:sync` infers ~26 "folder" articles from the nested `wiki/` submodule; without it those would be dropped from `articles.ts` (verified locally).
- After pushing to wiki-site, **bump the wiki-site submodule pointer** in this repo and push it with **`GH_PAT`** (not `GITHUB_TOKEN`, which wouldn't trigger CI) so `deploy-blog-gh-pages.yml` rebuilds and the post goes live automatically.

In `deploy-blog-gh-pages.yml`:
- Add the `wiki-site` **gitlink** path to the `paths` filter so a submodule-pointer bump actually triggers the deploy (`wiki-site/**` does not match the gitlink itself).

## Testing

- Both workflow YAMLs parse cleanly (`yaml.safe_load`); single trailing newline.
- Verified against the checked-out `wiki-site` submodule: content at `wiki-blog/`, scripts `blog:validate`/`blog:sync`, articles at `wiki-blog/artifacts/blog/src/lib/articles.ts`, and that `blog:sync` needs the nested `wiki` submodule (else 26 entries dropped).
- End-to-end runs on schedule/`workflow_dispatch` only (not on PRs), so full verification is a manual `Generate Product Update` run with `force` after merge.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_