### PR TITLE
feat: socketrelay web pixel pass — real model + runtime-bug fixes

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -457,3 +457,14 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   schema-drift gates green. Marked skills-taxonomy Design 🎨 / Web px ✅; Android pixel parity
   (`MobileSkillsTaxonomy.tsx`) remains ⬜. All four previously design-gated plugins are now web-pixel
   complete; no design-gated plugins remain.
+- 2026-05-29: UI circle-back — non-gated web pixel passes (designs existed since `dcaaf15`): mood,
+  gentlepulse, and socketrelay. Each aligned/rebuilt its shell to the design mockup + Loading/Empty
+  states and was decomposed into modular sub-components within the rule-116 limits. Real bugs fixed
+  along the way: mood (eligibility `?clientId=` + submission `{ clientId, moodValue, note }` + CSRF —
+  prior shell 400'd), gentlepulse (removed a dead duplicate `components/gentle-pulse/` dir), socketrelay
+  (prior shell read the paged `requests` response as a bare array and POSTed non-existent
+  `type`/`description`/`credits` fields without CSRF — rebuilt to the real request/claim/fulfillment
+  model). All counts derive from real data; unbacked mockup figures were omitted, not faked. typecheck,
+  lint, modularity, build:ci, EOF, parity, and schema-drift gates green for each. Marked mood,
+  gentlepulse, socketrelay Web px ✅; their Android pixel parity (`MobileMood.tsx`,
+  `MobileGentlePulse.tsx`, `MobileSocketRelay.tsx`) remains ⬜ for the dedicated Android sweep.

--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -106,7 +106,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | skills-hunt | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | foundation | 🎨 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | lighthouse | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
-| socketrelay | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| socketrelay | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | trusttransport | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | peer-programming | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | mood | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
@@ -130,6 +130,8 @@ Storage and projection rules:
 
 `web+android complete`. Web surface lives under `/apps/socketrelay`; Android surface lives under `packages/mobile/src/features/socketrelay`. Public projection, lifecycle status, and CSRF behaviors are behaviorally consistent across platforms.
 
+Web pixel pass (design `c5d83c0`): the `/apps/socketrelay` shell is rebuilt to `design/.../survivor-hub/SocketRelay.tsx` (feed / post / chat tabs, sidebar category filters + live stats, right impact panel) and its Loading/Empty states. The prior shell was broken against the real backend — it read `GET /api/socketrelay/requests` as a bare array (the route returns `{ items, page, pageSize, total }`) and POSTed `{ type, description, location, credits, urgency }` with no CSRF header, none of which the backend accepts. The rebuilt shell uses the real `SocketRelayRequest` model (`title`, `details`, `category`, `city`, `isPublic`, `status`), unwraps the paged response, claims via `POST /requests/:id/fulfill`, and lists fulfillment chats via `my-fulfillments` + `fulfillments/:id/chat`, with `x-ctf-csrf` on mutations. The mockup's need/offer/credits/urgency framing is not backed by the data model and was omitted rather than faked. Decomposed into modular sub-components (`sr-shared`, `sr-loading`, `sr-icon-rail`, `sr-sidebar`, `sr-feed`, `sr-post`, `sr-chat`, `sr-right-panel`) within the rule-116 limits. No schema/API change. The Android pixel pass to `MobileSocketRelay.tsx` remains tracked in `PRODUCTION_READINESS_PLAN.md`.
+
 ## 7) Seed Coverage Status
 
 `ctf/scripts/seedSocketRelay.mjs` seeds deterministic request lifecycle, fulfillment outcomes, and announcement states for dev validation.
@@ -141,6 +143,7 @@ Storage and projection rules:
 
 ## 9) Change Log
 
+- 2026-05-29: Web UI circle-back (design `c5d83c0`). Rebuilt the `/apps/socketrelay` shell to the `SocketRelay.tsx` mockup + Loading/Empty; fixed runtime bugs in the prior shell (read the paged `requests` response as a bare array; POSTed non-existent `type`/`description`/`location`/`credits` fields without CSRF). The rebuild uses the real request/claim/fulfillment model + `x-ctf-csrf` header and unwraps `{ items, ... }`; decomposed into modular sub-components within rule-116 limits; the mockup's unbacked need/offer/credits/urgency framing was omitted. No schema/API change.
 - 2026-05-18: Inventory updated to enforce Rule 120 living-snapshot model. Removed "Web-First Delivery Strategy and Android Deferrals" section, "Docs Lifecycle" meta section, and planning-state framing. Replaced narrative data model bullets with the actual `socketrelay_*` tables. Confirmed `web+android complete` and dedicated seed script.
 - 2026-02-25: Created initial SocketRelay CTF rewrite inventory.
 

--- a/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
@@ -1,442 +1,233 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
-import { StreamChatPanel } from "../shared/stream-chat-panel";
+import { Share2 } from "lucide-react";
 import {
-  Share2, Send, Plus, Search, Bell, Settings, MessageSquare,
-  AlertCircle, Heart, Shield,
-} from "lucide-react";
+  BG,
+  COLOR,
+  SUBTLE,
+  TEXT,
+  type SrChatCredentials,
+  type SrFulfillment,
+  type SrFulfillmentsResponse,
+  type SrListResponse,
+  type SrRequest,
+  type Tab,
+} from "./sr-shared";
+import { SocketRelayLoading } from "./sr-loading";
+import { SocketRelayIconRail } from "./sr-icon-rail";
+import { SocketRelaySidebar } from "./sr-sidebar";
+import { SocketRelayFeed } from "./sr-feed";
+import { SocketRelayPost, type PostDraft } from "./sr-post";
+import { SocketRelayChat } from "./sr-chat";
+import { SocketRelayRightPanel } from "./sr-right-panel";
 
-const COLOR = "#F43F5E";
+const EMPTY_DRAFT: PostDraft = { title: "", details: "", category: "", city: "", isPublic: false };
 
-interface Request {
-  id: string;
-  type: "need" | "offer";
-  description: string;
-  category: string;
-  location?: string;
-  credits?: number;
-  urgency?: "urgent" | "normal";
-  createdAt: string;
-  fulfilledAt?: string | null;
-  isAnonymous?: boolean;
+async function getJson<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) return null;
+  return (await res.json()) as T;
 }
 
-interface Fulfillment {
-  id: string;
-  requestId?: string;
-}
+type SocketRelayShellProps = {
+  userId?: string;
+  isAdmin?: boolean;
+  role?: string | null;
+};
 
