### PR TITLE
refactor: decompose ChymeLiveShell into modular sub-components

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -392,3 +392,10 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   "Reviews" → "Endorsements". Copy-only; no structural/API changes. Follow-up: `ChymeLiveShell` remains
   a pre-existing rule-116 violation (359 lines / complexity 40) not introduced here — a chyme
   modularity decomposition (matching the directory/lighthouse pattern) is tracked next.
+- 2026-05-29: Chyme modularity decomposition (the tracked follow-up above). Split the oversized
+  `ChymeLiveShell` (359 lines / complexity 40) into modular sub-components — `chyme-header`,
+  `chyme-sidebar`, `chyme-room-view`, `chyme-stage`, `chyme-chat-panel`, `chyme-controls`, and a
+  `chyme-shared` module — each within the 200-line / complexity-10 limits. No behavior, API, or copy
+  change; data wiring and the c5d83c0 copy are preserved. typecheck, lint, modularity, build:ci, EOF,
+  parity, and schema-drift gates green. All three circle-backed plugins (chyme, directory, lighthouse)
+  now satisfy rule 116.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-chyme-feature-inventory.md
@@ -107,6 +107,7 @@ Current status:
 
 ## Change Log
 
+- 2026-05-29: Modularity refactor. Decomposed the oversized `ChymeLiveShell` (359 lines / complexity 40, a pre-existing rule-116 violation) into modular sub-components (`chyme-header`, `chyme-sidebar`, `chyme-room-view`, `chyme-stage`, `chyme-chat-panel`, `chyme-controls`, `chyme-shared`), each within the 200-line / complexity-10 limits. No behavior, API, or copy change.
 - 2026-05-29: Design-sync reconcile to `c5d83c0`. Removed user-facing "GetStream" wording from `chyme-live-shell`: "Social Audio · GetStream Powered" → "Social Audio · End-to-End Encrypted", the chat "GetStream" badge → "Encrypted", and "Audio via GetStream" → "Audio — encrypted". Copy-only.
 - 2026-05-29: Web UI circle-back. Aligned `chyme-live-shell` to the `Chyme.tsx` mockup by replacing emoji glyphs with the mockup's lucide-react icons (Radio, Mic/MicOff, Hand, Phone, MessageSquare, Hash, Send, Volume2, Users, Lock, RefreshCw); structure and palette already matched. API wiring unchanged.
 - 2026-05-17: Updated inventory to enforce Rule 120 living-snapshot model. Removed Phase language (Delivery Phasing section); confirmed implementation is complete across web and Android. Renamed section to "Gaps and Known Technical Debt" (Rule 120 format).

