### PR TITLE
chore: agent branch-naming rule + disable CodeRabbit's redundant ESLint

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,3 +21,11 @@ reviews:
     # Only auto-review PRs that carry one of these labels.
     labels:
       - coderabbit
+  tools:
+    # Disable CodeRabbit's bundled ESLint. It runs ESLint 10 (flat-config only),
+    # which errors on this repo's classic .eslintrc.cjs ("'root' key not supported
+    # in flat config") and produces a recurring false failure on every PR. Our CI
+    # lints authoritatively with the repo's pinned ESLint 9, so CodeRabbit's copy is
+    # redundant noise. Revisit if/when the repo migrates to ESLint flat config.
+    eslint:
+      enabled: false

--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -3,6 +3,12 @@
 - The primary development environment is GitHub Codespaces.
 - All environment-type updates, additions, and tooling changes must be reflected in the devcontainer setup (e.g., .devcontainer/setup.sh, devcontainer.json) to ensure reproducibility and zero manual steps on container start.
 
+## Branch Naming (Critical — all agents)
+
+- Always create a descriptive, task-named branch and develop on it. Use a Conventional-Commit-style prefix plus a short kebab-case summary of the task: e.g. `feat/survivor-hub-feed-consolidation`, `fix/feed-csrf-dedup`, `chore/agent-branch-naming-rule`, `docs/brand-voice-lexicon`.
+- Never develop on, commit to, or open a PR from the auto-generated session branch that the Claude Code harness assigns (e.g. `claude/<random-slug>` such as `claude/loving-mendel-wwWF4`). That name is opaque and meaningless. Treat it as a throwaway base: immediately branch off it (or off `main`) to a descriptive name and push/open the PR from the descriptive branch.
+- Branch names must describe the task at hand — never an opaque/random string. This applies even when a session is initialized on a `claude/<slug>` branch: the first action for any code work is to create the descriptive branch.
+
 ## Search Tooling Policy
 
 - Prefer `rg`/ripgrep for recursive text and file discovery.


### PR DESCRIPTION
## Summary

Two small repo-governance changes:

### 1. Branch-naming rule (`.github/instructions/copilot-instructions.md`)
Agents must use a descriptive, task-named branch and stop developing on the opaque auto-generated `claude/<slug>` session branch.
- Always create a descriptive branch (Conventional-Commit-style prefix + kebab summary), e.g. `feat/survivor-hub-feed-consolidation`, `fix/feed-csrf-dedup`.
- Never commit to or open PRs from the harness-assigned `claude/<random-slug>` branch — treat it as a throwaway base and branch off it (or `main`) immediately.

This PR is itself on `chore/agent-descriptive-branch-naming-rule` (dogfooding the rule).

### 2. Disable CodeRabbit's bundled ESLint (`.coderabbit.yaml`)
CodeRabbit runs ESLint 10 (flat-config only), which errors on this repo's classic `.eslintrc.cjs` (`'root' key not supported in flat config`) and emits a recurring false failure on every PR. Our CI lints authoritatively with the repo's pinned ESLint 9, so CodeRabbit's copy is redundant noise. Disabled via `reviews.tools.eslint.enabled: false`. Revisit if the repo ever migrates to ESLint flat config.

Docs/config only; no schema/seed/contract/runtime change.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_