### PR TITLE
refactor: collapse duplicate unlock_audit_log and unlock_runtime_config tables

### DIFF
--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -879,22 +879,11 @@ ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS r
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS incentive_granted_at TIMESTAMPTZ;
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
-CREATE TABLE IF NOT EXISTS unlock_audit_log (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,
-  action TEXT NOT NULL,
-  details JSONB NOT NULL DEFAULT '{}'::jsonb,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS unlock_runtime_config (
-  singleton_id INTEGER PRIMARY KEY DEFAULT 1,
-  submission_window_hours INTEGER NOT NULL DEFAULT 168,
-  reminder_schedule_hours INTEGER[] NOT NULL DEFAULT ARRAY[0,24,72,168],
-  incentive_amount TEXT NOT NULL DEFAULT '100',
-  support_only_after_expiry BOOLEAN NOT NULL DEFAULT TRUE
-);
+-- Duplicate CREATE TABLE blocks for unlock_audit_log and unlock_runtime_config
+-- were removed here; the canonical definitions are above (unlock_audit_log
+-- keeps its richer column set). The ALTER ... ADD COLUMN reconciliation for
+-- unlock_runtime_config (for databases created before some columns existed)
+-- follows.
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS singleton_id INTEGER DEFAULT 1;
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS submission_window_hours INTEGER NOT NULL DEFAULT 168;
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS reminder_schedule_hours INTEGER[] NOT NULL DEFAULT ARRAY[0,24,72,168];

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -881,22 +881,11 @@ ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS r
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS incentive_granted_at TIMESTAMPTZ;
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
-CREATE TABLE IF NOT EXISTS unlock_audit_log (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,
-  action TEXT NOT NULL,
-  details JSONB NOT NULL DEFAULT '{}'::jsonb,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS unlock_runtime_config (
-  singleton_id INTEGER PRIMARY KEY DEFAULT 1,
-  submission_window_hours INTEGER NOT NULL DEFAULT 168,
-  reminder_schedule_hours INTEGER[] NOT NULL DEFAULT ARRAY[0,24,72,168],
-  incentive_amount TEXT NOT NULL DEFAULT '100',
-  support_only_after_expiry BOOLEAN NOT NULL DEFAULT TRUE
-);
+-- Duplicate CREATE TABLE blocks for unlock_audit_log and unlock_runtime_config
+-- were removed here; the canonical definitions are above (unlock_audit_log
+-- keeps its richer column set). The ALTER ... ADD COLUMN reconciliation for
+-- unlock_runtime_config (for databases created before some columns existed)
+-- follows.
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS singleton_id INTEGER DEFAULT 1;
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS submission_window_hours INTEGER NOT NULL DEFAULT 168;
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS reminder_schedule_hours INTEGER[] NOT NULL DEFAULT ARRAY[0,24,72,168];


### PR DESCRIPTION
## What this cleans up

Following the `levelup_enrollments` fix (#222), `schema.sql` still defined two other tables twice each:

- **`unlock_audit_log`** — the first block was the richer one (with `actor_user_id`, `command`, `metadata`, `policy_status`, `reason`, `request_id`, `target_user_id`); the second was a basic duplicate.
- **`unlock_runtime_config`** — both blocks were identical.

Because `CREATE TABLE IF NOT EXISTS` only builds from the first block it reaches, the duplicates were dead text — and the same drift hazard that produced the earlier seed failures.

## The change

- Remove the duplicate `CREATE TABLE` blocks, keeping the canonical definitions above (`unlock_audit_log` keeps its richer column set).
- Keep the existing `ALTER ... ADD COLUMN` reconciliation that brings older databases up to date. The rich `unlock_audit_log` columns are already reconciled later in the file (the `ALTER ... ADD COLUMN IF NOT EXISTS` block), so older databases still get them.
- Regenerate `schema.demo.sql` to match.

No behavior change — both tables resolve to the same shape they did before, just defined once.

## Verification

Each table is now defined exactly once, and all 12 reconciliation `ALTER`s (7 for `unlock_audit_log`, 5 for `unlock_runtime_config`) are preserved.

One duplicate remains in `schema.sql` — `chyme_rooms` — but both copies are **identical**, so it's harmless; I left it out of this change to keep the scope to the `unlock_*` tables you flagged. Easy to collapse too if you'd like.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGwKBN7TuT1tbBMsrRPury)_