### PR TITLE
docs: codify no-standalone-DM / transaction-scoped messaging rule

### DIFF
--- a/.github/instructions/100-product-context-and-experience-rules.mdc
+++ b/.github/instructions/100-product-context-and-experience-rules.mdc
@@ -34,6 +34,13 @@ Provide mandatory context so implementation decisions protect users and prevent 
 - Require explicit confirmation for irreversible actions.
 - Avoid social-pressure mechanics that can coerce disclosure or participation.
 
+## Messaging Scope and Lifecycle (No Standalone DMs)
+- There is no standalone or persistent direct messaging anywhere on the platform. The product has no DM inbox, no friend/contact messaging, and no open-ended private chat. This is a deliberate harm-reduction decision to deny perpetrators and bad actors an open channel to target vulnerable users.
+- Any 1:1 (two-party, private) messaging must be scoped to a single active plugin transaction (e.g., a TrustTransport trip, a SocketRelay fulfillment, a Foundation quote/connection) and limited to exactly the two parties to that transaction. The chat opens when the transaction starts.
+- When the transaction reaches a terminal state (completed, cancelled, or disputed) the chat closes: no new messages may be sent; both parties retain read-only access for a limited window; messages are retained server-side for moderation and abuse evidence per the plugin's deletion/retention contract. This applies equally to text, voice, and video.
+- The only non-transaction messaging surfaces are group/room surfaces that are not 1:1 — the Survivor Hub's single public "community" channel and group rooms like Chyme audio rooms and Peer-Programming cohort rooms. These must not expose any private 1:1 DM affordance.
+- Every plugin inventory that includes a 1:1 chat must document this transaction-bound open/close lifecycle (open on transaction start; read-only archive + retain on terminal state) in both its feature sections and its profile/deletion contract.
+
 ## Plugin Experience Guardrails
 - Plugins must inherit shared safety/privacy/accessibility defaults from platform layers.
 - Plugin commands must degrade safely and fail with clear, non-technical messaging.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
@@ -16,7 +16,7 @@ Foundation provides trauma-informed survivors with deterministic access to vette
 1. Provider discovery and search by service type, location, language, and trauma-informed criteria.
 2. Survivor-provider 1:1 text messaging with delivery/read/seen semantics and file attachment support.
 3. Voice and video session initiation and join for approved 1:1 participants.
-4. Quote request lifecycle (requested â†’ provider_responded â†’ closed) with immutable timeline view.
+4. Quote request lifecycle (requested â†’ provider_responded â†’ closed) with immutable timeline view. The 1:1 text/voice/video channel is scoped to an active connection/quote between exactly the two parties and opens with it; when the connection/quote reaches a terminal state (closed, declined, or ended) the chat closes â€” no new messages may be sent, both parties keep read-only access for a limited window, and message/session records are retained server-side for moderation/abuse evidence per the deletion contract. No 1:1 messaging exists outside an active connection/quote (platform rule 100, "Messaging Scope and Lifecycle").
 5. Connection and quote history lists scoped by actor ownership.
 6. In-app notifications for messages, quote state changes, and missed calls.
 7. Notification preferences and quiet-hour controls.
@@ -127,7 +127,7 @@ Seeded content:
     - Foundation reads Directory data through read-only projections only.
     - No Foundation command can mutate Directory behavior/data.
 
-### €” Contract and Policy Lock
+### ï¿½ï¿½ Contract and Policy Lock
 
 - [ ] Lock Foundation command contracts for full-v1.
   - Acceptance criteria:
@@ -142,7 +142,7 @@ Seeded content:
   - Acceptance criteria:
     - Contracts and inventory align with `.github/instructions/110-stream-maker-tier-rules.mdc` threshold model and fallback rules.
 
-### €” Schema, Migrations, and Retention
+### ï¿½ï¿½ Schema, Migrations, and Retention
 
 - [ ] Define Foundation extension/domain schema and migrations under `ctf/migrations/`.
   - Acceptance criteria:
@@ -157,7 +157,7 @@ Seeded content:
   - Acceptance criteria:
     - Migration replay and rollback steps are captured for PR evidence.
 
-### €” Core Service and Command Execution
+### ï¿½ï¿½ Core Service and Command Execution
 
 - [ ] Implement provider search service using Directory read-only projections.
   - Acceptance criteria:
