### PR TITLE
feat: mood web pixel pass — fix API contracts + honest community pulse

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -109,7 +109,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | socketrelay | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | trusttransport | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | peer-programming | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
-| mood | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| mood | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | gentlepulse | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | weekly-performance | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | gdp | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
@@ -468,3 +468,12 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   lint, modularity, build:ci, EOF, parity, and schema-drift gates green for each. Marked mood,
   gentlepulse, socketrelay Web px ✅; their Android pixel parity (`MobileMood.tsx`,
   `MobileGentlePulse.tsx`, `MobileSocketRelay.tsx`) remains ⬜ for the dedicated Android sweep.
+- 2026-05-29: UI circle-back — mood web pixel pass detail. Rebuilt the `/apps/mood` shell to `Mood.tsx`
+  + Empty/Loading. Fixed two real API-contract bugs in the prior shell: it called
+  `/api/mood/eligibility` with no `clientId` (route 400s without it) and POSTed `{ mood, note }` instead
+  of the required `{ clientId, moodValue, note }` + CSRF header — so check-in and submit both failed at
+  runtime. Now uses a per-device localStorage `clientId`, the eligibility cooldown gate, and a
+  CSRF-headed submit. Per owner ruling, the Community Pulse tab shows the design's honest empty state
+  instead of the prior shell's fabricated 7-day averages and distribution percentages (no aggregate-stats
+  backend exists). Decomposed into modular sub-components within rule-116 limits; removed banned
+  "Phase 2" text.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
@@ -80,6 +80,8 @@ Excluded route groups:
 2. Cooldown and validation semantics must match between web and Android.
 3. No Mood admin parity obligations in web/mobile for this rewrite scope.
 
