### PR TITLE
feat: clicklog web pixel pass — rebuild shell to design mockup

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -116,7 +116,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | service-credits | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | levelup | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | trust | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
-| clicklog | ⏳ | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| clicklog | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | unlock | ⏳ | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 
 For ⏳ rows: build backend now; UI (web + android) is gated on the parallel design pass — circle back when it lands.
@@ -412,3 +412,14 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   change; data wiring and the c5d83c0 copy are preserved. typecheck, lint, modularity, build:ci, EOF,
   parity, and schema-drift gates green. All three circle-backed plugins (chyme, directory, lighthouse)
   now satisfy rule 116.
+- 2026-05-29: UI circle-back — clicklog web pixel pass (first of the four plugins unblocked by the
+  `c5d83c0` design re-pin). Rebuilt the plain Tailwind `ClicklogShell` to the `ClickLog.tsx` mockup and
+  its Empty/Loading states: the dark (`#0F1117` / brand `#E91E8C`) icon-rail + sidebar (total +
+  this-week strip + encryption note) + circular log button with inline note form + recent-incidents
+  list + right-rail stats/safety-reminder layout. All counters derive from real `/api/clicklog` data
+  (no dummy counts); the modal became the mockup's inline form. Decomposed into modular sub-components
+  within the rule-116 limits, cleared the prior `any` lint debt, and dropped the unused `userId` prop.
+  No public state by design (ClickLog is private/auth-only). typecheck, lint, modularity, build:ci, EOF,
+  parity, and schema-drift gates green. Marked clicklog Design 🎨 / Web px ✅; Android pixel parity
+  (`MobileClickLog.tsx`) remains ⬜. Three design-gated plugins remain: skills-taxonomy,
+  weekly-performance, unlock.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-clicklog-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-clicklog-feature-inventory.md
@@ -51,6 +51,17 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 - Android: Implemented shell, full parity
 - See [plugin-parity-contracts.json](../../../config/plugin-parity-contracts.json)
 
