### PR TITLE
feat: Rasa NLU service for the AI Assistant

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,6 +22,7 @@ name: Build and push Docker images
 #   RENDER_SERVICE_ID_WEB             — Render service ID for ctf-web
 #   RENDER_SERVICE_ID_PM_MCP          — Render service ID for ctf-pm-mcp-server
 #   RENDER_SERVICE_ID_OLLAMA          — Render service ID for ctf-ollama
+#   RENDER_SERVICE_ID_RASA            — Render service ID for ctf-rasa
 #   RENDER_SERVICE_ID_FORMANCE        — Render service ID for ctf-formance-ledger
 
 on:
@@ -45,6 +46,7 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       pm-mcp-server: ${{ steps.filter.outputs.pm-mcp-server }}
       ollama: ${{ steps.filter.outputs.ollama }}
+      rasa: ${{ steps.filter.outputs.rasa }}
       formance: ${{ steps.filter.outputs.formance }}
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +65,8 @@ jobs:
               - 'ctf/packages/pm-mcp-server/**'
             ollama:
               - 'ctf/ops/ollama/**'
+            rasa:
+              - 'ctf/ops/rasa/**'
             formance:
               - 'ctf/ops/formance/Dockerfile.ledger'
 
@@ -216,6 +220,57 @@ jobs:
               -H "Content-Type: application/json" \
               -d '{}' \
               "https://api.render.com/v1/services/$RENDER_SERVICE_ID_OLLAMA/deploys"
+          fi
+
+  # ── ctf-rasa ────────────────────────────────────────────────────
+  # Only rebuilds when ctf/ops/rasa/** changes — the NLU model is trained at build
+  # time (rasa train nlu) and baked into the image, so the build can take a while.
+  build-rasa:
+    name: Build ctf-rasa
+    needs: changes
+    if: needs.changes.outputs.rasa == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ctf-rasa
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ctf/ops/rasa
+          file: ctf/ops/rasa/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ctf-rasa
+          cache-to: type=gha,scope=ctf-rasa,mode=max
+
+      - name: Trigger Render deploy
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID_RASA: ${{ secrets.RENDER_SERVICE_ID_RASA }}
+        run: |
+          if [ -n "$RENDER_API_KEY" ] && [ -n "$RENDER_SERVICE_ID_RASA" ]; then
+            curl -sf -X POST \
+              -H "Authorization: Bearer $RENDER_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d '{}' \
+              "https://api.render.com/v1/services/$RENDER_SERVICE_ID_RASA/deploys"
           fi
 
   # ── ctf-formance-ledger ─────────────────────────────────────────

--- a/ctf/docs/developer/RASA.md
+++ b/ctf/docs/developer/RASA.md
@@ -1,0 +1,146 @@
+# Rasa NLU Service (AI Assistant)
+
+How the self-hosted Rasa NLU service works on Render, how to deploy it, and how to enable it for
+the comic "AI Assistant" (`@comic`).
+
+## What this service is
+
+`ctf-rasa` is a **private** Render service (no public domain) running a Rasa 3.x **NLU-only**
+project. It exposes the stateless HTTP API endpoint `POST /model/parse`, which classifies an
+inbound `@comic` question into one of the comic intent categories (`housing`, `services`,
+`general`, `safety`, `benefits`) and returns a calibratable confidence.
+
+It is reachable only by the CTF web service over Render's internal network at
+`http://ctf-rasa:5005`. Defined in `render.yaml` (image
+`ghcr.io/chargingthefuture/ctf-rasa:latest`, built from `ctf/ops/rasa/Dockerfile`).
+
+The project lives in `ctf/ops/rasa/`:
+
+| File | Purpose |
+|---|---|
+| `config.yml` | NLU pipeline (WhitespaceTokenizer → featurizers → DIETClassifier → FallbackClassifier). No dialogue policies — NLU only. |
+| `domain.yml` | The five comic intents + minimal placeholder responses. |
+| `data/nlu.yml` | Seed NLU training examples per intent (starter set). |
+| `credentials.yml` | REST channel only (private-network use). |
+| `endpoints.yml` | Minimal; action server + SQL tracker store are **commented/deferred**. |
+| `Dockerfile` | `rasa/rasa:3.6.21`, trains the model at build time, serves `--enable-api` on 5005. |
+
+## Architecture
+
+Render has no persistent volumes, so the trained NLU model is **baked into the image at build
+time** — always present on startup, no runtime training and no network access needed on boot. This
+mirrors how `ctf-ollama` bakes its model.
+
+The comic backend uses Rasa **only to attach a real intent + confidence to each `@comic` turn**
+for the reviewer's display and for better training labels. **Generation still happens in the app
+via Ollama, and EVERY answer still goes to human review** — Rasa does **not** auto-publish anything.
+See the comic feature inventory for the operating-mode contract.
+
+## How the Dockerfile bakes the model
+
+```dockerfile
+FROM rasa/rasa:3.6.21
+USER root
+WORKDIR /app
+COPY . /app
+RUN ["rasa", "train", "nlu", "--num-threads", "1"]
+RUN chown -R 1001:1001 /app
+EXPOSE 5005
+USER 1001
+CMD ["run", "--enable-api", "-p", "5005", "--cors", "*"]
+```
+
+`rasa train nlu` writes a model tarball to `/app/models/`; that file persists in the image layer,
+so the runtime container starts with the model already on disk. The base image's `ENTRYPOINT` is
+`rasa`, so `CMD` only supplies the `run` subcommand and flags.
+
+## Deploy runbook
+
+1. **Edit the project** under `ctf/ops/rasa/` (e.g. add training examples to `data/nlu.yml`),
+   commit, and push to `main`. `build-images.yml` is **path-filtered on `ctf/ops/rasa/**`** — the
+   `ctf-rasa` image rebuilds (training the model) and pushes to
+   `ghcr.io/chargingthefuture/ctf-rasa:latest` only when these files change.
+2. **First time only — make the GHCR package public.** After the first successful build, go to
+   `github.com/orgs/chargingthefuture/packages` → `ctf-rasa` → Package settings → Change
+   visibility → **Public**. This lets Render pull the image without registry credentials (same
+   step as every other `ctf-*` image).
+3. **Render deploys** the pre-built image. If `RENDER_API_KEY` + `RENDER_SERVICE_ID_RASA` GitHub
+   secrets are set, the build job triggers the deploy automatically; otherwise deploy from the
+   Render dashboard / Blueprint sync.
+4. **Enable it on the web service.** Set `RASA_BASE_URL=http://ctf-rasa:5005` on **ctf-web** via
+   Infisical → Render Sync (the same mechanism that injects `OLLAMA_BASE_URL`). This is the switch:
+   once set, the comic backend calls Rasa; until set, it does not (see "Graceful degradation").
+
+> **Validation required before enabling in prod.** This project was authored to Rasa 3.x
+> conventions but has **not** been trained or run in this environment. Before flipping
+> `RASA_BASE_URL` on, confirm a real `rasa train nlu` succeeds in CI (the image build) and the
+> deployed service answers `POST /model/parse` — see "Confirming it works".
+
+## Web service configuration
+
+- `RASA_BASE_URL=http://ctf-rasa:5005` — the switch that enables the integration. Injected on
+  ctf-web via Infisical → Render Sync.
+- `RASA_MODEL` (optional) — informational label only; the served model is whatever was baked into
+  the image. Not required for the integration to work.
+
+## Graceful degradation (important)
+
+The comic backend is **safe by default**. In `lib/comic/rasa.ts`, `isRasaConfigured()` returns
+`true` **iff `RASA_BASE_URL` is set**. In `routeComicMessage` (`lib/comic/repository.ts`) the Rasa
+call is made **only** when `isRasaConfigured()` is true.
+
+- **`RASA_BASE_URL` unset** → no Rasa call; the user turn is stored with `intent: null` and
+  `nlu_confidence: null`, exactly as before this service existed. Behavior is byte-for-byte
+  unchanged.
+- **`RASA_BASE_URL` set but Rasa unreachable / errors / times out** → `parseComicIntent` catches
+  everything and returns `{ intent: null, confidence: null }`; the turn is stored with nulls and
+  routing continues. No request fails because of Rasa.
+
+Either way, **every answer still goes to human review** (`forceHumanReview()` is unchanged). Rasa
+provides labels, never an auto-publish bypass.
+
+## Confirming it works
+
+From a shell that can reach the private network (e.g. a Render shell on ctf-web):
+
+```sh
+curl -s -X POST http://ctf-rasa:5005/model/parse \
+  -H "Content-Type: application/json" \
+  -d '{"text":"i need emergency shelter tonight"}'
+```
+
+Expect JSON with `intent.name` (e.g. `housing`) and `intent.confidence` (a 0..1 float), plus an
+`intent_ranking` array. In the app, after setting `RASA_BASE_URL`, a new `@comic` turn's review
+item should show a real intent + a confidence band (instead of "Not yet scored").
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Build fails at `rasa train nlu` | Malformed `config.yml`/`domain.yml`/`nlu.yml`, or an intent in `nlu.yml` not declared in `domain.yml` | Validate the YAML; keep the five intents in sync across `domain.yml` and `data/nlu.yml` |
+| Build times out | Training too large for the CI runner | Reduce `DIETClassifier.epochs` or trim examples; keep `--num-threads 1` |
+| Review items still show "Not yet scored" | `RASA_BASE_URL` not set on ctf-web | Set `RASA_BASE_URL=http://ctf-rasa:5005` via Infisical → Render Sync |
+| `parseComicIntent` always returns null but the var is set | Service unreachable, wrong port, or `/model/parse` errored | Confirm `ctf-rasa` is healthy and listening on 5005; check the curl above |
+| Want to retrain on new data | Corrections accumulated in the app | Export via `GET /api/comic/training/export` (and the feed Rasa export), append the YAML under the matching intents in `data/nlu.yml`, commit → rebuild |
+
+## Notes
+
+- Never assign a public domain to `ctf-rasa` — it has no authentication and must stay
+  private-network only (same rule as `ctf-ollama`).
+- The intent set MUST stay in sync with the comic backend categories and with
+  `exportQuestionsForRasa` (`lib/feed/repository.ts`) so exported training YAML drops straight into
+  `data/nlu.yml`.
+
+## Deferred next steps (documented, NOT built here)
+
+These are intentionally out of scope for the initial service and are recorded so the path is clear:
+
+1. **Rasa custom action → Ollama for generation.** Move answer generation behind a Rasa custom
+   action (would add an action server + uncomment `action_endpoint` in `endpoints.yml`). Today
+   generation stays in the app (`generateComicDraft` → Ollama).
+2. **SQL tracker store on Neon.** Rasa's conversation event store, needed only for stateful
+   dialogue (stories). NLU `/model/parse` is stateless, so none is provisioned yet. When added,
+   inject credentials via Infisical → Render Sync (never commit them — public repo).
+3. **Raise the auto-respond threshold / confidence-based auto-publish.** A deliberate later step,
+   only once the owner trusts the bot. Until then `forceHumanReview()` stays `true` and **every**
+   answer is reviewed by a human regardless of confidence.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -181,15 +181,23 @@ Built on `feat/comic-ai-assistant`; all server-only routes (no rendered surface)
   (user, turn), re-rating updates in place. Mirrors the feed answer-rating pattern; feeds the CDD
   flywheel.
 
