### PR TITLE
feat: align Foundation web shell to design mockup with real-data bindings

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -109,7 +109,7 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 | feed-announcements (Hub data layer) | 🎨 | ✅ | ⬜ | ⬜ | 🟡 | ⬜ |
 | workforce | 🎨 | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | skills-hunt | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
-| foundation | 🎨 | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| foundation | 🎨 | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
 | lighthouse | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | socketrelay | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |
 | trusttransport | 🎨 | ✅ | ✅ | ⬜ | ✅ | ⬜ |

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
@@ -87,7 +87,8 @@ Cross-plugin read dependencies (read-only):
 
 ## Web and Android Delivery Status
 
-Parity status: **web+android complete**.
+- **Web:** delivered. `FoundationShell` (`ctf/packages/web/components/foundation/`) renders the survivor-facing experience against the live Foundation API — provider search/browse (`displayName`, `headline`, `bio`), provider profile, real two-step quote request (open connection thread → create quote on it), and quote history with lifecycle status. Decomposed under Rule 116 into `foundation-ui`, `foundation-rails`, `foundation-panels`, `foundation-profile`, and the orchestrating `foundation-shell`. Aligned to the canonical `survivor-hub/Foundation` design mockup; mockup-only fields with no backing API (star rating, job counts, hourly price, availability, inflated platform stats) are intentionally omitted rather than mocked, per the real-data-only rule.
+- **Android:** pending UI circle-back; tracked in the readiness table (Android ⬜).
 
 ## Seed Coverage Status
 
@@ -107,6 +108,7 @@ Seeded content:
 
 ## Change Log
 
