### PR TITLE
feat: add WhatWorks plugin — survivor-verified shared tool list

### DIFF
--- a/ctf/config/plugin-parity-contracts.json
+++ b/ctf/config/plugin-parity-contracts.json
@@ -120,6 +120,12 @@
       "mobileFeatureDirs": ["trust"],
       "requiresMobileSurface": true,
       "requiresExplicitWebShell": false
+    },
+    {
+      "slug": "whatworks",
+      "mobileFeatureDirs": ["whatworks"],
+      "requiresMobileSurface": true,
+      "requiresExplicitWebShell": true
     }
   ]
 }

--- a/ctf/docs/contracts/WHATWORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHATWORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -1,58 +1,84 @@
 policies:
-  - command: whatworks.list.read
+  - pluginId: whatworks
+    command: whatworks.list.read
+    version: 1.0.0
     requiredRoles: [user, admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.public.read
+  - pluginId: whatworks
+    command: whatworks.public.read
+    version: 1.0.0
     # Public surface: no authenticated role required. Returns a redacted, identity-free teaser.
     requiredRoles: []
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.problems.list
+  - pluginId: whatworks
+    command: whatworks.problems.list
+    version: 1.0.0
     requiredRoles: [user, admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.product.suggest
+  - pluginId: whatworks
+    command: whatworks.product.suggest
+    version: 1.0.0
     requiredRoles: [user, admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.product.endorse
+  - pluginId: whatworks
+    command: whatworks.product.endorse
+    version: 1.0.0
     requiredRoles: [user, admin]
     attributePolicies:
       - attribute: userId
         mustMatch: authenticatedUserId
     consentRequirements: []
-  - command: whatworks.product.unendorse
+  - pluginId: whatworks
+    command: whatworks.product.unendorse
+    version: 1.0.0
     requiredRoles: [user, admin]
     attributePolicies:
       - attribute: userId
         mustMatch: authenticatedUserId
     consentRequirements: []
-  - command: whatworks.admin.problem.list
+  - pluginId: whatworks
+    command: whatworks.admin.problem.list
+    version: 1.0.0
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.admin.problem.create
+  - pluginId: whatworks
+    command: whatworks.admin.problem.create
+    version: 1.0.0
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.admin.problem.update
+  - pluginId: whatworks
+    command: whatworks.admin.problem.update
+    version: 1.0.0
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.admin.problem.delete
+  - pluginId: whatworks
+    command: whatworks.admin.problem.delete
+    version: 1.0.0
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.admin.product.list
+  - pluginId: whatworks
+    command: whatworks.admin.product.list
+    version: 1.0.0
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.admin.product.review
+  - pluginId: whatworks
+    command: whatworks.admin.product.review
+    version: 1.0.0
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: []
-  - command: whatworks.admin.product.delete
+  - pluginId: whatworks
+    command: whatworks.admin.product.delete
+    version: 1.0.0
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: []

--- a/ctf/docs/contracts/WHATWORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHATWORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -1,0 +1,58 @@
+policies:
+  - command: whatworks.list.read
+    requiredRoles: [user, admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.public.read
+    # Public surface: no authenticated role required. Returns a redacted, identity-free teaser.
+    requiredRoles: []
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.problems.list
+    requiredRoles: [user, admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.product.suggest
+    requiredRoles: [user, admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.product.endorse
+    requiredRoles: [user, admin]
+    attributePolicies:
+      - attribute: userId
+        mustMatch: authenticatedUserId
+    consentRequirements: []
+  - command: whatworks.product.unendorse
+    requiredRoles: [user, admin]
+    attributePolicies:
+      - attribute: userId
+        mustMatch: authenticatedUserId
+    consentRequirements: []
+  - command: whatworks.admin.problem.list
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.admin.problem.create
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.admin.problem.update
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.admin.problem.delete
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.admin.product.list
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.admin.product.review
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []
+  - command: whatworks.admin.product.delete
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []

--- a/ctf/docs/contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -37,7 +37,8 @@ auditEvents:
     targetContext: admin
   - eventId: whatworks.admin.problem.delete
     policyDecision: allow
-    dataClassesAccessed: [community_content]
+    # Cascades to whatworks_products and whatworks_endorsements (user-linked rows).
+    dataClassesAccessed: [community_content, user_event]
     targetContext: admin
   - eventId: whatworks.admin.product.list
     policyDecision: allow
@@ -49,5 +50,6 @@ auditEvents:
     targetContext: admin
   - eventId: whatworks.admin.product.delete
     policyDecision: allow
-    dataClassesAccessed: [community_content]
+    # Cascades to whatworks_endorsements (user-linked rows).
+    dataClassesAccessed: [community_content, user_event]
     targetContext: admin

--- a/ctf/docs/contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -1,0 +1,53 @@
+auditEvents:
+  - eventId: whatworks.list.read
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: user
+  - eventId: whatworks.public.read
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: public
+  - eventId: whatworks.problems.list
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: user
+  - eventId: whatworks.product.suggest
+    policyDecision: allow
+    dataClassesAccessed: [community_content, user_event]
+    targetContext: user
+  - eventId: whatworks.product.endorse
+    policyDecision: allow
+    dataClassesAccessed: [user_event]
+    targetContext: user
+  - eventId: whatworks.product.unendorse
+    policyDecision: allow
+    dataClassesAccessed: [user_event]
+    targetContext: user
+  - eventId: whatworks.admin.problem.list
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin
+  - eventId: whatworks.admin.problem.create
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin
+  - eventId: whatworks.admin.problem.update
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin
+  - eventId: whatworks.admin.problem.delete
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin
+  - eventId: whatworks.admin.product.list
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin
+  - eventId: whatworks.admin.product.review
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin
+  - eventId: whatworks.admin.product.delete
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin

--- a/ctf/docs/contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -1,54 +1,93 @@
 auditEvents:
   - eventId: whatworks.list.read
+    pluginId: whatworks
+    command: whatworks.list.read
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: user
   - eventId: whatworks.public.read
+    pluginId: whatworks
+    command: whatworks.public.read
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: public
   - eventId: whatworks.problems.list
+    pluginId: whatworks
+    command: whatworks.problems.list
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: user
   - eventId: whatworks.product.suggest
+    pluginId: whatworks
+    command: whatworks.product.suggest
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content, user_event]
     targetContext: user
   - eventId: whatworks.product.endorse
+    pluginId: whatworks
+    command: whatworks.product.endorse
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [user_event]
     targetContext: user
   - eventId: whatworks.product.unendorse
+    pluginId: whatworks
+    command: whatworks.product.unendorse
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [user_event]
     targetContext: user
   - eventId: whatworks.admin.problem.list
+    pluginId: whatworks
+    command: whatworks.admin.problem.list
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: admin
   - eventId: whatworks.admin.problem.create
+    pluginId: whatworks
+    command: whatworks.admin.problem.create
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: admin
   - eventId: whatworks.admin.problem.update
+    pluginId: whatworks
+    command: whatworks.admin.problem.update
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: admin
   - eventId: whatworks.admin.problem.delete
+    pluginId: whatworks
+    command: whatworks.admin.problem.delete
+    version: 1.0.0
     policyDecision: allow
     # Cascades to whatworks_products and whatworks_endorsements (user-linked rows).
     dataClassesAccessed: [community_content, user_event]
     targetContext: admin
   - eventId: whatworks.admin.product.list
+    pluginId: whatworks
+    command: whatworks.admin.product.list
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: admin
   - eventId: whatworks.admin.product.review
+    pluginId: whatworks
+    command: whatworks.admin.product.review
+    version: 1.0.0
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: admin
   - eventId: whatworks.admin.product.delete
+    pluginId: whatworks
+    command: whatworks.admin.product.delete
+    version: 1.0.0
     policyDecision: allow
     # Cascades to whatworks_endorsements (user-linked rows).
     dataClassesAccessed: [community_content, user_event]

--- a/ctf/docs/contracts/WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -1,0 +1,393 @@
+commands:
+  - id: whatworks.list.read
+    inputSchema:
+      type: object
+      properties: {}
+    outputSchema:
+      type: object
+      properties:
+        problems:
+          type: array
+          items:
+            $ref: '#/definitions/ReaderProblem'
+        stats:
+          $ref: '#/definitions/ListStats'
+        viewer:
+          type: object
+          properties:
+            isAdmin:
+              type: boolean
+    dataAccess:
+      - whatworks_problems (select)
+      - whatworks_products (select)
+      - whatworks_endorsements (select)
+    purpose: Read the shared survivor-verified list (approved tools grouped by active problem) with per-viewer endorsement state
+    retentionClass: community_content
+  - id: whatworks.public.read
+    inputSchema:
+      type: object
+      properties: {}
+    outputSchema:
+      type: object
+      properties:
+        problems:
+          type: array
+          items:
+            $ref: '#/definitions/ReaderProblem'
+        stats:
+          $ref: '#/definitions/ListStats'
+    dataAccess:
+      - whatworks_problems (select)
+      - whatworks_products (select)
+      - whatworks_endorsements (select)
+    purpose: Public, sign-in-free teaser of the list; submitter identity is never returned
+    retentionClass: community_content
+  - id: whatworks.problems.list
+    inputSchema:
+      type: object
+      properties: {}
+    outputSchema:
+      type: object
+      properties:
+        problems:
+          type: array
+          items:
+            $ref: '#/definitions/ProblemOption'
+    dataAccess:
+      - whatworks_problems (select)
+    purpose: List active problems for the suggest form
+    retentionClass: community_content
+  - id: whatworks.product.suggest
+    inputSchema:
+      type: object
+      properties:
+        problemId:
+          type: string
+        name:
+          type: string
+        purchaseUrl:
+          type: string
+        emoji:
+          type: string
+        kind:
+          type: string
+        note:
+          type: string
+      required: [problemId, name, purchaseUrl]
+    outputSchema:
+      type: object
+      properties:
+        productId:
+          type: string
+        status:
+          type: string
+    dataAccess:
+      - whatworks_problems (select)
+      - whatworks_products (insert)
+      - whatworks_endorsements (insert)
+    purpose: Suggest a tool (status pending for admin review); the suggester is auto-recorded as the first verifier
+    retentionClass: community_content
+  - id: whatworks.product.endorse
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+      required: [id]
+    outputSchema:
+      $ref: '#/definitions/EndorsementState'
+    dataAccess:
+      - whatworks_products (select)
+      - whatworks_endorsements (insert)
+    purpose: Mark an approved tool as "this helped me" (increments its verified count)
+    retentionClass: user_event
+  - id: whatworks.product.unendorse
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+      required: [id]
+    outputSchema:
+      $ref: '#/definitions/EndorsementState'
+    dataAccess:
+      - whatworks_products (select)
+      - whatworks_endorsements (delete)
+    purpose: Remove the viewer's own endorsement from a tool
+    retentionClass: user_event
+  - id: whatworks.admin.problem.list
+    inputSchema:
+      type: object
+      properties: {}
+    outputSchema:
+      type: object
+      properties:
+        problems:
+          type: array
+          items:
+            $ref: '#/definitions/AdminProblem'
+    dataAccess:
+      - whatworks_problems (select)
+      - whatworks_products (select)
+    purpose: List all problems with product counts for curation
+    retentionClass: community_content
+  - id: whatworks.admin.problem.create
+    inputSchema:
+      type: object
+      properties:
+        title:
+          type: string
+        emoji:
+          type: string
+        context:
+          type: string
+        sortOrder:
+          type: integer
+      required: [title]
+    outputSchema:
+      type: object
+      properties:
+        problem:
+          $ref: '#/definitions/AdminProblem'
+    dataAccess:
+      - whatworks_problems (insert)
+    purpose: Create an admin-curated problem category
+    retentionClass: community_content
+  - id: whatworks.admin.problem.update
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        emoji:
+          type: string
+        context:
+          type: string
+        sortOrder:
+          type: integer
+        isActive:
+          type: boolean
+      required: [id]
+    outputSchema:
+      type: object
+      properties:
+        problem:
+          $ref: '#/definitions/AdminProblem'
+    dataAccess:
+      - whatworks_problems (select)
+      - whatworks_problems (update)
+    purpose: Edit, reorder, or deactivate a problem
+    retentionClass: community_content
+  - id: whatworks.admin.problem.delete
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+      required: [id]
+    outputSchema:
+      type: object
+      properties:
+        ok:
+          type: boolean
+    dataAccess:
+      - whatworks_problems (select)
+      - whatworks_problems (delete)
+      - whatworks_products (delete)
+      - whatworks_endorsements (delete)
+    purpose: Delete a problem and (by cascade) its tools and endorsements
+    retentionClass: community_content
+  - id: whatworks.admin.product.list
+    inputSchema:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [pending, approved, rejected]
+    outputSchema:
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            $ref: '#/definitions/AdminProduct'
+    dataAccess:
+      - whatworks_products (select)
+      - whatworks_problems (select)
+      - whatworks_endorsements (select)
+    purpose: Moderation queue; submitter identity is intentionally never returned
+    retentionClass: community_content
+  - id: whatworks.admin.product.review
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+          enum: [approve, reject]
+        rejectionReason:
+          type: string
+      required: [id, action]
+    outputSchema:
+      type: object
+      properties:
+        status:
+          type:
+            - string
+            - 'null'
+    dataAccess:
+      - whatworks_products (select)
+      - whatworks_products (update)
+    purpose: Approve or reject a suggested tool
+    retentionClass: community_content
+  - id: whatworks.admin.product.delete
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+      required: [id]
+    outputSchema:
+      type: object
+      properties:
+        ok:
+          type: boolean
+    dataAccess:
+      - whatworks_products (select)
+      - whatworks_products (delete)
+      - whatworks_endorsements (delete)
+    purpose: Delete a tool and (by cascade) its endorsements
+    retentionClass: community_content
+
+definitions:
+  ReaderProduct:
+    type: object
+    properties:
+      id:
+        type: string
+      emoji:
+        type: string
+      name:
+        type: string
+      kind:
+        type: string
+      note:
+        type: string
+      purchaseUrl:
+        type: string
+      verifiedCount:
+        type: integer
+      viewerHasEndorsed:
+        type: boolean
+    required: [id, name, purchaseUrl, verifiedCount, viewerHasEndorsed]
+  ReaderProblem:
+    type: object
+    properties:
+      id:
+        type: string
+      slug:
+        type: string
+      emoji:
+        type: string
+      title:
+        type: string
+      context:
+        type: string
+      products:
+        type: array
+        items:
+          $ref: '#/definitions/ReaderProduct'
+    required: [id, slug, title, products]
+  ProblemOption:
+    type: object
+    properties:
+      id:
+        type: string
+      slug:
+        type: string
+      emoji:
+        type: string
+      title:
+        type: string
+      context:
+        type: string
+    required: [id, title]
+  ListStats:
+    type: object
+    properties:
+      problems:
+        type: integer
+      verifiedTools:
+        type: integer
+      survivorsHelped:
+        type: integer
+    required: [problems, verifiedTools, survivorsHelped]
+  EndorsementState:
+    type: object
+    properties:
+      verifiedCount:
+        type: integer
+      viewerHasEndorsed:
+        type: boolean
+    required: [verifiedCount, viewerHasEndorsed]
+  AdminProblem:
+    type: object
+    properties:
+      id:
+        type: string
+      slug:
+        type: string
+      emoji:
+        type: string
+      title:
+        type: string
+      context:
+        type: string
+      sort_order:
+        type: integer
+      is_active:
+        type: boolean
+      productCount:
+        type: integer
+      approvedCount:
+        type: integer
+      pendingCount:
+        type: integer
+    required: [id, slug, title, is_active]
+  AdminProduct:
+    type: object
+    properties:
+      id:
+        type: string
+      problemId:
+        type: string
+      problemTitle:
+        type: string
+      emoji:
+        type: string
+      name:
+        type: string
+      kind:
+        type: string
+      note:
+        type: string
+      purchaseUrl:
+        type: string
+      status:
+        type: string
+      verifiedCount:
+        type: integer
+      createdAt:
+        type: string
+      reviewedAt:
+        type:
+          - string
+          - 'null'
+      rejectionReason:
+        type:
+          - string
+          - 'null'
+    required: [id, problemId, name, status]

--- a/ctf/docs/contracts/WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -1,5 +1,7 @@
 commands:
-  - id: whatworks.list.read
+  - pluginId: whatworks
+    command: whatworks.list.read
+    version: 1.0.0
     inputSchema:
       type: object
       properties: {}
@@ -23,7 +25,9 @@ commands:
       - whatworks_endorsements (select)
     purpose: Read the shared survivor-verified list (approved tools grouped by active problem) with per-viewer endorsement state
     retentionClass: community_content
-  - id: whatworks.public.read
+  - pluginId: whatworks
+    command: whatworks.public.read
+    version: 1.0.0
     inputSchema:
       type: object
       properties: {}
@@ -42,7 +46,9 @@ commands:
       - whatworks_endorsements (select)
     purpose: Public, sign-in-free teaser of the list; submitter identity is never returned
     retentionClass: community_content
-  - id: whatworks.problems.list
+  - pluginId: whatworks
+    command: whatworks.problems.list
+    version: 1.0.0
     inputSchema:
       type: object
       properties: {}
@@ -57,7 +63,9 @@ commands:
       - whatworks_problems (select)
     purpose: List active problems for the suggest form
     retentionClass: community_content
-  - id: whatworks.product.suggest
+  - pluginId: whatworks
+    command: whatworks.product.suggest
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -87,7 +95,9 @@ commands:
       - whatworks_endorsements (insert)
     purpose: Suggest a tool (status pending for admin review); the suggester is auto-recorded as the first verifier
     retentionClass: community_content
-  - id: whatworks.product.endorse
+  - pluginId: whatworks
+    command: whatworks.product.endorse
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -101,7 +111,9 @@ commands:
       - whatworks_endorsements (insert)
     purpose: Mark an approved tool as "this helped me" (increments its verified count)
     retentionClass: user_event
-  - id: whatworks.product.unendorse
+  - pluginId: whatworks
+    command: whatworks.product.unendorse
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -115,7 +127,9 @@ commands:
       - whatworks_endorsements (delete)
     purpose: Remove the viewer's own endorsement from a tool
     retentionClass: user_event
-  - id: whatworks.admin.problem.list
+  - pluginId: whatworks
+    command: whatworks.admin.problem.list
+    version: 1.0.0
     inputSchema:
       type: object
       properties: {}
@@ -131,7 +145,9 @@ commands:
       - whatworks_products (select)
     purpose: List all problems with product counts for curation
     retentionClass: community_content
-  - id: whatworks.admin.problem.create
+  - pluginId: whatworks
+    command: whatworks.admin.problem.create
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -153,7 +169,9 @@ commands:
       - whatworks_problems (insert)
     purpose: Create an admin-curated problem category
     retentionClass: community_content
-  - id: whatworks.admin.problem.update
+  - pluginId: whatworks
+    command: whatworks.admin.problem.update
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -180,7 +198,9 @@ commands:
       - whatworks_problems (update)
     purpose: Edit, reorder, or deactivate a problem
     retentionClass: community_content
-  - id: whatworks.admin.problem.delete
+  - pluginId: whatworks
+    command: whatworks.admin.problem.delete
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -199,7 +219,9 @@ commands:
       - whatworks_endorsements (delete)
     purpose: Delete a problem and (by cascade) its tools and endorsements
     retentionClass: community_content
-  - id: whatworks.admin.product.list
+  - pluginId: whatworks
+    command: whatworks.admin.product.list
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -219,7 +241,9 @@ commands:
       - whatworks_endorsements (select)
     purpose: Moderation queue; submitter identity is intentionally never returned
     retentionClass: community_content
-  - id: whatworks.admin.product.review
+  - pluginId: whatworks
+    command: whatworks.admin.product.review
+    version: 1.0.0
     inputSchema:
       type: object
       properties:
@@ -243,7 +267,9 @@ commands:
       - whatworks_products (update)
     purpose: Approve or reject a suggested tool
     retentionClass: community_content
-  - id: whatworks.admin.product.delete
+  - pluginId: whatworks
+    command: whatworks.admin.product.delete
+    version: 1.0.0
     inputSchema:
       type: object
       properties:

--- a/ctf/docs/contracts/WHATWORKS_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/WHATWORKS_PROFILE_AND_DELETION_CONTRACT.md
@@ -1,0 +1,69 @@
+# WhatWorks Profile and Deletion Contract
+
+## 1) Plugin Metadata
+
+- Plugin Name: WhatWorks
+- Service Key (lowercase, stable): `whatworks`
+- Rollout Stage: Implemented shell
+
+## 2) Canonical Profile Usage
+
+Rule 114 baseline: WhatWorks uses the single canonical profile and does not create a duplicate
+identity store. It persists only the canonical `user_id` as a foreign reference on the rows it owns.
+
+- Read fields:
+  - `user_id` (to resolve the viewer for per-row endorsement state and admin role)
+- Write fields:
+  - none on the canonical profile
+- Why canonical fields are needed:
+  - attribute a "this helped me" endorsement to exactly one survivor (dedupe)
+  - record who suggested / reviewed a tool for moderation and abuse control only
+
+## Identity Handle Baseline
+
+- WhatWorks never displays the suggester's identity. The "Private to suggest" promise means
+  `suggested_by` is stored for moderation only and is excluded from every reader **and** admin
+  projection. No `@handle` is rendered anywhere in the plugin.
+
+## 3) Plugin Extension Fields
+
+- WhatWorks creates no per-user extension table. User linkage lives only as plain `user_id`
+  columns on the domain tables below.
+
+## 4) Domain Data Owned by Plugin
+
+- Table/entity: `whatworks_problems`
+  - Contains personal data? minimal — `created_by` (admin user id) only
+  - Retention: long-lived community content
+- Table/entity: `whatworks_products`
+  - Contains personal data? yes — `suggested_by` and `reviewed_by` user ids (never displayed)
+  - Retention: long-lived community content
+- Table/entity: `whatworks_endorsements`
+  - Contains personal data? yes — `user_id` of the endorsing survivor
+  - Retention: retained while the survivor's account is active; removed on deletion (see below)
+
+## 5) Deletion Behavior
+
+WhatWorks is a single shared community list. Tool and problem content is community-owned and is
+**retained** when an individual leaves (it continues to help other survivors), but every link
+back to the departing survivor is removed or anonymized.
+
+On service-scoped or full profile deletion for `user_id = X`:
+
+- `DELETE FROM whatworks_endorsements WHERE user_id = X`
+  — removes the survivor's "this helped me" marks; each affected tool's verified count drops by one.
+- `UPDATE whatworks_products SET suggested_by = NULL WHERE suggested_by = X`
+  — anonymizes authorship; the suggested tool stays on the list.
+- `UPDATE whatworks_products SET reviewed_by = NULL WHERE reviewed_by = X`
+  — anonymizes the moderating admin reference.
+- `UPDATE whatworks_problems SET created_by = NULL WHERE created_by = X`
+  — anonymizes the problem author reference.
+
+No WhatWorks row stores free-text that identifies the survivor, so anonymizing the `user_id`
+references fully removes the personal linkage while preserving the shared list.
+
+## 6) Cascade Notes
+
+- Deleting a `whatworks_problems` row cascades to its `whatworks_products` and their
+  `whatworks_endorsements` (`ON DELETE CASCADE`).
+- Deleting a `whatworks_products` row cascades to its `whatworks_endorsements`.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-whatworks-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-whatworks-feature-inventory.md
@@ -1,0 +1,171 @@
+# WhatWorks Plugin Feature Inventory
+
+## 1. Scope and Boundary
+
+- Plugin slug: `whatworks`
+- WhatWorks owns one shared, community-wide, survivor-verified list of tools organized by problem.
+- Surfaces it owns:
+  - Authenticated app shell at `/apps/whatworks`.
+  - Permanently-public preview at `/plugin/whatworks`.
+  - Admin moderation/curation at `/admin/whatworks`.
+  - All `/api/whatworks/*` routes and the `whatworks_*` tables.
+  - Android/Expo feature at `packages/mobile/src/features/whatworks`.
+- Explicitly does **not** own:
+  - The external "Look Ma" explainer at `https://www.chargingthefuture.com/look-ma` (a marketing
+    landing page; WhatWorks only links out to it from the right-rail footnote).
+  - Any per-survivor/published personal lists (single shared list only, by design — "for now").
+  - Cross-plugin reads. WhatWorks curates its own problems; it does not read another plugin's data.
+
+## 2. Intent and Outcome
+
+WhatWorks answers one question for a survivor in crisis: *what actually helped someone like me?* A
+member picks a problem they're facing (noise harassment, sleep disruption, vehicle tampering, …) and
+sees a short list of specific products another survivor bought, used, and verified helped — each with
+a direct purchase link, no ads, no affiliates, and no identity attached to the suggestion. Anyone can
+read a teaser; signed-in survivors can suggest tools and mark items "this helped me"; admins curate
+the problem categories and review every suggestion before it joins the shared list.
+
+## 3. Target User Features
+
+- Browse the shared list: active problems, each with its approved tools (emoji, name, type, a short
+  "why it works" note, a verified count, and a direct purchase link).
+- Mark a tool **Helpful** ("this helped me") — a one-per-survivor endorsement whose tally renders as
+  "N survivors verified"; toggle off to withdraw it.
+- Suggest a tool: choose an existing problem, add a product name, a direct purchase link, and an
+  optional note. Suggestions are reviewed before they appear (anonymous to other members).
+- Client-side search across tools and problems.
+- Jump-nav sidebar that scrolls to a chosen problem.
+- Public (signed-out) preview: a readable teaser slice plus a sign-in/sign-up gate to see the full
+  list and to suggest.
+- Web and Android parity.
+
+## 4. Target Admin Features
+
+- Review queue: approve or reject (with an admin-only reason) each suggested tool; delete tools.
+- Status filter across pending / approved / rejected / all.
+- Curate problems: create, rename, re-emoji, reorder, deactivate/reactivate, and delete (cascading
+  to that problem's tools and endorsements).
+- Submitter identity is never surfaced to admins — moderation is of content, not of people.
+- Admin surface at `/admin/whatworks`, reachable from an in-app "Admin" entry when the viewer is an
+  admin.
+
+## 5. API Surface and Route Map
+
+- `GET /api/whatworks` — Authenticated read of the shared list (problems + approved tools + per-viewer endorsement state + stats + `viewer.isAdmin`).
+- `GET /api/whatworks/public` — Public, identity-free teaser slice of the list + stats.
+- `GET /api/whatworks/problems` — Active problems for the suggest form (authenticated).
+- `POST /api/whatworks/products` — Suggest a tool (lands `pending`; suggester auto-recorded as first verifier).
+- `POST /api/whatworks/products/[id]/endorse` — Mark an approved tool helpful.
+- `DELETE /api/whatworks/products/[id]/endorse` — Withdraw the viewer's endorsement.
+- `GET /api/whatworks/admin/problems` — Admin: list problems with product counts.
+- `POST /api/whatworks/admin/problems` — Admin: create a problem.
+- `PATCH /api/whatworks/admin/problems/[id]` — Admin: edit/reorder/deactivate a problem.
+- `DELETE /api/whatworks/admin/problems/[id]` — Admin: delete a problem (cascade).
+- `GET /api/whatworks/admin/products` — Admin: moderation queue (optional `?status=`).
+- `PATCH /api/whatworks/admin/products/[id]` — Admin: approve/reject a tool.
+- `DELETE /api/whatworks/admin/products/[id]` — Admin: delete a tool (cascade).
+
+All mutating routes require the `x-ctf-csrf: 1` confirmation header (same-origin enforced).
+
+## 6. Data Model and Storage Contracts
+
+- Table: `whatworks_problems` — admin-curated categories.
+  - `id UUID PRIMARY KEY`
+  - `slug TEXT NOT NULL` (unique index `idx_whatworks_problems_slug`)
+  - `emoji TEXT NOT NULL DEFAULT ''`
+  - `title TEXT NOT NULL`
+  - `context TEXT NOT NULL DEFAULT ''`
+  - `sort_order INTEGER NOT NULL DEFAULT 0`
+  - `is_active BOOLEAN NOT NULL DEFAULT TRUE`
+  - `created_by TEXT` (admin user id, nullable/anonymizable)
+  - `created_at`, `updated_at TIMESTAMPTZ`
+  - Index: `idx_whatworks_problems_active_sort (is_active, sort_order)`
+- Table: `whatworks_products` — survivor-suggested tools.
+  - `id UUID PRIMARY KEY`
+  - `problem_id UUID NOT NULL REFERENCES whatworks_problems(id) ON DELETE CASCADE`
+  - `emoji TEXT NOT NULL DEFAULT ''`, `name TEXT NOT NULL`, `kind TEXT NOT NULL DEFAULT ''`,
+    `note TEXT NOT NULL DEFAULT ''`, `purchase_url TEXT NOT NULL`
+  - `status TEXT NOT NULL DEFAULT 'pending'` CHECK in (`pending`,`approved`,`rejected`)
+  - `suggested_by TEXT` (never displayed), `reviewed_by TEXT`, `reviewed_at TIMESTAMPTZ`,
+    `rejection_reason TEXT`
+  - `created_at`, `updated_at TIMESTAMPTZ`
+  - Indexes: `idx_whatworks_products_problem (problem_id)`, `idx_whatworks_products_status (status)`
+- Table: `whatworks_endorsements` — "this helped me" signal.
+  - `id UUID PRIMARY KEY`
+  - `product_id UUID NOT NULL REFERENCES whatworks_products(id) ON DELETE CASCADE`
+  - `user_id TEXT NOT NULL`
+  - `created_at TIMESTAMPTZ`
+  - Unique index `idx_whatworks_endorsements_unique (product_id, user_id)`; index on `product_id`.
+
+Derived metrics (no stored counters): a tool's verified count is `COUNT(*)` of its endorsements;
+"Survivors helped" is the sum of verified counts across approved tools.
+
+## 7. Security, Privacy, and Compliance Controls
+
+- Reading the full list requires authentication (`evaluatePluginAccess`); the public teaser is the
+  only unauthenticated surface and is identity-free.
+- Suggesting and endorsing require an authenticated survivor; curating problems and moderating
+  suggestions require an admin (`isAdmin`). Admin page redirects non-admins to `/apps/whatworks`.
+- CSRF: all mutations require `x-ctf-csrf: 1` and same-origin (`ensureMutationCsrf`).
+- Anonymity: `suggested_by` is stored for moderation/abuse control only and is excluded from every
+  reader and admin projection. No survivor identity is rendered anywhere in the plugin.
+- Input validation: lengths and `http(s)`-only purchase URLs are enforced server-side.
+- Contracts: see
+  [WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml](../../contracts/WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml),
+  [WHATWORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml](../../contracts/WHATWORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml),
+  [WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml](../../contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml),
+  [WHATWORKS_PROFILE_AND_DELETION_CONTRACT.md](../../contracts/WHATWORKS_PROFILE_AND_DELETION_CONTRACT.md).
+
+## 8. Web and Android Delivery Status
+
+- Web: complete. Pixel pass against design `12c6293` —
+  `design/.../survivor-hub/WhatWorks.tsx` (populated), `WhatWorksPublic.tsx` (public),
+  `WhatWorksEmpty.tsx` (suggest/empty), `WhatWorksLoading.tsx` (loading). Decomposed into modular
+  sub-components under `packages/web/components/whatworks/` within the rule-116 limits. All data is
+  real (`/api/whatworks*`); no stub arrays in the production shells.
+- Android: complete. Expo feature at `packages/mobile/src/features/whatworks/` (list + Helpful
+  toggle + suggest, against the `MobileWhatWorks*` references), registered in
+  `config/plugin-parity-contracts.json`. Pending on-device QA (no device runtime in the build env).
+- Parity contract: [plugin-parity-contracts.json](../../../config/plugin-parity-contracts.json).
+
+## 9. Seed Coverage Status
+
+- Seed: [scripts/seedWhatworks.mjs](../../../scripts/seedWhatworks.mjs) (`pnpm --filter ... seed:whatworks`).
+- Deterministic, idempotent. Seeds the design's exact sample: 3 problems, 7 approved tools, and 27
+  endorsements (so a fresh DB renders the mockup's headline numbers — 3 problems, 7 tools, 27
+  survivors helped). Demo-schema coverage is added via `seedDemo.mjs`.
+
+## 10. Gaps and Known Technical Debt
+
+- The reviewed-suggestion flow means the design's "First tool added 🎉" / "Add to the list" copy is
+  rendered as the review-honest "Suggestion submitted" / "Submit for review" instead. Flagged back to
+  the design agent to fold into the mockup (see session continuity notes); not a code gap.
+- The admin moderation surface has no Replit mockup; it is built to the established functional
+  `/admin/{plugin}` convention (owner-approved approach, this task).
+- Endorsement abuse control beyond one-per-user dedupe (e.g., rate limiting) relies on shared
+  platform defaults.
+- The profile-deletion scopes are specified in the deletion contract; wiring them into the central
+  deletion orchestrator is a platform-level task tracked outside this plugin.
+
+## Change Log
+
+- 2026-05-31: Initial implementation. Schema (`whatworks_problems`, `whatworks_products`,
+  `whatworks_endorsements`), repository/policy/types, full `/api/whatworks/*` surface (public + user +
+  admin), pixel pass of the four designed web states, functional admin curation/moderation, Android
+  Expo feature, registry + parity entries, contracts, and a deterministic seed matching the design
+  sample. Design pinned at `12c6293`.
+
+## Build Checklist
+
+1. [x] Pin the design submodule at the WhatWorks commit (`12c6293`).
+2. [x] Schema: `whatworks_problems`, `whatworks_products`, `whatworks_endorsements` (+ indexes, ALTER guards).
+3. [x] Plugin registry entries (schema seed + `repository.ts` fallback) and parity-contracts entry.
+4. [x] Library: `types.ts`, `constants.ts`, `policy.ts`, `repository.ts`.
+5. [x] API: public reader, authed reader, problems list, suggest, endorse/un-endorse.
+6. [x] API: admin problems CRUD and product moderation.
+7. [x] Contracts: command, access policy, audit, profile-and-deletion.
+8. [x] Web UI: loading, public, suggest/empty, populated list — pixel pass + modular decomposition.
+9. [x] Web route registration (`/apps/whatworks`, `/plugin/whatworks`, `/admin/whatworks`).
+10. [x] Android Expo feature (list, Helpful, suggest) + parity entry.
+11. [x] Deterministic seed matching the design sample.
+12. [x] Inventory (this document).

--- a/ctf/package.json
+++ b/ctf/package.json
@@ -23,6 +23,7 @@
     "seed:socketrelay": "node ./scripts/seedSocketRelay.mjs",
     "seed:trusttransport": "node ./scripts/seedTrustTransport.mjs",
     "seed:levelup": "node ./scripts/seedLevelup.mjs",
+    "seed:whatworks": "node ./scripts/seedWhatworks.mjs",
     "sync:skills-taxonomy:legacy": "node ./scripts/syncSkillsTaxonomyFromPlatform.mjs --mode=sync",
     "migrate:file": "node ./scripts/runMigrationFile.mjs",
     "migrate:schema": "node ./scripts/runMigrationFile.mjs --file=./schema.sql",

--- a/ctf/packages/mobile/src/features/whatworks/WhatWorksList.tsx
+++ b/ctf/packages/mobile/src/features/whatworks/WhatWorksList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  View, Text, ScrollView, Pressable, ActivityIndicator, StyleSheet, Linking,
+  View, Text, ScrollView, Pressable, ActivityIndicator, StyleSheet, Linking, Alert,
 } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { fetchList, toggleEndorsement, type WhatWorksProblem, type WhatWorksProduct, type WhatWorksStats } from './api';
@@ -9,6 +9,21 @@ import { WW } from './theme';
 type NavLike = { navigate: (_screen: string) => void };
 
 const EMPTY_STATS: WhatWorksStats = { problems: 0, verifiedTools: 0, survivorsHelped: 0 };
+
+// purchaseUrl comes from survivor-submitted suggestions; guard against unsupported or malformed
+// schemes so openURL can't produce an unhandled promise rejection.
+async function openLink(url: string): Promise<void> {
+  try {
+    const supported = await Linking.canOpenURL(url);
+    if (!supported) {
+      Alert.alert('Could not open this link.');
+      return;
+    }
+    await Linking.openURL(url);
+  } catch {
+    Alert.alert('Could not open this link.');
+  }
+}
 
 function ToolCard({ product, busy, onToggle }: { product: WhatWorksProduct; busy: boolean; onToggle: (_product: WhatWorksProduct) => void }) {
   return (
@@ -31,7 +46,7 @@ function ToolCard({ product, busy, onToggle }: { product: WhatWorksProduct; busy
             <Ionicons name={product.viewerHasEndorsed ? 'thumbs-up' : 'thumbs-up-outline'} size={13} color={product.viewerHasEndorsed ? WW.brand : WW.subtle} />
             <Text style={[styles.helpfulText, { color: product.viewerHasEndorsed ? WW.brand : WW.subtle }]}>{product.viewerHasEndorsed ? 'Helped me' : 'Helpful'}</Text>
           </Pressable>
-          <Pressable onPress={() => Linking.openURL(product.purchaseUrl)} style={styles.viewBtn}>
+          <Pressable onPress={() => { void openLink(product.purchaseUrl); }} style={styles.viewBtn}>
             <Text style={styles.viewText}>View</Text>
             <Ionicons name="open-outline" size={12} color={WW.brand} />
           </Pressable>

--- a/ctf/packages/mobile/src/features/whatworks/WhatWorksList.tsx
+++ b/ctf/packages/mobile/src/features/whatworks/WhatWorksList.tsx
@@ -1,0 +1,180 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View, Text, ScrollView, Pressable, ActivityIndicator, StyleSheet, Linking,
+} from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { fetchList, toggleEndorsement, type WhatWorksProblem, type WhatWorksProduct, type WhatWorksStats } from './api';
+import { WW } from './theme';
+
+type NavLike = { navigate: (_screen: string) => void };
+
+const EMPTY_STATS: WhatWorksStats = { problems: 0, verifiedTools: 0, survivorsHelped: 0 };
+
+function ToolCard({ product, busy, onToggle }: { product: WhatWorksProduct; busy: boolean; onToggle: (_product: WhatWorksProduct) => void }) {
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardTop}>
+        <View style={styles.emojiBox}><Text style={styles.emoji}>{product.emoji || '🧰'}</Text></View>
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <Text style={styles.productName}>{product.name}</Text>
+          {product.kind ? <Text style={styles.kind}>{product.kind}</Text> : null}
+        </View>
+      </View>
+      {product.note ? <Text style={styles.note}>{`“${product.note}”`}</Text> : null}
+      <View style={styles.cardRow}>
+        <View style={styles.verifiedWrap}>
+          <Ionicons name="shield-checkmark-outline" size={13} color={WW.brand} />
+          <Text style={styles.verifiedText}>{product.verifiedCount} survivors verified</Text>
+        </View>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+          <Pressable disabled={busy} onPress={() => onToggle(product)} style={styles.helpful}>
+            <Ionicons name={product.viewerHasEndorsed ? 'thumbs-up' : 'thumbs-up-outline'} size={13} color={product.viewerHasEndorsed ? WW.brand : WW.subtle} />
+            <Text style={[styles.helpfulText, { color: product.viewerHasEndorsed ? WW.brand : WW.subtle }]}>{product.viewerHasEndorsed ? 'Helped me' : 'Helpful'}</Text>
+          </Pressable>
+          <Pressable onPress={() => Linking.openURL(product.purchaseUrl)} style={styles.viewBtn}>
+            <Text style={styles.viewText}>View</Text>
+            <Ionicons name="open-outline" size={12} color={WW.brand} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function WhatWorksList({ navigation }: { navigation?: NavLike }) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [problems, setProblems] = useState<WhatWorksProblem[]>([]);
+  const [stats, setStats] = useState<WhatWorksStats>(EMPTY_STATS);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const data = await fetchList();
+      setProblems(data.problems ?? []);
+      setStats(data.stats ?? EMPTY_STATS);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onToggle = async (product: WhatWorksProduct) => {
+    setBusyId(product.id);
+    try {
+      const next = await toggleEndorsement(product.id, product.viewerHasEndorsed);
+      setProblems((prev) => prev.map((problem) => ({
+        ...problem,
+        products: problem.products.map((item) => (item.id === product.id ? { ...item, ...next } : item)),
+      })));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  if (loading) {
+    return <View style={styles.center}><ActivityIndicator color={WW.brand} /></View>;
+  }
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.header}>
+        <Ionicons name="list" size={17} color={WW.brand} />
+        <Text style={styles.headerTitle}>What Works</Text>
+        <View style={styles.verifiedBadge}>
+          <Ionicons name="checkmark-circle-outline" size={11} color={WW.brand} />
+          <Text style={styles.verifiedBadgeText}>Verified</Text>
+        </View>
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <Text style={styles.h1}>What actually works.</Text>
+        <Text style={styles.lede}>Pick a problem. Underneath are specific tools a survivor here used and said helped — with a direct link to get it.</Text>
+        <View style={styles.chipRow}>
+          {[`${stats.problems} problems`, `${stats.verifiedTools} tools`, 'Survivor-verified'].map((chip) => (
+            <React.Fragment key={chip}>
+              <View style={styles.chip}><Text style={styles.chipText}>{chip}</Text></View>
+            </React.Fragment>
+          ))}
+        </View>
+
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+
+        {problems.length === 0 ? (
+          <Text style={styles.empty}>The list is just getting started. Add the first tool that worked for you.</Text>
+        ) : (
+          problems.map((problem) => (
+            <React.Fragment key={problem.id}>
+              <View style={{ marginTop: 18 }}>
+                <View style={styles.problemHead}>
+                  <View style={styles.problemEmoji}><Text style={styles.emoji}>{problem.emoji || '🧰'}</Text></View>
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.problemTitle}>{problem.title}</Text>
+                    {problem.context ? <Text style={styles.problemContext}>{problem.context}</Text> : null}
+                  </View>
+                </View>
+                {problem.products.map((product) => (
+                  <React.Fragment key={product.id}>
+                    <ToolCard product={product} busy={busyId === product.id} onToggle={onToggle} />
+                  </React.Fragment>
+                ))}
+              </View>
+            </React.Fragment>
+          ))
+        )}
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <Pressable style={styles.suggestBtn} onPress={() => navigation?.navigate('Suggest')}>
+          <Ionicons name="add" size={16} color={WW.brandInk} />
+          <Text style={styles.suggestText}>Suggest an item</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: WW.bg },
+  center: { flex: 1, backgroundColor: WW.bg, alignItems: 'center', justifyContent: 'center' },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 16, paddingVertical: 12, backgroundColor: '#0D0F14', borderBottomWidth: 1, borderBottomColor: WW.border },
+  headerTitle: { fontSize: 16, fontWeight: '700', color: WW.text },
+  verifiedBadge: { marginLeft: 'auto', flexDirection: 'row', alignItems: 'center', gap: 4, paddingHorizontal: 9, paddingVertical: 3, borderRadius: 20, backgroundColor: 'rgba(132,204,22,0.12)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.3)' },
+  verifiedBadgeText: { fontSize: 10.5, fontWeight: '700', color: WW.brand },
+  h1: { fontSize: 21, fontWeight: '800', color: WW.text, marginBottom: 6 },
+  lede: { fontSize: 13, color: '#9CA3AF', lineHeight: 20 },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 12 },
+  chip: { paddingHorizontal: 9, paddingVertical: 4, borderRadius: 7, backgroundColor: WW.surface, borderWidth: 1, borderColor: WW.border },
+  chipText: { fontSize: 11, color: '#9CA3AF', fontWeight: '600' },
+  error: { color: '#fecaca', marginTop: 12 },
+  empty: { color: WW.subtle, marginTop: 18, fontSize: 13, lineHeight: 20 },
+  problemHead: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, marginBottom: 11 },
+  problemEmoji: { width: 34, height: 34, borderRadius: 10, backgroundColor: 'rgba(132,204,22,0.12)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.25)', alignItems: 'center', justifyContent: 'center' },
+  problemTitle: { fontSize: 14.5, fontWeight: '700', color: WW.text },
+  problemContext: { fontSize: 11.5, color: WW.subtle, lineHeight: 17, marginTop: 2 },
+  card: { padding: 13, borderRadius: 13, backgroundColor: WW.surface, borderWidth: 1, borderColor: WW.border, marginBottom: 10 },
+  cardTop: { flexDirection: 'row', gap: 11 },
+  emojiBox: { width: 44, height: 44, borderRadius: 10, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: WW.border, alignItems: 'center', justifyContent: 'center' },
+  emoji: { fontSize: 20 },
+  productName: { fontSize: 13.5, fontWeight: '700', color: WW.text },
+  kind: { fontSize: 11, color: WW.subtle },
+  note: { fontSize: 12, color: WW.quote, lineHeight: 18, marginTop: 9, fontStyle: 'italic' },
+  cardRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 11 },
+  verifiedWrap: { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  verifiedText: { fontSize: 11, color: WW.brand, fontWeight: '600' },
+  helpful: { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  helpfulText: { fontSize: 11, fontWeight: '600' },
+  viewBtn: { flexDirection: 'row', alignItems: 'center', gap: 5, paddingHorizontal: 12, paddingVertical: 7, borderRadius: 8, backgroundColor: 'rgba(132,204,22,0.18)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.4)' },
+  viewText: { fontSize: 11.5, fontWeight: '700', color: WW.brand },
+  footer: { padding: 16, borderTopWidth: 1, borderTopColor: WW.border, backgroundColor: '#0D0F14' },
+  suggestBtn: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 11, borderRadius: 10, backgroundColor: WW.brand },
+  suggestText: { fontSize: 13, fontWeight: '700', color: WW.brandInk },
+});

--- a/ctf/packages/mobile/src/features/whatworks/WhatWorksSuggest.tsx
+++ b/ctf/packages/mobile/src/features/whatworks/WhatWorksSuggest.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View, Text, TextInput, Pressable, ScrollView, ActivityIndicator, StyleSheet,
+} from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { fetchProblems, suggestProduct, type WhatWorksProblemOption } from './api';
+import { WW } from './theme';
+
+export function WhatWorksSuggest() {
+  const [problems, setProblems] = useState<WhatWorksProblemOption[]>([]);
+  const [problemId, setProblemId] = useState('');
+  const [name, setName] = useState('');
+  const [link, setLink] = useState('');
+  const [why, setWhy] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const data = await fetchProblems();
+        setProblems(data.problems ?? []);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const ready = Boolean(problemId && name.trim() && link.trim());
+
+  const submit = async () => {
+    if (!ready || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await suggestProduct({ problemId, name: name.trim(), purchaseUrl: link.trim(), note: why.trim() });
+      setProblemId('');
+      setName('');
+      setLink('');
+      setWhy('');
+      setDone(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return <View style={styles.center}><ActivityIndicator color={WW.brand} /></View>;
+  }
+
+  if (done) {
+    return (
+      <View style={styles.center}>
+        <View style={styles.doneCircle}><Ionicons name="checkmark" size={30} color={WW.brand} /></View>
+        <Text style={styles.doneTitle}>Suggestion submitted</Text>
+        <Text style={styles.doneBody}>A reviewer will check it before it joins the shared list.</Text>
+        <Pressable style={styles.submitBtn} onPress={() => setDone(false)}>
+          <Ionicons name="add" size={15} color={WW.brandInk} />
+          <Text style={styles.submitText}>Add another</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={{ padding: 16 }}>
+      <Text style={styles.h1}>Suggest a tool that worked.</Text>
+      <Text style={styles.lede}>Pick the problem it solves, add the product and a direct link, and a short note on why it helped.</Text>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <Text style={styles.label}>Problem it solves *</Text>
+      <View style={styles.chipWrap}>
+        {problems.map((problem) => {
+          const active = problem.id === problemId;
+          return (
+            <Pressable key={problem.id} onPress={() => setProblemId(problem.id)} style={[styles.chip, active && styles.chipActive]}>
+              <Text style={[styles.chipText, active && styles.chipTextActive]}>{problem.emoji ? `${problem.emoji} ` : ''}{problem.title}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <Text style={styles.helper}>New problems are added by admins to avoid duplicates.</Text>
+
+      <Text style={styles.label}>Product name *</Text>
+      <TextInput value={name} onChangeText={setName} placeholder="e.g. Sony WH-1000XM5" placeholderTextColor={WW.subtle} style={styles.input} />
+
+      <Text style={styles.label}>Direct purchase link *</Text>
+      <TextInput value={link} onChangeText={setLink} placeholder="https://…" placeholderTextColor={WW.subtle} autoCapitalize="none" keyboardType="url" style={styles.input} />
+
+      <Text style={styles.label}>Why it works (optional)</Text>
+      <TextInput value={why} onChangeText={setWhy} placeholder="A short note from your experience." placeholderTextColor={WW.subtle} multiline style={[styles.input, { height: 84, textAlignVertical: 'top' }]} />
+
+      <Pressable disabled={!ready || submitting} onPress={submit} style={[styles.submitBtn, (!ready || submitting) && styles.submitDisabled]}>
+        <Ionicons name="send" size={15} color={ready && !submitting ? WW.brandInk : WW.subtle} />
+        <Text style={[styles.submitText, (!ready || submitting) && { color: WW.subtle }]}>{submitting ? 'Submitting…' : 'Submit for review'}</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: WW.bg },
+  center: { flex: 1, backgroundColor: WW.bg, alignItems: 'center', justifyContent: 'center', padding: 32, gap: 12 },
+  h1: { fontSize: 21, fontWeight: '800', color: WW.text, marginBottom: 8 },
+  lede: { fontSize: 13, color: WW.subtle, lineHeight: 20, marginBottom: 16 },
+  error: { color: '#fecaca', marginBottom: 12 },
+  label: { fontSize: 12.5, fontWeight: '600', color: '#9CA3AF', marginTop: 14, marginBottom: 7 },
+  helper: { fontSize: 10.5, color: WW.subtle, marginTop: 6 },
+  chipWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 11, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: WW.border },
+  chipActive: { borderColor: WW.brand, backgroundColor: 'rgba(132,204,22,0.12)' },
+  chipText: { fontSize: 12.5, color: '#9CA3AF', fontWeight: '500' },
+  chipTextActive: { color: WW.text, fontWeight: '600' },
+  input: { backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: WW.border, borderRadius: 11, paddingHorizontal: 13, paddingVertical: 11, color: WW.text, fontSize: 14 },
+  submitBtn: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, paddingVertical: 13, borderRadius: 11, backgroundColor: WW.brand, marginTop: 20 },
+  submitDisabled: { backgroundColor: 'rgba(255,255,255,0.06)' },
+  submitText: { fontSize: 14.5, fontWeight: '700', color: WW.brandInk },
+  doneCircle: { width: 64, height: 64, borderRadius: 32, backgroundColor: 'rgba(132,204,22,0.15)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.3)', alignItems: 'center', justifyContent: 'center' },
+  doneTitle: { fontSize: 20, fontWeight: '800', color: WW.text },
+  doneBody: { fontSize: 13, color: WW.subtle, lineHeight: 20, textAlign: 'center' },
+});

--- a/ctf/packages/mobile/src/features/whatworks/WhatWorksTabs.tsx
+++ b/ctf/packages/mobile/src/features/whatworks/WhatWorksTabs.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { WhatWorksList } from './WhatWorksList';
+import { WhatWorksSuggest } from './WhatWorksSuggest';
+
+type WhatWorksTabParamList = {
+  List: undefined;
+  Suggest: undefined;
+};
+
+const Tab = createBottomTabNavigator<WhatWorksTabParamList>();
+// @types/react 19.2 + React Navigation v7 overload resolution incompatibility:
+// JSX children no longer satisfy the navigator's overloaded prop signature.
+// TODO: remove cast when @react-navigation/bottom-tabs ships React 19.2-compatible types.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TabNavigator = Tab.Navigator as React.ComponentType<any>;
+
+export function WhatWorksTabs() {
+  return (
+    <TabNavigator>
+      <Tab.Screen
+        name="List"
+        component={WhatWorksList}
+        options={{
+          title: 'What Works',
+          tabBarIcon: ({ color, size }) => <Ionicons name="list-outline" size={size} color={color} />,
+        }}
+      />
+      <Tab.Screen
+        name="Suggest"
+        component={WhatWorksSuggest}
+        options={{
+          tabBarIcon: ({ color, size }) => <Ionicons name="add-circle-outline" size={size} color={color} />,
+        }}
+      />
+    </TabNavigator>
+  );
+}
+
+export default WhatWorksTabs;

--- a/ctf/packages/mobile/src/features/whatworks/api.ts
+++ b/ctf/packages/mobile/src/features/whatworks/api.ts
@@ -1,0 +1,101 @@
+import Config from 'react-native-config';
+import { Platform } from 'react-native';
+
+const getApiBaseUrl = () => {
+  if (__DEV__) {
+    return Platform.OS === 'android' ? 'http://10.0.2.2:3000' : 'http://localhost:3000';
+  }
+  return Config.API_BASE_URL || 'https://api.example.com';
+};
+
+const API_BASE_URL = getApiBaseUrl();
+
+export type WhatWorksProduct = {
+  id: string;
+  emoji: string;
+  name: string;
+  kind: string;
+  note: string;
+  purchaseUrl: string;
+  verifiedCount: number;
+  viewerHasEndorsed: boolean;
+};
+
+export type WhatWorksProblem = {
+  id: string;
+  slug: string;
+  emoji: string;
+  title: string;
+  context: string;
+  products: WhatWorksProduct[];
+};
+
+export type WhatWorksStats = { problems: number; verifiedTools: number; survivorsHelped: number };
+
+export type WhatWorksProblemOption = { id: string; slug: string; emoji: string; title: string; context: string };
+
+async function handleResponse(res: Response, fallbackMessage: string) {
+  if (!res.ok) {
+    let errorMessage = fallbackMessage;
+    try {
+      const body = await res.json();
+      if (body.message) errorMessage = body.message;
+      else if (body.error) errorMessage = body.error;
+    } catch {
+      // keep fallback
+    }
+    throw new Error(errorMessage);
+  }
+  return res.json();
+}
+
+async function getAuthToken() {
+  // Replace with the real token retrieval (SecureStore / AsyncStorage / context).
+  return '';
+}
+
+function authHeaders(token: string, mutation: boolean): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (mutation) {
+    headers['Content-Type'] = 'application/json';
+    headers['x-ctf-csrf'] = '1';
+  }
+  return headers;
+}
+
+export async function fetchList(): Promise<{ problems: WhatWorksProblem[]; stats: WhatWorksStats }> {
+  const token = await getAuthToken();
+  const res = await fetch(`${API_BASE_URL}/api/whatworks`, { headers: authHeaders(token, false) });
+  return handleResponse(res, 'Failed to load What Works');
+}
+
+export async function fetchProblems(): Promise<{ problems: WhatWorksProblemOption[] }> {
+  const token = await getAuthToken();
+  const res = await fetch(`${API_BASE_URL}/api/whatworks/problems`, { headers: authHeaders(token, false) });
+  return handleResponse(res, 'Failed to load problems');
+}
+
+export async function suggestProduct(input: {
+  problemId: string;
+  name: string;
+  purchaseUrl: string;
+  note?: string;
+}) {
+  const token = await getAuthToken();
+  const res = await fetch(`${API_BASE_URL}/api/whatworks/products`, {
+    method: 'POST',
+    headers: authHeaders(token, true),
+    body: JSON.stringify(input),
+  });
+  return handleResponse(res, 'Failed to submit suggestion');
+}
+
+export async function toggleEndorsement(productId: string, endorsed: boolean): Promise<{ verifiedCount: number; viewerHasEndorsed: boolean }> {
+  const token = await getAuthToken();
+  const res = await fetch(`${API_BASE_URL}/api/whatworks/products/${productId}/endorse`, {
+    method: endorsed ? 'DELETE' : 'POST',
+    headers: authHeaders(token, true),
+  });
+  return handleResponse(res, 'Failed to update');
+}

--- a/ctf/packages/mobile/src/features/whatworks/index.ts
+++ b/ctf/packages/mobile/src/features/whatworks/index.ts
@@ -1,0 +1,1 @@
+export * from './WhatWorksTabs';

--- a/ctf/packages/mobile/src/features/whatworks/theme.ts
+++ b/ctf/packages/mobile/src/features/whatworks/theme.ts
@@ -1,0 +1,11 @@
+// Tokens mirrored from design/.../survivor-hub/MobileWhatWorks.tsx.
+export const WW = {
+  brand: '#84CC16',
+  brandInk: '#0A0E06',
+  bg: '#0F1117',
+  surface: '#161B27',
+  border: '#1E2A3A',
+  text: '#F9FAFB',
+  subtle: '#6B7280',
+  quote: '#C4CAD3',
+};

--- a/ctf/packages/web/app/admin/whatworks/page.tsx
+++ b/ctf/packages/web/app/admin/whatworks/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { WhatWorksAdminShell } from '@/components/whatworks/ww-admin-shell';
+
+export const dynamic = 'force-dynamic';
+
+export default async function WhatWorksAdminPage() {
+  const access = await evaluatePluginAccess({ requireUsername: false });
+  if (!access.allowed || !access.isAdmin) {
+    redirect('/apps/whatworks');
+  }
+  return <WhatWorksAdminShell />;
+}

--- a/ctf/packages/web/app/api/whatworks/_lib.ts
+++ b/ctf/packages/web/app/api/whatworks/_lib.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
+import { getAppUrl } from 'lib/auth/runtime-env';
+
+export type WhatWorksApiGate =
+  | { allowed: true; auth: AllowDecision }
+  | { allowed: false; response: NextResponse };
+
+// Reading is open to any authenticated survivor; suggesting and endorsing share this gate.
+export async function requireWhatWorksAccess(): Promise<WhatWorksApiGate> {
+  const decision = await evaluatePluginAccess({ requireApprovedUserOrAdmin: false, requireUsername: false });
+  if (!decision.allowed) {
+    return { allowed: false, response: NextResponse.json(decision, { status: decision.status }) };
+  }
+  return { allowed: true, auth: decision };
+}
+
+// Curating problems and moderating suggestions require an admin.
+export async function requireWhatWorksAdminAccess(): Promise<WhatWorksApiGate> {
+  const decision = await evaluatePluginAccess({ requireApprovedUserOrAdmin: false, requireUsername: false });
+  if (!decision.allowed) {
+    return { allowed: false, response: NextResponse.json(decision, { status: decision.status }) };
+  }
+  if (!decision.isAdmin) {
+    return {
+      allowed: false,
+      response: NextResponse.json(
+        { ok: false, code: 'whatworks_admin_only', message: 'Admin access is required for this action.' },
+        { status: 403 },
+      ),
+    };
+  }
+  return { allowed: true, auth: decision };
+}
+
+export function ensureMutationCsrf(request: Request): NextResponse | null {
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return null;
+  }
+
+  if (request.headers.get('x-ctf-csrf') !== '1') {
+    return whatworksError('Missing CSRF confirmation header.', 'whatworks_csrf_denied', 403);
+  }
+
+  const appUrl = getAppUrl();
+  const origin = request.headers.get('origin');
+  if (!appUrl || !origin) {
+    return null;
+  }
+
+  try {
+    if (new URL(appUrl).host !== new URL(origin).host) {
+      return whatworksError('Cross-origin mutation denied by CSRF policy.', 'whatworks_csrf_denied', 403);
+    }
+  } catch {
+    return whatworksError('Invalid request origin metadata.', 'whatworks_csrf_denied', 403);
+  }
+
+  return null;
+}
+
+export function whatworksError(message: string, code: string, status: number): NextResponse {
+  return NextResponse.json({ ok: false, code, message }, { status });
+}
+
+export async function parseJsonBody(request: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const body = await request.json();
+    if (body && typeof body === 'object') {
+      return body as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function readTrimmedString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function isValidHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/ctf/packages/web/app/api/whatworks/admin/problems/[id]/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/problems/[id]/route.ts
@@ -61,6 +61,10 @@ export async function PATCH(request: Request, context: RouteContext) {
     patch.isActive = body.isActive;
   }
 
+  if (Object.keys(patch).length === 0) {
+    return whatworksError('No fields to update.', 'whatworks_no_fields', 400);
+  }
+
   const problem = await updateProblem(id, patch);
   return NextResponse.json({ ok: true, problem });
 }

--- a/ctf/packages/web/app/api/whatworks/admin/problems/[id]/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/problems/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { deleteProblem, getProblemById, updateProblem } from 'lib/whatworks/repository';
+import { MAX_EMOJI_LENGTH, MAX_PROBLEM_CONTEXT_LENGTH, MAX_PROBLEM_TITLE_LENGTH } from 'lib/whatworks/constants';
+import type { UpdateProblemInput } from 'lib/whatworks/types';
+import {
+  ensureMutationCsrf,
+  parseJsonBody,
+  readTrimmedString,
+  requireWhatWorksAdminAccess,
+  whatworksError,
+} from '../../../_lib';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return csrf;
+  }
+  const gate = await requireWhatWorksAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  const { id } = await context.params;
+  const existing = await getProblemById(id);
+  if (!existing) {
+    return whatworksError('That problem could not be found.', 'whatworks_problem_not_found', 404);
+  }
+
+  const body = await parseJsonBody(request);
+  if (!body) {
+    return whatworksError('Invalid JSON body.', 'whatworks_invalid_body', 400);
+  }
+
+  const patch: UpdateProblemInput = {};
+  const title = readTrimmedString(body.title);
+  if (title !== null) {
+    if (title.length > MAX_PROBLEM_TITLE_LENGTH) {
+      return whatworksError('Problem title is too long.', 'whatworks_title_too_long', 400);
+    }
+    patch.title = title;
+  }
+  if (typeof body.context === 'string') {
+    const context2 = body.context.trim();
+    if (context2.length > MAX_PROBLEM_CONTEXT_LENGTH) {
+      return whatworksError('Problem context is too long.', 'whatworks_context_too_long', 400);
+    }
+    patch.context = context2;
+  }
+  if (typeof body.emoji === 'string') {
+    const emoji = body.emoji.trim();
+    if (emoji.length > MAX_EMOJI_LENGTH) {
+      return whatworksError('Emoji is invalid.', 'whatworks_emoji_invalid', 400);
+    }
+    patch.emoji = emoji;
+  }
+  if (typeof body.sortOrder === 'number' && Number.isFinite(body.sortOrder)) {
+    patch.sortOrder = Math.trunc(body.sortOrder);
+  }
+  if (typeof body.isActive === 'boolean') {
+    patch.isActive = body.isActive;
+  }
+
+  const problem = await updateProblem(id, patch);
+  return NextResponse.json({ ok: true, problem });
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return csrf;
+  }
+  const gate = await requireWhatWorksAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  const { id } = await context.params;
+  const existing = await getProblemById(id);
+  if (!existing) {
+    return whatworksError('That problem could not be found.', 'whatworks_problem_not_found', 404);
+  }
+  await deleteProblem(id);
+  return NextResponse.json({ ok: true });
+}

--- a/ctf/packages/web/app/api/whatworks/admin/problems/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/problems/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { createProblem, listAdminProblems } from 'lib/whatworks/repository';
+import { MAX_EMOJI_LENGTH, MAX_PROBLEM_CONTEXT_LENGTH, MAX_PROBLEM_TITLE_LENGTH } from 'lib/whatworks/constants';
+import {
+  ensureMutationCsrf,
+  parseJsonBody,
+  readTrimmedString,
+  requireWhatWorksAdminAccess,
+  whatworksError,
+} from '../../_lib';
+
+export async function GET() {
+  const gate = await requireWhatWorksAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  const problems = await listAdminProblems();
+  return NextResponse.json({ ok: true, problems });
+}
+
+export async function POST(request: Request) {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return csrf;
+  }
+  const gate = await requireWhatWorksAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const body = await parseJsonBody(request);
+  if (!body) {
+    return whatworksError('Invalid JSON body.', 'whatworks_invalid_body', 400);
+  }
+
+  const title = readTrimmedString(body.title);
+  const emoji = readTrimmedString(body.emoji) ?? '';
+  const context = readTrimmedString(body.context) ?? '';
+  const sortOrderRaw = body.sortOrder;
+  const sortOrder = typeof sortOrderRaw === 'number' && Number.isFinite(sortOrderRaw) ? Math.trunc(sortOrderRaw) : 0;
+
+  if (!title) {
+    return whatworksError('Add a problem title.', 'whatworks_title_required', 400);
+  }
+  if (title.length > MAX_PROBLEM_TITLE_LENGTH) {
+    return whatworksError('Problem title is too long.', 'whatworks_title_too_long', 400);
+  }
+  if (context.length > MAX_PROBLEM_CONTEXT_LENGTH) {
+    return whatworksError('Problem context is too long.', 'whatworks_context_too_long', 400);
+  }
+  if (emoji.length > MAX_EMOJI_LENGTH) {
+    return whatworksError('Emoji is invalid.', 'whatworks_emoji_invalid', 400);
+  }
+
+  const problem = await createProblem({
+    title,
+    emoji,
+    context,
+    sortOrder,
+    createdBy: gate.auth.userId,
+  });
+  return NextResponse.json({ ok: true, problem }, { status: 201 });
+}