-type Tab = "feed" | "post" | "chat";
-
-const TABS: { icon: React.ElementType; key: Tab }[] = [
-  { icon: Share2, key: "feed" },
-  { icon: Plus, key: "post" },
-  { icon: MessageSquare, key: "chat" },
-];
-
-const CATEGORIES = ["All", "Food", "Transport", "Legal", "Employment", "Childcare", "Housing", "Mental Health"];
-
-function timeAgo(iso: string) {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins} min ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs} hr ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
-
-export function SocketRelayShell(_props: { userId?: string; isAdmin?: boolean; role?: string | null }) {
+export function SocketRelayShell({ userId }: SocketRelayShellProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [openRequests, setOpenRequests] = useState<Request[]>([]);
-  const [fulfillments, setFulfillments] = useState<Fulfillment[]>([]);
+  const [requests, setRequests] = useState<SrRequest[]>([]);
+  const [myRequestCount, setMyRequestCount] = useState(0);
+  const [fulfillments, setFulfillments] = useState<SrFulfillment[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [tab, setTab] = useState<Tab>("feed");
   const [category, setCategory] = useState("All");
-  const [postType, setPostType] = useState<"need" | "offer">("need");
-  const [postDescription, setPostDescription] = useState("");
-  const [postCategory, setPostCategory] = useState("");
-  const [postLocation, setPostLocation] = useState("");
-  const [postCredits, setPostCredits] = useState("");
+  const [search, setSearch] = useState("");
+  const [draft, setDraft] = useState<PostDraft>(EMPTY_DRAFT);
   const [postError, setPostError] = useState<string | null>(null);
   const [postSuccess, setPostSuccess] = useState(false);
-  const [selectedFulfillment, setSelectedFulfillment] = useState<Fulfillment | null>(null);
-  const [chatCredentials, setChatCredentials] = useState<Record<string, unknown> | null>(null);
+  const [selectedFulfillment, setSelectedFulfillment] = useState<SrFulfillment | null>(null);
+  const [chatCredentials, setChatCredentials] = useState<SrChatCredentials | null>(null);
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
 
-  async function fetchData(options?: { showLoading?: boolean }) {
+  const fetchData = useCallback(async (options?: { showLoading?: boolean }) => {
     if (options?.showLoading !== false) setLoading(true);
     setError(null);
     try {
-      const [openReqRes, fulfillmentsRes] = await Promise.all([
-        fetch("/api/socketrelay/requests"),
-        fetch("/api/socketrelay/my-fulfillments"),
+      const [reqData, myReqData, fulData] = await Promise.all([
+        getJson<SrListResponse>("/api/socketrelay/requests"),
+        getJson<SrListResponse>("/api/socketrelay/my-requests"),
+        getJson<SrFulfillmentsResponse>("/api/socketrelay/my-fulfillments"),
       ]);
-      if (openReqRes.ok) setOpenRequests(await openReqRes.json() as Request[]);
-      if (fulfillmentsRes.ok) setFulfillments(await fulfillmentsRes.json() as Fulfillment[]);
-    } catch (e: unknown) {
+      setRequests(reqData?.items ?? []);
+      setMyRequestCount(myReqData?.total ?? 0);
+      setFulfillments(fulData?.items ?? []);
+    } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load SocketRelay.");
     } finally {
       if (options?.showLoading !== false) setLoading(false);
     }
-  }
+  }, []);
 
-  useEffect(() => { void fetchData(); }, []);
+  useEffect(() => { void fetchData(); }, [fetchData]);
 
-  async function handleCreateRequest() {
-    if (!postDescription.trim()) { setPostError("Please describe what you need or offer."); return; }
+  async function handlePost() {
+    if (!draft.title.trim() || !draft.details.trim() || !draft.category.trim()) {
+      setPostError("Title, details, and category are required.");
+      return;
+    }
     setSubmitting(true);
     setPostError(null);
     setPostSuccess(false);
     try {
       const res = await fetch("/api/socketrelay/requests", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
         body: JSON.stringify({
-          type: postType,
-          description: postDescription,
-          category: postCategory || "General",
-          location: postLocation,
-          credits: postCredits ? Number(postCredits) : 0,
+          title: draft.title.trim(),
+          details: draft.details.trim(),
+          category: draft.category.trim(),
+          city: draft.city.trim() ? draft.city.trim() : null,
+          isPublic: draft.isPublic,
         }),
       });
-      if (!res.ok) throw new Error("Failed to create request");
-      setPostDescription("");
-      setPostCategory("");
-      setPostLocation("");
-      setPostCredits("");
+      if (!res.ok) {
+        const payload = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new Error(payload?.message ?? "Failed to create request.");
+      }
+      setDraft(EMPTY_DRAFT);
       setPostSuccess(true);
-      void fetchData({ showLoading: false });
-    } catch (e: unknown) {
+      await fetchData({ showLoading: false });
+    } catch (e) {
       setPostError(e instanceof Error ? e.message : "Failed to create request.");
     } finally {
       setSubmitting(false);
     }
   }
 
-  async function handleClaimFulfillment(id: string) {
+  async function handleClaim(requestId: string) {
     setSubmitting(true);
     try {
-      const res = await fetch(`/api/socketrelay/requests/${id}/fulfill`, { method: "POST" });
-      if (!res.ok) throw new Error("Failed to claim");
-      void fetchData({ showLoading: false });
+      const res = await fetch(`/api/socketrelay/requests/${requestId}/fulfill`, {
+        method: "POST",
+        headers: { "x-ctf-csrf": "1" },
+      });
+      if (res.ok) await fetchData({ showLoading: false });
     } catch {
-      // Silent — refresh will show updated state
+      // Refresh will reflect the latest state.
     } finally {
       setSubmitting(false);
     }
   }
 
-  async function fetchChatCredentials(fulfillment: Fulfillment) {
+  async function openFulfillmentChat(fulfillment: SrFulfillment) {
     setSelectedFulfillment(fulfillment);
     setChatCredentials(null);
     setChatError(null);
     setChatLoading(true);
     try {
-      const res = await fetch(`/api/socketrelay/fulfillments/${fulfillment.id}/chat`, { method: "POST" });
+      const res = await fetch(`/api/socketrelay/fulfillments/${fulfillment.id}/chat`, {
+        method: "POST",
+        headers: { "x-ctf-csrf": "1" },
+      });
       if (!res.ok) throw new Error("Failed to fetch chat credentials");
-      const data = await res.json() as Record<string, unknown>;
-      if (!data.ok) throw new Error(String(data.message ?? "No chat credentials"));
+      const data = (await res.json()) as SrChatCredentials;
+      if (!data.ok) throw new Error(data.message ?? "No chat credentials");
       setChatCredentials(data);
-    } catch (e: unknown) {
+    } catch (e) {
       setChatError(e instanceof Error ? e.message : "Failed to load chat");
     } finally {
       setChatLoading(false);
     }
   }
 
-  const filtered = openRequests.filter(
-    (r) => category === "All" || r.category === category
-  );
-
-  const needs = openRequests.filter((r) => r.type === "need").length;
-  const offers = openRequests.filter((r) => r.type === "offer").length;
-
-  if (loading) {
-    return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#6B7280" }}>
-        Loading SocketRelay…
-      </div>
-    );
-  }
-
+  if (loading) return <SocketRelayLoading />;
   if (error) {
     return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
+      <div style={{ width: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
         {error}
       </div>
     );
   }
 
+  const openCount = requests.filter((r) => r.status === "open").length;
+  const visible = requests.filter((r) => {
+    if (category !== "All" && r.category !== category) return false;
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      if (!`${r.title} ${r.details} ${r.city ?? ""}`.toLowerCase().includes(q)) return false;
+    }
+    return true;
+  });
+
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
-      {/* Icon rail */}
-      <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
-          <Share2 size={20} style={{ color: COLOR }} />
-        </div>
-        {TABS.map(({ icon: Icon, key }) => (
-          <button key={key} onClick={() => setTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
-            <Icon size={20} />
-          </button>
-        ))}
-        <div style={{ flex: 1 }} />
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
-          <Bell size={18} />
-        </button>
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
-          <Settings size={18} />
-        </button>
-        <Avatar style={{ width: 36, height: 36 }}>
-          <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
-        </Avatar>
-      </aside>
+    <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: "flex" }}>
+      <SocketRelayIconRail tab={tab} onTab={setTab} />
+      <SocketRelaySidebar
+        category={category}
+        onCategory={setCategory}
+        search={search}
+        onSearch={setSearch}
+        openCount={openCount}
+        myRequestCount={myRequestCount}
+        fulfillmentCount={fulfillments.length}
+      />
 
-      {/* Sidebar */}
-      <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
-        <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>SocketRelay</div>
-          <div style={{ position: "relative" }}>
-            <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
-            <input placeholder="Search requests…" style={{ width: "100%", padding: "7px 10px 7px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
-          </div>
-        </div>
-        <ScrollArea style={{ flex: 1 }}>
-          <div style={{ padding: "0 8px 16px" }}>
-            {CATEGORIES.map((c) => (
-              <div key={c} onClick={() => setCategory(c)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: category === c ? `${COLOR}18` : "transparent", borderLeft: category === c ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
-                <span style={{ fontSize: 13, color: category === c ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{c}</span>
-              </div>
-            ))}
-            <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", padding: "0 10px" }}>Live Stats</div>
-            {[
-              { l: "Open Needs", v: String(needs) },
-              { l: "Open Offers", v: String(offers) },
-              { l: "My Fulfillments", v: String(fulfillments.length) },
-            ].map(({ l, v }) => (
-              <div key={l} style={{ padding: "6px 10px", fontSize: 12, color: "#6B7280" }}>
-                {l}: <span style={{ color: COLOR, fontWeight: 600 }}>{v}</span>
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
-      </aside>
-
-      {/* Main */}
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
           <Share2 size={18} style={{ color: COLOR }} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>SocketRelay — Mutual Aid</div>
-            <div style={{ fontSize: 12, color: "#6B7280" }}>Real-time needs ↔ offers · Privacy-minimized</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>🔂 SocketRelay — Mutual Aid</div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>Real-time requests · Privacy-minimized</div>
           </div>
           <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-            {openRequests.length} open
+            {openCount} open
           </Badge>
         </header>
 
         {tab === "feed" && (
-          <ScrollArea style={{ flex: 1 }}>
-            <div style={{ padding: "20px 24px" }}>
-              <div style={{ display: "flex", gap: 8, marginBottom: 20 }}>
-                {["All", "Needs 🆘", "Offers 🤝"].map((f) => (
-                  <button key={f} style={{ padding: "6px 14px", borderRadius: 20, fontSize: 12, fontWeight: 600, background: f === "All" ? `${COLOR}20` : "rgba(255,255,255,0.04)", border: `1px solid ${f === "All" ? COLOR + "40" : "rgba(255,255,255,0.06)"}`, color: f === "All" ? COLOR : "#6B7280", cursor: "pointer" }}>
-                    {f}
-                  </button>
-                ))}
-              </div>
-              {filtered.length === 0 ? (
-                <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-                  <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(244,63,94,0.3)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                    <Share2 size={20} style={{ color: "rgba(244,63,94,0.4)" }} />
-                  </div>
-                  <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No requests yet</div>
-                  <div style={{ fontSize: 13, color: "#4B5563" }}>Be the first to post a need or offer.</div>
-                  <button onClick={() => setTab("post")} style={{ padding: "10px 20px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
-                    Post Now
-                  </button>
-                </div>
-              ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  {filtered.map((r) => {
-                    const fulfilled = !!r.fulfilledAt;
-                    return (
-                      <div key={r.id} style={{ padding: "18px 20px", borderRadius: 14, background: fulfilled ? "rgba(255,255,255,0.01)" : "rgba(255,255,255,0.02)", border: `1px solid ${r.type === "need" ? COLOR + (r.urgency === "urgent" ? "50" : "20") : "#22C55E30"}`, opacity: fulfilled ? 0.5 : 1 }}>
-                        <div style={{ display: "flex", gap: 12, alignItems: "flex-start" }}>
-                          <div style={{ width: 40, height: 40, borderRadius: 10, background: r.type === "need" ? `${COLOR}20` : "#22C55E20", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-                            {r.type === "need" ? <AlertCircle size={18} style={{ color: COLOR }} /> : <Heart size={18} style={{ color: "#22C55E" }} />}
-                          </div>
-                          <div style={{ flex: 1 }}>
-                            <div style={{ display: "flex", gap: 8, marginBottom: 6, alignItems: "center", flexWrap: "wrap" }}>
-                              <Badge style={{ background: r.type === "need" ? `${COLOR}20` : "#22C55E20", color: r.type === "need" ? COLOR : "#22C55E", border: `1px solid ${r.type === "need" ? COLOR + "40" : "#22C55E40"}`, fontSize: 11 }}>
-                                {r.type === "need" ? "Need 🆘" : "Offer 🤝"}
-                              </Badge>
-                              {r.category && (
-                                <Badge style={{ background: "rgba(255,255,255,0.04)", color: "#9CA3AF", border: "1px solid rgba(255,255,255,0.06)", fontSize: 11 }}>{r.category}</Badge>
-                              )}
-                              {r.urgency === "urgent" && (
-                                <Badge style={{ background: "#EF444420", color: "#EF4444", border: "1px solid #EF444440", fontSize: 11 }}>⚠ Urgent</Badge>
-                              )}
-                            </div>
-                            <div style={{ fontSize: 14, fontWeight: 600, color: "#F9FAFB", marginBottom: 6, lineHeight: 1.4 }}>{r.description}</div>
-                            <div style={{ display: "flex", gap: 12, fontSize: 12, color: "#6B7280", flexWrap: "wrap" }}>
-                              {r.isAnonymous === false ? null : <span>Anonymous</span>}
-                              {r.location && <span>· {r.location}</span>}
-                              <span>· {timeAgo(r.createdAt)}</span>
-                            </div>
-                          </div>
-                          <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-end", flexShrink: 0 }}>
-                            {(r.credits ?? 0) > 0 && (
-                              <div style={{ fontSize: 13, fontWeight: 700, color: "#F59E0B" }}>{r.credits} credits</div>
-                            )}
-                            {!fulfilled && (
-                              <button
-                                onClick={() => { void handleClaimFulfillment(r.id); }}
-                                disabled={submitting}
-                                style={{ padding: "8px 14px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, cursor: "pointer" }}
-                              >
-                                {r.type === "need" ? "I can Help" : "Connect"}
-                              </button>
-                            )}
-                            {fulfilled && (
-                              <div style={{ fontSize: 12, color: "#22C55E", fontWeight: 600 }}>✓ Fulfilled</div>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </ScrollArea>
+          <SocketRelayFeed
+            requests={visible}
+            currentUserId={userId}
+            submitting={submitting}
+            onClaim={(id) => void handleClaim(id)}
+            onPost={() => setTab("post")}
+          />
         )}
-
         {tab === "post" && (
-          <div style={{ flex: 1, padding: "32px 40px", overflowY: "auto" }}>
-            <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 20 }}>Post a Request or Offer</div>
-            <div style={{ display: "flex", gap: 8, marginBottom: 24 }}>
-              {(["need", "offer"] as const).map((t) => (
-                <button key={t} onClick={() => setPostType(t)} style={{ flex: 1, padding: "14px", borderRadius: 12, background: postType === t ? (t === "need" ? `${COLOR}20` : "#22C55E20") : "rgba(255,255,255,0.03)", border: `2px solid ${postType === t ? (t === "need" ? COLOR : "#22C55E") : "rgba(255,255,255,0.06)"}`, cursor: "pointer", textAlign: "center" }}>
-                  <div style={{ fontSize: 20, marginBottom: 4 }}>{t === "need" ? "🆘" : "🤝"}</div>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: postType === t ? (t === "need" ? COLOR : "#22C55E") : "#6B7280" }}>{t === "need" ? "I Need Help" : "I Can Help"}</div>
-                </button>
-              ))}
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-              <div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>What do you need / offer?</div>
-                <textarea
-                  value={postDescription}
-                  onChange={(e) => setPostDescription(e.target.value)}
-                  placeholder="Be specific about what help you need or can give…"
-                  rows={3}
-                  style={{ width: "100%", padding: "12px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", resize: "none", boxSizing: "border-box" }}
-                />
-              </div>
-              <div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>Category</div>
-                <input value={postCategory} onChange={(e) => setPostCategory(e.target.value)} placeholder="Food, Transport, Legal, Employment…" style={{ width: "100%", padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", boxSizing: "border-box" }} />
-              </div>
-              <div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>Location (privacy-protected)</div>
-                <input value={postLocation} onChange={(e) => setPostLocation(e.target.value)} placeholder="Neighborhood or city only — never exact address" style={{ width: "100%", padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", boxSizing: "border-box" }} />
-              </div>
-              <div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>Service Credits offered/requested</div>
-                <input value={postCredits} onChange={(e) => setPostCredits(e.target.value)} type="number" min="0" placeholder="0 if free" style={{ width: "100%", padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", boxSizing: "border-box" }} />
-              </div>
-              {postError && <div style={{ fontSize: 13, color: "#EF4444" }}>{postError}</div>}
-              {postSuccess && <div style={{ fontSize: 13, color: "#22C55E" }}>Posted successfully! View it in the feed.</div>}
-              <button
-                onClick={() => { void handleCreateRequest(); }}
-                disabled={submitting}
-                style={{ padding: "14px", borderRadius: 12, background: submitting ? "rgba(244,63,94,0.4)" : (postType === "need" ? COLOR : "#22C55E"), border: "none", color: "#fff", fontSize: 15, fontWeight: 800, cursor: submitting ? "not-allowed" : "pointer" }}
-              >
-                {submitting ? "Posting…" : postType === "need" ? "Post My Need" : "Post My Offer"}
-              </button>
-            </div>
-          </div>
+          <SocketRelayPost
+            draft={draft}
+            onChange={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+            submitting={submitting}
+            error={postError}
+            success={postSuccess}
+            onSubmit={() => void handlePost()}
+          />
         )}
-
         {tab === "chat" && (
-          <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
-            {fulfillments.length === 0 ? (
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: 32 }}>
-                <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(244,63,94,0.3)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                  <MessageSquare size={20} style={{ color: "rgba(244,63,94,0.4)" }} />
-                </div>
-                <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No active fulfillments</div>
-                <div style={{ fontSize: 13, color: "#4B5563", textAlign: "center" }}>When you help someone or receive help, chat channels appear here.</div>
-              </div>
-            ) : (
-              <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
-                <div style={{ width: 220, borderRight: "1px solid rgba(255,255,255,0.06)", padding: "12px 8px", overflowY: "auto" }}>
-                  <div style={{ fontSize: 11, fontWeight: 700, color: "#4B5563", textTransform: "uppercase", letterSpacing: "0.08em", padding: "0 8px", marginBottom: 8 }}>My Fulfillments</div>
-                  {fulfillments.map((f) => (
-                    <div key={f.id} onClick={() => { void fetchChatCredentials(f); }} style={{ padding: "10px 12px", borderRadius: 8, cursor: "pointer", background: selectedFulfillment?.id === f.id ? `${COLOR}18` : "transparent", border: selectedFulfillment?.id === f.id ? `1px solid ${COLOR}30` : "1px solid transparent", marginBottom: 4 }}>
-                      <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0" }}>Fulfillment {f.id.slice(0, 8)}</div>
-                    </div>
-                  ))}
-                </div>
-                <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
-                  {!selectedFulfillment && (
-                    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#4B5563", fontSize: 14 }}>
-                      Select a fulfillment to chat
-                    </div>
-                  )}
-                  {selectedFulfillment && chatLoading && (
-                    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#6B7280", fontSize: 14 }}>Loading chat…</div>
-                  )}
-                  {selectedFulfillment && chatError && (
-                    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF4444", fontSize: 14 }}>{chatError}</div>
-                  )}
-                  {selectedFulfillment && chatCredentials && (
-                    <StreamChatPanel
-                      streamApiKey={chatCredentials.streamApiKey as string}
-                      streamToken={chatCredentials.streamToken as string}
-                      streamUserId={chatCredentials.streamUserId as string}
-                      streamChannelId={(chatCredentials.streamChannelId as string) || selectedFulfillment.id}
-                    />
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
+          <SocketRelayChat
+            fulfillments={fulfillments}
+            selected={selectedFulfillment}
+            onSelect={(f) => void openFulfillmentChat(f)}
+            chatLoading={chatLoading}
+            chatError={chatError}
+            chatCredentials={chatCredentials}
+          />
         )}
       </div>
 
-      {/* Right panel */}
-      <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Impact</div>
-        {[
-          { l: "Open Needs", v: String(needs), c: COLOR },
-          { l: "Open Offers", v: String(offers), c: "#22C55E" },
-          { l: "My Fulfillments", v: String(fulfillments.length), c: "#A855F7" },
-          { l: "Total Requests", v: String(openRequests.length), c: "#F59E0B" },
-        ].map(({ l, v, c }) => (
-          <div key={l} style={{ padding: "14px 16px", borderRadius: 12, background: `${c}08`, border: `1px solid ${c}20`, marginBottom: 8 }}>
-            <div style={{ fontSize: 24, fontWeight: 800, color: c }}>{v}</div>
-            <div style={{ fontSize: 12, color: "#6B7280" }}>{l}</div>
-          </div>
-        ))}
-        <div style={{ marginTop: 8, padding: "14px 16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-            <Shield size={12} style={{ color: COLOR }} />
-            <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Privacy Minimized</span>
-          </div>
-          <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Public requests never include identifying information. All connections via encrypted channels.</div>
-        </div>
-        <button onClick={() => setTab("post")} style={{ width: "100%", marginTop: 12, padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
-          + Post a Need or Offer
-        </button>
-      </aside>
+      <SocketRelayRightPanel
+        openCount={openCount}
+        myRequestCount={myRequestCount}
+        fulfillmentCount={fulfillments.length}
+        totalCount={requests.length}
+        onPost={() => setTab("post")}
+      />
     </div>
   );
 }

--- a/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
@@ -31,6 +31,21 @@ async function getJson<T>(url: string): Promise<T | null> {
   return (await res.json()) as T;
 }
 
+// Load all three feed datasets at once, normalizing missing payloads to empties.
+// Kept out of the component so the loader stays within the rule-116 complexity limit.
+async function loadSocketRelayData(): Promise<{ requests: SrRequest[]; myRequestCount: number; fulfillments: SrFulfillment[] }> {
+  const [reqData, myReqData, fulData] = await Promise.all([
+    getJson<SrListResponse>("/api/socketrelay/requests"),
+    getJson<SrListResponse>("/api/socketrelay/my-requests"),
+    getJson<SrFulfillmentsResponse>("/api/socketrelay/my-fulfillments"),
+  ]);
+  return {
+    requests: reqData?.items ?? [],
+    myRequestCount: myReqData?.total ?? 0,
+    fulfillments: fulData?.items ?? [],
+  };
+}
+
 type SocketRelayShellProps = {
   userId?: string;
   isAdmin?: boolean;
@@ -55,22 +70,18 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async (options?: { showLoading?: boolean }) => {
-    if (options?.showLoading !== false) setLoading(true);
+  const fetchData = useCallback(async (showLoading = true) => {
+    if (showLoading) setLoading(true);
     setError(null);
     try {
-      const [reqData, myReqData, fulData] = await Promise.all([
-        getJson<SrListResponse>("/api/socketrelay/requests"),
-        getJson<SrListResponse>("/api/socketrelay/my-requests"),
-        getJson<SrFulfillmentsResponse>("/api/socketrelay/my-fulfillments"),
-      ]);
-      setRequests(reqData?.items ?? []);
-      setMyRequestCount(myReqData?.total ?? 0);
-      setFulfillments(fulData?.items ?? []);
+      const data = await loadSocketRelayData();
+      setRequests(data.requests);
+      setMyRequestCount(data.myRequestCount);
+      setFulfillments(data.fulfillments);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load SocketRelay.");
     } finally {
-      if (options?.showLoading !== false) setLoading(false);
+      if (showLoading) setLoading(false);
     }
   }, []);
 
@@ -102,7 +113,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
       }
       setDraft(EMPTY_DRAFT);
       setPostSuccess(true);
-      await fetchData({ showLoading: false });
+      await fetchData(false);
     } catch (e) {
       setPostError(e instanceof Error ? e.message : "Failed to create request.");
     } finally {
@@ -117,7 +128,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
         method: "POST",
         headers: { "x-ctf-csrf": "1" },
       });
-      if (res.ok) await fetchData({ showLoading: false });
+      if (res.ok) await fetchData(false);
     } catch {
       // Refresh will reflect the latest state.
     } finally {

--- a/ctf/packages/web/components/socketrelay/sr-chat.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-chat.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { MessageSquare } from "lucide-react";
+import { StreamChatPanel } from "../shared/stream-chat-panel";
+import { COLOR, FAINT, SUBTLE, type SrChatCredentials, type SrFulfillment } from "./sr-shared";
+
+function ChatPane({
+  selected,
+  chatLoading,
+  chatError,
+  chatCredentials,
+}: {
+  selected: SrFulfillment | null;
+  chatLoading: boolean;
+  chatError: string | null;
+  chatCredentials: SrChatCredentials | null;
+}) {
+  if (!selected) return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: FAINT, fontSize: 14 }}>Select a fulfillment to chat</div>;
+  if (chatLoading) return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE, fontSize: 14 }}>Loading chat…</div>;
+  if (chatError) return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF4444", fontSize: 14 }}>{chatError}</div>;
+  if (!chatCredentials?.streamApiKey) return null;
+  return (
+    <StreamChatPanel
+      streamApiKey={chatCredentials.streamApiKey}
+      streamToken={chatCredentials.streamToken as string}
+      streamUserId={chatCredentials.streamUserId as string}
+      streamChannelId={chatCredentials.streamChannelId || selected.id}
+    />
+  );
+}
+
+export function SocketRelayChat({
+  fulfillments,
+  selected,
+  onSelect,
+  chatLoading,
+  chatError,
+  chatCredentials,
+}: {
+  fulfillments: SrFulfillment[];
+  selected: SrFulfillment | null;
+  onSelect: (fulfillment: SrFulfillment) => void;
+  chatLoading: boolean;
+  chatError: string | null;
+  chatCredentials: SrChatCredentials | null;
+}) {
+  if (fulfillments.length === 0) {
+    return (
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: 32 }}>
+        <div style={{ width: 48, height: 48, borderRadius: "50%", border: `2px dashed ${COLOR}4D`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <MessageSquare size={20} style={{ color: `${COLOR}66` }} />
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No active fulfillments</div>
+        <div style={{ fontSize: 13, color: FAINT, textAlign: "center" }}>When you help someone or receive help, chat channels appear here.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+      <div style={{ width: 220, borderRight: "1px solid rgba(255,255,255,0.06)", padding: "12px 8px", overflowY: "auto" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, color: FAINT, textTransform: "uppercase", letterSpacing: "0.08em", padding: "0 8px", marginBottom: 8 }}>My Fulfillments</div>
+        {fulfillments.map((f) => (
+          <div key={f.id} onClick={() => onSelect(f)} style={{ padding: "10px 12px", borderRadius: 8, cursor: "pointer", background: selected?.id === f.id ? `${COLOR}18` : "transparent", border: selected?.id === f.id ? `1px solid ${COLOR}30` : "1px solid transparent", marginBottom: 4 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0" }}>Fulfillment {f.id.slice(0, 8)}</div>
+            <div style={{ fontSize: 11, color: SUBTLE, textTransform: "capitalize" }}>{f.status}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <ChatPane selected={selected} chatLoading={chatLoading} chatError={chatError} chatCredentials={chatCredentials} />
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/socketrelay/sr-feed.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-feed.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { MapPin, Share2 } from "lucide-react";
+import { COLOR, FAINT, SUBTLE, timeAgo, type SrRequest } from "./sr-shared";
+
+function CardAction({ open, isOwn, submitting, onClaim }: { open: boolean; isOwn: boolean; submitting: boolean; onClaim: () => void }) {
+  if (!open) return <div style={{ fontSize: 12, color: "#22C55E", fontWeight: 600 }}>✓ closed</div>;
+  if (isOwn) return <div style={{ fontSize: 12, color: SUBTLE }}>Your request</div>;
+  return (
+    <button onClick={onClaim} disabled={submitting} style={{ padding: "8px 14px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, cursor: submitting ? "not-allowed" : "pointer" }}>
+      I can help
+    </button>
+  );
+}
+
+function RequestCard({
+  request,
+  isOwn,
+  submitting,
+  onClaim,
+}: {
+  request: SrRequest;
+  isOwn: boolean;
+  submitting: boolean;
+  onClaim: (id: string) => void;
+}) {
+  const r = request;
+  const open = r.status === "open";
+  return (
+    <div style={{ padding: "18px 20px", borderRadius: 14, background: open ? "rgba(255,255,255,0.02)" : "rgba(255,255,255,0.01)", border: `1px solid ${COLOR}20`, opacity: open ? 1 : 0.6 }}>
+      <div style={{ display: "flex", gap: 12, alignItems: "flex-start" }}>
+        <div style={{ width: 40, height: 40, borderRadius: 10, background: `${COLOR}20`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+          <Share2 size={18} style={{ color: COLOR }} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", gap: 8, marginBottom: 6, alignItems: "center", flexWrap: "wrap" }}>
+            {r.category && <Badge style={{ background: "rgba(255,255,255,0.04)", color: "#9CA3AF", border: "1px solid rgba(255,255,255,0.06)", fontSize: 11 }}>{r.category}</Badge>}
+            {!r.isPublic && <Badge style={{ background: `${COLOR}15`, color: COLOR, border: `1px solid ${COLOR}30`, fontSize: 11 }}>Members only</Badge>}
+            <Badge style={{ background: open ? "#22C55E20" : "rgba(255,255,255,0.04)", color: open ? "#22C55E" : SUBTLE, border: `1px solid ${open ? "#22C55E40" : "rgba(255,255,255,0.06)"}`, fontSize: 11, textTransform: "capitalize" }}>{r.status}</Badge>
+          </div>
+          <div style={{ fontSize: 14, fontWeight: 600, color: "#F9FAFB", marginBottom: 4, lineHeight: 1.4 }}>{r.title}</div>
+          {r.details && <div style={{ fontSize: 13, color: "#9CA3AF", marginBottom: 6, lineHeight: 1.5 }}>{r.details}</div>}
+          <div style={{ display: "flex", gap: 12, fontSize: 12, color: SUBTLE, flexWrap: "wrap" }}>
+            {r.city && <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><MapPin size={11} /> {r.city}</span>}
+            <span>· {timeAgo(r.createdAtIso)}</span>
+          </div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-end", flexShrink: 0 }}>
+          <CardAction open={open} isOwn={isOwn} submitting={submitting} onClaim={() => onClaim(r.id)} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SocketRelayFeed({
+  requests,
+  currentUserId,
+  submitting,
+  onClaim,
+  onPost,
+}: {
+  requests: SrRequest[];
+  currentUserId: string | undefined;
+  submitting: boolean;
+  onClaim: (id: string) => void;
+  onPost: () => void;
+}) {
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ padding: "20px 24px" }}>
+        {requests.length === 0 ? (
+          <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+            <div style={{ width: 48, height: 48, borderRadius: "50%", border: `2px dashed ${COLOR}4D`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+              <Share2 size={20} style={{ color: `${COLOR}66` }} />
+            </div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No requests yet</div>
+            <div style={{ fontSize: 13, color: FAINT }}>Be the first to post a need or offer to your community.</div>
+            <button onClick={onPost} style={{ padding: "10px 20px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
+              Post Now
+            </button>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {requests.map((r) => (
+              <RequestCard key={r.id} request={r} isOwn={r.ownerUserId === currentUserId} submitting={submitting} onClaim={onClaim} />
+            ))}
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/ctf/packages/web/components/socketrelay/sr-icon-rail.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-icon-rail.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Bell, MessageSquare, Plus, Settings, Share2 } from "lucide-react";
+import { COLOR, SUBTLE, type Tab } from "./sr-shared";
+
+const NAV: { icon: React.ElementType; key: Tab }[] = [
+  { icon: Share2, key: "feed" },
+  { icon: Plus, key: "post" },
+  { icon: MessageSquare, key: "chat" },
+];
+
+export function SocketRelayIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => void }) {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <Share2 size={20} style={{ color: COLOR }} />
+      </div>
+      {NAV.map(({ icon: Icon, key }) => (
+        <button key={key} onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : SUBTLE }}>
+          <Icon size={20} />
+        </button>
+      ))}
+      <div style={{ flex: 1 }} />
+      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Bell size={18} /></button>
+      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Settings size={18} /></button>
+      <Avatar style={{ width: 36, height: 36 }}>
+        <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
+      </Avatar>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/socketrelay/sr-loading.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// STATE: Loading — data fetch in progress. Ported from
+// design/.../survivor-hub/SocketRelayLoading.tsx.
+import { BG } from "./sr-shared";
+
+export function SocketRelayLoading() {
+  return (
+    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
+      <div style={{ textAlign: "center", padding: "0 32px" }}>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
+          EXIT THEIR ECONOMY
+        </div>
+        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
+          EXIT THE PSYOP
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/socketrelay/sr-post.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-post.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { COLOR, SUBTLE } from "./sr-shared";
+
+export type PostDraft = {
+  title: string;
+  details: string;
+  category: string;
+  city: string;
+  isPublic: boolean;
+};
+
+export function SocketRelayPost({
+  draft,
+  onChange,
+  submitting,
+  error,
+  success,
+  onSubmit,
+}: {
+  draft: PostDraft;
+  onChange: (patch: Partial<PostDraft>) => void;
+  submitting: boolean;
+  error: string | null;
+  success: boolean;
+  onSubmit: () => void;
+}) {
+  const fieldStyle = { width: "100%", padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", boxSizing: "border-box" as const };
+  return (
+    <div style={{ flex: 1, padding: "32px 40px", overflowY: "auto" }}>
+      <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 20 }}>Post a Request</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 14, maxWidth: 620 }}>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>Title</div>
+          <input value={draft.title} onChange={(e) => onChange({ title: e.target.value })} placeholder="A short summary of what you need or can offer" style={fieldStyle} />
+        </div>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>Details</div>
+          <textarea value={draft.details} onChange={(e) => onChange({ details: e.target.value })} placeholder="Be specific about what help you need or can give…" rows={3} style={{ ...fieldStyle, resize: "none" }} />
+        </div>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>Category</div>
+          <input value={draft.category} onChange={(e) => onChange({ category: e.target.value })} placeholder="Food, Transport, Legal, Employment…" style={fieldStyle} />
+        </div>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>City (privacy-protected)</div>
+          <input value={draft.city} onChange={(e) => onChange({ city: e.target.value })} placeholder="City or neighborhood only — never exact address" style={fieldStyle} />
+        </div>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "#9CA3AF", cursor: "pointer" }}>
+          <input type="checkbox" checked={draft.isPublic} onChange={(e) => onChange({ isPublic: e.target.checked })} />
+          Make this request publicly visible (otherwise members-only)
+        </label>
+        {error && <div style={{ fontSize: 13, color: "#EF4444" }}>{error}</div>}
+        {success && <div style={{ fontSize: 13, color: "#22C55E" }}>Posted successfully! View it in the feed.</div>}
+        <button onClick={onSubmit} disabled={submitting} style={{ padding: "14px", borderRadius: 12, background: submitting ? `${COLOR}66` : COLOR, border: "none", color: "#fff", fontSize: 15, fontWeight: 800, cursor: submitting ? "not-allowed" : "pointer" }}>
+          {submitting ? "Posting…" : "Post Request"}
+        </button>
+        <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.6 }}>Requests never include identifying information beyond what you write. Connections happen via encrypted channels after someone offers to help.</div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/socketrelay/sr-right-panel.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-right-panel.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Shield } from "lucide-react";
+import { COLOR, SUBTLE } from "./sr-shared";
+
+export function SocketRelayRightPanel({
+  openCount,
+  myRequestCount,
+  fulfillmentCount,
+  totalCount,
+  onPost,
+}: {
+  openCount: number;
+  myRequestCount: number;
+  fulfillmentCount: number;
+  totalCount: number;
+  onPost: () => void;
+}) {
+  const cards = [
+    { l: "Open Requests", v: String(openCount), c: COLOR },
+    { l: "My Requests", v: String(myRequestCount), c: "#22C55E" },
+    { l: "My Fulfillments", v: String(fulfillmentCount), c: "#A855F7" },
+    { l: "Total Requests", v: String(totalCount), c: "#F59E0B" },
+  ];
+  return (
+    <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Impact</div>
+      {cards.map(({ l, v, c }) => (
+        <div key={l} style={{ padding: "14px 16px", borderRadius: 12, background: `${c}08`, border: `1px solid ${c}20`, marginBottom: 8 }}>
+          <div style={{ fontSize: 24, fontWeight: 800, color: c }}>{v}</div>
+          <div style={{ fontSize: 12, color: SUBTLE }}>{l}</div>
+        </div>
+      ))}
+      <div style={{ marginTop: 8, padding: "14px 16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+          <Shield size={12} style={{ color: COLOR }} />
+          <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Privacy Minimized</span>
+        </div>
+        <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.6 }}>Public requests never include identifying information. All connections via encrypted channels.</div>
+      </div>
+      <button onClick={onPost} style={{ width: "100%", marginTop: 12, padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
+        + Post a Request
+      </button>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/socketrelay/sr-shared.ts
+++ b/ctf/packages/web/components/socketrelay/sr-shared.ts
@@ -1,0 +1,67 @@
+// Shared constants, types, and helpers for the SocketRelay web shell.
+// Palette derives from design/.../survivor-hub/SocketRelay.tsx.
+// Types mirror lib/socketrelay/types.ts (the real backend model). The mockup's
+// need/offer/credits/urgency framing is not backed by the data model, so the
+// shell renders the real request/claim/fulfillment model instead.
+
+export const COLOR = "#FB923C";
+export const BG = "#0F1117";
+export const TEXT = "#E8EAF0";
+export const SUBTLE = "#6B7280";
+export const FAINT = "#4B5563";
+
+export type Tab = "feed" | "post" | "chat";
+
+export type SrRequestStatus = "open" | "claimed" | "closed" | "cancelled";
+
+export type SrRequest = {
+  id: string;
+  ownerUserId: string;
+  title: string;
+  details: string;
+  category: string;
+  city: string | null;
+  isPublic: boolean;
+  status: SrRequestStatus;
+  reopenedCount: number;
+  claimedFulfillmentId: string | null;
+  createdAtIso: string;
+  updatedAtIso: string;
+};
+
+export type SrFulfillment = {
+  id: string;
+  requestId: string;
+  requesterUserId: string;
+  fulfillerUserId: string;
+  status: "active" | "closed" | "cancelled";
+  closeReason: string | null;
+  createdAtIso: string;
+  updatedAtIso: string;
+};
+
+export type SrListResponse = { ok: boolean; items: SrRequest[]; page: number; pageSize: number; total: number };
+export type SrFulfillmentsResponse = { ok: boolean; items: SrFulfillment[] };
+
+export type SrChatCredentials = {
+  ok?: boolean;
+  message?: string;
+  streamApiKey?: string;
+  streamToken?: string;
+  streamUserId?: string;
+  streamChannelId?: string;
+};
+
+// Category filter chips (the request `category` is free text; these scope the feed).
+export const CATEGORIES = ["All", "Food", "Transport", "Legal", "Employment", "Childcare", "Housing", "Mental Health"];
+
+export function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(diff)) return "";
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins} min ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs} hr ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}

--- a/ctf/packages/web/components/socketrelay/sr-sidebar.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-sidebar.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Search } from "lucide-react";
+import { CATEGORIES, COLOR, FAINT, SUBTLE, TEXT } from "./sr-shared";
+
+export function SocketRelaySidebar({
+  category,
+  onCategory,
+  search,
+  onSearch,
+  openCount,
+  myRequestCount,
+  fulfillmentCount,
+}: {
+  category: string;
+  onCategory: (category: string) => void;
+  search: string;
+  onSearch: (value: string) => void;
+  openCount: number;
+  myRequestCount: number;
+  fulfillmentCount: number;
+}) {
+  const stats = [
+    { l: "Open Requests", v: String(openCount) },
+    { l: "My Requests", v: String(myRequestCount) },
+    { l: "My Fulfillments", v: String(fulfillmentCount) },
+  ];
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 12 }}>🔂 SocketRelay</div>
+        <div style={{ position: "relative" }}>
+          <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: FAINT }} />
+          <input value={search} onChange={(e) => onSearch(e.target.value)} placeholder="Search requests…" style={{ width: "100%", padding: "7px 10px 7px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+        </div>
+      </div>
+      <ScrollArea style={{ flex: 1 }}>
+        <div style={{ padding: "0 8px 16px" }}>
+          {CATEGORIES.map((c) => (
+            <div key={c} onClick={() => onCategory(c)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: category === c ? `${COLOR}18` : "transparent", borderLeft: category === c ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
+              <span style={{ fontSize: 13, color: category === c ? TEXT : "#9CA3AF", flex: 1 }}>{c}</span>
+            </div>
+          ))}
+          <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: FAINT, textTransform: "uppercase", padding: "0 10px" }}>Live Stats</div>
+          {stats.map(({ l, v }) => (
+            <div key={l} style={{ padding: "6px 10px", fontSize: 12, color: SUBTLE }}>
+              {l}: <span style={{ color: COLOR, fontWeight: 600 }}>{v}</span>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

UI circle-back for the **socketrelay** plugin (web). Rebuilds `/apps/socketrelay` to `design/.../survivor-hub/SocketRelay.tsx` and its Loading/Empty states, and **fixes runtime bugs** in the prior shell.

## Bug fixes (the prior shell was broken against the real backend)

- **Feed:** read `GET /api/socketrelay/requests` as a bare array, but the route returns `{ items, page, pageSize, total }` — the `.filter()` threw.
- **Post:** sent `{ type, description, location, credits, urgency }` with no CSRF header; the backend expects `{ title, details, category, city, isPublic }` + `x-ctf-csrf`, so every post 400'd.

The rebuild uses the **real `SocketRelayRequest` model**, unwraps the paged response, claims via `POST /requests/:id/fulfill`, and lists fulfillment chats via `my-fulfillments` + `fulfillments/:id/chat` — all with `x-ctf-csrf` on mutations.

## Honest data

The mockup's **need/offer/credits/urgency** framing has no backing in the data model (requests are `title/details/category/city/isPublic/status`), so it was **omitted rather than faked**.

## Modularity

Decomposed into `sr-shared`, `sr-loading`, `sr-icon-rail`, `sr-sidebar`, `sr-feed`, `sr-post`, `sr-chat`, `sr-right-panel`, plus the shell — each within `complexity:10` / `max-lines-per-function:200`.

**No backend change was needed** — the claim/fulfillment/chat routes already exist.

## Verification

- `pnpm typecheck` (shared/web/mobile) — green
- `pnpm --filter @ctf/web lint components/socketrelay/` — green
- Modularity gate on all socketrelay files — green
- `pnpm --filter @ctf/web build:ci` — green
- `check-eof-format.sh`, `check-web-android-parity.mjs`, `check-schema-drift.sh` — green

## Scope

Web-only pixel pass + runtime-bug fix. Android pixel pass (`MobileSocketRelay.tsx`) is part of the dedicated Android sweep after the web sweep, tracked in the plan.

Parity Ticket: #119


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_