+Web pixel pass (design `c5d83c0`): `ClicklogShell` is rebuilt to `design/.../survivor-hub/ClickLog.tsx`
+and its Empty/Loading states. The plain shell was replaced with the mockup's dark (`#0F1117` / brand
+`#E91E8C`) layout — icon rail, sidebar (total + this-week strip + encryption note), the large circular
+"Log Incident" button with an inline note form, the recent-incidents list, and the right-rail stats +
+safety reminder — decomposed into modular sub-components within the rule-116 limits. All counters
+(total, this-week weekday strip, this-week/this-month/with-notes/with-location stats) are derived from
+the real `/api/clicklog` data; none are dummy. The note form posts to `/api/clicklog` (optional
+geolocation via the browser), delete calls `DELETE /api/clicklog/:id`. ClickLog is a private, auth-only
+tool, so there is no public state (the `ClickLogPublic.tsx` mockup is not implemented by design). The
+Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READINESS_PLAN.md`.
+
 ## 9. Seed Coverage Status
 
 - See [scripts/seedClicklog.mjs](../../../scripts/seedClicklog.mjs)
@@ -64,5 +75,6 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 
 ## Change Log
 
+- 2026-05-29: Web UI circle-back (first design pass; unblocked by the `c5d83c0` design re-pin). Rebuilt `ClicklogShell` to the `ClickLog.tsx` mockup + Empty/Loading states, decomposed into modular sub-components (`clicklog-shared`, `clicklog-icon-rail`, `clicklog-sidebar`, `clicklog-right-rail`, `clicklog-log-panel`, `clicklog-incident-list`, `clicklog-empty-state`, `clicklog-loading`). All counts derive from real `/api/clicklog` data; the modal note form became the mockup's inline form; cleared the prior `any` lint debt; dropped the unused `userId` prop. No schema/API change.
 - 2026-05-18: Renamed "Risks & Known Technical Debt" to "Gaps and Known Technical Debt" per Rule 120 canonical heading.
 - 2026-04-13: Initial implementation and registration.

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -160,7 +160,7 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (selectedPlugin.slug === 'clicklog') {
-    return <ClicklogShell userId={decision.userId} />;
+    return <ClicklogShell />;
   }
 
   if (selectedPlugin.slug === 'chyme') {

--- a/ctf/packages/web/components/clicklog/clicklog-empty-state.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-empty-state.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+// STATE: Authenticated, no incidents logged yet. Ported from
+// design/.../survivor-hub/ClickLogEmpty.tsx.
+import { AlertTriangle, ShieldCheck } from "lucide-react";
+import { BG, BORDER, BRAND, SUBTLE, SURFACE, TEXT } from "./clicklog-shared";
+
+const STEPS = [
+  { icon: "👆", title: "One tap", desc: "Instantly log an incident — no typing required." },
+  { icon: "📝", title: "Add context", desc: "Optionally add notes or location to any log." },
+  { icon: "🔒", title: "Private", desc: "Encrypted. Only you can see your history." },
+];
+
+export function ClicklogEmptyState({ onLog }: { onLog: () => void }) {
+  return (
+    <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter',system-ui", color: TEXT, display: "flex", flexDirection: "column" }}>
+      <div style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 28px", gap: 12, background: "#0D0F14", flexShrink: 0 }}>
+        <AlertTriangle size={18} color={BRAND} />
+        <div>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>ClickLog</div>
+          <div style={{ fontSize: 12, color: SUBTLE }}>Personal incident counter — private &amp; encrypted</div>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: "48px 64px" }}>
+        <div style={{ maxWidth: 560, width: "100%", display: "flex", flexDirection: "column", alignItems: "center", gap: 28, textAlign: "center" }}>
+          <button
+            onClick={onLog}
+            style={{ width: 160, height: 160, borderRadius: "50%", background: BRAND, border: `4px solid ${BRAND}`, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 8, cursor: "pointer", boxShadow: `0 0 48px ${BRAND}30` }}
+          >
+            <AlertTriangle size={40} color="#fff" />
+            <span style={{ fontSize: 15, fontWeight: 800, color: "#fff" }}>Log Incident</span>
+          </button>
+
+          <div>
+            <div style={{ fontSize: 24, fontWeight: 800, color: TEXT, marginBottom: 10 }}>No incidents logged</div>
+            <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7, maxWidth: 440 }}>
+              ClickLog lets you silently track personal safety incidents — one tap, optionally add a note or location. All data is end-to-end encrypted and only visible to you.
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: 12, width: "100%" }}>
+            {STEPS.map((item) => (
+              <div key={item.title} style={{ flex: 1, padding: "14px", borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, textAlign: "center" }}>
+                <div style={{ fontSize: 24, marginBottom: 8 }}>{item.icon}</div>
+                <div style={{ fontSize: 12, fontWeight: 700, color: TEXT, marginBottom: 4 }}>{item.title}</div>
+                <div style={{ fontSize: 11, color: SUBTLE, lineHeight: 1.5 }}>{item.desc}</div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ padding: "12px 16px", borderRadius: 12, background: "rgba(233,30,140,0.05)", border: "1px solid rgba(233,30,140,0.15)", display: "flex", alignItems: "center", gap: 10 }}>
+            <ShieldCheck size={16} color={BRAND} />
+            <span style={{ fontSize: 12, color: SUBTLE }}>In an emergency, always contact local emergency services first.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/clicklog/clicklog-icon-rail.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-icon-rail.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { AlertTriangle, Bell, Clock, FileText, Settings } from "lucide-react";
+import { BORDER, BRAND, SUBTLE } from "./clicklog-shared";
+
+// The hub icon-rail chrome. ClickLog is a single-view tool, so the nav glyphs
+// are presentational (matching the mockup); the brand mark anchors the rail.
+const NAV = [AlertTriangle, Clock, FileText];
+
+export function ClicklogIconRail() {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${BRAND}25`, border: `1px solid ${BRAND}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <AlertTriangle size={20} color={BRAND} />
+      </div>
+      {NAV.map((Icon, i) => (
+        <div key={i} style={{ width: 44, height: 44, borderRadius: 12, background: i === 0 ? `${BRAND}20` : "transparent", border: i === 0 ? `1px solid ${BRAND}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", color: i === 0 ? BRAND : SUBTLE }}>
+          <Icon size={20} />
+        </div>
+      ))}
+      <div style={{ flex: 1 }} />
+      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Bell size={18} /></div>
+      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Settings size={18} /></div>
+      <div style={{ width: 32, height: 32, borderRadius: "50%", background: `${BRAND}20`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, color: BRAND }}>S</div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/clicklog/clicklog-incident-list.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-incident-list.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { AlertTriangle, MapPin, Trash2 } from "lucide-react";
+import type { ClicklogIncident } from "../../lib/clicklog/types";
+import { BORDER, BRAND, SUBTLE, SURFACE, TEXT, formatIncidentTime, hasLocation } from "./clicklog-shared";
+
+export function ClicklogIncidentList({
+  incidents,
+  onDelete,
+}: {
+  incidents: ClicklogIncident[];
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 14, fontWeight: 600, color: TEXT, marginBottom: 14 }}>Recent Incidents</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {incidents.map((incident) => (
+          <div key={incident.id} style={{ display: "flex", alignItems: "flex-start", gap: 12, padding: "14px 16px", borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}` }}>
+            <div style={{ width: 32, height: 32, borderRadius: 8, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+              <AlertTriangle size={14} color={BRAND} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 3 }}>{formatIncidentTime(incident.created_at)}</div>
+              {incident.metadata.notes && (
+                <div style={{ fontSize: 13, color: TEXT, lineHeight: 1.5, marginBottom: 4 }}>{incident.metadata.notes}</div>
+              )}
+              {hasLocation(incident) && (
+                <div style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 11, color: SUBTLE }}>
+                  <MapPin size={10} color={SUBTLE} /> Location recorded
+                </div>
+              )}
+            </div>
+            <button
+              onClick={() => onDelete(incident.id)}
+              aria-label="Delete incident"
+              style={{ width: 28, height: 28, borderRadius: 6, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE, flexShrink: 0 }}
+            >
+              <Trash2 size={13} />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/clicklog/clicklog-loading.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// STATE: Loading — data fetch in progress. Ported from
+// design/.../survivor-hub/ClickLogLoading.tsx.
+import { BG } from "./clicklog-shared";
+
+export function ClicklogLoading() {
+  return (
+    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
+      <div style={{ textAlign: "center", padding: "0 32px" }}>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
+          EXIT THEIR ECONOMY
+        </div>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
+          EXIT THE PSYOP
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/clicklog/clicklog-log-panel.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-log-panel.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { AlertTriangle, MapPin } from "lucide-react";
+import { MAX_NOTES_LENGTH } from "../../lib/clicklog/constants";
+import { BG, BORDER, BRAND, SUBTLE, SURFACE, TEXT } from "./clicklog-shared";
+
+export function ClicklogLogPanel({
+  logged,
+  showForm,
+  note,
+  submitting,
+  locationAdded,
+  onToggleForm,
+  onNoteChange,
+  onAddLocation,
+  onSubmit,
+  onCancel,
+}: {
+  logged: boolean;
+  showForm: boolean;
+  note: string;
+  submitting: boolean;
+  locationAdded: boolean;
+  onToggleForm: () => void;
+  onNoteChange: (value: string) => void;
+  onAddLocation: () => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  const buttonColor = logged ? "#22C55E" : BRAND;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16, marginBottom: 40 }}>
+      <button
+        onClick={onToggleForm}
+        style={{ width: 160, height: 160, borderRadius: "50%", background: buttonColor, border: `4px solid ${buttonColor}`, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 8, cursor: "pointer", boxShadow: `0 0 40px ${BRAND}30`, transition: "all 0.2s" }}
+      >
+        <AlertTriangle size={40} color="#fff" />
+        <span style={{ fontSize: 15, fontWeight: 800, color: "#fff" }}>{logged ? "Logged ✓" : "Log Incident"}</span>
+      </button>
+      <div style={{ fontSize: 12, color: SUBTLE, textAlign: "center" }}>
+        Tap to log an incident instantly.<br />Optionally add a note below.
+      </div>
+
+      {showForm && (
+        <div style={{ width: "100%", maxWidth: 480, padding: "16px", borderRadius: 14, background: SURFACE, border: `1px solid ${BRAND}30` }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 8 }}>Add a note (optional)</div>
+          <textarea
+            value={note}
+            onChange={(e) => onNoteChange(e.target.value)}
+            rows={3}
+            maxLength={MAX_NOTES_LENGTH}
+            placeholder="Describe what happened…"
+            style={{ width: "100%", padding: "10px 12px", background: BG, border: `1px solid ${BORDER}`, borderRadius: 10, fontSize: 13, color: TEXT, outline: "none", resize: "vertical", fontFamily: "inherit", boxSizing: "border-box" }}
+          />
+          <div style={{ display: "flex", gap: 8, marginTop: 10, alignItems: "center" }}>
+            <button
+              onClick={onAddLocation}
+              style={{ display: "flex", alignItems: "center", gap: 5, padding: "7px 12px", borderRadius: 8, background: locationAdded ? `${BRAND}18` : "rgba(255,255,255,0.04)", border: `1px solid ${locationAdded ? BRAND + "40" : BORDER}`, color: locationAdded ? BRAND : SUBTLE, fontSize: 12, cursor: "pointer" }}
+            >
+              <MapPin size={12} /> {locationAdded ? "Location added" : "Add location"}
+            </button>
+            <div style={{ flex: 1 }} />
+            <button onClick={onCancel} style={{ padding: "7px 14px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 12, cursor: "pointer" }}>Cancel</button>
+            <button onClick={onSubmit} disabled={submitting} style={{ padding: "7px 18px", borderRadius: 8, background: BRAND, border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: submitting ? "not-allowed" : "pointer", opacity: submitting ? 0.7 : 1 }}>Submit</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/clicklog/clicklog-right-rail.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-right-rail.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { BORDER, BRAND, SUBTLE, type ClicklogStats } from "./clicklog-shared";
+
+export function ClicklogRightRail({
+  stats,
+  loading,
+  onQuickLog,
+}: {
+  stats: ClicklogStats;
+  loading: boolean;
+  onQuickLog: () => void;
+}) {
+  const cards = [
+    { label: "This week", value: stats.week, color: BRAND },
+    { label: "This month", value: stats.month, color: "#F97316" },
+    { label: "With notes", value: stats.withNotes, color: "#9CA3AF" },
+    { label: "With location", value: stats.withLocation, color: "#06B6D4" },
+  ];
+
+  return (
+    <aside style={{ width: 280, borderLeft: `1px solid ${BORDER}`, background: "#0D0F14", padding: "20px 16px", flexShrink: 0, overflowY: "auto" }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Stats</div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 16 }}>
+        {cards.map(({ label, value, color }) => (
+          <div key={label} style={{ padding: "10px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${BORDER}`, textAlign: "center" }}>
+            <div style={{ fontSize: 20, fontWeight: 800, color }}>{value}</div>
+            <div style={{ fontSize: 10, color: SUBTLE, marginTop: 2 }}>{label}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ padding: "14px", borderRadius: 12, background: "rgba(233,30,140,0.05)", border: "1px solid rgba(233,30,140,0.15)", marginBottom: 14 }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: BRAND, marginBottom: 6 }}>Safety reminder</div>
+        <div style={{ fontSize: 11, color: SUBTLE, lineHeight: 1.6 }}>
+          ClickLog is for personal tracking only. In an emergency, always contact local emergency services first.
+        </div>
+      </div>
+      <button
+        onClick={onQuickLog}
+        disabled={loading}
+        style={{ width: "100%", padding: "9px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 12, cursor: loading ? "not-allowed" : "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}
+      >
+        <Plus size={13} /> Log without opening form
+      </button>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/clicklog/clicklog-shared.ts
+++ b/ctf/packages/web/components/clicklog/clicklog-shared.ts
@@ -1,0 +1,83 @@
+// Shared constants, types, and derivations for the ClickLog web shell.
+// Palette derives from design/.../survivor-hub/ClickLog.tsx.
+
+import type { ClicklogIncident } from "../../lib/clicklog/types";
+
+export const BRAND = "#E91E8C";
+export const BG = "#0F1117";
+export const SURFACE = "#161B27";
+export const BORDER = "#1E2A3A";
+export const TEXT = "#F9FAFB";
+export const SUBTLE = "#6B7280";
+export const FAINT = "#4B5563";
+
+export const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+// Monday-based weekday index (Mon=0 … Sun=6).
+function weekdayIndex(date: Date): number {
+  return (date.getDay() + 6) % 7;
+}
+
+function startOfWeek(now: Date): Date {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - weekdayIndex(d));
+  return d;
+}
+
+export type ClicklogStats = {
+  total: number;
+  week: number;
+  month: number;
+  withNotes: number;
+  withLocation: number;
+  weekdayCounts: number[];
+};
+
+export function hasLocation(incident: ClicklogIncident): boolean {
+  return typeof incident.metadata.latitude === "number" && typeof incident.metadata.longitude === "number";
+}
+
+function hasNotes(incident: ClicklogIncident): boolean {
+  return Boolean(incident.metadata.notes && incident.metadata.notes.trim().length > 0);
+}
+
+function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+export function deriveClicklogStats(incidents: ClicklogIncident[], now: Date = new Date()): ClicklogStats {
+  const weekStart = startOfWeek(now);
+  const weekdayCounts = [0, 0, 0, 0, 0, 0, 0];
+  let week = 0;
+  let month = 0;
+  let withNotes = 0;
+  let withLocation = 0;
+
+  for (const incident of incidents) {
+    const created = new Date(incident.created_at);
+    if (Number.isNaN(created.getTime())) continue;
+    if (created >= weekStart) {
+      week += 1;
+      weekdayCounts[weekdayIndex(created)] += 1;
+    }
+    if (isSameMonth(created, now)) month += 1;
+    if (hasNotes(incident)) withNotes += 1;
+    if (hasLocation(incident)) withLocation += 1;
+  }
+
+  return { total: incidents.length, week, month, withNotes, withLocation, weekdayCounts };
+}
+
+export function formatIncidentTime(createdAt: string, now: Date = new Date()): string {
+  const created = new Date(createdAt);
+  if (Number.isNaN(created.getTime())) return createdAt;
+  const time = created.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  const startToday = new Date(now);
+  startToday.setHours(0, 0, 0, 0);
+  const startYesterday = new Date(startToday);
+  startYesterday.setDate(startYesterday.getDate() - 1);
+  if (created >= startToday) return `Today, ${time}`;
+  if (created >= startYesterday) return `Yesterday, ${time}`;
+  return `${created.toLocaleDateString([], { month: "short", day: "numeric" })}, ${time}`;
+}