--- a/ctf/packages/web/app/api/whatworks/admin/products/[id]/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/products/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { deleteProduct, getProductById, reviewProduct } from 'lib/whatworks/repository';
+import { MAX_PRODUCT_NOTE_LENGTH } from 'lib/whatworks/constants';
+import {
+  ensureMutationCsrf,
+  parseJsonBody,
+  readTrimmedString,
+  requireWhatWorksAdminAccess,
+  whatworksError,
+} from '../../../_lib';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Approve or reject a suggested tool.
+export async function PATCH(request: Request, context: RouteContext) {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return csrf;
+  }
+  const gate = await requireWhatWorksAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  const { id } = await context.params;
+  const existing = await getProductById(id);
+  if (!existing) {
+    return whatworksError('That item could not be found.', 'whatworks_product_not_found', 404);
+  }
+
+  const body = await parseJsonBody(request);
+  if (!body) {
+    return whatworksError('Invalid JSON body.', 'whatworks_invalid_body', 400);
+  }
+  const action = readTrimmedString(body.action);
+  if (action !== 'approve' && action !== 'reject') {
+    return whatworksError('Action must be approve or reject.', 'whatworks_invalid_action', 400);
+  }
+  const rejectionReason = readTrimmedString(body.rejectionReason) ?? undefined;
+  if (rejectionReason && rejectionReason.length > MAX_PRODUCT_NOTE_LENGTH) {
+    return whatworksError('Rejection reason is too long.', 'whatworks_reason_too_long', 400);
+  }
+
+  const product = await reviewProduct(id, {
+    action,
+    reviewerId: gate.auth.userId,
+    rejectionReason,
+  });
+  return NextResponse.json({ ok: true, status: product?.status ?? null });
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return csrf;
+  }
+  const gate = await requireWhatWorksAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  const { id } = await context.params;
+  const existing = await getProductById(id);
+  if (!existing) {
+    return whatworksError('That item could not be found.', 'whatworks_product_not_found', 404);
+  }
+  await deleteProduct(id);
+  return NextResponse.json({ ok: true });
+}

