### PR TITLE
fix: make Clerk auth work in web middleware

### DIFF
--- a/ctf/packages/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/ctf/packages/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,7 +1,13 @@
 import { redirect } from 'next/navigation';
+import { getClerkSignInUrl } from 'lib/auth/clerk-env';
 
 // Sign-in is handled by the hosted account flow outside this app surface.
 // This page remains as a catch-all for legacy links or misconfigured redirects.
 export default function SignInPage() {
-  redirect('/apps');
+  const signInUrl = getClerkSignInUrl();
+  if (signInUrl) {
+    redirect(signInUrl);
+  }
+
+  redirect('/');
 }

--- a/ctf/packages/web/middleware.ts
+++ b/ctf/packages/web/middleware.ts
@@ -1,46 +1,34 @@
-import { clerkMiddleware, auth } from '@clerk/nextjs/server';
-import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
+import { clerkMiddleware } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
 import { getClerkRuntimeOptions } from './lib/auth/clerk-env';
 
-const clerkHandler = clerkMiddleware(getClerkRuntimeOptions());
+// Identity headers that the app reads in `lib/auth/request-identity.ts`. The
+// middleware is the only thing allowed to set them, so we always clear whatever
+// the client sent and then write the values we can actually verify from Clerk.
+// This both makes the signed-in user visible to the rest of the app and stops a
+// caller from spoofing these headers to look authenticated.
+const MANAGED_IDENTITY_HEADERS = [
+  'x-ctf-authenticated',
+  'x-ctf-auth-provider',
+  'x-ctf-user-id',
+];
 
-async function addRequestIdentityHeaders(request: NextRequest): Promise<Headers> {
-  const authState = await auth();
-  const headers = new Headers(request.headers);
-  headers.set('x-ctf-authenticated', authState.userId ? 'true' : 'false');
-  headers.set('x-ctf-auth-provider', 'clerk');
+export default clerkMiddleware(async (auth, request) => {
+  const { userId } = await auth();
 
-  if (authState.userId) {
-    headers.set('x-ctf-user-id', authState.userId);
+  const requestHeaders = new Headers(request.headers);
+  for (const header of MANAGED_IDENTITY_HEADERS) {
+    requestHeaders.delete(header);
   }
 
-  return headers;
-}
-
-export default async function middleware(request: NextRequest, event: NextFetchEvent) {
-  const response = await clerkHandler(request, event);
-
-  if (response.headers.get('location')) {
-    return response;
+  requestHeaders.set('x-ctf-authenticated', userId ? 'true' : 'false');
+  requestHeaders.set('x-ctf-auth-provider', 'clerk');
+  if (userId) {
+    requestHeaders.set('x-ctf-user-id', userId);
   }
 
-  const requestHeaders = await addRequestIdentityHeaders(request);
-  const nextResponse = NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  });
-
-  response.headers.forEach((value, key) => {
-    if (key.toLowerCase() === 'set-cookie') {
-      nextResponse.headers.append(key, value);
-    } else {
-      nextResponse.headers.set(key, value);
-    }
-  });
-
-  return nextResponse;
-}
+  return NextResponse.next({ request: { headers: requestHeaders } });
+}, getClerkRuntimeOptions());
 
 export const config = {
   matcher: [

--- a/ctf/packages/web/middleware.ts
+++ b/ctf/packages/web/middleware.ts
@@ -1,7 +1,46 @@
-import { clerkMiddleware } from '@clerk/nextjs/server';
+import { clerkMiddleware, auth } from '@clerk/nextjs/server';
+import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 import { getClerkRuntimeOptions } from './lib/auth/clerk-env';
 
-export default clerkMiddleware(getClerkRuntimeOptions());
+const clerkHandler = clerkMiddleware(getClerkRuntimeOptions());
+
+async function addRequestIdentityHeaders(request: NextRequest): Promise<Headers> {
+  const authState = await auth();
+  const headers = new Headers(request.headers);
+  headers.set('x-ctf-authenticated', authState.userId ? 'true' : 'false');
+  headers.set('x-ctf-auth-provider', 'clerk');
+
+  if (authState.userId) {
+    headers.set('x-ctf-user-id', authState.userId);
+  }
+
+  return headers;
+}
+
+export default async function middleware(request: NextRequest, event: NextFetchEvent) {
+  const response = await clerkHandler(request, event);
+
+  if (response.headers.get('location')) {
+    return response;
+  }
+
+  const requestHeaders = await addRequestIdentityHeaders(request);
+  const nextResponse = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') {
+      nextResponse.headers.append(key, value);
+    } else {
+      nextResponse.headers.set(key, value);
+    }
+  });
+
+  return nextResponse;
+}
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary

Fixes the web app's sign-in, which did not actually work.

The app figures out who is signed in by reading the request headers
`x-ctf-user-id`, `x-ctf-authenticated`, and `x-ctf-auth-provider`
(see `lib/auth/request-identity.ts`). Nothing was setting those headers, so
every visitor looked signed out no matter what.

The earlier version of this branch tried to add them but wrapped Clerk's
middleware in a plain function and called the standalone `auth()` helper, which
outside Clerk's middleware context has no access to the request's sign-in state.
It also left the wrapped handler's result possibly undefined, which failed the
type check on `middleware.ts`.

## What changed

- `middleware.ts` now uses Clerk's supported callback form,
  `clerkMiddleware(async (auth, request) => ...)`, so `auth()` returns the
  verified user. It clears the identity headers a caller might have sent, then
  sets them from the verified Clerk session and passes them on with
  `NextResponse.next`. This makes the signed-in user visible to the rest of the
  app and stops anyone from faking those headers to look signed in.
- `app/sign-in/[[...sign-in]]/page.tsx` (unchanged in this update) sends legacy
  sign-in links to the configured sign-in page.

## Checks

- `pnpm --filter @ctf/web run typecheck` — the two `middleware.ts` errors are
  resolved.
- PR title now uses a Conventional Commit prefix so the title check passes.

Parity Status: web+android complete
