### PR TITLE
fix: dedup PRODUCTION_READINESS_PLAN progress table

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -112,10 +112,8 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | foundation | 🎨 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | lighthouse | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | socketrelay | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
-| trusttransport | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
-| peer-programming | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | trusttransport | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
-| peer-programming | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| peer-programming | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | mood | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | gentlepulse | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | weekly-performance | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |


### PR DESCRIPTION
## Summary

Repairs the progress table in `ctf/docs/developer/PRODUCTION_READINESS_PLAN.md`. The recent concurrent plugin-PR merges left **two duplicated rows** — `trusttransport` and `peer-programming` each appeared twice (a stale `⬜` row alongside the correct `✅` row), giving 22 rows for 20 plugins. This collapses each to a single canonical row.

Verified: the table is back to exactly **20 unique plugin rows** in canonical order with correct statuses (service-credits / skills-hunt / feed-announcements / workforce / foundation still `⬜`; all others Web px `✅`).

This is exactly the damage the new "only flip your own row" editing convention (PR #164) prevents going forward.

### Gates
Docs-only; no behavior change → **not** labeled for CodeRabbit per the labeling policy. EOF green (the only EOF warnings are pre-existing ones in the `design/` submodule, untouched here).

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_