### PR TITLE
fix: make demo seed create the unique keys it upserts against

### DIFF
--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -793,6 +793,24 @@ async function seedWhatworks(c) {
   console.log('  ✓ whatworks');
 }
 
+// Make sure the unique keys the seed upserts against actually exist before we
+// start. The demo schema is provisioned separately, so it can lag behind
+// schema.sql — if a constraint the seed relies on was added recently, the live
+// demo schema may not have it yet and the matching `ON CONFLICT` would fail.
+// These statements are idempotent (`IF NOT EXISTS`) and run on the same
+// connection, so unqualified names resolve to the `demo` schema, exactly where
+// the seed writes. This keeps the seed self-sufficient even when the schema
+// hasn't been re-applied first.
+async function ensureSeedPrerequisites(c) {
+  const indexes = [
+    'CREATE UNIQUE INDEX IF NOT EXISTS levelup_curriculum_items_cohort_id_sequence_no_key ON levelup_curriculum_items(cohort_id, sequence_no)',
+    'CREATE UNIQUE INDEX IF NOT EXISTS levelup_milestones_cohort_id_sequence_no_key ON levelup_milestones(cohort_id, sequence_no)',
+  ];
+  for (const sql of indexes) {
+    await c.query(sql);
+  }
+}
+
 async function main() {
   const connStr =
     process.env.DATABASE_URL_DIRECT ||
@@ -809,6 +827,8 @@ async function main() {
   console.log(`Seeding demo schema for owner: ${OWNER}`);
 
   try {
+    await ensureSeedPrerequisites(client);
+
     await client.query('BEGIN');
 
     await seedServiceCredits(client);


### PR DESCRIPTION
**Closing — superseded by #217 (merged) and blocked by a deliberate gate.**

This added schema DDL inside `seedDemo.mjs`, which the **Schema Drift Gate** correctly rejects: any change to a seed script must be paired with a `ctf/schema.sql` change (the seed/schema blocker policy), and there's no legitimate schema change to pair here — those indexes already live in `schema.sql` from #216.

It's also redundant. The seed script's own contract says the schema must be provisioned first, and #217 (merged) already makes the **Seed demo schema** workflow apply the schema before seeding. The right fix is to trigger a fresh run of that workflow, not to put schema DDL in the seed.

Original description below.

---

## Why it's still failing

The seed kept failing at the LevelUp step with:

> there is no unique or exclusion constraint matching the ON CONFLICT specification

even after the two earlier fixes merged. The most likely reason: the failing run was a **re-run of the original (pre-fix) workflow run**. A GitHub Actions re-run replays the *original commit*, so it uses the old `seedDemo.mjs` and old `schema.demo.sql` and skips the new schema-apply step entirely — it will fail identically no matter what lands on `main`. A fresh "Run workflow" dispatch is what picks up the fixes.