### PR TITLE
ci: build live blog from wiki-site main and fix publish to match its layout

### DIFF
--- a/.github/workflows/deploy-blog-gh-pages.yml
+++ b/.github/workflows/deploy-blog-gh-pages.yml
@@ -1,13 +1,13 @@
 name: Deploy Blog to GitHub Pages
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "wiki-site"          # submodule pointer bump (gitlink path)
-      - "wiki-site/**"
-      - ".github/workflows/deploy-blog-gh-pages.yml"
+  # Triggered by the product-update workflow after it publishes to wiki-site,
+  # and runnable on demand. wiki-site is a separate repo and the single source
+  # of truth; this workflow clones its main branch at build time, so there is
+  # no submodule pin to keep in sync.
   workflow_dispatch:
+  repository_dispatch:
+    types: [wiki-site-updated]
 
 permissions:
   contents: read
@@ -22,29 +22,18 @@ jobs:
   build:
     name: Build Pages artifact
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: wiki-site/wiki-blog
-
     steps:
-      # Check out WITHOUT submodules, then init only the wiki-site submodule.
-      # submodules: true would init every sibling submodule (ctf-v2-deprecated,
-      # landing-page, etc.) — unnecessary here, and some have broken/unreachable
-      # pinned refs that fail the whole checkout. We only need wiki-site, and not
-      # recursively: the blog build reads the committed articles.ts and fetches
-      # wiki markdown at runtime, so wiki-site's nested submodules aren't needed.
-      # Content validation / articles.ts sync are enforced by wiki-site's own CI.
-      - uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - name: Check out wiki-site submodule only
-        working-directory: ${{ github.workspace }}
-        run: git submodule update --init wiki-site
+      # Clone wiki-site main (recursing its nested wiki/ submodule, which the
+      # article sync reads). The nested wiki-site/ directory is the pnpm
+      # workspace root; everything is built and uploaded from there.
+      - name: Clone wiki-site (main)
+        run: |
+          git clone --recurse-submodules --depth 1 \
+            https://github.com/chargingthefuture/wiki-site.git wiki-site-src
 
       - uses: pnpm/action-setup@v4
         with:
-          package_json_file: wiki-site/wiki-blog/package.json
+          package_json_file: wiki-site-src/wiki-site/package.json
 
       - uses: actions/setup-node@v4
         with:
@@ -54,15 +43,17 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Install dependencies
+        working-directory: wiki-site-src/wiki-site
         run: pnpm install --frozen-lockfile
 
       - name: Build for GitHub Pages
-        run: pnpm blog:build:pages
+        working-directory: wiki-site-src/wiki-site
+        run: pnpm wiki:build:pages
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: wiki-site/wiki-blog/artifacts/blog/dist/public
+          path: wiki-site-src/wiki-site/artifacts/wiki/dist/public
 
   deploy:
     name: Deploy to Pages

--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -134,9 +134,11 @@ jobs:
           git push
 
       # ── Blog registry (wiki-site) ─────────────────────────────────────────────
-      # Adds the update to the wiki-site blog (category "Updates") and bumps the
-      # wiki-site submodule pointer in THIS repo so deploy-blog-gh-pages.yml
-      # rebuilds and publishes the post to the live site.
+      # Adds the update to the wiki-site blog (category "Updates") on wiki-site's
+      # main branch, then triggers deploy-blog-gh-pages.yml to rebuild the live
+      # site. wiki-site is a separate repo with its own layout: the pnpm
+      # workspace lives in the nested wiki-site/ directory, with scripts
+      # wiki:validate / wiki:sync and articles at artifacts/wiki/src/lib.
       - name: Publish to wiki-site blog registry
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -150,13 +152,12 @@ jobs:
           CATEGORY="Updates"
           DATE=$(date +%Y-%m-%d)
 
-          # Clone wiki-site with its nested submodules: blog:sync infers extra
-          # "folder" articles from the nested wiki/ submodule, so it must be
-          # present or sync would drop them from articles.ts.
+          # Recurse submodules: wiki:sync infers extra "folder" articles from the
+          # nested wiki/ submodule, so it must be present or sync drops them.
           git clone --recurse-submodules \
             "https://x-access-token:${GH_PAT}@github.com/chargingthefuture/wiki-site.git" /tmp/wiki-site
 
-          cd /tmp/wiki-site/wiki-blog
+          cd /tmp/wiki-site/wiki-site
           SLUG="$SLUG" TITLE="$TITLE" EXCERPT="$EXCERPT" CATEGORY="$CATEGORY" DATE="$DATE" \
           yq -i '.articles += [{
             "slug": strenv(SLUG), "title": strenv(TITLE),
@@ -167,37 +168,29 @@ jobs:
 
           corepack enable
           pnpm install --frozen-lockfile
-          pnpm blog:validate
-          pnpm blog:sync
+          pnpm wiki:validate
+          pnpm wiki:sync
 
           cd /tmp/wiki-site
           git config user.name  "CTF CI Bot"
           git config user.email "ci@chargingthefuture.org"
