### PR TITLE
docs: codify CodeRabbit self-triage labeling + plan change-log convention

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -146,6 +146,37 @@ Use when Android parity is deferred; link to the tracking issue.
 
 All `.ts`, `.tsx`, `.js`, `.json`, `.yml`, `.yaml`, `.css` files must end with exactly one newline and no trailing blank lines. Validated by `ctf/scripts/check-eof-format.sh` on every PR.
 
+### CodeRabbit Review Labeling (self-triage)
+
+CodeRabbit auto-review is gated on the `coderabbit` label (see `.coderabbit.yaml`), and the
+account is on the **free tier**, so reviews are a scarce resource. Agents self-triage and apply the
+label **only when the change is genuinely complex/risky**, and **no more than once per hour**.
+
+- **Label `coderabbit`** when the PR touches any of: money / ServiceCredits ledger, auth/authz, CSRF,
+  data deletion, schema / migrations, new or changed API contracts, or brand-new stateful logic / a
+  whole new plugin.
+- **Do NOT label** pure restyles, rule-116 decompositions, icon swaps, or doc-sync PRs with **no
+  behavior change** — these are low-risk and waste the quota.
+- **Rate cap:** at most **one labeled PR per hour**. If several qualify in the same hour, label only
+  the riskiest and defer the rest to the next hour.
+- Apply the label via the GitHub MCP (`issue_write`) right after opening the PR. To force a one-off
+  review on an unlabeled PR, comment `@coderabbitai review` instead of labeling.
+
+### Updating `PRODUCTION_READINESS_PLAN.md` (avoid change-log merge conflicts)
+
+When several plugin PRs are open at once, all appending narrative to the **same** change-log section
+of `ctf/docs/developer/PRODUCTION_READINESS_PLAN.md` produces a merge conflict every time a sibling
+merges first. To avoid this:
+
+- In `PRODUCTION_READINESS_PLAN.md`, a per-plugin PR should **only flip that plugin's row** in the
+  progress table (the row is the single source of truth for delivery status). Do **not** append a
+  per-PR change-log entry there.
+- Put the detailed change-log narrative in that plugin's **own inventory file**
+  (`ctf/docs/developer/ctf-plugin-feature-inventories/ctf-<plugin>-feature-inventory.md`), which is
+  one file per plugin and therefore never collides with sibling PRs.
+- Reserve the plan's change-log section for cross-cutting milestones (infra, policy, multi-plugin
+  reconciliations), not routine per-plugin passes.
+
 ## Agent Startup Read Order
 
 - On each new task, read this `index.mdc` first.

--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -95,6 +95,11 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 > + pixel-perfect to `design` + parity + gates + deploy). Some plugin inventories still carry an older
 > "Parity: web+android complete" line that describes prior feature parity, **not** this bar — where the two
 > differ, this table wins. Inventory wording is normalized per plugin during its UI circle-back.
+>
+> **Editing convention (avoids merge conflicts):** a per-plugin PR should only flip its own row above;
+> put the detailed change-log narrative in that plugin's inventory file, not in the change log below.
+> Reserve the change log below for cross-cutting milestones. See the "Updating `PRODUCTION_READINESS_PLAN.md`"
+> note in `.github/instructions/copilot-instructions.md`.
 
 | Plugin | 🎨 Design | Backend | Web px | Android | Gates | Deployed |
 |---|---|---|---|---|---|---|


### PR DESCRIPTION
## Summary

Codifies two governance conventions agreed with the owner.

### 1. CodeRabbit review labeling (self-triage)
Auto-review is gated on the `coderabbit` label (`.coderabbit.yaml`) and the account is **free-tier**, so agents self-triage:
- **Label** only for genuinely complex/risky PRs: money / ServiceCredits ledger, auth/authz, CSRF, data deletion, schema/migrations, new or changed API contracts, or brand-new stateful logic / a whole new plugin.
- **Don't label** pure restyles, rule-116 decompositions, icon swaps, or doc-sync PRs with no behavior change.
- **Rate cap:** at most one labeled PR per hour; if several qualify, label only the riskiest.

### 2. `PRODUCTION_READINESS_PLAN.md` editing convention
To stop the recurring change-log merge conflicts when multiple plugin PRs are open concurrently:
- A per-plugin PR only **flips its own row** in the progress table (the row is the SoT for status).
- The detailed change-log narrative lives in that plugin's **own inventory file** (one file per plugin → never collides).
- The plan's change log is reserved for cross-cutting milestones.

Both are added to `.github/instructions/copilot-instructions.md`, with a short pointer in the plan doc's progress-checklist preamble.

### Gates
Docs-only. typecheck + EOF green; no behavior change → not labeled for CodeRabbit per the new policy itself.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_