### PR TITLE
fix: stop ctf-pm-mcp-server crash-loop by removing it from Render

### DIFF
--- a/.github/instructions/123-environment-configuration-rules.mdc
+++ b/.github/instructions/123-environment-configuration-rules.mdc
@@ -9,7 +9,7 @@
 
 No local dev. The v3 app runs as a **single production environment on Render**:
 the `ctf-web` service plus supporting services (`ctf-formance-ledger`,
-`ctf-ollama`, `ctf-pm-mcp-server`). There is no separate staging *deployment* —
+`ctf-ollama`). There is no separate staging *deployment* —
 splitting was constrained by Clerk's domain binding (one Clerk instance per
 domain), and v3 ships to the single production domain.
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,7 +20,6 @@ name: Build and push Docker images
 # OPTIONAL GITHUB SECRETS (enables auto-deploy to Render after image push):
 #   RENDER_API_KEY                    — Render API key
 #   RENDER_SERVICE_ID_WEB             — Render service ID for ctf-web
-#   RENDER_SERVICE_ID_PM_MCP          — Render service ID for ctf-pm-mcp-server
 #   RENDER_SERVICE_ID_OLLAMA          — Render service ID for ctf-ollama
 #   RENDER_SERVICE_ID_FORMANCE        — Render service ID for ctf-formance-ledger
 
@@ -43,7 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       web: ${{ steps.filter.outputs.web }}
-      pm-mcp-server: ${{ steps.filter.outputs.pm-mcp-server }}
       ollama: ${{ steps.filter.outputs.ollama }}
       formance: ${{ steps.filter.outputs.formance }}
     steps:
@@ -59,8 +57,6 @@ jobs:
               - 'ctf/package.json'
               - 'ctf/tsconfig.base.json'
               - 'ctf/pnpm-workspace.yaml'
-            pm-mcp-server:
-              - 'ctf/packages/pm-mcp-server/**'
             ollama:
               - 'ctf/ops/ollama/**'
             formance:
@@ -118,54 +114,6 @@ jobs:
               -H "Content-Type: application/json" \
               -d '{}' \
               "https://api.render.com/v1/services/$RENDER_SERVICE_ID_WEB/deploys"
-          fi
-
-  # ── ctf-pm-mcp-server ───────────────────────────────────────────
-  build-pm-mcp-server:
-    name: Build ctf-pm-mcp-server
-    needs: changes
-    if: needs.changes.outputs.pm-mcp-server == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/ctf-pm-mcp-server
-          tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - uses: docker/build-push-action@v6
-        with:
-          context: ctf/packages/pm-mcp-server
-          file: ctf/packages/pm-mcp-server/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=ctf-pm-mcp-server
-          cache-to: type=gha,scope=ctf-pm-mcp-server,mode=max
-
-      - name: Trigger Render deploy
-        env:
-          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_PM_MCP: ${{ secrets.RENDER_SERVICE_ID_PM_MCP }}
-        run: |
-          if [ -n "$RENDER_API_KEY" ] && [ -n "$RENDER_SERVICE_ID_PM_MCP" ]; then
-            curl -sf -X POST \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{}' \
-              "https://api.render.com/v1/services/$RENDER_SERVICE_ID_PM_MCP/deploys"
           fi
 
   # ── ctf-ollama ──────────────────────────────────────────────────

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -15,7 +15,6 @@ on:
         type: choice
         options:
           - ctf-web
-          - ctf-pm-mcp-server
           - ctf-ollama
           - ctf-formance-ledger
           - all
@@ -29,7 +28,6 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID_WEB: ${{ secrets.RENDER_SERVICE_ID_WEB }}
-          RENDER_SERVICE_ID_PM_MCP: ${{ secrets.RENDER_SERVICE_ID_PM_MCP }}
           RENDER_SERVICE_ID_OLLAMA: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
           RENDER_SERVICE_ID_FORMANCE: ${{ secrets.RENDER_SERVICE_ID_FORMANCE }}
           SERVICE: ${{ inputs.service }}
@@ -51,12 +49,10 @@ jobs:
 
           case "$SERVICE" in
             ctf-web)            deploy "$RENDER_SERVICE_ID_WEB"     "ctf-web" ;;
-            ctf-pm-mcp-server)  deploy "$RENDER_SERVICE_ID_PM_MCP"  "ctf-pm-mcp-server" ;;
             ctf-ollama)         deploy "$RENDER_SERVICE_ID_OLLAMA"   "ctf-ollama" ;;
             ctf-formance-ledger) deploy "$RENDER_SERVICE_ID_FORMANCE" "ctf-formance-ledger" ;;
             all)
               deploy "$RENDER_SERVICE_ID_WEB"     "ctf-web"
-              deploy "$RENDER_SERVICE_ID_PM_MCP"  "ctf-pm-mcp-server"
               deploy "$RENDER_SERVICE_ID_OLLAMA"  "ctf-ollama"
               deploy "$RENDER_SERVICE_ID_FORMANCE" "ctf-formance-ledger"
               ;;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,12 @@ chargingthefuture/          ← repo root
 
 No local dev. The v3 app runs as a **single production environment on Render**:
 the `ctf-web` service plus supporting services (`ctf-formance-ledger`,
-`ctf-ollama`, `ctf-pm-mcp-server`). There is no separate staging deployment.
+`ctf-ollama`). There is no separate staging deployment.
+
+> `pm-mcp-server` is a stdio MCP server and is **not** a Render service — it is
+> spawned on demand as a local subprocess by the PM agents (see
+> `ctf/docs/developer/PM.md`). Deploying a stdio server as a PaaS worker
+> crash-loops, so it must never be added back to `render.yaml`.
 
 **Canonical env contract:** the Infisical `production` environment is the single
 source of truth for all secrets (see below). Two integrations — GetStream and

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ctf/
 │   ├── mobile/                 # React Native app (Expo, EAS)
 │   ├── shared/                 # Shared TypeScript library
 │   ├── agent-mcp-server/       # Agentic MCP server (stdio transport)
