### PR TITLE
feat: skills-taxonomy web pixel pass — 3-column browser to design mockup

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -445,3 +445,15 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   modular sub-components within the rule-116 limits. typecheck, lint, modularity, build:ci, EOF, parity,
   and schema-drift gates green. Marked weekly-performance Design 🎨 / Web px ✅; Android pixel parity
   (`MobileWeeklyPerformance.tsx`) remains ⬜. One design-gated plugin remains: skills-taxonomy.
+- 2026-05-29: UI circle-back — skills-taxonomy web pixel pass (the last of the four plugins unblocked
+  by the `c5d83c0` re-pin). Rebuilt the `/apps/skills-taxonomy` browser from a summary/snapshot shell to
+  the `SkillsTaxonomy.tsx` mockup: the full-height 3-column hierarchy (sectors → job titles → skills)
+  with icon rail, breadcrumb, and in-role skill search, plus Empty (needs-seeding) and Loading states.
+  Loads the nested tree from the existing `GET /api/skills-taxonomy/hierarchy` (response `{ items }`) and
+  derives the columns client-side; sector/title counts use the real `jobTitles.length`/`skills.length`.
+  The mockup's demand/level/category chips have no backing in the data model and were omitted rather
+  than faked; admin add/edit/delete affordances link to `/admin/skills-taxonomy`. Decomposed into modular
+  sub-components within the rule-116 limits. typecheck, lint, modularity, build:ci, EOF, parity, and
+  schema-drift gates green. Marked skills-taxonomy Design 🎨 / Web px ✅; Android pixel parity
+  (`MobileSkillsTaxonomy.tsx`) remains ⬜. All four previously design-gated plugins are now web-pixel
+  complete; no design-gated plugins remain.

--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -99,7 +99,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | Plugin | 🎨 Design | Backend | Web px | Android | Gates | Deployed |
 |---|---|---|---|---|---|---|
 | chyme | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
-| skills-taxonomy | ⏳ | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| skills-taxonomy | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | directory | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | feed-announcements | 🎨 | 🟡 | ⬜ | ⬜ | ⬜ | ⬜ |
 | workforce | 🎨 | 🟡 | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-taxonomy-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-taxonomy-feature-inventory.md
@@ -139,6 +139,8 @@ Consumer routes:
 
 ## 10) Change Log
 
+- 2026-05-29: Web UI circle-back (design `c5d83c0`; unblocked by the design re-pin). Rebuilt the `/apps/skills-taxonomy` browser from the prior summary/snapshot shell to the `SkillsTaxonomy.tsx` mockup (3-column hierarchy + Empty/Loading). Loads the nested tree from the existing `GET /api/skills-taxonomy/hierarchy` (response `{ items }`) and derives the columns client-side; no schema/API change. Decomposed into modular sub-components (`st-shared`, `st-loading`, `st-icon-rail`, `st-empty-state`, `st-sectors-column`, `st-titles-column`, `st-skills-detail`, plus the browser and shell). Real data only; the mockup's demand/level/category chips were omitted as unbacked.
+
 - 2026-05-18: Replaced "Web and Android Parity Notes" with canonical "Web and Android Delivery Status" (`web+android complete`). Removed deferred-owner/milestone tracking and "Phase-0 baseline" framing per Rule 120. Renamed "Open Decisions" to canonical "Gaps and Known Technical Debt" and removed Android-parity-deferral entries.
 - 2026-03-02: Delivered web/API runtime baseline (migration + hierarchy/flattened routes + admin CRUD + dependency preview + delete safeguards + audit + CSRF + deterministic seed).
 - 2026-03-02: Added Option B legacy-data migration path (one-time backfill + incremental sync) from `platform/scripts/data/skills-data.ts` into plugin-owned taxonomy tables.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-taxonomy-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-taxonomy-feature-inventory.md