--- a/ctf/packages/web/components/clicklog/clicklog-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-shell.tsx
@@ -1,160 +1,147 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { Button } from "../ui/button";
-import { ScrollArea } from "../ui/scroll-area";
-import { MAX_NOTES_LENGTH } from "../../lib/clicklog/constants";
+import { useEffect, useState } from "react";
 import type { ClicklogIncident } from "../../lib/clicklog/types";
+import { BG, BORDER, BRAND, SUBTLE, TEXT, deriveClicklogStats } from "./clicklog-shared";
+import { ClicklogIconRail } from "./clicklog-icon-rail";
+import { ClicklogSidebar } from "./clicklog-sidebar";
+import { ClicklogRightRail } from "./clicklog-right-rail";
+import { ClicklogLogPanel } from "./clicklog-log-panel";
+import { ClicklogIncidentList } from "./clicklog-incident-list";
+import { ClicklogEmptyState } from "./clicklog-empty-state";
+import { ClicklogLoading } from "./clicklog-loading";
+import { AlertTriangle } from "lucide-react";
 
-interface ClicklogShellProps {
-  userId: string;
-}
+type Geo = { latitude?: number; longitude?: number };
 
-export function ClicklogShell({ userId }: ClicklogShellProps) {
-  const [loading, setLoading] = useState(false);
+export function ClicklogShell() {
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [incidents, setIncidents] = useState<ClicklogIncident[]>([]);
-  const [count, setCount] = useState(0);
-  const [showModal, setShowModal] = useState(false);
-  const [notes, setNotes] = useState("");
-  const [geo, setGeo] = useState<{ latitude?: number; longitude?: number }>({});
+  const [showForm, setShowForm] = useState(false);
+  const [note, setNote] = useState("");
+  const [geo, setGeo] = useState<Geo>({});
+  const [logged, setLogged] = useState(false);
 
-  const fetchIncidents = async () => {
-    setLoading(true);
+  async function fetchIncidents(initial = false): Promise<void> {
+    if (initial) setLoading(true);
     setError(null);
     try {
       const res = await fetch("/api/clicklog");
       if (!res.ok) throw new Error("Failed to fetch incidents");
-      const data = await res.json();
+      const data = (await res.json()) as { incidents: ClicklogIncident[]; count: number };
       setIncidents(data.incidents);
-      setCount(data.count);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to fetch incidents");
     } finally {
-      setLoading(false);
+      if (initial) setLoading(false);
     }
-  };
+  }
 
   useEffect(() => {
-    fetchIncidents();
+    void fetchIncidents(true);
   }, []);
 
-  const handleLogIncident = async () => {
-    setShowModal(true);
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (pos) => {
-          setGeo({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
-        },
-        () => {
-          setGeo({});
-        }
-      );
-    }
-  };
+  function flashLogged(): void {
+    setLogged(true);
+    setTimeout(() => setLogged(false), 2000);
+  }
 
-  const submitIncident = async () => {
-    setLoading(true);
+  function addLocation(): void {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setGeo({ latitude: pos.coords.latitude, longitude: pos.coords.longitude }),
+      () => setGeo({}),
+    );
+  }
+
+  async function postIncident(metadata: Record<string, unknown>): Promise<void> {
+    setBusy(true);
     setError(null);
     try {
       const res = await fetch("/api/clicklog", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ metadata: { ...geo, notes } }),
+        body: JSON.stringify({ metadata }),
       });
       if (!res.ok) throw new Error("Failed to log incident");
-      setShowModal(false);
-      setNotes("");
+      setShowForm(false);
+      setNote("");
       setGeo({});
+      flashLogged();
       await fetchIncidents();
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to log incident");
     } finally {
-      setLoading(false);
+      setBusy(false);
     }
