### PR TITLE
docs: align 3 deletion contracts with transaction-scoped messaging retention

### DIFF
--- a/ctf/docs/contracts/FOUNDATION_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/FOUNDATION_PROFILE_AND_DELETION_CONTRACT.md
@@ -93,6 +93,10 @@ Directory interaction rule:
 
 - Foundation reads Directory-projected provider data in read-only mode and MUST NOT mutate Directory behavior, records, workflows, or schema.
 
+### Transaction-scoped messaging retention
+
+Per platform rule 100 ("Messaging Scope and Lifecycle"), the 1:1 text/voice/video channel (`foundation_connection_threads`, `foundation_message_metadata`, `foundation_call_sessions`) is bound to an active connection/quote between exactly the two parties and has no existence outside it. When the connection/quote reaches a terminal state (closed, declined, or ended) the chat closes: no new messages may be sent, both parties retain read-only access for a limited window, and message/call records are retained server-side for moderation and abuse evidence. On service-scoped or full-account deletion, message bodies are hard-deleted or pseudonymized per the scopes below, while minimal moderation/abuse-evidence and Rule 114 audit metadata may be retained where policy or law requires (consistent with the retain-for-compliance scope).
+
 ## 5) Service-Scoped Deletion Contract
 
 When user deletes Foundation plugin usage only:
@@ -184,3 +188,4 @@ If user returns to Foundation after service-scoped deletion:
 ## Change Log
 
 - 2026-02-24: Created initial Foundation profile/deletion contract with explicit Directory read-only boundary, plugin-vs-account deletion behavior, and re-consent requirements.
+- 2026-05-31: Added transaction-scoped messaging retention (per rule 100): 1:1 text/voice/video channel closes on connection/quote terminal state (read-only window), retained server-side for moderation/abuse evidence; bodies hard-deleted/pseudonymized on deletion with minimal evidence/audit metadata retained per policy.

--- a/ctf/docs/contracts/SOCKETRELAY_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/SOCKETRELAY_PROFILE_AND_DELETION_CONTRACT.md
@@ -67,6 +67,10 @@ Rule 114 baseline: SocketRelay uses canonical identity and plugin extension rows
   - Retention period: compliance retention window
   - Legal/compliance note: Rule 114 deletion audit trail
 
+### Transaction-scoped messaging retention
+
+Per platform rule 100 ("Messaging Scope and Lifecycle"), the fulfillment chat (`socketrelay_messages`) is bound to a single fulfillment between exactly the two participants (request owner and fulfiller) and has no existence outside it. When the fulfillment reaches a terminal state (completed, cancelled, disputed) the chat closes: no new messages may be sent, both parties retain read-only access for a limited window, and messages are retained server-side for moderation and abuse evidence. On service-scoped or full-account deletion, message bodies are hard-deleted or pseudonymized per the scopes below, while minimal moderation/abuse-evidence and Rule 114 audit metadata may be retained where policy or law requires (consistent with the retain-for-compliance scope).
+
 ## 5) Service-Scoped Deletion Contract
 
 When user deletes SocketRelay usage only:
@@ -150,3 +154,4 @@ If user returns after service-scoped deletion:
 ## Change Log
 
 - 2026-02-25: Created initial draft.
+- 2026-05-31: Added transaction-scoped messaging retention (per rule 100): per-fulfillment 1:1 chat (`socketrelay_messages`) closes on terminal state (read-only window), retained server-side for moderation/abuse evidence; bodies hard-deleted/pseudonymized on deletion with minimal evidence/audit metadata retained per policy.

--- a/ctf/docs/contracts/TRUSTTRANSPORT_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/TRUSTTRANSPORT_PROFILE_AND_DELETION_CONTRACT.md
@@ -69,6 +69,10 @@ Rule 114 baseline: TrustTransport uses a single canonical profile and plugin ext
   - Retention period: compliance retention window
   - Legal/compliance note: Rule 114 deletion audit trail
 
+### Transaction-scoped messaging retention
+
+Per platform rule 100 ("Messaging Scope and Lifecycle"), the per-trip 1:1 chat is bound to a single trip/order between exactly the two parties (rider and driver) and has no existence outside it. When the trip reaches a terminal state (completed, cancelled, disputed) the chat closes: no new messages may be sent, both parties retain read-only access for a limited window, and chat records are retained server-side for moderation and abuse evidence. On service-scoped or full-account deletion, chat bodies are hard-deleted or pseudonymized per the scopes below, while minimal moderation/abuse-evidence and Rule 114 audit metadata may be retained where policy or law requires (consistent with the retain-for-compliance scope).
+
 ## 5) Service-Scoped Deletion Contract
 
 When user deletes TrustTransport usage only:
@@ -152,3 +156,4 @@ If user returns after service-scoped deletion:
 ## Change Log
 
 - 2026-02-25: Created initial draft.
+- 2026-05-31: Added transaction-scoped messaging retention (per rule 100): per-trip 1:1 chat closes on terminal state (read-only window), retained server-side for moderation/abuse evidence; bodies hard-deleted/pseudonymized on deletion with minimal evidence/audit metadata retained per policy.


### PR DESCRIPTION
## Summary

Closes the tracked follow-up from #178 (the no-standalone-DM / transaction-scoped messaging rule): aligns the three messaging plugins' profile/deletion contracts with the read-only-archive + retain semantics.

Each contract's "Domain Data Owned by Plugin" section now has a "Transaction-scoped messaging retention" note stating:
- the 1:1 chat is bound to one transaction between the two parties and has no existence outside it;
- on terminal state it closes (no new messages; both parties keep read-only access for a limited window; records retained server-side for moderation/abuse evidence);
- on service/full-account deletion, bodies are hard-deleted or pseudonymized while minimal evidence + Rule 114 audit metadata may be retained per policy.

Tailored per plugin: TrustTransport (per-trip; completed/cancelled/disputed), SocketRelay (per-fulfillment; `socketrelay_messages`), Foundation (per-connection/quote; text/voice/video — `foundation_connection_threads`/`foundation_message_metadata`/`foundation_call_sessions`). Change-log entries added.

Docs/contracts only; no schema/seed/runtime change.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_