### PR TITLE
fix: apply demo schema before seeding so the seed can't go stale

### DIFF
--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -28,6 +28,29 @@ jobs:
           cd ctf
           pnpm install
 
+      - name: Regenerate schema.demo.sql from schema.sql
+        run: node ctf/scripts/generateDemoSchema.mjs
+
+      - name: Install psql client
+        run: sudo apt-get install -y postgresql-client
+
+      - name: Bring the demo schema up to date
+        env:
+          DATABASE_URL_DIRECT: ${{ secrets.DATABASE_URL_DIRECT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          DB="${DATABASE_URL_DIRECT:-$DATABASE_URL}"
+          if [ -z "$DB" ]; then
+            echo "DATABASE_URL_DIRECT or DATABASE_URL secret is not set."
+            exit 1
+          fi
+          # Re-applying is safe: every statement uses IF NOT EXISTS / IF EXISTS
+          # guards. This makes sure the demo schema has every table, column, and
+          # constraint the seed relies on (for example the unique keys the seed
+          # upserts against) before we try to seed it.
+          psql "$DB" -v ON_ERROR_STOP=1 -f ctf/schema.demo.sql
+          echo "Demo schema is up to date."
+
       - name: Run demo seed
         env:
           DATABASE_URL_DIRECT: ${{ secrets.DATABASE_URL_DIRECT }}


### PR DESCRIPTION
## Why the seed kept failing

Even after the LevelUp unique keys merged (#216), the **Seed demo schema** workflow still failed at the same spot:

> there is no unique or exclusion constraint matching the ON CONFLICT specification

The reason: that workflow only ran `seedDemo.mjs` against whatever schema already lived in Neon. It never applied the schema. The live `demo` schema was provisioned before the unique keys existed, so it was missing them — and re-running the seed alone could never fix that, because nothing brought the schema up to date. The separate "Provision demo schema" workflow had to be run by hand first, which is easy to forget (and is exactly what happened here twice).

## The change

Add steps to the seed workflow, before the seed runs, that:

1. Regenerate `schema.demo.sql` from `schema.sql`.
2. Install the `psql` client.
3. Apply `schema.demo.sql` to the database.

This is the same idempotent provisioning the standalone provision workflow already does — every statement is guarded with `IF NOT EXISTS` / `IF EXISTS`, so re-applying is safe and just brings the schema current. The seed now always runs against an up-to-date schema, so a newly-added constraint in `schema.sql` can never again leave the seed broken.

## Completeness check

I audited every `ON CONFLICT` target in `seedDemo.mjs` against `schema.sql`. All of them now have a matching unique constraint or primary key (the LevelUp ones from #216; the rest were already covered, several via column-level `UNIQUE` / composite primary keys). So once the live schema is current, the seed runs end to end — not just past the LevelUp step.

## How to confirm

Re-run the **Seed demo schema** workflow. It will apply the schema first, then seed, and complete successfully — no separate provisioning step needed.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGwKBN7TuT1tbBMsrRPury)_