### PR TITLE
fix: exclude design/ submodule from EOF format check

### DIFF
--- a/ctf/scripts/check-eof-format.sh
+++ b/ctf/scripts/check-eof-format.sh
@@ -33,6 +33,7 @@ done < <(find . -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -nam
   -not -path "./coverage/*" \
   -not -path "./.turbo/*" \
   -not -path "./.pnpm-store/*" \
+  -not -path "./design/*" \
   -not -path "*/node_modules/*" \
   -not -path "*/.next/*" \
   -not -path "*/dist/*" \


### PR DESCRIPTION
## Summary

`ctf/scripts/check-eof-format.sh` scans the whole working tree for single-trailing-newline compliance but only excluded build/dependency dirs (`node_modules`, `.next`, `dist`, …) — **not the `design/` submodule**. The submodule is a separately-versioned repo (its own remote) containing files that don't satisfy this repo's EOF rule (`design/sync-manifest.json`, `design/pnpm-workspace.yaml`, `design/lib/api-spec/openapi.yaml`, `design/lib/db/src/schema/index.ts`, and several `components.json` / `index.css` files).

When CI checks out with the submodule populated, the **Formatting EOF** gate failed on those 8 files for **every PR**, regardless of the PR's own content — a false positive on files outside this repo's enforcement scope. (It passed intermittently only when the submodule happened to be absent, which is why the gate appeared flaky.)

## Fix

Add `-not -path "./design/*"` to the `find` invocation so the check covers only files this repo owns.

## Verification

- With the `design/` submodule **populated**: `check-eof-format.sh` now exits 0 (previously exited 1 on the 8 submodule files).
- Still catches real violations: a temporary missing-newline file under `ctf/packages/web/` is correctly flagged.
- Single-file change to the script; no app code touched.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_