-          git add wiki-blog/content-index.yaml wiki-blog/artifacts/blog/src/lib/articles.ts
+          git add wiki-site/content-index.yaml wiki-site/artifacts/wiki/src/lib/articles.ts
           if git commit -m "feat(blog): publish ${DATE} product update — ${SLUG}"; then
             git push
-            WIKI_SITE_SHA=$(git rev-parse HEAD)
+            PUBLISHED=1
           else
-            echo "No content-index changes; skipping wiki-site push."
-            WIKI_SITE_SHA=""
+            echo "No content-index changes; nothing to publish."
+            PUBLISHED=0
           fi
 
-          # Bump the wiki-site submodule pointer in this repo so the Pages deploy
-          # rebuilds from the new content. deploy-blog-gh-pages.yml triggers on
-          # changes to the "wiki-site" gitlink (see its paths filter).
-          if [ -n "$WIKI_SITE_SHA" ]; then
-            cd "$GITHUB_WORKSPACE"
-            git submodule update --init wiki-site
-            git -C wiki-site fetch origin
-            git -C wiki-site checkout "$WIKI_SITE_SHA"
-            git config user.name  "CTF CI Bot"
-            git config user.email "ci@chargingthefuture.org"
-            git add wiki-site
-            git commit -m "chore(blog): bump wiki-site to publish ${DATE} update — ${SLUG}"
-            # Push with GH_PAT (not GITHUB_TOKEN) so deploy-blog-gh-pages.yml is
-            # triggered — pushes authored by GITHUB_TOKEN do not start workflows.
-            git push "https://x-access-token:${GH_PAT}@github.com/chargingthefuture/chargingthefuture.git" \
-              "HEAD:${GITHUB_REF_NAME}"
+          # Trigger the Pages deploy, which clones wiki-site main and rebuilds.
+          if [ "$PUBLISHED" = "1" ]; then
+            curl -fsS -X POST \
+              -H "Authorization: Bearer ${GH_PAT}" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/chargingthefuture/chargingthefuture/dispatches \
+              -d '{"event_type":"wiki-site-updated"}'
+            echo "Dispatched wiki-site-updated to trigger Pages deploy."
           fi
 
       # ── Quora draft issue ─────────────────────────────────────────────────────


### PR DESCRIPTION
## What broke

The last product-update run failed at the publish step:
```
cd /tmp/wiki-site/wiki-blog: No such file or directory
```

Investigating revealed the real situation — **wiki-site has been restructured (blog → wiki) and the submodule pin in this repo is ~6 weeks stale**, so two layouts were in conflict:

| | Pinned submodule `c71b5c82` (Apr 12) | wiki-site `main` HEAD (today) |
|---|---|---|
| Dir | `wiki-blog/` | nested `wiki-site/` |
| Scripts | `blog:validate` / `blog:sync` / `blog:build:pages` | `wiki:validate` / `wiki:sync` / `wiki:build:pages` |
| Articles | `artifacts/blog/...` | `artifacts/wiki/src/lib/articles.ts` |

Consequences:
1. **#142 was misdiagnosed** — it was written against the stale *pinned* layout (`wiki-blog`/`blog:*`), but the publish step clones wiki-site's **main** branch, which uses the current `wiki-site/`/`wiki:*` layout. Hence the `cd .../wiki-blog` failure. (Content actually does reach wiki-site main — earlier runs created two `feat(blog): publish …` commits there.)
2. **The live site was stale** because `deploy-blog-gh-pages.yml` built from the **pinned submodule**, not wiki-site main, and the pin was never bumped.

## Fix

- **`deploy-blog-gh-pages.yml`** now clones **wiki-site main at build time** (`--recurse-submodules` for the nested `wiki/`), builds the nested `wiki-site/` workspace with `wiki:build:pages`, and uploads `artifacts/wiki/dist/public`. It no longer depends on this repo's checkout or the submodule pin, so it can't drift. Triggers: `workflow_dispatch` + `repository_dispatch` (`wiki-site-updated`).
- **Publish step** reverted to the `wiki:*` / nested `wiki-site/` layout matching main, and now sends a `repository_dispatch` (`wiki-site-updated`) via the REST API with `GH_PAT` after pushing — so the deploy runs automatically. Dropped the submodule-pin bump and the gitlink `paths` filter.

**wiki-site stays a separate repo and the single source of truth — nothing is vendored into this repo.** The stale submodule pin is now irrelevant to the deploy (can be removed later if desired).

## Testing

- Both workflow YAMLs parse cleanly; single trailing newline; no residual `wiki-blog`/`blog:*` references.
- Verified locally on wiki-site main: `pnpm wiki:build:pages` emits `artifacts/wiki/dist/public/index.html` + `404.html` with `BASE_PATH=/chargingthefuture/`.
- End-to-end runs on schedule/`workflow_dispatch` only (not on PRs); full verification is a manual `Generate Product Update` run with `force` after merge → it publishes to wiki-site and dispatches the deploy.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_