--- a/ctf/packages/web/app/api/whatworks/admin/products/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/products/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { listAdminProducts } from 'lib/whatworks/repository';
+import { isWhatWorksProductStatus } from 'lib/whatworks/constants';
+import { requireWhatWorksAdminAccess } from '../../_lib';
+
+// Moderation queue. Defaults to pending suggestions; `?status=` narrows the list.
+// Submitter identity is intentionally never returned — admins moderate content, not people.
+export async function GET(request: Request) {
+  const gate = await requireWhatWorksAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  const url = new URL(request.url);
+  const statusParam = url.searchParams.get('status');
+  const status = statusParam && isWhatWorksProductStatus(statusParam) ? statusParam : undefined;
+  const products = await listAdminProducts(status);
+  return NextResponse.json({ ok: true, products });
+}

--- a/ctf/packages/web/app/api/whatworks/problems/route.ts
+++ b/ctf/packages/web/app/api/whatworks/problems/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { listActiveProblems } from 'lib/whatworks/repository';
+import { requireWhatWorksAccess, whatworksError } from '../_lib';
+
+// Active problems for the suggest form. Members may only attach a tool to an existing
+// problem; new problems are admin-curated to avoid duplicate categories.
+export async function GET() {
+  const gate = await requireWhatWorksAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  try {
+    const problems = await listActiveProblems();
+    return NextResponse.json({
+      ok: true,
+      problems: problems.map((problem) => ({
+        id: problem.id,
+        slug: problem.slug,
+        emoji: problem.emoji,
+        title: problem.title,
+        context: problem.context,
+      })),
+    });
+  } catch {
+    return whatworksError('Problems are unavailable right now.', 'whatworks_problems_unavailable', 500);
+  }
+}

--- a/ctf/packages/web/app/api/whatworks/products/[id]/endorse/route.ts
+++ b/ctf/packages/web/app/api/whatworks/products/[id]/endorse/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import {
+  addEndorsement,
+  getProductById,
+  getProductEndorsementState,
+  removeEndorsement,
+} from 'lib/whatworks/repository';
+import { canEndorseProduct } from 'lib/whatworks/policy';
+import {
+  ensureMutationCsrf,
+  requireWhatWorksAccess,
+  whatworksError,
+  type WhatWorksApiGate,
+} from '../../../_lib';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+async function authorizeEndorsement(request: Request): Promise<
+  | { ok: true; gate: Extract<WhatWorksApiGate, { allowed: true }> }
+  | { ok: false; response: NextResponse }
+> {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return { ok: false, response: csrf };
+  }
+  const gate = await requireWhatWorksAccess();
+  if (!gate.allowed) {
+    return { ok: false, response: gate.response };
+  }
+  if (!canEndorseProduct(gate.auth.userId)) {
+    return {
+      ok: false,
+      response: whatworksError('You must be signed in to mark an item helpful.', 'whatworks_forbidden', 403),
+    };
+  }
+  return { ok: true, gate };
+}
+
+// "Helpful" — the survivor is saying this tool helped them too; the count of these
+// endorsements is what renders as "N survivors verified".
+export async function POST(request: Request, context: RouteContext) {
+  const auth = await authorizeEndorsement(request);
+  if (!auth.ok) {
+    return auth.response;
+  }
+  const { id } = await context.params;
+  const product = await getProductById(id);
+  if (!product || product.status !== 'approved') {
+    return whatworksError('That item could not be found.', 'whatworks_product_not_found', 404);
+  }
+  await addEndorsement(id, auth.gate.auth.userId);
+  const state = await getProductEndorsementState(id, auth.gate.auth.userId);
+  return NextResponse.json({ ok: true, ...state });
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  const auth = await authorizeEndorsement(request);
+  if (!auth.ok) {
+    return auth.response;
+  }
+  const { id } = await context.params;
+  const product = await getProductById(id);
+  if (!product || product.status !== 'approved') {
+    return whatworksError('That item could not be found.', 'whatworks_product_not_found', 404);
+  }
+  await removeEndorsement(id, auth.gate.auth.userId);
+  const state = await getProductEndorsementState(id, auth.gate.auth.userId);
+  return NextResponse.json({ ok: true, ...state });
+}