--- a/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
+++ b/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { Hash, Send } from 'lucide-react';
+import { BORDER, PRIMARY } from './chyme-shared';
+import type { ChymeMessage } from 'lib/chyme/types';
+
+export function ChymeChatPanel({
+  messages,
+  currentUserId,
+  draft,
+  onDraftChange,
+  onSend,
+  sending,
+  messagesEndRef,
+}: {
+  messages: ChymeMessage[];
+  currentUserId: string;
+  draft: string;
+  onDraftChange: (value: string) => void;
+  onSend: () => void;
+  sending: boolean;
+  messagesEndRef: RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <div style={{ width: 300, borderLeft: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', background: '#030d05', flexShrink: 0 }}>
+      <div style={{ padding: '14px 16px', borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <Hash size={14} style={{ color: PRIMARY }} />
+        <span style={{ fontSize: 14, fontWeight: 600, color: '#F0FDF4' }}>Room Chat</span>
+        <span style={{ marginLeft: 'auto', background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}25`, fontSize: 10, padding: '2px 8px', borderRadius: 12 }}>Encrypted</span>
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '12px 14px' }}>
+        {messages.length === 0 ? (
+          <div style={{ color: '#4B5563', fontSize: 13 }}>No messages yet.</div>
+        ) : (
+          messages.map((message) => (
+            <div key={message.id} style={{ marginBottom: 14 }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 2 }}>
+                <span style={{ fontSize: 13, fontWeight: 600, color: message.userId === currentUserId ? PRIMARY : '#A7F3D0' }}>{message.displayName}</span>
+                <span style={{ fontSize: 11, color: '#374151' }}>{new Date(message.sentAtIso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+              </div>
+              <div style={{ fontSize: 13, color: '#9CA3AF', lineHeight: 1.5 }}>{message.text}</div>
+            </div>
+          ))
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+      <div style={{ padding: '10px 14px', borderTop: `1px solid ${BORDER}` }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, borderRadius: 10, padding: '8px 12px' }}>
+          <input
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') onSend(); }}
+            placeholder="Send a message…"
+            style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 13, color: '#E8EAF0' }}
+          />
+          <button
+            onClick={onSend}
+            disabled={sending || !draft.trim()}
+            style={{ width: 28, height: 28, borderRadius: 6, background: draft.trim() ? PRIMARY : 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: draft.trim() ? 'pointer' : 'not-allowed' }}
+          >
+            <Send size={12} style={{ color: draft.trim() ? '#fff' : '#4B5563' }} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/chyme/chyme-controls.tsx
+++ b/ctf/packages/web/components/chyme/chyme-controls.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { Hand, Mic, MicOff, Phone, Volume2 } from 'lucide-react';
+import { BORDER, PRIMARY } from './chyme-shared';
+
+function toggleButtonStyle(active: boolean, activeBg: string, activeBorder: string, activeColor: string): CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '10px 18px',
+    borderRadius: 12,
+    background: active ? activeBg : 'rgba(255,255,255,0.04)',
+    border: `1px solid ${active ? activeBorder : 'rgba(255,255,255,0.08)'}`,
+    color: active ? activeColor : '#9CA3AF',
+    fontSize: 14,
+    fontWeight: 600,
+    cursor: 'pointer',
+  };
+}
+
+export function ChymeControls({
+  muted,
+  onToggleMute,
+  handRaised,
+  onToggleHand,
+  joinReady,
+  onLeave,
+}: {
+  muted: boolean;
+  onToggleMute: () => void;
+  handRaised: boolean;
+  onToggleHand: () => void;
+  joinReady: boolean;
+  onLeave: () => void;
+}) {
+  const muteStyle = muted
+    ? toggleButtonStyle(true, 'rgba(239,68,68,0.15)', 'rgba(239,68,68,0.4)', '#F87171')
+    : toggleButtonStyle(true, `${PRIMARY}18`, `${PRIMARY}40`, PRIMARY);
+  const handStyle = toggleButtonStyle(handRaised, 'rgba(234,179,8,0.15)', 'rgba(234,179,8,0.4)', '#FDE047');
+
+  return (
+    <div style={{ padding: '16px 24px', borderTop: `1px solid ${BORDER}`, background: '#030d05', display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
+      <button onClick={onToggleMute} style={muteStyle}>
+        {muted ? <MicOff size={16} /> : <Mic size={16} />}
+        {muted ? 'Unmute' : 'Mute'}
+      </button>
+      <button onClick={onToggleHand} style={handStyle}>
+        <Hand size={16} />
+        {handRaised ? 'Lower Hand' : 'Raise Hand'}
+      </button>
+      <div style={{ flex: 1 }} />
+      <div style={{ fontSize: 12, color: '#4B5563', display: 'flex', alignItems: 'center', gap: 6 }}>
+        <Volume2 size={14} /> Audio — encrypted
+      </div>
+      {joinReady && (
+        <button
+          onClick={onLeave}
+          style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 18px', borderRadius: 12, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#F87171', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
+        >
+          <Phone size={16} /> Leave
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/chyme/chyme-header.tsx
+++ b/ctf/packages/web/components/chyme/chyme-header.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Radio, RefreshCw } from 'lucide-react';
+import { BORDER, PRIMARY } from './chyme-shared';
+
+export function ChymeHeader({
+  participantCount,
+  isLive,
+  onRefresh,
+}: {
+  participantCount: number;
+  isLive: boolean;
+  onRefresh: () => void;
+}) {
+  return (
+    <header style={{ height: 60, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: '#030d05', flexShrink: 0 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ width: 36, height: 36, borderRadius: 10, background: `${PRIMARY}25`, border: `1px solid ${PRIMARY}40`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <Radio size={18} style={{ color: PRIMARY }} />
+        </div>
+        <div>
+          <div style={{ fontSize: 17, fontWeight: 800, color: '#F0FDF4' }}>Chyme 🎙️</div>
+          <div style={{ fontSize: 12, color: '#16A34A' }}>Social Audio · End-to-End Encrypted</div>
+        </div>
+      </div>
+      <div style={{ flex: 1 }} />
+      {isLive && (
+        <span style={{ background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}30`, fontSize: 11, padding: '4px 12px', borderRadius: 20 }}>
+          🔴 Live
+        </span>
+      )}
+      <span style={{ background: 'rgba(255,255,255,0.05)', color: '#9CA3AF', border: '1px solid rgba(255,255,255,0.08)', fontSize: 11, padding: '4px 12px', borderRadius: 20 }}>
+        {participantCount} Participants
+      </span>
+      <button
+        onClick={onRefresh}
+        style={{ width: 36, height: 36, borderRadius: 10, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: '#6B7280' }}
+        title="Refresh messages"
+      >
+        <RefreshCw size={16} />
+      </button>
+    </header>
+  );
+}

--- a/ctf/packages/web/components/chyme/chyme-live-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-live-shell.tsx
@@ -1,64 +1,17 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import {
-  Hand,
-  Hash,
-  Lock,
-  MessageSquare,
-  Mic,
-  MicOff,
-  Phone,
-  Radio,
-  RefreshCw,
-  Send,
-  Users,
-  Volume2,
-} from 'lucide-react';
-import { StreamVideoPanel } from '../shared/stream-video-panel';
+import { Radio } from 'lucide-react';
+import { DARK_BG, PRIMARY, type CurrentUser, requestJson } from './chyme-shared';
+import { ChymeHeader } from './chyme-header';
+import { ChymeSidebar } from './chyme-sidebar';
+import { ChymeRoomView } from './chyme-room-view';
 import type {
   ChymeDeletionResponse,
   ChymeJoinResponse,
   ChymeMessage,
   ChymeRoomResponse,
 } from 'lib/chyme/types';
-
-type CurrentUser = {
-  userId: string;
-  username: string | null;
-  displayName: string;
-};
-
-type RequestError = {
-  message: string;
-};
-
-async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(url, { cache: 'no-store', ...init });
-  const payload = (await response.json().catch(() => null)) as T | RequestError | null;
-  if (!response.ok) {
-    const message =
-      payload && typeof payload === 'object' && 'message' in payload
-        ? payload.message
-        : 'Request failed.';
-    throw new Error(message);
-  }
-  return payload as T;
-}
-
-const PRIMARY = '#22C55E';
-const DARK_BG = '#021006';
-const CARD_BG = '#041a0b';
-const BORDER = '#052e16';
-
-function initials(name: string): string {
-  return name
-    .split(' ')
-    .map((w) => w[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
-}
 
 export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
   const [room, setRoom] = useState<ChymeRoomResponse | null>(null);
@@ -172,92 +125,22 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
 
   return (
     <div style={{ minHeight: '100vh', width: '100%', background: DARK_BG, fontFamily: "'Inter', system-ui, sans-serif", color: '#E8EAF0', display: 'flex', flexDirection: 'column' }}>
-      {/* Top bar */}
-      <header style={{ height: 60, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: '#030d05', flexShrink: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 10, background: `${PRIMARY}25`, border: `1px solid ${PRIMARY}40`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Radio size={18} style={{ color: PRIMARY }} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800, color: '#F0FDF4' }}>Chyme 🎙️</div>
-            <div style={{ fontSize: 12, color: '#16A34A' }}>Social Audio · End-to-End Encrypted</div>
-          </div>
-        </div>
-        <div style={{ flex: 1 }} />
-        {room && (
-          <span style={{ background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}30`, fontSize: 11, padding: '4px 12px', borderRadius: 20 }}>
-            🔴 Live
-          </span>
-        )}
-        <span style={{ background: 'rgba(255,255,255,0.05)', color: '#9CA3AF', border: '1px solid rgba(255,255,255,0.08)', fontSize: 11, padding: '4px 12px', borderRadius: 20 }}>
-          {room?.participants.length ?? 0} Participants
-        </span>
-        <button
-          onClick={() => void refreshMessages()}
-          style={{ width: 36, height: 36, borderRadius: 10, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: '#6B7280' }}
-          title="Refresh messages"
-        >
-          <RefreshCw size={16} />
-        </button>
-      </header>
+      <ChymeHeader
+        participantCount={room?.participants.length ?? 0}
+        isLive={Boolean(room)}
+        onRefresh={() => void refreshMessages()}
+      />
 
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-        {/* Sidebar */}
-        <aside style={{ width: 300, borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', flexShrink: 0, background: '#030d05' }}>
-          <div style={{ padding: '16px 16px 12px' }}>
-            <button
-              onClick={() => void handleJoin()}
-              disabled={joinState === 'joining' || joinState === 'ready'}
-              style={{ width: '100%', padding: '12px 16px', borderRadius: 12, background: `linear-gradient(135deg, ${PRIMARY} 0%, #16A34A 100%)`, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: joinState === 'idle' ? 'pointer' : 'not-allowed', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, opacity: joinState !== 'idle' ? 0.7 : 1 }}
-            >
-              <Mic size={16} />
-              {joinState === 'joining' ? 'Joining…' : joinState === 'ready' ? '✓ Joined' : 'Join Room'}
-            </button>
-          </div>
+        <ChymeSidebar
+          loading={loading}
+          room={room}
+          joinState={joinState}
+          onJoin={() => void handleJoin()}
+          onServiceDelete={() => void handleServiceDelete()}
+          onFullDelete={() => void handleFullDelete()}
+        />
 
-          {/* Room info */}
-          {loading ? (
-            <div style={{ padding: '12px 16px', color: '#16A34A', fontSize: 13 }}>Loading room…</div>
-          ) : room ? (
-            <div style={{ padding: '12px', margin: '0 12px 12px', borderRadius: 12, background: `${PRIMARY}14`, border: `1px solid ${PRIMARY}40`, cursor: 'pointer' }}>
-              <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 8 }}>
-                <div style={{ width: 8, height: 8, borderRadius: '50%', background: PRIMARY, flexShrink: 0, marginTop: 6, boxShadow: `0 0 6px ${PRIMARY}` }} />
-                <div style={{ fontSize: 13, fontWeight: 600, color: '#F0FDF4', lineHeight: 1.4, flex: 1 }}>{room.roomName}</div>
-              </div>
-              <div style={{ fontSize: 12, color: '#16A34A', marginBottom: 6 }}>
-                Key: {room.roomKey} · {room.participants.length} participants
-              </div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <span style={{ fontSize: 10, color: PRIMARY, background: `${PRIMARY}15`, padding: '2px 8px', borderRadius: 20, border: `1px solid ${PRIMARY}25` }}>
-                  #{room.callActive ? 'live' : 'idle'}
-                </span>
-                <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 4, color: '#4B5563', fontSize: 12 }}>
-                  <Users size={12} /> {room.participants.length}
-                </span>
-              </div>
-            </div>
-          ) : (
-            <div style={{ padding: '12px 16px', color: '#4B5563', fontSize: 13 }}>No active room</div>
-          )}
-
-          {/* Deletion actions */}
-          <div style={{ marginTop: 'auto', padding: '12px 16px', borderTop: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <button
-              onClick={() => void handleServiceDelete()}
-              style={{ width: '100%', padding: '8px 12px', borderRadius: 8, background: 'transparent', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 12, cursor: 'pointer' }}
-            >
-              Delete Chyme Data
-            </button>
-            <button
-              onClick={() => void handleFullDelete()}
-              style={{ width: '100%', padding: '8px 12px', borderRadius: 8, background: 'transparent', border: '1px solid rgba(239,68,68,0.15)', color: '#fca5a5', fontSize: 12, cursor: 'pointer' }}
-            >
-              Delete Full Account
-            </button>
-          </div>
-        </aside>
-
-        {/* Main area */}
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           {error && (
             <div style={{ padding: '12px 24px', background: '#2b0b0b', border: `1px solid #7f1d1d`, color: '#fecaca', fontSize: 13, margin: 16, borderRadius: 12 }}>
@@ -278,160 +161,26 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
           )}
 
           {room && (
-            <>
-              {/* Room header */}
-              <div style={{ padding: '20px 24px 16px', borderBottom: `1px solid ${BORDER}`, flexShrink: 0 }}>
-                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
-                  <div style={{ flex: 1 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-                      <div style={{ width: 8, height: 8, borderRadius: '50%', background: PRIMARY, boxShadow: `0 0 8px ${PRIMARY}` }} />
-                      <span style={{ background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}30`, fontSize: 11, padding: '2px 10px', borderRadius: 20 }}>
-                        {room.callActive ? '🔴 Live' : 'Idle'}
-                      </span>
-                      <span style={{ fontSize: 12, color: '#4B5563' }}>Safe Space Room</span>
-                      <Lock size={12} style={{ color: '#4B5563' }} />
-                    </div>
-                    <div style={{ fontSize: 20, fontWeight: 800, color: '#F0FDF4', lineHeight: 1.3, marginBottom: 4 }}>{room.roomName}</div>
-                    <div style={{ fontSize: 13, color: '#16A34A' }}>{room.participants.length} participants · Signed in as {currentUser.displayName}</div>
-                  </div>
-                  <button
-                    onClick={() => setShowChat(!showChat)}
-                    style={{ padding: '8px 14px', borderRadius: 10, background: showChat ? `${PRIMARY}20` : 'rgba(255,255,255,0.04)', border: `1px solid ${showChat ? PRIMARY + '40' : 'rgba(255,255,255,0.08)'}`, color: showChat ? PRIMARY : '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}
-                  >
-                    <MessageSquare size={14} /> Chat
-                  </button>
-                </div>
-              </div>
-
-              <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-                {/* Stage */}
-                <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px' }}>
-                  {/* Stream video panel after join */}
-                  {joinInfo && joinState === 'ready' && (
-                    <div style={{ marginBottom: 24, padding: 16, borderRadius: 14, background: CARD_BG, border: `1px solid ${BORDER}` }}>
-                      <div style={{ fontSize: 13, fontWeight: 600, color: '#F0FDF4', marginBottom: 12 }}>Audio Room</div>
-                      <StreamVideoPanel
-                        streamApiKey={joinInfo.streamApiKey}
-                        streamToken={joinInfo.streamToken}
-                        streamUserId={joinInfo.streamUserId}
-                        streamChannelId={joinInfo.streamChannelId}
-                      />
-                    </div>
-                  )}
-
-                  {/* Participants on stage */}
-                  <div style={{ marginBottom: 24 }}>
-                    <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: '#4B5563', textTransform: 'uppercase', marginBottom: 16 }}>
-                      On Stage · {room.participants.length} Participants
-                    </div>
-                    {room.participants.length === 0 ? (
-                      <div style={{ color: '#4B5563', fontSize: 14 }}>No participants yet.</div>
-                    ) : (
-                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 20 }}>
-                        {room.participants.map((participant) => (
-                          <div key={participant.userId} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, width: 100 }}>
-                            <div style={{ position: 'relative' }}>
-                              <div style={{ width: 72, height: 72, borderRadius: '50%', background: `${PRIMARY}20`, border: `3px solid ${participant.userId === currentUser.userId ? PRIMARY : 'transparent'}`, display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: participant.userId === currentUser.userId ? `0 0 20px ${PRIMARY}50` : 'none' }}>
-                                <span style={{ fontSize: 20, fontWeight: 800, color: PRIMARY }}>{initials(participant.displayName)}</span>
-                              </div>
-                              <div style={{ position: 'absolute', bottom: 2, right: 2, width: 22, height: 22, borderRadius: '50%', background: PRIMARY, border: '2px solid #021006', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                                <Mic size={10} style={{ color: '#fff' }} />
-                              </div>
-                            </div>
-                            <div style={{ fontSize: 12, fontWeight: 600, color: '#E8EAF0', textAlign: 'center' }}>{participant.displayName}</div>
-                            <span style={{ fontSize: 10, background: participant.role === 'speaker' ? `${PRIMARY}20` : 'rgba(255,255,255,0.05)', color: participant.role === 'speaker' ? PRIMARY : '#6B7280', border: `1px solid ${participant.role === 'speaker' ? PRIMARY + '35' : 'transparent'}`, padding: '1px 8px', borderRadius: 20 }}>
-                              {participant.role}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Deletion status */}
-                  {deletionState && (
-                    <div style={{ padding: '12px 16px', borderRadius: 12, background: CARD_BG, border: `1px solid ${BORDER}`, fontSize: 13, color: '#A7F3D0' }}>
-                      Deletion: {deletionState.scope} / {deletionState.status} at {deletionState.requestedAtIso}
-                    </div>
-                  )}
-                </div>
-
-                {/* Chat panel */}
-                {showChat && (
-                  <div style={{ width: 300, borderLeft: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', background: '#030d05', flexShrink: 0 }}>
-                    <div style={{ padding: '14px 16px', borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <Hash size={14} style={{ color: PRIMARY }} />
-                      <span style={{ fontSize: 14, fontWeight: 600, color: '#F0FDF4' }}>Room Chat</span>
-                      <span style={{ marginLeft: 'auto', background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}25`, fontSize: 10, padding: '2px 8px', borderRadius: 12 }}>Encrypted</span>
-                    </div>
-                    <div style={{ flex: 1, overflowY: 'auto', padding: '12px 14px' }}>
-                      {messages.length === 0 ? (
-                        <div style={{ color: '#4B5563', fontSize: 13 }}>No messages yet.</div>
-                      ) : (
-                        messages.map((message) => (
-                          <div key={message.id} style={{ marginBottom: 14 }}>
-                            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 2 }}>
-                              <span style={{ fontSize: 13, fontWeight: 600, color: message.userId === currentUser.userId ? PRIMARY : '#A7F3D0' }}>{message.displayName}</span>
-                              <span style={{ fontSize: 11, color: '#374151' }}>{new Date(message.sentAtIso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
-                            </div>
-                            <div style={{ fontSize: 13, color: '#9CA3AF', lineHeight: 1.5 }}>{message.text}</div>
-                          </div>
-                        ))
-                      )}
-                      <div ref={messagesEndRef} />
-                    </div>
-                    <div style={{ padding: '10px 14px', borderTop: `1px solid ${BORDER}` }}>
-                      <div style={{ display: 'flex', gap: 8, alignItems: 'center', background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, borderRadius: 10, padding: '8px 12px' }}>
-                        <input
-                          value={draft}
-                          onChange={(e) => setDraft(e.target.value)}
-                          onKeyDown={(e) => { if (e.key === 'Enter') void handleSend(); }}
-                          placeholder="Send a message…"
-                          style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 13, color: '#E8EAF0' }}
-                        />
-                        <button
-                          onClick={() => void handleSend()}
-                          disabled={sending || !draft.trim()}
-                          style={{ width: 28, height: 28, borderRadius: 6, background: draft.trim() ? PRIMARY : 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: draft.trim() ? 'pointer' : 'not-allowed' }}
-                        >
-                          <Send size={12} style={{ color: draft.trim() ? '#fff' : '#4B5563' }} />
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {/* Room controls */}
-              <div style={{ padding: '16px 24px', borderTop: `1px solid ${BORDER}`, background: '#030d05', display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
-                <button
-                  onClick={() => setMuted(!muted)}
-                  style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 18px', borderRadius: 12, background: muted ? 'rgba(239,68,68,0.15)' : `${PRIMARY}18`, border: `1px solid ${muted ? 'rgba(239,68,68,0.4)' : PRIMARY + '40'}`, color: muted ? '#F87171' : PRIMARY, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
-                >
-                  {muted ? <MicOff size={16} /> : <Mic size={16} />}
-                  {muted ? 'Unmute' : 'Mute'}
-                </button>
-                <button
-                  onClick={() => setHandRaised(!handRaised)}
-                  style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 18px', borderRadius: 12, background: handRaised ? 'rgba(234,179,8,0.15)' : 'rgba(255,255,255,0.04)', border: `1px solid ${handRaised ? 'rgba(234,179,8,0.4)' : 'rgba(255,255,255,0.08)'}`, color: handRaised ? '#FDE047' : '#9CA3AF', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
-                >
-                  <Hand size={16} />
-                  {handRaised ? 'Lower Hand' : 'Raise Hand'}
-                </button>
-                <div style={{ flex: 1 }} />
-                <div style={{ fontSize: 12, color: '#4B5563', display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <Volume2 size={14} /> Audio — encrypted
-                </div>
-                {joinState === 'ready' && (
-                  <button
-                    onClick={() => { setJoinState('idle'); setJoinInfo(null); }}
-                    style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 18px', borderRadius: 12, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#F87171', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
-                  >
-                    <Phone size={16} /> Leave
-                  </button>
-                )}
-              </div>
-            </>
+            <ChymeRoomView
+              room={room}
+              currentUser={currentUser}
+              showChat={showChat}
+              onToggleChat={() => setShowChat((s) => !s)}
+              joinInfo={joinInfo}
+              joinReady={joinState === 'ready'}
+              deletionState={deletionState}
+              messages={messages}
+              draft={draft}
+              onDraftChange={setDraft}
+              onSend={() => void handleSend()}
+              sending={sending}
+              messagesEndRef={messagesEndRef}
+              muted={muted}
+              onToggleMute={() => setMuted((m) => !m)}
+              handRaised={handRaised}
+              onToggleHand={() => setHandRaised((h) => !h)}
+              onLeave={() => { setJoinState('idle'); setJoinInfo(null); }}
+            />
           )}
         </div>
       </div>

--- a/ctf/packages/web/components/chyme/chyme-room-view.tsx
+++ b/ctf/packages/web/components/chyme/chyme-room-view.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { Lock, MessageSquare } from 'lucide-react';
+import { BORDER, PRIMARY, type CurrentUser } from './chyme-shared';
+import { ChymeStage } from './chyme-stage';
+import { ChymeChatPanel } from './chyme-chat-panel';
+import { ChymeControls } from './chyme-controls';
+import type { ChymeDeletionResponse, ChymeJoinResponse, ChymeMessage, ChymeRoomResponse } from 'lib/chyme/types';
+
+export type ChymeRoomViewProps = {
+  room: ChymeRoomResponse;
+  currentUser: CurrentUser;
+  showChat: boolean;
+  onToggleChat: () => void;
+  joinInfo: ChymeJoinResponse | null;
+  joinReady: boolean;
+  deletionState: ChymeDeletionResponse | null;
+  messages: ChymeMessage[];
+  draft: string;
+  onDraftChange: (value: string) => void;
+  onSend: () => void;
+  sending: boolean;
+  messagesEndRef: RefObject<HTMLDivElement | null>;
+  muted: boolean;
+  onToggleMute: () => void;
+  handRaised: boolean;
+  onToggleHand: () => void;
+  onLeave: () => void;
+};
+
+export function ChymeRoomView(props: ChymeRoomViewProps) {
+  const { room, currentUser, showChat, onToggleChat } = props;
+  return (
+    <>
+      <div style={{ padding: '20px 24px 16px', borderBottom: `1px solid ${BORDER}`, flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+              <div style={{ width: 8, height: 8, borderRadius: '50%', background: PRIMARY, boxShadow: `0 0 8px ${PRIMARY}` }} />
+              <span style={{ background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}30`, fontSize: 11, padding: '2px 10px', borderRadius: 20 }}>
+                {room.callActive ? '🔴 Live' : 'Idle'}
+              </span>
+              <span style={{ fontSize: 12, color: '#4B5563' }}>Safe Space Room</span>
+              <Lock size={12} style={{ color: '#4B5563' }} />
+            </div>
+            <div style={{ fontSize: 20, fontWeight: 800, color: '#F0FDF4', lineHeight: 1.3, marginBottom: 4 }}>{room.roomName}</div>
+            <div style={{ fontSize: 13, color: '#16A34A' }}>{room.participants.length} participants · Signed in as {currentUser.displayName}</div>
+          </div>
+          <button
+            onClick={onToggleChat}
+            style={{ padding: '8px 14px', borderRadius: 10, background: showChat ? `${PRIMARY}20` : 'rgba(255,255,255,0.04)', border: `1px solid ${showChat ? PRIMARY + '40' : 'rgba(255,255,255,0.08)'}`, color: showChat ? PRIMARY : '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}
+          >
+            <MessageSquare size={14} /> Chat
+          </button>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        <ChymeStage
+          room={room}
+          currentUserId={currentUser.userId}
+          joinInfo={props.joinInfo}
+          joinReady={props.joinReady}
+          deletionState={props.deletionState}
+        />
+        {showChat && (
+          <ChymeChatPanel
+            messages={props.messages}
+            currentUserId={currentUser.userId}
+            draft={props.draft}
+            onDraftChange={props.onDraftChange}
+            onSend={props.onSend}
+            sending={props.sending}
+            messagesEndRef={props.messagesEndRef}
+          />
+        )}
+      </div>
+
+      <ChymeControls
+        muted={props.muted}
+        onToggleMute={props.onToggleMute}
+        handRaised={props.handRaised}
+        onToggleHand={props.onToggleHand}
+        joinReady={props.joinReady}
+        onLeave={props.onLeave}
+      />
+    </>
+  );
+}

--- a/ctf/packages/web/components/chyme/chyme-shared.ts
+++ b/ctf/packages/web/components/chyme/chyme-shared.ts
@@ -1,0 +1,39 @@
+// Shared constants, types, and helpers for the Chyme web shell.
+// Palette derives from design/.../survivor-hub/ChymeApp.tsx.
+
+export const PRIMARY = '#22C55E';
+export const DARK_BG = '#021006';
+export const CARD_BG = '#041a0b';
+export const BORDER = '#052e16';
+
+export type CurrentUser = {
+  userId: string;
+  username: string | null;
+  displayName: string;
+};
+
+type RequestError = {
+  message: string;
+};
+
+export async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, { cache: 'no-store', ...init });
+  const payload = (await response.json().catch(() => null)) as T | RequestError | null;
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === 'object' && 'message' in payload
+        ? payload.message
+        : 'Request failed.';
+    throw new Error(message);
+  }
+  return payload as T;
+}
+
+export function initials(name: string): string {
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}

--- a/ctf/packages/web/components/chyme/chyme-sidebar.tsx
+++ b/ctf/packages/web/components/chyme/chyme-sidebar.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Mic, Users } from 'lucide-react';
+import { BORDER, PRIMARY } from './chyme-shared';
+import type { ChymeRoomResponse } from 'lib/chyme/types';
+
+type JoinState = 'idle' | 'joining' | 'ready';
+
+export function ChymeSidebar({
+  loading,
+  room,
+  joinState,
+  onJoin,
+  onServiceDelete,
+  onFullDelete,
+}: {
+  loading: boolean;
+  room: ChymeRoomResponse | null;
+  joinState: JoinState;
+  onJoin: () => void;
+  onServiceDelete: () => void;
+  onFullDelete: () => void;
+}) {
+  const joinLabel = joinState === 'joining' ? 'Joining…' : joinState === 'ready' ? '✓ Joined' : 'Join Room';
+
+  return (
+    <aside style={{ width: 300, borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', flexShrink: 0, background: '#030d05' }}>
+      <div style={{ padding: '16px 16px 12px' }}>
+        <button
+          onClick={onJoin}
+          disabled={joinState === 'joining' || joinState === 'ready'}
+          style={{ width: '100%', padding: '12px 16px', borderRadius: 12, background: `linear-gradient(135deg, ${PRIMARY} 0%, #16A34A 100%)`, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: joinState === 'idle' ? 'pointer' : 'not-allowed', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, opacity: joinState !== 'idle' ? 0.7 : 1 }}
+        >
+          <Mic size={16} />
+          {joinLabel}
+        </button>
+      </div>
+
+      {loading ? (
+        <div style={{ padding: '12px 16px', color: '#16A34A', fontSize: 13 }}>Loading room…</div>
+      ) : room ? (
+        <div style={{ padding: '12px', margin: '0 12px 12px', borderRadius: 12, background: `${PRIMARY}14`, border: `1px solid ${PRIMARY}40`, cursor: 'pointer' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 8 }}>
+            <div style={{ width: 8, height: 8, borderRadius: '50%', background: PRIMARY, flexShrink: 0, marginTop: 6, boxShadow: `0 0 6px ${PRIMARY}` }} />
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#F0FDF4', lineHeight: 1.4, flex: 1 }}>{room.roomName}</div>
+          </div>
+          <div style={{ fontSize: 12, color: '#16A34A', marginBottom: 6 }}>
+            Key: {room.roomKey} · {room.participants.length} participants
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 10, color: PRIMARY, background: `${PRIMARY}15`, padding: '2px 8px', borderRadius: 20, border: `1px solid ${PRIMARY}25` }}>
+              #{room.callActive ? 'live' : 'idle'}
+            </span>
+            <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 4, color: '#4B5563', fontSize: 12 }}>
+              <Users size={12} /> {room.participants.length}
+            </span>
+          </div>
+        </div>
+      ) : (
+        <div style={{ padding: '12px 16px', color: '#4B5563', fontSize: 13 }}>No active room</div>
+      )}
+
+      <div style={{ marginTop: 'auto', padding: '12px 16px', borderTop: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <button
+          onClick={onServiceDelete}
+          style={{ width: '100%', padding: '8px 12px', borderRadius: 8, background: 'transparent', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 12, cursor: 'pointer' }}
+        >
+          Delete Chyme Data
+        </button>
+        <button
+          onClick={onFullDelete}
+          style={{ width: '100%', padding: '8px 12px', borderRadius: 8, background: 'transparent', border: '1px solid rgba(239,68,68,0.15)', color: '#fca5a5', fontSize: 12, cursor: 'pointer' }}
+        >
+          Delete Full Account
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/chyme/chyme-stage.tsx
+++ b/ctf/packages/web/components/chyme/chyme-stage.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Mic } from 'lucide-react';
+import { StreamVideoPanel } from '../shared/stream-video-panel';
+import { BORDER, CARD_BG, PRIMARY, initials } from './chyme-shared';
+import type { ChymeDeletionResponse, ChymeJoinResponse, ChymeRoomResponse } from 'lib/chyme/types';
+
+export function ChymeStage({
+  room,
+  currentUserId,
+  joinInfo,
+  joinReady,
+  deletionState,
+}: {
+  room: ChymeRoomResponse;
+  currentUserId: string;
+  joinInfo: ChymeJoinResponse | null;
+  joinReady: boolean;
+  deletionState: ChymeDeletionResponse | null;
+}) {
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px' }}>
+      {joinInfo && joinReady && (
+        <div style={{ marginBottom: 24, padding: 16, borderRadius: 14, background: CARD_BG, border: `1px solid ${BORDER}` }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#F0FDF4', marginBottom: 12 }}>Audio Room</div>
+          <StreamVideoPanel
+            streamApiKey={joinInfo.streamApiKey}
+            streamToken={joinInfo.streamToken}
+            streamUserId={joinInfo.streamUserId}
+            streamChannelId={joinInfo.streamChannelId}
+          />
+        </div>
+      )}
+
+      <div style={{ marginBottom: 24 }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: '#4B5563', textTransform: 'uppercase', marginBottom: 16 }}>
+          On Stage · {room.participants.length} Participants
+        </div>
+        {room.participants.length === 0 ? (
+          <div style={{ color: '#4B5563', fontSize: 14 }}>No participants yet.</div>
+        ) : (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 20 }}>
+            {room.participants.map((participant) => {
+              const isSelf = participant.userId === currentUserId;
+              const isSpeaker = participant.role === 'speaker';
+              return (
+                <div key={participant.userId} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, width: 100 }}>
+                  <div style={{ position: 'relative' }}>
+                    <div style={{ width: 72, height: 72, borderRadius: '50%', background: `${PRIMARY}20`, border: `3px solid ${isSelf ? PRIMARY : 'transparent'}`, display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: isSelf ? `0 0 20px ${PRIMARY}50` : 'none' }}>
+                      <span style={{ fontSize: 20, fontWeight: 800, color: PRIMARY }}>{initials(participant.displayName)}</span>
+                    </div>
+                    <div style={{ position: 'absolute', bottom: 2, right: 2, width: 22, height: 22, borderRadius: '50%', background: PRIMARY, border: '2px solid #021006', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      <Mic size={10} style={{ color: '#fff' }} />
+                    </div>
+                  </div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: '#E8EAF0', textAlign: 'center' }}>{participant.displayName}</div>
+                  <span style={{ fontSize: 10, background: isSpeaker ? `${PRIMARY}20` : 'rgba(255,255,255,0.05)', color: isSpeaker ? PRIMARY : '#6B7280', border: `1px solid ${isSpeaker ? PRIMARY + '35' : 'transparent'}`, padding: '1px 8px', borderRadius: 20 }}>
+                    {participant.role}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {deletionState && (
+        <div style={{ padding: '12px 16px', borderRadius: 12, background: CARD_BG, border: `1px solid ${BORDER}`, fontSize: 13, color: '#A7F3D0' }}>
+          Deletion: {deletionState.scope} / {deletionState.status} at {deletionState.requestedAtIso}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Decomposes `ChymeLiveShell` — a **pre-existing rule-116 violation** (359 lines / complexity 40) carried over from the backend pass — into modular sub-components, matching the pattern already applied to directory (#133) and lighthouse (#136). This was the tracked follow-up noted in the #139 reconcile.

## Changes

`ChymeLiveShell` now composes:
- `chyme-shared` — constants (`PRIMARY`/`DARK_BG`/`CARD_BG`/`BORDER`), `CurrentUser` type, `initials`, `requestJson`
- `chyme-header`
- `chyme-sidebar` — join button + room info + deletion actions
- `chyme-room-view` — room header; composes the three below
- `chyme-stage` — stream video panel + participants + deletion status
- `chyme-chat-panel`
- `chyme-controls` — mute/hand/leave (toggle-button styling extracted to a module helper to stay within the complexity limit)

The shell retains all state, effects, and handlers (data wiring unchanged) and passes callbacks down. No behavior, API, or copy change — the `c5d83c0` design copy (no "GetStream") is preserved verbatim.

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- `pnpm --filter @ctf/web lint components/chyme/` — green
- Modularity gate (`complexity:10`, `max-lines-per-function:200`) on all chyme files — green (was failing on the monolithic shell)
- `pnpm --filter @ctf/web build:ci` — green
- `check-eof-format.sh`, `check-web-android-parity.mjs`, `check-schema-drift.sh` — green

With this, all three circle-backed plugins (chyme, directory, lighthouse) satisfy rule 116.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_