@@ -175,7 +175,7 @@ Seeded content:
   - Acceptance criteria:
     - Actor ownership checks prevent cross-user history access.
 
-### €” Rate Limiting, Quotas, and Scalability
+### ï¿½ï¿½ Rate Limiting, Quotas, and Scalability
 
 - [ ] Implement command-level rate limiting for high-frequency actions.
   - Acceptance criteria:
@@ -190,7 +190,7 @@ Seeded content:
   - Acceptance criteria:
     - PR includes required note under `ctf/docs/quota-impact/` with fallback and observability sections.
 
-### €” Web Full-v1 Delivery
+### ï¿½ï¿½ Web Full-v1 Delivery
 
 - [ ] Deliver web provider search and profile preview flows.
   - Acceptance criteria:
@@ -205,7 +205,7 @@ Seeded content:
   - Acceptance criteria:
     - Users can review interaction history and control notification channels/quiet hours.
 
-### €” Android Parity Follow-up Tracking
+### ï¿½ï¿½ Android Parity Follow-up Tracking
 
 - [ ] Create parity tracking table for all web-delivered Foundation capabilities.
   - Acceptance criteria:
@@ -223,7 +223,7 @@ Seeded content:
   - Acceptance criteria:
     - Any deferred item includes approved risk note and final completion date.
 
-### €” Trauma-Informed and Accessibility Validation
+### ï¿½ï¿½ Trauma-Informed and Accessibility Validation
 
 - [ ] Validate trauma-informed UX constraints.
   - Acceptance criteria:
@@ -235,7 +235,7 @@ Seeded content:
   - Acceptance criteria:
     - Critical safety pathways are discoverable, clear, and policy-compliant.
 
-### €” Security, Compliance, and Deletion
+### ï¿½ï¿½ Security, Compliance, and Deletion
 
 - [ ] Verify authz, consent, region, and deny-condition enforcement.
   - Acceptance criteria:
@@ -284,3 +284,4 @@ Seeded content:
 ### Change Log
 
 - 2026-02-24: Created initial Foundation rewrite checklist with full-v1 gates for search, 1:1 text/voice/video, quote lifecycle, history, notifications, rate limiting/scalability, trauma-informed accessibility, and web-first to Android parity follow-up tracking.
+- 2026-05-31: Documented the transaction-scoped messaging lifecycle per platform rule 100 ("Messaging Scope and Lifecycle"): the 1:1 text/voice/video channel is bound to an active connection/quote and closes on terminal state (read-only window + records retained for moderation/abuse evidence); no 1:1 messaging outside an active connection/quote. Aligning the deletion contract to mirror this retention is a tracked follow-up.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
@@ -36,6 +36,7 @@ SocketRelay is a request-and-fulfillment plugin with profile management, request
 1. Participant-only chat retrieval and send flows for fulfillment threads.
 2. Access control constrained to request owner and fulfiller.
 3. Deterministic error semantics for unauthorized access paths.
+4. Lifecycle: the chat is scoped to a single fulfillment between exactly the two participants (request owner + fulfiller) and opens with the fulfillment. When the fulfillment reaches a terminal state (completed, cancelled, disputed) the chat closes: no new messages may be sent, both parties keep read-only access for a limited window, and `socketrelay_messages` are retained server-side for moderation/abuse evidence per the deletion contract. No 1:1 messaging exists outside an active fulfillment (platform rule 100, "Messaging Scope and Lifecycle").
 
 ### 1.5 Public Sharing Surface
 
@@ -108,7 +109,7 @@ Tables owned by this plugin:
 3. `socketrelay_request_events` — Event log for request state transitions.
 4. `socketrelay_fulfillments` — Fulfillment claims and outcomes per request.
 5. `socketrelay_fulfillment_participants` — Participant access records for fulfillment chats.
-6. `socketrelay_messages` — Participant-only chat messages on a fulfillment.
+6. `socketrelay_messages` — Participant-only chat messages on a fulfillment. The chat is transaction-scoped: after the fulfillment reaches a terminal state no new rows may be added; existing rows become read-only for the two participants for a limited window and are retained server-side for moderation/abuse evidence per the deletion contract (platform rule 100).
 7. `socketrelay_admin_audit_trail` — Audit log for admin mutations.
 
 Storage and projection rules:
