### PR TITLE
fix: stamp product-update dates in US Eastern, not UTC

### DIFF
--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -56,6 +56,12 @@ jobs:
       needs.check-changes.outputs.has_changes == 'true' ||
       inputs.force == true
     runs-on: ubuntu-latest
+    # Stamp all dates (wiki page slug, Quora draft issue, update tag) in US
+    # Eastern rather than the runner's UTC, so they match the project's local
+    # day. Applies to shell `date` and Node `new Date()`/toLocaleString in the
+    # steps below.
+    env:
+      TZ: America/New_York
     permissions:
       contents: write   # push update/* tag
       issues: write     # create Quora draft issue

--- a/ctf/scripts/generate-update.mjs
+++ b/ctf/scripts/generate-update.mjs
@@ -28,7 +28,10 @@ const brandVoice = readFileSync(
   'utf-8',
 ).slice(0, 3000);
 
-const today = new Date().toISOString().split('T')[0];
+// Date in the runner's local timezone (TZ env, set by the workflow) as
+// YYYY-MM-DD. Avoids toISOString(), which is always UTC and can land on the
+// next day shortly after local midnight. en-CA gives ISO-style YYYY-MM-DD.
+const today = new Date().toLocaleDateString('en-CA');
 
 const response = await fetch('https://api.anthropic.com/v1/messages', {
   method: 'POST',


### PR DESCRIPTION
## Problem

Auto-generated dates were a day ahead when the workflow ran shortly after UTC midnight. Example: Quora draft issue #147 was created at `2026-05-30T00:14:33Z` and titled **2026-05-30**, but it was still **2026-05-29** in US Eastern.

Every date in the pipeline was computed in UTC on the GitHub runner:
- `generate-update.mjs:31` → `new Date().toISOString()` (always UTC) — feeds `wikiPageName`/slug and the model's "Today"
- `generate-product-update.yml` → `date +%Y-%m-%d` for the Quora issue title and the `update/*` tag (UTC runner)

## Fix

- Job-level **`env: TZ: America/New_York`** so shell `date` and Node `new Date()` in every step format in US Eastern.
- `generate-update.mjs` switched from `new Date().toISOString()` (always UTC, ignores `TZ`) to **`new Date().toLocaleDateString('en-CA')`** (ISO-style `YYYY-MM-DD`, honors `TZ`).

## Testing

For the exact boundary instant `2026-05-30T00:14:33Z` (issue #147's `created_at`):
- UTC → `2026-05-30` (the wrong value)
- America/New_York → `2026-05-29` ✅

Confirmed `TZ=America/New_York` shifts both shell `date` and Node `new Date()` at process start; workflow YAML and `node --check` pass.

## Note

This fixes **date generation** in this repo. The wiki-site **rendering** has a separate, related off-by-one (it parses the `YYYY-MM-DD` string as UTC then formats in the viewer's local TZ) plus a request to show the "ET" label — both handled in the `wiki-site` repo separately.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4z5xmxVcGTkjsXiro2hgc)_