### PR TITLE
feat: weekly-performance web pixel pass — full dashboard to design mockup

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -111,7 +111,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | peer-programming | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | mood | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | gentlepulse | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
-| weekly-performance | ⏳ | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| weekly-performance | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | gdp | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | service-credits | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | levelup | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
@@ -434,3 +434,14 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   modular sub-components within the rule-116 limits. typecheck, lint, modularity, build:ci, EOF, parity,
   and schema-drift gates green. Marked unlock Design 🎨 / Web px ✅; Android pixel parity
   (`MobileUnlock.tsx`) remains ⬜. Two design-gated plugins remain: skills-taxonomy, weekly-performance.
+- 2026-05-29: UI circle-back — weekly-performance web pixel pass (third of the four plugins unblocked by
+  the `c5d83c0` re-pin). Replaced the baseline server-rendered summary shell with the full client
+  dashboard from `WeeklyPerformance.tsx` (+ Empty/Loading): icon rail, week-history sidebar, metric
+  cards, a this-week-vs-last-week comparison chart, and the week-summary right rail. Week selection
+  drives `GET /api/weekly-performance/weeks`, `/current-week`, and `/metrics` (with `compareWeekStartDate`
+  for deltas); admin export opens `GET /api/weekly-performance/export`. Real data only — the mockup's
+  fabricated daily series became a real per-metric current-vs-compare chart (scaled relative to the max
+  in view), and the unbacked "Top Apps" widget was omitted rather than faked. Decomposed into ten
+  modular sub-components within the rule-116 limits. typecheck, lint, modularity, build:ci, EOF, parity,
+  and schema-drift gates green. Marked weekly-performance Design 🎨 / Web px ✅; Android pixel parity
+  (`MobileWeeklyPerformance.tsx`) remains ⬜. One design-gated plugin remains: skills-taxonomy.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
@@ -83,6 +83,8 @@ Admin routes:
 
 `web+android complete`. Week-selector behavior, current-week polling policy, empty/error semantics, metric definitions, formatting, and deny reasons are consistent across web (`/apps/weekly-performance`) and Android (`packages/mobile/src/features/weekly-performance`).
 
+Web pixel pass (design `c5d83c0`): the user-facing shell is rebuilt to `design/.../survivor-hub/WeeklyPerformance.tsx` and its Empty/Loading states — icon rail, week-history sidebar, metric cards, a this-week-vs-last-week comparison chart, and a week-summary right rail. Week selection drives `GET /api/weekly-performance/weeks`, `/current-week`, and `/metrics` (with `compareWeekStartDate` for per-metric deltas); admin export opens `GET /api/weekly-performance/export`. Real data only — the mockup's fabricated daily series became a real per-metric current-vs-compare chart scaled relative to the max value in view, metric labels are humanized from `metric_key` (no label column exists), and the unbacked "Top Apps" widget was omitted rather than faked. Decomposed into modular sub-components within the rule-116 limits. Android pixel pass to `MobileWeeklyPerformance.tsx` remains tracked in `PRODUCTION_READINESS_PLAN.md`.
+
 ## 6) Seed Coverage Status
 
 Weekly performance metrics are derived from upstream plugin tables (workforce, service-credits, etc.); no dedicated seed script is required. Local validation runs against fixtures produced by upstream plugin seed scripts.