-│   ├── pm-mcp-server/          # PM feedback MCP worker
+│   ├── pm-mcp-server/          # PM feedback MCP server (stdio transport)
 │   ├── economic-models/        # Economic modeling utilities
 │   ├── education/              # Educational content & materials
 │   ├── eol/                    # End-of-life/deprecation tooling

--- a/ctf/packages/pm-mcp-server/Dockerfile
+++ b/ctf/packages/pm-mcp-server/Dockerfile
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:1
 # pm-mcp-server — TypeScript MCP server for PM feedback workflows (stdio transport)
 # Build context: ctf/packages/pm-mcp-server/
+#
+# NOTE: This image is for local / manual stdio invocation only — it is NOT a
+# Render service. A stdio MCP server exits as soon as stdin closes, which always
+# happens on a PaaS worker (no client connects via stdin), so it must never be
+# deployed as a Render `worker`. See render.yaml and ctf/docs/developer/PM.md.
 
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS builder

--- a/render.yaml
+++ b/render.yaml
@@ -68,21 +68,17 @@ services:
       #   INFISICAL_CLIENT_ID / INFISICAL_CLIENT_SECRET
       #   FORMANCE_POSTGRES_URI         — Neon Postgres URI for Formance ledger
 
-  # ── PM MCP Server ────────────────────────────────────────────────
-  # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-pm-mcp-server:latest
-  # Background worker — HTTP MCP transport for PM feedback workflows.
-  # Part of 100% agentic infrastructure orchestration.
-  # Secrets injected by Infisical → Render Sync.
-  - type: worker
-    name: ctf-pm-mcp-server
-    runtime: image
-    image:
-      url: ghcr.io/chargingthefuture/ctf-pm-mcp-server:latest
-    region: ohio
-    plan: starter
-    envVars:
-      - key: NODE_ENV
-        value: production
+  # ── PM MCP Server — intentionally NOT a Render service ───────────
+  # ctf/packages/pm-mcp-server is a stdio MCP server (StdioServerTransport).
+  # A stdio server exits as soon as stdin closes, which always happens on a
+  # Render PaaS worker (no MCP client connects via stdin), so deploying it here
+  # produces a permanent crash-loop and Render eventually suspends it. This is
+  # the same reason ctf-agent-mcp-server was removed (commit ced4c54).
+  # It is consumed locally: built, then registered as a stdio server in an AI
+  # client (see ctf/docs/developer/PM.md) and spawned as a subprocess on demand
+  # by the feedback-matcher / implementation agents. Do not re-add it as a
+  # worker. If a hosted, network-reachable PM MCP endpoint is ever needed, it
+  # must first be rewritten to a long-running HTTP transport.
 
   # ── Ollama ────────────────────────────────────────────────────────
   # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-ollama:latest


### PR DESCRIPTION
## Summary

Removes `ctf-pm-mcp-server` from all Render deployment configurations and CI/CD pipelines. The pm-mcp-server is a stdio MCP server that cannot be deployed as a long-running PaaS worker — it exits immediately when stdin closes (which always happens on Render), causing permanent crash-loops. Render eventually auto-suspended the service after repeated startup failures. It is instead consumed locally as a subprocess spawned on-demand by the PM agents.

Updates:
- **Infrastructure**: Removes the `ctf-pm-mcp-server` worker from `render.yaml`, leaving an explanatory comment so it is not re-added.
- **CI/CD**: Removes the build job, change-detection filter/output, and auto-deploy trigger from `build-images.yml`, plus the manual-redeploy option from `render-deploy.yml` (these existed only to deploy the now-removed service).
- **Documentation**: Updates `AGENTS.md`, `123-environment-configuration-rules.mdc`, and `README.md` to stop listing pm-mcp-server as a deployed Render service and document the local stdio model.
- **Dockerfile**: Adds a clarifying comment that the image is for local/manual stdio invocation only.

This aligns with the earlier removal of `ctf-agent-mcp-server` (commit ced4c54), which had the identical architectural constraint ("stdio MCP can't run as a worker").

## Parity

Parity Status: web+android complete

Infrastructure/CI-only change — there is no web or Android surface affected, so there is nothing to implement on either platform.

## Testing

- `render.yaml`, `build-images.yml`, and `render-deploy.yml` validated as parseable YAML.
- Repo EOF-format gate (`ctf/scripts/check-eof-format.sh`) passes.
- Confirmed no remaining references to `ctf-pm-mcp-server` / `RENDER_SERVICE_ID_PM_MCP` as a deployed service.

## Follow-up (manual, outside this PR)

- Delete the suspended `ctf-pm-mcp-server` service in the Render dashboard (removing it from the Blueprint stops Render managing/redeploying it, but Render does not auto-delete an existing service on sync).

## Compliance

- [x] No sensitive data exposed
- [x] Infrastructure change only, no user-facing impact

## Modularity Governance

- [x] Changes respect responsibility boundaries (infrastructure config, CI/CD, documentation)

https://claude.ai/code/session_01JAX2pJiSLCA8sSBBBzwFaY