### PR TITLE
fix: service-credits web pixel pass + rule-116 decomposition + transfer bug

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -118,7 +118,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | gentlepulse | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | weekly-performance | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | gdp | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
-| service-credits | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| service-credits | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | levelup | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | trust | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | clicklog | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-feature-inventory.md
@@ -216,7 +216,7 @@ Domain tables:
 
 ## 6) Web and Android Delivery Status
 
-`web+android complete`. Wallet creation, balance retrieval, transfer initiation, escrow resolution, governance, and treasury admin surfaces are consistent across web (`/apps/service-credits`) and Android (`packages/mobile/src/features/service-credits`). Error semantics and deny reasons match across platforms.
+`web+android complete` (functional). Wallet creation, balance retrieval, transfer initiation, escrow resolution, governance, and treasury admin surfaces are consistent across web (`/apps/service-credits`) and Android (`packages/mobile/src/features/service-credits`). Error semantics and deny reasons match across platforms. Web pixel pass complete: the shell (`service-credits-shell.tsx` + `sc-*` sub-components) is aligned to `design/.../survivor-hub/ServiceCredits.tsx` and decomposed within rule-116 limits. Per brand rules, balances render as "credits" only (never a fiat equivalent); per the real-data-only rule the design's hardcoded platform stats (issued/circulating/avg balance) and per-row "Start"/"chat" actions are omitted. Android pixel parity (`MobileServiceCredits.tsx`) is tracked for the dedicated Android sweep.
 
 ---
 
@@ -237,6 +237,7 @@ Service Credits seeds wallets, transfers, escrow holds, and dispute fixtures via
 
 ## 10) Change Log
 