@@ -95,6 +97,7 @@ Weekly performance metrics are derived from upstream plugin tables (workforce, s
 
 ## 8) Change Log
 
+- 2026-05-29: Web UI circle-back (design `c5d83c0`; unblocked by the design re-pin). Rebuilt the user-facing weekly-performance shell from the baseline server summary to the full client dashboard in `WeeklyPerformance.tsx` (+ Empty/Loading), wired to the documented read routes and the admin export. Decomposed into modular sub-components (`wp-shared`, `wp-loading`, `wp-icon-rail`, `wp-sidebar`, `wp-metric-cards`, `wp-comparison-chart`, `wp-empty-main`, `wp-dashboard-main`, `wp-right-rail`, plus the shell). Real data only; the dummy daily chart became a real this-week-vs-last-week per-metric comparison and the unbacked "Top Apps" widget was omitted. No schema/API change.
 - 2026-05-18: Replaced "Web and Android Parity Notes" with canonical "Web and Android Delivery Status" (`web+android complete`). Renamed "Open Decisions" to canonical "Gaps and Known Technical Debt" and removed Android-parity-milestone entry per Rule 105.
 - 2026-02-25: Created initial Weekly Performance plugin inventory.
 - 2026-02-25: Updated Weekly Performance plugin scope to remove financial/revenue metric reporting from dashboard parity.

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
@@ -1,43 +1,140 @@
-import Link from 'next/link';
-import { getCurrentWeek, listWeeks } from 'lib/weekly-performance/repository';
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  BG,
+  TEXT,
+  type ComparisonResponse,
+  type CurrentWeekResponse,
+  type MetricsResponse,
+  type WeeksResponse,
+  type WpComparison,
+  type WpMetric,
+  type WpWeek,
+} from "./wp-shared";
+import { WeeklyPerformanceLoading } from "./wp-loading";
+import { WeeklyPerformanceIconRail } from "./wp-icon-rail";
+import { WeeklyPerformanceSidebar } from "./wp-sidebar";
+import { WeeklyPerformanceDashboardMain } from "./wp-dashboard-main";
+import { WeeklyPerformanceRightRail } from "./wp-right-rail";
 
 type WeeklyPerformanceShellProps = {
   isAdmin: boolean;
 };
 