-  };
+  }
 
-  const handleDelete = async (id: string) => {
-    if (!window.confirm('Are you sure you want to delete this incident?')) {
-      return;
-    }
-    setLoading(true);
+  async function handleDelete(id: string): Promise<void> {
+    if (!window.confirm("Are you sure you want to delete this incident?")) return;
+    setBusy(true);
     setError(null);
     try {
       const res = await fetch(`/api/clicklog/${id}`, { method: "DELETE" });
       if (!res.ok) throw new Error("Failed to delete incident");
       await fetchIncidents();
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete incident");
     } finally {
-      setLoading(false);
+      setBusy(false);
     }
-  };
+  }
+
+  if (loading) return <ClicklogLoading />;
+
+  if (incidents.length === 0 && !showForm) {
+    return <ClicklogEmptyState onLog={() => setShowForm(true)} />;
+  }
+
+  const stats = deriveClicklogStats(incidents);
 
   return (
-    <div className="flex h-full">
-      <aside className="w-[72px] bg-muted flex flex-col items-center py-4">
-        <span className="text-3xl">📍</span>
-      </aside>
-      <main className="flex-1 p-6">
-        <div className="flex items-center gap-4 mb-4">
-          <div className="text-4xl font-bold">{count}</div>
-          <div className="text-lg">Incidents logged</div>
-          <Button onClick={handleLogIncident} disabled={loading} className="ml-auto">
-            Log Incident
-          </Button>
-        </div>
-        {error && <div className="text-red-500 mb-2">{error}</div>}
-        <ScrollArea className="h-96 border rounded-lg p-2 bg-white">
-          {incidents.length === 0 ? (
-            <div className="text-muted-foreground text-center py-8">No incidents logged yet.</div>
-          ) : (
-            incidents.map((incident) => (
-              <div key={incident.id} className="flex items-center justify-between border-b py-2">
-                <div>
-                  <div className="font-mono text-xs text-muted-foreground">
-                    {new Date(incident.created_at).toLocaleString()}
-                  </div>
-                  {incident.metadata.latitude && incident.metadata.longitude && (
-                    <div className="text-xs">
-                      Location: {incident.metadata.latitude.toFixed(4)}, {incident.metadata.longitude.toFixed(4)}
-                    </div>
-                  )}
-                  {incident.metadata.notes && (
-                    <div className="text-xs italic">{incident.metadata.notes}</div>
-                  )}
-                </div>
-                <Button variant="ghost" onClick={() => handleDelete(incident.id)} disabled={loading}>
-                  Delete
-                </Button>
-              </div>
-            ))
-          )}
-        </ScrollArea>
-        {showModal && (
-          <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-            <div className="bg-white rounded-lg p-6 w-80 shadow-lg">
-              <h2 className="text-lg font-semibold mb-2">Log Incident</h2>
-              <textarea
-                className="w-full border rounded p-2 mb-2"
-                rows={3}
-                placeholder="Optional notes"
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                maxLength={MAX_NOTES_LENGTH}
-              />
-              <div className="flex gap-2 mt-2">
-                <Button onClick={submitIncident} disabled={loading}>
-                  Submit
-                </Button>
-                <Button variant="outline" onClick={() => setShowModal(false)}>
-                  Cancel
-                </Button>
-              </div>
-            </div>
+    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+      <ClicklogIconRail />
+      <ClicklogSidebar total={stats.total} weekdayCounts={stats.weekdayCounts} />
+
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+          <AlertTriangle size={18} color={BRAND} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>Incident Log</div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>Personal safety tracking — {stats.total} incidents total</div>
           </div>
-        )}
-      </main>
+        </header>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "32px 48px" }}>
+          {error && (
+            <div style={{ marginBottom: 16, padding: "10px 14px", borderRadius: 10, background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)", color: "#fecaca", fontSize: 13 }}>
+              {error}
+            </div>
+          )}
+
+          <ClicklogLogPanel
+            logged={logged}
+            showForm={showForm}
+            note={note}
+            submitting={busy}
+            locationAdded={typeof geo.latitude === "number"}
+            onToggleForm={() => setShowForm((s) => !s)}
+            onNoteChange={setNote}
+            onAddLocation={addLocation}
+            onSubmit={() => void postIncident({ ...geo, notes: note })}
+            onCancel={() => { setShowForm(false); setNote(""); setGeo({}); }}
+          />
+
+          {incidents.length > 0 && (
+            <ClicklogIncidentList incidents={incidents} onDelete={(id) => void handleDelete(id)} />
+          )}
+        </div>
+      </div>
+
+      <ClicklogRightRail stats={stats} loading={busy} onQuickLog={() => void postIncident({})} />
     </div>
   );
 }

