### PR TITLE
refactor: collapse the duplicate chyme_rooms table definition

### DIFF
--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -1530,14 +1530,10 @@ ALTER TABLE IF EXISTS feed_timeline_projection ADD COLUMN IF NOT EXISTS created_
 ALTER TABLE IF EXISTS feed_timeline_projection ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 -- === CHYME ROOMS ===
-CREATE TABLE IF NOT EXISTS chyme_rooms (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  room_key TEXT NOT NULL UNIQUE,
-  room_name TEXT NOT NULL,
-  call_active BOOLEAN NOT NULL DEFAULT FALSE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+-- The canonical chyme_rooms definition is earlier in this file (placed before
+-- its dependent indexes). The duplicate CREATE TABLE that used to be here was
+-- removed; the ALTER ... ADD COLUMN reconciliation below still brings older
+-- databases up to date.
 ALTER TABLE IF EXISTS chyme_rooms ADD COLUMN IF NOT EXISTS id UUID;
 ALTER TABLE IF EXISTS chyme_rooms ADD COLUMN IF NOT EXISTS room_key TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS chyme_rooms ADD COLUMN IF NOT EXISTS room_name TEXT NOT NULL DEFAULT '';

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1532,14 +1532,10 @@ ALTER TABLE IF EXISTS feed_timeline_projection ADD COLUMN IF NOT EXISTS created_
 ALTER TABLE IF EXISTS feed_timeline_projection ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 -- === CHYME ROOMS ===
-CREATE TABLE IF NOT EXISTS chyme_rooms (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  room_key TEXT NOT NULL UNIQUE,
-  room_name TEXT NOT NULL,
-  call_active BOOLEAN NOT NULL DEFAULT FALSE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+-- The canonical chyme_rooms definition is earlier in this file (placed before
+-- its dependent indexes). The duplicate CREATE TABLE that used to be here was
+-- removed; the ALTER ... ADD COLUMN reconciliation below still brings older
+-- databases up to date.
 ALTER TABLE IF EXISTS chyme_rooms ADD COLUMN IF NOT EXISTS id UUID;
 ALTER TABLE IF EXISTS chyme_rooms ADD COLUMN IF NOT EXISTS room_key TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS chyme_rooms ADD COLUMN IF NOT EXISTS room_name TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## What this cleans up

`chyme_rooms` was the **last** table defined twice in `schema.sql`. Both copies were identical.

## The change

- Keep the canonical definition (the earlier one, intentionally placed before its dependent indexes, with its `uq_chyme_rooms_room_key` unique index).
- Remove the duplicate `CREATE TABLE`, leaving the `ALTER ... ADD COLUMN` reconciliation that brings older databases up to date.
- Regenerate `schema.demo.sql` to match.

No behavior change — the table resolves to the same shape, just defined once.

## Verification

After this, **every table in `schema.sql` is defined exactly once** — confirmed on both `schema.sql` and the generated `schema.demo.sql`. This closes out the duplicate-definition hazard that was behind the demo seed failures.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGwKBN7TuT1tbBMsrRPury)_