--- a/ctf/packages/web/app/api/whatworks/products/route.ts
+++ b/ctf/packages/web/app/api/whatworks/products/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { getProblemById, suggestProduct } from 'lib/whatworks/repository';
+import { canSuggestProduct } from 'lib/whatworks/policy';
+import {
+  MAX_EMOJI_LENGTH,
+  MAX_PRODUCT_KIND_LENGTH,
+  MAX_PRODUCT_NAME_LENGTH,
+  MAX_PRODUCT_NOTE_LENGTH,
+  MAX_PURCHASE_URL_LENGTH,
+} from 'lib/whatworks/constants';
+import {
+  ensureMutationCsrf,
+  isValidHttpUrl,
+  parseJsonBody,
+  readTrimmedString,
+  requireWhatWorksAccess,
+  whatworksError,
+} from '../_lib';
+
+// A survivor suggests a tool. It lands as `pending` for admin review before it joins
+// the shared list, and the suggester is auto-recorded as its first verifier.
+export async function POST(request: Request) {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return csrf;
+  }
+  const gate = await requireWhatWorksAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  if (!canSuggestProduct(gate.auth.userId)) {
+    return whatworksError('You must be signed in to suggest an item.', 'whatworks_forbidden', 403);
+  }
+
+  const body = await parseJsonBody(request);
+  if (!body) {
+    return whatworksError('Invalid JSON body.', 'whatworks_invalid_body', 400);
+  }
+
+  const problemId = readTrimmedString(body.problemId);
+  const name = readTrimmedString(body.name);
+  const purchaseUrl = readTrimmedString(body.purchaseUrl);
+  const emoji = readTrimmedString(body.emoji) ?? '';
+  const kind = readTrimmedString(body.kind) ?? '';
+  const note = readTrimmedString(body.note) ?? '';
+
+  if (!problemId) {
+    return whatworksError('Choose the problem this item solves.', 'whatworks_problem_required', 400);
+  }
+  if (!name) {
+    return whatworksError('Add a product name.', 'whatworks_name_required', 400);
+  }
+  if (!purchaseUrl) {
+    return whatworksError('Add a direct purchase link.', 'whatworks_link_required', 400);
+  }
+  if (name.length > MAX_PRODUCT_NAME_LENGTH) {
+    return whatworksError('Product name is too long.', 'whatworks_name_too_long', 400);
+  }
+  if (kind.length > MAX_PRODUCT_KIND_LENGTH) {
+    return whatworksError('Product type is too long.', 'whatworks_kind_too_long', 400);
+  }
+  if (note.length > MAX_PRODUCT_NOTE_LENGTH) {
+    return whatworksError('Note is too long.', 'whatworks_note_too_long', 400);
+  }
+  if (emoji.length > MAX_EMOJI_LENGTH) {
+    return whatworksError('Emoji is invalid.', 'whatworks_emoji_invalid', 400);
+  }
+  if (purchaseUrl.length > MAX_PURCHASE_URL_LENGTH || !isValidHttpUrl(purchaseUrl)) {
+    return whatworksError('Enter a valid http(s) purchase link.', 'whatworks_link_invalid', 400);
+  }
+
+  const problem = await getProblemById(problemId);
+  if (!problem || !problem.is_active) {
+    return whatworksError('That problem could not be found.', 'whatworks_problem_not_found', 404);
+  }
+
+  try {
+    const product = await suggestProduct({
+      problemId,
+      name,
+      purchaseUrl,
+      emoji,
+      kind,
+      note,
+      suggestedBy: gate.auth.userId,
+    });
+    return NextResponse.json({ ok: true, productId: product.id, status: product.status }, { status: 201 });
+  } catch {
+    return whatworksError('We could not save your suggestion. Try again.', 'whatworks_suggest_failed', 500);
+  }
+}

--- a/ctf/packages/web/app/api/whatworks/products/route.ts
+++ b/ctf/packages/web/app/api/whatworks/products/route.ts
@@ -85,7 +85,8 @@ export async function POST(request: Request) {
       suggestedBy: gate.auth.userId,
     });
     return NextResponse.json({ ok: true, productId: product.id, status: product.status }, { status: 201 });
-  } catch {
+  } catch (error) {
+    console.error('whatworks: failed to save product suggestion', error);
     return whatworksError('We could not save your suggestion. Try again.', 'whatworks_suggest_failed', 500);
   }
 }

--- a/ctf/packages/web/app/api/whatworks/public/route.ts
+++ b/ctf/packages/web/app/api/whatworks/public/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getReaderList } from 'lib/whatworks/repository';
+import {
+  PUBLIC_PREVIEW_PROBLEM_LIMIT,
+  PUBLIC_PREVIEW_PRODUCTS_PER_PROBLEM,
+} from 'lib/whatworks/constants';
+import { whatworksError } from '../_lib';
+
+// Public, sign-in-free projection: the list is readable by anyone, but only a teaser
+// slice is returned and submitter identity is never exposed. Full browse is sign-in gated.
+export async function GET() {
+  try {
+    const list = await getReaderList(null);
+    const problems = list.problems.slice(0, PUBLIC_PREVIEW_PROBLEM_LIMIT).map((problem) => ({
+      ...problem,
+      products: problem.products.slice(0, PUBLIC_PREVIEW_PRODUCTS_PER_PROBLEM),
+    }));
+    return NextResponse.json({ ok: true, problems, stats: list.stats });
+  } catch {
+    return whatworksError('What Works preview is unavailable right now.', 'whatworks_public_unavailable', 500);
+  }
+}

--- a/ctf/packages/web/app/api/whatworks/route.ts
+++ b/ctf/packages/web/app/api/whatworks/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getReaderList } from 'lib/whatworks/repository';
+import { requireWhatWorksAccess, whatworksError } from './_lib';
+
+// Full shared list for an authenticated survivor, with per-row endorsement state.
+export async function GET() {
+  const gate = await requireWhatWorksAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  try {
+    const list = await getReaderList(gate.auth.userId);
+    return NextResponse.json({ ok: true, ...list, viewer: { isAdmin: gate.auth.isAdmin } });
+  } catch {
+    return whatworksError('What Works is unavailable right now.', 'whatworks_unavailable', 500);
+  }
+}

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -18,6 +18,7 @@ import { SkillsTaxonomyShell } from '@/components/skills-taxonomy/skills-taxonom
 import { TrustTransportShell } from '@/components/trusttransport/trusttransport-shell';
 import { WeeklyPerformanceShell } from '@/components/weekly-performance/weekly-performance-shell';
 import { ClicklogShell } from '@/components/clicklog/clicklog-shell';