@@ -288,3 +289,4 @@ Web pixel pass (design `c5d83c0`): the `/apps/socketrelay` shell is rebuilt to `
 ### Change Log
 
 - 2026-02-25: Created initial SocketRelay CTF rewrite checklist with web-first release gating, tracked Android deferrals, lifecycle requirements, and explicit mitigation gates for legacy-known risks.
+- 2026-05-31: Documented the transaction-scoped messaging lifecycle per platform rule 100 ("Messaging Scope and Lifecycle"): the per-fulfillment 1:1 chat closes on terminal fulfillment state (read-only window + `socketrelay_messages` retained for moderation/abuse evidence); no messaging outside an active fulfillment. Aligning the deletion contract to mirror this retention is a tracked follow-up.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-feature-inventory.md
@@ -81,7 +81,7 @@ The plugin must provide equivalent core behavior across web and Android.
 ### 1.5 Order/Trip Lifecycle and Communications
 
 1. Canonical lifecycle states by mode (ride/package/food) with shared status vocabulary.
-2. In-context communication channel for each order/trip.
+2. In-context communication channel scoped to each order/trip between exactly the two parties (rider and driver). The chat opens with the trip and closes when the trip reaches a terminal state (completed, cancelled, disputed): no new messages may be sent, both parties keep read-only access for a limited window, and messages are retained server-side for moderation/abuse evidence per the deletion contract. No 1:1 messaging exists outside an active trip (platform rule 100, "Messaging Scope and Lifecycle").
 3. Clear non-technical status and failure messaging.
 
 ### 1.6 Earnings, Payouts, and Reputation
@@ -250,6 +250,7 @@ Tables owned by this plugin:
 - 2026-05-17: Updated inventory to enforce Rule 120 living-snapshot model. Removed Phase language (Delivery Phasing section) and unresolved decisions list.
 - 2026-04-06: Mobile rewrite with design-faithful UI (TrustTransport.tsx) for booking, tracking, chat flows and auth-gating. Admin features pending.
 - 2026-02-24: Created initial CTF rewrite inventory for TrustTransport (net-new plugin) with user/admin/API/data/security/parity scope.
+- 2026-05-31: Documented the transaction-scoped messaging lifecycle per platform rule 100 ("Messaging Scope and Lifecycle"): the per-trip 1:1 chat opens with the trip and closes on terminal state (read-only window + retained for moderation/abuse evidence); no messaging outside an active trip. Aligning the deletion contract to mirror this retention is a tracked follow-up.
 
 
 ## Build Checklist


### PR DESCRIPTION
## Summary

Audited every plugin inventory against the harm-reduction decision: no standalone/persistent direct messaging anywhere — any 1:1 chat must be bound to a single active plugin transaction and close when that transaction completes.

### Audit result
No plugin offers a standalone DM inbox. Survivor Hub already drops DMs (one public community channel). The three plugins with 1:1 chat are transaction-scoped, but the close-on-completion lifecycle was implicit and undocumented, and the principle wasn't captured as a platform rule.

### Changes
- `100-product-context-and-experience-rules.mdc` — new "Messaging Scope and Lifecycle (No Standalone DMs)" section: no DM inbox; 1:1 chat is scoped to one transaction between the two parties; on terminal state (completed/cancelled/disputed) it closes — no new messages, both parties keep read-only access for a limited window, retained server-side for moderation/abuse evidence; applies to text/voice/video. Group/public surfaces (Hub community channel, Chyme rooms, Peer-Programming cohorts) are the only non-transaction messaging and expose no 1:1 DM.
- TrustTransport / SocketRelay / Foundation inventories — state the per-trip / per-fulfillment / per-connection chat open+close lifecycle explicitly; SocketRelay `socketrelay_messages` data-model note updated; change-log entries added.

### Owner decision applied
Chat closure = read-only archive + retain (no new messages after terminal state; both parties keep read-only access for a window; retained for moderation/abuse evidence).

### Tracked follow-up
Align each plugin's profile/deletion contract to mirror this retention semantics (noted in each inventory; not in this PR).

Docs/rules only; no schema/seed/contract/runtime change.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_