+Web pixel pass (design `c5d83c0`): the `/apps/mood` shell is rebuilt to `design/.../survivor-hub/Mood.tsx` and its Empty/Loading states. The anonymous check-in flow is wired to the real API — `GET /api/mood/eligibility?clientId=` gates the form (per-device `clientId` persisted in localStorage), and `POST /api/mood/submissions` sends `{ clientId, moodValue, note }` with the `x-ctf-csrf` header. This fixes the prior shell, which called eligibility with no `clientId` and POSTed the wrong field names (both 400'd at runtime). The Community Pulse tab renders the design's honest empty state — there is no aggregate-stats backend yet, so the previous shell's fabricated 7-day averages and distribution percentages were removed rather than re-displayed. Decomposed into modular sub-components within the rule-116 limits; banned "Phase 2" wording removed. Android pixel pass to `MobileMood.tsx` remains tracked in `PRODUCTION_READINESS_PLAN.md`.
+
 ## 7) Seed Coverage Status
 
 Seed script requirement: Provide a deterministic plugin seed script with dummy development data for manual plugin validation in dev environments.
@@ -91,6 +93,7 @@ Seed script requirement: Provide a deterministic plugin seed script with dummy d
 
 ## 9) Change Log
 
+- 2026-05-29: Web UI circle-back (design `c5d83c0`). Rebuilt the mood shell to the `Mood.tsx` mockup + Empty/Loading; fixed the eligibility (`?clientId=`) and submission (`{ clientId, moodValue, note }` + CSRF header) API contracts that previously 400'd; replaced fabricated trend/distribution data with the design's honest Community Pulse empty state; decomposed into modular sub-components within the rule-116 limits; removed banned "Phase 2" wording. No schema/API change.
 - 2026-05-18: Renamed "Gaps, Ambiguities, and Known Debt (Planning)" to canonical "Gaps and Known Technical Debt" per Rule 120.
 - 2026-02-25: Created initial Mood CTF rewrite inventory.
 

--- a/ctf/packages/web/components/mood/mood-checkin.tsx
+++ b/ctf/packages/web/components/mood/mood-checkin.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { COLOR, MOODS, SUBTLE, daysUntil, type MoodEligibility } from "./mood-shared";
+
+function CooldownNotice({ eligibility, onViewCommunity }: { eligibility: MoodEligibility; onViewCommunity: () => void }) {
+  const days = daysUntil(eligibility.cooldownUntilIso);
+  return (
+    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 12, padding: 24 }}>
+      <div style={{ fontSize: 48 }}>💚</div>
+      <div style={{ fontSize: 20, fontWeight: 700, color: "#F9FAFB" }}>You&apos;ve checked in recently</div>
+      <div style={{ fontSize: 14, color: SUBTLE }}>
+        {days && days > 0 ? `Check back in ${days} day${days === 1 ? "" : "s"}.` : "Check back soon."}
+      </div>
+      <button type="button" onClick={onViewCommunity} style={{ marginTop: 8, padding: "10px 24px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 600, cursor: "pointer" }}>
+        View Community Pulse
+      </button>
+    </div>
+  );
+}
+
+export function MoodCheckin({
+  eligibility,
+  selected,
+  onSelect,
+  note,
+  onNoteChange,
+  submitting,
+  submitted,
+  error,
+  onSubmit,
+  onViewCommunity,
+}: {
+  eligibility: MoodEligibility | null;
+  selected: number | null;
+  onSelect: (value: number) => void;
+  note: string;
+  onNoteChange: (value: string) => void;
+  submitting: boolean;
+  submitted: boolean;
+  error: string | null;
+  onSubmit: () => void;
+  onViewCommunity: () => void;
+}) {
+  if (eligibility && !eligibility.eligible && !submitted) {
+    return <CooldownNotice eligibility={eligibility} onViewCommunity={onViewCommunity} />;
+  }
+
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ padding: "40px", maxWidth: 640, margin: "0 auto" }}>
+        {submitted ? (
+          <div style={{ textAlign: "center" }}>
+            <div style={{ fontSize: 80, marginBottom: 20 }}>💚</div>
+            <div style={{ fontSize: 28, fontWeight: 800, color: "#F9FAFB", marginBottom: 8 }}>Thank you for checking in.</div>
+            <div style={{ fontSize: 15, color: SUBTLE, marginBottom: 32 }}>You&apos;re part of a community of survivors supporting each other.</div>
+            <button type="button" onClick={onViewCommunity} style={{ padding: "10px 24px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 600, cursor: "pointer" }}>
+              See Community Pulse
+            </button>
+          </div>
+        ) : (
+          <>
+            <div style={{ textAlign: "center", marginBottom: 40 }}>
+              <div style={{ fontSize: 28, fontWeight: 800, color: "#F9FAFB", marginBottom: 8 }}>How are you feeling right now?</div>
+              <div style={{ fontSize: 15, color: SUBTLE }}>Anonymous, safe, and encrypted. Your check-in is never linked to your identity.</div>
+            </div>
+            <div style={{ display: "flex", gap: 16, justifyContent: "center", marginBottom: 40, flexWrap: "wrap" }}>
+              {MOODS.map((m) => (
+                <button key={m.value} type="button" onClick={() => onSelect(m.value)} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "20px 16px", borderRadius: 16, background: selected === m.value ? `${m.color}20` : "rgba(255,255,255,0.02)", border: `2px solid ${selected === m.value ? m.color : "rgba(255,255,255,0.06)"}`, cursor: "pointer" }}>
+                  <div style={{ fontSize: 40 }}>{m.emoji}</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: selected === m.value ? m.color : SUBTLE }}>{m.label}</div>
+                </button>
+              ))}
+            </div>
+            {selected && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+                <textarea value={note} onChange={(e) => onNoteChange(e.target.value)} placeholder="(Optional) Anything you'd like to add? Completely anonymous…" rows={3} style={{ width: "100%", padding: "14px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 12, fontSize: 14, color: "#E8EAF0", outline: "none", resize: "none", boxSizing: "border-box" }} />
+                <button type="button" onClick={onSubmit} disabled={submitting} style={{ padding: "14px", borderRadius: 12, background: COLOR, border: "none", color: "#fff", fontSize: 16, fontWeight: 800, cursor: submitting ? "not-allowed" : "pointer", opacity: submitting ? 0.7 : 1 }}>
+                  {submitting ? "Submitting…" : "Submit Anonymously"}
+                </button>
+                <div style={{ textAlign: "center", fontSize: 12, color: "#4B5563" }}>Not linked to your account · Encrypted · One check-in per week</div>
+              </div>
+            )}
+            {error && <div style={{ fontSize: 13, color: "#EF4444", marginTop: 12, textAlign: "center" }}>{error}</div>}
+          </>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/ctf/packages/web/components/mood/mood-community.tsx
+++ b/ctf/packages/web/components/mood/mood-community.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+// Community Pulse tab. There is no aggregate-stats backend yet (only
+// eligibility + submissions exist), so per the design's empty state this shows
+// the honest "data appears once members check in" placeholder rather than the
+// mockup's fabricated 7-day averages and distribution percentages.
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { BarChart2, Lock, Shield, Smile } from "lucide-react";
+import { BORDER, COLOR, DAYS, SUBTLE, SURFACE, TEXT } from "./mood-shared";
+
+export function MoodCommunity() {
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: 48 }}>
+        <div style={{ maxWidth: 460, textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
+          <div style={{ width: 80, height: 80, borderRadius: 24, background: `${COLOR}10`, border: `2px dashed ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <Smile size={34} color={`${COLOR}60`} />
+          </div>
+          <div style={{ fontSize: 20, fontWeight: 800, color: TEXT }}>Community pulse coming soon</div>
+          <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
+            Aggregated community mood trends appear here once enough members have checked in. All data is fully anonymous — no names, no IDs, only aggregated mood scores by day.
+          </div>
+
+          <div style={{ width: "100%", borderRadius: 14, border: `1px solid ${BORDER}`, background: SURFACE, padding: "20px 24px" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 16 }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: SUBTLE }}>7-day community average</span>
+              <span style={{ fontSize: 12, color: `${SUBTLE}80` }}>Waiting for check-ins…</span>
+            </div>
+            <div style={{ display: "flex", gap: 8, height: 80, alignItems: "flex-end" }}>
+              {DAYS.map((day) => (
+                <div key={day} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+                  <div style={{ flex: 1, width: "100%", borderRadius: "4px 4px 0 0", background: "rgba(255,255,255,0.04)", border: `1px dashed ${BORDER}`, minHeight: 40 }} />
+                  <span style={{ fontSize: 10, color: `${SUBTLE}60` }}>{day}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: 24 }}>
+            {[
+              { icon: Shield, label: "Anonymous by design" },
+              { icon: Lock, label: "Zero personal data stored" },
+            ].map(({ icon: Icon, label }) => (
+              <div key={label} style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 13, color: SUBTLE }}>
+                <Icon size={14} color={COLOR} /> {label}
+              </div>
+            ))}
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11, color: `${SUBTLE}90` }}>
+            <BarChart2 size={12} color={SUBTLE} /> Trends populate as the community grows.
+          </div>
+        </div>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/ctf/packages/web/components/mood/mood-crisis-rail.tsx
+++ b/ctf/packages/web/components/mood/mood-crisis-rail.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { COLOR, CRISIS_RESOURCES, SUBTLE } from "./mood-shared";
+
+export function MoodCrisisRail() {
+  return (
+    <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 12 }}>Crisis Resources</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
+        {CRISIS_RESOURCES.map((r) => (
+          <div key={r.name} style={{ padding: "12px 14px", borderRadius: 12, background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.18)" }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: "#F9FAFB", marginBottom: 2 }}>{r.name}</div>
+            <div style={{ fontSize: 12, color: COLOR, fontWeight: 600, marginBottom: 2 }}>{r.number}</div>
+            <div style={{ fontSize: 11, color: SUBTLE }}>{r.available}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ padding: "14px 16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}18` }}>
+        <div style={{ fontSize: 12, fontWeight: 700, color: COLOR, marginBottom: 8 }}>🔒 Privacy First</div>
+        <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.6 }}>Your mood check-in is anonymous and rate-limited per device. We never link submissions to your identity.</div>
+      </div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/mood/mood-icon-rail.tsx
+++ b/ctf/packages/web/components/mood/mood-icon-rail.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Bell, BarChart2, Settings, Smile } from "lucide-react";
+import { COLOR, SUBTLE, type Tab } from "./mood-shared";
+
+const NAV: { icon: React.ElementType; key: Tab }[] = [
+  { icon: Smile, key: "checkin" },
+  { icon: BarChart2, key: "community" },
+];
+
+export function MoodIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => void }) {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <Smile size={20} style={{ color: COLOR }} />
+      </div>
+      {NAV.map(({ icon: Icon, key }) => (
+        <button key={key} type="button" onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : SUBTLE }}>
+          <Icon size={20} />
+        </button>
+      ))}
+      <div style={{ flex: 1 }} />
+      <button type="button" aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Bell size={18} /></button>
+      <button type="button" aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Settings size={18} /></button>
+      <Avatar style={{ width: 36, height: 36 }}>
+        <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
+      </Avatar>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/mood/mood-loading.tsx
+++ b/ctf/packages/web/components/mood/mood-loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// STATE: Loading — data fetch in progress. Ported from
+// design/.../survivor-hub/MoodLoading.tsx.
+import { BG } from "./mood-shared";
+
+export function MoodLoading() {
+  return (
+    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
+      <div style={{ textAlign: "center", padding: "0 32px" }}>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
+          EXIT THEIR ECONOMY
+        </div>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
+          EXIT THE PSYOP
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/mood/mood-shared.ts
+++ b/ctf/packages/web/components/mood/mood-shared.ts
@@ -1,0 +1,69 @@
+// Shared constants, types, and helpers for the Mood web shell.
+// Palette derives from design/.../survivor-hub/Mood.tsx.
+
+export const COLOR = "#EC4899";
+export const BG = "#0F1117";
+export const SURFACE = "#161B27";
+export const BORDER = "#1E2A3A";
+export const TEXT = "#F9FAFB";
+export const SUBTLE = "#6B7280";
+export const FAINT = "#4B5563";
+
+export type Tab = "checkin" | "community";
+
+export type MoodOption = {
+  emoji: string;
+  label: string;
+  value: number;
+  color: string;
+};
+
+export const MOODS: MoodOption[] = [
+  { emoji: "😄", label: "Great", value: 5, color: "#22C55E" },
+  { emoji: "🙂", label: "Good", value: 4, color: "#84CC16" },
+  { emoji: "😐", label: "Okay", value: 3, color: "#F59E0B" },
+  { emoji: "😔", label: "Low", value: 2, color: "#F97316" },
+  { emoji: "😢", label: "Struggling", value: 1, color: "#EF4444" },
+];
+
+export const CRISIS_RESOURCES = [
+  { name: "National Hotline", number: "1-888-373-7888", available: "24/7" },
+  { name: "Crisis Text Line", number: "Text HOME to 233733", available: "24/7" },
+  { name: "RAINN Hotline", number: "1-800-656-4673", available: "24/7" },
+];
+
+export const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+// Eligibility response from GET /api/mood/eligibility?clientId=…
+export type MoodEligibility = {
+  ok: boolean;
+  eligible: boolean;
+  cooldownUntilIso: string | null;
+  lastSubmissionAtIso: string | null;
+};
+
+const CLIENT_ID_KEY = "ctf.mood.clientId";
+
+// Mood check-ins are anonymous and rate-limited per device, keyed by a random
+// client id persisted in localStorage (never tied to the account server-side).
+export function getMoodClientId(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const existing = window.localStorage.getItem(CLIENT_ID_KEY);
+    if (existing) return existing;
+    const generated = (window.crypto?.randomUUID?.() ?? `m-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    window.localStorage.setItem(CLIENT_ID_KEY, generated);
+    return generated;
+  } catch {
+    return "";
+  }
+}
+
+export function daysUntil(iso: string | null): number | null {
+  if (!iso) return null;
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) return null;
+  const diffMs = target - Date.now();
+  if (diffMs <= 0) return 0;
+  return Math.ceil(diffMs / (24 * 60 * 60 * 1000));
+}

--- a/ctf/packages/web/components/mood/mood-shell.tsx
+++ b/ctf/packages/web/components/mood/mood-shell.tsx
@@ -1,324 +1,106 @@
-'use client';
+"use client";
 
-  import { useEffect, useState } from 'react';
-  import { Smile, TrendingUp, MessageSquare, Bell, Settings, Lock, Send, Plus } from 'lucide-react';
-  import { ScrollArea } from '@/components/ui/scroll-area';
-  import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-  import { Badge } from '@/components/ui/badge';
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Smile } from "lucide-react";
+import { COLOR, getMoodClientId, type MoodEligibility, type Tab } from "./mood-shared";
+import { MoodLoading } from "./mood-loading";
+import { MoodIconRail } from "./mood-icon-rail";
+import { MoodSidebar } from "./mood-sidebar";
+import { MoodCheckin } from "./mood-checkin";
+import { MoodCommunity } from "./mood-community";
+import { MoodCrisisRail } from "./mood-crisis-rail";
 
-  const COLOR = '#EC4899';
+export default function MoodShell() {
+  const [tab, setTab] = useState<Tab>("checkin");
+  const [loading, setLoading] = useState(true);
+  const [clientId, setClientId] = useState("");
+  const [eligibility, setEligibility] = useState<MoodEligibility | null>(null);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  interface CommunityStats {
-    totalUsers?: number;
-    activeToday?: number;
-    weeklyTrend?: Array<{ day: string; value: number }>;
-    [key: string]: unknown;
-  }
-
-  const MOODS = [
-    { emoji: '😄', label: 'Great', value: 5, color: '#22C55E' },
-    { emoji: '🙂', label: 'Good', value: 4, color: '#84CC16' },
-    { emoji: '😐', label: 'Okay', value: 3, color: '#F59E0B' },
-    { emoji: '😔', label: 'Low', value: 2, color: '#F97316' },
-    { emoji: '😢', label: 'Struggling', value: 1, color: '#EF4444' },
-  ];
-
-  const CRISIS_RESOURCES = [
-    { name: 'National Hotline', number: '1-888-373-7888', available: '24/7' },
-    { name: 'Crisis Text Line', number: 'Text HOME to 233733', available: '24/7' },
-    { name: 'RAINN Hotline', number: '1-800-656-4673', available: '24/7' },
-  ];
-
-  type Tab = 'checkin' | 'trends' | 'chat';
-
-  export default function MoodShell() {
-    const [tab, setTab] = useState<Tab>('checkin');
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [eligible, setEligible] = useState<boolean | null>(null);
-    const [daysUntilEligible, setDaysUntilEligible] = useState<number | null>(null);
-    const [communityStats, setCommunityStats] = useState<CommunityStats | null>(null);
-    const [submitted, setSubmitted] = useState(false);
-    const [selected, setSelected] = useState<number | null>(null);
-    const [input, setInput] = useState('');
-    const [submitting, setSubmitting] = useState(false);
-
-    useEffect(() => {
-      const controller = new AbortController();
-      async function fetchEligibility() {
-        setLoading(true);
-        setError(null);
-        try {
-          const res = await fetch('/api/mood/eligibility', { signal: controller.signal });
-          if (!res.ok) throw new Error('Failed to check eligibility');
-          const data = await res.json() as { eligible: boolean; daysUntilEligible?: number; communityStats?: CommunityStats };
-          if (controller.signal.aborted) return;
-          setEligible(data.eligible);
-          setDaysUntilEligible(data.daysUntilEligible ?? null);
-          if (data.communityStats && typeof data.communityStats === 'object') {
-            setCommunityStats(data.communityStats);
-          }
-        } catch (e: unknown) {
-          if (controller.signal.aborted) return;
-          setError(e instanceof Error ? e.message : 'Failed to load mood data.');
-        } finally {
-          if (!controller.signal.aborted) setLoading(false);
-        }
-      }
-      void fetchEligibility();
-      return () => { controller.abort(); };
-    }, []);
-
-    async function handleSubmit() {
-      if (!selected || submitting) return;
-      setSubmitting(true);
-      setError(null);
+  useEffect(() => {
+    const id = getMoodClientId();
+    setClientId(id);
+    const controller = new AbortController();
+    async function loadEligibility() {
+      setLoading(true);
       try {
-        const res = await fetch('/api/mood/submissions', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ mood: selected, note: input }),
-        });
-        if (!res.ok) throw new Error('Failed to submit mood');
-        setSubmitted(true);
-      } catch (e: unknown) {
-        setError(e instanceof Error ? e.message : 'Submission failed.');
+        const res = await fetch(`/api/mood/eligibility?clientId=${encodeURIComponent(id)}`, { signal: controller.signal, cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to check eligibility.");
+        const data = (await res.json()) as MoodEligibility;
+        if (!controller.signal.aborted) setEligibility(data);
+      } catch (e) {
+        if (!controller.signal.aborted) setError(e instanceof Error ? e.message : "Failed to load mood data.");
       } finally {
-        setSubmitting(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     }
+    void loadEligibility();
+    return () => { controller.abort(); };
+  }, []);
 
-    if (loading) return <div className="p-8 text-center text-muted-foreground">Loading mood check-in…</div>;
-    if (error && tab === 'checkin') return <div className="text-red-500 p-4">{error}</div>;
-
-    const weeklyTrend: Array<{ day: string; value: number }> = communityStats?.weeklyTrend ?? [
-      { day: 'Mon', value: 3.4 }, { day: 'Tue', value: 3.7 }, { day: 'Wed', value: 3.2 },
-      { day: 'Thu', value: 3.9 }, { day: 'Fri', value: 4.1 }, { day: 'Sat', value: 3.8 },
-      { day: 'Sun', value: 4.0 },
-    ];
-    const maxTrend = Math.max(...weeklyTrend.map((d) => d.value), 1);
-
-    return (
-      <div style={{ width: '100%', height: '100%', minHeight: '100vh', background: '#0F1117', fontFamily: 'Inter, system-ui, sans-serif', color: '#E8EAF0', display: 'flex' }}>
-        {/* 72px icon rail */}
-        <aside style={{ width: 72, background: '#090B0F', borderRight: '1px solid rgba(255,255,255,0.06)', display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-          <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
-            <Smile size={20} style={{ color: COLOR }} />
-          </div>
-          {([
-            { icon: Smile, key: 'checkin', label: 'Check-in' },
-            { icon: TrendingUp, key: 'trends', label: 'Trends' },
-            { icon: MessageSquare, key: 'chat', label: 'Chat' },
-          ] as const).map(({ icon: Icon, key, label }) => (
-            <button key={key} type="button" onClick={() => setTab(key)} title={label}
-              style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : 'transparent', border: tab === key ? `1px solid ${COLOR}40` : '1px solid transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: tab === key ? COLOR : '#6B7280' }}>
-              <Icon size={20} />
-            </button>
-          ))}
-          <div style={{ flex: 1 }} />
-          <button type="button" aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: '#6B7280' }}><Bell size={18} /></button>
-          <button type="button" aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: '#6B7280' }}><Settings size={18} /></button>
-          <Avatar style={{ width: 36, height: 36 }}>
-            <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
-          </Avatar>
-        </aside>
-
-        {/* Second sidebar with community stats */}
-        <aside style={{ width: 200, background: '#0D0F14', borderRight: '1px solid rgba(255,255,255,0.06)', display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
-          <div style={{ padding: '20px 16px 12px' }}>
-            <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: '#6B7280', textTransform: 'uppercase', marginBottom: 12 }}>😁 Mood</div>
-          </div>
-          <ScrollArea style={{ flex: 1 }}>
-            <div style={{ padding: '0 8px 16px' }}>
-              {(['checkin', 'trends', 'chat'] as const).map((key) => (
-                <button key={key} type="button" onClick={() => setTab(key)}
-                  style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 8, cursor: 'pointer', background: tab === key ? `${COLOR}18` : 'transparent', borderLeft: tab === key ? `2px solid ${COLOR}` : '2px solid transparent', marginLeft: 2, marginBottom: 2, border: 'none', width: 'calc(100% - 4px)', textAlign: 'left' }}>
-                  <span style={{ fontSize: 13, color: tab === key ? '#E8EAF0' : '#9CA3AF', flex: 1, textTransform: 'capitalize' }}>{key === 'checkin' ? 'Check-in' : key.charAt(0).toUpperCase() + key.slice(1)}</span>
-                </button>
-              ))}
-              {communityStats && (
-                <>
-                  <div style={{ margin: '16px 0 8px', fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: '#4B5563', textTransform: 'uppercase', padding: '0 10px' }}>Community</div>
-                  {communityStats.totalUsers != null && (
-                    <div style={{ padding: '6px 10px', fontSize: 12, color: '#6B7280' }}>Members: <span style={{ color: COLOR, fontWeight: 600 }}>{(communityStats.totalUsers as number).toLocaleString()}</span></div>
-                  )}
-                  {communityStats.activeToday != null && (
-                    <div style={{ padding: '6px 10px', fontSize: 12, color: '#6B7280' }}>Active today: <span style={{ color: COLOR, fontWeight: 600 }}>{(communityStats.activeToday as number).toLocaleString()}</span></div>
-                  )}
-                </>
-              )}
-            </div>
-          </ScrollArea>
-        </aside>
-
-        {/* Main content */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-          <header style={{ height: 56, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: '#0D0F14', flexShrink: 0 }}>
-            <Smile size={18} style={{ color: COLOR }} />
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 15, fontWeight: 600, color: '#E8EAF0' }}>😁 Mood — Anonymous Check-ins</div>
-              <div style={{ fontSize: 12, color: '#6B7280' }}>Zero tracking · Community wellness · Phase 2</div>
-            </div>
-            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: '3px 10px', borderRadius: 20 }}>🔒 Anonymous</Badge>
-          </header>
-
-          {tab === 'checkin' ? (
-            eligible === false ? (
-              <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', flexDirection: 'column', gap: 12, padding: 24 }}>
-                <div style={{ fontSize: 48 }}>⏳</div>
-                <div style={{ fontSize: 20, fontWeight: 700, color: '#F9FAFB' }}>Already checked in</div>
-                <div style={{ fontSize: 14, color: '#6B7280' }}>Check back in {daysUntilEligible ?? '?'} day{daysUntilEligible !== 1 ? 's' : ''}.</div>
-                <button type="button" onClick={() => setTab('trends')}
-                  style={{ marginTop: 8, padding: '10px 24px', borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
-                  View Community Trends
-                </button>
-              </div>
-            ) : (
-              <ScrollArea style={{ flex: 1 }}>
-                <div style={{ padding: '40px', maxWidth: 640, margin: '0 auto' }}>
-                  {!submitted ? (
-                    <>
-                      <div style={{ textAlign: 'center', marginBottom: 40 }}>
-                        <div style={{ fontSize: 28, fontWeight: 800, color: '#F9FAFB', marginBottom: 8 }}>How are you feeling right now?</div>
-                        <div style={{ fontSize: 15, color: '#6B7280' }}>Anonymous, safe, and encrypted. Your mood is submitted anonymously and encrypted to our backend.</div>
-                      </div>
-                      <div style={{ display: 'flex', gap: 16, justifyContent: 'center', marginBottom: 40 }}>
-                        {MOODS.map((m) => (
-                          <button key={m.value} type="button" onClick={() => setSelected(m.value)}
-                            style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, padding: '20px 16px', borderRadius: 16, background: selected === m.value ? `${m.color}20` : 'rgba(255,255,255,0.02)', border: `2px solid ${selected === m.value ? m.color : 'rgba(255,255,255,0.06)'}`, cursor: 'pointer' }}>
-                            <div style={{ fontSize: 40 }}>{m.emoji}</div>
-                            <div style={{ fontSize: 12, fontWeight: 600, color: selected === m.value ? m.color : '#6B7280' }}>{m.label}</div>
-                          </button>
-                        ))}
-                      </div>
-                      {selected && (
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-                          <textarea value={input} onChange={(e) => setInput(e.target.value)} placeholder="(Optional) Anything you'd like to add? Completely anonymous…" rows={3}
-                            style={{ width: '100%', padding: '14px 16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 12, fontSize: 14, color: '#E8EAF0', outline: 'none', resize: 'none', boxSizing: 'border-box' }} />
-                          <button type="button" onClick={() => void handleSubmit()} disabled={submitting}
-                            style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 16, fontWeight: 800, cursor: submitting ? 'not-allowed' : 'pointer', opacity: submitting ? 0.7 : 1 }}>
-                            Submit Anonymously
-                          </button>
-                          <div style={{ textAlign: 'center', fontSize: 12, color: '#4B5563' }}>Not linked to your account · Encrypted · Instant deletion available</div>
-                        </div>
-                      )}
-                      {error && <div style={{ fontSize: 13, color: '#EF4444', marginTop: 12, textAlign: 'center' }}>{error}</div>}
-                    </>
-                  ) : (
-                    <div style={{ textAlign: 'center' }}>
-                      <div style={{ fontSize: 80, marginBottom: 20 }}>💚</div>
-                      <div style={{ fontSize: 28, fontWeight: 800, color: '#F9FAFB', marginBottom: 8 }}>Thank you for checking in.</div>
-                      <div style={{ fontSize: 15, color: '#6B7280', marginBottom: 32 }}>You're part of a community of survivors supporting each other.</div>
-                      <button type="button" onClick={() => setTab('trends')}
-                        style={{ padding: '10px 24px', borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
-                        See Community Trends
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </ScrollArea>
-            )
-          ) : tab === 'trends' ? (
-            <ScrollArea style={{ flex: 1 }}>
-              <div style={{ padding: '24px' }}>
-                <div style={{ marginBottom: 24, padding: '20px 24px', borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(236,72,153,0.03) 100%)`, border: `1px solid ${COLOR}20` }}>
-                  <div style={{ fontSize: 20, fontWeight: 800, color: '#F9FAFB', marginBottom: 4 }}>Community Mood — 7-Day Trend</div>
-                  <div style={{ fontSize: 14, color: '#6B7280' }}>Aggregated · Fully anonymous · No individual data ever shared</div>
-                </div>
-                {/* Bar chart */}
-                <div style={{ padding: '24px', borderRadius: 16, background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.06)', marginBottom: 20 }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: '#F9FAFB', marginBottom: 20 }}>Average Mood Score (1–5)</div>
-                  <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12, height: 120 }}>
-                    {weeklyTrend.map((d) => {
-                      const heightPct = (d.value / maxTrend) * 100;
-                      return (
-                        <div key={d.day} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
-                          <div style={{ fontSize: 11, color: COLOR, fontWeight: 700 }}>{d.value.toFixed(1)}</div>
-                          <div style={{ width: '100%', borderRadius: '4px 4px 0 0', background: `linear-gradient(to top,${COLOR},${COLOR}80)`, height: `${heightPct}%`, minHeight: 4, transition: 'height 0.3s' }} />
-                          <div style={{ fontSize: 11, color: '#6B7280' }}>{d.day}</div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-                {/* Mood distribution */}
-                <div style={{ padding: '24px', borderRadius: 16, background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.06)' }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: '#F9FAFB', marginBottom: 16 }}>Community Mood Distribution</div>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                    {MOODS.map((m) => {
-                      const fakePct = [38, 27, 18, 10, 7][5 - m.value];
-                      return (
-                        <div key={m.value}>
-                          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
-                            <span style={{ color: '#E8EAF0' }}>{m.emoji} {m.label}</span>
-                            <span style={{ color: m.color, fontWeight: 700 }}>{fakePct}%</span>
-                          </div>
-                          <div style={{ height: 6, background: 'rgba(255,255,255,0.04)', borderRadius: 3, overflow: 'hidden' }}>
-                            <div style={{ height: '100%', background: m.color, borderRadius: 3, width: `${fakePct}%` }} />
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div style={{ marginTop: 16, fontSize: 11, color: '#4B5563', lineHeight: 1.6 }}>
-                    Distribution based on aggregated community data · Individual submissions are never identifiable
-                  </div>
-                </div>
-              </div>
-            </ScrollArea>
-          ) : (
-            /* Chat tab — informational, no live messaging (no API backing) */
-            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-              <ScrollArea style={{ flex: 1 }}>
-                <div style={{ padding: '24px' }}>
-                  <div style={{ padding: '20px 24px', borderRadius: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}15`, marginBottom: 16 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                      <Lock size={14} style={{ color: COLOR }} />
-                      <span style={{ fontSize: 13, fontWeight: 700, color: COLOR }}>Peer Support — Coming Soon</span>
-                    </div>
-                    <div style={{ fontSize: 14, color: '#6B7280', lineHeight: 1.7 }}>
-                      Anonymous peer support chat is in development. For immediate support, use the crisis resources below.
-                    </div>
-                  </div>
-                </div>
-              </ScrollArea>
-              <div style={{ padding: '8px 24px 20px', flexShrink: 0 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 16px', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.06)', borderRadius: 14 }}>
-                  <Plus size={18} style={{ color: '#4B5563' }} />
-                  <input disabled placeholder="Chat coming soon…"
-                    style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 14, color: '#4B5563', cursor: 'not-allowed' }} />
-                  <Send size={14} style={{ color: '#4B5563' }} />
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Right rail — crisis resources */}
-        <aside style={{ width: 280, borderLeft: '1px solid rgba(255,255,255,0.06)', background: '#0D0F14', padding: '20px 16px', flexShrink: 0 }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: '#6B7280', textTransform: 'uppercase', marginBottom: 12 }}>Crisis Resources</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
-            {CRISIS_RESOURCES.map((r) => (
-              <div key={r.name} style={{ padding: '12px 14px', borderRadius: 12, background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.18)' }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: '#F9FAFB', marginBottom: 2 }}>{r.name}</div>
-                <div style={{ fontSize: 12, color: COLOR, fontWeight: 600, marginBottom: 2 }}>{r.number}</div>
-                <div style={{ fontSize: 11, color: '#6B7280' }}>{r.available}</div>
-              </div>
-            ))}
-          </div>
-          <div style={{ padding: '14px 16px', borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}18`, marginBottom: 12 }}>
-            <div style={{ fontSize: 12, fontWeight: 700, color: COLOR, marginBottom: 8 }}>🔒 Privacy First</div>
-            <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.6 }}>Your mood check-in is 100% anonymous. We never link submissions to your identity.</div>
-          </div>
-          {communityStats?.activeToday != null && (
-            <div style={{ padding: '14px 16px', borderRadius: 12, background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.04)' }}>
-              <div style={{ fontSize: 12, fontWeight: 700, color: '#9CA3AF', marginBottom: 6 }}>Today</div>
-              <div style={{ fontSize: 22, fontWeight: 800, color: COLOR, marginBottom: 2 }}>{(communityStats.activeToday as number).toLocaleString()}</div>
-              <div style={{ fontSize: 12, color: '#6B7280' }}>survivors checked in</div>
-            </div>
-          )}
-        </aside>
-      </div>
-    );
+  async function handleSubmit() {
+    if (!selected || submitting || !clientId) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/mood/submissions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({ clientId, moodValue: selected, note: note.trim() ? note.trim() : null }),
+      });
+      if (!res.ok) {
+        const payload = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new Error(payload?.message ?? "Submission failed.");
+      }
+      setSubmitted(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Submission failed.");
+    } finally {
+      setSubmitting(false);
+    }
   }
-  
+
+  if (loading) return <MoodLoading />;
+
+  return (
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+      <MoodIconRail tab={tab} onTab={setTab} />
+      <MoodSidebar tab={tab} onTab={setTab} />
+
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+          <Smile size={18} style={{ color: COLOR }} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>😁 Mood — Anonymous Check-ins</div>
+            <div style={{ fontSize: 12, color: "#6B7280" }}>Zero tracking · Community wellness</div>
+          </div>
+          <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>🔒 Anonymous</Badge>
+        </header>
+
+        {tab === "checkin" ? (
+          <MoodCheckin
+            eligibility={eligibility}
+            selected={selected}
+            onSelect={setSelected}
+            note={note}
+            onNoteChange={setNote}
+            submitting={submitting}
+            submitted={submitted}
+            error={error}
+            onSubmit={() => void handleSubmit()}
+            onViewCommunity={() => setTab("community")}
+          />
+        ) : (
+          <MoodCommunity />
+        )}
+      </div>
+
+      <MoodCrisisRail />
+    </div>
+  );
+}

--- a/ctf/packages/web/components/mood/mood-sidebar.tsx
+++ b/ctf/packages/web/components/mood/mood-sidebar.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Lock } from "lucide-react";
+import { COLOR, SUBTLE, TEXT, type Tab } from "./mood-shared";
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: "checkin", label: "Check-in" },
+  { key: "community", label: "Community Pulse" },
+];
+
+export function MoodSidebar({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => void }) {
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 12 }}>😁 Mood</div>
+        <div style={{ padding: "14px 16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+            <Lock size={12} style={{ color: COLOR }} />
+            <span style={{ fontSize: 12, fontWeight: 700, color: COLOR }}>100% Anonymous</span>
+          </div>
+          <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.6 }}>Your mood is never linked to your identity. Encrypted and rate-limited per device.</div>
+        </div>
+      </div>
+      <ScrollArea style={{ flex: 1 }}>
+        <div style={{ padding: "0 8px 16px" }}>
+          {TABS.map(({ key, label }) => (
+            <button key={key} type="button" onClick={() => onTab(key)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: tab === key ? `${COLOR}18` : "transparent", borderLeft: tab === key ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2, border: "none", width: "calc(100% - 4px)", textAlign: "left" }}>
+              <span style={{ fontSize: 13, color: tab === key ? TEXT : "#9CA3AF", flex: 1 }}>{label}</span>
+            </button>
+          ))}
+        </div>
+      </ScrollArea>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

