### PR TITLE
fix: seed chyme_messages with its real columns so the demo seed completes

### DIFF
--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -230,6 +230,15 @@ CREATE TABLE IF NOT EXISTS chyme_messages (
   text TEXT NOT NULL CHECK (char_length(text) BETWEEN 1 AND 1000),
   sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+-- Column reconciliation so older databases converge on the current shape
+-- (added nullable / with safe defaults so they never fail on populated tables).
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS room_id UUID;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS username TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS display_name TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS text TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 CREATE INDEX IF NOT EXISTS idx_chyme_messages_room_sent_at ON chyme_messages(room_id, sent_at DESC);
 CREATE INDEX IF NOT EXISTS idx_chyme_messages_user_id ON chyme_messages(user_id);
 CREATE TABLE IF NOT EXISTS chyme_deletion_events (

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -215,6 +215,15 @@ CREATE TABLE IF NOT EXISTS chyme_messages (
   text TEXT NOT NULL CHECK (char_length(text) BETWEEN 1 AND 1000),
   sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+-- Column reconciliation so older databases converge on the current shape
+-- (added nullable / with safe defaults so they never fail on populated tables).
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS room_id UUID;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS username TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS display_name TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS text TEXT;
+ALTER TABLE IF EXISTS chyme_messages ADD COLUMN IF NOT EXISTS sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 CREATE INDEX IF NOT EXISTS idx_chyme_messages_room_sent_at ON chyme_messages(room_id, sent_at DESC);
 CREATE INDEX IF NOT EXISTS idx_chyme_messages_user_id ON chyme_messages(user_id);
 CREATE TABLE IF NOT EXISTS chyme_deletion_events (

--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -566,16 +566,17 @@ async function seedChyme(c) {
     );
   }
 
+  const memberDisplayNames = { [OWNER]: 'Demo Participant', [PEER_1]: 'Alex Rivera' };
   const messages = [
     [PEER_1, 'Hey — welcome to the demo environment!'],
     [OWNER, 'Thanks! Just exploring the platform. Looks great.'],
     [PEER_1, 'Let me know if you have any questions about how it works.'],
   ];
-  for (const [uid, body] of messages) {
+  for (const [uid, text] of messages) {
     await c.query(
-      `INSERT INTO chyme_messages (room_id, sender_user_id, body)
-       VALUES ($1::uuid, $2, $3)`,
-      [ID.room, uid, body],
+      `INSERT INTO chyme_messages (room_id, user_id, display_name, text)
+       VALUES ($1::uuid, $2, $3, $4)`,
+      [ID.room, uid, memberDisplayNames[uid] ?? 'Demo User', text],
     );
   }
 


### PR DESCRIPTION
## Progress, then the next layer

After the earlier fixes, the demo seed now clears **13 plugins** (service-credits through foundation) and then fails at chyme with:

```
seed:demo failed: column "sender_user_id" of relation "chyme_messages" does not exist
```

## Cause

The demo seed's `chyme_messages` insert was written against a shape that never existed — it used `sender_user_id` and `body`. The real table (and the app's own insert in `ctf/packages/web/lib/chyme/repository.ts`) uses `room_id, user_id, username, display_name, avatar_url, text, sent_at`.

## The fix

- **Seed:** insert `room_id, user_id, display_name, text` (the required columns), deriving the display name from the demo members.
- **Schema:** add the `ALTER ... ADD COLUMN IF NOT EXISTS` reconciliation for `chyme_messages` that the project's migration rules call for (only `author_username` had one). The columns are added nullable or with a safe default, so the statements are no-ops on databases that already have them and never fail on populated tables. Regenerated `schema.demo.sql` to match.

## Completeness check

I re-audited **every** remaining seed `INSERT` against the schema, two ways:
- every column the seed names exists in its table, and
- no required (NOT NULL, no default) column is omitted by any insert.

Both come back clean, so the seed should now run all the way to `Demo schema seeded for …` — not just past chyme.

## How to verify

Run a fresh **Seed demo schema** dispatch.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGwKBN7TuT1tbBMsrRPury)_