@@ -125,6 +125,8 @@ Consumer routes:
 
 `web+android complete`. Web admin taxonomy management lives under `/apps/skills-taxonomy`; Android consumes the same read models via `packages/mobile/src/features/skills-taxonomy`. Hierarchy/flattened reads, admin CRUD, dependency-impact preview, and destructive delete safeguards are consistent across platforms.
 
+Web pixel pass (design `c5d83c0`): the user-facing `/apps/skills-taxonomy` surface is rebuilt to `design/.../survivor-hub/SkillsTaxonomy.tsx` and its Empty/Loading states — the full-height 3-column browser (sectors → job titles → skills) with icon rail, breadcrumb, and in-role skill search. The whole tree loads from the existing `GET /api/skills-taxonomy/hierarchy` route (response `{ items }`); sectors/titles/skills are derived client-side from that nested payload, and sector/title counts use the real `jobTitles.length` / `skills.length`. The mockup's demand/level/category chips and per-sector totals have no backing in the data model and were omitted rather than faked; admin create/edit/delete affordances link to the dedicated `/admin/skills-taxonomy` route. Decomposed into modular sub-components within the rule-116 limits. The Android pixel pass to `MobileSkillsTaxonomy.tsx` remains tracked in `PRODUCTION_READINESS_PLAN.md`.
+
 ## 8) Seed Coverage Status
 
 - `ctf/scripts/seedSkillsTaxonomy.mjs` is the deterministic backfill script and imports canonical legacy source data.