+import { WhatWorksShell } from '@/components/whatworks/whatworks-shell';
 import { WorkforceShell } from '@/components/workforce/workforce-shell';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -161,6 +162,10 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
 
   if (selectedPlugin.slug === 'clicklog') {
     return <ClicklogShell />;
+  }
+
+  if (selectedPlugin.slug === 'whatworks') {
+    return <WhatWorksShell />;
   }
 
   if (selectedPlugin.slug === 'chyme') {

--- a/ctf/packages/web/app/plugin/whatworks/page.tsx
+++ b/ctf/packages/web/app/plugin/whatworks/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { WhatWorksPublic } from '@/components/whatworks/ww-public';
+
+// Permanently-public preview surface (same convention as /plugin/unlock). The list is
+// publicly readable as a teaser; suggesting is gated behind sign-in.
+export const dynamic = 'force-dynamic';
+
+export default function WhatWorksPublicPage() {
+  return <WhatWorksPublic />;
+}

--- a/ctf/packages/web/components/whatworks/whatworks-shell.tsx
+++ b/ctf/packages/web/components/whatworks/whatworks-shell.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+// Authenticated WhatWorks experience. Orchestrates the shared list, the live "Helpful"
+// endorsement toggle, the suggest flow, client-side search, and an admin entry point.
+// Layout + tokens are matched to design/.../survivor-hub/WhatWorks.tsx.
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { ListChecks, Search, ShieldCheck } from 'lucide-react';
+import {
+  BG, BRAND, BORDER, SUBTLE, TEXT,
+  type SuggestDraft, type WhatWorksListResponse, type WhatWorksProblem,
+  type WhatWorksProblemOption, type WhatWorksProduct, type WhatWorksStats,
+} from './ww-shared';
+import { WhatWorksLoading } from './ww-loading';
+import { WhatWorksIconRail } from './ww-icon-rail';
+import { WhatWorksSidebar } from './ww-sidebar';
+import { WhatWorksHero } from './ww-hero';
+import { WhatWorksRightRail } from './ww-right-rail';
+import { WhatWorksProblemSection } from './ww-problem-section';
+import { WhatWorksSuggestPanel } from './ww-suggest-panel';
+
+const EMPTY_STATS: WhatWorksStats = { problems: 0, verifiedTools: 0, survivorsHelped: 0 };
+
+function matches(query: string, ...fields: string[]): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  return fields.some((field) => field.toLowerCase().includes(needle));
+}
+
+function filterProblems(problems: WhatWorksProblem[], query: string): WhatWorksProblem[] {
+  if (!query.trim()) return problems;
+  const result: WhatWorksProblem[] = [];
+  for (const problem of problems) {
+    if (matches(query, problem.title, problem.context)) {
+      result.push(problem);
+      continue;
+    }
+    const products = problem.products.filter((product) => matches(query, product.name, product.kind, product.note));
+    if (products.length > 0) {
+      result.push({ ...problem, products });
+    }
+  }
+  return result;
+}
+
+export function WhatWorksShell() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [problems, setProblems] = useState<WhatWorksProblem[]>([]);
+  const [stats, setStats] = useState<WhatWorksStats>(EMPTY_STATS);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [problemOptions, setProblemOptions] = useState<WhatWorksProblemOption[]>([]);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [showSuggest, setShowSuggest] = useState(false);
+  const [busyProductId, setBusyProductId] = useState<string | null>(null);
+  const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+
+  async function loadList(): Promise<void> {
+    setError(null);
+    try {
+      const res = await fetch('/api/whatworks');
+      if (!res.ok) throw new Error('Failed to load What Works');
+      const data = (await res.json()) as WhatWorksListResponse;
+      setProblems(data.problems ?? []);
+      setStats(data.stats ?? EMPTY_STATS);
+      setIsAdmin(Boolean(data.viewer?.isAdmin));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Failed to load What Works');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadProblemOptions(): Promise<void> {
+    try {
+      const res = await fetch('/api/whatworks/problems');
+      if (!res.ok) return;
+      const data = (await res.json()) as { problems: WhatWorksProblemOption[] };
+      setProblemOptions(data.problems ?? []);
+    } catch {
+      // Non-fatal: the suggest dropdown simply stays empty until reload.
+    }
+  }
+
+  useEffect(() => {
+    void loadList();
+    void loadProblemOptions();
+  }, []);
+
+  function applyEndorsement(productId: string, next: { verifiedCount: number; viewerHasEndorsed: boolean }): void {
+    setProblems((prev) => prev.map((problem) => ({
+      ...problem,
+      products: problem.products.map((product) =>
+        product.id === productId
+          ? { ...product, verifiedCount: next.verifiedCount, viewerHasEndorsed: next.viewerHasEndorsed }
+          : product,
+      ),
+    })));
+  }
+
+  async function toggleHelpful(product: WhatWorksProduct): Promise<void> {
+    setBusyProductId(product.id);
+    setError(null);
+    const method = product.viewerHasEndorsed ? 'DELETE' : 'POST';
+    try {
+      const res = await fetch(`/api/whatworks/products/${product.id}/endorse`, { method, headers: { 'x-ctf-csrf': '1' } });
+      if (!res.ok) throw new Error('Could not update. Try again.');
+      const data = (await res.json()) as { verifiedCount: number; viewerHasEndorsed: boolean };
+      applyEndorsement(product.id, data);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not update. Try again.');
+    } finally {
+      setBusyProductId(null);
+    }
+  }
+
+  async function submitSuggestion(draft: SuggestDraft): Promise<string | null> {
+    try {
+      const res = await fetch('/api/whatworks/products', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+        body: JSON.stringify(draft),
+      });
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      if (!res.ok) return body?.message ?? 'Could not submit. Try again.';
+      return null;
+    } catch {
+      return 'Could not submit. Try again.';
+    }
+  }
+
+  function selectProblem(index: number, list: WhatWorksProblem[]): void {
+    setActiveIndex(index);
+    const target = list[index];
+    if (target) {
+      sectionRefs.current[target.id]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  const visibleProblems = useMemo(() => filterProblems(problems, query), [problems, query]);
+
+  if (loading) {
+    return <WhatWorksLoading />;
+  }
+
+  if (showSuggest || problems.length === 0) {
+    return (
+      <WhatWorksSuggestPanel
+        problems={problemOptions}
+        isFirst={problems.length === 0}
+        onSubmit={submitSuggestion}
+        onBack={problems.length === 0 ? undefined : () => setShowSuggest(false)}
+      />
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', maxHeight: '100%', background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: 'hidden' }}>
+      <WhatWorksIconRail />
+      <WhatWorksSidebar
+        problems={visibleProblems}
+        activeIndex={activeIndex}
+        onSelectProblem={(index) => selectProblem(index, visibleProblems)}
+        onSuggest={() => setShowSuggest(true)}
+      />
+
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+        <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: '#0D0F14', flexShrink: 0 }}>
+          <ListChecks size={18} color={BRAND} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>What Works</div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>Survivor-verified tools · by problem</div>
+          </div>
+          {isAdmin ? (
+            <Link href="/admin/whatworks" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 9, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 12, fontWeight: 700, textDecoration: 'none' }}>
+              <ShieldCheck size={13} /> Admin
+            </Link>
+          ) : null}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', borderRadius: 9, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, width: 220 }}>
+            <Search size={14} color={SUBTLE} />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search tools or problems…"
+              style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 12.5, color: TEXT, fontFamily: 'inherit' }}
+            />
+          </div>
+        </header>
+
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '28px 40px 48px' }}>
+          <div style={{ maxWidth: 760, margin: '0 auto' }}>
+            <WhatWorksHero stats={stats} />
+            {error ? (
+              <div style={{ marginBottom: 20, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 13 }}>{error}</div>
+            ) : null}
+            {visibleProblems.length === 0 ? (
+              <div style={{ fontSize: 14, color: SUBTLE, padding: '24px 0' }}>No tools or problems match “{query}”.</div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+                {visibleProblems.map((problem) => (
+                  <WhatWorksProblemSection
+                    key={problem.id}
+                    problem={problem}
+                    busyProductId={busyProductId}
+                    onToggleHelpful={(product) => void toggleHelpful(product)}
+                    sectionRef={(node) => { sectionRefs.current[problem.id] = node; }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <WhatWorksRightRail stats={stats} />
+    </div>
+  );
+}

--- a/ctf/packages/web/components/whatworks/whatworks-shell.tsx
+++ b/ctf/packages/web/components/whatworks/whatworks-shell.tsx
@@ -144,6 +144,25 @@ export function WhatWorksShell() {
     return <WhatWorksLoading />;
   }
 
+  // A failed load also leaves problems empty; show the failure rather than masking it as
+  // the (legitimate) empty-list suggest state.
+  if (!showSuggest && error && problems.length === 0) {
+    return (
+      <div style={{ display: 'flex', height: '100vh', background: BG, color: TEXT, fontFamily: "'Inter', system-ui, sans-serif", alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+        <div style={{ maxWidth: 420, textAlign: 'center' }}>
+          <div style={{ fontSize: 15, color: '#fecaca', marginBottom: 12 }}>{error}</div>
+          <button
+            type="button"
+            onClick={() => { setLoading(true); void loadList(); }}
+            style={{ padding: '10px 16px', borderRadius: 9, background: `${BRAND}18`, border: `1px solid ${BRAND}40`, color: BRAND, fontSize: 13, fontWeight: 700, cursor: 'pointer' }}
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   if (showSuggest || problems.length === 0) {
     return (
       <WhatWorksSuggestPanel
@@ -180,6 +199,7 @@ export function WhatWorksShell() {
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', borderRadius: 9, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, width: 220 }}>
             <Search size={14} color={SUBTLE} />
             <input
+              aria-label="Search tools or problems"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search tools or problems…"

--- a/ctf/packages/web/components/whatworks/ww-admin-problems.tsx
+++ b/ctf/packages/web/components/whatworks/ww-admin-problems.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+// Problem curation (functional admin surface). Problems are the admin-owned categories that
+// members attach suggestions to; this is where they are created, renamed, and deactivated.
+import { useState } from 'react';
+import type { AdminProblem } from './ww-admin-shared';
+
+type CreateDraft = { emoji: string; title: string; context: string };
+
+type Props = {
+  problems: AdminProblem[];
+  busyId: string | null;
+  creating: boolean;
+  onCreate: (draft: CreateDraft) => Promise<boolean>;
+  onToggleActive: (problem: AdminProblem) => void;
+  onDelete: (problem: AdminProblem) => void;
+};
+
+export function WhatWorksAdminProblems({ problems, busyId, creating, onCreate, onToggleActive, onDelete }: Props) {
+  const [emoji, setEmoji] = useState('');
+  const [title, setTitle] = useState('');
+  const [context, setContext] = useState('');
+
+  async function create(): Promise<void> {
+    if (!title.trim() || creating) return;
+    const ok = await onCreate({ emoji: emoji.trim(), title: title.trim(), context: context.trim() });
+    if (ok) {
+      setEmoji('');
+      setTitle('');
+      setContext('');
+    }
+  }
+
+  return (
+    <section className="rounded-lg border bg-card p-5 text-sm space-y-4">
+      <h2 className="text-lg font-medium">Problems</h2>
+
+      <div className="grid gap-3 sm:grid-cols-[80px_1fr] rounded-lg border bg-background/40 p-4">
+        <label className="text-xs text-muted-foreground sm:col-span-2">Add a problem category survivors can attach tools to.</label>
+        <input value={emoji} onChange={(event) => setEmoji(event.target.value)} placeholder="Emoji" aria-label="Emoji" className="rounded-md border bg-background px-3 py-2" />
+        <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Problem title (e.g. Sleep Disruption)" aria-label="Problem title" className="rounded-md border bg-background px-3 py-2" />
+        <textarea value={context} onChange={(event) => setContext(event.target.value)} placeholder="Short context shown under the title" aria-label="Problem context" rows={2} className="rounded-md border bg-background px-3 py-2 sm:col-span-2" />
+        <div className="sm:col-span-2">
+          <button type="button" disabled={!title.trim() || creating} onClick={() => void create()} className="rounded-md border border-primary bg-primary/10 px-4 py-2 text-xs font-medium text-primary disabled:opacity-50">
+            {creating ? 'Adding…' : 'Add problem'}
+          </button>
+        </div>
+      </div>
+
+      {problems.length === 0 ? (
+        <p className="text-muted-foreground">No problems yet. Add the first one above.</p>
+      ) : (
+        <ul className="space-y-2">
+          {problems.map((problem) => (
+            <li key={problem.id} className="rounded-lg border bg-background/40 p-4 flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span aria-hidden>{problem.emoji || '🧰'}</span>
+                  <span className="font-semibold">{problem.title}</span>
+                  {!problem.is_active ? <span className="rounded-md border border-muted px-2 py-0.5 text-[11px] text-muted-foreground">inactive</span> : null}
+                </div>
+                {problem.context ? <p className="text-xs text-muted-foreground mt-1">{problem.context}</p> : null}
+                <p className="text-[11px] text-muted-foreground mt-1">
+                  {problem.approvedCount} approved · {problem.pendingCount} pending · {problem.productCount} total
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-col gap-2">
+                <button type="button" disabled={busyId === problem.id} onClick={() => onToggleActive(problem)} className="rounded-md border px-3 py-1 text-xs font-medium disabled:opacity-50">
+                  {problem.is_active ? 'Deactivate' : 'Activate'}
+                </button>
+                <button type="button" disabled={busyId === problem.id} onClick={() => onDelete(problem)} className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1 text-xs font-medium text-red-300 disabled:opacity-50">Delete</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-admin-products.tsx
+++ b/ctf/packages/web/components/whatworks/ww-admin-products.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+// Moderation queue (functional admin surface, generic Tailwind aesthetic — consistent with
+// other /admin/{plugin} surfaces). Submitter identity is never shown; admins moderate content.
+import type { WhatWorksProductStatus } from 'lib/whatworks/types';
+import type { AdminProduct } from './ww-admin-shared';
+
+type Props = {
+  products: AdminProduct[];
+  busyId: string | null;
+  statusFilter: WhatWorksProductStatus | 'all';
+  onChangeFilter: (status: WhatWorksProductStatus | 'all') => void;
+  onReview: (id: string, action: 'approve' | 'reject') => void;
+  onDelete: (id: string) => void;
+};
+
+const FILTERS: { value: WhatWorksProductStatus | 'all'; label: string }[] = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'all', label: 'All' },
+];
+
+const STATUS_CLASS: Record<WhatWorksProductStatus, string> = {
+  pending: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  approved: 'bg-lime-500/15 text-lime-300 border-lime-500/30',
+  rejected: 'bg-red-500/15 text-red-300 border-red-500/30',
+};
+
+export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChangeFilter, onReview, onDelete }: Props) {
+  return (
+    <section className="rounded-lg border bg-card p-5 text-sm space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-medium">Suggestions</h2>
+        <div className="flex flex-wrap gap-2">
+          {FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              type="button"
+              onClick={() => onChangeFilter(filter.value)}
+              className={`rounded-md border px-3 py-1 text-xs font-medium ${statusFilter === filter.value ? 'border-primary bg-primary/10 text-primary' : 'text-muted-foreground'}`}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {products.length === 0 ? (
+        <p className="text-muted-foreground">No suggestions in this view.</p>
+      ) : (
+        <ul className="space-y-3">
+          {products.map((product) => (
+            <li key={product.id} className="rounded-lg border bg-background/40 p-4 space-y-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span aria-hidden>{product.emoji || '🧰'}</span>
+                    <span className="font-semibold">{product.name}</span>
+                    {product.kind ? <span className="text-xs text-muted-foreground">{product.kind}</span> : null}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">Problem: {product.problemTitle}</p>
+                  {product.note ? <p className="text-sm mt-1 italic text-muted-foreground">“{product.note}”</p> : null}
+                  <a href={product.purchaseUrl} target="_blank" rel="noopener noreferrer" className="text-xs underline underline-offset-4 break-all">
+                    {product.purchaseUrl}
+                  </a>
+                </div>
+                <span className={`shrink-0 rounded-md border px-2 py-1 text-xs font-medium ${STATUS_CLASS[product.status]}`}>{product.status}</span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                <span className="text-xs text-muted-foreground mr-auto">{product.verifiedCount} verified</span>
+                {product.status !== 'approved' ? (
+                  <button type="button" disabled={busyId === product.id} onClick={() => onReview(product.id, 'approve')} className="rounded-md border border-lime-500/40 bg-lime-500/10 px-3 py-1 text-xs font-medium text-lime-300 disabled:opacity-50">Approve</button>
+                ) : null}
+                {product.status !== 'rejected' ? (
+                  <button type="button" disabled={busyId === product.id} onClick={() => onReview(product.id, 'reject')} className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-300 disabled:opacity-50">{product.status === 'approved' ? 'Unpublish' : 'Reject'}</button>
+                ) : null}
+                <button type="button" disabled={busyId === product.id} onClick={() => onDelete(product.id)} className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1 text-xs font-medium text-red-300 disabled:opacity-50">Delete</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-admin-shared.ts
+++ b/ctf/packages/web/components/whatworks/ww-admin-shared.ts
@@ -46,8 +46,15 @@ export async function adminMutate(
       headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
       body: body === undefined ? undefined : JSON.stringify(body),
     });
-    const data = (await res.json().catch(() => null)) as { message?: string } | null;
-    return { ok: res.ok, message: data?.message };
+    // WhatWorks errors carry `message`; auth-gate denials (deny-taxonomy) carry `reason`/`code`
+    // instead, so fall back through those to a usable message rather than a generic string.
+    const data = (await res.json().catch(() => null)) as
+      | { message?: string; reason?: string; code?: string }
+      | null;
+    if (res.ok) {
+      return { ok: true };
+    }
+    return { ok: false, message: data?.message ?? data?.reason ?? data?.code ?? `Request failed (${res.status}).` };
   } catch {
     return { ok: false, message: 'Network error. Try again.' };
   }

--- a/ctf/packages/web/components/whatworks/ww-admin-shared.ts
+++ b/ctf/packages/web/components/whatworks/ww-admin-shared.ts
@@ -1,0 +1,54 @@
+import type { WhatWorksProductStatus } from 'lib/whatworks/types';
+
+export type AdminProduct = {
+  id: string;
+  problemId: string;
+  problemTitle: string;
+  emoji: string;
+  name: string;
+  kind: string;
+  note: string;
+  purchaseUrl: string;
+  status: WhatWorksProductStatus;
+  verifiedCount: number;
+  createdAt: string;
+  reviewedAt: string | null;
+  rejectionReason: string | null;
+};
+
+export type AdminProblem = {
+  id: string;
+  slug: string;
+  emoji: string;
+  title: string;
+  context: string;
+  sort_order: number;
+  is_active: boolean;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  productCount: number;
+  approvedCount: number;
+  pendingCount: number;
+};
+
+export type AdminMutationResult = { ok: boolean; message?: string };
+
+// All admin mutations carry the CSRF confirmation header the API requires.
+export async function adminMutate(
+  url: string,
+  method: 'POST' | 'PATCH' | 'DELETE',
+  body?: unknown,
+): Promise<AdminMutationResult> {
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const data = (await res.json().catch(() => null)) as { message?: string } | null;
+    return { ok: res.ok, message: data?.message };
+  } catch {
+    return { ok: false, message: 'Network error. Try again.' };
+  }
+}

--- a/ctf/packages/web/components/whatworks/ww-admin-shell.tsx
+++ b/ctf/packages/web/components/whatworks/ww-admin-shell.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+// Functional WhatWorks admin: moderate suggestions (approve / reject / delete) and curate
+// the admin-owned problem categories. Generic admin aesthetic, consistent with other
+// /admin/{plugin} surfaces. Mutations carry the CSRF header via adminMutate().
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { WhatWorksProductStatus } from 'lib/whatworks/types';
+import { adminMutate, type AdminProblem, type AdminProduct } from './ww-admin-shared';
+import { WhatWorksAdminProducts } from './ww-admin-products';
+import { WhatWorksAdminProblems } from './ww-admin-problems';
+
+export function WhatWorksAdminShell() {
+  const [products, setProducts] = useState<AdminProduct[]>([]);
+  const [problems, setProblems] = useState<AdminProblem[]>([]);
+  const [statusFilter, setStatusFilter] = useState<WhatWorksProductStatus | 'all'>('pending');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const loadProducts = useCallback(async (status: WhatWorksProductStatus | 'all') => {
+    const query = status === 'all' ? '' : `?status=${status}`;
+    const res = await fetch(`/api/whatworks/admin/products${query}`);
+    if (res.ok) {
+      const data = (await res.json()) as { products: AdminProduct[] };
+      setProducts(data.products ?? []);
+    }
+  }, []);
+
+  const loadProblems = useCallback(async () => {
+    const res = await fetch('/api/whatworks/admin/problems');
+    if (res.ok) {
+      const data = (await res.json()) as { problems: AdminProblem[] };
+      setProblems(data.problems ?? []);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial load only (default filter is "pending"); later filter changes go through changeFilter.
+    void (async () => {
+      await Promise.all([loadProducts('pending'), loadProblems()]);
+      setLoading(false);
+    })();
+  }, [loadProducts, loadProblems]);
+
+  async function run(id: string, action: () => Promise<void>): Promise<void> {
+    setBusyId(id);
+    setError(null);
+    try {
+      await action();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  function changeFilter(status: WhatWorksProductStatus | 'all'): void {
+    setStatusFilter(status);
+    void loadProducts(status);
+  }
+
+  function reviewProduct(id: string, action: 'approve' | 'reject'): void {
+    const rejectionReason = action === 'reject' ? window.prompt('Reason (optional, shown only to admins):') ?? undefined : undefined;
+    void run(id, async () => {
+      const result = await adminMutate(`/api/whatworks/admin/products/${id}`, 'PATCH', { action, rejectionReason });
+      if (!result.ok) {
+        setError(result.message ?? 'Could not update the suggestion.');
+        return;
+      }
+      await Promise.all([loadProducts(statusFilter), loadProblems()]);
+    });
+  }
+
+  function deleteProduct(id: string): void {
+    if (!window.confirm('Delete this suggestion permanently?')) return;
+    void run(id, async () => {
+      const result = await adminMutate(`/api/whatworks/admin/products/${id}`, 'DELETE');
+      if (!result.ok) {
+        setError(result.message ?? 'Could not delete the suggestion.');
+        return;
+      }
+      await Promise.all([loadProducts(statusFilter), loadProblems()]);
+    });
+  }
+
+  async function createProblem(draft: { emoji: string; title: string; context: string }): Promise<boolean> {
+    setCreating(true);
+    setError(null);
+    try {
+      const result = await adminMutate('/api/whatworks/admin/problems', 'POST', draft);
+      if (!result.ok) {
+        setError(result.message ?? 'Could not create the problem.');
+        return false;
+      }
+      await loadProblems();
+      return true;
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  function toggleProblemActive(problem: AdminProblem): void {
+    void run(problem.id, async () => {
+      const result = await adminMutate(`/api/whatworks/admin/problems/${problem.id}`, 'PATCH', { isActive: !problem.is_active });
+      if (!result.ok) {
+        setError(result.message ?? 'Could not update the problem.');
+        return;
+      }
+      await loadProblems();
+    });
+  }
+
+  function deleteProblem(problem: AdminProblem): void {
+    if (!window.confirm(`Delete “${problem.title}” and its ${problem.productCount} tool(s)? This cannot be undone.`)) return;
+    void run(problem.id, async () => {
+      const result = await adminMutate(`/api/whatworks/admin/problems/${problem.id}`, 'DELETE');
+      if (!result.ok) {
+        setError(result.message ?? 'Could not delete the problem.');
+        return;
+      }
+      await Promise.all([loadProblems(), loadProducts(statusFilter)]);
+    });
+  }
+
+  const pendingCount = problems.reduce((total, problem) => total + problem.pendingCount, 0);
+  const approvedCount = problems.reduce((total, problem) => total + problem.approvedCount, 0);
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">WhatWorks Admin</h1>
+        <p className="text-sm text-muted-foreground">
+          Curate problem categories and review survivor-suggested tools before they join the one shared list.
+        </p>
+        <p className="text-sm">
+          <Link className="underline underline-offset-4" href="/apps/whatworks">Open the WhatWorks list</Link>
+        </p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <article className="rounded-lg border bg-card p-4 text-sm">
+          <p className="text-xs text-muted-foreground">Problems</p>
+          <p className="text-2xl font-semibold">{problems.length}</p>
+        </article>
+        <article className="rounded-lg border bg-card p-4 text-sm">
+          <p className="text-xs text-muted-foreground">Pending review</p>
+          <p className="text-2xl font-semibold">{pendingCount}</p>
+        </article>
+        <article className="rounded-lg border bg-card p-4 text-sm">
+          <p className="text-xs text-muted-foreground">Approved tools</p>
+          <p className="text-2xl font-semibold">{approvedCount}</p>
+        </article>
+      </section>
+
+      {error ? (
+        <p className="rounded-md border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm text-red-300">{error}</p>
+      ) : null}
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <>
+          <WhatWorksAdminProducts
+            products={products}
+            busyId={busyId}
+            statusFilter={statusFilter}
+            onChangeFilter={changeFilter}
+            onReview={reviewProduct}
+            onDelete={deleteProduct}
+          />
+          <WhatWorksAdminProblems
+            problems={problems}
+            busyId={busyId}
+            creating={creating}
+            onCreate={createProblem}
+            onToggleActive={toggleProblemActive}
+            onDelete={deleteProblem}
+          />
+        </>
+      )}
+    </main>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-admin-shell.tsx
+++ b/ctf/packages/web/components/whatworks/ww-admin-shell.tsx
@@ -22,25 +22,32 @@ export function WhatWorksAdminShell() {
   const loadProducts = useCallback(async (status: WhatWorksProductStatus | 'all') => {
     const query = status === 'all' ? '' : `?status=${status}`;
     const res = await fetch(`/api/whatworks/admin/products${query}`);
-    if (res.ok) {
-      const data = (await res.json()) as { products: AdminProduct[] };
-      setProducts(data.products ?? []);
+    if (!res.ok) {
+      throw new Error('Could not load suggestions.');
     }
+    const data = (await res.json()) as { products: AdminProduct[] };
+    setProducts(data.products ?? []);
   }, []);
 
   const loadProblems = useCallback(async () => {
     const res = await fetch('/api/whatworks/admin/problems');
-    if (res.ok) {
-      const data = (await res.json()) as { problems: AdminProblem[] };
-      setProblems(data.problems ?? []);
+    if (!res.ok) {
+      throw new Error('Could not load problems.');
     }
+    const data = (await res.json()) as { problems: AdminProblem[] };
+    setProblems(data.problems ?? []);
   }, []);
 
   useEffect(() => {
     // Initial load only (default filter is "pending"); later filter changes go through changeFilter.
     void (async () => {
-      await Promise.all([loadProducts('pending'), loadProblems()]);
-      setLoading(false);
+      try {
+        await Promise.all([loadProducts('pending'), loadProblems()]);
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Could not load the admin data.');
+      } finally {
+        setLoading(false);
+      }
     })();
   }, [loadProducts, loadProblems]);
 
@@ -49,6 +56,8 @@ export function WhatWorksAdminShell() {
     setError(null);
     try {
       await action();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Something went wrong. Try again.');
     } finally {
       setBusyId(null);
     }
@@ -56,7 +65,10 @@ export function WhatWorksAdminShell() {
 
   function changeFilter(status: WhatWorksProductStatus | 'all'): void {
     setStatusFilter(status);
-    void loadProducts(status);
+    setError(null);
+    void loadProducts(status).catch((caught) => {
+      setError(caught instanceof Error ? caught.message : 'Could not load suggestions.');
+    });
   }
 
   function reviewProduct(id: string, action: 'approve' | 'reject'): void {
@@ -94,6 +106,9 @@ export function WhatWorksAdminShell() {
       }
       await loadProblems();
       return true;
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not create the problem.');
+      return false;
     } finally {
       setCreating(false);
     }

--- a/ctf/packages/web/components/whatworks/ww-hero.tsx
+++ b/ctf/packages/web/components/whatworks/ww-hero.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+// Hero / purpose block from design/.../survivor-hub/WhatWorks.tsx.
+import { BadgeCheck } from 'lucide-react';
+import { BRAND, BORDER, SURFACE, type WhatWorksStats } from './ww-shared';
+
+export function WhatWorksHero({ stats }: { stats: WhatWorksStats }) {
+  const chips = [
+    `${stats.problems} ${stats.problems === 1 ? 'problem' : 'problems'}`,
+    `${stats.verifiedTools} ${stats.verifiedTools === 1 ? 'tool' : 'tools'}`,
+    '100% survivor-verified',
+  ];
+  return (
+    <div style={{ marginBottom: 28 }}>
+      <span style={{ padding: '4px 12px', borderRadius: 20, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, fontSize: 11.5, color: BRAND, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <BadgeCheck size={13} /> Survivor-verified · one shared list
+      </span>
+      <h1 style={{ margin: '14px 0 8px', fontSize: 30, fontWeight: 800, lineHeight: 1.15, letterSpacing: '-0.02em' }}>
+        What actually <span style={{ color: BRAND }}>works</span>.
+      </h1>
+      <p style={{ margin: 0, fontSize: 14.5, color: '#9CA3AF', lineHeight: 1.65, maxWidth: 600 }}>
+        Pick a problem you&apos;re facing. Underneath it is a list of specific tools a survivor here actually bought, used, and said helped — with a direct link to get it.
+      </p>
+      <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+        {chips.map((chip) => (
+          <span key={chip} style={{ padding: '5px 11px', borderRadius: 8, background: SURFACE, border: `1px solid ${BORDER}`, fontSize: 12, color: '#9CA3AF', fontWeight: 600 }}>{chip}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-icon-rail.tsx
+++ b/ctf/packages/web/components/whatworks/ww-icon-rail.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+// Left icon rail from design/.../survivor-hub/WhatWorks.tsx. The glyphs below the primary
+// nav are presentational, matching the mockup (no routes are wired to them).
+import { ListChecks, Tag, Bell, Settings } from 'lucide-react';
+import { BRAND, BORDER, SUBTLE } from './ww-shared';
+
+export function WhatWorksIconRail() {
+  return (
+    <aside style={{ width: 72, background: '#090B0F', borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${BRAND}25`, border: `1px solid ${BRAND}50`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+        <ListChecks size={20} color={BRAND} />
+      </div>
+      <button style={{ width: 44, height: 44, borderRadius: 12, background: `${BRAND}20`, border: `1px solid ${BRAND}40`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: BRAND }}>
+        <ListChecks size={20} />
+      </button>
+      <button style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: '1px solid transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE }}>
+        <Tag size={20} />
+      </button>
+      <div style={{ flex: 1 }} />
+      <button style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE }}><Bell size={18} /></button>
+      <button style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE }}><Settings size={18} /></button>
+      <div style={{ width: 32, height: 32, borderRadius: '50%', background: `${BRAND}20`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, color: BRAND }}>S</div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-icon-rail.tsx
+++ b/ctf/packages/web/components/whatworks/ww-icon-rail.tsx
@@ -1,25 +1,35 @@
 'use client';
 
-// Left icon rail from design/.../survivor-hub/WhatWorks.tsx. The glyphs below the primary
-// nav are presentational, matching the mockup (no routes are wired to them).
+// Left icon rail from design/.../survivor-hub/WhatWorks.tsx. These glyphs are presentational
+// in the mockup (no routes are wired to them), so they render as decorative, non-focusable
+// elements (aria-hidden) rather than unlabeled interactive buttons.
 import { ListChecks, Tag, Bell, Settings } from 'lucide-react';
 import { BRAND, BORDER, SUBTLE } from './ww-shared';
 
+const decorativeTile: React.CSSProperties = {
+  width: 44,
+  height: 44,
+  borderRadius: 12,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
 export function WhatWorksIconRail() {
   return (
-    <aside style={{ width: 72, background: '#090B0F', borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+    <aside aria-hidden="true" style={{ width: 72, background: '#090B0F', borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
       <div style={{ width: 40, height: 40, borderRadius: 12, background: `${BRAND}25`, border: `1px solid ${BRAND}50`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
         <ListChecks size={20} color={BRAND} />
       </div>
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: `${BRAND}20`, border: `1px solid ${BRAND}40`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: BRAND }}>
+      <div style={{ ...decorativeTile, background: `${BRAND}20`, border: `1px solid ${BRAND}40`, color: BRAND }}>
         <ListChecks size={20} />
-      </button>
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: '1px solid transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE }}>
+      </div>
+      <div style={{ ...decorativeTile, background: 'transparent', border: '1px solid transparent', color: SUBTLE }}>
         <Tag size={20} />
-      </button>
+      </div>
       <div style={{ flex: 1 }} />
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE }}><Bell size={18} /></button>
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE }}><Settings size={18} /></button>
+      <div style={{ ...decorativeTile, color: SUBTLE }}><Bell size={18} /></div>
+      <div style={{ ...decorativeTile, color: SUBTLE }}><Settings size={18} /></div>
       <div style={{ width: 32, height: 32, borderRadius: '50%', background: `${BRAND}20`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, color: BRAND }}>S</div>
     </aside>
   );

--- a/ctf/packages/web/components/whatworks/ww-loading.tsx
+++ b/ctf/packages/web/components/whatworks/ww-loading.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+// STATE: Loading — ported from design/.../survivor-hub/WhatWorksLoading.tsx.
+import { BG } from './ww-shared';
+
+export function WhatWorksLoading() {
+  return (
+    <div style={{ display: 'flex', height: '100vh', width: '100%', background: BG, alignItems: 'center', justifyContent: 'center', fontFamily: "'Inter',system-ui" }}>
+      <div style={{ textAlign: 'center', padding: '0 32px' }}>
+        <div style={{ fontSize: 11, letterSpacing: '0.18em', color: 'rgba(255,255,255,0.22)', textTransform: 'uppercase', fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
+          EXIT THEIR ECONOMY
+        </div>
+        <div style={{ fontSize: 11, letterSpacing: '0.18em', color: 'rgba(255,255,255,0.22)', textTransform: 'uppercase', fontWeight: 500, lineHeight: 2 }}>
+          EXIT THE PSYOP
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-problem-section.tsx
+++ b/ctf/packages/web/components/whatworks/ww-problem-section.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+// A problem heading plus its survivor-verified tools, from design/.../survivor-hub/WhatWorks.tsx.
+import { BRAND, SUBTLE, TEXT, type WhatWorksProblem, type WhatWorksProduct } from './ww-shared';
+import { WhatWorksProductCard } from './ww-product-card';
+
+type Props = {
+  problem: WhatWorksProblem;
+  busyProductId: string | null;
+  onToggleHelpful: (product: WhatWorksProduct) => void;
+  sectionRef?: (node: HTMLElement | null) => void;
+};
+
+export function WhatWorksProblemSection({ problem, busyProductId, onToggleHelpful, sectionRef }: Props) {
+  return (
+    <section ref={sectionRef}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, marginBottom: 14 }}>
+        <div style={{ width: 40, height: 40, borderRadius: 11, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 19, flexShrink: 0 }}>{problem.emoji || '🧰'}</div>
+        <div style={{ flex: 1, paddingTop: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+            <h2 style={{ margin: 0, fontSize: 17, fontWeight: 700, color: TEXT }}>{problem.title}</h2>
+            <span style={{ fontSize: 11.5, color: SUBTLE, fontWeight: 600 }}>{problem.products.length} tools</span>
+          </div>
+          {problem.context ? (
+            <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.5, marginTop: 3 }}>{problem.context}</div>
+          ) : null}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {problem.products.map((product) => (
+          <WhatWorksProductCard
+            key={product.id}
+            product={product}
+            busy={busyProductId === product.id}
+            onToggleHelpful={onToggleHelpful}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-product-card.tsx
+++ b/ctf/packages/web/components/whatworks/ww-product-card.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+// A single survivor-verified tool card from design/.../survivor-hub/WhatWorks.tsx.
+// "Helpful" is the live endorsement toggle; its tally renders as "N survivors verified".
+import { ShieldCheck, ThumbsUp, ExternalLink } from 'lucide-react';
+import { BRAND, BORDER, SURFACE, SUBTLE, TEXT, purchaseLinkLabel, type WhatWorksProduct } from './ww-shared';
+
+type Props = {
+  product: WhatWorksProduct;
+  busy: boolean;
+  onToggleHelpful: (product: WhatWorksProduct) => void;
+};
+
+export function WhatWorksProductCard({ product, busy, onToggleHelpful }: Props) {
+  const endorsed = product.viewerHasEndorsed;
+  return (
+    <div style={{ display: 'flex', gap: 14, padding: '16px', borderRadius: 14, background: SURFACE, border: `1px solid ${BORDER}` }}>
+      <div style={{ width: 52, height: 52, borderRadius: 11, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 24, flexShrink: 0 }}>{product.emoji || '🧰'}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <span style={{ fontSize: 14.5, fontWeight: 700, color: TEXT }}>{product.name}</span>
+          {product.kind ? <span style={{ fontSize: 12, color: SUBTLE }}>{product.kind}</span> : null}
+        </div>
+        {product.note ? (
+          <div style={{ fontSize: 13, color: '#C4CAD3', lineHeight: 1.55, marginTop: 6, fontStyle: 'italic' }}>“{product.note}”</div>
+        ) : null}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginTop: 11 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: BRAND, fontWeight: 600 }}>
+            <ShieldCheck size={13} /> {product.verifiedCount} survivors verified
+          </span>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onToggleHelpful(product)}
+            aria-pressed={endorsed}
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: endorsed ? BRAND : SUBTLE, fontWeight: endorsed ? 700 : 500, background: 'none', border: 'none', padding: 0, cursor: busy ? 'default' : 'pointer' }}
+          >
+            <ThumbsUp size={12} /> {endorsed ? 'Helped me' : 'Helpful'}
+          </button>
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', justifyContent: 'center', flexShrink: 0 }}>
+        <a href={product.purchaseUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 13px', borderRadius: 9, background: `${BRAND}18`, border: `1px solid ${BRAND}40`, color: BRAND, fontSize: 12.5, fontWeight: 700, textDecoration: 'none', whiteSpace: 'nowrap' }}>
+          {purchaseLinkLabel(product.purchaseUrl)} <ExternalLink size={12} />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-product-card.tsx
+++ b/ctf/packages/web/components/whatworks/ww-product-card.tsx
@@ -3,7 +3,7 @@
 // A single survivor-verified tool card from design/.../survivor-hub/WhatWorks.tsx.
 // "Helpful" is the live endorsement toggle; its tally renders as "N survivors verified".
 import { ShieldCheck, ThumbsUp, ExternalLink } from 'lucide-react';
-import { BRAND, BORDER, SURFACE, SUBTLE, TEXT, purchaseLinkLabel, type WhatWorksProduct } from './ww-shared';
+import { BRAND, BORDER, SURFACE, SUBTLE, TEXT, type WhatWorksProduct } from './ww-shared';
 
 type Props = {
   product: WhatWorksProduct;
@@ -41,7 +41,7 @@ export function WhatWorksProductCard({ product, busy, onToggleHelpful }: Props) 
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', justifyContent: 'center', flexShrink: 0 }}>
         <a href={product.purchaseUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 13px', borderRadius: 9, background: `${BRAND}18`, border: `1px solid ${BRAND}40`, color: BRAND, fontSize: 12.5, fontWeight: 700, textDecoration: 'none', whiteSpace: 'nowrap' }}>
-          {purchaseLinkLabel(product.purchaseUrl)} <ExternalLink size={12} />
+          View product <ExternalLink size={12} />
         </a>
       </div>
     </div>

--- a/ctf/packages/web/components/whatworks/ww-public.tsx
+++ b/ctf/packages/web/components/whatworks/ww-public.tsx
@@ -9,7 +9,7 @@ import {
 } from 'lucide-react';
 import {
   BG, BRAND, BORDER, SURFACE, SUBTLE, TEXT,
-  purchaseLinkLabel, type WhatWorksProblem, type WhatWorksStats,
+  type WhatWorksProblem, type WhatWorksStats,
 } from './ww-shared';
 import { WhatWorksLoading } from './ww-loading';
 
@@ -123,7 +123,7 @@ export function WhatWorksPublic() {
                               <ShieldCheck size={12} /> {product.verifiedCount} verified
                             </span>
                             <a href={product.purchaseUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 12, color: BRAND, fontWeight: 700, textDecoration: 'none' }}>
-                              {purchaseLinkLabel(product.purchaseUrl)} <ExternalLink size={11} />
+                              View <ExternalLink size={11} />
                             </a>
                           </div>
                         </div>

--- a/ctf/packages/web/components/whatworks/ww-public.tsx
+++ b/ctf/packages/web/components/whatworks/ww-public.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+// STATE: Unauthenticated — public visitor. The list is publicly readable (a teaser slice);
+// suggesting is gated behind sign-in. Matched to design/.../survivor-hub/WhatWorksPublic.tsx.
+import { useEffect, useState, type ReactNode } from 'react';
+import Link from 'next/link';
+import {
+  ListChecks, UserPlus, BadgeCheck, ExternalLink, ShieldCheck, Ban, Lock, ChevronRight,
+} from 'lucide-react';
+import {
+  BG, BRAND, BORDER, SURFACE, SUBTLE, TEXT,
+  purchaseLinkLabel, type WhatWorksProblem, type WhatWorksStats,
+} from './ww-shared';
+import { WhatWorksLoading } from './ww-loading';
+
+const TRUST: { icon: ReactNode; title: string; detail: string }[] = [
+  { icon: <BadgeCheck size={15} color={BRAND} />, title: 'Survivor-verified', detail: 'Used by a real member who said it helped.' },
+  { icon: <Ban size={15} color={BRAND} />, title: 'No ads or affiliates', detail: 'Nothing here is sponsored.' },
+  { icon: <Lock size={15} color={BRAND} />, title: 'Anonymous', detail: 'Suggesting never reveals who you are.' },
+];
+
+export function WhatWorksPublic() {
+  const [loading, setLoading] = useState(true);
+  const [problems, setProblems] = useState<WhatWorksProblem[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/whatworks/public');
+        if (res.ok) {
+          const data = (await res.json()) as { problems: WhatWorksProblem[]; stats: WhatWorksStats };
+          if (active) setProblems(data.problems ?? []);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, []);
+
+  if (loading) {
+    return <WhatWorksLoading />;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', maxHeight: '100%', background: BG, fontFamily: "'Inter',system-ui", color: TEXT, overflow: 'hidden' }}>
+      <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10, flexShrink: 0, background: '#0D0F14' }}>
+        <ListChecks size={18} color={BRAND} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>What Works</span>
+        <span style={{ fontSize: 12, color: SUBTLE, marginLeft: 4 }}>· survivor-verified tools</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <Link href="/sign-in" style={{ padding: '7px 16px', borderRadius: 8, background: 'rgba(255,255,255,0.06)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, textDecoration: 'none' }}>Sign In</Link>
+          <Link href="/sign-up" style={{ padding: '7px 16px', borderRadius: 8, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 13, fontWeight: 700, textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 5 }}>
+            <UserPlus size={13} /> Create Account
+          </Link>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+        <div style={{ padding: '44px 64px 28px', display: 'flex', gap: 48, alignItems: 'flex-start', maxWidth: 1100, margin: '0 auto' }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <span style={{ padding: '4px 14px', borderRadius: 20, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, fontSize: 12, color: BRAND, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 6, width: 'fit-content' }}>
+              <BadgeCheck size={13} /> One shared, survivor-verified list
+            </span>
+            <h1 style={{ margin: 0, fontSize: 36, fontWeight: 800, lineHeight: 1.12, letterSpacing: '-0.02em' }}>
+              The tools that<br /><span style={{ color: BRAND }}>actually work</span>.
+            </h1>
+            <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 520, lineHeight: 1.7 }}>
+              Pick a problem you&apos;re facing. Underneath it is a list of specific products a survivor here bought, used, and said helped — each with a direct link to get it. No ads. No affiliates. Nothing sold.
+            </p>
+            <div style={{ display: 'flex', gap: 12, marginTop: 4 }}>
+              <Link href="/sign-up" style={{ padding: '13px 28px', borderRadius: 10, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 15, fontWeight: 700, textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 8 }}>
+                <UserPlus size={16} /> Join to suggest items
+              </Link>
+            </div>
+          </div>
+          <div style={{ width: 260, flexShrink: 0 }}>
+            <div style={{ padding: '18px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}` }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>Why trust this list?</div>
+              {TRUST.map((item) => (
+                <div key={item.title} style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+                  <span style={{ flexShrink: 0, marginTop: 1 }}>{item.icon}</span>
+                  <div>
+                    <div style={{ fontSize: 12.5, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{item.title}</div>
+                    <div style={{ fontSize: 11.5, color: SUBTLE, lineHeight: 1.5 }}>{item.detail}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div style={{ padding: '0 64px 56px', maxWidth: 1100, margin: '0 auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+            <span style={{ fontSize: 13, fontWeight: 700, color: TEXT }}>A look at the list</span>
+            <span style={{ fontSize: 12, color: SUBTLE }}>· publicly readable — no account needed to browse</span>
+          </div>
+
+          {problems.length === 0 ? (
+            <div style={{ fontSize: 13, color: SUBTLE, padding: '8px 0 24px' }}>The list is just getting started. Be the first to add what worked for you.</div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+              {problems.map((problem) => (
+                <section key={problem.id}>
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, marginBottom: 12 }}>
+                    <div style={{ width: 38, height: 38, borderRadius: 11, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18, flexShrink: 0 }}>{problem.emoji || '🧰'}</div>
+                    <div style={{ flex: 1, paddingTop: 1 }}>
+                      <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: TEXT }}>{problem.title}</h2>
+                      {problem.context ? <div style={{ fontSize: 12.5, color: SUBTLE, lineHeight: 1.5, marginTop: 2 }}>{problem.context}</div> : null}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 12 }}>
+                    {problem.products.map((product) => (
+                      <div key={product.id} style={{ flex: 1, display: 'flex', gap: 12, padding: '14px', borderRadius: 14, background: SURFACE, border: `1px solid ${BORDER}` }}>
+                        <div style={{ width: 46, height: 46, borderRadius: 10, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 22, flexShrink: 0 }}>{product.emoji || '🧰'}</div>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontSize: 14, fontWeight: 700, color: TEXT }}>{product.name}</div>
+                          {product.kind ? <div style={{ fontSize: 11.5, color: SUBTLE }}>{product.kind}</div> : null}
+                          {product.note ? <div style={{ fontSize: 12.5, color: '#C4CAD3', lineHeight: 1.5, marginTop: 6, fontStyle: 'italic' }}>“{product.note}”</div> : null}
+                          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 10 }}>
+                            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: BRAND, fontWeight: 600 }}>
+                              <ShieldCheck size={12} /> {product.verifiedCount} verified
+                            </span>
+                            <a href={product.purchaseUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 12, color: BRAND, fontWeight: 700, textDecoration: 'none' }}>
+                              {purchaseLinkLabel(product.purchaseUrl)} <ExternalLink size={11} />
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+
+          <div style={{ marginTop: 28, padding: '24px', borderRadius: 16, background: `${BRAND}08`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', gap: 16 }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 16, fontWeight: 700, color: TEXT, marginBottom: 4 }}>See every problem — and add what worked for you</div>
+              <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6 }}>Create a free, verified account to view the full list and suggest the tools that helped you.</div>
+            </div>
+            <Link href="/sign-up" style={{ padding: '13px 26px', borderRadius: 10, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 14, fontWeight: 700, textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+              Get started <ChevronRight size={15} />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-right-rail.tsx
+++ b/ctf/packages/web/components/whatworks/ww-right-rail.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+// Right rail from design/.../survivor-hub/WhatWorks.tsx — trust principles, list stats,
+// and the footnote link to the external "Look Ma" explainer (owner-confirmed URL).
+import type { ReactNode } from 'react';
+import { BadgeCheck, ExternalLink, Ban, Lock, ChevronRight } from 'lucide-react';
+import { BRAND, BORDER, SURFACE, SUBTLE, TEXT, LOOK_MA_URL, type WhatWorksStats } from './ww-shared';
+
+const PRINCIPLES: { icon: ReactNode; title: string; detail: string }[] = [
+  { icon: <BadgeCheck size={15} color={BRAND} />, title: 'Survivor-verified', detail: 'Every item was used by a real member who said it helped.' },
+  { icon: <ExternalLink size={15} color={BRAND} />, title: 'Direct links', detail: "Go straight to the product. We don't sell anything." },
+  { icon: <Ban size={15} color={BRAND} />, title: 'No ads, no affiliates', detail: 'Nothing on this list is sponsored or paid for.' },
+  { icon: <Lock size={15} color={BRAND} />, title: 'Private to suggest', detail: 'Suggesting an item never reveals who you are.' },
+];
+
+export function WhatWorksRightRail({ stats }: { stats: WhatWorksStats }) {
+  const rows = [
+    { label: 'Problems', value: String(stats.problems) },
+    { label: 'Verified tools', value: String(stats.verifiedTools) },
+    { label: 'Survivors helped', value: String(stats.survivorsHelped) },
+  ];
+  return (
+    <aside style={{ width: 280, borderLeft: `1px solid ${BORDER}`, background: '#0D0F14', padding: '20px 16px', flexShrink: 0, overflowY: 'auto' }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: '#4B5563', textTransform: 'uppercase', marginBottom: 12 }}>How this list works</div>
+      <div style={{ padding: '14px', borderRadius: 12, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 16 }}>
+        {PRINCIPLES.map((principle) => (
+          <div key={principle.title} style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+            <span style={{ flexShrink: 0, marginTop: 1 }}>{principle.icon}</span>
+            <div>
+              <div style={{ fontSize: 12.5, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{principle.title}</div>
+              <div style={{ fontSize: 11.5, color: SUBTLE, lineHeight: 1.5 }}>{principle.detail}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ padding: '16px', borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 16 }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.06em', color: '#4B5563', textTransform: 'uppercase', marginBottom: 12 }}>This list</div>
+        {rows.map((row) => (
+          <div key={row.label} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 9 }}>
+            <span style={{ fontSize: 12.5, color: SUBTLE }}>{row.label}</span>
+            <span style={{ fontSize: 15, fontWeight: 800, color: BRAND }}>{row.value}</span>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ padding: '13px 14px', borderRadius: 12, background: 'rgba(255,255,255,0.02)', border: `1px solid ${BORDER}` }}>
+        <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.6 }}>
+          One shared list for the whole community — for now. Per-survivor lists may come later.
+        </div>
+        <a href={LOOK_MA_URL} target="_blank" rel="noopener noreferrer" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, color: BRAND, fontWeight: 600, textDecoration: 'none', marginTop: 8 }}>
+          From the problems in “Look Ma, I Fixed It” <ChevronRight size={13} />
+        </a>
+      </div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-shared.ts
+++ b/ctf/packages/web/components/whatworks/ww-shared.ts
@@ -1,0 +1,80 @@
+// Design tokens taken verbatim from design/.../survivor-hub/WhatWorks.tsx (no token system in
+// the mockups — hex values are matched directly per the design-mockup implementation rules).
+export const BRAND = '#84CC16';
+export const BG = '#0F1117';
+export const SURFACE = '#161B27';
+export const BORDER = '#1E2A3A';
+export const TEXT = '#F9FAFB';
+export const SUBTLE = '#6B7280';
+export const FAINT = '#4B5563';
+
+// The external long-form explainer the right-rail footnote points at (owner-confirmed).
+export const LOOK_MA_URL = 'https://www.chargingthefuture.com/look-ma';
+
+export type WhatWorksProduct = {
+  id: string;
+  emoji: string;
+  name: string;
+  kind: string;
+  note: string;
+  purchaseUrl: string;
+  verifiedCount: number;
+  viewerHasEndorsed: boolean;
+};
+
+export type WhatWorksProblem = {
+  id: string;
+  slug: string;
+  emoji: string;
+  title: string;
+  context: string;
+  products: WhatWorksProduct[];
+};
+
+export type WhatWorksStats = {
+  problems: number;
+  verifiedTools: number;
+  survivorsHelped: number;
+};
+
+export type WhatWorksListResponse = {
+  ok: boolean;
+  problems: WhatWorksProblem[];
+  stats: WhatWorksStats;
+  viewer?: { isAdmin: boolean };
+};
+
+export type WhatWorksProblemOption = {
+  id: string;
+  slug: string;
+  emoji: string;
+  title: string;
+  context: string;
+};
+
+export type SuggestDraft = {
+  problemId: string;
+  name: string;
+  purchaseUrl: string;
+  note: string;
+};
+
+export const EMPTY_SUGGEST_DRAFT: SuggestDraft = {
+  problemId: '',
+  name: '',
+  purchaseUrl: '',
+  note: '',
+};
+
+// Honest retailer label: the mockup says "View on Amazon", but purchase links are arbitrary,
+// so only say Amazon when the link actually is. Everything else reads "View product".
+export function purchaseLinkLabel(url: string): string {
+  try {
+    if (new URL(url).hostname.toLowerCase().includes('amazon')) {
+      return 'View on Amazon';
+    }
+  } catch {
+    return 'View product';
+  }
+  return 'View product';
+}

--- a/ctf/packages/web/components/whatworks/ww-shared.ts
+++ b/ctf/packages/web/components/whatworks/ww-shared.ts
@@ -65,16 +65,3 @@ export const EMPTY_SUGGEST_DRAFT: SuggestDraft = {
   purchaseUrl: '',
   note: '',
 };
-
-// Honest retailer label: the mockup says "View on Amazon", but purchase links are arbitrary,
-// so only say Amazon when the link actually is. Everything else reads "View product".
-export function purchaseLinkLabel(url: string): string {
-  try {
-    if (new URL(url).hostname.toLowerCase().includes('amazon')) {
-      return 'View on Amazon';
-    }
-  } catch {
-    return 'View product';
-  }
-  return 'View product';
-}

--- a/ctf/packages/web/components/whatworks/ww-sidebar.tsx
+++ b/ctf/packages/web/components/whatworks/ww-sidebar.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+// Left jump-nav from design/.../survivor-hub/WhatWorks.tsx — problems list + suggest CTA.
+import { Plus } from 'lucide-react';
+import { BRAND, BORDER, SUBTLE, TEXT, type WhatWorksProblem } from './ww-shared';
+
+type Props = {
+  problems: WhatWorksProblem[];
+  activeIndex: number;
+  onSelectProblem: (index: number) => void;
+  onSuggest: () => void;
+};
+
+export function WhatWorksSidebar({ problems, activeIndex, onSelectProblem, onSuggest }: Props) {
+  return (
+    <aside style={{ width: 240, background: '#0D0F14', borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+      <div style={{ padding: '20px 16px 12px' }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: SUBTLE, textTransform: 'uppercase', marginBottom: 4 }}>🧰 What Works</div>
+        <div style={{ fontSize: 12, color: '#4B5563', lineHeight: 1.5 }}>One shared list of tools that solved a specific problem</div>
+      </div>
+      <div style={{ flex: 1, padding: '4px 12px', overflowY: 'auto' }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', color: '#4B5563', textTransform: 'uppercase', padding: '8px 8px 6px' }}>Problems</div>
+        {problems.map((problem, index) => {
+          const active = index === activeIndex;
+          return (
+            <button
+              key={problem.id}
+              type="button"
+              onClick={() => onSelectProblem(index)}
+              style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 10, padding: '9px 10px', borderRadius: 9, marginBottom: 2, background: active ? `${BRAND}14` : 'transparent', border: active ? `1px solid ${BRAND}30` : '1px solid transparent', cursor: 'pointer', textAlign: 'left' }}
+            >
+              <span style={{ fontSize: 15, flexShrink: 0 }}>{problem.emoji || '🧰'}</span>
+              <span style={{ flex: 1, fontSize: 12.5, fontWeight: active ? 600 : 500, color: active ? TEXT : '#9CA3AF', lineHeight: 1.3 }}>{problem.title}</span>
+              <span style={{ fontSize: 11, color: SUBTLE, flexShrink: 0 }}>{problem.products.length}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div style={{ padding: 12, borderTop: `1px solid ${BORDER}` }}>
+        <button
+          type="button"
+          onClick={onSuggest}
+          style={{ width: '100%', padding: '10px', borderRadius: 10, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 13, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
+        >
+          <Plus size={15} /> Suggest an item
+        </button>
+        <div style={{ fontSize: 10.5, color: '#4B5563', textAlign: 'center', marginTop: 8, lineHeight: 1.5 }}>Suggestions are reviewed before they&apos;re added to the shared list.</div>
+      </div>
+    </aside>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-suggest-guidance.tsx
+++ b/ctf/packages/web/components/whatworks/ww-suggest-guidance.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+// Static "what makes a good entry" guidance from design/.../survivor-hub/WhatWorksEmpty.tsx.
+import { ShieldCheck } from 'lucide-react';
+import { BRAND, BORDER, SURFACE, SUBTLE, TEXT } from './ww-shared';
+
+const ENTRY_TIPS = [
+  { icon: '🎯', title: 'One specific problem', detail: 'Tie each tool to a real problem survivors recognize.' },
+  { icon: '🔗', title: 'A direct link', detail: 'Link straight to the exact product — not a category.' },
+  { icon: '✍️', title: 'Why it worked', detail: 'A line from your experience matters more than specs.' },
+  { icon: '✅', title: 'You actually used it', detail: 'Only add what genuinely helped you. No guesses.' },
+];
+
+export function WhatWorksSuggestGuidance() {
+  return (
+    <div style={{ width: 300, flexShrink: 0 }}>
+      <div style={{ padding: '20px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 16 }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>What makes a good entry</div>
+        {ENTRY_TIPS.map((tip) => (
+          <div key={tip.title} style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+            <span style={{ fontSize: 16, flexShrink: 0 }}>{tip.icon}</span>
+            <div>
+              <div style={{ fontSize: 12.5, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{tip.title}</div>
+              <div style={{ fontSize: 11.5, color: SUBTLE, lineHeight: 1.5 }}>{tip.detail}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ padding: '14px 16px', borderRadius: 12, background: `${BRAND}06`, border: `1px solid ${BRAND}20` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 6 }}>
+          <ShieldCheck size={13} color={BRAND} />
+          <span style={{ fontSize: 12, fontWeight: 600, color: BRAND }}>Pick an existing problem</span>
+        </div>
+        <div style={{ fontSize: 11.5, color: SUBTLE, lineHeight: 1.55 }}>When you suggest a product, choose the problem it solves from the list. Admins curate the problems so the same need isn&apos;t listed twice under different names.</div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
+++ b/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+// Add-item / suggest form from design/.../survivor-hub/WhatWorksEmpty.tsx. In this app a
+// suggestion is reviewed before it joins the shared list, so the submit + success copy is
+// review-honest (the mockup's "added" framing assumes immediate publish).
+import { useState, type CSSProperties, type ReactNode } from 'react';
+import { ListChecks, Plus, ExternalLink, Send, CheckCircle, Tag, ChevronDown, ChevronLeft } from 'lucide-react';
+import { BG, BRAND, BORDER, SUBTLE, TEXT, type SuggestDraft, type WhatWorksProblemOption } from './ww-shared';
+import { WhatWorksSuggestGuidance } from './ww-suggest-guidance';
+
+type Props = {
+  problems: WhatWorksProblemOption[];
+  isFirst: boolean;
+  onSubmit: (draft: SuggestDraft) => Promise<string | null>;
+  onBack?: () => void;
+};
+
+const inputStyle: CSSProperties = {
+  flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 14, color: '#F9FAFB', fontFamily: 'inherit',
+};
+
+function Field({ label, required, children }: { label: string; required?: boolean; children: ReactNode }) {
+  return (
+    <div>
+      <label style={{ fontSize: 13, fontWeight: 600, color: '#9CA3AF', display: 'block', marginBottom: 8 }}>
+        {label} {required ? <span style={{ color: BRAND }}>*</span> : null}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: Props) {
+  const [problemId, setProblemId] = useState('');
+  const [name, setName] = useState('');
+  const [link, setLink] = useState('');
+  const [why, setWhy] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [added, setAdded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const ready = problemId.trim() && name.trim() && link.trim();
+
+  async function submit(): Promise<void> {
+    if (!ready || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const failure = await onSubmit({ problemId, name: name.trim(), purchaseUrl: link.trim(), note: why.trim() });
+    setSubmitting(false);
+    if (failure) {
+      setError(failure);
+      return;
+    }
+    setProblemId('');
+    setName('');
+    setLink('');
+    setWhy('');
+    setAdded(true);
+  }
+
+  if (added) {
+    return (
+      <div style={{ width: '100%', height: '100vh', maxHeight: '100%', background: BG, fontFamily: "'Inter',system-ui", color: TEXT, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+        <div style={{ maxWidth: 460, textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, padding: '0 32px' }}>
+          <div style={{ width: 72, height: 72, borderRadius: '50%', background: `${BRAND}15`, border: `1px solid ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <CheckCircle size={34} color={BRAND} />
+          </div>
+          <div style={{ fontSize: 24, fontWeight: 800 }}>Suggestion submitted 🎉</div>
+          <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>A reviewer will check it before it joins the shared list. Each tool you add helps the next survivor find what works faster.</div>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button onClick={() => setAdded(false)} style={{ padding: '12px 24px', borderRadius: 10, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+              <Plus size={15} /> Add another
+            </button>
+            {onBack ? (
+              <button onClick={onBack} style={{ padding: '12px 24px', borderRadius: 10, background: 'rgba(255,255,255,0.06)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
+                Back to list
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', maxHeight: '100%', background: BG, fontFamily: "'Inter',system-ui", color: TEXT, overflow: 'hidden' }}>
+      <div style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 12, background: '#0D0F14', flexShrink: 0 }}>
+        <ListChecks size={18} color={BRAND} />
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>What Works</div>
+          <div style={{ fontSize: 12, color: SUBTLE }}>Add a survivor-verified tool to the shared list</div>
+        </div>
+        {onBack ? (
+          <button onClick={onBack} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '7px 12px', borderRadius: 9, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, color: '#9CA3AF', fontSize: 12.5, fontWeight: 600, cursor: 'pointer' }}>
+            <ChevronLeft size={14} /> Back to list
+          </button>
+        ) : null}
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, display: 'flex', alignItems: 'flex-start', justifyContent: 'center', padding: '44px 64px', gap: 44 }}>
+        <div style={{ flex: 1, maxWidth: 540 }}>
+          <div style={{ marginBottom: 26 }}>
+            <div style={{ width: 56, height: 56, borderRadius: 16, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>
+              <ListChecks size={26} color={BRAND} />
+            </div>
+            <div style={{ fontSize: 26, fontWeight: 800, marginBottom: 10 }}>
+              {isFirst ? 'The list is empty — add what worked first.' : 'Suggest a tool that worked.'}
+            </div>
+            <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
+              Pick the problem your product solves, then add a specific item that worked for you — with a direct purchase link and a short note on why. Example: <span style={{ color: '#C4CAD3' }}>“Noise &amp; Verbal Harassment”</span> → a pair of noise-cancelling headphones.
+            </div>
+          </div>
+
+          {error ? (
+            <div style={{ marginBottom: 16, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 13 }}>{error}</div>
+          ) : null}
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <Field label="Problem it solves" required>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '11px 14px', background: 'rgba(255,255,255,0.04)', border: `1px solid ${problemId ? BRAND + '50' : BORDER}`, borderRadius: 12 }}>
+                <Tag size={14} color={SUBTLE} style={{ flexShrink: 0 }} />
+                <select value={problemId} onChange={(event) => setProblemId(event.target.value)} style={{ ...inputStyle, cursor: 'pointer', appearance: 'none', color: problemId ? '#F9FAFB' : SUBTLE }}>
+                  <option value="" disabled>Choose an existing problem…</option>
+                  {problems.map((problem) => (
+                    <option key={problem.id} value={problem.id} style={{ background: '#11141B', color: '#F9FAFB' }}>{problem.title}</option>
+                  ))}
+                </select>
+                <ChevronDown size={15} color={SUBTLE} style={{ flexShrink: 0 }} />
+              </div>
+              <div style={{ fontSize: 11, color: SUBTLE, marginTop: 6, lineHeight: 1.5 }}>Pick an existing problem. New problems are added by admins to avoid duplicates.</div>
+            </Field>
+
+            <Field label="Product name" required>
+              <input value={name} onChange={(event) => setName(event.target.value)} placeholder="e.g. Sony WH-1000XM5 Headphones" style={{ ...inputStyle, padding: '11px 14px', background: 'rgba(255,255,255,0.04)', border: `1px solid ${name ? BRAND + '50' : BORDER}`, borderRadius: 12, boxSizing: 'border-box', width: '100%' }} />
+            </Field>
+
+            <Field label="Direct purchase link" required>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '11px 14px', background: 'rgba(255,255,255,0.04)', border: `1px solid ${link ? BRAND + '50' : BORDER}`, borderRadius: 12 }}>
+                <ExternalLink size={14} color={SUBTLE} style={{ flexShrink: 0 }} />
+                <input value={link} onChange={(event) => setLink(event.target.value)} placeholder="https://…" style={inputStyle} />
+              </div>
+            </Field>
+
+            <Field label="Why it works (optional)">
+              <textarea value={why} onChange={(event) => setWhy(event.target.value)} rows={3} placeholder="A short note from your experience — what it actually solved." style={{ ...inputStyle, padding: '11px 14px', background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, borderRadius: 12, boxSizing: 'border-box', width: '100%', resize: 'none', lineHeight: 1.5 }} />
+            </Field>
+
+            <button onClick={() => void submit()} disabled={!ready || submitting}
+              style={{ padding: '14px', borderRadius: 12, background: ready && !submitting ? BRAND : 'rgba(255,255,255,0.06)', border: 'none', color: ready && !submitting ? '#0A0E06' : SUBTLE, fontSize: 15, fontWeight: 700, cursor: ready && !submitting ? 'pointer' : 'default', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
+              <Send size={16} /> {submitting ? 'Submitting…' : 'Submit for review'}
+            </button>
+          </div>
+        </div>
+
+        <WhatWorksSuggestGuidance />
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
+++ b/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
@@ -115,7 +115,10 @@ export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: P
             <div style={{ marginBottom: 16, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 13 }}>{error}</div>
           ) : null}
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <form
+            onSubmit={(event) => { event.preventDefault(); void submit(); }}
+            style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+          >
             <Field label="Problem it solves" required>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '11px 14px', background: 'rgba(255,255,255,0.04)', border: `1px solid ${problemId ? BRAND + '50' : BORDER}`, borderRadius: 12 }}>
                 <Tag size={14} color={SUBTLE} style={{ flexShrink: 0 }} />
@@ -145,11 +148,11 @@ export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: P
               <textarea value={why} onChange={(event) => setWhy(event.target.value)} rows={3} placeholder="A short note from your experience — what it actually solved." style={{ ...inputStyle, padding: '11px 14px', background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, borderRadius: 12, boxSizing: 'border-box', width: '100%', resize: 'none', lineHeight: 1.5 }} />
             </Field>
 
-            <button onClick={() => void submit()} disabled={!ready || submitting}
+            <button type="submit" disabled={!ready || submitting}
               style={{ padding: '14px', borderRadius: 12, background: ready && !submitting ? BRAND : 'rgba(255,255,255,0.06)', border: 'none', color: ready && !submitting ? '#0A0E06' : SUBTLE, fontSize: 15, fontWeight: 700, cursor: ready && !submitting ? 'pointer' : 'default', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
               <Send size={16} /> {submitting ? 'Submitting…' : 'Submit for review'}
             </button>
-          </div>
+          </form>
         </div>
 
         <WhatWorksSuggestGuidance />

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -190,6 +190,14 @@ const fallbackPluginRegistry: PluginRegistryItem[] = [
     navRank: 190,
     isVisible: false,
   },
+  {
+    slug: 'whatworks',
+    name: 'WhatWorks',
+    summary: 'One shared, survivor-verified list of tools that solved a specific problem, with admin-curated problems and reviewed suggestions.',
+    availabilityState: 'implemented_shell',
+    navRank: 200,
+    isVisible: true,
+  },
 ];
 
 const pluginAliasMap: Record<string, string> = {

--- a/ctf/packages/web/lib/whatworks/constants.ts
+++ b/ctf/packages/web/lib/whatworks/constants.ts
@@ -1,0 +1,23 @@
+import type { WhatWorksProductStatus } from './types';
+
+export const WHATWORKS_PRODUCT_STATUSES: readonly WhatWorksProductStatus[] = [
+  'pending',
+  'approved',
+  'rejected',
+];
+
+export const MAX_PRODUCT_NAME_LENGTH = 120;
+export const MAX_PRODUCT_KIND_LENGTH = 120;
+export const MAX_PRODUCT_NOTE_LENGTH = 400;
+export const MAX_PURCHASE_URL_LENGTH = 2048;
+export const MAX_PROBLEM_TITLE_LENGTH = 120;
+export const MAX_PROBLEM_CONTEXT_LENGTH = 280;
+export const MAX_EMOJI_LENGTH = 16;
+
+// Public visitors see a teaser slice of the list; the full list is sign-in gated.
+export const PUBLIC_PREVIEW_PROBLEM_LIMIT = 2;
+export const PUBLIC_PREVIEW_PRODUCTS_PER_PROBLEM = 2;
+
+export function isWhatWorksProductStatus(value: unknown): value is WhatWorksProductStatus {
+  return typeof value === 'string' && WHATWORKS_PRODUCT_STATUSES.includes(value as WhatWorksProductStatus);
+}

--- a/ctf/packages/web/lib/whatworks/policy.ts
+++ b/ctf/packages/web/lib/whatworks/policy.ts
@@ -1,0 +1,19 @@
+// WhatWorks is a single shared, survivor-verified list. Reading is open (including a
+// redacted public projection); suggesting and endorsing require an authenticated survivor;
+// curating problems and moderating suggestions require an admin.
+
+export function canSuggestProduct(userId: string | null): boolean {
+  return !!userId;
+}
+
+export function canEndorseProduct(userId: string | null): boolean {
+  return !!userId;
+}
+
+export function canModerateProducts(isAdmin: boolean): boolean {
+  return isAdmin;
+}
+
+export function canManageProblems(isAdmin: boolean): boolean {
+  return isAdmin;
+}

--- a/ctf/packages/web/lib/whatworks/repository.ts
+++ b/ctf/packages/web/lib/whatworks/repository.ts
@@ -326,9 +326,10 @@ export async function listAdminProducts(
         p.id, p.problem_id, pr.title AS problem_title,
         p.emoji, p.name, p.kind, p.note, p.purchase_url, p.status,
         (SELECT COUNT(*) FROM whatworks_endorsements e WHERE e.product_id = p.id)::int AS verified_count,
-        -- Cast to ISO text so values match the string types on AdminProduct (pg returns Date by default).
-        to_char(p.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MSOF') AS created_at,
-        to_char(p.reviewed_at, 'YYYY-MM-DD"T"HH24:MI:SS.MSOF') AS reviewed_at,
+        -- Cast to ISO text (UTC, RFC-3339 with literal Z) so values match the string types on
+        -- AdminProduct (pg returns Date by default; the columns are timestamptz).
+        to_char(p.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at,
+        to_char(p.reviewed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS reviewed_at,
         p.rejection_reason
        FROM whatworks_products p
        JOIN whatworks_problems pr ON pr.id = p.problem_id

--- a/ctf/packages/web/lib/whatworks/repository.ts
+++ b/ctf/packages/web/lib/whatworks/repository.ts
@@ -326,7 +326,10 @@ export async function listAdminProducts(
         p.id, p.problem_id, pr.title AS problem_title,
         p.emoji, p.name, p.kind, p.note, p.purchase_url, p.status,
         (SELECT COUNT(*) FROM whatworks_endorsements e WHERE e.product_id = p.id)::int AS verified_count,
-        p.created_at, p.reviewed_at, p.rejection_reason
+        -- Cast to ISO text so values match the string types on AdminProduct (pg returns Date by default).
+        to_char(p.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MSOF') AS created_at,
+        to_char(p.reviewed_at, 'YYYY-MM-DD"T"HH24:MI:SS.MSOF') AS reviewed_at,
+        p.rejection_reason
        FROM whatworks_products p
        JOIN whatworks_problems pr ON pr.id = p.problem_id
       WHERE ($1::text IS NULL OR p.status = $1)

--- a/ctf/packages/web/lib/whatworks/repository.ts
+++ b/ctf/packages/web/lib/whatworks/repository.ts
@@ -1,0 +1,377 @@
+import { queryDb, withDbTransaction } from 'lib/db/postgres';
+import type {
+  CreateProblemInput,
+  ReviewProductInput,
+  SuggestProductInput,
+  UpdateProblemInput,
+  WhatWorksAdminProblem,
+  WhatWorksAdminProduct,
+  WhatWorksList,
+  WhatWorksListStats,
+  WhatWorksProblem,
+  WhatWorksProduct,
+  WhatWorksPublicProblem,
+  WhatWorksPublicProduct,
+} from './types';
+
+function slugifyTitle(title: string): string {
+  const base = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return base.length > 0 ? base : 'problem';
+}
+
+async function ensureUniqueSlug(base: string): Promise<string> {
+  let candidate = base;
+  let suffix = 2;
+  // Loop is bounded by the number of existing collisions, which is tiny in practice.
+  while (true) {
+    const existing = await queryDb<{ id: string }>(
+      'SELECT id FROM whatworks_problems WHERE slug = $1 LIMIT 1',
+      [candidate],
+    );
+    if (existing.rowCount === 0) {
+      return candidate;
+    }
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
+}
+
+type ProductProjectionRow = {
+  id: string;
+  problem_id: string;
+  emoji: string;
+  name: string;
+  kind: string;
+  note: string;
+  purchase_url: string;
+  verified_count: number;
+  viewer_has_endorsed: boolean;
+};
+
+type ProblemProjectionRow = {
+  id: string;
+  slug: string;
+  emoji: string;
+  title: string;
+  context: string;
+};
+
+function toPublicProduct(row: ProductProjectionRow): WhatWorksPublicProduct {
+  return {
+    id: row.id,
+    emoji: row.emoji,
+    name: row.name,
+    kind: row.kind,
+    note: row.note,
+    purchaseUrl: row.purchase_url,
+    verifiedCount: Number(row.verified_count ?? 0),
+    viewerHasEndorsed: Boolean(row.viewer_has_endorsed),
+  };
+}
+
+// Single shared reader list: active problems that have at least one approved product,
+// each with the approved products beneath it. `viewerId` toggles the per-row endorsed flag.
+export async function getReaderList(viewerId: string | null): Promise<WhatWorksList> {
+  const problemsResult = await queryDb<ProblemProjectionRow>(
+    `SELECT id, slug, emoji, title, context
+       FROM whatworks_problems
+      WHERE is_active = TRUE
+      ORDER BY sort_order ASC, created_at ASC`,
+  );
+
+  const productsResult = await queryDb<ProductProjectionRow>(
+    `SELECT
+        p.id, p.problem_id, p.emoji, p.name, p.kind, p.note, p.purchase_url,
+        (SELECT COUNT(*) FROM whatworks_endorsements e WHERE e.product_id = p.id)::int AS verified_count,
+        CASE
+          WHEN $1::text IS NULL THEN FALSE
+          ELSE EXISTS (
+            SELECT 1 FROM whatworks_endorsements e
+             WHERE e.product_id = p.id AND e.user_id = $1
+          )
+        END AS viewer_has_endorsed
+       FROM whatworks_products p
+       JOIN whatworks_problems pr ON pr.id = p.problem_id
+      WHERE p.status = 'approved' AND pr.is_active = TRUE
+      ORDER BY p.created_at ASC`,
+    [viewerId],
+  );
+
+  const productsByProblem = new Map<string, WhatWorksPublicProduct[]>();
+  for (const row of productsResult.rows) {
+    const list = productsByProblem.get(row.problem_id) ?? [];
+    list.push(toPublicProduct(row));
+    productsByProblem.set(row.problem_id, list);
+  }
+
+  const problems: WhatWorksPublicProblem[] = [];
+  let verifiedTools = 0;
+  for (const problem of problemsResult.rows) {
+    const products = productsByProblem.get(problem.id) ?? [];
+    if (products.length === 0) {
+      continue;
+    }
+    verifiedTools += products.length;
+    problems.push({
+      id: problem.id,
+      slug: problem.slug,
+      emoji: problem.emoji,
+      title: problem.title,
+      context: problem.context,
+      products,
+    });
+  }
+
+  const stats = await getListStats(problems.length, verifiedTools);
+  return { problems, stats };
+}
+
+async function getListStats(problemCount: number, verifiedTools: number): Promise<WhatWorksListStats> {
+  // "Survivors helped" is the total number of times a survivor marked an approved tool as
+  // helping them (the sum of every tool's verified count), matching the design's headline metric.
+  const helped = await queryDb<{ survivors_helped: number }>(
+    `SELECT COUNT(*)::int AS survivors_helped
+       FROM whatworks_endorsements e
+       JOIN whatworks_products p ON p.id = e.product_id
+       JOIN whatworks_problems pr ON pr.id = p.problem_id
+      WHERE p.status = 'approved' AND pr.is_active = TRUE`,
+  );
+  return {
+    problems: problemCount,
+    verifiedTools,
+    survivorsHelped: Number(helped.rows[0]?.survivors_helped ?? 0),
+  };
+}
+
+export async function listActiveProblems(): Promise<WhatWorksProblem[]> {
+  const result = await queryDb<WhatWorksProblem>(
+    `SELECT * FROM whatworks_problems
+      WHERE is_active = TRUE
+      ORDER BY sort_order ASC, created_at ASC`,
+  );
+  return result.rows;
+}
+
+export async function getProblemById(id: string): Promise<WhatWorksProblem | null> {
+  const result = await queryDb<WhatWorksProblem>(
+    'SELECT * FROM whatworks_problems WHERE id = $1 LIMIT 1',
+    [id],
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function getProductById(id: string): Promise<WhatWorksProduct | null> {
+  const result = await queryDb<WhatWorksProduct>(
+    'SELECT * FROM whatworks_products WHERE id = $1 LIMIT 1',
+    [id],
+  );
+  return result.rows[0] ?? null;
+}
+
+// Suggesting records the product as pending review and auto-counts the suggester as
+// its first verifier (they used it and said it helped).
+export async function suggestProduct(input: SuggestProductInput): Promise<WhatWorksProduct> {
+  return withDbTransaction(async (client) => {
+    const inserted = await client.query<WhatWorksProduct>(
+      `INSERT INTO whatworks_products
+         (problem_id, emoji, name, kind, note, purchase_url, status, suggested_by)
+       VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7)
+       RETURNING *`,
+      [
+        input.problemId,
+        input.emoji ?? '',
+        input.name,
+        input.kind ?? '',
+        input.note ?? '',
+        input.purchaseUrl,
+        input.suggestedBy,
+      ],
+    );
+    const product = inserted.rows[0];
+    await client.query(
+      `INSERT INTO whatworks_endorsements (product_id, user_id)
+       VALUES ($1, $2)
+       ON CONFLICT (product_id, user_id) DO NOTHING`,
+      [product.id, input.suggestedBy],
+    );
+    return product;
+  });
+}
+
+export async function addEndorsement(productId: string, userId: string): Promise<void> {
+  await queryDb(
+    `INSERT INTO whatworks_endorsements (product_id, user_id)
+     VALUES ($1, $2)
+     ON CONFLICT (product_id, user_id) DO NOTHING`,
+    [productId, userId],
+  );
+}
+
+export async function removeEndorsement(productId: string, userId: string): Promise<void> {
+  await queryDb(
+    'DELETE FROM whatworks_endorsements WHERE product_id = $1 AND user_id = $2',
+    [productId, userId],
+  );
+}
+
+export async function getProductEndorsementState(
+  productId: string,
+  userId: string | null,
+): Promise<{ verifiedCount: number; viewerHasEndorsed: boolean }> {
+  const result = await queryDb<{ verified_count: number; viewer_has_endorsed: boolean }>(
+    `SELECT
+        (SELECT COUNT(*) FROM whatworks_endorsements e WHERE e.product_id = $1)::int AS verified_count,
+        CASE
+          WHEN $2::text IS NULL THEN FALSE
+          ELSE EXISTS (SELECT 1 FROM whatworks_endorsements e WHERE e.product_id = $1 AND e.user_id = $2)
+        END AS viewer_has_endorsed`,
+    [productId, userId],
+  );
+  const row = result.rows[0];
+  return {
+    verifiedCount: Number(row?.verified_count ?? 0),
+    viewerHasEndorsed: Boolean(row?.viewer_has_endorsed),
+  };
+}
+
+export async function listAdminProblems(): Promise<WhatWorksAdminProblem[]> {
+  const result = await queryDb<WhatWorksProblem & {
+    product_count: number;
+    approved_count: number;
+    pending_count: number;
+  }>(
+    `SELECT
+        pr.*,
+        COUNT(p.id)::int AS product_count,
+        COUNT(p.id) FILTER (WHERE p.status = 'approved')::int AS approved_count,
+        COUNT(p.id) FILTER (WHERE p.status = 'pending')::int AS pending_count
+       FROM whatworks_problems pr
+       LEFT JOIN whatworks_products p ON p.problem_id = pr.id
+      GROUP BY pr.id
+      ORDER BY pr.sort_order ASC, pr.created_at ASC`,
+  );
+  return result.rows.map((row) => ({
+    ...row,
+    productCount: Number(row.product_count ?? 0),
+    approvedCount: Number(row.approved_count ?? 0),
+    pendingCount: Number(row.pending_count ?? 0),
+  }));
+}
+
+export async function createProblem(input: CreateProblemInput): Promise<WhatWorksProblem> {
+  const slug = await ensureUniqueSlug(slugifyTitle(input.title));
+  const result = await queryDb<WhatWorksProblem>(
+    `INSERT INTO whatworks_problems (slug, emoji, title, context, sort_order, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [slug, input.emoji ?? '', input.title, input.context ?? '', input.sortOrder ?? 0, input.createdBy],
+  );
+  return result.rows[0];
+}
+
+export async function updateProblem(
+  id: string,
+  patch: UpdateProblemInput,
+): Promise<WhatWorksProblem | null> {
+  const result = await queryDb<WhatWorksProblem>(
+    `UPDATE whatworks_problems
+        SET emoji = COALESCE($2, emoji),
+            title = COALESCE($3, title),
+            context = COALESCE($4, context),
+            sort_order = COALESCE($5, sort_order),
+            is_active = COALESCE($6, is_active),
+            updated_at = NOW()
+      WHERE id = $1
+      RETURNING *`,
+    [
+      id,
+      patch.emoji ?? null,
+      patch.title ?? null,
+      patch.context ?? null,
+      patch.sortOrder ?? null,
+      patch.isActive ?? null,
+    ],
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function deleteProblem(id: string): Promise<boolean> {
+  const result = await queryDb('DELETE FROM whatworks_problems WHERE id = $1', [id]);
+  return (result.rowCount ?? 0) > 0;
+}
+
+export async function listAdminProducts(
+  status?: WhatWorksProduct['status'],
+): Promise<WhatWorksAdminProduct[]> {
+  const result = await queryDb<{
+    id: string;
+    problem_id: string;
+    problem_title: string;
+    emoji: string;
+    name: string;
+    kind: string;
+    note: string;
+    purchase_url: string;
+    status: WhatWorksProduct['status'];
+    verified_count: number;
+    created_at: string;
+    reviewed_at: string | null;
+    rejection_reason: string | null;
+  }>(
+    `SELECT
+        p.id, p.problem_id, pr.title AS problem_title,
+        p.emoji, p.name, p.kind, p.note, p.purchase_url, p.status,
+        (SELECT COUNT(*) FROM whatworks_endorsements e WHERE e.product_id = p.id)::int AS verified_count,
+        p.created_at, p.reviewed_at, p.rejection_reason
+       FROM whatworks_products p
+       JOIN whatworks_problems pr ON pr.id = p.problem_id
+      WHERE ($1::text IS NULL OR p.status = $1)
+      ORDER BY
+        CASE WHEN p.status = 'pending' THEN 0 ELSE 1 END ASC,
+        p.created_at DESC`,
+    [status ?? null],
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    problemId: row.problem_id,
+    problemTitle: row.problem_title,
+    emoji: row.emoji,
+    name: row.name,
+    kind: row.kind,
+    note: row.note,
+    purchaseUrl: row.purchase_url,
+    status: row.status,
+    verifiedCount: Number(row.verified_count ?? 0),
+    createdAt: row.created_at,
+    reviewedAt: row.reviewed_at,
+    rejectionReason: row.rejection_reason,
+  }));
+}
+
+export async function reviewProduct(
+  id: string,
+  input: ReviewProductInput,
+): Promise<WhatWorksProduct | null> {
+  const nextStatus = input.action === 'approve' ? 'approved' : 'rejected';
+  const result = await queryDb<WhatWorksProduct>(
+    `UPDATE whatworks_products
+        SET status = $2,
+            reviewed_by = $3,
+            reviewed_at = NOW(),
+            rejection_reason = $4,
+            updated_at = NOW()
+      WHERE id = $1
+      RETURNING *`,
+    [id, nextStatus, input.reviewerId, input.action === 'reject' ? input.rejectionReason ?? null : null],
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function deleteProduct(id: string): Promise<boolean> {
+  const result = await queryDb('DELETE FROM whatworks_products WHERE id = $1', [id]);
+  return (result.rowCount ?? 0) > 0;
+}

--- a/ctf/packages/web/lib/whatworks/types.ts
+++ b/ctf/packages/web/lib/whatworks/types.ts
@@ -1,0 +1,120 @@
+export type WhatWorksProductStatus = 'pending' | 'approved' | 'rejected';
+
+// Raw storage rows
+export type WhatWorksProblem = {
+  id: string;
+  slug: string;
+  emoji: string;
+  title: string;
+  context: string;
+  sort_order: number;
+  is_active: boolean;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WhatWorksProduct = {
+  id: string;
+  problem_id: string;
+  emoji: string;
+  name: string;
+  kind: string;
+  note: string;
+  purchase_url: string;
+  status: WhatWorksProductStatus;
+  suggested_by: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  rejection_reason: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+// Reader projection — never exposes submitter identity (anonymity promise).
+export type WhatWorksPublicProduct = {
+  id: string;
+  emoji: string;
+  name: string;
+  kind: string;
+  note: string;
+  purchaseUrl: string;
+  verifiedCount: number;
+  viewerHasEndorsed: boolean;
+};
+
+export type WhatWorksPublicProblem = {
+  id: string;
+  slug: string;
+  emoji: string;
+  title: string;
+  context: string;
+  products: WhatWorksPublicProduct[];
+};
+
+export type WhatWorksListStats = {
+  problems: number;
+  verifiedTools: number;
+  survivorsHelped: number;
+};
+
+export type WhatWorksList = {
+  problems: WhatWorksPublicProblem[];
+  stats: WhatWorksListStats;
+};
+
+// Admin projections
+export type WhatWorksAdminProblem = WhatWorksProblem & {
+  productCount: number;
+  approvedCount: number;
+  pendingCount: number;
+};
+
+export type WhatWorksAdminProduct = {
+  id: string;
+  problemId: string;
+  problemTitle: string;
+  emoji: string;
+  name: string;
+  kind: string;
+  note: string;
+  purchaseUrl: string;
+  status: WhatWorksProductStatus;
+  verifiedCount: number;
+  createdAt: string;
+  reviewedAt: string | null;
+  rejectionReason: string | null;
+};
+
+// Inputs
+export type SuggestProductInput = {
+  problemId: string;
+  name: string;
+  purchaseUrl: string;
+  emoji?: string;
+  kind?: string;
+  note?: string;
+  suggestedBy: string;
+};
+
+export type CreateProblemInput = {
+  emoji?: string;
+  title: string;
+  context?: string;
+  sortOrder?: number;
+  createdBy: string;
+};
+
+export type UpdateProblemInput = {
+  emoji?: string;
+  title?: string;
+  context?: string;
+  sortOrder?: number;
+  isActive?: boolean;
+};
+
+export type ReviewProductInput = {
+  action: 'approve' | 'reject';
+  reviewerId: string;
+  rejectionReason?: string;
+};

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -13,6 +13,83 @@ CREATE INDEX IF NOT EXISTS idx_clicklog_incidents_user_id ON clicklog_incidents(
 CREATE INDEX IF NOT EXISTS idx_clicklog_incidents_created_at ON clicklog_incidents(created_at DESC);
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
+-- === WHAT WORKS (survivor-verified shared tool list, organized by problem) ===
+-- One shared, community-wide list. Problems are admin-curated categories; products are
+-- survivor-suggested tools reviewed (pending -> approved) before they appear. Endorsements
+-- are the "this helped me" signal whose count renders as "N survivors verified". The
+-- suggester's identity is stored for moderation/abuse control only and is never exposed in
+-- any reader or admin projection (the anonymity promise on the suggest flow).
+CREATE TABLE IF NOT EXISTS whatworks_problems (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL,
+  emoji TEXT NOT NULL DEFAULT '',
+  title TEXT NOT NULL,
+  context TEXT NOT NULL DEFAULT '',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS id UUID;
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS slug TEXT;
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS emoji TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS context TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS created_by TEXT;
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS whatworks_problems ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE UNIQUE INDEX IF NOT EXISTS idx_whatworks_problems_slug ON whatworks_problems(slug);
+CREATE INDEX IF NOT EXISTS idx_whatworks_problems_active_sort ON whatworks_problems(is_active, sort_order);
+
+CREATE TABLE IF NOT EXISTS whatworks_products (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  problem_id UUID NOT NULL REFERENCES whatworks_problems(id) ON DELETE CASCADE,
+  emoji TEXT NOT NULL DEFAULT '',
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT '',
+  note TEXT NOT NULL DEFAULT '',
+  purchase_url TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','approved','rejected')),
+  suggested_by TEXT,
+  reviewed_by TEXT,
+  reviewed_at TIMESTAMPTZ,
+  rejection_reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS id UUID;
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS problem_id UUID;
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS emoji TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS name TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS note TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS purchase_url TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS suggested_by TEXT;
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS reviewed_by TEXT;
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS rejection_reason TEXT;
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS whatworks_products ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE INDEX IF NOT EXISTS idx_whatworks_products_problem ON whatworks_products(problem_id);
+CREATE INDEX IF NOT EXISTS idx_whatworks_products_status ON whatworks_products(status);
+
+CREATE TABLE IF NOT EXISTS whatworks_endorsements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id UUID NOT NULL REFERENCES whatworks_products(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS whatworks_endorsements ADD COLUMN IF NOT EXISTS id UUID;
+ALTER TABLE IF EXISTS whatworks_endorsements ADD COLUMN IF NOT EXISTS product_id UUID;
+ALTER TABLE IF EXISTS whatworks_endorsements ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE IF EXISTS whatworks_endorsements ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE INDEX IF NOT EXISTS idx_whatworks_endorsements_product ON whatworks_endorsements(product_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_whatworks_endorsements_unique ON whatworks_endorsements(product_id, user_id);
+
 -- === currencies (app-wide reference table; see issue #120) ===
 -- Curated catalog of currencies usable across value-bearing plugins. Defined early so any table
 -- that FK-references currencies(code) (LightHouse rent, Foundation provider rate, TrustTransport,
@@ -1523,7 +1600,8 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('weekly-performance', 'Weekly Performance',   'Week selection/guardrails with metrics, comparisons, and export gate checks.',                    'implemented_shell', 140, TRUE),
   ('gdp',                'GDP',                  'Aggregate transparency and admin publish flows with compliance controls.',                        'implemented_shell', 150, TRUE),
   ('service-credits',    'Service Credits',      'Wallet/transfers/escrow/disputes and treasury governance workflows.',                             'implemented_shell', 160, TRUE),
-  ('levelup',            'LevelUp',              'Flexible training cohorts with milestone escrow release, trainer payouts, stipends, and disputes.','implemented_shell', 170, TRUE)
+  ('levelup',            'LevelUp',              'Flexible training cohorts with milestone escrow release, trainer payouts, stipends, and disputes.','implemented_shell', 170, TRUE),
+  ('whatworks',          'WhatWorks',            'One shared, survivor-verified list of tools that solved a specific problem, with admin-curated problems and reviewed suggestions.','implemented_shell', 200, TRUE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,
   summary            = EXCLUDED.summary,

--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -777,7 +777,7 @@ async function seedWhatworks(c) {
            (id, problem_id, emoji, name, kind, note, purchase_url, status, suggested_by, reviewed_by, reviewed_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, 'approved', $8, $9, NOW())
          ON CONFLICT (id) DO NOTHING`,
-        [productId, problemId, product.emoji, product.name, product.kind, product.note, `https://www.amazon.com/s?k=${encodeURIComponent(product.name)}`, endorsers[0], OWNER],
+        [productId, problemId, product.emoji, product.name, product.kind, product.note, `https://duckduckgo.com/?q=${encodeURIComponent(product.name)}`, endorsers[0], OWNER],
       );
       for (let index = 0; index < product.verified; index += 1) {
         await c.query(

--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -729,6 +729,70 @@ async function seedClicklog(c) {
   console.log('  ✓ clicklog');
 }
 
+async function seedWhatworks(c) {
+  const endorsers = [OWNER, PEER_1, PEER_2, 'demo-ww-001', 'demo-ww-002', 'demo-ww-003'];
+  const problems = [
+    {
+      slug: 'noise-verbal-harassment', emoji: '🎧', title: 'Noise & Verbal Harassment',
+      context: 'Slurs through the wall, street harassment, or constant noise meant to wear you down.',
+      products: [
+        { emoji: '🎧', name: 'Sony WH-1000XM5', kind: 'Over-ear · active noise cancelling', note: 'Blocks voices, not just hum. The only thing that quieted the through-wall talking for me.', verified: 6 },
+        { emoji: '🔇', name: 'Loop Quiet 2', kind: 'Reusable ear plugs', note: 'Discreet and comfortable enough to sleep in. Takes the edge off without total silence.', verified: 4 },
+        { emoji: '🎵', name: 'JLab Go Air Pop', kind: 'Budget ANC earbuds', note: 'Cheap, pocketable, and good enough to get me through a shift.', verified: 3 },
+      ],
+    },
+    {
+      slug: 'sleep-disruption', emoji: '🌙', title: 'Sleep Disruption',
+      context: 'Noise, light, or hypervigilance keeping you up at night.',
+      products: [
+        { emoji: '🌑', name: 'Manta Sleep Mask', kind: 'Blackout eye mask', note: 'Zero pressure on the eyes, total darkness. First full night of sleep in months.', verified: 5 },
+        { emoji: '🌬️', name: 'Yogasleep Dohm', kind: 'White noise machine', note: 'A real fan inside, not a loop. Masks footsteps and voices outside the door.', verified: 4 },
+      ],
+    },
+    {
+      slug: 'vehicle-tampering', emoji: '🚗', title: 'Vehicle Tampering',
+      context: 'Worried about hidden trackers or tampering on your car.',
+      products: [
+        { emoji: '📡', name: 'GPS Tracker Detector', kind: 'RF bug sweeper', note: 'Found a tracker tucked under my bumper in about ten minutes.', verified: 3 },
+        { emoji: '🛞', name: 'Tire Pressure Monitor', kind: 'Solar cap sensors (TPMS)', note: 'Catches slow leaks before they strand me somewhere at night.', verified: 2 },
+      ],
+    },
+  ];
+
+  let sortOrder = 0;
+  for (const problem of problems) {
+    const problemId = sha256id('whatworks-problem', problem.slug);
+    await c.query(
+      `INSERT INTO whatworks_problems (id, slug, emoji, title, context, sort_order, is_active, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, TRUE, $7)
+       ON CONFLICT (id) DO NOTHING`,
+      [problemId, problem.slug, problem.emoji, problem.title, problem.context, sortOrder, OWNER],
+    );
+    sortOrder += 1;
+
+    for (const product of problem.products) {
+      const productId = sha256id('whatworks-product', problem.slug, product.name);
+      await c.query(
+        `INSERT INTO whatworks_products
+           (id, problem_id, emoji, name, kind, note, purchase_url, status, suggested_by, reviewed_by, reviewed_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'approved', $8, $9, NOW())
+         ON CONFLICT (id) DO NOTHING`,
+        [productId, problemId, product.emoji, product.name, product.kind, product.note, `https://www.amazon.com/s?k=${encodeURIComponent(product.name)}`, endorsers[0], OWNER],
+      );
+      for (let index = 0; index < product.verified; index += 1) {
+        await c.query(
+          `INSERT INTO whatworks_endorsements (id, product_id, user_id)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (product_id, user_id) DO NOTHING`,
+          [sha256id('whatworks-endorsement', productId, endorsers[index % endorsers.length]), productId, endorsers[index % endorsers.length]],
+        );
+      }
+    }
+  }
+
+  console.log('  ✓ whatworks');
+}
+
 async function main() {
   const connStr =
     process.env.DATABASE_URL_DIRECT ||

--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -830,6 +830,7 @@ async function main() {
     await seedSkillsTaxonomy(client);
     await seedSocketRelay(client);
     await seedClicklog(client);
+    await seedWhatworks(client);
 
     await client.query('COMMIT');
     console.log(`\nDemo schema seeded successfully for ${OWNER}.`);

--- a/ctf/scripts/seedWhatworks.mjs
+++ b/ctf/scripts/seedWhatworks.mjs
@@ -1,0 +1,112 @@
+import { queryDb } from '../packages/web/lib/db/postgres.ts';
+import crypto from 'crypto';
+
+// Deterministic, idempotent seed for the WhatWorks shared list. Mirrors the design sample so a
+// fresh DB renders the exact populated mockup: 3 problems, 7 approved tools, 27 endorsements
+// (sum of per-tool verified counts === the design's "Survivors helped" headline of 27).
+
+const SEED_USER_POOL = [
+  'whatworks-seed-user-001',
+  'whatworks-seed-user-002',
+  'whatworks-seed-user-003',
+  'whatworks-seed-user-004',
+  'whatworks-seed-user-005',
+  'whatworks-seed-user-006',
+];
+const SEED_ADMIN = 'whatworks-seed-admin';
+
+function det(label) {
+  const hex = crypto.createHash('sha256').update(label).digest('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+function amazon(name) {
+  return `https://www.amazon.com/s?k=${encodeURIComponent(name)}`;
+}
+
+const PROBLEMS = [
+  {
+    slug: 'noise-verbal-harassment',
+    emoji: '🎧',
+    title: 'Noise & Verbal Harassment',
+    context: 'Slurs through the wall, street harassment, or constant noise meant to wear you down.',
+    products: [
+      { emoji: '🎧', name: 'Sony WH-1000XM5', kind: 'Over-ear · active noise cancelling', note: 'Blocks voices, not just hum. The only thing that quieted the through-wall talking for me.', verified: 6 },
+      { emoji: '🔇', name: 'Loop Quiet 2', kind: 'Reusable ear plugs', note: 'Discreet and comfortable enough to sleep in. Takes the edge off without total silence.', verified: 4 },
+      { emoji: '🎵', name: 'JLab Go Air Pop', kind: 'Budget ANC earbuds', note: 'Cheap, pocketable, and good enough to get me through a shift.', verified: 3 },
+    ],
+  },
+  {
+    slug: 'sleep-disruption',
+    emoji: '🌙',
+    title: 'Sleep Disruption',
+    context: 'Noise, light, or hypervigilance keeping you up at night.',
+    products: [
+      { emoji: '🌑', name: 'Manta Sleep Mask', kind: 'Blackout eye mask', note: 'Zero pressure on the eyes, total darkness. First full night of sleep in months.', verified: 5 },
+      { emoji: '🌬️', name: 'Yogasleep Dohm', kind: 'White noise machine', note: 'A real fan inside, not a loop. Masks footsteps and voices outside the door.', verified: 4 },
+    ],
+  },
+  {
+    slug: 'vehicle-tampering',
+    emoji: '🚗',
+    title: 'Vehicle Tampering',
+    context: 'Worried about hidden trackers or tampering on your car.',
+    products: [
+      { emoji: '📡', name: 'GPS Tracker Detector', kind: 'RF bug sweeper', note: 'Found a tracker tucked under my bumper in about ten minutes.', verified: 3 },
+      { emoji: '🛞', name: 'Tire Pressure Monitor', kind: 'Solar cap sensors (TPMS)', note: 'Catches slow leaks before they strand me somewhere at night.', verified: 2 },
+    ],
+  },
+];
+
+async function seed() {
+  await queryDb('BEGIN');
+  try {
+    let sortOrder = 0;
+    for (const problem of PROBLEMS) {
+      const problemId = det(`whatworks-problem-${problem.slug}`);
+      await queryDb(
+        `INSERT INTO whatworks_problems (id, slug, emoji, title, context, sort_order, is_active, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, TRUE, $7)
+         ON CONFLICT (id) DO NOTHING`,
+        [problemId, problem.slug, problem.emoji, problem.title, problem.context, sortOrder, SEED_ADMIN],
+      );
+      sortOrder += 1;
+
+      for (const product of problem.products) {
+        const productId = det(`whatworks-product-${problem.slug}-${product.name}`);
+        await queryDb(
+          `INSERT INTO whatworks_products
+             (id, problem_id, emoji, name, kind, note, purchase_url, status, suggested_by, reviewed_by, reviewed_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, 'approved', $8, $9, NOW())
+           ON CONFLICT (id) DO NOTHING`,
+          [productId, problemId, product.emoji, product.name, product.kind, product.note, amazon(product.name), SEED_USER_POOL[0], SEED_ADMIN],
+        );
+
+        for (let index = 0; index < product.verified; index += 1) {
+          const userId = SEED_USER_POOL[index % SEED_USER_POOL.length];
+          await queryDb(
+            `INSERT INTO whatworks_endorsements (id, product_id, user_id)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (product_id, user_id) DO NOTHING`,
+            [det(`whatworks-endorsement-${productId}-${userId}`), productId, userId],
+          );
+        }
+      }
+    }
+
+    await queryDb('COMMIT');
+    console.log('Seeded WhatWorks problems, tools, and endorsements.');
+  } catch (err) {
+    try {
+      await queryDb('ROLLBACK');
+    } catch (rollbackErr) {
+      console.error('Rollback failed:', rollbackErr);
+    }
+    throw err;
+  }
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ctf/scripts/seedWhatworks.mjs
+++ b/ctf/scripts/seedWhatworks.mjs
@@ -20,8 +20,8 @@ function det(label) {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
-function amazon(name) {
-  return `https://www.amazon.com/s?k=${encodeURIComponent(name)}`;
+function searchUrl(name) {
+  return `https://duckduckgo.com/?q=${encodeURIComponent(name)}`;
 }
 
 const PROBLEMS = [
@@ -79,7 +79,7 @@ async function seed() {
              (id, problem_id, emoji, name, kind, note, purchase_url, status, suggested_by, reviewed_by, reviewed_at)
            VALUES ($1, $2, $3, $4, $5, $6, $7, 'approved', $8, $9, NOW())
            ON CONFLICT (id) DO NOTHING`,
-          [productId, problemId, product.emoji, product.name, product.kind, product.note, amazon(product.name), SEED_USER_POOL[0], SEED_ADMIN],
+          [productId, problemId, product.emoji, product.name, product.kind, product.note, searchUrl(product.name), SEED_USER_POOL[0], SEED_ADMIN],
         );
 
         for (let index = 0; index < product.verified; index += 1) {

--- a/ctf/scripts/seedWhatworks.mjs
+++ b/ctf/scripts/seedWhatworks.mjs
@@ -1,9 +1,28 @@
-import { queryDb } from '../packages/web/lib/db/postgres.ts';
+#!/usr/bin/env node
+
+import { Pool } from 'pg';
 import crypto from 'crypto';
 
 // Deterministic, idempotent seed for the WhatWorks shared list. Mirrors the design sample so a
 // fresh DB renders the exact populated mockup: 3 problems, 7 approved tools, 27 endorsements
 // (sum of per-tool verified counts === the design's "Survivors helped" headline of 27).
+//
+// Uses a self-contained pg Pool + a single client-bound transaction (the canonical seed pattern,
+// like seedFoundation/seedSocketRelay) so every statement runs atomically on one connection and
+// the script loads under plain `node` without a TypeScript loader.
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+const pool = new Pool({
+  connectionString: requireEnv('DATABASE_URL'),
+  ssl: { rejectUnauthorized: false },
+});
 
 const SEED_USER_POOL = [
   'whatworks-seed-user-001',
@@ -58,13 +77,15 @@ const PROBLEMS = [
   },
 ];
 
-async function seed() {
-  await queryDb('BEGIN');
+async function main() {
+  const client = await pool.connect();
   try {
+    await client.query('BEGIN');
+
     let sortOrder = 0;
     for (const problem of PROBLEMS) {
       const problemId = det(`whatworks-problem-${problem.slug}`);
-      await queryDb(
+      await client.query(
         `INSERT INTO whatworks_problems (id, slug, emoji, title, context, sort_order, is_active, created_by)
          VALUES ($1, $2, $3, $4, $5, $6, TRUE, $7)
          ON CONFLICT (id) DO NOTHING`,
@@ -74,7 +95,7 @@ async function seed() {
 
       for (const product of problem.products) {
         const productId = det(`whatworks-product-${problem.slug}-${product.name}`);
-        await queryDb(
+        await client.query(
           `INSERT INTO whatworks_products
              (id, problem_id, emoji, name, kind, note, purchase_url, status, suggested_by, reviewed_by, reviewed_at)
            VALUES ($1, $2, $3, $4, $5, $6, $7, 'approved', $8, $9, NOW())
@@ -84,7 +105,7 @@ async function seed() {
 
         for (let index = 0; index < product.verified; index += 1) {
           const userId = SEED_USER_POOL[index % SEED_USER_POOL.length];
-          await queryDb(
+          await client.query(
             `INSERT INTO whatworks_endorsements (id, product_id, user_id)
              VALUES ($1, $2, $3)
              ON CONFLICT (product_id, user_id) DO NOTHING`,
@@ -94,19 +115,20 @@ async function seed() {
       }
     }
 
-    await queryDb('COMMIT');
+    await client.query('COMMIT');
     console.log('Seeded WhatWorks problems, tools, and endorsements.');
   } catch (err) {
-    try {
-      await queryDb('ROLLBACK');
-    } catch (rollbackErr) {
+    await client.query('ROLLBACK').catch((rollbackErr) => {
       console.error('Rollback failed:', rollbackErr);
-    }
+    });
     throw err;
+  } finally {
+    client.release();
+    await pool.end();
   }
 }
 
-seed().catch((err) => {
+main().catch((err) => {
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

Implements the WhatWorks plugin — a single shared, community-wide list of survivor-verified tools organized by problem category. Survivors can browse approved tools, mark items as helpful, and suggest new tools for admin review. Admins curate problem categories and moderate suggestions before they appear on the shared list.

**Key features:**
- Authenticated reader list with per-viewer endorsement state
- Public teaser preview (identity-free, sign-in-free)
- Survivor suggestion flow (pending review before approval)
- Admin moderation queue and problem curation interface
- Mobile support (Android/iOS tabs for list and suggest)
- Full anonymity guarantee: suggester identity never exposed to readers

**Surfaces:**
- `/apps/whatworks` — authenticated app shell
- `/plugin/whatworks` — permanently public preview
- `/admin/whatworks` — admin moderation and curation
- `/api/whatworks/*` — backend routes
- Mobile: `packages/mobile/src/features/whatworks`

## Parity

Parity Status: web+android complete

- Design: `design/` submodule updated with WhatWorks mockups (pinned at 12c6293)

## Testing

- [x] Web tested (list read, suggest, endorse, admin flows)
- [x] Android tested (WhatWorksList, WhatWorksSuggest tabs)
- [x] Accessibility checks completed (semantic HTML, icon labels, keyboard nav)

## Compliance

- [x] Privacy/security impact reviewed
  - Suggester identity stored for moderation only, never exposed in any reader/admin projection
  - Endorsements deduplicated per user via canonical profile
  - CSRF protection on all mutations
  - Admin-only routes gated via `requireWhatWorksAdminAccess()`
- [x] No sensitive data exposed in logs/telemetry
  - User IDs only stored for moderation/abuse control
  - Public projections strip all identity

## Modularity Governance

- [x] Changed files respect responsibility boundaries
  - `lib/whatworks/repository.ts` — data access layer
  - `lib/whatworks/policy.ts` — authorization rules
  - `lib/whatworks/types.ts` — shared type definitions
  - `lib/whatworks/constants.ts` — validation limits
  - `components/whatworks/ww-*.tsx` — UI components (shell, sidebar, cards, admin panels)
  - `app/api/whatworks/*` — API routes (read, suggest, endorse, admin)
  - `packages/mobile/src/features/whatworks/` — mobile feature
- [x] Complexity gates pass
  - Repository functions: single responsibility (list, suggest, endorse, review, curate)
  - Components: focused on layout/presentation; state management in shell
  - API routes: thin wrappers around repository + policy checks
- [x] Tightly-coupled helpers remain in-file with justification
  - `slugifyTitle()` and `ensureUniqueSlug()` in repository (problem slug generation)
  - `matches()` and `filterProblems()` in shell (client-side search)
  - `toPublicProduct()` in repository (projection helper)

## Schema & Seed

- Added `whatworks_problems`, `whatworks_products`, `whatworks_endorsements` tables
- Deterministic seed script (`scripts/seedWhatworks.mjs`) mirrors design mockup (3 problems, 7 approved tools, 27 endorsements)
- Demo seed integration in `seedDemo.mjs`

## Contracts

- Command contracts: `WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml`
- Access policy: `WHATWORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml`
- Audit contracts: `WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml`
- Profile/deletion: `WHATWORKS_PROFILE_AND_DELETION_CONTRACT.md`

https://claude.ai/code/session_01E8MGvBbuCepR6ruNrihAum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced WhatWorks — a survivor-verified tools & resources platform
  * Browse curated problem categories and tool cards on web and mobile
  * Submit suggestions for new tools and view a public preview without signing in
  * Endorse helpful items to increase community verification counts
  * Mobile: list and suggest screens with bottom-tab navigation
  * Admin: moderation UI for reviewing suggestions and managing problem categories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->