-export async function WeeklyPerformanceShell({ isAdmin }: WeeklyPerformanceShellProps) {
-  const [currentWeek, weeks] = await Promise.all([getCurrentWeek(), listWeeks()]);
+type ShellData = {
+  weeks: WpWeek[];
+  activeUsers: number | null;
+  initialWeekStart: string | null;
+};
+
+function priorWeekStart(weeks: WpWeek[], selected: string | null): string | null {
+  if (!selected) return null;
+  const sorted = [...weeks].sort((a, b) => b.weekStartDate.localeCompare(a.weekStartDate));
+  const index = sorted.findIndex((w) => w.weekStartDate === selected);
+  if (index < 0 || index + 1 >= sorted.length) return null;
+  return sorted[index + 1].weekStartDate;
+}
+
+async function fetchShellData(): Promise<ShellData> {
+  const [weeksRes, currentRes] = await Promise.all([
+    fetch("/api/weekly-performance/weeks", { cache: "no-store" }),
+    fetch("/api/weekly-performance/current-week", { cache: "no-store" }),
+  ]);
+  if (!weeksRes.ok) throw new Error("Failed to load weeks.");
+  const weeksData = (await weeksRes.json()) as WeeksResponse;
+  const currentData = currentRes.ok ? ((await currentRes.json()) as CurrentWeekResponse) : null;
+  return {
+    weeks: weeksData.weeks,
+    activeUsers: currentData?.activeUsersLast7Days ?? null,
+    initialWeekStart: currentData?.currentWeek?.weekStartDate ?? weeksData.weeks[0]?.weekStartDate ?? null,
+  };
+}
+
+export function WeeklyPerformanceShell({ isAdmin }: WeeklyPerformanceShellProps) {
+  const [loading, setLoading] = useState(true);
+  const [weeks, setWeeks] = useState<WpWeek[]>([]);
+  const [selectedWeekStart, setSelectedWeekStart] = useState<string | null>(null);
+  const [activeUsers, setActiveUsers] = useState<number | null>(null);
+  const [metrics, setMetrics] = useState<WpMetric[]>([]);
+  const [comparison, setComparison] = useState<WpComparison | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchShellData()
+      .then((data) => {
+        if (!active) return;
+        setWeeks(data.weeks);
+        setActiveUsers(data.activeUsers);
+        setSelectedWeekStart(data.initialWeekStart);
+      })
+      .catch((e) => {
+        if (active) setError(e instanceof Error ? e.message : "Failed to load Weekly Performance.");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => { active = false; };
+  }, []);
+
+  const loadWeekData = useCallback(async (weekStartDate: string, compareWeekStartDate: string | null) => {
+    setMetrics([]);
+    setComparison(null);
+    const metricsRes = await fetch(`/api/weekly-performance/metrics?weekStartDate=${encodeURIComponent(weekStartDate)}`, { cache: "no-store" });
+    if (metricsRes.ok) {
+      setMetrics(((await metricsRes.json()) as MetricsResponse).metrics ?? []);
+    }
+    if (compareWeekStartDate) {
+      const cmpRes = await fetch(`/api/weekly-performance/metrics?weekStartDate=${encodeURIComponent(weekStartDate)}&compareWeekStartDate=${encodeURIComponent(compareWeekStartDate)}`, { cache: "no-store" });
+      if (cmpRes.ok) {
+        setComparison(((await cmpRes.json()) as ComparisonResponse).comparison ?? null);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!selectedWeekStart) return;
+    void loadWeekData(selectedWeekStart, priorWeekStart(weeks, selectedWeekStart));
+  }, [selectedWeekStart, weeks, loadWeekData]);
+
+  if (loading) return <WeeklyPerformanceLoading />;
+
+  const selectedWeek = weeks.find((w) => w.weekStartDate === selectedWeekStart) ?? null;
+
+  function exportSelected() {
+    if (selectedWeekStart) {
+      window.open(`/api/weekly-performance/export?weekStartDate=${encodeURIComponent(selectedWeekStart)}`, "_blank");
+    }
+  }
 
   return (
-    <main className="mx-auto max-w-6xl px-6 py-10 space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Weekly Performance</h1>
-        <p className="text-sm text-muted-foreground">
-          Week navigation guardrails with non-financial metrics, comparison routes, and gated export behavior.
-        </p>
-      </header>
-
-      <section className="rounded-lg border bg-card p-5 space-y-2 text-sm">
-        <h2 className="text-lg font-medium">Current week</h2>
-        <p>Start: {currentWeek?.weekStartDate ?? 'n/a'}</p>
-        <p>End: {currentWeek?.weekEndDate ?? 'n/a'}</p>
-        <p>Status: {currentWeek?.status ?? 'n/a'}</p>
-      </section>
-
-      <section className="rounded-lg border bg-card p-5 space-y-2 text-sm">
-        <h2 className="text-lg font-medium">Recent weeks</h2>
-        <p>Total tracked weeks: {weeks.length}</p>
-      </section>
-
-      {isAdmin ? (
-        <p className="text-sm">
-          <Link className="underline underline-offset-4" href="/admin/weekly-performance">Open /admin/weekly-performance</Link>
-        </p>
-      ) : null}
-
-      <p className="text-sm">
-        <Link className="underline underline-offset-4" href="/">Return to home</Link>
-      </p>
-    </main>
+    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+      <WeeklyPerformanceIconRail />
+      <WeeklyPerformanceSidebar
+        weeks={weeks}
+        selectedWeekStart={selectedWeekStart}
+        onSelect={setSelectedWeekStart}
+        isAdmin={isAdmin}
+        onExport={exportSelected}
+      />
+      {error ? (
+        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#F87171", fontSize: 14 }}>{error}</div>
+      ) : (
+        <WeeklyPerformanceDashboardMain
+          week={selectedWeek}
+          metrics={metrics}
+          comparison={comparison}
+          isAdmin={isAdmin}
+          onExport={exportSelected}
+        />
+      )}
+      <WeeklyPerformanceRightRail
+        week={selectedWeek}
+        metricCount={metrics.length}
+        activeUsersLast7Days={activeUsers}
+        isAdmin={isAdmin}
+      />
+    </div>
   );
 }

--- a/ctf/packages/web/components/weekly-performance/wp-comparison-chart.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-comparison-chart.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { BORDER, BRAND, SUBTLE, SURFACE, TEXT, type WpComparison, humanizeMetricKey } from "./wp-shared";
+
+type Row = { metricKey: string; current: number; prev: number };
+
+function buildRows(comparison: WpComparison): Row[] {
+  const keys = new Set<string>([
+    ...comparison.base.map((m) => m.metricKey),
+    ...comparison.compare.map((m) => m.metricKey),
+  ]);
+  const rows: Row[] = [];
+  for (const metricKey of keys) {
+    const current = comparison.base.find((m) => m.metricKey === metricKey)?.metricValue ?? 0;
+    const prev = comparison.compare.find((m) => m.metricKey === metricKey)?.metricValue ?? 0;
+    rows.push({ metricKey, current, prev });
+  }
+  return rows;
+}
+
+// Honest analog of the mockup's "this week vs last week" daily bar chart: the
+// data model has no daily breakdown, so this plots each metric's real current
+// vs prior value, scaled relative to the max value in view (not a fake 0–100).
+export function WeeklyPerformanceComparisonChart({ comparison }: { comparison: WpComparison | null }) {
+  if (!comparison) return null;
+  const rows = buildRows(comparison);
+  if (rows.length === 0) return null;
+
+  const max = Math.max(1, ...rows.map((r) => Math.max(Math.abs(r.current), Math.abs(r.prev))));
+
+  return (
+    <div style={{ padding: "20px 24px", borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 24 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: TEXT }}>This week vs last week</div>
+        <div style={{ display: "flex", gap: 12, fontSize: 11 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 5 }}><div style={{ width: 10, height: 10, borderRadius: 2, background: BRAND }} /><span style={{ color: SUBTLE }}>This week</span></div>
+          <div style={{ display: "flex", alignItems: "center", gap: 5 }}><div style={{ width: 10, height: 10, borderRadius: 2, background: "rgba(255,255,255,0.15)" }} /><span style={{ color: SUBTLE }}>Last week</span></div>
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 16, height: 140 }}>
+        {rows.map((row) => (
+          <div key={row.metricKey} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6, minWidth: 0 }}>
+            <div style={{ display: "flex", alignItems: "flex-end", gap: 4, height: 100 }}>
+              <div title={`Last week: ${row.prev}`} style={{ width: 16, height: `${(Math.abs(row.prev) / max) * 100}%`, borderRadius: "3px 3px 0 0", background: "rgba(255,255,255,0.12)" }} />
+              <div title={`This week: ${row.current}`} style={{ width: 16, height: `${(Math.abs(row.current) / max) * 100}%`, borderRadius: "3px 3px 0 0", background: BRAND }} />
+            </div>
+            <span style={{ fontSize: 10, color: SUBTLE, textAlign: "center", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%" }}>{humanizeMetricKey(row.metricKey)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-dashboard-main.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-dashboard-main.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { BarChart2, CheckCircle, Download } from "lucide-react";
+import { BORDER, BRAND, SUBTLE, TEXT, type WpComparison, type WpMetric, type WpWeek, formatWeekRange, isLiveWeek } from "./wp-shared";
+import { WeeklyPerformanceMetricCards } from "./wp-metric-cards";
+import { WeeklyPerformanceComparisonChart } from "./wp-comparison-chart";
+import { WeeklyPerformanceEmptyMain } from "./wp-empty-main";
+
+export function WeeklyPerformanceDashboardMain({
+  week,
+  metrics,
+  comparison,
+  isAdmin,
+  onExport,
+}: {
+  week: WpWeek | null;
+  metrics: WpMetric[];
+  comparison: WpComparison | null;
+  isAdmin: boolean;
+  onExport: () => void;
+}) {
+  const live = isLiveWeek(week);
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+        <BarChart2 size={18} color={BRAND} />
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>{week ? `Week of ${formatWeekRange(week)}` : "Weekly Performance"}</div>
+          <div style={{ fontSize: 12, color: SUBTLE }}>Non-financial platform metrics</div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "4px 12px", borderRadius: 20, background: live ? `${BRAND}15` : "rgba(255,255,255,0.05)", border: `1px solid ${live ? BRAND + "40" : BORDER}`, fontSize: 11, fontWeight: 600, color: live ? BRAND : SUBTLE }}>
+          {live ? "● In Progress" : <><CheckCircle size={11} /> Closed</>}
+        </div>
+        {isAdmin && week && (
+          <button onClick={onExport} style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 8, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
+            <Download size={14} /> Export
+          </button>
+        )}
+      </header>
+
+      {metrics.length === 0 ? (
+        <WeeklyPerformanceEmptyMain week={week} />
+      ) : (
+        <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
+          <WeeklyPerformanceMetricCards metrics={metrics} comparison={comparison} />
+          <WeeklyPerformanceComparisonChart comparison={comparison} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-empty-main.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-empty-main.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+// Empty main-column content when the selected week has no metrics yet.
+// Ported from design/.../survivor-hub/WeeklyPerformanceEmpty.tsx (chrome lives
+// in the dashboard; this is the inner placeholder).
+import { BarChart2, Clock } from "lucide-react";
+import { BORDER, BRAND, SUBTLE, SURFACE, TEXT, type WpWeek, formatWeekRange, isLiveWeek } from "./wp-shared";
+
+export function WeeklyPerformanceEmptyMain({ week }: { week: WpWeek | null }) {
+  const inProgress = isLiveWeek(week);
+  return (
+    <div style={{ flex: 1, overflowY: "auto", padding: "40px 48px" }}>
+      <div style={{ padding: "28px 32px", borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 32 }}>
+        <div style={{ textAlign: "center", padding: "32px 0", display: "flex", flexDirection: "column", alignItems: "center", gap: 14 }}>
+          <div style={{ width: 64, height: 64, borderRadius: 18, background: `${BRAND}10`, border: `1px dashed ${BRAND}25`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <BarChart2 size={28} style={{ color: BRAND, opacity: 0.4 }} />
+          </div>
+          <div style={{ fontSize: 18, fontWeight: 700, color: TEXT }}>
+            {inProgress ? "Metrics appear when the week closes" : "No metrics recorded for this week"}
+          </div>
+          <div style={{ fontSize: 13, color: SUBTLE, maxWidth: 440, lineHeight: 1.6 }}>
+            {inProgress
+              ? "Engagement data is collected throughout the week. The dashboard populates once the week is marked closed by an admin."
+              : "This week has no recorded metrics."}
+          </div>
+          {week && (
+            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 20px", borderRadius: 20, background: "rgba(255,255,255,0.03)", border: `1px solid ${BORDER}` }}>
+              <Clock size={14} color={SUBTLE} />
+              <span style={{ fontSize: 12, color: SUBTLE }}>Week: {formatWeekRange(week)}</span>
+            </div>
+          )}
+        </div>
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 8, height: 80, opacity: 0.15 }}>
+          {[50, 65, 45, 75, 80, 55, 30].map((h, i) => (
+            <div key={i} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+              <div style={{ width: "80%", height: `${h}%`, borderRadius: "3px 3px 0 0", background: BRAND }} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-icon-rail.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-icon-rail.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { BarChart2, Bell, Calendar, Settings, TrendingUp } from "lucide-react";
+import { BORDER, BRAND, SUBTLE } from "./wp-shared";
+
+// Hub icon-rail chrome. Weekly Performance is a single dashboard view, so the
+// nav glyphs are presentational (matching the mockup); the brand mark anchors it.
+const NAV = [BarChart2, TrendingUp, Calendar];
+
+export function WeeklyPerformanceIconRail() {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${BRAND}25`, border: `1px solid ${BRAND}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <BarChart2 size={20} color={BRAND} />
+      </div>
+      {NAV.map((Icon, i) => (
+        <div key={i} style={{ width: 44, height: 44, borderRadius: 12, background: i === 0 ? `${BRAND}20` : "transparent", border: i === 0 ? `1px solid ${BRAND}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", color: i === 0 ? BRAND : SUBTLE }}>
+          <Icon size={20} />
+        </div>
+      ))}
+      <div style={{ flex: 1 }} />
+      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Bell size={18} /></div>
+      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Settings size={18} /></div>
+      <div style={{ width: 32, height: 32, borderRadius: "50%", background: `${BRAND}25`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, color: BRAND }}>S</div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-loading.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// STATE: Loading — data fetch in progress. Ported from
+// design/.../survivor-hub/WeeklyPerformanceLoading.tsx.
+import { BG } from "./wp-shared";
+
+export function WeeklyPerformanceLoading() {
+  return (
+    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
+      <div style={{ textAlign: "center", padding: "0 32px" }}>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
+          EXIT THEIR ECONOMY
+        </div>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
+          EXIT THE PSYOP
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-metric-cards.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-metric-cards.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { TrendingUp } from "lucide-react";
+import { BRAND, SUBTLE, SURFACE, type WpComparison, type WpMetric, formatDelta, formatMetricValue, humanizeMetricKey } from "./wp-shared";
+
+const CARD_COLORS = ["#A78BFA", "#22C55E", BRAND, "#06B6D4", "#EC4899", "#F97316"];
+
+// delta = current − prior, joined by metricKey from the comparison payload.
+function deltaFor(comparison: WpComparison | null, metricKey: string): number | null {
+  if (!comparison) return null;
+  const current = comparison.base.find((m) => m.metricKey === metricKey);
+  const prior = comparison.compare.find((m) => m.metricKey === metricKey);
+  if (!current || !prior) return null;
+  return current.metricValue - prior.metricValue;
+}
+
+export function WeeklyPerformanceMetricCards({
+  metrics,
+  comparison,
+}: {
+  metrics: WpMetric[];
+  comparison: WpComparison | null;
+}) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 12, marginBottom: 24 }}>
+      {metrics.map((metric, i) => {
+        const color = CARD_COLORS[i % CARD_COLORS.length];
+        const delta = deltaFor(comparison, metric.metricKey);
+        const positive = (delta ?? 0) >= 0;
+        return (
+          <div key={metric.metricKey} style={{ padding: "18px 16px", borderRadius: 14, background: SURFACE, border: `1px solid ${color}20` }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+              <span style={{ fontSize: 11, color: SUBTLE }}>{humanizeMetricKey(metric.metricKey)}</span>
+              <TrendingUp size={14} color={color} />
+            </div>
+            <div style={{ fontSize: 26, fontWeight: 800, color, marginBottom: 4 }}>{formatMetricValue(metric.metricValue, metric.metricUnit)}</div>
+            {delta !== null ? (
+              <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: positive ? "#22C55E" : "#F87171" }}>
+                <TrendingUp size={11} /> {formatDelta(delta, metric.metricUnit)}
+              </div>
+            ) : (
+              <div style={{ fontSize: 11, color: SUBTLE }}>No prior-week comparison</div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-right-rail.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-right-rail.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { BarChart2, Lock } from "lucide-react";
+import { BORDER, BRAND, SUBTLE, TEXT, type WpWeek, formatWeekRange, isLiveWeek } from "./wp-shared";
+
+export function WeeklyPerformanceRightRail({
+  week,
+  metricCount,
+  activeUsersLast7Days,
+  isAdmin,
+}: {
+  week: WpWeek | null;
+  metricCount: number;
+  activeUsersLast7Days: number | null;
+  isAdmin: boolean;
+}) {
+  const rows: { k: string; v: string }[] = [];
+  if (week) {
+    rows.push({ k: "Status", v: isLiveWeek(week) ? "In Progress" : "Closed" });
+    rows.push({ k: "Metrics tracked", v: String(metricCount) });
+  }
+  if (activeUsersLast7Days !== null) {
+    rows.push({ k: "Active users (7d)", v: activeUsersLast7Days.toLocaleString() });
+  }
+
+  return (
+    <aside style={{ width: 280, borderLeft: `1px solid ${BORDER}`, background: "#0D0F14", padding: "20px 16px", flexShrink: 0, overflowY: "auto" }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Week Summary</div>
+      <div style={{ padding: "16px", borderRadius: 14, background: `${BRAND}08`, border: `1px solid ${BRAND}20`, marginBottom: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+          <BarChart2 size={14} color={BRAND} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: BRAND }}>{week ? formatWeekRange(week) : "No week selected"}</span>
+        </div>
+        {rows.map(({ k, v }) => (
+          <div key={k} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 6 }}>
+            <span style={{ color: SUBTLE }}>{k}</span>
+            <span style={{ color: TEXT, fontWeight: 500 }}>{v}</span>
+          </div>
+        ))}
+      </div>
+      {!isAdmin && (
+        <div style={{ padding: "12px 14px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${BORDER}`, display: "flex", alignItems: "center", gap: 8 }}>
+          <Lock size={13} color={SUBTLE} />
+          <span style={{ fontSize: 11, color: SUBTLE }}>Export available to admins</span>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-shared.ts
+++ b/ctf/packages/web/components/weekly-performance/wp-shared.ts
@@ -1,0 +1,95 @@
+// Shared constants, types, and helpers for the Weekly Performance web shell.
+// Palette derives from design/.../survivor-hub/WeeklyPerformance.tsx.
+// Types mirror the shapes returned by lib/weekly-performance/repository.ts
+// (which exports inferred return types rather than named types).
+
+export const BRAND = "#F59E0B";
+export const BG = "#0F1117";
+export const SURFACE = "#161B27";
+export const BORDER = "#1E2A3A";
+export const TEXT = "#F9FAFB";
+export const SUBTLE = "#6B7280";
+export const FAINT = "#4B5563";
+
+export type WeekStatus = "open" | "locked" | "published";
+
+export type WpWeek = {
+  weekStartDate: string;
+  weekEndDate: string;
+  status: WeekStatus;
+};
+
+export type WpMetric = {
+  metricKey: string;
+  metricValue: number;
+  metricUnit: string;
+  sourcePlugin: string;
+};
+
+export type WpComparison = {
+  baseWeek: string;
+  compareWeek: string;
+  base: WpMetric[];
+  compare: WpMetric[];
+};
+
+export type CurrentWeekResponse = {
+  ok: boolean;
+  currentWeek: WpWeek | null;
+  activeUsersLast7Days: number;
+};
+
+export type WeeksResponse = { ok: boolean; weeks: WpWeek[] };
+export type MetricsResponse = { ok: boolean; metrics: WpMetric[] };
+export type ComparisonResponse = { ok: boolean; comparison: WpComparison };
+
+// A week is "live" while open; locked/published weeks are closed.
+export function isLiveWeek(week: WpWeek | null): boolean {
+  return week?.status === "open";
+}
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function parts(dateIso: string): { month: number; day: number; year: number } | null {
+  const d = new Date(dateIso);
+  if (Number.isNaN(d.getTime())) return null;
+  return { month: d.getUTCMonth(), day: d.getUTCDate(), year: d.getUTCFullYear() };
+}
+
+// "May 19–25, 2025" style range label from a week's start/end ISO dates.
+export function formatWeekRange(week: WpWeek): string {
+  const start = parts(week.weekStartDate);
+  const end = parts(week.weekEndDate);
+  if (!start || !end) return `${week.weekStartDate} – ${week.weekEndDate}`;
+  const startLabel = `${MONTHS[start.month]} ${start.day}`;
+  const endLabel = start.month === end.month ? `${end.day}` : `${MONTHS[end.month]} ${end.day}`;
+  return `${startLabel}–${endLabel}, ${end.year}`;
+}
+
+// Turn a snake/camel metric key into a readable label (no label column exists).
+export function humanizeMetricKey(key: string): string {
+  return key
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function formatMetricValue(value: number, unit: string): string {
+  const formatted = Number.isInteger(value)
+    ? value.toLocaleString()
+    : value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  if (!unit) return formatted;
+  if (unit === "%" || unit === "x") return `${formatted}${unit}`;
+  return `${formatted} ${unit}`;
+}
+
+export function formatDelta(delta: number, unit: string): string {
+  const suffix = unit === "%" ? "%" : "";
+  const sign = delta > 0 ? "+" : delta < 0 ? "-" : "";
+  const magnitude = Number.isInteger(delta)
+    ? Math.abs(delta).toLocaleString()
+    : Math.abs(delta).toLocaleString(undefined, { maximumFractionDigits: 2 });
+  return `${sign}${magnitude}${suffix} vs last week`;
+}

--- a/ctf/packages/web/components/weekly-performance/wp-sidebar.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-sidebar.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { BORDER, BRAND, FAINT, SUBTLE, TEXT, type WpWeek, formatWeekRange, isLiveWeek } from "./wp-shared";
+
+export function WeeklyPerformanceSidebar({
+  weeks,
+  selectedWeekStart,
+  onSelect,
+  isAdmin,
+  onExport,
+}: {
+  weeks: WpWeek[];
+  selectedWeekStart: string | null;
+  onSelect: (weekStartDate: string) => void;
+  isAdmin: boolean;
+  onExport: () => void;
+}) {
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 4 }}>📊 Weekly Performance</div>
+        <div style={{ fontSize: 12, color: FAINT, lineHeight: 1.5 }}>Week-over-week platform metrics</div>
+      </div>
+      <div style={{ flex: 1, overflowY: "auto", padding: "0 8px 12px" }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", color: "#374151", textTransform: "uppercase", padding: "4px 10px 8px" }}>Week History</div>
+        {weeks.length === 0 ? (
+          <div style={{ padding: "8px 10px", fontSize: 12, color: SUBTLE }}>No weeks tracked yet.</div>
+        ) : (
+          weeks.map((week) => {
+            const selected = week.weekStartDate === selectedWeekStart;
+            const live = isLiveWeek(week);
+            return (
+              <button key={week.weekStartDate} onClick={() => onSelect(week.weekStartDate)} style={{ width: "100%", display: "flex", alignItems: "center", gap: 8, padding: "9px 10px", borderRadius: 8, cursor: "pointer", background: selected ? `${BRAND}18` : "transparent", borderLeft: selected ? `2px solid ${BRAND}` : "2px solid transparent", marginLeft: 2, marginBottom: 2, border: "none", textAlign: "left" }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 12, color: selected ? TEXT : "#9CA3AF", fontWeight: selected ? 600 : 400 }}>{formatWeekRange(week)}</div>
+                </div>
+                <span style={{ fontSize: 10, padding: "2px 6px", borderRadius: 10, background: live ? `${BRAND}20` : "rgba(255,255,255,0.05)", color: live ? BRAND : SUBTLE, fontWeight: 600 }}>{live ? "LIVE" : "Closed"}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+      {isAdmin && (
+        <div style={{ padding: 12, borderTop: `1px solid ${BORDER}` }}>
+          <div style={{ padding: "10px 12px", borderRadius: 10, background: `${BRAND}08`, border: `1px solid ${BRAND}20` }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: BRAND, marginBottom: 6 }}>Admin Controls</div>
+            <a href="/admin/weekly-performance" style={{ width: "100%", padding: "7px", borderRadius: 7, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, color: TEXT, fontSize: 11, cursor: "pointer", marginBottom: 5, display: "block", textAlign: "center", textDecoration: "none", boxSizing: "border-box" }}>Manage weeks</a>
+            <button onClick={onExport} style={{ width: "100%", padding: "7px", borderRadius: 7, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 11, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 5 }}>
+              <Download size={11} /> Export CSV
+            </button>
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

Third UI circle-back of the four plugins unblocked by the `c5d83c0` design re-pin (#137). Replaces the baseline server-rendered summary shell (`WeeklyPerformanceShell` — a few `<section>`s) with the full client dashboard from `design/.../survivor-hub/WeeklyPerformance.tsx` and its Empty/Loading states.

## Changes

Dark (`#0F1117` / brand `#F59E0B`) dashboard matching the mockup:
- **Icon rail** + **week-history sidebar** (LIVE/Closed badges; admin controls: manage-weeks link + Export CSV)
- **Metric cards** with per-metric deltas
- **Comparison chart** + **week-summary right rail** (status, metrics tracked, active users (7d); "Export available to admins" note for non-admins)
- **Empty** main (week-in-progress placeholder) and **Loading** state

Wiring: week selection drives `GET /api/weekly-performance/weeks`, `/current-week`, and `/metrics` (adding `compareWeekStartDate` to fetch the prior week's deltas); the admin **Export** opens `GET /api/weekly-performance/export?weekStartDate=…`.

Honest data: the real metric shape is `{ metricKey, metricValue, metricUnit, sourcePlugin }` (no label, no daily breakdown). So: the mockup's **daily** bar series became a real **this-week-vs-last-week per-metric** chart scaled relative to the max value in view (not a fake 0–100); metric labels are **humanized from `metric_key`**; and the mockup's **"Top Apps This Week"** widget (no backing data) was **omitted rather than faked**.

Modularity: decomposed into `wp-shared`, `wp-loading`, `wp-icon-rail`, `wp-sidebar`, `wp-metric-cards`, `wp-comparison-chart`, `wp-empty-main`, `wp-dashboard-main`, `wp-right-rail`, plus the shell — each within `complexity:10` / `max-lines-per-function:200`. Route call site unchanged (still passes `isAdmin`).

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- `pnpm --filter @ctf/web lint components/weekly-performance/` — green
- Modularity gate on all WP files — green
- `pnpm --filter @ctf/web build:ci` — green
- `check-eof-format.sh`, `check-web-android-parity.mjs`, `check-schema-drift.sh` — green

## Scope

Web-only pixel pass. The Android pixel pass (`MobileWeeklyPerformance.tsx` → React Native feature) is deferred and tracked in the plan. **One design-gated plugin remains: skills-taxonomy.**

Parity Ticket: #119


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_