--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { BG, TEXT, type StSector } from "./st-shared";
+import { SkillsTaxonomyIconRail } from "./st-icon-rail";
+import { SkillsTaxonomySectorsColumn } from "./st-sectors-column";
+import { SkillsTaxonomyTitlesColumn } from "./st-titles-column";
+import { SkillsTaxonomySkillsDetail } from "./st-skills-detail";
+import { SkillsTaxonomyEmptyState } from "./st-empty-state";
+import { SkillsTaxonomyLoading } from "./st-loading";
+
+export function SkillsTaxonomyBrowser({ isAdmin }: { isAdmin: boolean }) {
+  const [sectors, setSectors] = useState<StSector[]>([]);
+  const [selectedSectorId, setSelectedSectorId] = useState<string | null>(null);
+  const [selectedJobTitleId, setSelectedJobTitleId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/skills-taxonomy/hierarchy", { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Failed to load taxonomy.");
+        const data = (await res.json()) as { items: StSector[] };
+        if (cancelled) return;
+        setSectors(data.items ?? []);
+        setSelectedSectorId(data.items?.[0]?.id ?? null);
+      })
+      .catch(() => { if (!cancelled) setError("Failed to load taxonomy."); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const selectedSector = sectors.find((s) => s.id === selectedSectorId) ?? null;
+  const selectedJobTitle = selectedSector?.jobTitles.find((t) => t.id === selectedJobTitleId) ?? null;
+  const visibleSkills = useMemo(() => {
+    const all = selectedJobTitle?.skills ?? [];
+    const q = search.trim().toLowerCase();
+    return q ? all.filter((sk) => sk.name.toLowerCase().includes(q)) : all;
+  }, [selectedJobTitle, search]);
+
+  if (loading) return <SkillsTaxonomyLoading />;
+  if (!error && sectors.length === 0) return <SkillsTaxonomyEmptyState isAdmin={isAdmin} />;
+
+  return (
+    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+      <SkillsTaxonomyIconRail />
+      <SkillsTaxonomySectorsColumn
+        sectors={sectors}
+        selectedSectorId={selectedSectorId}
+        onSelect={(id) => { setSelectedSectorId(id); setSelectedJobTitleId(null); setSearch(""); }}
+        isAdmin={isAdmin}
+      />
+      <SkillsTaxonomyTitlesColumn
+        sector={selectedSector}
+        selectedJobTitleId={selectedJobTitleId}
+        onSelect={(id) => { setSelectedJobTitleId(id); setSearch(""); }}
+        isAdmin={isAdmin}
+      />
+      {error ? (
+        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#F87171", fontSize: 14 }}>{error}</div>
+      ) : (
+        <SkillsTaxonomySkillsDetail
+          sector={selectedSector}
+          jobTitle={selectedJobTitle}
+          skills={visibleSkills}
+          search={search}
+          onSearch={setSearch}
+          isAdmin={isAdmin}
+        />
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-shell.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-shell.tsx
@@ -1,90 +1,14 @@
-import Link from 'next/link';
-import { getFlattened, getHierarchy } from 'lib/skills-taxonomy/repository';
+"use client";
+
+import { SkillsTaxonomyBrowser } from "./skills-taxonomy-browser";
 
 type SkillsTaxonomyShellProps = {
   isAdmin: boolean;
 };
 
-export async function SkillsTaxonomyShell({ isAdmin }: SkillsTaxonomyShellProps) {
-  const [hierarchy, flattened] = await Promise.all([
-    getHierarchy(false),
-    getFlattened(false, true),
-  ]);
-
-  const sectorCount = hierarchy.length;
-  const jobTitleCount = hierarchy.reduce((acc, sector) => acc + sector.jobTitles.length, 0);
-  const skillCount = flattened.length;
-
-  return (
-    <main className="mx-auto max-w-6xl px-6 py-10 space-y-8">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Skills Taxonomy</h1>
-        <p className="text-sm text-muted-foreground">
-          Hierarchy and flattened projections for sectors, job titles, and skills, with admin mutation surfaces.
-        </p>
-      </header>
-
-      <section className="grid gap-4 md:grid-cols-3">
-        <article className="rounded-lg border bg-card p-4">
-          <p className="text-xs text-muted-foreground">Sectors</p>
-          <p className="text-2xl font-semibold">{sectorCount}</p>
-        </article>
-        <article className="rounded-lg border bg-card p-4">
-          <p className="text-xs text-muted-foreground">Job titles</p>
-          <p className="text-2xl font-semibold">{jobTitleCount}</p>
-        </article>
-        <article className="rounded-lg border bg-card p-4">
-          <p className="text-xs text-muted-foreground">Skills</p>
-          <p className="text-2xl font-semibold">{skillCount}</p>
-        </article>
-      </section>
-
-      <section className="rounded-lg border bg-card p-5 space-y-3">
-        <h2 className="text-lg font-medium">Hierarchy snapshot</h2>
-        <ul className="space-y-3 text-sm">
-          {hierarchy.slice(0, 6).map((sector) => (
-            <li key={sector.id} className="rounded border p-3">
-              <p className="font-medium">{sector.name}</p>
-              <p className="text-muted-foreground">
-                {sector.jobTitles.length} job titles
-              </p>
-            </li>
-          ))}
-          {hierarchy.length === 0 ? <li className="text-muted-foreground">No sectors available.</li> : null}
-        </ul>
-      </section>
-
-      <section className="rounded-lg border bg-card p-5 space-y-3">
-        <h2 className="text-lg font-medium">Flattened projection snapshot</h2>
-        <ul className="space-y-2 text-sm">
-          {flattened.slice(0, 10).map((item) => (
-            <li key={item.skillId} className="rounded border p-2">
-              <p className="font-medium">{item.skillName}</p>
-              <p className="text-muted-foreground">{item.sectorName} · {item.jobTitleName}</p>
-            </li>
-          ))}
-          {flattened.length === 0 ? <li className="text-muted-foreground">No flattened taxonomy records available.</li> : null}
-        </ul>
-      </section>
-
-      <section className="rounded-lg border bg-card p-5 text-sm space-y-2">
-        <h2 className="text-lg font-medium">API surface</h2>
-        <ul className="list-disc pl-5 space-y-1">
-          <li><code>GET /api/skills-taxonomy/hierarchy</code></li>
-          <li><code>GET /api/skills-taxonomy/flattened</code></li>
-          {isAdmin ? (
-            <>
-              <li><code>POST /api/skills-taxonomy/admin/sectors</code></li>
-              <li><code>POST /api/skills-taxonomy/admin/job-titles</code></li>
-              <li><code>POST /api/skills-taxonomy/admin/skills</code></li>
-            </>
-          ) : null}
-        </ul>
-      </section>
-
-      <p className="text-sm">
-        <Link className="underline underline-offset-4" href="/">Return to home</Link>
-      </p>
-    </main>
-  );
+// The Skills Taxonomy surface is the full-height 3-column browser
+// (sectors → job titles → skills) from design/.../survivor-hub/SkillsTaxonomy.tsx.
+// Admin management lives on the dedicated /admin/skills-taxonomy route.
+export function SkillsTaxonomyShell({ isAdmin }: SkillsTaxonomyShellProps) {
+  return <SkillsTaxonomyBrowser isAdmin={isAdmin} />;
 }

--- a/ctf/packages/web/components/skills-taxonomy/st-empty-state.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-empty-state.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+// STATE: Authenticated, taxonomy not yet populated. Ported from
+// design/.../survivor-hub/SkillsTaxonomyEmpty.tsx.
+import { Award, Briefcase, Layers } from "lucide-react";
+import { BG, BORDER, BRAND, SUBTLE, SURFACE, TEXT } from "./st-shared";
+
+const LEVELS = [
+  { icon: Briefcase, label: "Sectors", desc: "Top-level industry groups" },
+  { icon: Award, label: "Job Titles", desc: "Roles within each sector" },
+  { icon: Layers, label: "Skills", desc: "Competencies per role" },
+];
+
+export function SkillsTaxonomyEmptyState({ isAdmin }: { isAdmin: boolean }) {
+  return (
+    <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter',system-ui", color: TEXT, display: "flex", flexDirection: "column" }}>
+      <div style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 28px", gap: 12, background: "#0D0F14", flexShrink: 0 }}>
+        <Layers size={18} color={BRAND} />
+        <div>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>Skills Taxonomy</div>
+          <div style={{ fontSize: 12, color: SUBTLE }}>3-level hierarchy — sectors, job titles, skills</div>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: "48px 64px" }}>
+        <div style={{ maxWidth: 520, textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 24 }}>
+          <div style={{ width: 88, height: 88, borderRadius: 24, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <Layers size={42} style={{ color: BRAND, opacity: 0.6 }} />
+          </div>
+          <div>
+            <div style={{ fontSize: 24, fontWeight: 800, color: TEXT, marginBottom: 10 }}>No taxonomy data yet</div>
+            <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
+              The skills taxonomy hasn&apos;t been populated. {isAdmin
+                ? "Add the first sector to begin building the 3-level hierarchy."
+                : "An admin needs to add the first sector to begin building the 3-level hierarchy."}
+            </div>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 10, width: "100%", maxWidth: 360 }}>
+            {LEVELS.map(({ icon: Icon, label, desc }) => (
+              <div key={label} style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 16px", borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, textAlign: "left" }}>
+                <Icon size={18} color={BRAND} />
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: TEXT }}>{label}</div>
+                  <div style={{ fontSize: 11, color: SUBTLE }}>{desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+          {isAdmin && (
+            <a href="/admin/skills-taxonomy" style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 24px", borderRadius: 12, background: BRAND, border: "none", color: "#fff", fontSize: 14, fontWeight: 700, cursor: "pointer", textDecoration: "none" }}>
+              Manage taxonomy
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-taxonomy/st-icon-rail.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-icon-rail.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Award, Bell, Briefcase, Layers, Settings } from "lucide-react";
+import { BORDER, BRAND, SUBTLE } from "./st-shared";
+
+// Hub icon-rail chrome. Skills Taxonomy is a single browser view, so the nav
+// glyphs are presentational (matching the mockup); the brand mark anchors it.
+const NAV = [Layers, Briefcase, Award];
+
+export function SkillsTaxonomyIconRail() {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${BRAND}25`, border: `1px solid ${BRAND}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <Layers size={20} color={BRAND} />
+      </div>
+      {NAV.map((Icon, i) => (
+        <div key={i} style={{ width: 44, height: 44, borderRadius: 12, background: i === 0 ? `${BRAND}20` : "transparent", border: i === 0 ? `1px solid ${BRAND}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", color: i === 0 ? BRAND : SUBTLE }}>
+          <Icon size={20} />
+        </div>
+      ))}
+      <div style={{ flex: 1 }} />
+      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Bell size={18} /></div>
+      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Settings size={18} /></div>
+      <div style={{ width: 32, height: 32, borderRadius: "50%", background: `${BRAND}25`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, color: BRAND }}>S</div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/skills-taxonomy/st-loading.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// STATE: Loading — data fetch in progress. Ported from
+// design/.../survivor-hub/SkillsTaxonomyLoading.tsx.
+import { BG } from "./st-shared";
+
+export function SkillsTaxonomyLoading() {
+  return (
+    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
+      <div style={{ textAlign: "center", padding: "0 32px" }}>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
+          EXIT THEIR ECONOMY
+        </div>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
+          EXIT THE PSYOP
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-taxonomy/st-sectors-column.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-sectors-column.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { BORDER, FAINT, SUBTLE, TEXT, countLabel, sectorColor, type StSector } from "./st-shared";
+
+export function SkillsTaxonomySectorsColumn({
+  sectors,
+  selectedSectorId,
+  onSelect,
+  isAdmin,
+}: {
+  sectors: StSector[];
+  selectedSectorId: string | null;
+  onSelect: (sectorId: string) => void;
+  isAdmin: boolean;
+}) {
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 4 }}>📚 Skills Taxonomy</div>
+        <div style={{ fontSize: 12, color: FAINT, lineHeight: 1.5 }}>3-level hierarchy browser</div>
+      </div>
+      <div style={{ flex: 1, overflowY: "auto", padding: "0 8px 12px" }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", color: "#374151", textTransform: "uppercase", padding: "4px 10px 8px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <span>Sectors ({sectors.length})</span>
+          {isAdmin && <a href="/admin/skills-taxonomy" title="Manage taxonomy" style={{ color: SUBTLE, display: "flex" }}><Plus size={12} /></a>}
+        </div>
+        {sectors.map((s, i) => {
+          const color = sectorColor(i);
+          const selected = s.id === selectedSectorId;
+          return (
+            <button key={s.id} onClick={() => onSelect(s.id)} style={{ width: "100%", display: "flex", alignItems: "center", gap: 10, padding: "10px", borderRadius: 8, cursor: "pointer", background: selected ? `${color}18` : "transparent", borderLeft: selected ? `2px solid ${color}` : "2px solid transparent", marginBottom: 2, border: "none", textAlign: "left" }}>
+              <div style={{ width: 10, height: 10, borderRadius: "50%", background: color, flexShrink: 0 }} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, color: selected ? TEXT : "#9CA3AF", fontWeight: selected ? 600 : 400 }}>{s.name}</div>
+                <div style={{ fontSize: 10, color: SUBTLE }}>{countLabel(s.jobTitles.length, "title")}</div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/skills-taxonomy/st-shared.ts
+++ b/ctf/packages/web/components/skills-taxonomy/st-shared.ts
@@ -1,0 +1,35 @@
+// Shared constants, types, and helpers for the Skills Taxonomy web shell.
+// Palette derives from design/.../survivor-hub/SkillsTaxonomy.tsx.
+// Types mirror the nested hierarchy returned by GET /api/skills-taxonomy/hierarchy
+// (lib/skills-taxonomy/types.ts: TaxonomyHierarchy*). The whole tree arrives in
+// one request, so the browser derives sectors/titles/skills client-side.
+
+import type {
+  TaxonomyHierarchyJobTitle,
+  TaxonomyHierarchySector,
+  TaxonomyHierarchySkill,
+} from "../../lib/skills-taxonomy/types";
+
+export type StSector = TaxonomyHierarchySector;
+export type StJobTitle = TaxonomyHierarchyJobTitle;
+export type StSkill = TaxonomyHierarchySkill;
+
+export const BRAND = "#8B5CF6";
+export const BG = "#0F1117";
+export const SURFACE = "#161B27";
+export const BORDER = "#1E2A3A";
+export const TEXT = "#F9FAFB";
+export const SUBTLE = "#6B7280";
+export const FAINT = "#4B5563";
+
+// Stable per-sector accent colors (the data model has no color column; the
+// mockup assigns a fixed palette across the sector list).
+const SECTOR_COLORS = ["#8B5CF6", "#EC4899", "#F59E0B", "#06B6D4", "#22C55E", "#EF4444", "#A78BFA", "#F97316"];
+
+export function sectorColor(index: number): string {
+  return SECTOR_COLORS[index % SECTOR_COLORS.length];
+}
+
+export function countLabel(count: number, singular: string): string {
+  return `${count.toLocaleString()} ${count === 1 ? singular : `${singular}s`}`;
+}

--- a/ctf/packages/web/components/skills-taxonomy/st-skills-detail.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-skills-detail.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ChevronRight, Hash, Plus, Search } from "lucide-react";
+import { BORDER, BRAND, SUBTLE, TEXT, type StJobTitle, type StSector, type StSkill } from "./st-shared";
+
+export function SkillsTaxonomySkillsDetail({
+  sector,
+  jobTitle,
+  skills,
+  search,
+  onSearch,
+  isAdmin,
+}: {
+  sector: StSector | null;
+  jobTitle: StJobTitle | null;
+  skills: StSkill[];
+  search: string;
+  onSearch: (value: string) => void;
+  isAdmin: boolean;
+}) {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+        <Search size={16} color={SUBTLE} />
+        <input
+          value={search}
+          onChange={(e) => onSearch(e.target.value)}
+          placeholder="Search skills in this role…"
+          style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: TEXT }}
+        />
+        {isAdmin && (
+          <a href="/admin/skills-taxonomy" style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 8, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 13, fontWeight: 600, cursor: "pointer", textDecoration: "none" }}>
+            <Plus size={14} /> Add Skill
+          </a>
+        )}
+      </header>
+
+      <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 20, fontSize: 13, color: SUBTLE, flexWrap: "wrap" }}>
+          <span>{sector?.name ?? "Sectors"}</span><ChevronRight size={14} />
+          <span>{jobTitle?.name ?? "Job Titles"}</span><ChevronRight size={14} />
+          <span style={{ color: TEXT, fontWeight: 600 }}>Skills</span>
+        </div>
+
+        {!jobTitle ? (
+          <div style={{ color: SUBTLE, fontSize: 14 }}>Select a job title to view its skills.</div>
+        ) : skills.length === 0 ? (
+          <div style={{ color: SUBTLE, fontSize: 14 }}>No skills recorded for this role yet.</div>
+        ) : (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {skills.map((sk) => (
+              <span key={sk.id} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 20, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, fontSize: 13, color: BRAND, fontWeight: 500 }}>
+                <Hash size={12} /> {sk.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-taxonomy/st-titles-column.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-titles-column.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Briefcase, Plus } from "lucide-react";
+import { BORDER, BRAND, SUBTLE, TEXT, countLabel, type StJobTitle, type StSector } from "./st-shared";
+
+export function SkillsTaxonomyTitlesColumn({
+  sector,
+  selectedJobTitleId,
+  onSelect,
+  isAdmin,
+}: {
+  sector: StSector | null;
+  selectedJobTitleId: string | null;
+  onSelect: (jobTitleId: string) => void;
+  isAdmin: boolean;
+}) {
+  const jobTitles: StJobTitle[] = sector?.jobTitles ?? [];
+  return (
+    <aside style={{ width: 260, background: "#0D0F14", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 700, color: TEXT }}>Job Titles</div>
+          <div style={{ fontSize: 11, color: SUBTLE }}>{sector ? `${sector.name} sector` : "Select a sector"}</div>
+        </div>
+        {isAdmin && sector && (
+          <a href="/admin/skills-taxonomy" title="Manage taxonomy" style={{ width: 28, height: 28, borderRadius: 8, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, display: "flex", alignItems: "center", justifyContent: "center", color: BRAND, textDecoration: "none" }}><Plus size={14} /></a>
+        )}
+      </div>
+      <div style={{ flex: 1, overflowY: "auto", padding: "0 8px 12px" }}>
+        {!sector ? (
+          <div style={{ padding: "8px 10px", fontSize: 12, color: SUBTLE }}>Select a sector to view its job titles.</div>
+        ) : jobTitles.length === 0 ? (
+          <div style={{ padding: "8px 10px", fontSize: 12, color: SUBTLE }}>No job titles in this sector yet.</div>
+        ) : (
+          jobTitles.map((t) => {
+            const selected = t.id === selectedJobTitleId;
+            return (
+              <button key={t.id} onClick={() => onSelect(t.id)} style={{ width: "100%", display: "flex", alignItems: "center", gap: 8, padding: "12px 10px", borderRadius: 8, cursor: "pointer", background: selected ? `${BRAND}14` : "transparent", marginBottom: 4, border: selected ? `1px solid ${BRAND}30` : "1px solid transparent", textAlign: "left" }}>
+                <Briefcase size={14} color={selected ? BRAND : SUBTLE} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, color: selected ? TEXT : "#9CA3AF", fontWeight: selected ? 600 : 400 }}>{t.name}</div>
+                  <div style={{ fontSize: 10, color: SUBTLE }}>{countLabel(t.skills.length, "skill")}</div>
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

The **last** of the four plugins unblocked by the `c5d83c0` design re-pin (#137). Rebuilds the `/apps/skills-taxonomy` surface from its prior summary/snapshot shell to the full 3-column browser in `design/.../survivor-hub/SkillsTaxonomy.tsx`, plus its Empty/Loading states.

## Changes

Dark (`#0F1117` / brand `#8B5CF6`) 3-column hierarchy matching the mockup:
- **Icon rail** + **Sectors column** (accent dots, real "N titles" counts) + **Job Titles column** (real "N skills" counts) + **Skills detail** (breadcrumb, skill chips, in-role search box)
- **Empty** state — "No taxonomy data yet" with the 3-level explainer (admin sees a "Manage taxonomy" CTA)
- **Loading** state

Data: the whole nested tree loads from the existing `GET /api/skills-taxonomy/hierarchy` route (response shape `{ items }`, `TaxonomyHierarchySector[]`); sectors → job titles → skills are derived client-side from that payload, so column counts use the real `jobTitles.length` / `skills.length`. No new API or schema.

Honest data: the mockup's `demand` / `level` / `category` chips and per-sector skill totals have no backing in the data model, so they were **omitted rather than faked**. The mockup's inline add/edit/delete buttons become links to the dedicated `/admin/skills-taxonomy` route (admins only) rather than non-functional icons.

Modularity: decomposed into `st-shared`, `st-loading`, `st-icon-rail`, `st-empty-state`, `st-sectors-column`, `st-titles-column`, `st-skills-detail`, plus the browser and a thin shell — each within `complexity:10` / `max-lines-per-function:200`. Route call site unchanged (still passes `isAdmin`).

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- `pnpm --filter @ctf/web lint components/skills-taxonomy/` — green
- Modularity gate on all skills-taxonomy files — green
- `pnpm --filter @ctf/web build:ci` — green
- `check-eof-format.sh`, `check-web-android-parity.mjs`, `check-schema-drift.sh` — green

## Scope

Web-only pixel pass. Android pixel pass (`MobileSkillsTaxonomy.tsx` → React Native) deferred and tracked. **With this, all four previously design-gated plugins (clicklog, unlock, weekly-performance, skills-taxonomy) are web-pixel complete — no design-gated plugins remain.**

Parity Ticket: #119


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_