### PR TITLE
refactor: skills-hunt admin shell rule-116 decomposition

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-feature-inventory.md
@@ -196,6 +196,7 @@ Admin/moderator routes:
 
 ## 9) Change Log
 
+- 2026-05-30: Admin moderation shell rule-116 follow-up (the deferred item from the user-shell pass). Decomposed the 253-line `skills-hunt-admin-shell.tsx` (213-line render + a complexity-11 action arrow) into `sha-shared.ts` (constants, reject-reason prompt), `sha-filters.tsx` (round/status chips + bulk toolbar), `sha-table.tsx` (table + extracted `SubmissionRow`/`RowActions`), and a thin shell. Behavior preserved exactly (review/bulk-review POST `{ action, notes }` with `x-ctf-csrf`, pending-only selection, sequential bulk apply); added aria-labels on the row checkboxes. No design mockup exists for this internal surface and none is required â€” pure behavior-preserving decomposition, no new rendered surface. No schema/route/contract changes.
 - 2026-05-30: Web pixel pass for the user shell. Aligned to the design mockup (brand color #A855F7 -> #D946EF; aria-labeled lucide icon rail with unread badge) and decomposed the 845-line monolith into modular sub-components within rule-116 limits: sh-shared.ts, sh-use-nomination-form.ts, sh-icon-rail, sh-notifications, sh-sidebar, sh-skills-picker, sh-scout-tab, sh-leaderboard-tab, sh-missions-tab, sh-my-finds-tab, sh-right-panel, thin shell. All data stays bound to the real routes; no mocks. Admin shell (/admin/skills-hunt) left as a tracked rule-116 follow-up. No schema/route/contract changes.
 
 - 2026-05-18: Renamed "Web and Android Delivery Strategy" to canonical "Web and Android Delivery Status" and confirmed `web+android complete`. Renamed "Gaps, Ambiguities, and Known Debt (Planning)" to canonical "Gaps and Known Technical Debt". Removed Android-parity-deferral entry per Rule 105.
@@ -216,7 +217,7 @@ Admin/moderator routes:
 - [x] Confirm Directory boundary semantics.
   - Only governed generation of unclaimed profiles is allowed; ownership lifecycle remains Directory-authoritative. Reaffirmed 2026-05-11.
 
-### €” Contract Lock
+### ï¿½ï¿½ Contract Lock
 
 - [x] Define Skills Hunt plugin command contracts for v1.
   - Evidence: `ctf/docs/contracts/SKILLS_HUNT_PLUGIN_COMMAND_CONTRACTS.yaml`.
@@ -226,7 +227,7 @@ Admin/moderator routes:
   - Evidence: `ctf/docs/contracts/SKILLS_HUNT_PLUGIN_AUDIT_CONTRACTS.yaml`.
 - [x] Add command for `skills-hunt.submission.report` (community moderation report) and `skills-hunt.profile.delete` (GDPR delete) to all three contracts. Landed in `SKILLS_HUNT_PLUGIN_COMMAND_CONTRACTS.yaml`, `..._ACCESS_POLICY_CONTRACTS.yaml`, `..._AUDIT_CONTRACTS.yaml` (2026-05-12 changelog entries).
 
-### €” Schema, Migrations, and Retention
+### ï¿½ï¿½ Schema, Migrations, and Retention
 
 - [x] Define Skills Hunt domain schema for v1 baseline.
 - [x] **Add new columns/tables for v2 (Wave 1):** Landed in commit `f3aeb3f`.
@@ -251,7 +252,7 @@ Admin/moderator routes:
   - **Rollback path** (only if the rewrite must be reverted): each new column has a defined default; rollback can `DROP COLUMN IF EXISTS` per column safely. No data loss for pre-rewrite rows since the legacy code didn't read the new columns. Do NOT drop `directory_profiles.deleted_at` or `directory_profiles.unclaimed_handle` without first clearing UI/route handlers that consume them (see `app/apps/directory/[handle]/page.tsx`).
   - **No `DROP TABLE` rollback is supported** â€” `skills_hunt_submission_reports` and `skills_hunt_missions` may carry production data; backup before drop.
 
-### €” Core Contributor Flow
+### ï¿½ï¿½ Core Contributor Flow
 
 - [x] Implement rounds list/get surfaces.
   - `GET /api/skills-hunt/rounds`, `GET /api/skills-hunt/admin/rounds`.
@@ -267,7 +268,7 @@ Admin/moderator routes:
   - [x] Taxonomy-driven skills parsing â€” submission POST forwards `proposedSkills` and `validateSubmissionInput` enforces `skills + proposedSkills â‰¤ 10`, each label â‰¤ 40 chars, `proposedSkills â‰¤ 10`. `createSubmission` persists `proposed_skills` to the JSONB column on insert.
   - [x] Align display name (2â€“100 chars, letters/digits/spaces only) and bio (â‰¤ 280, optional) limits with spec. Server validator uses `SKILLS_HUNT_MIN_DISPLAY_NAME_LENGTH`, `SKILLS_HUNT_MAX_DISPLAY_NAME_LENGTH`, `SKILLS_HUNT_DISPLAY_NAME_PATTERN`, and `SKILLS_HUNT_MAX_BIO_LENGTH` constants. UI already enforces matching limits in the shell.
 
-### €” Review and Scoring Flow
+### ï¿½ï¿½ Review and Scoring Flow
 
 - [x] Implement moderator/admin submission review actions (accept/reject/edit/flag).
 - [x] Implement baseline scoring engine.
@@ -286,7 +287,7 @@ Admin/moderator routes:
   - [x] Read-only `getReputationProfile(userId)` exported for future admin dashboard / submit-time UI hint.
 - [x] Enforce rejection-rate guardrails (existing 80% block â€” to be replaced by reputation system in Wave 2).
 
-### €” Leaderboard, Rewards, and Notifications
+### ï¿½ï¿½ Leaderboard, Rewards, and Notifications
 
 - [x] Implement baseline leaderboard rebuild and retrieval (individual + team mode columns).
 - [x] Implement achievements (3 generic count-based codes).
@@ -321,7 +322,7 @@ Admin/moderator routes:
   - [x] `round-ending-soon` â€” `notifyRoundsEndingSoon()` cron entry point at `POST /api/skills-hunt/admin/notifications/round-ending-soon` (admin-gated, CSRF). Idempotent per `(user, round)`; wire a daily scheduler to invoke.
 - [x] **Wave 2 â€” notification center UI** (web + mobile) with unread badge. Web: bell icon in the icon rail toggles a popover anchored above the secondary sidebar, with a red `unreadCount` badge and per-row mark-read on click. Mobile: top-bar bell with the same badge opens an inline inbox above the tabbar. Both poll `/api/skills-hunt/notifications` every 30s.
 
-### €” Directory Projection and Safety
+### ï¿½ï¿½ Directory Projection and Safety
 
 - [x] Implement governed unclaimed Directory profile generation via `maybeAutoGenerateDirectoryProfile`.
 - [x] **Wave 1 â€” Directory schema additions** (commit `f3aeb3f`):
@@ -339,7 +340,7 @@ Admin/moderator routes:
   - `app/apps/directory/[handle]/page.tsx` renders the purple "Community generated" pill, the `@unclaimed_handle` monospace line, and "Nominated by @handle" attribution. Uses design's `#A855F7` palette per rule 126.
 - [x] **Wave 1 â€” backfill migration** assigning `community-<6hex>` to existing 60 unclaimed profiles (commit `f3aeb3f`, idempotent DO block).
 
-### €” Security, Compliance, and Deletion
+### ï¿½ï¿½ Security, Compliance, and Deletion
 
 - [x] Verify authz/deny conditions and audit integrity on existing endpoints.
 - [x] **Wave 2 â€” soft-delete + GDPR endpoint:**
@@ -355,13 +356,13 @@ Admin/moderator routes:
     - Exports `evaluateUsernamePolicy` and `isReservedUsername`. Submissions POST returns `SKILLS_HUNT_RESERVED_USERNAME` (403) when caller's Clerk username matches a reserved prefix.
   - [x] Document Clerk dashboard configuration in `123-environment-configuration-rules.mdc`. New "Reserved Username Prefixes" section instructs operators to add `community-` to the disallowed-prefix blocklist on every Clerk instance.
 
-### €” Validation, Seeds, and Release Gates
+### ï¿½ï¿½ Validation, Seeds, and Release Gates
 
 - [x] Update seed script `ctf/scripts/seedSkillsHunt.mjs` for new schema columns (`proposed_skills`, `participation_points`, `credit_granted`, `url_validation_result`, leaderboard `first_match_count` / `pending_points` / `last_submission_at`) and new test case: a `community-generated` Directory profile with `@community-seed01` handle linked to the seed submission via `skills_hunt_directory_profiles`.
 - [x] Update plugin registry availability state: `'implemented_shell'` â†’ `'alpha'`. `PluginAvailabilityState` widened to include `'alpha' | 'beta'`. Flip to `'beta'` after the e2e smoke test and a real staging cohort run.
 - [x] Add type-safe end-to-end smoke: rounds list â†’ submit â†’ admin accept â†’ leaderboard rebuild â†’ notification fan-out â†’ unclaimed Directory profile with `@handle`. `ctf/scripts/smokeSkillsHuntE2e.mjs` asserts on the deterministic post-state left by `seed:skills-hunt`. Invoke with `pnpm smoke:skills-hunt`. Both scripts are idempotent, so the seed + smoke can be chained safely in CI / on-demand.
 
-### €” UI Surfaces (consolidated)
+### ï¿½ï¿½ UI Surfaces (consolidated)
 
 - [x] **Wave 1 â€” submission flow** (replaces the planned modal). Post-design lock (continuity Â§2.4) replaced the in-place Directory modal with a navigation to `/apps/skills-hunt?tab=scout`. The form lives in `skills-hunt-shell.tsx` Scout tab and satisfies every original sub-item:
   - [x] Heading: "Nominate a Survivor" (Replit lexicon â€” see continuity Â§2.8).

--- a/ctf/packages/web/components/skills-hunt/sha-filters.tsx
+++ b/ctf/packages/web/components/skills-hunt/sha-filters.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { SkillsHuntRound, SkillsHuntSubmissionStatus } from "lib/skills-hunt/types";
+import { COLOR, STATUS_OPTIONS } from "./sha-shared";
+
+export function SkillsHuntAdminFilters({
+  rounds,
+  activeRoundId,
+  onRound,
+  statusFilter,
+  onStatus,
+}: {
+  rounds: SkillsHuntRound[];
+  activeRoundId: string | null;
+  onRound: (id: string) => void;
+  statusFilter: SkillsHuntSubmissionStatus;
+  onStatus: (s: SkillsHuntSubmissionStatus) => void;
+}) {
+  return (
+    <>
+      <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
+        {rounds.map((r) => {
+          const active = activeRoundId === r.id;
+          return (
+            <button key={r.id} type="button" onClick={() => onRound(r.id)}
+              style={{ padding: "6px 14px", borderRadius: 20, background: active ? `${COLOR}25` : "rgba(255,255,255,0.04)", border: `1px solid ${active ? COLOR + "60" : "rgba(255,255,255,0.08)"}`, color: active ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer" }}>
+              {r.name} <span style={{ opacity: 0.6 }}>· {r.status}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ display: "flex", gap: 6, marginBottom: 16 }}>
+        {STATUS_OPTIONS.map((s) => {
+          const active = statusFilter === s.key;
+          return (
+            <button key={s.key} type="button" onClick={() => onStatus(s.key)}
+              style={{ padding: "4px 12px", borderRadius: 20, background: active ? `${s.color}25` : "rgba(255,255,255,0.04)", border: `1px solid ${active ? s.color + "60" : "rgba(255,255,255,0.08)"}`, color: active ? s.color : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer" }}>
+              {s.label}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export function SkillsHuntAdminBulkBar({
+  count,
+  onAccept,
+  onReject,
+  onClear,
+}: {
+  count: number;
+  onAccept: () => void;
+  onReject: () => void;
+  onClear: () => void;
+}) {
+  if (count === 0) return null;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px", marginBottom: 12, borderRadius: 10, background: `${COLOR}10`, border: `1px solid ${COLOR}30` }}>
+      <span style={{ fontSize: 12, color: COLOR, fontWeight: 600 }}>{count} selected</span>
+      <button type="button" onClick={onAccept} style={{ padding: "6px 14px", borderRadius: 8, background: "#22C55E", border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: "pointer" }}>Bulk accept</button>
+      <button type="button" onClick={onReject} style={{ padding: "6px 14px", borderRadius: 8, background: "#EF4444", border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: "pointer" }}>Bulk reject</button>
+      <button type="button" onClick={onClear} style={{ padding: "6px 14px", borderRadius: 8, background: "transparent", border: "1px solid rgba(255,255,255,0.15)", color: "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer" }}>Clear</button>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/sha-shared.ts
+++ b/ctf/packages/web/components/skills-hunt/sha-shared.ts
@@ -1,0 +1,34 @@
+// Shared constants and types for the Skills Hunt admin/moderation shell.
+import type { SkillsHuntSubmissionStatus } from "lib/skills-hunt/types";
+
+export const COLOR = "#A855F7";
+
+export const STATUS_OPTIONS: Array<{ key: SkillsHuntSubmissionStatus; label: string; color: string }> = [
+  { key: "pending",  label: "Pending",  color: "#F59E0B" },
+  { key: "accepted", label: "Accepted", color: "#22C55E" },
+  { key: "rejected", label: "Rejected", color: "#EF4444" },
+  { key: "flagged",  label: "Flagged",  color: COLOR },
+];
+
+export const REJECT_REASONS = [
+  "Insufficient social proof / Quora unverifiable",
+  "Display name violates spec (2–100 alphanumeric+spaces)",
+  "Skills don't match taxonomy and no valid proposed skill",
+  "Suspected duplicate of an existing accepted submission",
+  "Suspected trafficker / bad-faith actor",
+  "Other (see notes)",
+];
+
+export type ReviewAction = "accept" | "reject" | "flag";
+
+// Prompts for a reject reason (numbered pick or free text). Returns null if the
+// moderator cancels.
+export function promptRejectReason(): string | null {
+  if (typeof window === "undefined") return null;
+  const numbered = REJECT_REASONS.map((r, i) => `${i + 1}. ${r}`).join("\n");
+  const choice = window.prompt(`Reject reason (1-${REJECT_REASONS.length}) or free text:\n${numbered}`, "1");
+  if (choice == null) return null;
+  const idx = Number.parseInt(choice, 10);
+  if (Number.isInteger(idx) && idx >= 1 && idx <= REJECT_REASONS.length) return REJECT_REASONS[idx - 1];
+  return choice.trim() || null;
+}

--- a/ctf/packages/web/components/skills-hunt/sha-table.tsx
+++ b/ctf/packages/web/components/skills-hunt/sha-table.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import type { SkillsHuntSubmission } from "lib/skills-hunt/types";
+import { COLOR } from "./sha-shared";
+
+interface RowProps {
+  submission: SkillsHuntSubmission;
+  selected: boolean;
+  acting: boolean;
+  onToggle: (id: string) => void;
+  onAccept: (id: string) => void;
+  onReject: (id: string) => void;
+  onFlag: (id: string) => void;
+}
+
+function SkillsCell({ submission }: { submission: SkillsHuntSubmission }) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+      {submission.skills.map((sk) => (
+        <span key={sk} style={{ padding: "1px 7px", borderRadius: 10, background: `${COLOR}20`, color: COLOR, fontSize: 11 }}>{sk}</span>
+      ))}
+      {submission.proposedSkills.map((sk) => (
+        <span key={sk} style={{ padding: "1px 7px", borderRadius: 10, background: "rgba(251,191,36,0.15)", color: "#FBBF24", fontSize: 11 }}>{sk} ✎</span>
+      ))}
+    </div>
+  );
+}
+
+function RowActions({ submission, acting, onAccept, onReject, onFlag }: Omit<RowProps, "selected" | "onToggle">) {
+  if (submission.status !== "pending") {
+    return <span style={{ fontSize: 11, color: "#6B7280" }}>{submission.reviewAction ?? submission.status}</span>;
+  }
+  const btn = (bg: string, border: string, color: string): React.CSSProperties => ({
+    padding: "4px 10px", borderRadius: 6, background: bg, border, color, fontSize: 11, fontWeight: 700, cursor: "pointer", opacity: acting ? 0.5 : 1,
+  });
+  return (
+    <div style={{ display: "flex", gap: 6 }}>
+      <button type="button" disabled={acting} onClick={() => onAccept(submission.id)} style={btn("#22C55E", "none", "#fff")}>Accept</button>
+      <button type="button" disabled={acting} onClick={() => onReject(submission.id)} style={btn("#EF4444", "none", "#fff")}>Reject</button>
+      <button type="button" disabled={acting} onClick={() => onFlag(submission.id)} style={btn(`${COLOR}30`, `1px solid ${COLOR}60`, COLOR)}>Flag</button>
+    </div>
+  );
+}
+
+function SubmissionRow(props: RowProps) {
+  const { submission: s, selected, onToggle } = props;
+  const urlColor = s.urlValidationResult === "dead" ? "#EF4444" : s.urlValidationResult === "valid" ? "#22C55E" : "#6B7280";
+  return (
+    <tr style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+      <td style={{ padding: "10px 6px" }}>
+        <input type="checkbox" checked={selected} onChange={() => onToggle(s.id)} disabled={s.status !== "pending"} aria-label={`Select ${s.displayName}`} />
+      </td>
+      <td style={{ padding: "10px 6px" }}>
+        <div style={{ fontWeight: 600, color: "#F9FAFB" }}>{s.submitterUsername ?? s.submitterUserId.slice(0, 8)}</div>
+        <div style={{ fontSize: 11, color: "#4B5563" }}>{new Date(s.createdAtIso).toLocaleString()}</div>
+      </td>
+      <td style={{ padding: "10px 6px" }}>{s.displayName}</td>
+      <td style={{ padding: "10px 6px", maxWidth: 280 }}><SkillsCell submission={s} /></td>
+      <td style={{ padding: "10px 6px" }}>
+        {s.quoraProfileUrl
+          ? <a href={s.quoraProfileUrl} target="_blank" rel="noopener noreferrer" style={{ color: "#3B82F6", fontSize: 11 }}>open ↗</a>
+          : <span style={{ color: "#4B5563" }}>—</span>}
+      </td>
+      <td style={{ padding: "10px 6px", fontSize: 11, color: urlColor }}>{s.urlValidationResult ?? "—"}</td>
+      <td style={{ padding: "10px 6px", color: COLOR, fontWeight: 700 }}>{s.pointsAwarded}</td>
+      <td style={{ padding: "10px 6px" }}><RowActions {...props} /></td>
+    </tr>
+  );
+}
+
+export function SkillsHuntAdminTable({
+  submissions,
+  selected,
+  acting,
+  allPendingSelected,
+  onToggleAll,
+  onToggle,
+  onAccept,
+  onReject,
+  onFlag,
+}: {
+  submissions: SkillsHuntSubmission[];
+  selected: Set<string>;
+  acting: string | null;
+  allPendingSelected: boolean;
+  onToggleAll: () => void;
+  onToggle: (id: string) => void;
+  onAccept: (id: string) => void;
+  onReject: (id: string) => void;
+  onFlag: (id: string) => void;
+}) {
+  const headCell: React.CSSProperties = { padding: "8px 6px" };
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+      <thead>
+        <tr style={{ textAlign: "left", color: "#6B7280", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+          <th style={{ ...headCell, width: 32 }}>
+            <input type="checkbox" checked={allPendingSelected} onChange={onToggleAll} aria-label="Select all pending" />
+          </th>
+          <th style={headCell}>Submitter</th>
+          <th style={headCell}>Display Name</th>
+          <th style={headCell}>Skills</th>
+          <th style={headCell}>Quora</th>
+          <th style={headCell}>URL check</th>
+          <th style={headCell}>Pts</th>
+          <th style={{ ...headCell, width: 220 }}>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {submissions.map((s) => (
+          <SubmissionRow
+            key={s.id}
+            submission={s}
+            selected={selected.has(s.id)}
+            acting={acting === s.id}
+            onToggle={onToggle}
+            onAccept={onAccept}
+            onReject={onReject}
+            onFlag={onFlag}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
@@ -2,25 +2,23 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { SkillsHuntRound, SkillsHuntSubmission, SkillsHuntSubmissionStatus } from "lib/skills-hunt/types";
-
-const COLOR = "#A855F7";
-const STATUS_OPTIONS: Array<{ key: SkillsHuntSubmissionStatus; label: string; color: string }> = [
-  { key: "pending",  label: "Pending",  color: "#F59E0B" },
-  { key: "accepted", label: "Accepted", color: "#22C55E" },
-  { key: "rejected", label: "Rejected", color: "#EF4444" },
-  { key: "flagged",  label: "Flagged",  color: COLOR },
-];
-
-const REJECT_REASONS = [
-  "Insufficient social proof / Quora unverifiable",
-  "Display name violates spec (2–100 alphanumeric+spaces)",
-  "Skills don't match taxonomy and no valid proposed skill",
-  "Suspected duplicate of an existing accepted submission",
-  "Suspected trafficker / bad-faith actor",
-  "Other (see notes)",
-];
+import { COLOR, promptRejectReason, type ReviewAction } from "./sha-shared";
+import { SkillsHuntAdminFilters, SkillsHuntAdminBulkBar } from "./sha-filters";
+import { SkillsHuntAdminTable } from "./sha-table";
 
 type Props = { rounds: SkillsHuntRound[] };
+
+function AdminHeader() {
+  return (
+    <header style={{ marginBottom: 24, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
+      <div>
+        <h1 style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", margin: 0 }}>Skills Hunt — Moderation</h1>
+        <div style={{ fontSize: 13, color: "#6B7280" }}>Review nominations, accept / reject / flag, bulk-act on a status set.</div>
+      </div>
+      <a href="/apps/skills-hunt" style={{ fontSize: 13, color: COLOR, textDecoration: "none" }}>← Open player shell</a>
+    </header>
+  );
+}
 
 export function SkillsHuntAdminShell({ rounds }: Props) {
   const [activeRoundId, setActiveRoundId] = useState<string | null>(rounds[0]?.id ?? null);
@@ -29,7 +27,7 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [acting, setActing] = useState<string | null>(null); // submissionId currently in-flight
+  const [acting, setActing] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!activeRoundId) return;
@@ -38,7 +36,7 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
     try {
       const res = await fetch(`/api/skills-hunt/admin/rounds/${activeRoundId}/submissions?status=${statusFilter}&pageSize=100`);
       if (!res.ok) throw new Error("Failed to load submissions");
-      const data = await res.json() as { items: SkillsHuntSubmission[] };
+      const data = (await res.json()) as { items: SkillsHuntSubmission[] };
       setSubmissions(data.items);
       setSelected(new Set());
     } catch (e) {
@@ -50,7 +48,7 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
 
   useEffect(() => { void refresh(); }, [refresh]);
 
-  async function reviewOne(submissionId: string, action: "accept" | "reject" | "flag", notes: string | null) {
+  async function reviewOne(submissionId: string, action: ReviewAction, notes: string | null) {
     setActing(submissionId);
     try {
       const res = await fetch(`/api/skills-hunt/admin/submissions/${submissionId}/review`, {
@@ -59,7 +57,7 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
         body: JSON.stringify({ action, notes }),
       });
       if (!res.ok) {
-        const err = await res.json() as { message?: string };
+        const err = (await res.json()) as { message?: string };
         throw new Error(err.message ?? "Review failed");
       }
     } catch (e) {
@@ -69,14 +67,25 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
     }
   }
 
+  async function reviewAndRefresh(id: string, action: ReviewAction, notes: string | null) {
+    await reviewOne(id, action, notes);
+    await refresh();
+  }
+
+  function onReject(id: string) {
+    const reason = promptRejectReason();
+    if (reason === null) return;
+    void reviewAndRefresh(id, "reject", reason);
+  }
+
   async function bulkReview(action: "accept" | "reject") {
     if (selected.size === 0) return;
     const notes = action === "reject" ? promptRejectReason() : null;
     if (action === "reject" && notes === null) return;
     // Defensive filter: only act on currently-pending submissions even if a
     // status change between select-and-act sneaks non-pending IDs in.
-    const pendingIds = new Set(submissions.filter(s => s.status === "pending").map(s => s.id));
-    const ids = Array.from(selected).filter(id => pendingIds.has(id));
+    const pendingIds = new Set(submissions.filter((s) => s.status === "pending").map((s) => s.id));
+    const ids = Array.from(selected).filter((id) => pendingIds.has(id));
     for (const id of ids) {
       // Sequential so the leaderboard rebuilds settle row-by-row.
       await reviewOne(id, action, notes);
@@ -84,18 +93,8 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
     await refresh();
   }
 
-  function promptRejectReason(): string | null {
-    if (typeof window === "undefined") return null;
-    const numbered = REJECT_REASONS.map((r, i) => `${i + 1}. ${r}`).join("\n");
-    const choice = window.prompt(`Reject reason (1-${REJECT_REASONS.length}) or free text:\n${numbered}`, "1");
-    if (choice == null) return null;
-    const idx = Number.parseInt(choice, 10);
-    if (Number.isInteger(idx) && idx >= 1 && idx <= REJECT_REASONS.length) return REJECT_REASONS[idx - 1];
-    return choice.trim() || null;
-  }
-
   function toggleOne(id: string) {
-    setSelected(prev => {
+    setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id); else next.add(id);
       return next;
@@ -103,77 +102,23 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
   }
 
   function toggleAllVisible() {
-    // Only pending rows are actionable; never select accepted/rejected/flagged.
-    const pendingIds = submissions.filter(s => s.status === "pending").map(s => s.id);
+    const pendingIds = submissions.filter((s) => s.status === "pending").map((s) => s.id);
     if (selected.size === pendingIds.length) setSelected(new Set());
     else setSelected(new Set(pendingIds));
   }
 
+  const pendingCount = submissions.filter((s) => s.status === "pending").length;
+  const allPendingSelected = pendingCount > 0 && selected.size === pendingCount;
+
   return (
     <div style={{ minHeight: "100vh", background: "#0F1117", color: "#E8EAF0", fontFamily: "'Inter', system-ui, sans-serif", padding: 24 }}>
-      <header style={{ marginBottom: 24, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
-        <div>
-          <h1 style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", margin: 0 }}>Skills Hunt — Moderation</h1>
-          <div style={{ fontSize: 13, color: "#6B7280" }}>Review nominations, accept / reject / flag, bulk-act on a status set.</div>
-        </div>
-        <a href="/apps/skills-hunt" style={{ fontSize: 13, color: COLOR, textDecoration: "none" }}>← Open player shell</a>
-      </header>
-
+      <AdminHeader />
       {rounds.length === 0 ? (
         <div style={{ color: "#6B7280" }}>No rounds yet. Create one before moderating.</div>
       ) : (
         <>
-          <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
-            {rounds.map(r => (
-              <button
-                key={r.id}
-                onClick={() => setActiveRoundId(r.id)}
-                style={{
-                  padding: "6px 14px",
-                  borderRadius: 20,
-                  background: activeRoundId === r.id ? `${COLOR}25` : "rgba(255,255,255,0.04)",
-                  border: `1px solid ${activeRoundId === r.id ? COLOR + "60" : "rgba(255,255,255,0.08)"}`,
-                  color: activeRoundId === r.id ? COLOR : "#9CA3AF",
-                  fontSize: 12,
-                  fontWeight: 600,
-                  cursor: "pointer",
-                }}
-              >
-                {r.name} <span style={{ opacity: 0.6 }}>· {r.status}</span>
-              </button>
-            ))}
-          </div>
-
-          <div style={{ display: "flex", gap: 6, marginBottom: 16 }}>
-            {STATUS_OPTIONS.map(s => (
-              <button
-                key={s.key}
-                onClick={() => setStatusFilter(s.key)}
-                style={{
-                  padding: "4px 12px",
-                  borderRadius: 20,
-                  background: statusFilter === s.key ? `${s.color}25` : "rgba(255,255,255,0.04)",
-                  border: `1px solid ${statusFilter === s.key ? s.color + "60" : "rgba(255,255,255,0.08)"}`,
-                  color: statusFilter === s.key ? s.color : "#9CA3AF",
-                  fontSize: 12,
-                  fontWeight: 600,
-                  cursor: "pointer",
-                }}
-              >
-                {s.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Bulk toolbar */}
-          {selected.size > 0 && (
-            <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px", marginBottom: 12, borderRadius: 10, background: `${COLOR}10`, border: `1px solid ${COLOR}30` }}>
-              <span style={{ fontSize: 12, color: COLOR, fontWeight: 600 }}>{selected.size} selected</span>
-              <button onClick={() => bulkReview("accept")} style={{ padding: "6px 14px", borderRadius: 8, background: "#22C55E", border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: "pointer" }}>Bulk accept</button>
-              <button onClick={() => bulkReview("reject")} style={{ padding: "6px 14px", borderRadius: 8, background: "#EF4444", border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: "pointer" }}>Bulk reject</button>
-              <button onClick={() => setSelected(new Set())} style={{ padding: "6px 14px", borderRadius: 8, background: "transparent", border: "1px solid rgba(255,255,255,0.15)", color: "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer" }}>Clear</button>
-            </div>
-          )}
+          <SkillsHuntAdminFilters rounds={rounds} activeRoundId={activeRoundId} onRound={setActiveRoundId} statusFilter={statusFilter} onStatus={setStatusFilter} />
+          <SkillsHuntAdminBulkBar count={selected.size} onAccept={() => void bulkReview("accept")} onReject={() => void bulkReview("reject")} onClear={() => setSelected(new Set())} />
 
           {error && <div style={{ marginBottom: 12, color: "#EF4444", fontSize: 13 }}>{error}</div>}
           {loading ? (
@@ -181,70 +126,17 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
           ) : submissions.length === 0 ? (
             <div style={{ color: "#6B7280", fontSize: 13 }}>No submissions matching this filter.</div>
           ) : (
-            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
-              <thead>
-                <tr style={{ textAlign: "left", color: "#6B7280", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em" }}>
-                  <th style={{ padding: "8px 6px", width: 32 }}>
-                    <input type="checkbox" checked={selected.size > 0 && selected.size === submissions.filter(s => s.status === "pending").length} onChange={toggleAllVisible} />
-                  </th>
-                  <th style={{ padding: "8px 6px" }}>Submitter</th>
-                  <th style={{ padding: "8px 6px" }}>Display Name</th>
-                  <th style={{ padding: "8px 6px" }}>Skills</th>
-                  <th style={{ padding: "8px 6px" }}>Quora</th>
-                  <th style={{ padding: "8px 6px" }}>URL check</th>
-                  <th style={{ padding: "8px 6px" }}>Pts</th>
-                  <th style={{ padding: "8px 6px", width: 220 }}>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {submissions.map(s => {
-                  const isSel = selected.has(s.id);
-                  const isActing = acting === s.id;
-                  return (
-                    <tr key={s.id} style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}>
-                      <td style={{ padding: "10px 6px" }}>
-                        <input type="checkbox" checked={isSel} onChange={() => toggleOne(s.id)} disabled={s.status !== "pending"} />
-                      </td>
-                      <td style={{ padding: "10px 6px" }}>
-                        <div style={{ fontWeight: 600, color: "#F9FAFB" }}>{s.submitterUsername ?? s.submitterUserId.slice(0, 8)}</div>
-                        <div style={{ fontSize: 11, color: "#4B5563" }}>{new Date(s.createdAtIso).toLocaleString()}</div>
-                      </td>
-                      <td style={{ padding: "10px 6px" }}>{s.displayName}</td>
-                      <td style={{ padding: "10px 6px", maxWidth: 280 }}>
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-                          {s.skills.map(sk => (
-                            <span key={sk} style={{ padding: "1px 7px", borderRadius: 10, background: `${COLOR}20`, color: COLOR, fontSize: 11 }}>{sk}</span>
-                          ))}
-                          {s.proposedSkills.map(sk => (
-                            <span key={sk} style={{ padding: "1px 7px", borderRadius: 10, background: "rgba(251,191,36,0.15)", color: "#FBBF24", fontSize: 11 }}>{sk} ✎</span>
-                          ))}
-                        </div>
-                      </td>
-                      <td style={{ padding: "10px 6px" }}>
-                        {s.quoraProfileUrl ? (
-                          <a href={s.quoraProfileUrl} target="_blank" rel="noopener noreferrer" style={{ color: "#3B82F6", fontSize: 11 }}>open ↗</a>
-                        ) : <span style={{ color: "#4B5563" }}>—</span>}
-                      </td>
-                      <td style={{ padding: "10px 6px", fontSize: 11, color: s.urlValidationResult === "dead" ? "#EF4444" : s.urlValidationResult === "valid" ? "#22C55E" : "#6B7280" }}>
-                        {s.urlValidationResult ?? "—"}
-                      </td>
-                      <td style={{ padding: "10px 6px", color: COLOR, fontWeight: 700 }}>{s.pointsAwarded}</td>
-                      <td style={{ padding: "10px 6px" }}>
-                        {s.status === "pending" ? (
-                          <div style={{ display: "flex", gap: 6 }}>
-                            <button disabled={isActing} onClick={async () => { await reviewOne(s.id, "accept", null); await refresh(); }} style={{ padding: "4px 10px", borderRadius: 6, background: "#22C55E", border: "none", color: "#fff", fontSize: 11, fontWeight: 700, cursor: "pointer", opacity: isActing ? 0.5 : 1 }}>Accept</button>
-                            <button disabled={isActing} onClick={async () => { const r = promptRejectReason(); if (r === null) return; await reviewOne(s.id, "reject", r); await refresh(); }} style={{ padding: "4px 10px", borderRadius: 6, background: "#EF4444", border: "none", color: "#fff", fontSize: 11, fontWeight: 700, cursor: "pointer", opacity: isActing ? 0.5 : 1 }}>Reject</button>
-                            <button disabled={isActing} onClick={async () => { await reviewOne(s.id, "flag", null); await refresh(); }} style={{ padding: "4px 10px", borderRadius: 6, background: `${COLOR}30`, border: `1px solid ${COLOR}60`, color: COLOR, fontSize: 11, fontWeight: 700, cursor: "pointer", opacity: isActing ? 0.5 : 1 }}>Flag</button>
-                          </div>
-                        ) : (
-                          <span style={{ fontSize: 11, color: "#6B7280" }}>{s.reviewAction ?? s.status}</span>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+            <SkillsHuntAdminTable
+              submissions={submissions}
+              selected={selected}
+              acting={acting}
+              allPendingSelected={allPendingSelected}
+              onToggleAll={toggleAllVisible}
+              onToggle={toggleOne}
+              onAccept={(id) => void reviewAndRefresh(id, "accept", null)}
+              onReject={onReject}
+              onFlag={(id) => void reviewAndRefresh(id, "flag", null)}
+            />
           )}
         </>
       )}


### PR DESCRIPTION
## Summary

The deferred rule-116 follow-up from the skills-hunt user-shell pass (#166). Decomposes the 253-line `skills-hunt-admin-shell.tsx` (213-line render + a complexity-11 inline action arrow) into modular pieces within rule-116 limits.

### Components
- `sha-shared.ts` — `COLOR`, `STATUS_OPTIONS`, `REJECT_REASONS`, `promptRejectReason`
- `sha-filters.tsx` — round chips, status chips, bulk-action toolbar
- `sha-table.tsx` — submissions table + extracted `SubmissionRow` / `RowActions` (kills the complexity-11 per-row action arrow)
- `skills-hunt-admin-shell.tsx` — thin orchestration shell

### Behavior preserved exactly
Review / bulk-review POST `{ action, notes }` with the `x-ctf-csrf` header; pending-only selection guard; sequential bulk apply so leaderboard rebuilds settle row-by-row. Added `aria-label`s on the row checkboxes.

### Design gate
No design mockup exists for this internal moderation surface and none is required — this is a pure behavior-preserving decomposition with no new rendered surface, no layout/IA change. No schema/route/contract changes.

### Docs
Change-log entry in the skills-hunt inventory (no plan row change — skills-hunt is already Web px ✅).

### Gates (local)
typecheck, modularity (`complexity:["error",10]`, `max-lines-per-function: 200`), flat lint, `build:ci`, EOF, web/android parity, schema-drift — all green.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_