UI circle-back for the **mood** plugin (web). Rebuilds `/apps/mood` to `design/.../survivor-hub/Mood.tsx` and its Empty/Loading states, and **fixes two runtime API-contract bugs** in the prior shell.

## Bug fixes (the prior shell failed at runtime)

- **Eligibility:** now calls `GET /api/mood/eligibility?clientId=<id>` — the route returns **400** without `clientId`, so the check-in tab always errored. `clientId` is an anonymous, per-device id persisted in `localStorage`, never tied to the account.
- **Submission:** now POSTs `{ clientId, moodValue, note }` with the `x-ctf-csrf: 1` header. The prior shell sent `{ mood, note }` and no CSRF header, so every submit **400'd**.

## Honest data

The **Community Pulse** tab renders the design's honest empty state. There is **no aggregate-stats backend** (only `eligibility` + `submissions` exist), so the prior shell's fabricated 7-day averages and `fakePct` mood-distribution percentages were **removed**, not re-displayed.

## Modularity + cleanup

- Decomposed the oversized shell (**280 lines / complexity 21**, a pre-existing rule-116 violation) into `mood-shared`, `mood-loading`, `mood-icon-rail`, `mood-sidebar`, `mood-checkin`, `mood-community`, `mood-crisis-rail`, plus the shell — each within `complexity:10` / `max-lines-per-function:200`.
- Removed banned "Phase 2" wording.

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- `pnpm --filter @ctf/web lint components/mood/` — green
- Modularity gate on all mood files — green
- `pnpm --filter @ctf/web build:ci` — green
- `check-eof-format.sh`, `check-web-android-parity.mjs`, `check-schema-drift.sh` — green

## Scope

Web-only pixel pass + the API-contract fix. Android pixel pass (`MobileMood.tsx`) deferred and tracked in the plan.

Parity Ticket: #119


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_