+- 2026-05-31: Web pixel pass. Rebuilt `FoundationShell` to match the canonical `survivor-hub/Foundation` design mockup and bind to real API contracts only. Fixed three pre-existing data bugs: provider search now reads `{ items }` (was treating the response as a raw array), quote history now calls `GET /api/foundation/quotes/history` (was calling the GET-less `/api/foundation/quotes`), and "Request Quote" now performs the real two-step flow (POST `/connections/threads` then POST `/quotes` with `x-ctf-csrf: 1`) instead of posting an unsupported `{ providerId, description }` body. Decomposed the shell into five Rule-116-compliant files. Dropped mockup fields with no backing API (rating, jobs, price, availability, hard-coded platform stats). Web px flipped to ✅ in the readiness table.
 - 2026-05-17: Updated inventory to enforce Rule 120 living-snapshot model. Removed Phase language (Delivery Phasing sections), Planned section headers, and planning ambiguities. Confirmed web+android complete delivery status. Clarified technical debt (quote schema, fallback copy, notification strategy, capacity assumptions) as known limitations, not unimplemented features.
 - 2026-02-24: Created initial Foundation CTF rewrite inventory with full-v1 scope for search, 1:1 text/voice/video, quote lifecycle, history, notifications, rate limiting, and scalability.
 

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -202,7 +202,7 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (selectedPlugin.slug === 'foundation') {
-    return <FoundationShell userId={decision.userId} isAdmin={decision.isAdmin} />;
+    return <FoundationShell />;
   }
 
   if (selectedPlugin.slug === 'lighthouse') {

--- a/ctf/packages/web/components/foundation/foundation-panels.tsx
+++ b/ctf/packages/web/components/foundation/foundation-panels.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Hammer, FileText, Wrench, Send, Plus, ArrowUpRight } from "lucide-react";
+import {
+  COLOR, initials, quoteStatus, formatQuoteDate,
+  type ProviderView, type QuoteView,
+} from "./foundation-ui";
+
+const INFO_MSGS = [
+  { id: 1, text: "Foundation connects you with vetted trade providers. Safety-first — every provider is background-checked and trauma-informed. What do you need help with?" },
+  { id: 2, text: "Search by trade or keyword, then open a provider to request a quote. Service Credits are accepted on all bookings.", action: "Browse Providers" },
+];
+
+const EMPTY_STEPS = [
+  "Request an electrician, plumber, or other trade",
+  "Get quotes from vetted providers",
+  "Accept a quote and pay with Service Credits",
+];
+
+export function BrowsePanel({
+  providers, onSelect,
+}: {
+  providers: ProviderView[];
+  onSelect: (p: ProviderView) => void;
+}) {
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ padding: "24px" }}>
+        <div style={{ marginBottom: 20, padding: "20px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(239,68,68,0.05) 100%)`, border: `1px solid ${COLOR}20` }}>
+          <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Find Vetted Trade Providers</div>
+          <div style={{ fontSize: 14, color: "#9CA3AF" }}>Background-checked · Trauma-informed · Service Credits accepted</div>
+        </div>
+        {providers.length === 0 ? (
+          <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+            <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(239,68,68,0.3)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+              <Hammer size={20} style={{ color: "rgba(239,68,68,0.4)" }} />
+            </div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No providers found</div>
+            <div style={{ fontSize: 13, color: "#4B5563" }}>Try adjusting your search or trade filter.</div>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {providers.map((p) => (
+              <button key={p.profileId} onClick={() => onSelect(p)} style={{ width: "100%", textAlign: "left", padding: "18px 20px", borderRadius: 14, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}18`, cursor: "pointer", display: "flex", gap: 16, alignItems: "center" }}>
+                <Avatar style={{ width: 52, height: 52, flexShrink: 0 }}>
+                  <AvatarFallback style={{ background: `${COLOR}20`, color: COLOR, fontSize: 18, fontWeight: 800 }}>{initials(p.displayName)}</AvatarFallback>
+                </Avatar>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", marginBottom: 4 }}>{p.displayName}</div>
+                  {p.headline && <div style={{ fontSize: 13, color: "#9CA3AF", marginBottom: 6 }}>{p.headline}</div>}
+                  {p.bio && <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.5, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{p.bio}</div>}
+                </div>
+                <span style={{ padding: "7px 16px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, flexShrink: 0 }}>
+                  View Profile
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+export function QuotesPanel({
+  quotes, onBrowse,
+}: {
+  quotes: QuoteView[];
+  onBrowse: () => void;
+}) {
+  return (
+    <ScrollArea style={{ flex: 1 }}>
+      <div style={{ padding: "24px" }}>
+        <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>My Quote Requests</div>
+        <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>Track your service requests and responses</div>
+        {quotes.length === 0 ? (
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "48px 24px", gap: 16 }}>
+            <div style={{ width: 64, height: 64, borderRadius: 18, background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.2)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+              <FileText size={28} style={{ color: COLOR, opacity: 0.5 }} />
+            </div>
+            <div style={{ textAlign: "center", maxWidth: 360 }}>
+              <div style={{ fontSize: 18, fontWeight: 700, color: "#F9FAFB", marginBottom: 8 }}>No quote requests yet</div>
+              <div style={{ fontSize: 14, color: "#6B7280", lineHeight: 1.7 }}>When you request quotes from trade providers, they&apos;ll appear here so you can track status and manage your service history in one place.</div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10, width: "100%", maxWidth: 400 }}>
+              {EMPTY_STEPS.map((step, i) => (
+                <div key={step} style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 16px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: "1px dashed rgba(239,68,68,0.15)" }}>
+                  <div style={{ width: 22, height: 22, borderRadius: "50%", background: `${COLOR}15`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0, fontSize: 11, fontWeight: 700, color: COLOR }}>{i + 1}</div>
+                  <span style={{ fontSize: 13, color: "#6B7280" }}>{step}</span>
+                </div>
+              ))}
+            </div>
+            <button onClick={onBrowse} style={{ padding: "12px 24px", borderRadius: 12, background: COLOR, border: "none", color: "#fff", fontSize: 14, fontWeight: 700, cursor: "pointer", display: "flex", alignItems: "center", gap: 8 }}>
+              <Wrench size={16} /> Request a Trade Service
+            </button>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {quotes.map((q) => {
+              const status = quoteStatus(q.lifecycleState);
+              return (
+                <div key={q.id} style={{ padding: "18px 20px", borderRadius: 14, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}20`, display: "flex", gap: 14, alignItems: "center" }}>
+                  <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}15`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+                    <FileText size={18} style={{ color: COLOR }} />
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB", marginBottom: 2 }}>{q.serviceType}</div>
+                    <div style={{ fontSize: 12, color: "#6B7280" }}>Requested {formatQuoteDate(q.createdAtIso)}</div>
+                  </div>
+                  <Badge style={{ background: status.bg, color: status.fg, border: `1px solid ${status.bd}`, fontSize: 11 }}>{status.label}</Badge>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+export function ChatPanel({
+  input, onInput, onSend, onBrowse,
+}: {
+  input: string;
+  onInput: (v: string) => void;
+  onSend: () => void;
+  onBrowse: () => void;
+}) {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+      <ScrollArea style={{ flex: 1, padding: "16px 24px" }}>
+        <div style={{ paddingBottom: 8 }}>
+          {INFO_MSGS.map((msg) => (
+            <div key={msg.id} style={{ display: "flex", gap: 10, alignItems: "flex-end", marginBottom: 12 }}>
+              <div style={{ width: 32, height: 32, borderRadius: 10, background: `${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+                <Hammer size={14} style={{ color: COLOR }} />
+              </div>
+              <div style={{ maxWidth: "70%", display: "flex", flexDirection: "column", gap: 6 }}>
+                <div style={{ padding: "12px 16px", borderRadius: "16px 16px 16px 4px", background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.06)", fontSize: 14, lineHeight: 1.6, color: "#E8EAF0" }}>
+                  {msg.text}
+                </div>
+                {msg.action && (
+                  <button onClick={onBrowse} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", alignSelf: "flex-start" }}>
+                    {msg.action} <ArrowUpRight size={13} />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+      <div style={{ padding: "8px 24px 20px", flexShrink: 0, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 14 }}>
+          <Plus size={18} style={{ color: "#4B5563" }} />
+          <input
+            value={input}
+            onChange={(e) => onInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") onSend(); }}
+            placeholder="Describe what you need help with…"
+            style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: "#E8EAF0" }}
+          />
+          <button onClick={onSend} aria-label="Send" style={{ width: 32, height: 32, borderRadius: 8, background: input.trim() ? COLOR : "rgba(255,255,255,0.06)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
+            <Send size={14} style={{ color: input.trim() ? "#fff" : "#4B5563" }} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/foundation/foundation-profile.tsx
+++ b/ctf/packages/web/components/foundation/foundation-profile.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Shield } from "lucide-react";
+import { COLOR, FONT, initials, type ProviderView } from "./foundation-ui";
+
+export function ProviderProfile({
+  provider, submitting, quoteError, quoteSuccess, onBack, onRequestQuote,
+}: {
+  provider: ProviderView;
+  submitting: boolean;
+  quoteError: string | null;
+  quoteSuccess: boolean;
+  onBack: () => void;
+  onRequestQuote: () => void;
+}) {
+  return (
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: FONT, color: "#E8EAF0", display: "flex", flexDirection: "column" }}>
+      <div style={{ height: 56, borderBottom: `1px solid ${COLOR}25`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+        <button onClick={onBack} style={{ color: COLOR, background: "none", border: "none", cursor: "pointer", fontSize: 14, display: "flex", alignItems: "center", gap: 6 }}>
+          ← Back
+        </button>
+        <div style={{ flex: 1, fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>Provider Profile</div>
+      </div>
+      <div style={{ flex: 1, padding: "32px 40px", overflowY: "auto", display: "flex", gap: 32, flexWrap: "wrap" }}>
+        <div style={{ flex: 2, minWidth: 320 }}>
+          <div style={{ display: "flex", gap: 24, marginBottom: 28 }}>
+            <Avatar style={{ width: 80, height: 80 }}>
+              <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 28, fontWeight: 800 }}>{initials(provider.displayName)}</AvatarFallback>
+            </Avatar>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 24, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>{provider.displayName}</div>
+              {provider.headline && <div style={{ fontSize: 15, color: "#9CA3AF" }}>{provider.headline}</div>}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <button
+                onClick={onRequestQuote}
+                disabled={submitting}
+                style={{ padding: "10px 20px", borderRadius: 10, background: COLOR, border: "none", color: "#fff", fontWeight: 700, fontSize: 14, cursor: submitting ? "default" : "pointer", opacity: submitting ? 0.7 : 1 }}
+              >
+                {submitting ? "Requesting…" : "Request Quote"}
+              </button>
+            </div>
+          </div>
+          {quoteError && <div style={{ fontSize: 13, color: "#EF4444", marginBottom: 12 }}>{quoteError}</div>}
+          {quoteSuccess && <div style={{ fontSize: 13, color: "#22C55E", marginBottom: 12 }}>Quote requested. Check the Quotes tab.</div>}
+          {provider.bio && (
+            <div style={{ padding: "20px", borderRadius: 14, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}18` }}>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>About</div>
+              <div style={{ fontSize: 14, color: "#9CA3AF", lineHeight: 1.7 }}>{provider.bio}</div>
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1, minWidth: 240 }}>
+          <div style={{ padding: "16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+              <Shield size={14} style={{ color: COLOR }} />
+              <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Safety Guarantee</span>
+            </div>
+            <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>This provider is background-checked and trauma-informed. Service Credits accepted on all bookings.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/foundation/foundation-rails.tsx
+++ b/ctf/packages/web/components/foundation/foundation-rails.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Hammer, Search, Shield, Bell, Settings, MessageSquare, Wrench, FileText,
+} from "lucide-react";
+import { COLOR, TRADES, initials, type FoundationTab, type ProviderView } from "./foundation-ui";
+
+const TABS: { icon: React.ElementType; key: FoundationTab; label: string }[] = [
+  { icon: Wrench, key: "browse", label: "Browse" },
+  { icon: FileText, key: "quotes", label: "Quotes" },
+  { icon: MessageSquare, key: "chat", label: "Chat" },
+];
+
+export function IconRail({ tab, onTab }: { tab: FoundationTab; onTab: (t: FoundationTab) => void }) {
+  return (
+    <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+        <Hammer size={20} style={{ color: COLOR }} />
+      </div>
+      {TABS.map(({ icon: Icon, key, label }) => (
+        <button key={key} onClick={() => onTab(key)} aria-label={label} title={label} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
+          <Icon size={20} />
+        </button>
+      ))}
+      <div style={{ flex: 1 }} />
+      <button aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
+        <Bell size={18} />
+      </button>
+      <button aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
+        <Settings size={18} />
+      </button>
+      <Avatar style={{ width: 36, height: 36 }}>
+        <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
+      </Avatar>
+    </aside>
+  );
+}
+
+export function FilterSidebar({
+  query, onQuery, trade, onTrade,
+}: {
+  query: string;
+  onQuery: (v: string) => void;
+  trade: string;
+  onTrade: (t: string) => void;
+}) {
+  return (
+    <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <div style={{ padding: "20px 16px 12px" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>Foundation</div>
+        <div style={{ position: "relative", marginBottom: 12 }}>
+          <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
+          <input
+            value={query}
+            onChange={(e) => onQuery(e.target.value)}
+            placeholder="Search providers…"
+            style={{ width: "100%", padding: "7px 10px 7px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }}
+          />
+        </div>
+      </div>
+      <ScrollArea style={{ flex: 1 }}>
+        <div style={{ padding: "0 8px 16px" }}>
+          {TRADES.map((t) => (
+            <button key={t} onClick={() => onTrade(t)} style={{ width: "100%", textAlign: "left", display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: trade === t ? `${COLOR}18` : "transparent", borderLeft: trade === t ? `2px solid ${COLOR}` : "2px solid transparent", border: "none", marginLeft: 2, marginBottom: 2 }}>
+              <span style={{ fontSize: 13, color: trade === t ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{t}</span>
+            </button>
+          ))}
+        </div>
+      </ScrollArea>
+    </aside>
+  );
+}
+
+export function RightRail({
+  providers, quoteCount, onBrowse, onSelect,
+}: {
+  providers: ProviderView[];
+  quoteCount: number;
+  onBrowse: () => void;
+  onSelect: (p: ProviderView) => void;
+}) {
+  return (
+    <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Providers</div>
+      {providers.slice(0, 4).map((p) => (
+        <button key={p.profileId} onClick={() => onSelect(p)} style={{ width: "100%", textAlign: "left", display: "flex", gap: 10, alignItems: "center", padding: "10px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}15`, marginBottom: 8, cursor: "pointer" }}>
+          <Avatar style={{ width: 36, height: 36 }}>
+            <AvatarFallback style={{ background: `${COLOR}20`, color: COLOR, fontSize: 14, fontWeight: 700 }}>{initials(p.displayName)}</AvatarFallback>
+          </Avatar>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.displayName}</div>
+            {p.headline && <div style={{ fontSize: 11, color: "#6B7280", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.headline}</div>}
+          </div>
+        </button>
+      ))}
+      {providers.length === 0 && (
+        <div style={{ fontSize: 12, color: "#4B5563", textAlign: "center", padding: "16px 0" }}>No providers loaded.</div>
+      )}
+      <div style={{ marginTop: 16, padding: "14px 16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+          <Shield size={14} style={{ color: COLOR }} />
+          <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Safety Guarantee</span>
+        </div>
+        <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Every provider is background-checked and trauma-informed. Service Credits accepted on all bookings.</div>
+      </div>
+      <div style={{ marginTop: 12, padding: "14px 16px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Your Activity</div>
+        {[{ l: "Providers", v: String(providers.length) }, { l: "My Quotes", v: String(quoteCount) }].map(({ l, v }) => (
+          <div key={l} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, padding: "5px 0", color: "#6B7280" }}>
+            <span>{l}</span>
+            <span style={{ color: COLOR, fontWeight: 600 }}>{v}</span>
+          </div>
+        ))}
+      </div>
+      <button onClick={onBrowse} style={{ width: "100%", marginTop: 12, padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
+        Browse All Providers
+      </button>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/foundation/foundation-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-shell.tsx
@@ -1,250 +1,135 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
-import {
-  Hammer, Search, CheckCircle, Shield, Send, Plus,
-  Bell, Settings, MessageSquare, ArrowUpRight, Wrench,
-} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Hammer } from "lucide-react";
+import { COLOR, FONT, type FoundationTab, type ProviderView, type QuoteView } from "./foundation-ui";
+import { IconRail, FilterSidebar, RightRail } from "./foundation-rails";
+import { BrowsePanel, QuotesPanel, ChatPanel } from "./foundation-panels";
+import { ProviderProfile } from "./foundation-profile";
 
-const COLOR = "#EF4444";
+const CSRF_HEADERS = { "Content-Type": "application/json", "x-ctf-csrf": "1" };
 
-interface Provider {
-  id: string;
-  name: string;
-  trade?: string;
-  location?: string;
-  rating?: number;
-  available?: boolean;
-  credits?: boolean;
-  verified?: boolean;
-  avatar?: string;
-  price?: string;
+function Centered({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: FONT, color }}>
+      {children}
+    </div>
+  );
 }
 
-interface Quote {
-  id: string;
-  providerId?: string;
-  providerName?: string;
-  trade?: string;
-  status: string;
-  amount?: number;
-  createdAt?: string;
-}
-
-type Tab = "browse" | "quotes" | "chat";
-
-const TABS: { icon: React.ElementType; key: Tab }[] = [
-  { icon: Wrench, key: "browse" },
-  { icon: Hammer, key: "quotes" },
-  { icon: MessageSquare, key: "chat" },
-];
-
-const TRADES = ["All Trades", "Electrician", "Plumber", "HVAC", "Carpenter", "Painter", "Contractor", "Landscaper"];
-
-const INFO_MSGS = [
-  { id: 1, text: "Foundation connects you with vetted trade providers. Safety-first — all providers are background-checked. What do you need help with?" },
-  { id: 2, text: "Search by trade, location, or service. Use the browse tab to find providers and request quotes. Service Credits accepted.", action: "Browse Providers" },
-];
-
-function initials(name: string) {
-  return name.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase();
-}
-
-export function FoundationShell(_props: { userId?: string; isAdmin?: boolean }) {
+export function FoundationShell() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [providers, setProviders] = useState<Provider[]>([]);
-  const [quotes, setQuotes] = useState<Quote[]>([]);
-  const [tab, setTab] = useState<Tab>("browse");
+  const [providers, setProviders] = useState<ProviderView[]>([]);
+  const [quotes, setQuotes] = useState<QuoteView[]>([]);
+  const [tab, setTab] = useState<FoundationTab>("browse");
   const [trade, setTrade] = useState("All Trades");
   const [query, setQuery] = useState("");
-  const [selected, setSelected] = useState<Provider | null>(null);
+  const [selected, setSelected] = useState<ProviderView | null>(null);
   const [chatInput, setChatInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [quoteError, setQuoteError] = useState<string | null>(null);
   const [quoteSuccess, setQuoteSuccess] = useState(false);
 
+  // Trade filter has no client-side field to match on; it scopes the server search query.
+  const searchTerm = [trade === "All Trades" ? "" : trade, query].filter(Boolean).join(" ").trim();
+
+  const loadQuotes = useCallback(async () => {
+    const res = await fetch("/api/foundation/quotes/history");
+    if (res.ok) {
+      const data = (await res.json()) as { items?: QuoteView[] };
+      setQuotes(data.items ?? []);
+    }
+  }, []);
+
   useEffect(() => {
+    let active = true;
     async function load() {
       setLoading(true);
       setError(null);
       try {
-        const [searchRes, quotesRes] = await Promise.all([
-          fetch(`/api/foundation/providers/search?${new URLSearchParams(query ? { q: query } : {})}`),
-          fetch("/api/foundation/quotes"),
+        const params = new URLSearchParams(searchTerm ? { q: searchTerm } : {});
+        const [searchRes] = await Promise.all([
+          fetch(`/api/foundation/providers/search?${params}`),
+          loadQuotes(),
         ]);
-        if (searchRes.ok) setProviders(await searchRes.json() as Provider[]);
-        if (quotesRes.ok) {
-          const data = await quotesRes.json() as { items?: Quote[] } | Quote[];
-          setQuotes(Array.isArray(data) ? data : (data.items ?? []));
+        if (!active) return;
+        if (searchRes.ok) {
+          const data = (await searchRes.json()) as { items?: ProviderView[] };
+          setProviders(data.items ?? []);
         }
       } catch (e: unknown) {
-        setError(e instanceof Error ? e.message : "Failed to load Foundation.");
+        if (active) setError(e instanceof Error ? e.message : "Failed to load Foundation.");
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     }
     void load();
-  }, [query]);
+    return () => {
+      active = false;
+    };
+  }, [searchTerm, loadQuotes]);
 
-  async function handleRequestQuote(providerId: string) {
+  // Real quote creation is two steps: open a connection thread, then request a quote on it.
+  const requestQuote = useCallback(async (provider: ProviderView) => {
     setSubmitting(true);
     setQuoteError(null);
     setQuoteSuccess(false);
     try {
-      const res = await fetch("/api/foundation/quotes", {
+      const threadRes = await fetch("/api/foundation/connections/threads", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ providerId, description: "Service request" }),
+        headers: CSRF_HEADERS,
+        body: JSON.stringify({ providerId: provider.profileId }),
       });
-      if (!res.ok) throw new Error("Failed to request quote");
+      if (!threadRes.ok) throw new Error("Could not open a connection with this provider.");
+      const threadData = (await threadRes.json()) as { thread?: { id?: string } };
+      const threadId = threadData.thread?.id;
+      if (!threadId) throw new Error("Connection response was incomplete.");
+
+      const serviceType = provider.headline?.trim() || "General trade service";
+      const quoteRes = await fetch("/api/foundation/quotes", {
+        method: "POST",
+        headers: CSRF_HEADERS,
+        body: JSON.stringify({ threadId, serviceType }),
+      });
+      if (!quoteRes.ok) throw new Error("Could not submit the quote request.");
+
       setQuoteSuccess(true);
-      const quotesRes = await fetch("/api/foundation/quotes");
-      if (quotesRes.ok) {
-        const data = await quotesRes.json() as { items?: Quote[] } | Quote[];
-        setQuotes(Array.isArray(data) ? data : (data.items ?? []));
-      }
+      await loadQuotes();
+      setSelected(null);
       setTab("quotes");
     } catch (e: unknown) {
       setQuoteError(e instanceof Error ? e.message : "Failed to request quote.");
     } finally {
       setSubmitting(false);
     }
-  }
-
-  const filtered = providers.filter(
-    (p) => trade === "All Trades" || p.trade === trade
-  );
+  }, [loadQuotes]);
 
   if (loading) {
-    return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#6B7280" }}>
-        Loading Foundation…
-      </div>
-    );
+    return <Centered color="#6B7280">Loading Foundation…</Centered>;
   }
 
   if (error) {
-    return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
-        {error}
-      </div>
-    );
+    return <Centered color="#EF4444">{error}</Centered>;
   }
 
   if (selected) {
-    const p = selected;
     return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex", flexDirection: "column" }}>
-        <div style={{ height: 56, borderBottom: `1px solid ${COLOR}25`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <button onClick={() => setSelected(null)} style={{ color: COLOR, background: "none", border: "none", cursor: "pointer", fontSize: 14, display: "flex", alignItems: "center", gap: 6 }}>
-            ← Back
-          </button>
-          <div style={{ flex: 1, fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>Provider Profile</div>
-        </div>
-        <div style={{ flex: 1, padding: "32px 40px", overflowY: "auto" }}>
-          <div style={{ display: "flex", gap: 24, marginBottom: 28 }}>
-            <Avatar style={{ width: 80, height: 80 }}>
-              <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 28, fontWeight: 800 }}>{p.avatar ?? initials(p.name)}</AvatarFallback>
-            </Avatar>
-            <div style={{ flex: 1 }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 4 }}>
-                <div style={{ fontSize: 24, fontWeight: 800, color: "#F9FAFB" }}>{p.name}</div>
-                {p.verified && <CheckCircle size={18} style={{ color: COLOR }} />}
-              </div>
-              <div style={{ fontSize: 15, color: "#9CA3AF", marginBottom: 8 }}>
-                {p.trade}{p.location ? ` · ${p.location}` : ""}
-              </div>
-              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                {p.rating && <Badge style={{ background: "rgba(250,204,21,0.1)", color: "#FBBF24", border: "1px solid rgba(250,204,21,0.2)", fontSize: 12 }}>⭐ {p.rating}</Badge>}
-                <Badge style={{ background: p.available ? "#22C55E20" : "rgba(255,255,255,0.05)", color: p.available ? "#22C55E" : "#6B7280", border: `1px solid ${p.available ? "#22C55E40" : "rgba(255,255,255,0.08)"}`, fontSize: 12 }}>
-                  {p.available ? "● Available Now" : "○ Unavailable"}
-                </Badge>
-                {p.credits && <Badge style={{ background: "#F59E0B15", color: "#F59E0B", border: "1px solid #F59E0B30", fontSize: 12 }}>Accepts Service Credits ✓</Badge>}
-              </div>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              <button
-                onClick={() => { void handleRequestQuote(p.id); }}
-                disabled={submitting}
-                style={{ padding: "10px 20px", borderRadius: 10, background: COLOR, border: "none", color: "#fff", fontWeight: 700, fontSize: 14, cursor: "pointer" }}
-              >
-                {submitting ? "Requesting…" : "Request Quote"}
-              </button>
-              <button style={{ padding: "10px 20px", borderRadius: 10, background: "rgba(255,255,255,0.05)", border: `1px solid ${COLOR}35`, color: COLOR, fontWeight: 600, fontSize: 14, cursor: "pointer" }}>
-                Message
-              </button>
-            </div>
-          </div>
-          {quoteError && <div style={{ fontSize: 13, color: "#EF4444", marginBottom: 12 }}>{quoteError}</div>}
-          {quoteSuccess && <div style={{ fontSize: 13, color: "#22C55E", marginBottom: 12 }}>Quote requested! Check the Quotes tab.</div>}
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            {p.price && <Badge style={{ background: `${COLOR}10`, color: COLOR, border: `1px solid ${COLOR}25`, fontSize: 13, padding: "5px 12px" }}>{p.price}</Badge>}
-          </div>
-        </div>
-      </div>
+      <ProviderProfile
+        provider={selected}
+        submitting={submitting}
+        quoteError={quoteError}
+        quoteSuccess={quoteSuccess}
+        onBack={() => { setSelected(null); setQuoteError(null); setQuoteSuccess(false); }}
+        onRequestQuote={() => { void requestQuote(selected); }}
+      />
     );
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
-      {/* Icon rail */}
-      <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
-          <Hammer size={20} style={{ color: COLOR }} />
-        </div>
-        {TABS.map(({ icon: Icon, key }) => (
-          <button key={key} onClick={() => setTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
-            <Icon size={20} />
-          </button>
-        ))}
-        <div style={{ flex: 1 }} />
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
-          <Bell size={18} />
-        </button>
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
-          <Settings size={18} />
-        </button>
-        <Avatar style={{ width: 36, height: 36 }}>
-          <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
-        </Avatar>
-      </aside>
-
-      {/* Sidebar */}
-      <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
-        <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>Foundation</div>
-          <div style={{ position: "relative", marginBottom: 12 }}>
-            <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search providers…"
-              style={{ width: "100%", padding: "7px 10px 7px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }}
-            />
-          </div>
-        </div>
-        <ScrollArea style={{ flex: 1 }}>
-          <div style={{ padding: "0 8px 16px" }}>
-            {TRADES.map((t) => (
-              <div key={t} onClick={() => setTrade(t)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: trade === t ? `${COLOR}18` : "transparent", borderLeft: trade === t ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
-                <span style={{ fontSize: 13, color: trade === t ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{t}</span>
-              </div>
-            ))}
-            <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", padding: "0 10px" }}>Platform Stats</div>
-            {[{ l: "Providers", v: String(providers.length) }, { l: "My Quotes", v: String(quotes.length) }].map(({ l, v }) => (
-              <div key={l} style={{ padding: "6px 10px", fontSize: 12, color: "#6B7280" }}>
-                {l}: <span style={{ color: COLOR, fontWeight: 600 }}>{v}</span>
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
-      </aside>
-
-      {/* Main */}
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: FONT, color: "#E8EAF0", display: "flex" }}>
+      <IconRail tab={tab} onTab={setTab} />
+      <FilterSidebar query={query} onQuery={setQuery} trade={trade} onTrade={setTrade} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
           <Hammer size={18} style={{ color: COLOR }} />
@@ -252,176 +137,19 @@ export function FoundationShell(_props: { userId?: string; isAdmin?: boolean }) 
             <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Foundation — Trade Services</div>
             <div style={{ fontSize: 12, color: "#6B7280" }}>Vetted providers · Background-checked · Safe</div>
           </div>
-          <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-            ✓ Verified Providers
-          </Badge>
         </header>
-
-        {tab === "browse" && (
-          <ScrollArea style={{ flex: 1 }}>
-            <div style={{ padding: "24px" }}>
-              <div style={{ marginBottom: 20, padding: "20px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(239,68,68,0.05) 100%)`, border: `1px solid ${COLOR}20` }}>
-                <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Find Vetted Trade Providers</div>
-                <div style={{ fontSize: 14, color: "#9CA3AF" }}>Background-checked · Trauma-informed · Service Credits accepted</div>
-              </div>
-              {filtered.length === 0 ? (
-                <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-                  <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(239,68,68,0.3)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                    <Hammer size={20} style={{ color: "rgba(239,68,68,0.4)" }} />
-                  </div>
-                  <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No providers found</div>
-                  <div style={{ fontSize: 13, color: "#4B5563" }}>Try adjusting your search or trade filter.</div>
-                </div>
-              ) : (
-                <div style={{ display: "grid", gridTemplateColumns: "repeat(2,1fr)", gap: 14 }}>
-                  {filtered.map((p) => (
-                    <div key={p.id} onClick={() => setSelected(p)} style={{ padding: "20px", borderRadius: 16, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}20`, cursor: "pointer" }}>
-                      <div style={{ display: "flex", gap: 14, marginBottom: 14, alignItems: "flex-start" }}>
-                        <Avatar style={{ width: 48, height: 48, flexShrink: 0 }}>
-                          <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 18, fontWeight: 800 }}>{p.avatar ?? initials(p.name)}</AvatarFallback>
-                        </Avatar>
-                        <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
-                            <div style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
-                            {p.verified && <CheckCircle size={14} style={{ color: COLOR, flexShrink: 0 }} />}
-                          </div>
-                          <div style={{ fontSize: 12, color: "#9CA3AF", marginBottom: 4 }}>{p.trade}</div>
-                          {p.location && <div style={{ fontSize: 11, color: "#4B5563" }}>{p.location}</div>}
-                        </div>
-                        <div style={{ textAlign: "right", flexShrink: 0 }}>
-                          {p.rating && <div style={{ fontSize: 13, fontWeight: 700, color: "#FBBF24" }}>⭐ {p.rating}</div>}
-                          <div style={{ width: 8, height: 8, borderRadius: "50%", background: p.available ? "#22C55E" : "#4B5563", marginLeft: "auto", marginTop: 4 }} />
-                        </div>
-                      </div>
-                      <div style={{ display: "flex", gap: 8, marginBottom: 12, flexWrap: "wrap" }}>
-                        {p.price && <Badge style={{ background: `${COLOR}10`, color: COLOR, border: `1px solid ${COLOR}25`, fontSize: 11 }}>{p.price}</Badge>}
-                        {p.credits && <Badge style={{ background: "#F59E0B10", color: "#F59E0B", border: "1px solid #F59E0B25", fontSize: 11 }}>Credits ✓</Badge>}
-                      </div>
-                      <button style={{ width: "100%", padding: "8px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, cursor: "pointer" }}>
-                        View Profile
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </ScrollArea>
-        )}
-
-        {tab === "quotes" && (
-          <ScrollArea style={{ flex: 1 }}>
-            <div style={{ padding: "24px" }}>
-              <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>My Quotes</div>
-              <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>Track your quote requests and accepted proposals</div>
-              {quotes.length === 0 ? (
-                <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-                  <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(239,68,68,0.3)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                    <Hammer size={20} style={{ color: "rgba(239,68,68,0.4)" }} />
-                  </div>
-                  <div style={{ fontSize: 15, fontWeight: 600, color: "#9CA3AF" }}>No quotes yet</div>
-                  <div style={{ fontSize: 13, color: "#4B5563" }}>Browse providers and request a quote to get started.</div>
-                  <button onClick={() => setTab("browse")} style={{ padding: "10px 20px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
-                    Browse Providers
-                  </button>
-                </div>
-              ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  {quotes.map((q) => (
-                    <div key={q.id} style={{ padding: "18px 20px", borderRadius: 14, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}20`, display: "flex", gap: 14, alignItems: "center" }}>
-                      <Avatar style={{ width: 40, height: 40 }}>
-                        <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 14, fontWeight: 700 }}>
-                          {q.providerName ? initials(q.providerName) : "?"}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div style={{ flex: 1 }}>
-                        <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB", marginBottom: 2 }}>{q.providerName ?? q.providerId ?? "Provider"}</div>
-                        {q.trade && <div style={{ fontSize: 12, color: "#9CA3AF" }}>{q.trade}</div>}
-                      </div>
-                      <div style={{ textAlign: "right" }}>
-                        <Badge style={{ background: q.status === "Accepted" ? "#22C55E20" : `${COLOR}15`, color: q.status === "Accepted" ? "#22C55E" : COLOR, border: `1px solid ${q.status === "Accepted" ? "#22C55E40" : COLOR + "30"}`, fontSize: 11, display: "block", marginBottom: 4 }}>
-                          {q.status}
-                        </Badge>
-                        {q.amount && <div style={{ fontSize: 14, fontWeight: 700, color: "#F59E0B" }}>${q.amount}</div>}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </ScrollArea>
-        )}
-
+        {tab === "browse" && <BrowsePanel providers={providers} onSelect={setSelected} />}
+        {tab === "quotes" && <QuotesPanel quotes={quotes} onBrowse={() => setTab("browse")} />}
         {tab === "chat" && (
-          <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
-            <ScrollArea style={{ flex: 1, padding: "16px 24px" }}>
-              <div style={{ paddingBottom: 8 }}>
-                {INFO_MSGS.map((msg) => (
-                  <div key={msg.id} style={{ display: "flex", gap: 10, alignItems: "flex-end", marginBottom: 12 }}>
-                    <div style={{ width: 32, height: 32, borderRadius: 10, background: `${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-                      <Hammer size={14} style={{ color: COLOR }} />
-                    </div>
-                    <div style={{ maxWidth: "70%", display: "flex", flexDirection: "column", gap: 6 }}>
-                      <div style={{ padding: "12px 16px", borderRadius: "16px 16px 16px 4px", background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.06)", fontSize: 14, lineHeight: 1.6, color: "#E8EAF0" }}>
-                        {msg.text}
-                      </div>
-                      {msg.action && (
-                        <button onClick={() => setTab("browse")} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", alignSelf: "flex-start" }}>
-                          {msg.action} <ArrowUpRight size={13} />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </ScrollArea>
-            <div style={{ padding: "8px 24px 20px", flexShrink: 0, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 16px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 14 }}>
-                <Plus size={18} style={{ color: "#4B5563" }} />
-                <input
-                  value={chatInput}
-                  onChange={(e) => setChatInput(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") setChatInput(""); }}
-                  placeholder="Describe what you need help with…"
-                  style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: "#E8EAF0" }}
-                />
-                <button onClick={() => setChatInput("")} style={{ width: 32, height: 32, borderRadius: 8, background: chatInput.trim() ? COLOR : "rgba(255,255,255,0.06)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
-                  <Send size={14} style={{ color: chatInput.trim() ? "#fff" : "#4B5563" }} />
-                </button>
-              </div>
-            </div>
-          </div>
+          <ChatPanel
+            input={chatInput}
+            onInput={setChatInput}
+            onSend={() => setChatInput("")}
+            onBrowse={() => setTab("browse")}
+          />
         )}
       </div>
-
-      {/* Right panel */}
-      <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Top Providers</div>
-        {providers.slice(0, 4).map((p) => (
-          <div key={p.id} onClick={() => setSelected(p)} style={{ display: "flex", gap: 10, alignItems: "center", padding: "10px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${COLOR}15`, marginBottom: 8, cursor: "pointer" }}>
-            <Avatar style={{ width: 36, height: 36 }}>
-              <AvatarFallback style={{ background: `${COLOR}25`, color: COLOR, fontSize: 14, fontWeight: 700 }}>{p.avatar ?? initials(p.name)}</AvatarFallback>
-            </Avatar>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
-              <div style={{ fontSize: 11, color: "#6B7280" }}>{p.trade}</div>
-            </div>
-            {p.available && <div style={{ width: 8, height: 8, borderRadius: "50%", background: "#22C55E", flexShrink: 0 }} />}
-          </div>
-        ))}
-        {providers.length === 0 && !loading && (
-          <div style={{ fontSize: 12, color: "#4B5563", textAlign: "center", padding: "16px 0" }}>No providers loaded.</div>
-        )}
-        <div style={{ marginTop: 16, padding: "16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
-            <Shield size={14} style={{ color: COLOR }} />
-            <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Safety Guarantee</span>
-          </div>
-          <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>All providers are background-checked and trauma-informed. Service Credits accepted.</div>
-        </div>
-        <button onClick={() => setTab("browse")} style={{ width: "100%", marginTop: 12, padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 700, cursor: "pointer" }}>
-          Browse All Providers
-        </button>
-      </aside>
+      <RightRail providers={providers} quoteCount={quotes.length} onBrowse={() => setTab("browse")} onSelect={setSelected} />
     </div>
   );
 }

--- a/ctf/packages/web/components/foundation/foundation-ui.ts
+++ b/ctf/packages/web/components/foundation/foundation-ui.ts
@@ -1,0 +1,64 @@
+import type { FoundationQuoteState } from "@/lib/foundation/types";
+
+export const COLOR = "#EF4444";
+export const FONT = "'Inter', system-ui, sans-serif";
+
+/** Provider view model — only fields the real search API returns. */
+export interface ProviderView {
+  profileId: string;
+  providerUserId: string;
+  displayName: string;
+  headline: string | null;
+  bio: string | null;
+  score: number;
+}
+
+/** Quote view model — only fields the real quote-history API returns. */
+export interface QuoteView {
+  id: string;
+  threadId: string;
+  serviceType: string;
+  lifecycleState: FoundationQuoteState;
+  createdAtIso: string;
+}
+
+export type FoundationTab = "browse" | "quotes" | "chat";
+
+/** Trade filters map to the search `q` param; "All Trades" clears it. */
+export const TRADES = [
+  "All Trades",
+  "Electrician",
+  "Plumber",
+  "HVAC",
+  "Carpenter",
+  "Painter",
+  "Contractor",
+  "Landscaper",
+];
+
+export function initials(name: string): string {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+const QUOTE_STATUS: Record<FoundationQuoteState, { label: string; fg: string; bg: string; bd: string }> = {
+  requested: { label: "Pending", fg: COLOR, bg: `${COLOR}15`, bd: `${COLOR}30` },
+  provider_responded: { label: "Responded", fg: "#22C55E", bg: "#22C55E20", bd: "#22C55E40" },
+  closed: { label: "Closed", fg: "#6B7280", bg: "rgba(255,255,255,0.04)", bd: "rgba(255,255,255,0.08)" },
+};
+
+export function quoteStatus(state: FoundationQuoteState) {
+  return QUOTE_STATUS[state] ?? QUOTE_STATUS.requested;
+}
+
+export function formatQuoteDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}


### PR DESCRIPTION
## Summary

Foundation's web pixel pass: rebuilds `FoundationShell` to match the canonical `survivor-hub/Foundation` design mockup (design submodule synced to `a460914`) while binding **only** to fields the real Foundation API returns. The pass doubles as a correctness fix — the previous shell rendered against a mock `Provider` shape that the real search API never returns.

### Data bugs fixed (the shell was wired to contracts that don't exist)
- **Provider search**: response is `{ ok, items, total, pagination }` — the shell treated it as a raw array, so the provider list was always empty.
- **Quote history**: lives at `GET /api/foundation/quotes/history` returning `{ items }`. The shell called `GET /api/foundation/quotes`, which has no GET handler.
- **Request Quote**: real flow is two steps — `POST /api/foundation/connections/threads { providerId }` → `POST /api/foundation/quotes { threadId, serviceType }`, both requiring the `x-ctf-csrf: 1` header. The shell posted an unsupported `{ providerId, description }` body to a single endpoint.

### Real-data-only discipline
Mockup elements with no backing API are **omitted, not mocked**: star ratings, job counts, hourly price, availability dots, and the hard-coded "Platform Stats" (8,400+ / 124K / 4.8★ / 67%). The right-rail stats card now shows real loaded counts ("Your Activity"). Providers render `displayName` / `headline` / `bio`; the relevance `score` is internal and not surfaced as a rating.

### Rule 116 decomposition
The 427-line shell is split into five focused files under `components/foundation/`:
- `foundation-ui.ts` — view models, color/font tokens, quote-status + date helpers
- `foundation-rails.tsx` — icon rail, trade filter sidebar, right rail
- `foundation-panels.tsx` — browse / quotes (with empty-state guide) / chat panels
- `foundation-profile.tsx` — provider detail view
- `foundation-shell.tsx` — orchestration + corrected data flow

Trade-filter chips now scope the server search `q` param (there is no client-side `trade` field to filter on).

### Verification
- `pnpm typecheck` green (web + mobile + shared via pre-push gate)
- `pnpm build` succeeds
- `eslint` clean on all changed files
- `check-eof-format.sh` passes for `ctf/` files
- Branched off `main`; the `design` submodule pointer bump is intentionally **not** included.

### Inventory / readiness
- Foundation **Web px** flipped to ✅ in `PRODUCTION_READINESS_PLAN.md`.
- Inventory "Web and Android Delivery Status" + Change Log updated (also corrected a stale "web+android complete" claim — Android remains ⬜).

> Note: the readiness table's Foundation **Backend** cell is flipped by the open PR #181, not here. This PR only touches the **Web px** cell, so the two should merge without conflict on that row.

Parity Ticket: #183