+- 2026-05-30: Web pixel pass — aligned the shell to `design/.../survivor-hub/ServiceCredits.tsx` and decomposed the 556-line monolith into modular sub-components (`sc-shared.ts`, `sc-icon-rail`, `sc-sidebar`, `sc-wallet-tab`, `sc-earn-tab`, `sc-info-tab`, `sc-send-panel`, thin shell) within rule-116 limits. Fixed a real transfer bug: the prior shell POSTed `{ toUserId, amount }` with no `idempotencyKey` and no `x-ctf-csrf` header, so `/api/service-credits/transfers` rejected every peer transfer (CSRF + required-field 400s); the Send panel now sends `{ recipientUserId, amount, idempotencyKey }` with the CSRF header. Brand: fixed "Service Credits" → "ServiceCredits" in the info copy; balances render as "credits" only (no fiat). Per real-data-only, omitted the design's hardcoded platform stats and the non-functional per-row "Start"/chat actions; aria-labels added to icon rail + transfer inputs. Dropped unused `userId`/`isAdmin` props at the call site. No schema/route/contract changes.
 - 2026-05-18: Replaced "Web and Android Parity Plan" with canonical "Web and Android Delivery Status" (`web+android complete`); removed web-first/Android-backlog language. Renamed "Gaps, Ambiguities, and Technical Debt (Current)" to canonical "Gaps and Known Technical Debt" and removed Android-parity-timeline-pending entry per Rule 105.
 - 2026-02-25: Added approved account-deletion treasury reclaim policy.
 - 2026-02-24: Initial Service Credits CTF rewrite inventory created.

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -238,7 +238,7 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (selectedPlugin.slug === 'service-credits') {
-    return <ServiceCreditsShell userId={decision.userId} isAdmin={decision.isAdmin} />;
+    return <ServiceCreditsShell />;
   }
 
   if (selectedPlugin.slug === 'levelup') {

--- a/ctf/packages/web/components/service-credits/sc-earn-tab.tsx
+++ b/ctf/packages/web/components/service-credits/sc-earn-tab.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { COLOR } from "./sc-shared";
+import { EARN_METHODS, SPEND_OPTIONS } from "./service-credits.constants";
+
+// Static program guide describing real earn/spend mechanics across plugins.
+// The design's per-row "Start →" button is omitted — it has no backing action
+// here (each program lives in its own plugin), so we show the reward only
+// rather than a non-functional button.
+export function ServiceCreditsEarnTab() {
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ padding: "24px" }}>
+        <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Earn ServiceCredits</div>
+        <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>Contribute to the community and get rewarded</div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, marginBottom: 28 }}>
+          {EARN_METHODS.map((m) => (
+            <div key={m.title} style={{ padding: "18px 20px", borderRadius: 14, background: "rgba(255,255,255,0.02)", border: `1px solid ${m.color}25`, display: "flex", alignItems: "center", gap: 16 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB", marginBottom: 4 }}>{m.title}</div>
+                <Badge style={{ background: `${m.color}15`, color: m.color, border: `1px solid ${m.color}30`, fontSize: 11 }}>{m.difficulty}</Badge>
+              </div>
+              <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>{m.credits}</div>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 12 }}>Where to Spend</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 10 }}>
+          {SPEND_OPTIONS.map((s) => (
+            <div key={s.title} style={{ padding: "16px", borderRadius: 14, background: `${s.color}08`, border: `1px solid ${s.color}20` }}>
+              <div style={{ fontSize: 28, marginBottom: 8 }}>{s.icon}</div>
+              <div style={{ fontSize: 13, fontWeight: 700, color: "#E8EAF0", marginBottom: 4 }}>{s.title}</div>
+              <div style={{ fontSize: 12, color: s.color, fontWeight: 600 }}>{s.credits}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/ctf/packages/web/components/service-credits/sc-icon-rail.tsx
+++ b/ctf/packages/web/components/service-credits/sc-icon-rail.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Coins, TrendingUp, MessageSquare, Bell, Settings } from "lucide-react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { COLOR, type Tab } from "./sc-shared";
+
+const TABS: { icon: React.ElementType; key: Tab; label: string }[] = [
+  { icon: Coins, key: "wallet", label: "Wallet" },
+  { icon: TrendingUp, key: "earn", label: "Earn" },
+  { icon: MessageSquare, key: "info", label: "Info" },
+];
+
+const railBtn: React.CSSProperties = {
+  width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer",
+};
+
+export function ServiceCreditsIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => void }) {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <Coins size={20} style={{ color: COLOR }} />
+      </div>
+      {TABS.map(({ icon: Icon, key, label }) => (
+        <button key={key} type="button" aria-label={label} aria-current={tab === key ? "page" : undefined} onClick={() => onTab(key)}
+          style={{ ...railBtn, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", color: tab === key ? COLOR : "#6B7280" }}>
+          <Icon size={20} />
+        </button>
+      ))}
+      <div style={{ flex: 1 }} />
+      <button type="button" aria-label="Notifications" style={{ ...railBtn, background: "transparent", border: "none", color: "#6B7280" }}><Bell size={18} /></button>
+      <button type="button" aria-label="Settings" style={{ ...railBtn, background: "transparent", border: "none", color: "#6B7280" }}><Settings size={18} /></button>
+      <Avatar style={{ width: 36, height: 36 }}>
+        <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
+      </Avatar>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/service-credits/sc-info-tab.tsx
+++ b/ctf/packages/web/components/service-credits/sc-info-tab.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Coins } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { COLOR } from "./sc-shared";
+import { INFO_MSGS } from "./service-credits.constants";
+
+// Informational panel (the design's "chat" tab) — static explainer messages
+// about how ServiceCredits work. No AI/Stream chat is wired; the real transfer
+// action lives in the right-hand Send panel.
+export function ServiceCreditsInfoTab() {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <ScrollArea style={{ flex: 1, padding: "24px" }}>
+        <div style={{ padding: "0 0 16px" }}>
+          {INFO_MSGS.map((msg) => (
+            <div key={msg.id} style={{ display: "flex", gap: 10, alignItems: "flex-end", marginBottom: 12 }}>
+              <div style={{ width: 32, height: 32, borderRadius: 10, background: `${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+                <Coins size={14} style={{ color: COLOR }} />
+              </div>
+              <div style={{ maxWidth: "70%" }}>
+                <div style={{ padding: "12px 16px", borderRadius: "16px 16px 16px 4px", background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.06)", fontSize: 14, lineHeight: 1.6, color: "#E8EAF0" }}>
+                  {msg.text}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+      <div style={{ padding: "8px 24px 20px", flexShrink: 0, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+        <div style={{ textAlign: "center", fontSize: 12, color: "#4B5563" }}>Use the Send Credits panel on the right to transfer credits to another member.</div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/service-credits/sc-send-panel.tsx
+++ b/ctf/packages/web/components/service-credits/sc-send-panel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle, Shield } from "lucide-react";
+import { ACCEPTED_APPS, COLOR, type WalletData, idempotencyKey } from "./sc-shared";
+
+const inputField: React.CSSProperties = {
+  width: "100%", padding: "10px 12px", background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 8, fontSize: 13, color: "#E8EAF0", outline: "none", marginBottom: 12, boxSizing: "border-box",
+};
+const inputLabel: React.CSSProperties = { fontSize: 12, color: "#9CA3AF", marginBottom: 6, display: "block" };
+
+function SendForm({ wallet, onSent }: { wallet: WalletData | null; onSent: () => Promise<void> }) {
+  const [recipient, setRecipient] = useState("");
+  const [amount, setAmount] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const numeric = Number(amount);
+  const canSend = !submitting && recipient.trim().length > 0 && amount.length > 0 && !Number.isNaN(numeric) && numeric > 0;
+
+  async function send() {
+    setSubmitting(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      if (numeric > (wallet?.availableBalance ?? 0)) throw new Error("Insufficient balance");
+      const res = await fetch("/api/service-credits/transfers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({ recipientUserId: recipient.trim(), amount: numeric, idempotencyKey: idempotencyKey() }),
+      });
+      if (!res.ok) {
+        const d = (await res.json()) as { message?: string };
+        throw new Error(d.message ?? "Failed to create transfer.");
+      }
+      await onSent();
+      setSuccess(true);
+      setRecipient("");
+      setAmount("");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to create transfer.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div style={{ padding: "16px", borderRadius: 14, marginBottom: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+      <label htmlFor="sc-recipient" style={inputLabel}>Recipient</label>
+      <input id="sc-recipient" value={recipient} onChange={(e) => setRecipient(e.target.value)} aria-label="Recipient username or ID" placeholder="Survivor username or ID…" style={inputField} />
+      <label htmlFor="sc-amount" style={inputLabel}>Amount</label>
+      <input id="sc-amount" value={amount} onChange={(e) => setAmount(e.target.value)} type="number" min="1" aria-label="Amount in credits" placeholder="Amount (e.g. 50)" style={inputField} />
+      {error && <div style={{ fontSize: 12, color: "#EF4444", marginBottom: 8 }}>{error}</div>}
+      {success && <div style={{ fontSize: 12, color: "#22C55E", marginBottom: 8 }}>Credits sent successfully!</div>}
+      <button type="button" disabled={!canSend} onClick={send}
+        style={{ width: "100%", padding: "10px", borderRadius: 10, background: canSend ? COLOR : "rgba(245,158,11,0.4)", border: "none", color: "#0F1117", fontSize: 14, fontWeight: 800, cursor: canSend ? "pointer" : "not-allowed" }}>
+        {submitting ? "Sending…" : "Send Credits"}
+      </button>
+    </div>
+  );
+}
+
+export function ServiceCreditsSendPanel({ wallet, onSent }: { wallet: WalletData | null; onSent: () => Promise<void> }) {
+  return (
+    <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Send Credits</div>
+      <SendForm wallet={wallet} onSent={onSent} />
+
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Accepted Everywhere</div>
+      {ACCEPTED_APPS.map((app) => (
+        <div key={app} style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 0", borderBottom: "1px solid rgba(255,255,255,0.04)", fontSize: 13, color: "#9CA3AF" }}>
+          <CheckCircle size={12} style={{ color: "#22C55E" }} />
+          {app}
+        </div>
+      ))}
+
+      <div style={{ marginTop: 16, padding: "14px 16px", borderRadius: 12, background: `${COLOR}06`, border: `1px solid ${COLOR}18` }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+          <Shield size={12} style={{ color: COLOR }} />
+          <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Formance Ledger</span>
+        </div>
+        <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Every transaction is recorded on the Formance open-source ledger. Transparent, immutable, and verifiable.</div>
+      </div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/service-credits/sc-shared.ts
+++ b/ctf/packages/web/components/service-credits/sc-shared.ts
@@ -1,0 +1,22 @@
+// Shared constants, types, and helpers for the ServiceCredits web shell.
+// Palette/layout derive from design/.../survivor-hub/ServiceCredits.tsx.
+//
+// Brand rules (critical): "ServiceCredits" is one word and a utility token —
+// it must NEVER be shown at a fiat / dollar equivalent. Balances render as
+// "credits" only.
+
+export const COLOR = "#F59E0B";
+export const BG = "#0F1117";
+
+export type WalletData = { availableBalance: number; escrowBalance: number };
+export type Tab = "wallet" | "earn" | "info";
+
+export const ACCEPTED_APPS = ["LightHouse", "TrustTransport", "Directory", "Foundation", "SocketRelay"];
+
+export function fmtCredits(n: number): string {
+  return n.toLocaleString();
+}
+
+export function idempotencyKey(): string {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}

--- a/ctf/packages/web/components/service-credits/sc-shared.ts
+++ b/ctf/packages/web/components/service-credits/sc-shared.ts
@@ -18,5 +18,9 @@ export function fmtCredits(n: number): string {
 }
 
 export function idempotencyKey(): string {
+  // Prefer a cryptographically strong UUID for this money-transfer key; fall back
+  // for non-secure contexts where crypto.randomUUID is unavailable.
+  const cryptoObj = typeof globalThis !== "undefined" ? globalThis.crypto : undefined;
+  if (cryptoObj?.randomUUID) return cryptoObj.randomUUID();
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }

--- a/ctf/packages/web/components/service-credits/sc-sidebar.tsx
+++ b/ctf/packages/web/components/service-credits/sc-sidebar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { COLOR } from "./sc-shared";
 
-// Nav labels mirror the design. Per the real-data-only rule the design's
-// hardcoded "Platform Stats" (142M issued / 89M circulating / avg balance)
-// are omitted — there is no aggregate-stats route to back them.
+// Section labels mirror the design. These are descriptive labels, not controls
+// (real navigation lives in the icon rail), so they carry no pointer/click
+// affordance. Per the real-data-only rule the design's hardcoded "Platform
+// Stats" (142M issued / 89M circulating / avg balance) are omitted — there is
+// no aggregate-stats route to back them.
 const NAV = ["My Wallet", "Transaction History", "Earn Credits", "Spend Credits", "Peer Transfer"];
 
 export function ServiceCreditsSidebar() {
@@ -16,9 +17,9 @@ export function ServiceCreditsSidebar() {
       </div>
       <ScrollArea style={{ flex: 1 }}>
         <div style={{ padding: "0 8px 16px" }}>
-          {NAV.map((f, i) => (
-            <div key={f} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: i === 0 ? `${COLOR}18` : "transparent", borderLeft: i === 0 ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
-              <span style={{ fontSize: 13, color: i === 0 ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{f}</span>
+          {NAV.map((f) => (
+            <div key={f} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, marginLeft: 2, marginBottom: 2 }}>
+              <span style={{ fontSize: 13, color: "#9CA3AF", flex: 1 }}>{f}</span>
             </div>
           ))}
         </div>

--- a/ctf/packages/web/components/service-credits/sc-sidebar.tsx
+++ b/ctf/packages/web/components/service-credits/sc-sidebar.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { COLOR } from "./sc-shared";
+
+// Nav labels mirror the design. Per the real-data-only rule the design's
+// hardcoded "Platform Stats" (142M issued / 89M circulating / avg balance)
+// are omitted — there is no aggregate-stats route to back them.
+const NAV = ["My Wallet", "Transaction History", "Earn Credits", "Spend Credits", "Peer Transfer"];
+
+export function ServiceCreditsSidebar() {
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>ServiceCredits</div>
+      </div>
+      <ScrollArea style={{ flex: 1 }}>
+        <div style={{ padding: "0 8px 16px" }}>
+          {NAV.map((f, i) => (
+            <div key={f} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: i === 0 ? `${COLOR}18` : "transparent", borderLeft: i === 0 ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
+              <span style={{ fontSize: 13, color: i === 0 ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{f}</span>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/service-credits/sc-wallet-tab.tsx
+++ b/ctf/packages/web/components/service-credits/sc-wallet-tab.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Coins } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { COLOR, fmtCredits } from "./sc-shared";
+
+function BalanceCard({ balance }: { balance: number }) {
+  return (
+    <div style={{ marginBottom: 24, padding: "28px 32px", borderRadius: 20, border: `1px solid ${COLOR}30`, background: `linear-gradient(135deg,${COLOR}25 0%,rgba(245,158,11,0.05) 100%)` }}>
+      <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 8 }}>Your Balance</div>
+      <div style={{ fontSize: 56, fontWeight: 900, color: "#F9FAFB", lineHeight: 1, marginBottom: 4 }}>
+        {fmtCredits(balance)} <span style={{ fontSize: 20, color: COLOR, fontWeight: 700 }}>credits</span>
+      </div>
+      <div style={{ fontSize: 14, color: "#6B7280" }}>usable across all mini-apps</div>
+    </div>
+  );
+}
+
+function StatsRow({ balance, escrow }: { balance: number; escrow: number }) {
+  const stats = [
+    { l: "Available Balance", v: fmtCredits(balance), c: "#22C55E" },
+    { l: "In Escrow", v: fmtCredits(escrow), c: "#EF4444" },
+    { l: "Total Balance", v: fmtCredits(balance + escrow), c: COLOR },
+  ];
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginBottom: 24 }}>
+      {stats.map(({ l, v, c }) => (
+        <div key={l} style={{ padding: "16px", borderRadius: 12, background: `${c}08`, border: `1px solid ${c}18` }}>
+          <div style={{ fontSize: 20, fontWeight: 800, color: c, marginBottom: 4 }}>{v}</div>
+          <div style={{ fontSize: 12, color: "#6B7280" }}>{l}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TransactionsEmpty() {
+  return (
+    <div style={{ padding: "40px 24px", borderRadius: 16, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB", marginBottom: 16, alignSelf: "flex-start" }}>Recent Transactions</div>
+      <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(245,158,11,0.3)", display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <Coins size={20} style={{ color: "rgba(245,158,11,0.4)" }} />
+      </div>
+      <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>No transactions yet</div>
+      <div style={{ fontSize: 13, color: "#4B5563", textAlign: "center" }}>Your transaction history will appear here as you earn and spend credits.</div>
+    </div>
+  );
+}
+
+export function ServiceCreditsWalletTab({ balance, escrow }: { balance: number; escrow: number }) {
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ padding: "24px" }}>
+        <BalanceCard balance={balance} />
+        <StatsRow balance={balance} escrow={escrow} />
+        <TransactionsEmpty />
+      </div>
+    </ScrollArea>
+  );
+}

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -1,256 +1,53 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  Coins, Bell, Settings, MessageSquare,
-  TrendingUp, CheckCircle, ArrowDown, ArrowUp, RefreshCw, Shield,
-  ArrowUpRight,
-} from "lucide-react";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Coins } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { EARN_METHODS, SPEND_OPTIONS, INFO_MSGS } from "./service-credits.constants";
+import { BG, COLOR, fmtCredits, type Tab, type WalletData } from "./sc-shared";
+import { ServiceCreditsIconRail } from "./sc-icon-rail";
+import { ServiceCreditsSidebar } from "./sc-sidebar";
+import { ServiceCreditsWalletTab } from "./sc-wallet-tab";
+import { ServiceCreditsEarnTab } from "./sc-earn-tab";
+import { ServiceCreditsInfoTab } from "./sc-info-tab";
+import { ServiceCreditsSendPanel } from "./sc-send-panel";
 
-const COLOR = "#F59E0B";
+function CenteredNote({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <div style={{ width: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center", color, fontFamily: "'Inter', system-ui, sans-serif" }}>
+      {children}
+    </div>
+  );
+}
 
-// ============================================================================
-// Reusable Style Constants
-// ============================================================================
+function ShellHeader({ balance }: { balance: number }) {
+  return (
+    <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+      <Coins size={18} style={{ color: COLOR }} />
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>ServiceCredits — Utility Tokens</div>
+        <div style={{ fontSize: 12, color: "#6B7280" }}>Earn · Spend · Trade · Across all mini-apps</div>
+      </div>
+      <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
+        {fmtCredits(balance)} credits
+      </Badge>
+    </header>
+  );
+}
 
-const baseContainerStyle: React.CSSProperties = {
-  width: "100%",
-  height: "100%",
-  minHeight: "100vh",
-  background: "#0F1117",
-  fontFamily: "'Inter', system-ui, sans-serif",
-  display: "flex",
-};
-
-const mainLayoutStyle: React.CSSProperties = {
-  ...baseContainerStyle,
-  color: "#E8EAF0",
-};
-
-const iconRailStyle: React.CSSProperties = {
-  width: 72,
-  background: "#090B0F",
-  borderRight: "1px solid rgba(255,255,255,0.06)",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  paddingTop: 16,
-  paddingBottom: 16,
-  gap: 8,
-  flexShrink: 0,
-};
-
-const iconButtonStyle: React.CSSProperties = {
-  width: 44,
-  height: 44,
-  borderRadius: 12,
-  background: "transparent",
-  border: "none",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  cursor: "pointer",
-  color: "#6B7280",
-};
-
-const sidebarStyle: React.CSSProperties = {
-  width: 240,
-  background: "#0D0F14",
-  borderRight: "1px solid rgba(255,255,255,0.06)",
-  display: "flex",
-  flexDirection: "column",
-  flexShrink: 0,
-};
-
-const headerStyle: React.CSSProperties = {
-  height: 56,
-  borderBottom: "1px solid rgba(255,255,255,0.06)",
-  display: "flex",
-  alignItems: "center",
-  padding: "0 24px",
-  gap: 16,
-  background: "#0D0F14",
-  flexShrink: 0,
-};
-
-const mainContentStyle: React.CSSProperties = {
-  flex: 1,
-  display: "flex",
-  flexDirection: "column",
-  minWidth: 0,
-};
-
-const contentPaddingStyle: React.CSSProperties = {
-  padding: "24px",
-};
-
-const balanceCardStyle: React.CSSProperties = {
-  marginBottom: 24,
-  padding: "28px 32px",
-  borderRadius: 20,
-  border: `1px solid ${COLOR}30`,
-};
-
-const buttonGridStyle: React.CSSProperties = {
-  display: "flex",
-  gap: 12,
-};
-
-const buttonBaseStyle: React.CSSProperties = {
-  flex: 1,
-  padding: "12px",
-  borderRadius: 12,
-  border: "none",
-  fontSize: 14,
-  fontWeight: 700,
-  cursor: "pointer",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  gap: 6,
-};
-
-const statGridStyle: React.CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "repeat(4,1fr)",
-  gap: 12,
-  marginBottom: 24,
-};
-
-const statCardStyle: React.CSSProperties = {
-  padding: "16px",
-  borderRadius: 12,
-};
-
-const emptyStateStyle: React.CSSProperties = {
-  padding: "40px 24px",
-  borderRadius: 16,
-  background: "rgba(255,255,255,0.02)",
-  border: "1px solid rgba(255,255,255,0.06)",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  justifyContent: "center",
-};
-
-const cardContainerStyle: React.CSSProperties = {
-  display: "flex",
-  flexDirection: "column",
-  gap: 12,
-  marginBottom: 28,
-};
-
-const earnMethodCardStyle: React.CSSProperties = {
-  padding: "18px 20px",
-  borderRadius: 14,
-  background: "rgba(255,255,255,0.02)",
-  display: "flex",
-  alignItems: "center",
-  gap: 16,
-};
-
-const spendGridStyle: React.CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "repeat(3,1fr)",
-  gap: 10,
-};
-
-const spendCardStyle: React.CSSProperties = {
-  padding: "16px",
-  borderRadius: 14,
-  cursor: "pointer",
-};
-
-const messageBubbleStyle: React.CSSProperties = {
-  display: "flex",
-  gap: 10,
-  alignItems: "flex-end",
-  marginBottom: 12,
-};
-
-const rightPanelStyle: React.CSSProperties = {
-  width: 280,
-  borderLeft: "1px solid rgba(255,255,255,0.06)",
-  background: "#0D0F14",
-  padding: "20px 16px",
-  flexShrink: 0,
-};
-
-const inputContainerStyle: React.CSSProperties = {
-  padding: "16px",
-  borderRadius: 14,
-  marginBottom: 16,
-};
-
-const inputFieldStyle: React.CSSProperties = {
-  width: "100%",
-  padding: "10px 12px",
-  background: "rgba(255,255,255,0.05)",
-  border: "1px solid rgba(255,255,255,0.08)",
-  borderRadius: 8,
-  fontSize: 13,
-  color: "#E8EAF0",
-  outline: "none",
-  marginBottom: 12,
-  boxSizing: "border-box",
-};
-
-const inputLabelStyle: React.CSSProperties = {
-  fontSize: 12,
-  color: "#9CA3AF",
-  marginBottom: 6,
-  display: "block",
-};
-
-const infoMessageStyle: React.CSSProperties = {
-  padding: "12px 16px",
-  borderRadius: "16px 16px 16px 4px",
-  background: "rgba(255,255,255,0.05)",
-  border: "1px solid rgba(255,255,255,0.06)",
-  fontSize: 14,
-  lineHeight: 1.6,
-  color: "#E8EAF0",
-};
-
-const formanceInfoStyle: React.CSSProperties = {
-  marginTop: 16,
-  padding: "14px 16px",
-  borderRadius: 12,
-};
-
-type WalletData = { availableBalance: number; escrowBalance: number };
-type Tab = "wallet" | "earn" | "chat";
-
-const TABS: { icon: React.ElementType; key: Tab }[] = [
-  { icon: Coins, key: "wallet" },
-  { icon: TrendingUp, key: "earn" },
-  { icon: MessageSquare, key: "chat" },
-];
-
-export function ServiceCreditsShell(_props: { userId?: string; isAdmin?: boolean }) {
+export function ServiceCreditsShell() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [wallet, setWallet] = useState<WalletData | null>(null);
   const [tab, setTab] = useState<Tab>("wallet");
-  const [submitting, setSubmitting] = useState(false);
-  const [transferError, setTransferError] = useState<string | null>(null);
-  const [transferSuccess, setTransferSuccess] = useState(false);
-  const [recipient, setRecipient] = useState("");
-  const [sendAmount, setSendAmount] = useState("");
 
   async function refreshWallet() {
     const res = await fetch("/api/service-credits/wallet");
-    if (res.ok) {
-      const data = await res.json();
-      if (data.wallet && typeof data.wallet.availableBalance === 'number' && typeof data.wallet.escrowBalance === 'number') {
-        setWallet(data.wallet as WalletData);
-      } else {
-        throw new Error("Invalid wallet data structure");
-      }
+    if (!res.ok) return;
+    const data = (await res.json()) as { wallet?: WalletData };
+    if (data.wallet && typeof data.wallet.availableBalance === "number" && typeof data.wallet.escrowBalance === "number") {
+      setWallet(data.wallet);
+    } else {
+      throw new Error("Invalid wallet data structure");
     }
   }
 
@@ -262,295 +59,23 @@ export function ServiceCreditsShell(_props: { userId?: string; isAdmin?: boolean
       .finally(() => setLoading(false));
   }, []);
 
-type TransferRequest = { toUserId: string; amount: number };
-
-async function handleTransfer(transfer: TransferRequest) {
-  setSubmitting(true);
-  setTransferError(null);
-  setTransferSuccess(false);
-  try {
-    if (!transfer.toUserId.trim()) {
-      throw new Error("Recipient ID is required");
-    }
-    if (isNaN(transfer.amount) || transfer.amount <= 0) {
-      throw new Error("Amount must be a positive number");
-    }
-    if (transfer.amount > (wallet?.availableBalance ?? 0)) {
-      throw new Error("Insufficient balance");
-    }
-    const res = await fetch("/api/service-credits/transfers", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(transfer),
-    });
-    if (!res.ok) throw new Error("Failed to create transfer");
-    await refreshWallet();
-    setTransferSuccess(true);
-    setRecipient("");
-    setSendAmount("");
-  } catch (e: unknown) {
-    setTransferError(e instanceof Error ? e.message : "Failed to create transfer.");
-  } finally {
-    setSubmitting(false);
-  }
-}
-
-  const fmt = (n: number) => n.toLocaleString();
-
-  if (loading) {
-    return (
-      <div style={{ ...baseContainerStyle, color: "#6B7280", alignItems: "center", justifyContent: "center" }}>
-        Loading wallet…
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div style={{ ...baseContainerStyle, color: "#EF4444", alignItems: "center", justifyContent: "center" }}>
-        {error}
-      </div>
-    );
-  }
+  if (loading) return <CenteredNote color="#6B7280">Loading wallet…</CenteredNote>;
+  if (error) return <CenteredNote color="#EF4444">{error}</CenteredNote>;
 
   const balance = wallet?.availableBalance ?? 0;
   const escrow = wallet?.escrowBalance ?? 0;
 
   return (
-    <div style={mainLayoutStyle}>
-      {/* Icon rail */}
-      <aside style={iconRailStyle}>
-        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
-          <Coins size={20} style={{ color: COLOR }} />
-        </div>
-        {TABS.map(({ icon: Icon, key }) => (
-          <button key={key} onClick={() => setTab(key)} style={{ ...iconButtonStyle, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", color: tab === key ? COLOR : "#6B7280" }}>
-            <Icon size={20} />
-          </button>
-        ))}
-        <div style={{ flex: 1 }} />
-        <button style={iconButtonStyle}>
-          <Bell size={18} />
-        </button>
-        <button style={iconButtonStyle}>
-          <Settings size={18} />
-        </button>
-        <Avatar style={{ width: 36, height: 36 }}>
-          <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
-        </Avatar>
-      </aside>
-
-      {/* Sidebar */}
-      <aside style={sidebarStyle}>
-        <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>Service Credits</div>
-        </div>
-        <ScrollArea style={{ flex: 1 }}>
-          <div style={{ padding: "0 8px 16px" }}>
-            {["My Wallet", "Transaction History", "Earn Credits", "Spend Credits", "Peer Transfer", "Analytics"].map((f, i) => (
-              <div key={f} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: i === 0 ? `${COLOR}18` : "transparent", borderLeft: i === 0 ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
-                <span style={{ fontSize: 13, color: i === 0 ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{f}</span>
-              </div>
-            ))}
-            <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", padding: "0 10px" }}>Platform Stats</div>
-            {[{ l: "Total Credits Issued", v: "142M" }, { l: "In Circulation", v: "89M" }, { l: "Avg Balance", v: "1,847" }].map(({ l, v }) => (
-              <div key={l} style={{ padding: "6px 10px", fontSize: 12, color: "#6B7280" }}>
-                {l}: <span style={{ color: COLOR, fontWeight: 600 }}>{v}</span>
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
-      </aside>
-
-      {/* Main */}
-      <div style={mainContentStyle}>
-        <header style={headerStyle}>
-          <Coins size={18} style={{ color: COLOR }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Service Credits — Utility Tokens</div>
-            <div style={{ fontSize: 12, color: "#6B7280" }}>Earn · Spend · Trade · Across all mini-apps</div>
-          </div>
-          <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-            {fmt(balance)} Credits
-          </Badge>
-        </header>
-
-        {tab === "wallet" && (
-          <ScrollArea style={{ flex: 1 }}>
-            <div style={contentPaddingStyle}>
-              {/* Balance card */}
-              <div style={{ ...balanceCardStyle, background: `linear-gradient(135deg,${COLOR}25 0%,rgba(245,158,11,0.05) 100%)` }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 8 }}>Your Balance</div>
-                <div style={{ fontSize: 56, fontWeight: 900, color: "#F9FAFB", lineHeight: 1, marginBottom: 4 }}>
-                  {fmt(balance)} <span style={{ fontSize: 20, color: COLOR, fontWeight: 700 }}>credits</span>
-                </div>
-                <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>
-                  ≈ ${fmt(Math.round(balance / 10))} USD purchasing power across all mini-apps
-                </div>
-                <div style={buttonGridStyle}>
-                  <button style={{ ...buttonBaseStyle, background: COLOR, color: "#0F1117", fontWeight: 800 }}>
-                    <ArrowUp size={16} /> Send
-                  </button>
-                  <button style={{ ...buttonBaseStyle, background: "rgba(255,255,255,0.06)", border: `1px solid ${COLOR}30`, color: COLOR }}>
-                    <ArrowDown size={16} /> Request
-                  </button>
-                  <button style={{ ...buttonBaseStyle, background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.08)", color: "#9CA3AF", fontWeight: 600 }}>
-                    <RefreshCw size={16} /> Swap
-                  </button>
-                </div>
-              </div>
-
-              {/* Stats row */}
-              <div style={statGridStyle}>
-                {[
-                  { l: "Available Balance", v: fmt(balance), c: "#22C55E" },
-                  { l: "In Escrow", v: fmt(escrow), c: "#EF4444" },
-                  { l: "Total Balance", v: fmt(balance + escrow), c: COLOR },
-                  { l: "Network Rank", v: "—", c: "#A855F7" },
-                ].map(({ l, v, c }) => (
-                  <div key={l} style={{ ...statCardStyle, background: `${c}08`, border: `1px solid ${c}18` }}>
-                    <div style={{ fontSize: 20, fontWeight: 800, color: c, marginBottom: 4 }}>{v}</div>
-                    <div style={{ fontSize: 12, color: "#6B7280" }}>{l}</div>
-                  </div>
-                ))}
-              </div>
-
-              {/* Transactions empty state */}
-              <div style={emptyStateStyle}>
-                <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB", marginBottom: 16, alignSelf: "flex-start" }}>Recent Transactions</div>
-                <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(245,158,11,0.3)", display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
-                  <Coins size={20} style={{ color: "rgba(245,158,11,0.4)" }} />
-                </div>
-                <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF", marginBottom: 6 }}>No transactions yet</div>
-                <div style={{ fontSize: 13, color: "#4B5563", textAlign: "center" }}>Your transaction history will appear here as you earn and spend credits.</div>
-              </div>
-            </div>
-          </ScrollArea>
-        )}
-
-        {tab === "earn" && (
-          <ScrollArea style={{ flex: 1 }}>
-            <div style={contentPaddingStyle}>
-              <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Earn Service Credits</div>
-              <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>Contribute to the community and get rewarded</div>
-              <div style={cardContainerStyle}>
-                {EARN_METHODS.map((m) => (
-                  <div key={m.title} style={{ ...earnMethodCardStyle, border: `1px solid ${m.color}25` }}>
-                    <div style={{ flex: 1 }}>
-                      <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB", marginBottom: 4 }}>{m.title}</div>
-                      <Badge style={{ background: `${m.color}15`, color: m.color, border: `1px solid ${m.color}30`, fontSize: 11 }}>{m.difficulty}</Badge>
-                    </div>
-                    <div style={{ textAlign: "right" }}>
-                      <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>{m.credits}</div>
-                      <button style={{ padding: "7px 14px", borderRadius: 8, background: `${m.color}15`, border: `1px solid ${m.color}30`, color: m.color, fontSize: 12, fontWeight: 600, cursor: "pointer", marginTop: 6 }}>
-                        Start →
-                      </button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-              <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 12 }}>Where to Spend</div>
-              <div style={spendGridStyle}>
-                {SPEND_OPTIONS.map((s) => (
-                  <div key={s.title} style={{ ...spendCardStyle, background: `${s.color}08`, border: `1px solid ${s.color}20` }}>
-                    <div style={{ fontSize: 28, marginBottom: 8 }}>{s.icon}</div>
-                    <div style={{ fontSize: 13, fontWeight: 700, color: "#E8EAF0", marginBottom: 4 }}>{s.title}</div>
-                    <div style={{ fontSize: 12, color: s.color, fontWeight: 600 }}>{s.credits}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </ScrollArea>
-        )}
-
-        {tab === "chat" && (
-          <div style={mainContentStyle}>
-            <ScrollArea style={{ flex: 1, padding: "24px" }}>
-              <div style={{ padding: "0 0 16px" }}>
-                {INFO_MSGS.map((msg) => (
-                  <div key={msg.id} style={messageBubbleStyle}>
-                    <div style={{ width: 32, height: 32, borderRadius: 10, background: `${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-                      <Coins size={14} style={{ color: COLOR }} />
-                    </div>
-                    <div style={{ maxWidth: "70%", display: "flex", flexDirection: "column", gap: 6 }}>
-                      <div style={infoMessageStyle}>
-                        {msg.text}
-                      </div>
-                      {msg.action && (
-                        <button style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", alignSelf: "flex-start" }}>
-                          {msg.action} <ArrowUpRight size={13} />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </ScrollArea>
-            <div style={{ padding: "8px 24px 20px", flexShrink: 0, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
-              <div style={{ textAlign: "center", fontSize: 12, color: "#4B5563" }}>Use the Send Credits panel on the right to transfer credits to another member.</div>
-            </div>
-          </div>
-        )}
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+      <ServiceCreditsIconRail tab={tab} onTab={setTab} />
+      <ServiceCreditsSidebar />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <ShellHeader balance={balance} />
+        {tab === "wallet" && <ServiceCreditsWalletTab balance={balance} escrow={escrow} />}
+        {tab === "earn" && <ServiceCreditsEarnTab />}
+        {tab === "info" && <ServiceCreditsInfoTab />}
       </div>
-
-      {/* Right panel */}
-      <aside style={rightPanelStyle}>
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Send Credits</div>
-        <div style={{ ...inputContainerStyle, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-          <label htmlFor="recipient-input" style={inputLabelStyle}>
-            Recipient
-          </label>
-          <input
-            id="recipient-input"
-            value={recipient}
-            onChange={(e) => setRecipient(e.target.value)}
-            placeholder="Survivor username or ID…"
-            style={{ ...inputFieldStyle, marginBottom: 12 }}
-          />
-          <label htmlFor="amount-input" style={inputLabelStyle}>
-            Amount
-          </label>
-          <input
-            id="amount-input"
-            value={sendAmount}
-            onChange={(e) => setSendAmount(e.target.value)}
-            placeholder="Amount (e.g. 50)"
-            type="number"
-            min="1"
-            style={inputFieldStyle}
-          />
-          {transferError && <div style={{ fontSize: 12, color: "#EF4444", marginBottom: 8 }}>{transferError}</div>}
-          {transferSuccess && <div style={{ fontSize: 12, color: "#22C55E", marginBottom: 8 }}>Credits sent successfully!</div>}
-          <button
-            disabled={submitting || !recipient.trim() || !sendAmount || isNaN(Number(sendAmount)) || Number(sendAmount) <= 0}
-            onClick={() => { 
-              const amount = Number(sendAmount);
-              if (!isNaN(amount) && amount > 0) {
-                void handleTransfer({ toUserId: recipient.trim(), amount });
-              }
-            }}
-            style={{ width: "100%", padding: "10px", borderRadius: 10, background: submitting ? "rgba(245,158,11,0.4)" : COLOR, border: "none", color: "#0F1117", fontSize: 14, fontWeight: 800, cursor: submitting ? "not-allowed" : "pointer" }}
-          >
-            {submitting ? "Sending…" : "Send Credits"}
-          </button>
-        </div>
-
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Accepted Everywhere</div>
-        {["🏠 LightHouse", "📦 TrustTransport", "📇 Directory", "🪛 Foundation", "🔂 SocketRelay"].map((app) => (
-          <div key={app} style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 0", borderBottom: "1px solid rgba(255,255,255,0.04)", fontSize: 13, color: "#9CA3AF" }}>
-            <CheckCircle size={12} style={{ color: "#22C55E" }} />
-            {app}
-          </div>
-        ))}
-
-        <div style={{ ...formanceInfoStyle, background: `${COLOR}06`, border: `1px solid ${COLOR}18` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-            <Shield size={12} style={{ color: COLOR }} />
-            <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Formance Ledger</span>
-          </div>
-          <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Every transaction is recorded on the Formance open-source ledger. Transparent, immutable, and verifiable.</div>
-        </div>
-      </aside>
+      <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} />
     </div>
   );
 }

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -42,7 +42,7 @@ export function ServiceCreditsShell() {
 
   async function refreshWallet() {
     const res = await fetch("/api/service-credits/wallet");
-    if (!res.ok) return;
+    if (!res.ok) throw new Error(`Failed to load wallet (${res.status}).`);
     const data = (await res.json()) as { wallet?: WalletData };
     if (data.wallet && typeof data.wallet.availableBalance === "number" && typeof data.wallet.escrowBalance === "number") {
       setWallet(data.wallet);

--- a/ctf/packages/web/components/service-credits/service-credits.constants.ts
+++ b/ctf/packages/web/components/service-credits/service-credits.constants.ts
@@ -15,6 +15,6 @@ export const SPEND_OPTIONS = [
 ];
 
 export const INFO_MSGS = [
-  { id: 1, text: "Service Credits are your utility tokens for the entire Survivor Hub economy. Earn, spend, trade — across all mini-apps." },
+  { id: 1, text: "ServiceCredits are your utility tokens for the entire Survivor Hub economy. Earn, spend, trade — across all mini-apps." },
   { id: 2, text: "5 ways to earn right now: Skills Hunt round (+200), Facilitating a cohort (+500), Profile verification (+50), Referrals (+100 each), or 30-day GentlePulse streak (+150).", action: "Verify Profile Now" },
 ];


### PR DESCRIPTION
## Summary

UI circle-back: **ServiceCredits** web pixel pass. Aligns the shell to `design/.../survivor-hub/ServiceCredits.tsx` and breaks the 556-line monolith into modular sub-components within rule-116 limits (shell now 81 lines).

### Components
- `sc-shared.ts` — palette, `WalletData`/`Tab` types, helpers (`fmtCredits`, `idempotencyKey`)
- `sc-icon-rail` / `sc-sidebar` — chrome (aria-labelled icon buttons)
- `sc-wallet-tab` — balance card + available/escrow/total stats + honest empty transactions state
- `sc-earn-tab` — earn/spend program guide
- `sc-info-tab` — static explainer (the design's "chat" tab; no AI/Stream wired)
- `sc-send-panel` — peer transfer form + accepted-apps + Formance ledger note
- `service-credits-shell.tsx` — thin composer

### 🐛 Real transfer bug fixed
The prior shell POSTed `{ toUserId, amount }` with **no `idempotencyKey` and no `x-ctf-csrf` header**, so `/api/service-credits/transfers` rejected **every** peer transfer (CSRF guard + required-field 400s). The Send panel now sends `{ recipientUserId, amount, idempotencyKey }` with the CSRF header, matching the route contract exactly.

### Brand & real-data compliance
- "Service Credits" → **"ServiceCredits"** in the info copy.
- Balances render as **"credits"** only — never a fiat/dollar equivalent.
- Per real-data-only: omitted the design's hardcoded platform stats (issued / circulating / avg balance) and the non-functional per-row "Start" / chat-input actions.
- `aria-label` on icon-rail buttons and transfer inputs; dropped unused `userId`/`isAdmin` props at the call site.

No schema/route/contract changes — the API surface and `WalletData` shape are unchanged; only the (previously broken) client request was corrected.

### Docs
- `PRODUCTION_READINESS_PLAN.md`: service-credits row flipped (row-only, per #164's convention).
- service-credits inventory: delivery-status update + change-log entry (incl. the transfer-bug fix).

### Gates (local)
typecheck, modularity (`complexity:["error",10]`, `max-lines-per-function: 200`), flat lint, `build:ci`, EOF, web/android parity, schema-drift — all green.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reorganized Service Credits interface with tabbed navigation between wallet, earn, and info sections.
  * Added dedicated Send Credits sidebar panel for transferring credits to other members.
  * Wallet tab now displays balance summary and transaction statistics.
  * Earn tab provides guidance on earning and spending credits.

* **Documentation**
  * Updated production readiness tracking and feature inventory for service credits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chargingthefuture/chargingthefuture/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->