-Interim engine reality: **Ollama is deployed, Rasa is not.** `lib/comic/rasa.ts`
-`isRasaConfigured()` returns false until `RASA_BASE_URL` is set, so `policy.forceHumanReview()`
-routes **every** `@comic` draft to human review — nothing unreviewed is surfaced to the asker.
+Engine reality: **Ollama is deployed; the Rasa NLU service is now scaffolded** (image + Render
+pserv + CI) and **integrated** for intent/confidence. `lib/comic/rasa.ts` `isRasaConfigured()` is
+true iff `RASA_BASE_URL` is set; `parseComicIntent` POSTs to `${RASA_BASE_URL}/model/parse` with a
+timeout + try/catch, returning `{ intent, confidence }` (null on any failure). When configured,
+`routeComicMessage` attaches the **real** intent + `nlu_confidence` to the user turn; when not, the
+turn keeps the prior null/null (no Rasa call — byte-for-byte unchanged). **Critically,
+`policy.forceHumanReview()` now returns `true` unconditionally** (decoupled from Rasa config), so
+**every** `@comic` answer still goes to human review — Rasa supplies labels only, never an
+auto-publish bypass. Generation still happens in the app via Ollama (`generateComicDraft`), not via
+Rasa. See `ctf/ops/rasa/` + `ctf/docs/developer/RASA.md`.
 
 ### Target (`@comic`)
 - Mention routing also to ride the Hub message path (`POST /api/hub/messages`) once that stub
   is wired; today the dedicated `POST /api/comic/message` is the server entry point.
