### PR TITLE
refactor: skills-hunt user shell web pixel pass + rule-116 decomposition

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -108,7 +108,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | directory | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | feed-announcements | 🎨 | 🟡 | ⬜ | ⬜ | ⬜ | ⬜ |
 | workforce | 🎨 | 🟡 | ⬜ | ⬜ | ⬜ | ⬜ |
-| skills-hunt | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| skills-hunt | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | foundation | 🎨 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | lighthouse | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | socketrelay | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-feature-inventory.md
@@ -182,7 +182,7 @@ Admin/moderator routes:
 
 ## 6) Web and Android Delivery Status
 
-`web+android complete`. Round, submission, leaderboard, review, and scoring outcomes are consistent across web (`/apps/skills-hunt`) and Android (`packages/mobile/src/features/skills-hunt`).
+`web+android complete`. Round, submission, leaderboard, review, and scoring outcomes are consistent across web (`/apps/skills-hunt`) and Android (`packages/mobile/src/features/skills-hunt`). Web pixel pass complete for the user shell: `skills-hunt-shell.tsx` + `sh-*` sub-components are aligned to `design/.../survivor-hub/SkillsHunt.tsx` (brand color #D946EF, aria-labeled lucide icon rail, taxonomy skills picker, scout/leaderboard/missions/my-finds tabs) and decomposed within rule-116 limits; all tabs bind real round/leaderboard/missions/submissions/achievements/notifications routes (no fabricated figures). The admin moderation shell (`/admin/skills-hunt`) is a tracked rule-116 follow-up. Android pixel parity (`MobileSkillsHunt.tsx`) is tracked for the dedicated Android sweep.
 
 ## 7) Seed Coverage Status
 
@@ -195,6 +195,8 @@ Admin/moderator routes:
 3. Team leaderboard aggregation by profession taxonomy depends on Skills Taxonomy sign-off on grouping semantics.
 
 ## 9) Change Log
+
+- 2026-05-30: Web pixel pass for the user shell. Aligned to the design mockup (brand color #A855F7 -> #D946EF; aria-labeled lucide icon rail with unread badge) and decomposed the 845-line monolith into modular sub-components within rule-116 limits: sh-shared.ts, sh-use-nomination-form.ts, sh-icon-rail, sh-notifications, sh-sidebar, sh-skills-picker, sh-scout-tab, sh-leaderboard-tab, sh-missions-tab, sh-my-finds-tab, sh-right-panel, thin shell. All data stays bound to the real routes; no mocks. Admin shell (/admin/skills-hunt) left as a tracked rule-116 follow-up. No schema/route/contract changes.
 
 - 2026-05-18: Renamed "Web and Android Delivery Strategy" to canonical "Web and Android Delivery Status" and confirmed `web+android complete`. Renamed "Gaps, Ambiguities, and Known Debt (Planning)" to canonical "Gaps and Known Technical Debt". Removed Android-parity-deferral entry per Rule 105.
 - 2026-02-24: Created initial Skills Hunt CTF rewrite inventory.

--- a/ctf/packages/web/components/skills-hunt/sh-icon-rail.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-icon-rail.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Search, Bell, Settings } from "lucide-react";
+import { COLOR, TABS, type Tab } from "./sh-shared";
+
+export function SkillsHuntIconRail({
+  tab,
+  onTab,
+  notifOpen,
+  onToggleNotif,
+  unreadCount,
+}: {
+  tab: Tab;
+  onTab: (tab: Tab) => void;
+  notifOpen: boolean;
+  onToggleNotif: () => void;
+  unreadCount: number;
+}) {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <Search size={20} style={{ color: COLOR }} />
+      </div>
+      {TABS.map(({ key, icon: Icon, label }) => (
+        <button key={key} type="button" aria-label={label} aria-current={tab === key ? "page" : undefined} onClick={() => onTab(key)}
+          style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
+          <Icon size={20} />
+        </button>
+      ))}
+      <div style={{ flex: 1 }} />
+      <button type="button" aria-label="Notifications" aria-expanded={notifOpen} onClick={onToggleNotif}
+        style={{ position: "relative", width: 44, height: 44, borderRadius: 12, background: notifOpen ? `${COLOR}20` : "transparent", border: notifOpen ? `1px solid ${COLOR}40` : "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: notifOpen ? COLOR : "#6B7280" }}>
+        <Bell size={18} />
+        {unreadCount > 0 && (
+          <span style={{ position: "absolute", top: 6, right: 6, minWidth: 18, height: 18, borderRadius: 9, background: "#EF4444", color: "#fff", fontSize: 10, fontWeight: 800, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+      <button type="button" aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
+        <Settings size={18} />
+      </button>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-leaderboard-tab.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-leaderboard-tab.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { COLOR, initials, rankColor, rankDisplay, type SkillsHuntLeaderboardItem } from "./sh-shared";
+
+function LeaderboardRow({ entry, isMe }: { entry: SkillsHuntLeaderboardItem; isMe: boolean }) {
+  return (
+    <div style={{ padding: "16px 20px", borderRadius: 14, background: isMe ? `${COLOR}12` : "rgba(255,255,255,0.02)", border: `1px solid ${isMe ? COLOR + "40" : "rgba(255,255,255,0.06)"}`, display: "flex", alignItems: "center", gap: 16 }}>
+      <div style={{ width: 32, height: 32, borderRadius: 8, background: entry.rank <= 3 ? `${rankColor(entry.rank)}20` : "rgba(255,255,255,0.04)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 16, fontWeight: 800, color: rankColor(entry.rank), flexShrink: 0 }}>
+        {rankDisplay(entry.rank)}
+      </div>
+      <div style={{ width: 40, height: 40, borderRadius: "50%", background: `${COLOR}25`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 15, fontWeight: 800, color: COLOR, flexShrink: 0 }}>
+        {initials(entry.usernameSnapshot ?? "?")}
+      </div>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 14, fontWeight: 700, color: isMe ? COLOR : "#F9FAFB" }}>
+          {entry.usernameSnapshot ?? "Anonymous"}{isMe ? " (You)" : ""}
+        </div>
+        <div style={{ fontSize: 12, color: "#6B7280" }}>
+          {entry.acceptedCount} accepted · {entry.firstMatchCount} first-match{entry.firstMatchCount !== 1 ? "es" : ""}
+        </div>
+      </div>
+      <div style={{ textAlign: "right" }}>
+        <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>{entry.score} pts</div>
+        {entry.pendingPoints > 0 && <div style={{ fontSize: 11, color: "#F59E0B" }}>+{entry.pendingPoints} ⏳ pending</div>}
+      </div>
+    </div>
+  );
+}
+
+export function SkillsHuntLeaderboardTab({
+  loading,
+  leaderboard,
+  userId,
+}: {
+  loading: boolean;
+  leaderboard: SkillsHuntLeaderboardItem[];
+  userId?: string;
+}) {
+  return (
+    <>
+      <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Scout Leaderboard</div>
+      <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 4 }}>Ranked by accepted points · tie-break: first-match count, then earliest submission</div>
+      <div style={{ fontSize: 12, color: "#4B5563", marginBottom: 20 }}>Pending points (⏳) convert to accepted points after admin review.</div>
+
+      {loading ? (
+        <div style={{ fontSize: 14, color: "#6B7280" }}>Loading leaderboard…</div>
+      ) : leaderboard.length === 0 ? (
+        <div style={{ fontSize: 14, color: "#6B7280" }}>No entries yet — be the first scout!</div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {leaderboard.map((p) => <LeaderboardRow key={p.rank} entry={p} isMe={p.userId === userId} />)}
+        </div>
+      )}
+    </>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-missions-tab.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-missions-tab.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Target, Lock, CheckCircle } from "lucide-react";
+import { COLOR, type SkillsHuntMissionWithProgress, type Tab } from "./sh-shared";
+
+function missionView(mission: SkillsHuntMissionWithProgress) {
+  const progressCount = mission.progress?.progressCount ?? 0;
+  return {
+    isLocked: mission.status === "locked",
+    color: mission.colorHex ?? COLOR,
+    progressCount,
+    pct: Math.min(100, (progressCount / Math.max(1, mission.goalTarget)) * 100),
+    isComplete: mission.progress?.completedAtIso != null,
+  };
+}
+
+function MissionTitleRow({ title, isLocked, isComplete }: { title: string; isLocked: boolean; isComplete: boolean }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+      <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>{title}</div>
+      {isLocked && <Lock size={13} style={{ color: "#4B5563" }} />}
+      {isComplete && <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, color: "#22C55E", fontWeight: 700 }}><CheckCircle size={12} /> Complete</span>}
+    </div>
+  );
+}
+
+function ScoutButton({ isLocked, color, onScout }: { isLocked: boolean; color: string; onScout: () => void }) {
+  return (
+    <button type="button" onClick={onScout} disabled={isLocked} style={{ padding: "10px 20px", borderRadius: 10, background: isLocked ? "rgba(255,255,255,0.04)" : color, border: "none", color: isLocked ? "#4B5563" : "#fff", fontSize: 13, fontWeight: 700, cursor: isLocked ? "default" : "pointer" }}>
+      {isLocked ? "Locked" : "Scout Now"}
+    </button>
+  );
+}
+
+function MissionCard({ mission, onScout }: { mission: SkillsHuntMissionWithProgress; onScout: () => void }) {
+  const { isLocked, color, progressCount, pct, isComplete } = missionView(mission);
+  return (
+    <div style={{ padding: "20px 24px", borderRadius: 16, background: "rgba(255,255,255,0.02)", border: `1px solid ${isLocked ? "rgba(255,255,255,0.06)" : color + "35"}`, opacity: isLocked ? 0.6 : 1 }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 16 }}>
+        <div style={{ flex: 1 }}>
+          <MissionTitleRow title={mission.title} isLocked={isLocked} isComplete={isComplete} />
+          {mission.description && <div style={{ fontSize: 12, color: "#9CA3AF", marginBottom: 10, lineHeight: 1.5 }}>{mission.description}</div>}
+          <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 4, color: "#6B7280" }}>
+            <span>{progressCount}/{mission.goalTarget} complete</span>
+            {mission.bonusPoints > 0 && <span style={{ color, fontWeight: 700 }}>+{mission.bonusPoints} pts</span>}
+          </div>
+          <div style={{ height: 6, background: "rgba(255,255,255,0.05)", borderRadius: 3, overflow: "hidden" }}>
+            <div style={{ height: "100%", background: color, borderRadius: 3, width: `${pct}%` }} />
+          </div>
+        </div>
+        <ScoutButton isLocked={isLocked} color={color} onScout={onScout} />
+      </div>
+    </div>
+  );
+}
+
+export function SkillsHuntMissionsTab({
+  noActiveRound,
+  loading,
+  missions,
+  onNavTab,
+}: {
+  noActiveRound: boolean;
+  loading: boolean;
+  missions: SkillsHuntMissionWithProgress[];
+  onNavTab: (tab: Tab) => void;
+}) {
+  return (
+    <>
+      <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Active Missions</div>
+      <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>Complete missions to earn bonus points and unlock badges</div>
+      {noActiveRound ? (
+        <div style={{ fontSize: 14, color: "#6B7280" }}>No active round — no missions yet.</div>
+      ) : loading ? (
+        <div style={{ fontSize: 14, color: "#6B7280" }}>Loading missions…</div>
+      ) : missions.length === 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "40px 24px", gap: 16, textAlign: "center" }}>
+          <div style={{ width: 64, height: 64, borderRadius: 20, background: `${COLOR}10`, border: `1px dashed ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <Target size={28} style={{ color: COLOR, opacity: 0.5 }} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>No missions for this round yet</div>
+          <div style={{ fontSize: 13, color: "#6B7280", maxWidth: 360, lineHeight: 1.7 }}>An admin can publish missions for this round; they&apos;ll appear here.</div>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {missions.map((m) => <MissionCard key={m.id} mission={m} onScout={() => onNavTab("scout")} />)}
+        </div>
+      )}
+    </>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-my-finds-tab.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-my-finds-tab.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { COLOR, initials, submissionStatusStyle, type SkillsHuntSubmission, type Tab } from "./sh-shared";
+
+function FindCard({ find }: { find: SkillsHuntSubmission }) {
+  const st = submissionStatusStyle(find.status);
+  return (
+    <div style={{ padding: "16px 20px", borderRadius: 14, background: "rgba(255,255,255,0.02)", border: `1px solid ${find.status === "accepted" ? "#22C55E20" : "rgba(255,255,255,0.06)"}`, display: "flex", alignItems: "flex-start", gap: 16 }}>
+      <div style={{ width: 40, height: 40, borderRadius: "50%", background: `${COLOR}20`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 14, fontWeight: 700, color: COLOR, flexShrink: 0 }}>
+        {initials(find.displayName)}
+      </div>
+      <div style={{ flex: 1 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB" }}>{find.displayName}</div>
+          <span style={{ padding: "2px 8px", borderRadius: 10, fontSize: 11, fontWeight: 700, background: st.bg, color: st.color, border: `1px solid ${st.border}` }}>{st.label}</span>
+          {find.quoraProfileUrl && <span style={{ fontSize: 11, color: "#4B5563" }}>Quora ✓</span>}
+        </div>
+        {(find.skills.length > 0 || find.proposedSkills.length > 0) && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {find.skills.map((s) => (
+              <span key={s} style={{ padding: "2px 8px", borderRadius: 10, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", fontSize: 12, color: "#9CA3AF" }}>{s}</span>
+            ))}
+            {find.proposedSkills.map((s) => (
+              <span key={s} style={{ padding: "2px 8px", borderRadius: 10, background: "rgba(251,191,36,0.08)", border: "1px solid rgba(251,191,36,0.2)", fontSize: 12, color: "#FBBF24" }}>{s}</span>
+            ))}
+          </div>
+        )}
+        {find.pointsAwarded > 0 && <div style={{ fontSize: 12, color: COLOR, marginTop: 6, fontWeight: 600 }}>+{find.pointsAwarded} pts earned</div>}
+      </div>
+      <div style={{ fontSize: 11, color: "#4B5563", flexShrink: 0 }}>{new Date(find.createdAtIso).toLocaleDateString()}</div>
+    </div>
+  );
+}
+
+export function SkillsHuntMyFindsTab({
+  noActiveRound,
+  loading,
+  myFinds,
+  onNavTab,
+}: {
+  noActiveRound: boolean;
+  loading: boolean;
+  myFinds: SkillsHuntSubmission[];
+  onNavTab: (tab: Tab) => void;
+}) {
+  return (
+    <>
+      <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>My Finds</div>
+      <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>People you&apos;ve nominated · display names only for privacy</div>
+      {noActiveRound ? (
+        <div style={{ fontSize: 14, color: "#6B7280" }}>No active round — no finds to display.</div>
+      ) : loading ? (
+        <div style={{ fontSize: 14, color: "#6B7280" }}>Loading your finds…</div>
+      ) : myFinds.length === 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "40px 24px", gap: 16, textAlign: "center" }}>
+          <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>No nominations yet</div>
+          <div style={{ fontSize: 13, color: "#6B7280", maxWidth: 360, lineHeight: 1.7 }}>Switch to the Scout tab to nominate your first survivor.</div>
+          <button type="button" onClick={() => onNavTab("scout")} style={{ padding: "10px 24px", borderRadius: 10, background: COLOR, border: "none", color: "#fff", fontSize: 13, fontWeight: 700, cursor: "pointer", display: "flex", alignItems: "center", gap: 8 }}>
+            <Plus size={14} /> Nominate a Survivor
+          </button>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {myFinds.map((f) => <FindCard key={f.id} find={f} />)}
+        </div>
+      )}
+    </>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-notifications.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-notifications.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { COLOR, type SkillsHuntNotification } from "./sh-shared";
+
+export function SkillsHuntNotifications({
+  notifications,
+  onClose,
+  onMarkRead,
+}: {
+  notifications: SkillsHuntNotification[];
+  onClose: () => void;
+  onMarkRead: (id: string) => void;
+}) {
+  return (
+    <div style={{ position: "absolute", left: 80, top: 60, width: 360, maxHeight: 480, overflowY: "auto", background: "#0D0F14", border: `1px solid ${COLOR}40`, borderRadius: 14, zIndex: 50, boxShadow: "0 12px 32px rgba(0,0,0,0.4)" }}>
+      <div style={{ padding: "12px 16px", borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 13, fontWeight: 700, color: "#F9FAFB" }}>Notifications</span>
+        <button type="button" aria-label="Close notifications" onClick={onClose} style={{ background: "none", border: "none", color: "#6B7280", cursor: "pointer", fontSize: 18, lineHeight: 1 }}>×</button>
+      </div>
+      {notifications.length === 0 ? (
+        <div style={{ padding: 24, fontSize: 13, color: "#6B7280", textAlign: "center" }}>No notifications yet.</div>
+      ) : (
+        <div>
+          {notifications.map((n) => (
+            <button
+              key={n.id}
+              type="button"
+              onClick={() => !n.isRead && onMarkRead(n.id)}
+              style={{
+                display: "block", width: "100%", textAlign: "left", padding: "10px 16px",
+                borderBottom: "1px solid rgba(255,255,255,0.04)",
+                background: n.isRead ? "transparent" : `${COLOR}08`,
+                border: "none", borderLeft: n.isRead ? "2px solid transparent" : `2px solid ${COLOR}`,
+                cursor: n.isRead ? "default" : "pointer",
+              }}
+            >
+              <div style={{ fontSize: 13, fontWeight: n.isRead ? 500 : 700, color: "#F9FAFB", marginBottom: 2 }}>{n.title}</div>
+              <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.4 }}>{n.body}</div>
+              <div style={{ fontSize: 11, color: "#4B5563", marginTop: 4 }}>{new Date(n.createdAtIso).toLocaleString()}</div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-right-panel.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-right-panel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { COLOR, badgeMeta, type SkillsHuntAchievement, type SkillsHuntLeaderboardItem } from "./sh-shared";
+
+function ScoutStats({ entry }: { entry: SkillsHuntLeaderboardItem }) {
+  const cells = [
+    { l: "Accepted", v: String(entry.acceptedCount) },
+    { l: "Pending ⏳", v: String(entry.pendingPoints) },
+    { l: "Rank", v: `#${entry.rank}` },
+  ];
+  return (
+    <>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Your Scout Stats</div>
+      <div style={{ padding: "16px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}20`, marginBottom: 16 }}>
+        <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+          {cells.map(({ l, v }) => (
+            <div key={l} style={{ flex: 1, textAlign: "center", padding: "10px 6px", borderRadius: 10, background: "rgba(255,255,255,0.04)" }}>
+              <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>{v}</div>
+              <div style={{ fontSize: 10, color: "#6B7280" }}>{l}</div>
+            </div>
+          ))}
+        </div>
+        {entry.rareSkillBonus > 0 && <div style={{ fontSize: 12, color: "#6B7280" }}>💎 {entry.rareSkillBonus} rare skill pts</div>}
+      </div>
+    </>
+  );
+}
+
+export function SkillsHuntRightPanel({
+  currentUserEntry,
+  achievements,
+  showModeratorTools,
+}: {
+  currentUserEntry: SkillsHuntLeaderboardItem | null;
+  achievements: SkillsHuntAchievement[];
+  showModeratorTools: boolean;
+}) {
+  return (
+    <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0, overflowY: "auto" }}>
+      {currentUserEntry ? (
+        <ScoutStats entry={currentUserEntry} />
+      ) : (
+        <div style={{ padding: "16px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}20`, marginBottom: 16 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: COLOR, marginBottom: 4 }}>Start scouting</div>
+          <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.5 }}>Nominate your first survivor to appear on the leaderboard.</div>
+        </div>
+      )}
+
+      {achievements.length > 0 && (
+        <>
+          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Badges Earned</div>
+          {achievements.map((a) => {
+            const meta = badgeMeta(a.code, a.description);
+            return (
+              <div key={a.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 10px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}15`, marginBottom: 6 }}>
+                <div style={{ fontSize: 20 }}>{meta.emoji}</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, color: "#E8EAF0" }}>{a.title}</div>
+                  <div style={{ fontSize: 11, color: "#4B5563" }}>{meta.desc}</div>
+                </div>
+              </div>
+            );
+          })}
+        </>
+      )}
+
+      {showModeratorTools && (
+        <div style={{ marginTop: 16, padding: "14px 16px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", marginBottom: 8 }}>Moderator Tools</div>
+          <a href="/admin/skills-hunt" style={{ display: "block", padding: "8px 12px", borderRadius: 8, background: `${COLOR}10`, border: `1px solid ${COLOR}25`, color: COLOR, fontSize: 12, fontWeight: 600, textDecoration: "none", textAlign: "center" }}>
+            Admin Panel →
+          </a>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-scout-tab.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-scout-tab.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Search, CheckCircle, ExternalLink, Send } from "lucide-react";
+import { COLOR, BIO_MAX, type Tab } from "./sh-shared";
+import { SkillsPicker } from "./sh-skills-picker";
+
+export interface ScoutFormModel {
+  displayName: string;
+  bio: string;
+  quora: string;
+  skills: string[];
+  proposedSkills: string[];
+  freeText: string;
+  openCategory: string | null;
+  submitting: boolean;
+  submitError: string | null;
+  allSkillCount: number;
+  canAddMore: boolean;
+  onDisplayName: (v: string) => void;
+  onBio: (v: string) => void;
+  onQuora: (v: string) => void;
+  onToggleSkill: (s: string) => void;
+  onRemoveProposed: (s: string) => void;
+  onOpenCategory: (c: string | null) => void;
+  onFreeText: (v: string) => void;
+  onAddProposed: () => void;
+  onSubmit: () => void;
+}
+
+const WHY_ITEMS = [
+  { icon: "🧩", text: "You nominate someone you believe may be a survivor — certainty not required" },
+  { icon: "🔗", text: "Quora profile = social proof, reducing trafficker infiltration risk" },
+  { icon: "⚡", text: "Skills from the taxonomy populate the Directory so we can trade and build our own economy" },
+  { icon: "🏆", text: "Points are granted on admin acceptance — taxonomy skills earn more" },
+];
+
+function NoActiveRound() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "60px 24px", gap: 20, textAlign: "center" }}>
+      <div style={{ width: 72, height: 72, borderRadius: 20, background: `${COLOR}10`, border: `1px dashed ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Search size={32} style={{ color: COLOR, opacity: 0.5 }} />
+      </div>
+      <div>
+        <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 8 }}>No active round right now</div>
+        <div style={{ fontSize: 14, color: "#6B7280", maxWidth: 400, lineHeight: 1.7 }}>Check back soon — rounds open when there are survivors ready to be nominated. Your nominations help build the Directory so the economy can grow.</div>
+      </div>
+    </div>
+  );
+}
+
+function SubmittedState({ onReset, onViewLeaderboard }: { onReset: () => void; onViewLeaderboard: () => void }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "60px 24px", gap: 16, textAlign: "center" }}>
+      <div style={{ width: 72, height: 72, borderRadius: "50%", background: "#22C55E20", border: "1px solid #22C55E40", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <CheckCircle size={36} style={{ color: "#22C55E" }} />
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB" }}>Nomination submitted!</div>
+      <div style={{ fontSize: 14, color: "#6B7280", maxWidth: 400, lineHeight: 1.7 }}>
+        Thank you for growing the network. This submission is under review — you&apos;ll earn points once accepted.
+      </div>
+      <div style={{ display: "flex", gap: 12 }}>
+        <button type="button" onClick={onReset} style={{ padding: "12px 24px", borderRadius: 12, background: COLOR, border: "none", color: "#fff", fontSize: 14, fontWeight: 700, cursor: "pointer" }}>Nominate Another</button>
+        <button type="button" onClick={onViewLeaderboard} style={{ padding: "12px 24px", borderRadius: 12, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "#9CA3AF", fontSize: 14, fontWeight: 600, cursor: "pointer" }}>View Leaderboard</button>
+      </div>
+    </div>
+  );
+}
+
+function WhyThisWorks() {
+  return (
+    <div style={{ width: 260, flexShrink: 0 }}>
+      <div style={{ padding: "18px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, marginBottom: 12 }}>Why this works</div>
+        {WHY_ITEMS.map((item, i) => (
+          <div key={i} style={{ display: "flex", gap: 10, marginBottom: 12, alignItems: "flex-start" }}>
+            <span style={{ fontSize: 18, flexShrink: 0 }}>{item.icon}</span>
+            <span style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.5 }}>{item.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function fieldBorder(active: boolean): string {
+  return `1px solid ${active ? COLOR + "50" : "rgba(255,255,255,0.1)"}`;
+}
+
+function NominationFields({ form }: { form: ScoutFormModel }) {
+  return (
+    <>
+      <div>
+        <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
+          Display Name <span style={{ color: COLOR }}>*</span>
+          <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400, marginLeft: 6 }}>2–100 chars, letters and spaces only</span>
+        </label>
+        <input value={form.displayName} onChange={(e) => form.onDisplayName(e.target.value.replace(/[^a-zA-Z\s]/g, "").slice(0, 100))} aria-label="Display name" placeholder="e.g. Amara Williams"
+          style={{ width: "100%", padding: "10px 14px", background: "rgba(255,255,255,0.04)", border: fieldBorder(form.displayName.length >= 2), borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", boxSizing: "border-box" }} />
+        <div style={{ fontSize: 11, color: "#4B5563", textAlign: "right", marginTop: 3 }}>{form.displayName.length}/100</div>
+      </div>
+
+      <div>
+        <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
+          Bio <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400 }}>(optional)</span>
+        </label>
+        <textarea value={form.bio} onChange={(e) => form.onBio(e.target.value.slice(0, BIO_MAX))} rows={2} aria-label="Bio" placeholder="e.g. Lives in Houston, works in construction, connected through mutual contact…"
+          style={{ width: "100%", padding: "10px 14px", background: "rgba(255,255,255,0.04)", border: fieldBorder(Boolean(form.bio)), borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", resize: "vertical", boxSizing: "border-box", fontFamily: "inherit" }} />
+        <div style={{ fontSize: 11, color: form.bio.length > 240 ? "#F59E0B" : "#4B5563", textAlign: "right", marginTop: 3 }}>{form.bio.length}/{BIO_MAX}</div>
+      </div>
+
+      <div>
+        <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
+          Quora Profile URL <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400 }}>(social proof — highly recommended)</span>
+        </label>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", background: "rgba(255,255,255,0.04)", border: fieldBorder(Boolean(form.quora)), borderRadius: 10 }}>
+          <ExternalLink size={14} style={{ color: "#6B7280", flexShrink: 0 }} />
+          <input value={form.quora} onChange={(e) => form.onQuora(e.target.value)} aria-label="Quora profile URL" placeholder="https://quora.com/profile/..."
+            style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: "#E8EAF0" }} />
+        </div>
+        <div style={{ fontSize: 11, color: "#4B5563", marginTop: 4 }}>Quora activity helps verify this is a real person — reduces risk of trafficker infiltration.</div>
+      </div>
+    </>
+  );
+}
+
+function NominationForm({ form }: { form: ScoutFormModel }) {
+  const canSubmit = form.displayName.trim().length >= 2 && form.allSkillCount > 0 && !form.submitting;
+  return (
+    <div style={{ flex: 1, maxWidth: 580 }}>
+      <div style={{ marginBottom: 20 }}>
+        <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Nominate a Survivor</div>
+        <div style={{ fontSize: 13, color: "#6B7280", lineHeight: 1.6 }}>Think of someone you believe may be a survivor — you don&apos;t need to be 100% certain. Their Quora profile helps verify their identity, and their skills join our economy.</div>
+      </div>
+
+      {form.submitError && (
+        <div style={{ marginBottom: 16, padding: "10px 14px", borderRadius: 10, background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)", color: "#EF4444", fontSize: 13 }}>{form.submitError}</div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <NominationFields form={form} />
+
+        <SkillsPicker
+          skills={form.skills}
+          proposedSkills={form.proposedSkills}
+          freeText={form.freeText}
+          openCategory={form.openCategory}
+          canAddMore={form.canAddMore}
+          allSkillCount={form.allSkillCount}
+          onToggleSkill={form.onToggleSkill}
+          onRemoveProposed={form.onRemoveProposed}
+          onOpenCategory={form.onOpenCategory}
+          onFreeText={form.onFreeText}
+          onAddProposed={form.onAddProposed}
+        />
+
+        <button type="button" onClick={form.onSubmit} disabled={!canSubmit}
+          style={{ padding: "14px", borderRadius: 12, background: canSubmit ? COLOR : "rgba(255,255,255,0.05)", border: "none", color: canSubmit ? "#fff" : "#4B5563", fontSize: 15, fontWeight: 700, cursor: canSubmit ? "pointer" : "default", display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}>
+          <Send size={16} /> {form.submitting ? "Submitting…" : "Submit Nomination · earn points on acceptance"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SkillsHuntScoutTab({
+  noActiveRound,
+  submitted,
+  form,
+  onReset,
+  onNavTab,
+}: {
+  noActiveRound: boolean;
+  submitted: boolean;
+  form: ScoutFormModel;
+  onReset: () => void;
+  onNavTab: (tab: Tab) => void;
+}) {
+  if (noActiveRound) return <NoActiveRound />;
+  if (submitted) return <SubmittedState onReset={onReset} onViewLeaderboard={() => onNavTab("leaderboard")} />;
+  return (
+    <div style={{ display: "flex", gap: 24 }}>
+      <NominationForm form={form} />
+      <WhyThisWorks />
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-shared.ts
+++ b/ctf/packages/web/components/skills-hunt/sh-shared.ts
@@ -1,0 +1,86 @@
+// Shared constants, types, and helpers for the Skills Hunt web shell.
+// Palette/layout derive from design/.../survivor-hub/SkillsHunt.tsx.
+import { Search, Trophy, Target, Users } from "lucide-react";
+import type {
+  SkillsHuntRound,
+  SkillsHuntLeaderboardItem,
+  SkillsHuntAchievement,
+  SkillsHuntNotification,
+  SkillsHuntSubmission,
+  SkillsHuntMissionWithProgress,
+} from "lib/skills-hunt/types";
+
+export type {
+  SkillsHuntRound,
+  SkillsHuntLeaderboardItem,
+  SkillsHuntAchievement,
+  SkillsHuntNotification,
+  SkillsHuntSubmission,
+  SkillsHuntMissionWithProgress,
+};
+
+export const COLOR = "#D946EF";
+export const BG = "#0F1117";
+export const BIO_MAX = 280;
+export const MAX_SKILLS = 10;
+
+export const SKILL_TAXONOMY: Record<string, string[]> = {
+  "Technology":         ["Software Engineering", "UI/UX Design", "Data Analysis", "Cybersecurity", "Web Development", "IT Support"],
+  "Healthcare":         ["Nursing", "Counseling", "Mental Health", "Physical Therapy", "Home Health Aide"],
+  "Trades":             ["Carpentry", "Plumbing", "Electrical", "Welding", "HVAC", "Masonry", "Auto Repair"],
+  "Creative":           ["Graphic Design", "Photography", "Video Editing", "Music Production", "Writing & Editing"],
+  "Education":          ["Teaching", "Tutoring", "Translation", "Sign Language Interpretation"],
+  "Business & Legal":   ["Accounting", "Legal Aid", "Paralegal", "Marketing", "Bookkeeping"],
+  "Food & Hospitality": ["Cooking", "Catering", "Barista", "Event Planning"],
+  "Agriculture":        ["Farming", "Landscaping", "Animal Care"],
+  "Beauty & Wellness":  ["Hair Styling", "Cosmetology", "Massage Therapy", "Esthetics"],
+};
+
+export const BADGE_META: Record<string, { emoji: string; desc: string }> = {
+  "first-finder":         { emoji: "🔍", desc: "First accepted submission for a URL" },
+  "diversity-champion":   { emoji: "🌍", desc: "Skills spanning 3+ sectors" },
+  "rare-talent-scout":    { emoji: "💎", desc: "Found a rare skill (<50% recruited)" },
+  "quality-contributor":  { emoji: "⭐", desc: "10 accepted with no admin edits" },
+  "leaderboard-champion": { emoji: "🏆", desc: "Reached top 10 on the leaderboard" },
+  "accepted-first":       { emoji: "✅", desc: "First accepted submission" },
+  "accepted-five":        { emoji: "🎯", desc: "5 accepted submissions" },
+  "accepted-ten":         { emoji: "🌟", desc: "10 accepted submissions" },
+};
+
+export function badgeMeta(code: string, fallbackDesc: string): { emoji: string; desc: string } {
+  return BADGE_META[code] ?? { emoji: "🏅", desc: fallbackDesc };
+}
+
+export type Tab = "scout" | "leaderboard" | "missions" | "my-finds";
+
+export const TABS: { key: Tab; icon: typeof Search; label: string }[] = [
+  { key: "scout",       icon: Search, label: "Scout" },
+  { key: "leaderboard", icon: Trophy, label: "Leaderboard" },
+  { key: "missions",    icon: Target, label: "Missions" },
+  { key: "my-finds",    icon: Users,  label: "My Finds" },
+];
+
+export function rankDisplay(rank: number): string {
+  if (rank === 1) return "🥇";
+  if (rank === 2) return "🥈";
+  if (rank === 3) return "🥉";
+  return `#${rank}`;
+}
+
+export function rankColor(rank: number): string {
+  if (rank === 1) return "#F59E0B";
+  if (rank === 2) return "#9CA3AF";
+  if (rank === 3) return "#CD7C2F";
+  return "#6B7280";
+}
+
+export function submissionStatusStyle(status: string): { bg: string; color: string; border: string; label: string } {
+  if (status === "accepted") return { bg: "#22C55E20", color: "#22C55E", border: "#22C55E40", label: "✓ Accepted" };
+  if (status === "rejected") return { bg: "rgba(239,68,68,0.12)", color: "#EF4444", border: "rgba(239,68,68,0.3)", label: "✗ Rejected" };
+  if (status === "flagged")  return { bg: `${COLOR}20`, color: COLOR, border: `${COLOR}40`, label: "⚑ Flagged" };
+  return { bg: "rgba(255,165,0,0.15)", color: "#F59E0B", border: "rgba(255,165,0,0.3)", label: "⏳ Pending" };
+}
+
+export function initials(name: string): string {
+  return name.split(" ").map((n) => n[0] ?? "").join("").slice(0, 2).toUpperCase();
+}

--- a/ctf/packages/web/components/skills-hunt/sh-sidebar.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-sidebar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { COLOR, TABS, badgeMeta, type SkillsHuntAchievement, type SkillsHuntLeaderboardItem, type Tab } from "./sh-shared";
+
+function ScoutingScore({ entry }: { entry: SkillsHuntLeaderboardItem }) {
+  return (
+    <div style={{ padding: 12, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ padding: "10px 12px", borderRadius: 10, background: `${COLOR}10`, border: `1px solid ${COLOR}25` }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: COLOR, marginBottom: 2 }}>Your Scouting Score</div>
+        <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB" }}>{entry.score} pts</div>
+        <div style={{ fontSize: 11, color: "#6B7280" }}>
+          {entry.acceptedCount} accepted · +{entry.pendingPoints} pending · Rank #{entry.rank}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SkillsHuntSidebar({
+  tab,
+  onTab,
+  achievements,
+  currentUserEntry,
+}: {
+  tab: Tab;
+  onTab: (tab: Tab) => void;
+  achievements: SkillsHuntAchievement[];
+  currentUserEntry: SkillsHuntLeaderboardItem | null;
+}) {
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 4 }}>Skills Hunt</div>
+        <div style={{ fontSize: 12, color: "#4B5563", lineHeight: 1.5, marginBottom: 12 }}>Nominate survivors — populate the Directory, build the economy.</div>
+      </div>
+      <div style={{ flex: 1, overflowY: "auto", padding: "0 8px 16px" }}>
+        {TABS.map(({ key, icon: Icon, label }) => (
+          <button key={key} type="button" onClick={() => onTab(key)} style={{ width: "100%", display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: tab === key ? `${COLOR}18` : "transparent", borderLeft: tab === key ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2, border: "none", textAlign: "left" }}>
+            <Icon size={14} style={{ color: tab === key ? COLOR : "#6B7280" }} />
+            <span style={{ fontSize: 13, color: tab === key ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{label}</span>
+          </button>
+        ))}
+
+        {achievements.length > 0 && (
+          <>
+            <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", padding: "0 10px" }}>Your Badges</div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, padding: "0 10px" }}>
+              {achievements.map((a) => {
+                const meta = badgeMeta(a.code, a.description);
+                return (
+                  <div key={a.id} title={`${a.title}: ${meta.desc}`} style={{ width: 32, height: 32, borderRadius: 8, background: `${COLOR}20`, border: `1px solid ${COLOR}40`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 16, cursor: "pointer" }}>
+                    {meta.emoji}
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+
+      {currentUserEntry && <ScoutingScore entry={currentUserEntry} />}
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-skills-picker.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-skills-picker.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { X, ChevronDown } from "lucide-react";
+import { COLOR, SKILL_TAXONOMY } from "./sh-shared";
+
+interface SkillsPickerProps {
+  skills: string[];
+  proposedSkills: string[];
+  freeText: string;
+  openCategory: string | null;
+  canAddMore: boolean;
+  allSkillCount: number;
+  onToggleSkill: (s: string) => void;
+  onRemoveProposed: (s: string) => void;
+  onOpenCategory: (c: string | null) => void;
+  onFreeText: (v: string) => void;
+  onAddProposed: () => void;
+}
+
+function SelectedChips({ skills, proposedSkills, onToggleSkill, onRemoveProposed }: Pick<SkillsPickerProps, "skills" | "proposedSkills" | "onToggleSkill" | "onRemoveProposed">) {
+  if (skills.length === 0 && proposedSkills.length === 0) return null;
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 10 }}>
+      {skills.map((s) => (
+        <span key={s} style={{ display: "flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 20, background: `${COLOR}20`, border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600 }}>
+          {s}
+          <button type="button" aria-label={`Remove ${s}`} onClick={() => onToggleSkill(s)} style={{ background: "none", border: "none", color: COLOR, cursor: "pointer", padding: 0, lineHeight: 1 }}><X size={11} /></button>
+        </span>
+      ))}
+      {proposedSkills.map((s) => (
+        <span key={s} style={{ display: "flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 20, background: "rgba(251,191,36,0.12)", border: "1px solid rgba(251,191,36,0.3)", fontSize: 12, color: "#FBBF24", fontWeight: 600 }}>
+          {s} <span style={{ fontSize: 10, opacity: 0.7 }}>✎</span>
+          <button type="button" aria-label={`Remove ${s}`} onClick={() => onRemoveProposed(s)} style={{ background: "none", border: "none", color: "#FBBF24", cursor: "pointer", padding: 0, lineHeight: 1 }}><X size={11} /></button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function CategoryRow({ category, categorySkills, skills, isOpen, canAddMore, onOpenCategory, onToggleSkill }: {
+  category: string;
+  categorySkills: string[];
+  skills: string[];
+  isOpen: boolean;
+  canAddMore: boolean;
+  onOpenCategory: (c: string | null) => void;
+  onToggleSkill: (s: string) => void;
+}) {
+  const selectedCount = categorySkills.filter((s) => skills.includes(s)).length;
+  return (
+    <div>
+      <button type="button" onClick={() => onOpenCategory(isOpen ? null : category)}
+        style={{ width: "100%", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "10px 14px", background: isOpen ? `${COLOR}10` : "rgba(255,255,255,0.02)", border: "none", borderBottom: "1px solid rgba(255,255,255,0.06)", cursor: "pointer", color: isOpen ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600 }}>
+        <span>{category}</span>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {selectedCount > 0 && (
+            <span style={{ fontSize: 11, background: `${COLOR}25`, color: COLOR, borderRadius: 10, padding: "1px 7px", fontWeight: 700 }}>{selectedCount} selected</span>
+          )}
+          <ChevronDown size={14} style={{ transform: isOpen ? "rotate(180deg)" : "none", transition: "transform 0.15s" }} />
+        </div>
+      </button>
+      {isOpen && (
+        <div style={{ padding: "10px 14px", display: "flex", flexWrap: "wrap", gap: 7, background: "rgba(255,255,255,0.01)" }}>
+          {categorySkills.map((s) => {
+            const selected = skills.includes(s);
+            return (
+              <button key={s} type="button" onClick={() => { if (canAddMore || selected) onToggleSkill(s); }}
+                style={{ padding: "4px 12px", borderRadius: 20, background: selected ? `${COLOR}25` : "rgba(255,255,255,0.04)", border: `1px solid ${selected ? COLOR + "60" : "rgba(255,255,255,0.08)"}`, color: selected ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: selected ? 700 : 400, cursor: canAddMore || selected ? "pointer" : "default", opacity: !canAddMore && !selected ? 0.4 : 1 }}>
+                {selected ? "✓ " : ""}{s}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SkillsPicker(props: SkillsPickerProps) {
+  const { skills, proposedSkills, freeText, openCategory, canAddMore, allSkillCount, onToggleSkill, onRemoveProposed, onOpenCategory, onFreeText, onAddProposed } = props;
+  return (
+    <div>
+      <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
+        Skills <span style={{ color: COLOR }}>*</span>
+        <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400, marginLeft: 6 }}>pick from taxonomy (max 10)</span>
+      </label>
+
+      <SelectedChips skills={skills} proposedSkills={proposedSkills} onToggleSkill={onToggleSkill} onRemoveProposed={onRemoveProposed} />
+
+      {canAddMore && (
+        <div style={{ border: "1px solid rgba(255,255,255,0.1)", borderRadius: 10, overflow: "hidden", marginBottom: 10 }}>
+          {Object.entries(SKILL_TAXONOMY).map(([category, categorySkills]) => (
+            <CategoryRow key={category} category={category} categorySkills={categorySkills} skills={skills} isOpen={openCategory === category} canAddMore={canAddMore} onOpenCategory={onOpenCategory} onToggleSkill={onToggleSkill} />
+          ))}
+        </div>
+      )}
+
+      {canAddMore && (
+        <div>
+          <div style={{ fontSize: 11, color: "#4B5563", marginBottom: 6 }}>Don&apos;t see what you need? Add free-text skills (comma or newline separated — each ≤ 40 chars):</div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <input
+              value={freeText}
+              onChange={(e) => onFreeText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onAddProposed(); } }}
+              aria-label="Add free-text skills"
+              placeholder="e.g. Tie-dye, Beekeeping, Kintsugi…"
+              style={{ flex: 1, padding: "8px 12px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: "#E8EAF0", outline: "none" }}
+            />
+            <button type="button" onClick={onAddProposed} style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(251,191,36,0.1)", border: "1px solid rgba(251,191,36,0.25)", color: "#FBBF24", cursor: "pointer", fontSize: 12, fontWeight: 600 }}>Add</button>
+          </div>
+          <div style={{ fontSize: 11, color: "#4B5563", marginTop: 4 }}>Yellow chips = proposed skills — admin can promote them to the taxonomy later.</div>
+        </div>
+      )}
+
+      {!canAddMore && <div style={{ fontSize: 11, color: "#6B7280", padding: "6px 0" }}>Maximum 10 skills reached.</div>}
+      <div style={{ fontSize: 11, color: "#4B5563", marginTop: 6 }}>{allSkillCount}/10 skills added</div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
+++ b/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { MAX_SKILLS, type SkillsHuntRound } from "./sh-shared";
+import type { ScoutFormModel } from "./sh-scout-tab";
+
+// Owns the nomination-form state, the submit/reset handlers, and assembly of the
+// ScoutFormModel passed to the Scout tab. Kept out of the shell to honor rule-116.
+export function useNominationForm(activeRound: SkillsHuntRound | null): {
+  form: ScoutFormModel;
+  submitted: boolean;
+  resetForm: () => void;
+} {
+  const [displayName, setDisplayName] = useState("");
+  const [bio, setBio] = useState("");
+  const [quora, setQuora] = useState("");
+  const [skills, setSkills] = useState<string[]>([]);
+  const [proposedSkills, setProposed] = useState<string[]>([]);
+  const [freeText, setFreeText] = useState("");
+  const [openCategory, setOpenCategory] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const allSkillCount = skills.length + proposedSkills.length;
+  const canAddMore = allSkillCount < MAX_SKILLS;
+
+  function toggleSkill(s: string) {
+    setSkills((prev) => (prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]));
+  }
+
+  function addProposed() {
+    const tokens = freeText.split(/[,\n]+/).map((t) => t.trim()).filter(
+      (t) => t && t.length <= 40 && !skills.includes(t) && !proposedSkills.includes(t),
+    );
+    if (tokens.length && allSkillCount + tokens.length <= MAX_SKILLS) {
+      setProposed((prev) => [...prev, ...tokens]);
+    }
+    setFreeText("");
+  }
+
+  async function handleSubmit() {
+    if (!activeRound || displayName.trim().length < 2 || allSkillCount === 0) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const res = await fetch(`/api/skills-hunt/rounds/${activeRound.id}/submissions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          displayName: displayName.trim(),
+          bio: bio.trim(),
+          quoraProfileUrl: quora.trim(),
+          skills,
+          proposedSkills,
+          claimedProfessions: [],
+        }),
+      });
+      if (!res.ok) {
+        const err = (await res.json()) as { message?: string };
+        throw new Error(err.message ?? "Failed to submit nomination.");
+      }
+      setSubmitted(true);
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : "Failed to submit nomination.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function resetForm() {
+    setDisplayName(""); setBio(""); setQuora("");
+    setSkills([]); setProposed([]); setFreeText("");
+    setSubmitted(false); setSubmitError(null);
+  }
+
+  const form: ScoutFormModel = {
+    displayName, bio, quora, skills, proposedSkills, freeText, openCategory,
+    submitting, submitError, allSkillCount, canAddMore,
+    onDisplayName: setDisplayName, onBio: setBio, onQuora: setQuora,
+    onToggleSkill: toggleSkill,
+    onRemoveProposed: (s) => setProposed((prev) => prev.filter((x) => x !== s)),
+    onOpenCategory: setOpenCategory, onFreeText: setFreeText, onAddProposed: addProposed,
+    onSubmit: () => void handleSubmit(),
+  };
+
+  return { form, submitted, resetForm };
+}

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -1,76 +1,88 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { Search } from "lucide-react";
 import {
-  Search, Trophy, Target, Users, Plus, X, ExternalLink,
-  Bell, Settings, CheckCircle, Send, ChevronDown,
-} from "lucide-react";
-import type {
-  SkillsHuntRound,
-  SkillsHuntLeaderboardItem,
-  SkillsHuntAchievement,
-  SkillsHuntNotification,
-  SkillsHuntSubmission,
-  SkillsHuntMissionWithProgress,
-} from "lib/skills-hunt/types";
+  BG, COLOR, TABS, type Tab,
+  type SkillsHuntRound, type SkillsHuntLeaderboardItem, type SkillsHuntAchievement,
+  type SkillsHuntNotification, type SkillsHuntSubmission, type SkillsHuntMissionWithProgress,
+} from "./sh-shared";
+import { SkillsHuntIconRail } from "./sh-icon-rail";
+import { SkillsHuntNotifications } from "./sh-notifications";
+import { SkillsHuntSidebar } from "./sh-sidebar";
+import { SkillsHuntScoutTab, type ScoutFormModel } from "./sh-scout-tab";
+import { SkillsHuntLeaderboardTab } from "./sh-leaderboard-tab";
+import { SkillsHuntMissionsTab } from "./sh-missions-tab";
+import { SkillsHuntMyFindsTab } from "./sh-my-finds-tab";
+import { SkillsHuntRightPanel } from "./sh-right-panel";
+import { useNominationForm } from "./sh-use-nomination-form";
 
-const COLOR = "#A855F7";
-
-const SKILL_TAXONOMY: Record<string, string[]> = {
-  "Technology":         ["Software Engineering", "UI/UX Design", "Data Analysis", "Cybersecurity", "Web Development", "IT Support"],
-  "Healthcare":         ["Nursing", "Counseling", "Mental Health", "Physical Therapy", "Home Health Aide"],
-  "Trades":             ["Carpentry", "Plumbing", "Electrical", "Welding", "HVAC", "Masonry", "Auto Repair"],
-  "Creative":           ["Graphic Design", "Photography", "Video Editing", "Music Production", "Writing & Editing"],
-  "Education":          ["Teaching", "Tutoring", "Translation", "Sign Language Interpretation"],
-  "Business & Legal":   ["Accounting", "Legal Aid", "Paralegal", "Marketing", "Bookkeeping"],
-  "Food & Hospitality": ["Cooking", "Catering", "Barista", "Event Planning"],
-  "Agriculture":        ["Farming", "Landscaping", "Animal Care"],
-  "Beauty & Wellness":  ["Hair Styling", "Cosmetology", "Massage Therapy", "Esthetics"],
-};
-
-const BADGE_META: Record<string, { emoji: string; desc: string }> = {
-  "first-finder":         { emoji: "🔍", desc: "First accepted submission for a URL" },
-  "diversity-champion":   { emoji: "🌍", desc: "Skills spanning 3+ sectors" },
-  "rare-talent-scout":    { emoji: "💎", desc: "Found a rare skill (<50% recruited)" },
-  "quality-contributor":  { emoji: "⭐", desc: "10 accepted with no admin edits" },
-  "leaderboard-champion": { emoji: "🏆", desc: "Reached top 10 on the leaderboard" },
-  "accepted-first":       { emoji: "✅", desc: "First accepted submission" },
-  "accepted-five":        { emoji: "🎯", desc: "5 accepted submissions" },
-  "accepted-ten":         { emoji: "🌟", desc: "10 accepted submissions" },
-};
-
-type Tab = "scout" | "leaderboard" | "missions" | "my-finds";
-
-const TABS: { key: Tab; icon: typeof Search; label: string }[] = [
-  { key: "scout",       icon: Search, label: "Scout" },
-  { key: "leaderboard", icon: Trophy, label: "Leaderboard" },
-  { key: "missions",    icon: Target, label: "Missions" },
-  { key: "my-finds",    icon: Users,  label: "My Finds" },
-];
-
-function rankDisplay(rank: number): string {
-  if (rank === 1) return "🥇";
-  if (rank === 2) return "🥈";
-  if (rank === 3) return "🥉";
-  return `#${rank}`;
+function CenteredNote({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <div style={{ width: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ fontSize: 14, color }}>{children}</div>
+    </div>
+  );
 }
 
-function rankColor(rank: number): string {
-  if (rank === 1) return "#F59E0B";
-  if (rank === 2) return "#9CA3AF";
-  if (rank === 3) return "#CD7C2F";
-  return "#6B7280";
+function ShellHeader({ activeRound }: { activeRound: SkillsHuntRound | null }) {
+  return (
+    <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+      <Search size={18} style={{ color: COLOR }} />
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Skills Hunt</div>
+        <div style={{ fontSize: 12, color: "#6B7280" }}>
+          {activeRound ? activeRound.name : "Nominate survivors · build the Directory · grow the economy"}
+        </div>
+      </div>
+      {activeRound && (
+        <span style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>Round active</span>
+      )}
+    </header>
+  );
 }
 
-function submissionStatusStyle(status: string): { bg: string; color: string; border: string; label: string } {
-  if (status === "accepted") return { bg: "#22C55E20", color: "#22C55E", border: "#22C55E40", label: "✓ Accepted" };
-  if (status === "rejected") return { bg: "rgba(239,68,68,0.12)", color: "#EF4444", border: "rgba(239,68,68,0.3)", label: "✗ Rejected" };
-  if (status === "flagged")  return { bg: `${COLOR}20`, color: COLOR, border: `${COLOR}40`, label: "⚑ Flagged" };
-  return { bg: "rgba(255,165,0,0.15)", color: "#F59E0B", border: "rgba(255,165,0,0.3)", label: "⏳ Pending" };
+interface ShellData {
+  tab: Tab;
+  setTab: (t: Tab) => void;
+  noActiveRound: boolean;
+  submitted: boolean;
+  form: ScoutFormModel;
+  resetForm: () => void;
+  loadingLeaderboard: boolean;
+  leaderboard: SkillsHuntLeaderboardItem[];
+  userId?: string;
+  loadingMissions: boolean;
+  missions: SkillsHuntMissionWithProgress[];
+  loadingFinds: boolean;
+  myFinds: SkillsHuntSubmission[];
 }
 
-function initials(name: string): string {
-  return name.split(" ").map(n => n[0] ?? "").join("").slice(0, 2).toUpperCase();
+function deriveShellState(args: {
+  leaderboard: SkillsHuntLeaderboardItem[];
+  serverCurrentUserEntry: SkillsHuntLeaderboardItem | null;
+  userId?: string;
+  rounds: SkillsHuntRound[];
+  notifications: SkillsHuntNotification[];
+}) {
+  return {
+    currentUserEntry: args.leaderboard.find((item) => item.userId === args.userId) ?? args.serverCurrentUserEntry,
+    noActiveRound: args.rounds.length === 0,
+    unreadCount: args.notifications.filter((n) => !n.isRead).length,
+  };
+}
+
+function ShellContent(d: ShellData) {
+  if (d.tab === "scout") {
+    return <SkillsHuntScoutTab noActiveRound={d.noActiveRound} submitted={d.submitted} form={d.form} onReset={d.resetForm} onNavTab={d.setTab} />;
+  }
+  if (d.tab === "leaderboard") {
+    return <SkillsHuntLeaderboardTab loading={d.loadingLeaderboard} leaderboard={d.leaderboard} userId={d.userId} />;
+  }
+  if (d.tab === "missions") {
+    return <SkillsHuntMissionsTab noActiveRound={d.noActiveRound} loading={d.loadingMissions} missions={d.missions} onNavTab={d.setTab} />;
+  }
+  return <SkillsHuntMyFindsTab noActiveRound={d.noActiveRound} loading={d.loadingFinds} myFinds={d.myFinds} onNavTab={d.setTab} />;
 }
 
 export function SkillsHuntShell({
@@ -98,20 +110,7 @@ export function SkillsHuntShell({
   const [loadingFinds, setLoadingFinds] = useState(false);
   const [globalError, setGlobalError] = useState<string | null>(null);
 
-  const [displayName, setDisplayName] = useState("");
-  const [bio, setBio] = useState("");
-  const [quora, setQuora] = useState("");
-  const [skills, setSkills] = useState<string[]>([]);
-  const [proposedSkills, setProposed] = useState<string[]>([]);
-  const [freeText, setFreeText] = useState("");
-  const [openCategory, setOpenCategory] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [submitted, setSubmitted] = useState(false);
-
-  const BIO_MAX = 280;
-  const allSkillCount = skills.length + proposedSkills.length;
-  const canAddMore = allSkillCount < 10;
+  const { form, submitted, resetForm } = useNominationForm(activeRound);
 
   const initialTabRead = useRef(false);
   useEffect(() => {
@@ -119,7 +118,7 @@ export function SkillsHuntShell({
     initialTabRead.current = true;
     if (typeof window !== "undefined") {
       const p = new URLSearchParams(window.location.search).get("tab") as Tab | null;
-      if (p && TABS.some(t => t.key === p)) setTab(p);
+      if (p && TABS.some((t) => t.key === p)) setTab(p);
     }
   }, []);
 
@@ -135,11 +134,11 @@ export function SkillsHuntShell({
         ]);
         if (controller.signal.aborted) return;
         if (!roundsRes.ok) throw new Error("rounds");
-        const roundsData = await roundsRes.json() as { rounds: SkillsHuntRound[] };
+        const roundsData = (await roundsRes.json()) as { rounds: SkillsHuntRound[] };
         setRounds(roundsData.rounds);
         setActiveRound(roundsData.rounds[0] ?? null);
         if (achRes.ok) {
-          const achData = await achRes.json() as { achievements: SkillsHuntAchievement[] };
+          const achData = (await achRes.json()) as { achievements: SkillsHuntAchievement[] };
           setAchievements(achData.achievements);
         }
       } catch (e) {
@@ -149,7 +148,7 @@ export function SkillsHuntShell({
         if (!controller.signal.aborted) setLoadingRounds(false);
       }
     }
-    load();
+    void load();
     return () => controller.abort();
   }, []);
 
@@ -161,14 +160,14 @@ export function SkillsHuntShell({
       try {
         const res = await fetch(`/api/skills-hunt/rounds/${activeRound!.id}/leaderboard`, { signal: controller.signal });
         if (controller.signal.aborted || !res.ok) return;
-        const data = await res.json() as { items: SkillsHuntLeaderboardItem[]; currentUserEntry?: SkillsHuntLeaderboardItem | null };
+        const data = (await res.json()) as { items: SkillsHuntLeaderboardItem[]; currentUserEntry?: SkillsHuntLeaderboardItem | null };
         setLeaderboard(data.items);
         setServerCurrentUserEntry(data.currentUserEntry ?? null);
       } finally {
         if (!controller.signal.aborted) setLoadingLeaderboard(false);
       }
     }
-    load();
+    void load();
     return () => controller.abort();
   }, [activeRound]);
 
@@ -180,13 +179,13 @@ export function SkillsHuntShell({
       try {
         const res = await fetch(`/api/skills-hunt/rounds/${activeRound!.id}/submissions`, { signal: controller.signal });
         if (controller.signal.aborted || !res.ok) return;
-        const data = await res.json() as { items: SkillsHuntSubmission[] };
+        const data = (await res.json()) as { items: SkillsHuntSubmission[] };
         setMyFinds(data.items);
       } finally {
         if (!controller.signal.aborted) setLoadingFinds(false);
       }
     }
-    load();
+    void load();
     return () => controller.abort();
   }, [tab, activeRound]);
 
@@ -198,648 +197,64 @@ export function SkillsHuntShell({
       try {
         const res = await fetch(`/api/skills-hunt/rounds/${activeRound!.id}/missions`, { signal: controller.signal });
         if (controller.signal.aborted || !res.ok) return;
-        const data = await res.json() as { items: SkillsHuntMissionWithProgress[] };
+        const data = (await res.json()) as { items: SkillsHuntMissionWithProgress[] };
         setMissions(data.items);
       } finally {
         if (!controller.signal.aborted) setLoadingMissions(false);
       }
     }
-    load();
+    void load();
     return () => controller.abort();
   }, [tab, activeRound]);
 
-  // Notifications: poll every 30s for unread; GetStream is out of scope
-  // (continuity §2.11). Manual refresh on dropdown open + after mark-read.
+  // Notifications: poll every 30s for unread (GetStream is out of scope; continuity §2.11).
   useEffect(() => {
     let cancelled = false;
     async function load() {
       try {
         const res = await fetch("/api/skills-hunt/notifications");
         if (cancelled || !res.ok) return;
-        const data = await res.json() as { notifications: SkillsHuntNotification[] };
+        const data = (await res.json()) as { notifications: SkillsHuntNotification[] };
         setNotifications(data.notifications);
       } catch { /* ignore polling errors */ }
     }
-    load();
+    void load();
     const timer = setInterval(load, 30_000);
     return () => { cancelled = true; clearInterval(timer); };
   }, []);
 
   async function markRead(notificationId: string) {
     try {
-      await fetch(`/api/skills-hunt/notifications/${notificationId}/read`, {
-        method: "POST",
-        headers: { "x-ctf-csrf": "1" },
-      });
-      setNotifications(prev => prev.map(n => n.id === notificationId ? { ...n, isRead: true } : n));
+      await fetch(`/api/skills-hunt/notifications/${notificationId}/read`, { method: "POST", headers: { "x-ctf-csrf": "1" } });
+      setNotifications((prev) => prev.map((n) => (n.id === notificationId ? { ...n, isRead: true } : n)));
     } catch { /* swallow — UX falls through to next poll */ }
   }
 
-  const unreadCount = notifications.filter(n => !n.isRead).length;
+  if (loadingRounds) return <CenteredNote color="#6B7280">Loading Skills Hunt…</CenteredNote>;
+  if (globalError) return <CenteredNote color="#EF4444">{globalError}</CenteredNote>;
 
-  const toggleSkill = (s: string) => {
-    setSkills(prev => prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s]);
-  };
-
-  const addProposed = () => {
-    const tokens = freeText.split(/[,\n]+/).map(t => t.trim()).filter(
-      t => t && t.length <= 40 && !skills.includes(t) && !proposedSkills.includes(t)
-    );
-    if (tokens.length && allSkillCount + tokens.length <= 10) {
-      setProposed(prev => [...prev, ...tokens]);
-    }
-    setFreeText("");
-  };
-
-  async function handleSubmit() {
-    if (!activeRound || displayName.trim().length < 2 || allSkillCount === 0) return;
-    setSubmitting(true);
-    setSubmitError(null);
-    try {
-      const res = await fetch(`/api/skills-hunt/rounds/${activeRound.id}/submissions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          displayName: displayName.trim(),
-          bio: bio.trim(),
-          quoraProfileUrl: quora.trim(),
-          skills,
-          proposedSkills,
-          claimedProfessions: [],
-        }),
-      });
-      if (!res.ok) {
-        const err = await res.json() as { message?: string };
-        throw new Error(err.message ?? "Failed to submit nomination.");
-      }
-      setSubmitted(true);
-    } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : "Failed to submit nomination.");
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  function resetForm() {
-    setDisplayName(""); setBio(""); setQuora("");
-    setSkills([]); setProposed([]); setFreeText("");
-    setSubmitted(false); setSubmitError(null);
-  }
-
-  // Prefer in-list entry (top-100), fall back to server-provided entry for users outside the cap.
-  const currentUserEntry = leaderboard.find(item => item.userId === userId) ?? serverCurrentUserEntry;
-  const noActiveRound = rounds.length === 0;
-
-  if (loadingRounds) {
-    return (
-      <div style={{ width: "100%", minHeight: "100vh", background: "#0F1117", display: "flex", alignItems: "center", justifyContent: "center" }}>
-        <div style={{ fontSize: 14, color: "#6B7280" }}>Loading Skills Hunt…</div>
-      </div>
-    );
-  }
-
-  if (globalError) {
-    return (
-      <div style={{ width: "100%", minHeight: "100vh", background: "#0F1117", display: "flex", alignItems: "center", justifyContent: "center" }}>
-        <div style={{ fontSize: 14, color: "#EF4444" }}>{globalError}</div>
-      </div>
-    );
-  }
+  const { currentUserEntry, noActiveRound, unreadCount } = deriveShellState({ leaderboard, serverCurrentUserEntry, userId, rounds, notifications });
+  const showModeratorTools = isAdmin || isModerator;
 
   return (
-    <div style={{ position: "relative", width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
-
-      {/* Icon rail */}
-      <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
-          <Search size={20} style={{ color: COLOR }} />
-        </div>
-        {TABS.map(({ key, icon: Icon }) => (
-          <button key={key} onClick={() => setTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
-            <Icon size={20} />
-          </button>
-        ))}
-        <div style={{ flex: 1 }} />
-        <button onClick={() => setNotifOpen(o => !o)} style={{ position: "relative", width: 44, height: 44, borderRadius: 12, background: notifOpen ? `${COLOR}20` : "transparent", border: notifOpen ? `1px solid ${COLOR}40` : "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: notifOpen ? COLOR : "#6B7280" }}>
-          <Bell size={18} />
-          {unreadCount > 0 && (
-            <span style={{ position: "absolute", top: 6, right: 6, minWidth: 18, height: 18, borderRadius: 9, background: "#EF4444", color: "#fff", fontSize: 10, fontWeight: 800, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
-              {unreadCount > 99 ? "99+" : unreadCount}
-            </span>
-          )}
-        </button>
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Settings size={18} /></button>
-      </aside>
-
-      {/* Notification popover — anchored to the bell, overlays the secondary sidebar */}
+    <div style={{ position: "relative", width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+      <SkillsHuntIconRail tab={tab} onTab={setTab} notifOpen={notifOpen} onToggleNotif={() => setNotifOpen((o) => !o)} unreadCount={unreadCount} />
       {notifOpen && (
-        <div style={{ position: "absolute", left: 80, top: 60, width: 360, maxHeight: 480, overflowY: "auto", background: "#0D0F14", border: `1px solid ${COLOR}40`, borderRadius: 14, zIndex: 50, boxShadow: "0 12px 32px rgba(0,0,0,0.4)" }}>
-          <div style={{ padding: "12px 16px", borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-            <span style={{ fontSize: 13, fontWeight: 700, color: "#F9FAFB" }}>Notifications</span>
-            <button onClick={() => setNotifOpen(false)} style={{ background: "none", border: "none", color: "#6B7280", cursor: "pointer", fontSize: 18, lineHeight: 1 }}>×</button>
-          </div>
-          {notifications.length === 0 ? (
-            <div style={{ padding: 24, fontSize: 13, color: "#6B7280", textAlign: "center" }}>No notifications yet.</div>
-          ) : (
-            <div>
-              {notifications.map(n => (
-                <button
-                  key={n.id}
-                  onClick={() => !n.isRead && markRead(n.id)}
-                  style={{
-                    display: "block", width: "100%", textAlign: "left",
-                    padding: "10px 16px",
-                    borderBottom: "1px solid rgba(255,255,255,0.04)",
-                    background: n.isRead ? "transparent" : `${COLOR}08`,
-                    border: "none", borderLeft: n.isRead ? "2px solid transparent" : `2px solid ${COLOR}`,
-                    cursor: n.isRead ? "default" : "pointer",
-                  }}
-                >
-                  <div style={{ fontSize: 13, fontWeight: n.isRead ? 500 : 700, color: "#F9FAFB", marginBottom: 2 }}>{n.title}</div>
-                  <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.4 }}>{n.body}</div>
-                  <div style={{ fontSize: 11, color: "#4B5563", marginTop: 4 }}>{new Date(n.createdAtIso).toLocaleString()}</div>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+        <SkillsHuntNotifications notifications={notifications} onClose={() => setNotifOpen(false)} onMarkRead={(id) => void markRead(id)} />
       )}
-
-      {/* Secondary sidebar */}
-      <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
-        <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 4 }}>🔍 Skills Hunt</div>
-          <div style={{ fontSize: 12, color: "#4B5563", lineHeight: 1.5, marginBottom: 12 }}>Nominate survivors — populate the Directory, build the economy.</div>
-        </div>
-        <div style={{ flex: 1, overflowY: "auto", padding: "0 8px 16px" }}>
-          {TABS.map(({ key, icon: Icon, label }) => (
-            <button key={key} onClick={() => setTab(key)} style={{ width: "100%", display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: tab === key ? `${COLOR}18` : "transparent", borderLeft: tab === key ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2, border: "none", textAlign: "left" }}>
-              <Icon size={14} style={{ color: tab === key ? COLOR : "#6B7280" }} />
-              <span style={{ fontSize: 13, color: tab === key ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{label}</span>
-            </button>
-          ))}
-
-          {achievements.length > 0 && (
-            <>
-              <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", padding: "0 10px" }}>Your Badges</div>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, padding: "0 10px" }}>
-                {achievements.map((a) => {
-                  const meta = BADGE_META[a.code] ?? { emoji: "🏅", desc: a.description };
-                  return (
-                    <div key={a.id} title={`${a.title}: ${meta.desc}`} style={{ width: 32, height: 32, borderRadius: 8, background: `${COLOR}20`, border: `1px solid ${COLOR}40`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 16, cursor: "pointer" }}>
-                      {meta.emoji}
-                    </div>
-                  );
-                })}
-              </div>
-            </>
-          )}
-        </div>
-
-        {currentUserEntry && (
-          <div style={{ padding: 12, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
-            <div style={{ padding: "10px 12px", borderRadius: 10, background: `${COLOR}10`, border: `1px solid ${COLOR}25` }}>
-              <div style={{ fontSize: 12, fontWeight: 600, color: COLOR, marginBottom: 2 }}>Your Scouting Score</div>
-              <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB" }}>{currentUserEntry.score} pts</div>
-              <div style={{ fontSize: 11, color: "#6B7280" }}>
-                {currentUserEntry.acceptedCount} accepted · +{currentUserEntry.pendingPoints} pending · Rank #{currentUserEntry.rank}
-              </div>
-            </div>
-          </div>
-        )}
-      </aside>
-
-      {/* Main content */}
+      <SkillsHuntSidebar tab={tab} onTab={setTab} achievements={achievements} currentUserEntry={currentUserEntry} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <Search size={18} style={{ color: COLOR }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Skills Hunt</div>
-            <div style={{ fontSize: 12, color: "#6B7280" }}>
-              {activeRound ? activeRound.name : "Nominate survivors · build the Directory · grow the economy"}
-            </div>
-          </div>
-          {activeRound && (
-            <span style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>Round active</span>
-          )}
-        </header>
-
+        <ShellHeader activeRound={activeRound} />
         <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
-
-          {/* SCOUT TAB */}
-          {tab === "scout" && (
-            noActiveRound ? (
-              <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "60px 24px", gap: 20, textAlign: "center" }}>
-                <div style={{ width: 72, height: 72, borderRadius: 20, background: `${COLOR}10`, border: `1px dashed ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
-                  <Search size={32} style={{ color: COLOR, opacity: 0.5 }} />
-                </div>
-                <div>
-                  <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 8 }}>No active round right now</div>
-                  <div style={{ fontSize: 14, color: "#6B7280", maxWidth: 400, lineHeight: 1.7 }}>Check back soon — rounds open when there are survivors ready to be nominated. Your nominations help build the Directory so the economy can grow.</div>
-                </div>
-              </div>
-            ) : submitted ? (
-              <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "60px 24px", gap: 16, textAlign: "center" }}>
-                <div style={{ width: 72, height: 72, borderRadius: "50%", background: "#22C55E20", border: "1px solid #22C55E40", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                  <CheckCircle size={36} style={{ color: "#22C55E" }} />
-                </div>
-                <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB" }}>Nomination submitted!</div>
-                <div style={{ fontSize: 14, color: "#6B7280", maxWidth: 400, lineHeight: 1.7 }}>
-                  Thank you for growing the network. This submission is under review — you&apos;ll earn points once accepted.
-                </div>
-                <div style={{ display: "flex", gap: 12 }}>
-                  <button onClick={resetForm} style={{ padding: "12px 24px", borderRadius: 12, background: COLOR, border: "none", color: "#fff", fontSize: 14, fontWeight: 700, cursor: "pointer" }}>Nominate Another</button>
-                  <button onClick={() => setTab("leaderboard")} style={{ padding: "12px 24px", borderRadius: 12, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "#9CA3AF", fontSize: 14, fontWeight: 600, cursor: "pointer" }}>View Leaderboard</button>
-                </div>
-              </div>
-            ) : (
-              <div style={{ display: "flex", gap: 24 }}>
-                <div style={{ flex: 1, maxWidth: 580 }}>
-                  <div style={{ marginBottom: 20 }}>
-                    <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Nominate a Survivor</div>
-                    <div style={{ fontSize: 13, color: "#6B7280", lineHeight: 1.6 }}>Think of someone you believe may be a survivor — you don&apos;t need to be 100% certain. Their Quora profile helps verify their identity, and their skills join our economy.</div>
-                  </div>
-
-                  {submitError && (
-                    <div style={{ marginBottom: 16, padding: "10px 14px", borderRadius: 10, background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)", color: "#EF4444", fontSize: 13 }}>{submitError}</div>
-                  )}
-
-                  <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-
-                    <div>
-                      <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
-                        Display Name <span style={{ color: COLOR }}>*</span>
-                        <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400, marginLeft: 6 }}>2–100 chars, letters and spaces only</span>
-                      </label>
-                      <input
-                        value={displayName}
-                        onChange={e => setDisplayName(e.target.value.replace(/[^a-zA-Z\s]/g, "").slice(0, 100))}
-                        placeholder="e.g. Amara Williams"
-                        style={{ width: "100%", padding: "10px 14px", background: "rgba(255,255,255,0.04)", border: `1px solid ${displayName.length >= 2 ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", boxSizing: "border-box" }}
-                      />
-                      <div style={{ fontSize: 11, color: "#4B5563", textAlign: "right", marginTop: 3 }}>{displayName.length}/100</div>
-                    </div>
-
-                    <div>
-                      <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
-                        Bio <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400 }}>(optional)</span>
-                      </label>
-                      <textarea
-                        value={bio}
-                        onChange={e => setBio(e.target.value.slice(0, BIO_MAX))}
-                        rows={2}
-                        placeholder="e.g. Lives in Houston, works in construction, connected through mutual contact…"
-                        style={{ width: "100%", padding: "10px 14px", background: "rgba(255,255,255,0.04)", border: `1px solid ${bio ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, borderRadius: 10, fontSize: 14, color: "#E8EAF0", outline: "none", resize: "vertical", boxSizing: "border-box", fontFamily: "inherit" }}
-                      />
-                      <div style={{ fontSize: 11, color: bio.length > 240 ? "#F59E0B" : "#4B5563", textAlign: "right", marginTop: 3 }}>{bio.length}/{BIO_MAX}</div>
-                    </div>
-
-                    <div>
-                      <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
-                        Quora Profile URL <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400 }}>(social proof — highly recommended)</span>
-                      </label>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", background: "rgba(255,255,255,0.04)", border: `1px solid ${quora ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, borderRadius: 10 }}>
-                        <ExternalLink size={14} style={{ color: "#6B7280", flexShrink: 0 }} />
-                        <input
-                          value={quora}
-                          onChange={e => setQuora(e.target.value)}
-                          placeholder="https://quora.com/profile/..."
-                          style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: "#E8EAF0" }}
-                        />
-                      </div>
-                      <div style={{ fontSize: 11, color: "#4B5563", marginTop: 4 }}>Quora activity helps verify this is a real person — reduces risk of trafficker infiltration.</div>
-                    </div>
-
-                    <div>
-                      <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
-                        Skills <span style={{ color: COLOR }}>*</span>
-                        <span style={{ fontSize: 11, color: "#4B5563", fontWeight: 400, marginLeft: 6 }}>pick from taxonomy (max 10)</span>
-                      </label>
-
-                      {(skills.length > 0 || proposedSkills.length > 0) && (
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 10 }}>
-                          {skills.map(s => (
-                            <span key={s} style={{ display: "flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 20, background: `${COLOR}20`, border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600 }}>
-                              {s}
-                              <button onClick={() => toggleSkill(s)} style={{ background: "none", border: "none", color: COLOR, cursor: "pointer", padding: 0, lineHeight: 1 }}><X size={11} /></button>
-                            </span>
-                          ))}
-                          {proposedSkills.map(s => (
-                            <span key={s} style={{ display: "flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 20, background: "rgba(251,191,36,0.12)", border: "1px solid rgba(251,191,36,0.3)", fontSize: 12, color: "#FBBF24", fontWeight: 600 }}>
-                              {s} <span style={{ fontSize: 10, opacity: 0.7 }}>✎</span>
-                              <button onClick={() => setProposed(prev => prev.filter(x => x !== s))} style={{ background: "none", border: "none", color: "#FBBF24", cursor: "pointer", padding: 0, lineHeight: 1 }}><X size={11} /></button>
-                            </span>
-                          ))}
-                        </div>
-                      )}
-
-                      {canAddMore && (
-                        <div style={{ border: "1px solid rgba(255,255,255,0.1)", borderRadius: 10, overflow: "hidden", marginBottom: 10 }}>
-                          {Object.entries(SKILL_TAXONOMY).map(([category, categorySkills]) => (
-                            <div key={category}>
-                              <button
-                                onClick={() => setOpenCategory(openCategory === category ? null : category)}
-                                style={{ width: "100%", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "10px 14px", background: openCategory === category ? `${COLOR}10` : "rgba(255,255,255,0.02)", border: "none", borderBottom: "1px solid rgba(255,255,255,0.06)", cursor: "pointer", color: openCategory === category ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600 }}
-                              >
-                                <span>{category}</span>
-                                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                                  {categorySkills.filter(s => skills.includes(s)).length > 0 && (
-                                    <span style={{ fontSize: 11, background: `${COLOR}25`, color: COLOR, borderRadius: 10, padding: "1px 7px", fontWeight: 700 }}>
-                                      {categorySkills.filter(s => skills.includes(s)).length} selected
-                                    </span>
-                                  )}
-                                  <ChevronDown size={14} style={{ transform: openCategory === category ? "rotate(180deg)" : "none", transition: "transform 0.15s" }} />
-                                </div>
-                              </button>
-                              {openCategory === category && (
-                                <div style={{ padding: "10px 14px", display: "flex", flexWrap: "wrap", gap: 7, background: "rgba(255,255,255,0.01)" }}>
-                                  {categorySkills.map(s => {
-                                    const selected = skills.includes(s);
-                                    return (
-                                      <button
-                                        key={s}
-                                        onClick={() => { if (canAddMore || selected) toggleSkill(s); }}
-                                        style={{ padding: "4px 12px", borderRadius: 20, background: selected ? `${COLOR}25` : "rgba(255,255,255,0.04)", border: `1px solid ${selected ? COLOR + "60" : "rgba(255,255,255,0.08)"}`, color: selected ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: selected ? 700 : 400, cursor: canAddMore || selected ? "pointer" : "default", opacity: !canAddMore && !selected ? 0.4 : 1 }}
-                                      >
-                                        {selected ? "✓ " : ""}{s}
-                                      </button>
-                                    );
-                                  })}
-                                </div>
-                              )}
-                            </div>
-                          ))}
-                        </div>
-                      )}
-
-                      {canAddMore && (
-                        <div>
-                          <div style={{ fontSize: 11, color: "#4B5563", marginBottom: 6 }}>Don&apos;t see what you need? Add free-text skills (comma or newline separated — each ≤ 40 chars):</div>
-                          <div style={{ display: "flex", gap: 8 }}>
-                            <input
-                              value={freeText}
-                              onChange={e => setFreeText(e.target.value)}
-                              onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); addProposed(); } }}
-                              placeholder="e.g. Tie-dye, Beekeeping, Kintsugi…"
-                              style={{ flex: 1, padding: "8px 12px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: "#E8EAF0", outline: "none" }}
-                            />
-                            <button onClick={addProposed} style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(251,191,36,0.1)", border: "1px solid rgba(251,191,36,0.25)", color: "#FBBF24", cursor: "pointer", fontSize: 12, fontWeight: 600 }}>Add</button>
-                          </div>
-                          <div style={{ fontSize: 11, color: "#4B5563", marginTop: 4 }}>Yellow chips = proposed skills — admin can promote them to the taxonomy later.</div>
-                        </div>
-                      )}
-
-                      {!canAddMore && <div style={{ fontSize: 11, color: "#6B7280", padding: "6px 0" }}>Maximum 10 skills reached.</div>}
-                      <div style={{ fontSize: 11, color: "#4B5563", marginTop: 6 }}>{allSkillCount}/10 skills added</div>
-                    </div>
-
-                    <button
-                      onClick={handleSubmit}
-                      disabled={submitting || displayName.trim().length < 2 || allSkillCount === 0}
-                      style={{ padding: "14px", borderRadius: 12, background: (displayName.trim().length >= 2 && allSkillCount > 0 && !submitting) ? COLOR : "rgba(255,255,255,0.05)", border: "none", color: (displayName.trim().length >= 2 && allSkillCount > 0 && !submitting) ? "#fff" : "#4B5563", fontSize: 15, fontWeight: 700, cursor: (displayName.trim().length >= 2 && allSkillCount > 0 && !submitting) ? "pointer" : "default", display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}
-                    >
-                      <Send size={16} /> {submitting ? "Submitting…" : "Submit Nomination · earn points on acceptance"}
-                    </button>
-                  </div>
-                </div>
-
-                <div style={{ width: 260, flexShrink: 0 }}>
-                  <div style={{ padding: "18px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-                    <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, marginBottom: 12 }}>Why this works</div>
-                    {[
-                      { icon: "🧩", text: "You nominate someone you believe may be a survivor — certainty not required" },
-                      { icon: "🔗", text: "Quora profile = social proof, reducing trafficker infiltration risk" },
-                      { icon: "⚡", text: "Skills from the taxonomy populate the Directory so we can trade and build our own economy" },
-                      { icon: "🏆", text: "Points are granted on admin acceptance — taxonomy skills earn more" },
-                    ].map((item, i) => (
-                      <div key={i} style={{ display: "flex", gap: 10, marginBottom: 12, alignItems: "flex-start" }}>
-                        <span style={{ fontSize: 18, flexShrink: 0 }}>{item.icon}</span>
-                        <span style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.5 }}>{item.text}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            )
-          )}
-
-          {/* LEADERBOARD TAB */}
-          {tab === "leaderboard" && (
-            <>
-              <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Scout Leaderboard</div>
-              <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 4 }}>Ranked by accepted points · tie-break: first-match count, then earliest submission</div>
-              <div style={{ fontSize: 12, color: "#4B5563", marginBottom: 20 }}>Pending points (⏳) convert to accepted points after admin review.</div>
-
-              {loadingLeaderboard ? (
-                <div style={{ fontSize: 14, color: "#6B7280" }}>Loading leaderboard…</div>
-              ) : leaderboard.length === 0 ? (
-                <div style={{ fontSize: 14, color: "#6B7280" }}>No entries yet — be the first scout!</div>
-              ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-                  {leaderboard.map((p) => {
-                    const isMe = p.userId === userId;
-                    return (
-                      <div key={p.rank} style={{ padding: "16px 20px", borderRadius: 14, background: isMe ? `${COLOR}12` : "rgba(255,255,255,0.02)", border: `1px solid ${isMe ? COLOR + "40" : "rgba(255,255,255,0.06)"}`, display: "flex", alignItems: "center", gap: 16 }}>
-                        <div style={{ width: 32, height: 32, borderRadius: 8, background: p.rank <= 3 ? `${rankColor(p.rank)}20` : "rgba(255,255,255,0.04)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 16, fontWeight: 800, color: rankColor(p.rank), flexShrink: 0 }}>
-                          {rankDisplay(p.rank)}
-                        </div>
-                        <div style={{ width: 40, height: 40, borderRadius: "50%", background: `${COLOR}25`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 15, fontWeight: 800, color: COLOR, flexShrink: 0 }}>
-                          {initials(p.usernameSnapshot ?? "?")}
-                        </div>
-                        <div style={{ flex: 1 }}>
-                          <div style={{ fontSize: 14, fontWeight: 700, color: isMe ? COLOR : "#F9FAFB" }}>
-                            {p.usernameSnapshot ?? "Anonymous"}{isMe ? " (You)" : ""}
-                          </div>
-                          <div style={{ fontSize: 12, color: "#6B7280" }}>
-                            {p.acceptedCount} accepted · {p.firstMatchCount} first-match{p.firstMatchCount !== 1 ? "es" : ""}
-                          </div>
-                        </div>
-                        <div style={{ textAlign: "right" }}>
-                          <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>{p.score} pts</div>
-                          {p.pendingPoints > 0 && (
-                            <div style={{ fontSize: 11, color: "#F59E0B" }}>+{p.pendingPoints} ⏳ pending</div>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </>
-          )}
-
-          {tab === "missions" && (
-            <>
-              <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Active Missions</div>
-              <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>Complete missions to earn bonus points and unlock badges</div>
-              {noActiveRound ? (
-                <div style={{ fontSize: 14, color: "#6B7280" }}>No active round — no missions yet.</div>
-              ) : loadingMissions ? (
-                <div style={{ fontSize: 14, color: "#6B7280" }}>Loading missions…</div>
-              ) : missions.length === 0 ? (
-                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "40px 24px", gap: 16, textAlign: "center" }}>
-                  <div style={{ width: 64, height: 64, borderRadius: 20, background: `${COLOR}10`, border: `1px dashed ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
-                    <Target size={28} style={{ color: COLOR, opacity: 0.5 }} />
-                  </div>
-                  <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>No missions for this round yet</div>
-                  <div style={{ fontSize: 13, color: "#6B7280", maxWidth: 360, lineHeight: 1.7 }}>An admin can publish missions for this round; they&apos;ll appear here.</div>
-                </div>
-              ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-                  {missions.map((m) => {
-                    const isLocked = m.status === "locked";
-                    const color = m.colorHex ?? COLOR;
-                    const progressCount = m.progress?.progressCount ?? 0;
-                    const pct = Math.min(100, (progressCount / Math.max(1, m.goalTarget)) * 100);
-                    const isComplete = m.progress?.completedAtIso != null;
-                    return (
-                      <div key={m.id} style={{ padding: "20px 24px", borderRadius: 16, background: "rgba(255,255,255,0.02)", border: `1px solid ${isLocked ? "rgba(255,255,255,0.06)" : color + "35"}`, opacity: isLocked ? 0.6 : 1 }}>
-                        <div style={{ display: "flex", alignItems: "flex-start", gap: 16 }}>
-                          <div style={{ flex: 1 }}>
-                            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
-                              <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>{m.title}</div>
-                              {isLocked && <span style={{ fontSize: 11, color: "#4B5563" }}>🔒</span>}
-                              {isComplete && <span style={{ fontSize: 11, color: "#22C55E", fontWeight: 700 }}>✓ Complete</span>}
-                            </div>
-                            {m.description && <div style={{ fontSize: 12, color: "#9CA3AF", marginBottom: 10, lineHeight: 1.5 }}>{m.description}</div>}
-                            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 4, color: "#6B7280" }}>
-                              <span>{progressCount}/{m.goalTarget} complete</span>
-                              {m.bonusPoints > 0 && <span style={{ color, fontWeight: 700 }}>+{m.bonusPoints} pts</span>}
-                            </div>
-                            <div style={{ height: 6, background: "rgba(255,255,255,0.05)", borderRadius: 3, overflow: "hidden" }}>
-                              <div style={{ height: "100%", background: color, borderRadius: 3, width: `${pct}%` }} />
-                            </div>
-                          </div>
-                          <button onClick={() => setTab("scout")} disabled={isLocked} style={{ padding: "10px 20px", borderRadius: 10, background: isLocked ? "rgba(255,255,255,0.04)" : color, border: "none", color: isLocked ? "#4B5563" : "#fff", fontSize: 13, fontWeight: 700, cursor: isLocked ? "default" : "pointer" }}>
-                            {isLocked ? "Locked" : "Scout Now"}
-                          </button>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </>
-          )}
-
-          {/* MY FINDS TAB */}
-          {tab === "my-finds" && (
-            <>
-              <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>My Finds</div>
-              <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>People you&apos;ve nominated · display names only for privacy</div>
-
-              {noActiveRound ? (
-                <div style={{ fontSize: 14, color: "#6B7280" }}>No active round — no finds to display.</div>
-              ) : loadingFinds ? (
-                <div style={{ fontSize: 14, color: "#6B7280" }}>Loading your finds…</div>
-              ) : myFinds.length === 0 ? (
-                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "40px 24px", gap: 16, textAlign: "center" }}>
-                  <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>No nominations yet</div>
-                  <div style={{ fontSize: 13, color: "#6B7280", maxWidth: 360, lineHeight: 1.7 }}>Switch to the Scout tab to nominate your first survivor.</div>
-                  <button onClick={() => setTab("scout")} style={{ padding: "10px 24px", borderRadius: 10, background: COLOR, border: "none", color: "#fff", fontSize: 13, fontWeight: 700, cursor: "pointer", display: "flex", alignItems: "center", gap: 8 }}>
-                    <Plus size={14} /> Nominate a Survivor
-                  </button>
-                </div>
-              ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  {myFinds.map((f) => {
-                    const st = submissionStatusStyle(f.status);
-                    return (
-                      <div key={f.id} style={{ padding: "16px 20px", borderRadius: 14, background: "rgba(255,255,255,0.02)", border: `1px solid ${f.status === "accepted" ? "#22C55E20" : "rgba(255,255,255,0.06)"}`, display: "flex", alignItems: "flex-start", gap: 16 }}>
-                        <div style={{ width: 40, height: 40, borderRadius: "50%", background: `${COLOR}20`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 14, fontWeight: 700, color: COLOR, flexShrink: 0 }}>
-                          {initials(f.displayName)}
-                        </div>
-                        <div style={{ flex: 1 }}>
-                          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
-                            <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB" }}>{f.displayName}</div>
-                            <span style={{ padding: "2px 8px", borderRadius: 10, fontSize: 11, fontWeight: 700, background: st.bg, color: st.color, border: `1px solid ${st.border}` }}>
-                              {st.label}
-                            </span>
-                            {f.quoraProfileUrl && <span style={{ fontSize: 11, color: "#4B5563" }}>Quora ✓</span>}
-                          </div>
-                          {(f.skills.length > 0 || f.proposedSkills.length > 0) && (
-                            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                              {f.skills.map(s => (
-                                <span key={s} style={{ padding: "2px 8px", borderRadius: 10, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", fontSize: 12, color: "#9CA3AF" }}>{s}</span>
-                              ))}
-                              {f.proposedSkills.map(s => (
-                                <span key={s} style={{ padding: "2px 8px", borderRadius: 10, background: "rgba(251,191,36,0.08)", border: "1px solid rgba(251,191,36,0.2)", fontSize: 12, color: "#FBBF24" }}>{s}</span>
-                              ))}
-                            </div>
-                          )}
-                          {f.pointsAwarded > 0 && (
-                            <div style={{ fontSize: 12, color: COLOR, marginTop: 6, fontWeight: 600 }}>+{f.pointsAwarded} pts earned</div>
-                          )}
-                        </div>
-                        <div style={{ fontSize: 11, color: "#4B5563", flexShrink: 0 }}>{new Date(f.createdAtIso).toLocaleDateString()}</div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </>
-          )}
-
+          <ShellContent
+            tab={tab} setTab={setTab} noActiveRound={noActiveRound} submitted={submitted} form={form} resetForm={resetForm}
+            loadingLeaderboard={loadingLeaderboard} leaderboard={leaderboard} userId={userId}
+            loadingMissions={loadingMissions} missions={missions}
+            loadingFinds={loadingFinds} myFinds={myFinds}
+          />
         </div>
       </div>
-
-      {/* Right panel */}
-      <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0, overflowY: "auto" }}>
-        {currentUserEntry ? (
-          <>
-            <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Your Scout Stats</div>
-            <div style={{ padding: "16px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}20`, marginBottom: 16 }}>
-              <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
-                {[
-                  { l: "Accepted", v: String(currentUserEntry.acceptedCount) },
-                  { l: "Pending ⏳", v: String(currentUserEntry.pendingPoints) },
-                  { l: "Rank", v: `#${currentUserEntry.rank}` },
-                ].map(({ l, v }) => (
-                  <div key={l} style={{ flex: 1, textAlign: "center", padding: "10px 6px", borderRadius: 10, background: "rgba(255,255,255,0.04)" }}>
-                    <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>{v}</div>
-                    <div style={{ fontSize: 10, color: "#6B7280" }}>{l}</div>
-                  </div>
-                ))}
-              </div>
-              {currentUserEntry.rareSkillBonus > 0 && (
-                <div style={{ fontSize: 12, color: "#6B7280" }}>💎 {currentUserEntry.rareSkillBonus} rare skill pts</div>
-              )}
-            </div>
-          </>
-        ) : (
-          <div style={{ padding: "16px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}20`, marginBottom: 16 }}>
-            <div style={{ fontSize: 13, fontWeight: 600, color: COLOR, marginBottom: 4 }}>Start scouting</div>
-            <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.5 }}>Nominate your first survivor to appear on the leaderboard.</div>
-          </div>
-        )}
-
-        {achievements.length > 0 && (
-          <>
-            <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Badges Earned</div>
-            {achievements.map(a => {
-              const meta = BADGE_META[a.code] ?? { emoji: "🏅", desc: a.description };
-              return (
-                <div key={a.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 10px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}15`, marginBottom: 6 }}>
-                  <div style={{ fontSize: 20 }}>{meta.emoji}</div>
-                  <div style={{ flex: 1 }}>
-                    <div style={{ fontSize: 13, color: "#E8EAF0" }}>{a.title}</div>
-                    <div style={{ fontSize: 11, color: "#4B5563" }}>{meta.desc}</div>
-                  </div>
-                </div>
-              );
-            })}
-          </>
-        )}
-
-        {(isAdmin || isModerator) && (
-          <div style={{ marginTop: 16, padding: "14px 16px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
-            <div style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", marginBottom: 8 }}>Moderator Tools</div>
-            <a href="/admin/skills-hunt" style={{ display: "block", padding: "8px 12px", borderRadius: 8, background: `${COLOR}10`, border: `1px solid ${COLOR}25`, color: COLOR, fontSize: 12, fontWeight: 600, textDecoration: "none", textAlign: "center" }}>
-              Admin Panel →
-            </a>
-          </div>
-        )}
-      </aside>
+      <SkillsHuntRightPanel currentUserEntry={currentUserEntry} achievements={achievements} showModeratorTools={showModeratorTools} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

UI circle-back: Skills Hunt **user shell** web pixel pass. The shell was already fully real-data-driven (no mocks). This aligns it to `design/.../survivor-hub/SkillsHunt.tsx` and breaks the 845-line monolith into modular sub-components within rule-116 limits (shell now ~259 lines).

### Components
- `sh-shared.ts` — palette, skill taxonomy, badge meta, type re-exports, helpers
- `sh-use-nomination-form.ts` — nomination form state + submit/reset hook
- `sh-icon-rail` / `sh-notifications` / `sh-sidebar` / `sh-right-panel` — chrome
- `sh-skills-picker` — taxonomy accordion + chips + free-text proposals
- `sh-scout-tab` — nomination form (no-active-round / submitted / form states)
- `sh-leaderboard-tab` / `sh-missions-tab` / `sh-my-finds-tab` — tab panels
- `skills-hunt-shell.tsx` — thin composer (`deriveShellState` + `ShellContent` dispatch)

### Alignment & a11y
- Brand color `#A855F7` → design `#D946EF`.
- `aria-label` / `aria-current` on icon-only rail buttons; `aria-label` on form inputs and notification controls.
- Emoji badges/medals kept — they match the design mockup; the icon rail uses lucide.

### Data binding
Unchanged — all tabs bind real `rounds` / `leaderboard` / `missions` / `submissions` / `achievements` / `notifications` routes; no fabricated figures. Submission POST and notification mark-read behavior preserved exactly.

### Scope note
The separate admin moderation shell (`/admin/skills-hunt`, `skills-hunt-admin-shell.tsx`, 228-line render) is a **tracked rule-116 follow-up** — left untouched to keep this PR focused.

### Docs
- `PRODUCTION_READINESS_PLAN.md`: skills-hunt row flipped (row-only, per #164's convention).
- skills-hunt inventory: delivery-status update + change-log entry.

### Gates (local)
typecheck, modularity, flat lint, `build:ci`, EOF, web/android parity, schema-drift — all green.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_