--- a/ctf/packages/web/components/clicklog/clicklog-sidebar.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-sidebar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { BORDER, BRAND, FAINT, SUBTLE, SURFACE, WEEKDAYS } from "./clicklog-shared";
+
+export function ClicklogSidebar({ total, weekdayCounts }: { total: number; weekdayCounts: number[] }) {
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 4 }}>🚨 ClickLog</div>
+        <div style={{ fontSize: 12, color: FAINT, lineHeight: 1.5 }}>Personal incident counter — private &amp; encrypted</div>
+      </div>
+      <div style={{ padding: "0 12px", flex: 1 }}>
+        <div style={{ padding: "16px", borderRadius: 14, background: `${BRAND}08`, border: `1px solid ${BRAND}18`, marginBottom: 14 }}>
+          <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 4 }}>Total Logged</div>
+          <div style={{ fontSize: 36, fontWeight: 800, color: BRAND }}>{total}</div>
+          <div style={{ fontSize: 11, color: SUBTLE, marginTop: 4 }}>incidents · all time</div>
+        </div>
+        <div style={{ padding: "12px", borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}` }}>
+          <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 8 }}>This week</div>
+          <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12 }}>
+            {WEEKDAYS.map((d, i) => {
+              const count = weekdayCounts[i] ?? 0;
+              const active = count > 0;
+              return (
+                <div key={d} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+                  <div style={{ width: 20, height: 20, borderRadius: "50%", background: active ? `${BRAND}25` : "rgba(255,255,255,0.04)", border: `1px solid ${active ? BRAND + "40" : BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 9, fontWeight: 700, color: active ? BRAND : SUBTLE }}>
+                    {active ? String(count) : ""}
+                  </div>
+                  <span style={{ fontSize: 8, color: SUBTLE }}>{d[0]}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      <div style={{ padding: 12, borderTop: `1px solid ${BORDER}` }}>
+        <div style={{ fontSize: 11, color: FAINT, lineHeight: 1.5 }}>🔒 All data is end-to-end encrypted. Only you can see your incidents.</div>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