-- Auto-reply branch (above-threshold) activates only once Rasa supplies a real, calibratable
-  confidence; until then the interim policy forces human review on all drafts.
+- Auto-reply branch (above-threshold) is **deliberately deferred** — even though Rasa now supplies
+  a real, calibratable confidence, `forceHumanReview()` stays unconditionally true until the owner
+  chooses to raise the auto-respond threshold. No confidence-based auto-publish exists yet.
 - Rasa/Ollama are reached **server-side only**; no third-party LLM egress (parity with the
   Hub's stance — and Ollama is self-hosted, so it is not third-party).
 
@@ -207,8 +215,11 @@ DBs converge: `comic_conversations(channel, status)`, `comic_turns(role, engine,
    [hub|feed], `status` text [open|closed], `created_at`, `updated_at`). Indexed on `user_id`,
    `created_at`.
 2. `comic_turns` — one row per turn (`id` uuid pk, `conversation_id` uuid FK→comic_conversations,
-   `role` ∈ user|bot|human, `body`, `intent` null, `nlu_confidence` numeric(5,4) null, `engine`
-   ∈ rasa|ollama|template|human, `created_at`). Indexed on `conversation_id`, `created_at`.
+   `role` ∈ user|bot|human, `body`, `intent` text null, `nlu_confidence` numeric(5,4) null [0..1],
+   `engine` ∈ rasa|ollama|template|human, `created_at`). Indexed on `conversation_id`, `created_at`.
+   **`intent` + `nlu_confidence` on the user turn are Rasa-sourced when `RASA_BASE_URL` is set**
+   (`routeComicMessage` → `parseComicIntent` → `/model/parse`); they remain null when Rasa is
+   unconfigured or the parse fails (graceful degradation). Bot/draft turns keep null intent/confidence.
 3. `comic_review_queue` — supervision state (`id` uuid pk, `turn_id` uuid FK→comic_turns
    ON DELETE CASCADE, `status` ∈ pending|approved|corrected|rejected, `reviewer_user_id` null,
    `corrected_body` null, `answer_turn_id` uuid null FK→comic_turns ON DELETE SET NULL,
@@ -230,7 +241,9 @@ DBs converge: `comic_conversations(channel, status)`, `comic_turns(role, engine,
    is FK'd into `feed_answers` and cannot host comic turns, so comic gets its own ratings table.
 
 **Rasa tracker store:** Rasa's own SQL event store, provisioned in the same Neon Postgres
-(managed by Rasa, not hand-authored here). Deferred — Rasa is not deployed.
+(managed by Rasa, not hand-authored here). **Still deferred** — the scaffolded Rasa service is
+**NLU-only** (`/model/parse` is stateless and needs no tracker store); `endpoints.yml` leaves the
+`tracker_store` block commented. Provision it only when stateful dialogue (stories) is added.
 
 **Reused:** Note: `llm_inference_log` has NOT-NULL FKs into `feed_questions`/`feed_answers`, so
 comic generation is **not** forced into that feed-shaped table; comic captures request/response on
@@ -266,8 +279,16 @@ Target: `web+android` parity.
   (`/api/comic/message`, `/api/comic/review`, `/api/comic/review/[turnId]/resolve`,
   `/api/comic/training/export`), contracts, and a deterministic seed are landed. `@comic`
   mention routing, conversation/turn capture, Ollama drafting, the human-in-the-loop review
-  queue, correction→training, and Rasa NLU export are implemented. Interim policy forces human
-  review on every draft (Rasa undeployed).
+  queue, correction→training, and Rasa NLU export are implemented.
+- **Rasa NLU service: scaffolded + integrated (not yet trained/deployed in prod).** The
+  `ctf-rasa` private Render pserv (`ctf/ops/rasa/`: `config.yml` DIET+FallbackClassifier pipeline,
+  `domain.yml` with the 5 intents, seed `data/nlu.yml`, `credentials.yml`, deferred `endpoints.yml`,
+  `Dockerfile` that trains at build time) + the `build-images.yml` `ctf-rasa` image build +
+  `render.yaml` pserv block. The backend `lib/comic/rasa.ts` now implements `parseComicIntent`
+  (`POST /model/parse`, timeout + try/catch, nulls on failure); `routeComicMessage` stores the real
+  intent + `nlu_confidence` on the user turn when `RASA_BASE_URL` is set. **Policy is unchanged:
+  `forceHumanReview()` returns true unconditionally — every answer is still human-reviewed.** A real
+  `rasa train nlu`/deploy validation is required before enabling in prod (see RASA.md).
 - **Web UI: complete** (design `9a4a1af`, locked/owner-approved). Two surfaces delivered:
   - **Asker surface** in the unified community/home chat (`components/community-shell/`): AI
     Assistant answer cards (cyan #0EA5E9, Sparkles, "AI Assistant" label, 🤖 AI Q&A badge, Q/A)
@@ -286,13 +307,16 @@ Target: `web+android` parity.
     clear / "All caught up"), loading, and detail with editable corrected-text and Approve /
     Edit&approve / Reject actions; each item shows question, AI draft, provenance (engine/intent/
     safety category — real fields, no fabricated source documents), and confidence (the real
-    `nlu_confidence`, surfaced as "Not yet scored" while Rasa is undeployed). Wired to
-    `GET /api/comic/review` and `POST /api/comic/review/[turnId]/resolve`.
+    `nlu_confidence`, now Rasa-populated on the user turn when `RASA_BASE_URL` is set, otherwise
+    surfaced as "Not yet scored"). Wired to `GET /api/comic/review` and
+    `POST /api/comic/review/[turnId]/resolve`.
 - **Android: deferred — parity ticket.** The mobile `@comic` surfaces (Mobile*/MobileAIConsent
   designs) are not built in this pass; tracked for parity (`plugin-parity-contracts.json` entry +
   the feature dir land together when the mobile feature is built). Blocked behind a running Rasa for
   the auto-reply branch.
-- **Still deferred:** standing up the Rasa service + tracker store; replacing the home-chat
+- **Still deferred:** a real `rasa train nlu`/deploy validation + setting `RASA_BASE_URL` in prod;
+  the Rasa custom action that calls Ollama for generation; the SQL tracker store; raising the
+  auto-respond threshold / any confidence-based auto-publish; replacing the home-chat
   `getActionForText` router with Rasa-backed routing; the layered content filter / threshold
   tuning; RAG grounding.
 
@@ -373,6 +397,31 @@ here (web only).
 
 ## Change Log
 
+- 2026-05-31: **Stood up the self-hosted Rasa NLU service + wired the backend** on
+  `feat/rasa-assistant-service` (infra + a SAFE, label-only backend integration; no UI). Added the
+  Rasa 3.x **NLU-only** project under `ctf/ops/rasa/` (`config.yml` WhitespaceTokenizer →
+  featurizers → DIETClassifier → FallbackClassifier; `domain.yml` with the 5 comic intents +
+  minimal responses; seed `data/nlu.yml`; `credentials.yml` REST channel; `endpoints.yml` with the
+  action server + SQL tracker store left commented/deferred) and a `Dockerfile`
+  (`rasa/rasa:3.6.21`, trains the model at build time via `rasa train nlu`, serves
+  `run --enable-api` on 5005). Added the `ctf-rasa` private `pserv` to `render.yaml` (reached at
+  `http://ctf-rasa:5005`; `RASA_BASE_URL` injected on `ctf-web` via Infisical, same pattern as
+  `OLLAMA_BASE_URL`), the path-filtered `ctf-rasa` image build in `build-images.yml`, and the
+  `ctf/docs/developer/RASA.md` deploy runbook. **Backend (SAFE):** implemented `lib/comic/rasa.ts`
+  (`isRasaConfigured()` true iff `RASA_BASE_URL` set; `parseComicIntent(text)` POSTs to
+  `/model/parse` with a timeout + try/catch, returning `{ intent, confidence }` — null on any
+  failure, mirroring `lib/chatbot/ollama.ts`); `routeComicMessage` now stores the **real** intent +
+  `nlu_confidence` on the user turn when Rasa is configured (and the prior null/null, with **no**
+  Rasa call, when it is not — byte-for-byte unchanged). **Safety posture unchanged:**
+  `policy.forceHumanReview()` now returns `true` **unconditionally** (previously
+  `!isRasaConfigured()`, which would have stopped review the moment Rasa was configured) — **every**
+  answer still goes to human review; Rasa supplies labels only, never an auto-publish bypass.
+  Generation still happens in the app via Ollama (`generateComicDraft`), not via Rasa. **Deferred
+  (documented as next steps, not built):** the Rasa custom action → Ollama for generation; the SQL
+  tracker store; raising the auto-respond threshold / any confidence-based auto-publish. Web build +
+  typecheck pass; schema-drift + no-ai-prompts gates pass. A real `rasa train nlu`/deploy validation
+  is required before flipping `RASA_BASE_URL` on in prod (per RASA.md). Backend/infra only — no UI
+  (no design gate). Parity: web+android complete (backend/infra).
 - 2026-05-31: Built the **web UI** on `feat/comic-ai-assistant` against the LOCKED design `9a4a1af`
   (pointer bumped per rule 128). **Asker surface** in the community/home chat
   (`components/community-shell/`: `shell-chat-panel.tsx`, `use-home-chat.ts`, `comic-cards.tsx`,
@@ -443,10 +492,16 @@ Ordered; dependencies noted; no phases. A task with no dependency can run anytim
       `@comic` mention chip + helper, rating row, first-use consent modal. Done 2026-05-31 against
       design `9a4a1af`. Added asker read (`GET /api/comic/conversation`) and answer rating
       (`POST /api/comic/answers/[turnId]/rate` + `comic_answer_ratings`).
-- [ ] Stand up self-hosted Rasa; tracker store on Neon; custom action → Ollama; consume the
+- [~] Stand up self-hosted Rasa; tracker store on Neon; custom action → Ollama; consume the
       (fixed) NLU export.
-  - Blocked by: schema. Parallel to routing/console. Acceptance: Rasa returns intent + real
-    confidence; custom action calls Ollama with graceful fallback; export double-loop fixed.
+  - **NLU service scaffolded + integrated (2026-05-31):** `ctf/ops/rasa/` Rasa 3.x NLU project
+    (DIET + FallbackClassifier), `Dockerfile` (trains at build time), `render.yaml` `ctf-rasa`
+    pserv, `build-images.yml` `ctf-rasa` build (path-filtered), `RASA.md` runbook; `lib/comic/rasa.ts`
+    `parseComicIntent` (`/model/parse`) wired into `routeComicMessage` to populate the user turn's
+    intent + `nlu_confidence` when `RASA_BASE_URL` is set (graceful no-op otherwise). A real
+    `rasa train nlu`/deploy validation + prod `RASA_BASE_URL` is still required before enabling.
+  - **Still deferred:** the SQL tracker store; the custom action → Ollama for generation (generation
+    stays in the app); consuming the (still-double-looping) feed NLU export.
 - [ ] Replace home-chat `getActionForText` with Rasa-backed routing.
   - Blocked by: running Rasa. Acceptance: keyword map retired; routing comes from Rasa.
 - [ ] Export corrected turns → Rasa training; retrain loop; raise the auto-respond threshold

--- a/ctf/ops/README.md
+++ b/ctf/ops/README.md
@@ -31,3 +31,7 @@ docker-compose -f ops/docker-compose.yml down
 ## Ollama
 
 `ollama/Dockerfile` — custom image for the `ctf-ollama` Render service with the model baked in at build time. Render builds from this file; changing the model means updating the `ARG OLLAMA_MODEL` line and pushing. See `docs/developer/OLLAMA.md` for full instructions.
+
+## Rasa (AI Assistant NLU)
+
+`rasa/` — Rasa 3.x **NLU-only** project + `Dockerfile` for the `ctf-rasa` Render service. The NLU model is **trained at build time** (`rasa train nlu`) and baked into the image, so the container serves the stateless `POST /model/parse` endpoint with no runtime training. The comic backend (`lib/comic/rasa.ts`) calls it server-side at `http://ctf-rasa:5005` to attach a real intent + confidence to each `@comic` turn. Image rebuilds only when `ctf/ops/rasa/**` changes (path-filtered in `build-images.yml`). The action server and SQL tracker store are deferred. See `docs/developer/RASA.md` for the deploy runbook.

--- a/ctf/ops/rasa/Dockerfile
+++ b/ctf/ops/rasa/Dockerfile
@@ -1,0 +1,47 @@
+# Custom image for the `ctf-rasa` Render service — the NLU brain for the "AI Assistant" (@comic).
+#
+# Mirrors the ctf-ollama pattern: the model is BAKED IN AT BUILD TIME so it is always present on
+# startup (Render has no persistent volumes). Here "baking" means running `rasa train nlu` during
+# the build and shipping the resulting model tarball inside the image. At runtime the container
+# serves the stateless NLU HTTP API (`POST /model/parse`) that the comic backend calls.
+#
+# Pin a concrete Rasa 3.x release (not a floating tag) so rebuilds are reproducible. The official
+# rasa/rasa image already contains Rasa Open Source + its Python deps.
+#
+# Build:  docker build -t ghcr.io/chargingthefuture/ctf-rasa:latest ctf/ops/rasa
+# (CI builds + pushes this automatically when ctf/ops/rasa/** changes — see build-images.yml.)
+FROM rasa/rasa:3.6.21
+
+# The base image runs as the unprivileged `1001` user with `rasa` as its ENTRYPOINT. Switch to
+# root only to copy files into the image and train, then drop back to the non-root user to run.
+USER root
+
+WORKDIR /app
+
+# Copy the whole NLU project (config.yml, domain.yml, data/, credentials.yml, endpoints.yml).
+COPY . /app
+
+# Train the NLU model at build time. The trained model tarball is written to /app/models/ and is
+# preserved in this image layer, so the runtime container starts with the model already on disk and
+# never needs to train (or reach the network) on boot. `--num-threads 1` keeps the build within the
+# CI runner's resource envelope. Override the ENTRYPOINT for this one RUN so we can call `rasa`
+# with the `train` subcommand explicitly.
+RUN ["rasa", "train", "nlu", "--num-threads", "1"]
+
+# Make sure the non-root runtime user owns the project + baked model.
+RUN chown -R 1001:1001 /app
+
+EXPOSE 5005
+
+# Drop back to the unprivileged user the base image ships with.
+USER 1001
+
+# The base image's ENTRYPOINT is `rasa`; CMD supplies the subcommand + flags:
+#   run            — start the server
+#   --enable-api   — expose the HTTP API, including the stateless NLU `POST /model/parse`
+#   -p 5005        — listen on the documented internal port
+#   --cors "*"     — allow cross-origin (the caller is a server-side fetch on the private network;
+#                    harmless and avoids surprises if tested from a browser tool)
+# Render injects PORT, but Rasa is reached at the fixed internal URL http://ctf-rasa:5005, so the
+# port is pinned to 5005 here to match RASA_BASE_URL on the web service.
+CMD ["run", "--enable-api", "-p", "5005", "--cors", "*"]

--- a/ctf/ops/rasa/config.yml
+++ b/ctf/ops/rasa/config.yml
@@ -1,0 +1,42 @@
+# Rasa 3.x NLU pipeline for the CTF "AI Assistant" (@comic).
+#
+# This is an NLU-only project: it classifies an inbound @comic question into one of the
+# comic intent categories (housing / services / general / safety / benefits) and returns a
+# calibratable confidence. The /model/parse endpoint is stateless — no dialogue policies are
+# needed yet, so the `policies:` block is intentionally omitted (dialogue management,
+# rules/stories, and the Ollama custom action are deferred; see ctf/docs/developer/RASA.md).
+#
+# recipe + assistant_id are required by Rasa 3.x. assistant_id is a stable identifier for the
+# trained model; bump it if you fork the project.
+recipe: default.v1
+assistant_id: ctf-comic-nlu
+
+# `language` controls the spaCy/whitespace tokenizer + featurizer language. English for now.
+language: en
+
+pipeline:
+  # Tokenize on whitespace. Swap to SpacyTokenizer + SpacyFeaturizer later if richer linguistic
+  # features are needed; WhitespaceTokenizer keeps the image small and the build fast.
+  - name: WhitespaceTokenizer
+  # Bag-of-words style featurizers feeding the intent classifier.
+  - name: RegexFeaturizer
+  - name: LexicalSyntacticFeaturizer
+  - name: CountVectorsFeaturizer
+  - name: CountVectorsFeaturizer
+    analyzer: char_wb
+    min_ngram: 1
+    max_ngram: 4
+  # DIET is Rasa's transformer-based intent classifier. 100 epochs is a reasonable starter for a
+  # small seed set; raise as the corrected-turn export grows the training data.
+  - name: DIETClassifier
+    epochs: 100
+    constrain_similarities: true
+  # EntitySynonymMapper normalizes any synonym-annotated entities (none seeded yet, harmless).
+  - name: EntitySynonymMapper
+  # FallbackClassifier converts low-confidence predictions into the special `nlu_fallback` intent.
+  # The backend does NOT auto-publish on confidence today (every answer goes to human review), so
+  # this threshold only affects how an uncertain turn is *labeled* for the reviewer. The threshold
+  # is a starting point and will be calibrated once the correction flywheel accumulates data.
+  - name: FallbackClassifier
+    threshold: 0.5
+    ambiguity_threshold: 0.1

--- a/ctf/ops/rasa/credentials.yml
+++ b/ctf/ops/rasa/credentials.yml
@@ -1,0 +1,9 @@
+# Rasa channel credentials for the CTF "AI Assistant" (@comic).
+#
+# Only the built-in REST channel is enabled. The comic backend talks to Rasa server-side over the
+# private Render network using the HTTP API (`POST /model/parse`), enabled by `rasa run --enable-api`
+# in the Dockerfile; the REST channel below also exposes `POST /webhooks/rest/webhook` for ad-hoc
+# message testing. No external messaging channels (Slack, Telegram, etc.) are configured — this
+# service is private-network only and must never be given a public domain.
+rest:
+  # The REST channel takes no extra config.

--- a/ctf/ops/rasa/data/nlu.yml
+++ b/ctf/ops/rasa/data/nlu.yml
@@ -1,0 +1,86 @@
+# Rasa 3.x seed NLU training data for the CTF "AI Assistant" (@comic).
+#
+# Intents = the five comic categories. These are a reasonable STARTER set so `rasa train nlu`
+# produces a usable model on the very first build. As the human-in-the-loop correction flywheel
+# runs, the app accumulates labelled examples and can emit additional training data via the comic
+# training export (GET /api/comic/training/export) and the feed Rasa export
+# (GET /api/feed/admin/questions/export → exportQuestionsForRasa). Append that exported YAML under
+# the matching intents below, then rebuild the image to retrain. Keep examples free of any real
+# survivor identifying details.
+version: "3.1"
+
+nlu:
+  - intent: housing
+    examples: |
+      - how do i find a safe place to stay tonight
+      - i need emergency shelter
+      - are there transitional housing options near me
+      - help me find affordable housing
+      - i lost my home and need somewhere to go
+      - what housing programs can i apply for
+      - i need a shelter that takes pets
+      - where can my family stay this week
+      - i am about to be evicted what are my options
+      - is there long term housing support available
+      - i need help paying rent
+      - how do i get on a housing waitlist
+
+  - intent: services
+    examples: |
+      - how do i get connected to a caseworker
+      - i need help finding a counselor
+      - are there free legal services
+      - where can i get food assistance
+      - i need childcare support
+      - help me find a doctor i can afford
+      - are there job training programs
+      - i need transportation to an appointment
+      - how do i find a support group
+      - can someone help me with paperwork
+      - i need mental health support
+      - where do i go for clothing donations
+
+  - intent: benefits
+    examples: |
+      - how do i apply for snap benefits
+      - am i eligible for medicaid
+      - help me sign up for unemployment
+      - what financial assistance can i get
+      - how do i get a replacement id card
+      - i need help applying for disability
+      - what benefits am i entitled to
+      - how do i enroll in health insurance
+      - can i get help with utility bills
+      - how do i apply for cash assistance
+      - what tax credits can i claim
+      - help me understand my benefits options
+
+  - intent: safety
+    examples: |
+      - i do not feel safe right now
+      - how do i make a safety plan
+      - i need to talk to someone about my situation
+      - how do i keep my location private
+      - what should i do if i feel unsafe at home
+      - i need protective resources
+      - how do i document what is happening to me
+      - i am worried about my safety
+      - what are my options if i need to leave quickly
+      - how do i stay anonymous on this platform
+      - i need help staying safe
+      - who can i reach out to in an emergency
+
+  - intent: general
+    examples: |
+      - hello
+      - hi there
+      - thank you for the help
+      - what can you help me with
+      - how does this platform work
+      - can you tell me more
+      - i have a question
+      - what is charging the future
+      - how do i use the directory
+      - where do i start
+      - good morning
+      - can you explain how this works

--- a/ctf/ops/rasa/domain.yml
+++ b/ctf/ops/rasa/domain.yml
@@ -1,0 +1,34 @@
+# Rasa 3.x domain for the CTF "AI Assistant" (@comic) — NLU-only.
+#
+# Intents are the five comic categories. They MUST stay in sync with the comic backend's intent
+# vocabulary and with `exportQuestionsForRasa` (lib/feed/repository.ts) so that exported training
+# YAML drops straight into data/nlu.yml. Generation itself happens in the app via Ollama; this
+# domain carries only minimal placeholder responses so `rasa train nlu` succeeds and the project is
+# valid. Dialogue (rules/stories/actions) is deferred — see ctf/docs/developer/RASA.md.
+version: "3.1"
+
+intents:
+  - housing
+  - services
+  - general
+  - safety
+  - benefits
+
+# Placeholder responses. The app does not consume these for answer generation (Ollama drafts the
+# answer and every draft goes to human review). They exist so the domain is well-formed; real
+# survivor-safe copy is owned by the app/brand-voice layer, not by Rasa.
+responses:
+  utter_housing:
+    - text: "Routing your housing question to the assistant."
+  utter_services:
+    - text: "Routing your services question to the assistant."
+  utter_general:
+    - text: "Routing your question to the assistant."
+  utter_safety:
+    - text: "A teammate will help with this directly."
+  utter_benefits:
+    - text: "Routing your benefits question to the assistant."
+
+session_config:
+  session_expiration_time: 60
+  carry_over_slots_to_new_session: true

--- a/ctf/ops/rasa/endpoints.yml
+++ b/ctf/ops/rasa/endpoints.yml
@@ -1,0 +1,28 @@
+# Rasa endpoints for the CTF "AI Assistant" (@comic).
+#
+# Intentionally minimal. The only thing the comic backend uses today is the stateless NLU
+# `POST /model/parse` endpoint, which needs NO action server and NO tracker store. The blocks below
+# are DEFERRED and left commented as a record of the planned next steps (see
+# ctf/docs/developer/RASA.md → "Deferred next steps"):
+#
+#   1. action_endpoint — required only once a Rasa custom action calls Ollama for free-form answer
+#      generation. Until then, generation stays in the app (lib/comic/repository.ts →
+#      generateComicDraft) and no action server runs.
+#
+#   2. tracker_store — Rasa's SQL conversation event store, provisioned in the same Neon Postgres.
+#      Required only for stateful dialogue (multi-turn stories). NLU /model/parse is stateless, so
+#      no tracker store is needed yet. When enabled, inject the connection settings via Infisical →
+#      Render Sync (never commit credentials — this is a public repo).
+#
+# DEFERRED — do not uncomment until the corresponding feature is built:
+#
+# action_endpoint:
+#   url: "http://ctf-rasa-actions:5055/webhook"
+#
+# tracker_store:
+#   type: SQL
+#   dialect: "postgresql"
+#   url: ${RASA_TRACKER_DB_HOST}
+#   db: ${RASA_TRACKER_DB_NAME}
+#   username: ${RASA_TRACKER_DB_USER}
+#   password: ${RASA_TRACKER_DB_PASSWORD}

--- a/ctf/packages/web/lib/comic/policy.ts
+++ b/ctf/packages/web/lib/comic/policy.ts
@@ -2,7 +2,6 @@ import type { AllowDecision } from 'lib/auth/server-authz';
 import { pluginAuthDeny, type PluginDenyResponse } from 'lib/auth/deny-taxonomy';
 import { COMIC_MENTION_REGEX, COMIC_SAFETY_CATEGORIES } from './constants';
 import type { ComicSafetyEvaluation } from './types';
-import { isRasaConfigured } from './rasa';
 
 export function ensureComicAdmin(decision: AllowDecision): PluginDenyResponse | null {
   if (decision.isAdmin) {
@@ -50,10 +49,13 @@ export function evaluateComicSafety(text: string): ComicSafetyEvaluation {
   return { flagged: false, category: null };
 }
 
-// Interim operating mode: with Rasa undeployed there is no calibrated NLU confidence, so we
-// cannot auto-publish anything. Every non-safety-flagged @comic draft is forced to human review;
-// safety-flagged turns are human-first with no draft generated. This returns true while review
-// must be forced (i.e. always, until Rasa lands and supplies a real confidence to gate on).
+// Operating mode: EVERY @comic answer goes to human review — full stop. There is deliberately NO
+// confidence-based auto-publish bypass. Standing up the Rasa NLU service (which now supplies a real
+// intent + confidence for the reviewer's display and for training labels) does NOT change this:
+// raising the auto-respond threshold / enabling any auto-publish is a separate, deliberate later
+// step taken only once the owner trusts the bot. Until then this returns true unconditionally so
+// nothing unreviewed is ever surfaced to the asker. (Safety-flagged turns are handled human-first
+// with no draft generated, upstream in routeComicMessage.)
 export function forceHumanReview(): boolean {
-  return !isRasaConfigured();
+  return true;
 }

--- a/ctf/packages/web/lib/comic/rasa.ts
+++ b/ctf/packages/web/lib/comic/rasa.ts
@@ -1,36 +1,138 @@
-// Interim Rasa client for the @comic assistant.
+// Rasa NLU client for the @comic "AI Assistant".
 //
-// Rasa is NOT deployed yet. Until `RASA_BASE_URL` is configured, `isRasaConfigured()` returns
-// false, which the policy layer uses to FORCE human review of every @comic draft: with no real
-// NLU confidence we cannot safely auto-publish, so the bot drafts via Ollama and the draft is
-// enqueued to the review queue rather than returned to the asker.
+// `ctf-rasa` is a private, self-hosted Rasa 3.x NLU service (see ctf/ops/rasa/ and
+// ctf/docs/developer/RASA.md). It exposes the stateless `POST /model/parse` endpoint, which
+// classifies an inbound question into one of the comic intent categories and returns a
+// calibratable confidence. This module wraps that endpoint defensively (timeout + try/catch),
+// mirroring lib/chatbot/ollama.ts.
 //
-// When Rasa lands, set `RASA_BASE_URL` and implement `parseMessage` to call the Rasa HTTP API
-// (`/model/parse`) so the policy can branch on a real, calibratable confidence.
+// SAFETY POSTURE — UNCHANGED. Rasa here only supplies a REAL intent + confidence to label each
+// @comic turn (for the reviewer's display and for better training data). It does NOT gate
+// auto-publish: `policy.forceHumanReview()` still forces EVERY answer through human review. The
+// integration is also graceful: if `RASA_BASE_URL` is unset, `isRasaConfigured()` is false and no
+// Rasa call is made; if the service errors or times out, the parse returns nulls and routing
+// continues unchanged.
 
 const RASA_BASE_URL = process.env.RASA_BASE_URL ?? '';
+// Informational label only; the served model is whatever was baked into the ctf-rasa image. Not
+// required for the integration to function.
 export const RASA_MODEL = process.env.RASA_MODEL ?? '';
+const RASA_TIMEOUT_MS = 8_000;
 
+// Coarse intent + confidence for a single @comic turn. Both null when Rasa is unconfigured or the
+// parse fails for any reason — callers must treat null as "no NLU signal" and degrade gracefully.
+export type ComicIntentResult = {
+  intent: string | null;
+  confidence: number | null;
+};
+
+// Richer parse shape (adds entities) for callers that want the full NLU payload. Entities are not
+// consumed by the comic backend yet but are surfaced here for forward compatibility.
 export type RasaParseResult = {
   intent: string | null;
   confidence: number | null;
   entities: Array<{ entity: string; value: string }>;
 };
 
+// Shape of the relevant fields of Rasa's `POST /model/parse` response. Everything is optional so a
+// malformed/partial payload degrades to nulls rather than throwing.
+type RasaParseResponse = {
+  intent?: {
+    name?: string | null;
+    confidence?: number | null;
+  } | null;
+  entities?: Array<{
+    entity?: string | null;
+    value?: unknown;
+  }> | null;
+};
+
 export function isRasaConfigured(): boolean {
   return RASA_BASE_URL.trim().length > 0;
 }
 
-// Placeholder until Rasa is deployed. Returns null (no NLU signal) while unconfigured so the
-// policy keeps forcing human review. Implement the real `/model/parse` call when RASA_BASE_URL
-// is set.
+function toFiniteNumberOrNull(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function normalizeIntentName(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function mapEntities(
+  entities: RasaParseResponse['entities'],
+): Array<{ entity: string; value: string }> {
+  if (!Array.isArray(entities)) {
+    return [];
+  }
+  const mapped: Array<{ entity: string; value: string }> = [];
+  for (const item of entities) {
+    const entity = normalizeIntentName(item?.entity);
+    if (entity === null) {
+      continue;
+    }
+    mapped.push({ entity, value: String(item?.value ?? '') });
+  }
+  return mapped;
+}
+
+// Call Rasa `POST /model/parse` with the raw question text. Returns the full parse (intent +
+// confidence + entities) or null on any failure. Defensive throughout: aborts on timeout and never
+// throws to the caller.
 export async function parseMessageWithRasa(body: string): Promise<RasaParseResult | null> {
   if (!isRasaConfigured() || body.trim().length === 0) {
     return null;
   }
 
-  // Not implemented yet — Rasa service is not deployed. Returning null keeps the human-review
-  // path active even if the env var is set before the service is actually reachable.
-  // TODO(rasa): POST `body` to `${RASA_BASE_URL}/model/parse` and map intent/confidence/entities.
-  return null;
+  const url = `${RASA_BASE_URL.replace(/\/$/, '')}/model/parse`;
+  const startedAt = Date.now();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), RASA_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: body }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      console.error('[comic/rasa] HTTP error', { status: response.status, latencyMs: Date.now() - startedAt });
+      return null;
+    }
+
+    const data = (await response.json()) as RasaParseResponse;
+
+    return {
+      intent: normalizeIntentName(data.intent?.name),
+      confidence: toFiniteNumberOrNull(data.intent?.confidence),
+      entities: mapEntities(data.entities),
+    };
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      console.error('[comic/rasa] Request timed out', { timeoutMs: RASA_TIMEOUT_MS });
+    } else {
+      console.error('[comic/rasa] Parse failed', err);
+    }
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// Convenience wrapper used by the message router: returns just `{ intent, confidence }`, both null
+// on any failure (unconfigured, network error, timeout, malformed payload). The router stores these
+// on the user turn so the reviewer sees a real NLU label. NEVER throws.
+export async function parseComicIntent(text: string): Promise<ComicIntentResult> {
+  const parsed = await parseMessageWithRasa(text);
+  if (parsed === null) {
+    return { intent: null, confidence: null };
+  }
+  return { intent: parsed.intent, confidence: parsed.confidence };
 }

--- a/ctf/packages/web/lib/comic/repository.ts
+++ b/ctf/packages/web/lib/comic/repository.ts
@@ -327,20 +327,24 @@ export async function routeComicMessage(
   const channel = normalizeChannel(input.channel);
   const safety = evaluateComicSafety(questionBody);
 
-  // Real NLU label for the user turn when Rasa is configured; otherwise the unchanged null/null
-  // default (no Rasa call). `parseComicIntent` never throws and returns nulls on any failure, so a
-  // Rasa outage degrades gracefully. This is label-only: it does NOT affect human-review routing
-  // (every answer is still reviewed) — it improves the reviewer's display and training data.
+  // Gate on the rate limit FIRST (its own short, read-only transaction) so a throttled user never
+  // triggers a (slow) Rasa call. The check is just a COUNT of recent turns, so running it separately
+  // from the insert below is safe — the tiny concurrency window is acceptable for a soft throttle.
+  const allowed = await withDbTransaction((client) => evaluateComicRateLimit(client, actorId));
+  if (!allowed) {
+    throw new Error('rate_limit_exceeded');
+  }
+
+  // Real NLU label for the user turn when Rasa is configured — only reached for allowed messages;
+  // otherwise the unchanged null/null default (no Rasa call). `parseComicIntent` never throws and
+  // returns nulls on any failure, so a Rasa outage degrades gracefully. This is label-only: it does
+  // NOT affect human-review routing (every answer is still reviewed) — it improves the reviewer's
+  // display and training data.
   const nlu = isRasaConfigured()
     ? await parseComicIntent(questionBody)
     : { intent: null, confidence: null };
 
   return withDbTransaction(async (client) => {
-    const allowed = await evaluateComicRateLimit(client, actorId);
-    if (!allowed) {
-      throw new Error('rate_limit_exceeded');
-    }
-
     const conversationId = await resolveConversation(client, actorId, channel, input.conversationId ?? null);
 
     const userTurnId = await insertTurn(client, {

--- a/ctf/packages/web/lib/comic/repository.ts
+++ b/ctf/packages/web/lib/comic/repository.ts
@@ -22,6 +22,7 @@ import {
   passesComicModeration,
   stripComicMention,
 } from './policy';
+import { isRasaConfigured, parseComicIntent } from './rasa';
 import type {
   ComicAnswerRatingValue,
   ComicAskerStreamItem,
@@ -326,6 +327,14 @@ export async function routeComicMessage(
   const channel = normalizeChannel(input.channel);
   const safety = evaluateComicSafety(questionBody);
 
+  // Real NLU label for the user turn when Rasa is configured; otherwise the unchanged null/null
+  // default (no Rasa call). `parseComicIntent` never throws and returns nulls on any failure, so a
+  // Rasa outage degrades gracefully. This is label-only: it does NOT affect human-review routing
+  // (every answer is still reviewed) — it improves the reviewer's display and training data.
+  const nlu = isRasaConfigured()
+    ? await parseComicIntent(questionBody)
+    : { intent: null, confidence: null };
+
   return withDbTransaction(async (client) => {
     const allowed = await evaluateComicRateLimit(client, actorId);
     if (!allowed) {
@@ -338,8 +347,8 @@ export async function routeComicMessage(
       conversationId,
       role: 'user',
       body: questionBody,
-      intent: null,
-      nluConfidence: null,
+      intent: nlu.intent,
+      nluConfidence: nlu.confidence,
       engine: 'human',
     });
 
@@ -357,8 +366,9 @@ export async function routeComicMessage(
       };
     }
 
-    // Not safety-flagged: draft via Ollama, capture as a bot turn, enqueue for review. While
-    // Rasa is undeployed `forceHumanReview()` is always true, so nothing is auto-published.
+    // Not safety-flagged: draft via Ollama, capture as a bot turn, enqueue for review.
+    // `forceHumanReview()` is unconditionally true (no confidence-based auto-publish), so nothing
+    // is ever auto-published — Rasa only supplied the user turn's intent/confidence label above.
     const draft = await generateComicDraft(questionBody);
     const draftTurnId = await insertTurn(client, {
       conversationId,

--- a/render.yaml
+++ b/render.yaml
@@ -100,6 +100,30 @@ services:
       - key: OLLAMA_MODEL
         value: llama3.2
 
+  # ── Rasa (AI Assistant NLU) ──────────────────────────────────────
+  # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-rasa:latest
+  # Private service — reachable by other Render services via internal URL only;
+  # NEVER assign a public domain (no auth, private-network only, like ctf-ollama).
+  # The NLU model is trained + baked into the image at build time (rasa train nlu),
+  # so the container serves the stateless /model/parse endpoint with no runtime
+  # training. Image only rebuilt when ctf/ops/rasa/** changes (path-filtered in
+  # build-images.yml).
+  #
+  # The web service (ctf-web) reaches it at http://ctf-rasa:5005. RASA_BASE_URL is
+  # injected on ctf-web via Infisical → Render Sync (same pattern as OLLAMA_BASE_URL)
+  # — set RASA_BASE_URL=http://ctf-rasa:5005 there. Until that var is set, the comic
+  # backend's isRasaConfigured() stays false and behavior is unchanged (graceful
+  # degradation — no Rasa call). See ctf/docs/developer/RASA.md.
+  - type: pserv
+    name: ctf-rasa
+    runtime: image
+    image:
+      url: ghcr.io/chargingthefuture/ctf-rasa:latest
+    region: ohio
+    # Standard (2GB/1CPU) — DIET-based NLU model load + inference needs more than
+    # the starter tier; mirrors the ctf-ollama sizing.
+    plan: standard
+
   # ── Infisical (secrets management) ───────────────────────────────
   # DEFERRED to Railway (cost optimization: $5/mo on Railway vs $7/mo on Render).
   # Railway Infisical instance configured with Render Sync integration to push

--- a/render.yaml
+++ b/render.yaml
@@ -123,6 +123,11 @@ services:
     # Standard (2GB/1CPU) — DIET-based NLU model load + inference needs more than
     # the starter tier; mirrors the ctf-ollama sizing.
     plan: standard
+    envVars:
+      # Pin the listen port so Render's injected PORT matches the Dockerfile's fixed `-p 5005` and
+      # ctf-web's RASA_BASE_URL (http://ctf-rasa:5005), removing any ambiguity for health checks.
+      - key: PORT
+        value: "5005"
 
   # ── Infisical (secrets management) ───────────────────────────────
   # DEFERRED to Railway (cost optimization: $5/mo on Railway vs $7/mo on Render).


### PR DESCRIPTION
## Summary

Stands up a self-hosted **Rasa 3.x NLU-only** service (`ctf-rasa`) for the comic "AI Assistant" (`@comic`) and wires the comic backend to use it for **real intent + confidence labels**. This is infra + a small, **SAFE, label-only** backend integration — **no UI** (no design gate).

### A. Rasa NLU project + image (`ctf/ops/rasa/`)
- `config.yml` — NLU pipeline: WhitespaceTokenizer → RegexFeaturizer/LexicalSyntactic/CountVectors → **DIETClassifier** → **FallbackClassifier** (threshold). No dialogue policies (NLU `/model/parse` is stateless).
- `domain.yml` — the 5 comic intents (`housing`, `services`, `general`, `safety`, `benefits`) + minimal placeholder responses.
- `data/nlu.yml` — a reasonable starter set of NLU examples per intent (the app can later append `exportQuestionsForRasa` / comic-training-export output).
- `credentials.yml` — REST channel only. `endpoints.yml` — action server + SQL tracker store left **commented/deferred**.
- `Dockerfile` — `rasa/rasa:3.6.21`, **trains the model at build time** (`rasa train nlu`), serves `run --enable-api` on port 5005.

### B. Render + CI wiring
- `render.yaml` — `ctf-rasa` private `pserv` (`runtime: image`, `ghcr.io/chargingthefuture/ctf-rasa:latest`, region ohio, standard plan), mirroring `ctf-ollama`. Web reaches it at `http://ctf-rasa:5005`; `RASA_BASE_URL` injected on `ctf-web` via Infisical (same pattern as `OLLAMA_BASE_URL`).
- `.github/workflows/build-images.yml` — path-filtered (`ctf/ops/rasa/**`) `ctf-rasa` image build mirroring the `ctf-ollama` entry.
- `ctf/docs/developer/RASA.md` — deploy runbook mirroring `OLLAMA.md` (build → make GHCR package public → Render deploys → set `RASA_BASE_URL`; confirm; troubleshooting; deferred pieces).

### C. Backend integration (SAFE)
- `lib/comic/rasa.ts` — real client: `isRasaConfigured()` true iff `RASA_BASE_URL` set; `parseComicIntent(text)` POSTs `{ text }` to `${RASA_BASE_URL}/model/parse` with a timeout + try/catch, returning `{ intent, confidence }` (null on any failure). Mirrors the defensive style of `lib/chatbot/ollama.ts`.
- `routeComicMessage` (`repository.ts`) — when configured, stores the **real** intent + `nlu_confidence` on the user turn; when not configured, **byte-for-byte unchanged** (null/null, no Rasa call).
- Inventory (`ctf-comic-feature-inventory.md`) — Rasa sections, Data Model note (intent/`nlu_confidence` now Rasa-sourced when configured), Change Log, Build-Checklist updated.

## Safety / operating mode — UNCHANGED
- **EVERY answer still goes to human review.** `policy.forceHumanReview()` now returns `true` **unconditionally** (previously `!isRasaConfigured()`, which would have silently stopped review the moment Rasa was configured). Rasa supplies labels only — **no** confidence-based auto-publish bypass.
- Generation still happens in the app via Ollama (`generateComicDraft`); generation is **not** routed through Rasa.
- **Graceful degradation:** `RASA_BASE_URL` unset → no Rasa call; set but unreachable/error/timeout → `parseComicIntent` returns nulls and routing continues. No request fails because of Rasa.

## Deferred (documented as next steps, NOT built)
- The Rasa custom action that calls Ollama for generation (would add an action server + `action_endpoint`).
- The SQL tracker store on Neon (NLU `/model/parse` is stateless).
- Raising the auto-respond threshold / any confidence-based auto-publish (deliberate later step once the owner trusts the bot).

## Validation
- `pnpm -C ctf/packages/web build` (build:ci) passes; pre-commit typecheck + pre-push build passed on push. Changed `lib/comic/*.ts` lint clean; no `any` introduced.
- `check-schema-drift.sh` passes (no schema/contract changes). `check-no-ai-prompts.sh --ref-range origin/main...HEAD` passes. EOF formatting OK on all changed files.
- **Cannot train/deploy/run Rasa in this environment** — the project is authored to Rasa 3.x conventions; a real `rasa train nlu` (the CI image build) + a deployed `/model/parse` check are **required before flipping `RASA_BASE_URL` on in prod** (noted in RASA.md).

Parity Status: web+android complete

https://claude.ai/code/session_01KEzmwU4fVSSeDNJWYRXbhL

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEzmwU4fVSSeDNJWYRXbhL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated an intent classification service to tag user questions into topics (housing, services, benefits, safety, general) with confidence scores.
  * Intent labels and confidence are now recorded on user turns when the service is enabled.

* **Bug Fixes**
  * Throttled requests no longer trigger intent classification calls.

* **Documentation**
  * Added comprehensive deployment, operation, and troubleshooting docs; service is safe-by-default when unset or unreachable.

* **Behavior**
  * Human review remains enforced (no auto-publish based on confidence).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->