### PR TITLE
chore: silence CodeRabbit review-status comments in PR threads

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,10 @@
 # Note: a committed .coderabbit.yaml overrides the CodeRabbit org-UI settings
 # for this repository.
 reviews:
+  # Suppress the "Review skipped / in progress / completed" status COMMENT in the
+  # PR thread. Real reviews (walkthrough + inline comments) still post when a review
+  # actually runs; the skipped state remains visible as the CodeRabbit commit status.
+  review_status: false
   auto_review:
     enabled: true
     # Never spend review credits on draft PRs.


### PR DESCRIPTION
## Summary

Stops CodeRabbit from posting "Review skipped" comments on every label-gated PR by setting **`reviews.review_status: false`** in the repo `.coderabbit.yaml`.

### Why the org-UI setting wasn't working
CodeRabbit's run config on PRs reports `Configuration used: Path: .coderabbit.yaml`. A committed repo-level `.coderabbit.yaml` **fully overrides** the org-UI settings, so the org-level `review_status: false` was being ignored and the skip comment kept posting.

### What this changes
- Suppresses only the status/skip **comment** in the PR thread.
- Real reviews (walkthrough + inline comments) still post when a review actually runs — via the `coderabbit` label or a manual `@coderabbitai review` trigger.
- The skipped state remains visible as the non-blocking **CodeRabbit commit status**, which is the intended way to see it.

No code or behavior changes beyond CodeRabbit comment noise.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_