### PR TITLE
fix: remove legacy level_id from levelup_enrollments so demo seed completes

### DIFF
--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -248,20 +248,11 @@ COMMIT;
 
 -- === peer-programming placeholder ===
 -- === levelup_enrollments ===
-CREATE TABLE IF NOT EXISTS levelup_enrollments (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,
-  level_id TEXT NOT NULL,
-  enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  status TEXT NOT NULL DEFAULT 'active',
-  UNIQUE (user_id, level_id)
-);
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT '';
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS level_id TEXT NOT NULL DEFAULT '';
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active';
-CREATE UNIQUE INDEX IF NOT EXISTS uq_levelup_enrollments_user_level ON levelup_enrollments(user_id, level_id);
+-- The canonical definition lives further below (the cohort-based table).
+-- An earlier level_id-based table used to be defined here; it was legacy
+-- cruft that left a level_id NOT NULL column with no default and blocked
+-- cohort-based inserts. It has been removed, and any database that still
+-- carries the legacy column has it dropped next to the canonical block.
 CREATE TABLE IF NOT EXISTS peer_programming_weekly_topics (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   week_start_date DATE NOT NULL,
@@ -938,6 +929,12 @@ DO $$ BEGIN
     EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS levelup_enrollments_cohort_id_user_id_key ON levelup_enrollments(cohort_id, user_id)';
   END IF;
 END $$;
+-- Shed the legacy level_id column if an older database still carries it.
+-- It was NOT NULL with no default, so cohort-based inserts (which never set
+-- it) failed. Dropping the column also removes its dependent
+-- uq_levelup_enrollments_user_level index. Safe no-op on databases that
+-- never had the legacy column.
+ALTER TABLE IF EXISTS levelup_enrollments DROP COLUMN IF EXISTS level_id;
 CREATE TABLE IF NOT EXISTS trusttransport_requests (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   requester_user_id TEXT NOT NULL,

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -233,20 +233,11 @@ COMMIT;
 
 -- === peer-programming placeholder ===
 -- === levelup_enrollments ===
-CREATE TABLE IF NOT EXISTS levelup_enrollments (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,
-  level_id TEXT NOT NULL,
-  enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  status TEXT NOT NULL DEFAULT 'active',
-  UNIQUE (user_id, level_id)
-);
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT '';
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS level_id TEXT NOT NULL DEFAULT '';
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
-ALTER TABLE IF EXISTS levelup_enrollments ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active';
-CREATE UNIQUE INDEX IF NOT EXISTS uq_levelup_enrollments_user_level ON levelup_enrollments(user_id, level_id);
+-- The canonical definition lives further below (the cohort-based table).
+-- An earlier level_id-based table used to be defined here; it was legacy
+-- cruft that left a level_id NOT NULL column with no default and blocked
+-- cohort-based inserts. It has been removed, and any database that still
+-- carries the legacy column has it dropped next to the canonical block.
 CREATE TABLE IF NOT EXISTS peer_programming_weekly_topics (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   week_start_date DATE NOT NULL,
@@ -940,6 +931,12 @@ DO $$ BEGIN
     EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS levelup_enrollments_cohort_id_user_id_key ON levelup_enrollments(cohort_id, user_id)';
   END IF;
 END $$;
+-- Shed the legacy level_id column if an older database still carries it.
+-- It was NOT NULL with no default, so cohort-based inserts (which never set
+-- it) failed. Dropping the column also removes its dependent
+-- uq_levelup_enrollments_user_level index. Safe no-op on databases that
+-- never had the legacy column.
+ALTER TABLE IF EXISTS levelup_enrollments DROP COLUMN IF EXISTS level_id;
 CREATE TABLE IF NOT EXISTS trusttransport_requests (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   requester_user_id TEXT NOT NULL,


### PR DESCRIPTION
## Progress, then a new error

After the upsert fix (#220) merged, the demo seed got **past** LevelUp curriculum and milestones — so `ON CONFLICT (id)` works — and then failed on a different, deeper problem:

```
seed:demo failed: null value in column "level_id" of relation "levelup_enrollments" violates not-null constraint
```

## Cause: `levelup_enrollments` was defined twice

`schema.sql` had two `CREATE TABLE` blocks for `levelup_enrollments`:

- an older **`level_id`-based** block (first), and
- the current **`cohort_id`-based** block (later).

Because `CREATE TABLE IF NOT EXISTS` only builds from the first one it reaches, the table was created from the legacy block, leaving a `level_id NOT NULL` column **with no default**. The current design is cohort-based and never sets `level_id` (and no app code, script, or view references it anywhere), so every cohort-based insert hit the not-null violation.

## The fix

- Remove the stale `level_id`-based definition, so the table has a single, canonical cohort-based definition.
- Drop the leftover column from any database that already carries it:
  `ALTER TABLE IF EXISTS levelup_enrollments DROP COLUMN IF EXISTS level_id;`
  This also removes its dependent `uq_levelup_enrollments_user_level` index automatically. It's a safe no-op on databases that never had the column.
- Regenerate `schema.demo.sql` to match.

I confirmed `level_id` is unused: it appears nowhere in `ctf/packages`, `ctf/scripts`, or `ctf/docs`, and no view depends on it (the only view, `skills_taxonomy_dependency_graph`, is unrelated). So dropping it is safe and removes long-standing schema cruft.

## Note

This drops a legacy database column (`levelup_enrollments.level_id`). It holds no data the app uses, but it is a destructive schema change, so worth a careful eye. I did **not** add the `coderabbit` label this round only to stay within the one-review-per-hour budget already spent earlier today — happy to label it if you'd like the review.

## How to verify

Run the **Seed demo schema** workflow (fresh dispatch). It should now apply the schema and seed all the way through to "Demo schema seeded for …".

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGwKBN7TuT1tbBMsrRPury)_