First UI circle-back of the four plugins unblocked by the `c5d83c0` design re-pin (#137). Replaces the plain Tailwind/shadcn `ClicklogShell` with a pixel build of `design/.../survivor-hub/ClickLog.tsx` and its Empty/Loading states.

## Changes

Dark layout (`#0F1117` / brand `#E91E8C`) matching the mockup:
- **Icon rail** + **left sidebar** (Total Logged + this-week weekday strip + end-to-end-encryption note)
- **Main column**: the large circular "Log Incident" button with an **inline note form** (was a modal), and the recent-incidents list with delete
- **Right rail**: stats grid + safety reminder + "log without opening form"
- **Empty** state (`ClickLogEmpty.tsx`) — big button + "how it works" + safety note; **Loading** state (`ClickLogLoading.tsx`)

Honest data: every counter — Total Logged, the this-week weekday strip, and the right-rail This week / This month / With notes / With location — is **derived from the real `/api/clicklog` data**, not the mockup's dummy numbers. Posting uses `POST /api/clicklog` (optional browser geolocation); delete uses `DELETE /api/clicklog/:id`. API/schema unchanged.

ClickLog is a private, auth-only tool, so there is **no public state** (the `ClickLogPublic.tsx` mockup is intentionally not implemented).

Modularity + lint: decomposed into `clicklog-shared`, `-icon-rail`, `-sidebar`, `-right-rail`, `-log-panel`, `-incident-list`, `-empty-state`, `-loading` (each within `complexity:10` / `max-lines-per-function:200`); cleared the prior `any` lint debt; dropped the unused `userId` prop (updated the route call site).

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- `pnpm --filter @ctf/web lint components/clicklog/` — green
- Modularity gate on all clicklog files — green
- `pnpm --filter @ctf/web build:ci` — green
- `check-eof-format.sh`, `check-web-android-parity.mjs`, `check-schema-drift.sh` — green

## Scope

Web-only pixel pass. The Android pixel pass (`MobileClickLog.tsx` → React Native feature) is deferred and tracked in the plan. Three design-gated plugins remain (skills-taxonomy, weekly-performance, unlock).

Parity Ticket: #119


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_