### PR TITLE
feat: add account deletion engine, orchestrator, and routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,9 @@ jobs:
       - name: Validate account deletion registry against schema
         run: node ctf/scripts/check-deletion-registry.mjs
 
+      - name: Validate account deletion engine SQL generation
+        run: node ctf/scripts/check-deletion-engine.mjs
+
   pr-parity-status:
     name: PR Parity Status
     runs-on: ubuntu-latest

--- a/ctf/docs/developer/ACCOUNT_DELETION_REGISTRY.md
+++ b/ctf/docs/developer/ACCOUNT_DELETION_REGISTRY.md
@@ -56,14 +56,39 @@ To run locally:
 node ctf/scripts/check-deletion-registry.mjs
 ```
 
+## The engine and orchestrator
+
+The registry is data; two small modules turn it into action:
+
+- **`deletion-engine.ts`** — a pure translator. `planTable` / `planDeletion` turn a registry entry
+  into the exact SQL to run (`DELETE FROM <table> WHERE <userColumn> = $1`, or an idempotent
+  `UPDATE ... SET <softDeleteColumn> = NOW() WHERE <userColumn> = $1 AND <softDeleteColumn> IS NULL`,
+  or nothing for `retain`). Because it is pure, its output is checked without a database by
+  `ctf/scripts/check-deletion-engine.mjs` (run in CI). `executeEntry` runs the plan against an open
+  transaction.
+- **`deletion-orchestrator.ts`** — `deleteServiceScopeData(slug, userId)` deletes one plugin's data;
+  `deleteAllAccountData(userId)` deletes every plugin's data. Both run inside a single
+  `withDbTransaction` (so a failure rolls back rather than half-deleting a user), record one
+  `account_deletion_events` row, and log an `[account.audit]` line. Identifiers come only from the
+  registry; the user id is always the bound parameter `$1`, never inlined.
+
+Money is out of scope for the engine. ServiceCredits wallets/ledgers are `retain` in the registry
+and are settled by the existing reclaim flow (`markFullAccountDeletionRequested` →
+`enqueueServiceCreditsDeletionReclaim` → the service-credits adapter outbox). The full-account route
+calls that reclaim flow first, then runs the orchestrator; the engine never moves credits.
+
+## API routes
+
+- `DELETE /api/account/services/:slug` — delete just one plugin's data. The `:slug` is validated
+  against the registry; plugins that are not service-scoped (money/aggregate-only) return a clear
+  409 instead of a silent no-op.
+- `DELETE /api/account/full-account` — record the request, queue the ServiceCredits reclaim, then
+  delete the user's data across every plugin.
+
+Both require an authenticated caller (self-service only — a deletion only ever touches the caller's
+own rows) and the same-origin `x-ctf-csrf: 1` guard used elsewhere.
+
 ## What is intentionally NOT here yet
 
-- The **orchestrator** that performs a full-account deletion across all plugins and walks a
-  `requested → processing → completed` status.
-- The **per-plugin "delete my data" API routes** for plugins that have a registry entry but no route
-  yet.
 - The **Account & Data UI** (web + mobile) — design-gated; no mockup exists in the `design/`
-  submodule yet (Rule 127).
-
-These are deliberately separate, individually-reviewable steps because they perform irreversible
-deletes and touch the money ledger.
+  submodule yet (Rule 127). The backend above is what that UI will call once its design lands.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -134,7 +134,7 @@
 
 ## 5) Change Log
 
-- 2026-06-01: Added the cross-plugin account/per-service data deletion backend (registry-driven engine + orchestrator, `account_deletion_events` table, `DELETE /api/account/services/:slug` and a real-delete `DELETE /api/account/full-account`). Documented in section 1.2 and `ACCOUNT_DELETION_REGISTRY.md`. No UI (design-gated).
+- 2026-06-01: Added the cross-plugin account/per-service data deletion backend (registry-driven engine + orchestrator, `account_deletion_events` table, `DELETE /api/account/services/:slug` and `DELETE /api/account/full-account`, which now orchestrates the mixed delete/soft-delete/retain plan across every plugin instead of only recording a request). Documented in section 1.2 and `ACCOUNT_DELETION_REGISTRY.md`. No UI (design-gated).
 - 2026-04-01: Completed external-link safety primitive parity implementation across web and Android with full feature feature parity (origin-based detection, safe-open dialogs, copy/open actions).
 - 2026-02-25: Expanded CTF non-plugin parity inventory to full retained/excluded scope; marked weekly performance and skills taxonomy as plugin-owned; removed generic chat/admin activity feed carryover requirements; documented compliance position for audit-evidence-first admin activity feed removal.
 - 2026-02-25: Removed weekly-performance legacy-evidence pointer so weekly rewrite parity remains sourced from plugin-inventory documents.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -25,6 +25,25 @@
 3. Onboarding and account-approval gating state handling.
 4. Terms-acceptance requirement and persisted acceptance contract.
 
+**Account and per-service data deletion (cross-plugin, backend):**
+
+- Driven by the account deletion registry (`ctf/packages/web/lib/account/deletion-registry.ts`,
+  validated against `schema.sql` in CI). See `ctf/docs/developer/ACCOUNT_DELETION_REGISTRY.md`.
+- `ctf/packages/web/lib/account/deletion-engine.ts` — pure planner that turns each registry entry
+  into delete / idempotent soft-delete SQL (or nothing for retained money/audit tables); checked by
+  `ctf/scripts/check-deletion-engine.mjs`.
+- `ctf/packages/web/lib/account/deletion-orchestrator.ts` — runs a service-scope or whole-account
+  deletion in a single transaction, records one `account_deletion_events` row, logs an
+  `[account.audit]` line. Money is settled only by the existing ServiceCredits reclaim flow, never
+  hard-deleted here.
+- API: `DELETE /api/account/services/:slug` (one plugin) and `DELETE /api/account/full-account`
+  (every plugin + ServiceCredits reclaim). Both are self-service (caller's own rows only) and
+  same-origin CSRF-guarded.
+- Data model: `account_deletion_events` (id, user_id, scope, service_name, requested_at,
+  completed_at, status, summary).
+- The user-facing Account & Data UI that calls these routes is design-gated (Rule 127) and not yet
+  built.
+
 ### 1.3 Pricing Tier and Payment Admin (API/Control Contract Only)
 
 1. Pricing tier and payment administration remains a non-plugin backend contract area.
@@ -115,6 +134,7 @@
 
 ## 5) Change Log
 
+- 2026-06-01: Added the cross-plugin account/per-service data deletion backend (registry-driven engine + orchestrator, `account_deletion_events` table, `DELETE /api/account/services/:slug` and a real-delete `DELETE /api/account/full-account`). Documented in section 1.2 and `ACCOUNT_DELETION_REGISTRY.md`. No UI (design-gated).
 - 2026-04-01: Completed external-link safety primitive parity implementation across web and Android with full feature feature parity (origin-based detection, safe-open dialogs, copy/open actions).
 - 2026-02-25: Expanded CTF non-plugin parity inventory to full retained/excluded scope; marked weekly performance and skills taxonomy as plugin-owned; removed generic chat/admin activity feed carryover requirements; documented compliance position for audit-evidence-first admin activity feed removal.
 - 2026-02-25: Removed weekly-performance legacy-evidence pointer so weekly rewrite parity remains sourced from plugin-inventory documents.

--- a/ctf/packages/web/app/api/account/_lib.ts
+++ b/ctf/packages/web/app/api/account/_lib.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { getAppUrl } from 'lib/auth/runtime-env';
+import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
+
+// Shared helpers for the account-level deletion routes under `/api/account/**`.
+//
+// Auth posture matches the existing account routes (full-account, chyme-profile, skills-hunt-
+// profile): any signed-in identity may delete their own data, including unlock-pending users, so a
+// user can always exercise their right to be forgotten. There is no role requirement — deletion is
+// strictly self-service and only ever touches the caller's own rows.
+
+export async function requireAccountAccess() {
+  const decision = await evaluatePluginAccess({
+    requireUsername: false,
+    requireApprovedUserOrAdmin: false,
+    allowUnlockSupportOnly: true,
+  });
+  if (!decision.allowed) {
+    return { allowed: false as const, response: NextResponse.json(decision, { status: decision.status }) };
+  }
+
+  return { allowed: true as const, auth: decision };
+}
+
+// Same-origin CSRF guard for state-changing requests, mirroring the per-plugin `ensureMutationCsrf`
+// helpers. Requires the `x-ctf-csrf: 1` header and, when origin metadata is present, a matching
+// host. Returns a 403 response to short-circuit, or null to proceed.
+export function ensureMutationCsrf(request: Request): NextResponse | null {
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return null;
+  }
+
+  if (request.headers.get('x-ctf-csrf') !== '1') {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.csrfDenied, message: 'Missing CSRF confirmation header.' },
+      { status: 403 },
+    );
+  }
+
+  const appUrl = getAppUrl();
+  const origin = request.headers.get('origin');
+  if (!appUrl || !origin) {
+    return null;
+  }
+
+  try {
+    if (new URL(appUrl).host !== new URL(origin).host) {
+      return NextResponse.json(
+        { ok: false, code: ACCOUNT_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
+        { status: 403 },
+      );
+    }
+  } catch {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+
+  return null;
+}

--- a/ctf/packages/web/app/api/account/full-account/route.ts
+++ b/ctf/packages/web/app/api/account/full-account/route.ts
@@ -3,8 +3,10 @@ import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { markFullAccountDeletionRequested } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
+import { deleteAllAccountData } from 'lib/account/deletion-orchestrator';
+import { ensureMutationCsrf } from '../_lib';
 
-export async function DELETE() {
+export async function DELETE(request: Request) {
   const decision = await evaluatePluginAccess({
     requireUsername: false,
     requireApprovedUserOrAdmin: false,
@@ -14,8 +16,21 @@ export async function DELETE() {
     return NextResponse.json(decision, { status: decision.status });
   }
 
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
   try {
-    const deletion = await markFullAccountDeletionRequested(decision.userId);
+    // First record the request and queue the ServiceCredits reclaim (money settlement runs through
+    // the existing adapter outbox; wallets/ledgers are retained, not deleted). This stays in place
+    // exactly as before so the financial flow is unchanged.
+    const reclaim = await markFullAccountDeletionRequested(decision.userId);
+
+    // Then actually delete the user's data across every plugin, driven by the deletion registry.
+    // Runs in its own transaction; money tables are `retain` in the registry so this never touches
+    // the ledger.
+    const deletion = await deleteAllAccountData(decision.userId);
 
     logChymeAudit({
       pluginId: 'chyme',
@@ -30,7 +45,17 @@ export async function DELETE() {
       errorCategory: null,
     });
 
-    return NextResponse.json(deletion, { status: 202 });
+    return NextResponse.json(
+      {
+        ok: true,
+        scope: 'account',
+        status: 'completed',
+        requestedAtIso: reclaim.requestedAtIso,
+        completedAtIso: deletion.requestedAtIso,
+        tablesAffected: deletion.tables.length,
+      },
+      { status: 200 },
+    );
   } catch {
     logChymeAudit({
       pluginId: 'chyme',
@@ -49,7 +74,7 @@ export async function DELETE() {
       {
         ok: false,
         code: CHYME_ERROR_CODE.persistenceUnavailable,
-        message: 'Unable to record full-account deletion request.',
+        message: 'Unable to complete full-account deletion.',
       },
       { status: 503 },
     );

--- a/ctf/packages/web/app/api/account/full-account/route.ts
+++ b/ctf/packages/web/app/api/account/full-account/route.ts
@@ -1,20 +1,18 @@
 import { NextResponse } from 'next/server';
-import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { markFullAccountDeletionRequested } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
 import { deleteAllAccountData } from 'lib/account/deletion-orchestrator';
-import { ensureMutationCsrf } from '../_lib';
+import { requireAccountAccess, ensureMutationCsrf } from '../_lib';
 
 export async function DELETE(request: Request) {
-  const decision = await evaluatePluginAccess({
-    requireUsername: false,
-    requireApprovedUserOrAdmin: false,
-    allowUnlockSupportOnly: true,
-  });
-  if (!decision.allowed) {
-    return NextResponse.json(decision, { status: decision.status });
+  // Share the centralized account auth contract with the per-service delete route so the two
+  // deletion endpoints can't drift in policy or response shape.
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
   }
+  const userId = gate.auth.userId;
 
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -24,18 +22,20 @@ export async function DELETE(request: Request) {
   try {
     // First record the request and queue the ServiceCredits reclaim (money settlement runs through
     // the existing adapter outbox; wallets/ledgers are retained, not deleted). This stays in place
-    // exactly as before so the financial flow is unchanged.
-    const reclaim = await markFullAccountDeletionRequested(decision.userId);
+    // exactly as before so the financial flow is unchanged. The reclaim insert is idempotent on its
+    // deletion-request key, so a client retry re-queues the same reclaim rather than double-settling.
+    const reclaim = await markFullAccountDeletionRequested(userId);
 
     // Then actually delete the user's data across every plugin, driven by the deletion registry.
     // Runs in its own transaction; money tables are `retain` in the registry so this never touches
-    // the ledger.
-    const deletion = await deleteAllAccountData(decision.userId);
+    // the ledger. The request timestamp from above is the canonical "requested at"; the orchestrator
+    // stamps completion separately.
+    const deletion = await deleteAllAccountData(userId, reclaim.requestedAtIso);
 
     logChymeAudit({
       pluginId: 'chyme',
       command: 'account.profile.delete.full',
-      actorId: decision.userId,
+      actorId: userId,
       status: 'allow',
       reason: 'account_deletion_requested',
       target: {
@@ -50,8 +50,8 @@ export async function DELETE(request: Request) {
         ok: true,
         scope: 'account',
         status: 'completed',
-        requestedAtIso: reclaim.requestedAtIso,
-        completedAtIso: deletion.requestedAtIso,
+        requestedAtIso: deletion.requestedAtIso,
+        completedAtIso: deletion.completedAtIso,
         tablesAffected: deletion.tables.length,
       },
       { status: 200 },
@@ -60,7 +60,7 @@ export async function DELETE(request: Request) {
     logChymeAudit({
       pluginId: 'chyme',
       command: 'account.profile.delete.full',
-      actorId: decision.userId,
+      actorId: userId,
       status: 'allow',
       reason: 'account_deletion_requested',
       target: {

--- a/ctf/packages/web/app/api/account/services/[slug]/route.ts
+++ b/ctf/packages/web/app/api/account/services/[slug]/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { requireAccountAccess, ensureMutationCsrf } from '../../_lib';
+import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
+import { getDeletionEntry } from 'lib/account/deletion-registry';
+import {
+  deleteServiceScopeData,
+  ServiceScopeNotSupportedError,
+} from 'lib/account/deletion-orchestrator';
+
+// Generic per-plugin "delete my data for this service" endpoint.
+//
+// One route handles every service-scoped plugin instead of a hand-written file per plugin: the
+// `[slug]` is validated against the account deletion registry (which is itself validated against
+// the database schema in CI), and the registry-driven orchestrator performs the deletion in a
+// single transaction. Plugins that have no standalone deletion (money/aggregate-only, e.g.
+// ServiceCredits, GDP, Weekly Performance) return a clear 4xx rather than a silent no-op.
+//
+// DELETE /api/account/services/:slug
+export async function DELETE(request: Request, context: { params: Promise<{ slug: string }> }) {
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const { slug } = await context.params;
+  const entry = getDeletionEntry(slug);
+  if (!entry) {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.unknownService, message: `Unknown service "${slug}".` },
+      { status: 404 },
+    );
+  }
+  if (!entry.serviceScopeSupported) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: ACCOUNT_ERROR_CODE.serviceScopeUnsupported,
+        message: `Service "${slug}" cannot be deleted on its own; it is settled only as part of full-account deletion.`,
+      },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const result = await deleteServiceScopeData(slug, gate.auth.userId);
+    return NextResponse.json(
+      {
+        ok: true,
+        scope: 'service',
+        service: result.serviceName,
+        status: 'completed',
+        requestedAtIso: result.requestedAtIso,
+        tablesAffected: result.tables.length,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    // The orchestrator already rejects unsupported plugins, but guard here too for safety.
+    if (error instanceof ServiceScopeNotSupportedError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: ACCOUNT_ERROR_CODE.serviceScopeUnsupported,
+          message: `Service "${slug}" cannot be deleted on its own.`,
+        },
+        { status: 409 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        ok: false,
+        code: ACCOUNT_ERROR_CODE.persistenceUnavailable,
+        message: `Unable to delete ${slug} data.`,
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/account/services/[slug]/route.ts
+++ b/ctf/packages/web/app/api/account/services/[slug]/route.ts
@@ -5,6 +5,7 @@ import { getDeletionEntry } from 'lib/account/deletion-registry';
 import {
   deleteServiceScopeData,
   ServiceScopeNotSupportedError,
+  UnknownServiceError,
 } from 'lib/account/deletion-orchestrator';
 
 // Generic per-plugin "delete my data for this service" endpoint.
@@ -55,12 +56,20 @@ export async function DELETE(request: Request, context: { params: Promise<{ slug
         service: result.serviceName,
         status: 'completed',
         requestedAtIso: result.requestedAtIso,
+        completedAtIso: result.completedAtIso,
         tablesAffected: result.tables.length,
       },
       { status: 200 },
     );
   } catch (error) {
-    // The orchestrator already rejects unsupported plugins, but guard here too for safety.
+    // The route pre-checks already reject unknown/unsupported slugs, but the orchestrator throws
+    // these too, so map them defensively to the same statuses.
+    if (error instanceof UnknownServiceError) {
+      return NextResponse.json(
+        { ok: false, code: ACCOUNT_ERROR_CODE.unknownService, message: `Unknown service "${slug}".` },
+        { status: 404 },
+      );
+    }
     if (error instanceof ServiceScopeNotSupportedError) {
       return NextResponse.json(
         {

--- a/ctf/packages/web/lib/account/audit.ts
+++ b/ctf/packages/web/lib/account/audit.ts
@@ -1,0 +1,49 @@
+// Audit logger for account-level deletion actions, matching the per-plugin audit shape used across
+// the app (see e.g. `lib/chyme/audit.ts`): a single structured JSON line on `console.info` with a
+// stable `[account.audit]` prefix. There is no shared audit sink in this codebase yet; each area
+// logs its own line, so this mirrors that convention rather than inventing a new one.
+
+import { randomUUID } from 'crypto';
+
+export type AccountAuditEvent = {
+  /** Stable command name, e.g. 'account.data.delete.service' or 'account.profile.delete.full'. */
+  readonly command: string;
+  /** The user whose data is being deleted (also the actor — deletion is self-service). */
+  readonly actorId: string;
+  readonly status: 'allow' | 'deny';
+  readonly reason: string;
+  /** 'service' for a single plugin, 'account' for the whole account. */
+  readonly scope: 'service' | 'account';
+  /** Plugin slug for service scope; omitted/undefined for account scope. */
+  readonly serviceName?: string;
+  readonly result: 'success' | 'failure';
+  readonly errorCategory: string | null;
+  /** Optional extra detail (e.g. per-table row counts). Kept free of personal data. */
+  readonly metadata?: Record<string, unknown>;
+};
+
+export function logAccountAudit(event: AccountAuditEvent): void {
+  const payload = {
+    eventId: randomUUID(),
+    timestamp: new Date().toISOString(),
+    actorId: event.actorId,
+    pluginId: 'account',
+    command: event.command,
+    commandVersion: '1.0.0',
+    policyDecision: {
+      status: event.status,
+      reason: event.reason,
+    },
+    targetContext: {
+      scope: event.scope,
+      ...(event.serviceName ? { serviceName: event.serviceName } : {}),
+    },
+    result: {
+      status: event.result,
+      errorCategory: event.errorCategory ?? 'none',
+    },
+    metadata: event.metadata ?? {},
+  };
+
+  console.info('[account.audit]', JSON.stringify(payload));
+}

--- a/ctf/packages/web/lib/account/constants.ts
+++ b/ctf/packages/web/lib/account/constants.ts
@@ -1,0 +1,13 @@
+// Error codes for the account-level deletion API (the cross-plugin orchestrator routes under
+// `/api/account/**`). Mirrors the per-plugin `*_ERROR_CODE` constant objects used elsewhere so the
+// JSON error shape is consistent across the app.
+
+export const ACCOUNT_ERROR_CODE = {
+  invalidPayload: 'ACCOUNT_INVALID_PAYLOAD',
+  csrfDenied: 'ACCOUNT_CSRF_DENIED',
+  serviceScopeUnsupported: 'ACCOUNT_SERVICE_SCOPE_UNSUPPORTED',
+  unknownService: 'ACCOUNT_UNKNOWN_SERVICE',
+  persistenceUnavailable: 'ACCOUNT_PERSISTENCE_UNAVAILABLE',
+} as const;
+
+export type AccountErrorCode = (typeof ACCOUNT_ERROR_CODE)[keyof typeof ACCOUNT_ERROR_CODE];

--- a/ctf/packages/web/lib/account/deletion-engine.ts
+++ b/ctf/packages/web/lib/account/deletion-engine.ts
@@ -1,0 +1,118 @@
+// Account deletion engine — turns a plugin's entry in the account deletion registry into the
+// concrete database operations that delete (or soft-delete) that user's data, and runs them.
+//
+// This is split from the orchestrator on purpose: `planDeletion` is a pure function (no database,
+// no clock, no randomness) so its output can be checked exactly — see
+// `ctf/scripts/check-deletion-engine.mjs`, which asserts the generated SQL for every registry
+// entry without needing a database. `executeEntry` is the thin part that actually runs the plan
+// against a live transaction.
+//
+// The registry is the single source of truth for which tables a user owns and how each is handled;
+// this file only knows how to translate those three actions into SQL:
+//   - delete       → DELETE FROM <table> WHERE <userColumn> = $1
+//   - soft-delete  → UPDATE <table> SET <softDeleteColumn> = NOW()
+//                      WHERE <userColumn> = $1 AND <softDeleteColumn> IS NULL
+//   - retain       → no operation (money ledgers, audit trails, shared content)
+//
+// Tables in each registry entry are already ordered child-before-parent, so plain deletes respect
+// foreign keys when run in order.
+
+import type { PoolClient } from 'pg';
+import type { OwnedTable, PluginDeletionEntry } from './deletion-registry';
+
+/** A single database operation produced from one owned table. */
+export type DeletionStatement = {
+  /** Real table this operates on. */
+  readonly table: string;
+  /** Which registry action produced it. */
+  readonly action: 'delete' | 'soft-delete';
+  /** Parameterized SQL with `$1` bound to the user id. */
+  readonly sql: string;
+};
+
+/**
+ * Pure translation of one owned table into a SQL statement, or `null` for `retain` (no-op).
+ *
+ * Identifiers (table / column names) come only from the registry, which is itself validated
+ * against `schema.sql` by `check-deletion-registry.mjs`, so they are never user input — they are
+ * safe to interpolate. The user id is always passed as the bound parameter `$1`, never inlined.
+ */
+export function planTable(owned: OwnedTable): DeletionStatement | null {
+  switch (owned.action) {
+    case 'retain':
+      return null;
+    case 'delete':
+      if (!owned.userColumn) {
+        throw new Error(`Table "${owned.table}" is action "delete" but has no userColumn.`);
+      }
+      return {
+        table: owned.table,
+        action: 'delete',
+        sql: `DELETE FROM ${owned.table} WHERE ${owned.userColumn} = $1`,
+      };
+    case 'soft-delete':
+      if (!owned.userColumn) {
+        throw new Error(`Table "${owned.table}" is action "soft-delete" but has no userColumn.`);
+      }
+      if (!owned.softDeleteColumn) {
+        throw new Error(`Table "${owned.table}" is action "soft-delete" but has no softDeleteColumn.`);
+      }
+      return {
+        table: owned.table,
+        action: 'soft-delete',
+        sql:
+          `UPDATE ${owned.table} SET ${owned.softDeleteColumn} = NOW() ` +
+          `WHERE ${owned.userColumn} = $1 AND ${owned.softDeleteColumn} IS NULL`,
+      };
+    default: {
+      // Exhaustiveness guard: a new action must be handled here explicitly.
+      const unreachable: never = owned.action;
+      throw new Error(`Unhandled deletion action: ${String(unreachable)}`);
+    }
+  }
+}
+
+/**
+ * Pure plan for a whole plugin entry: the ordered list of statements to run (retains dropped),
+ * preserving the registry's child-before-parent ordering.
+ */
+export function planDeletion(entry: PluginDeletionEntry): DeletionStatement[] {
+  const statements: DeletionStatement[] = [];
+  for (const owned of entry.tables) {
+    const statement = planTable(owned);
+    if (statement) {
+      statements.push(statement);
+    }
+  }
+  return statements;
+}
+
+/** Per-table outcome of running a deletion, for the audit/event record. */
+export type DeletionTableResult = {
+  readonly table: string;
+  readonly action: 'delete' | 'soft-delete';
+  /** Rows affected (deleted or soft-deleted). */
+  readonly rowCount: number;
+};
+
+/**
+ * Run a plugin entry's deletion plan against an open transaction client. The caller owns the
+ * transaction (begin/commit/rollback) so several plugins can be deleted atomically in one account
+ * deletion. Returns the per-table row counts.
+ */
+export async function executeEntry(
+  client: PoolClient,
+  entry: PluginDeletionEntry,
+  userId: string,
+): Promise<DeletionTableResult[]> {
+  const results: DeletionTableResult[] = [];
+  for (const statement of planDeletion(entry)) {
+    const result = await client.query(statement.sql, [userId]);
+    results.push({
+      table: statement.table,
+      action: statement.action,
+      rowCount: result.rowCount ?? 0,
+    });
+  }
+  return results;
+}

--- a/ctf/packages/web/lib/account/deletion-orchestrator.ts
+++ b/ctf/packages/web/lib/account/deletion-orchestrator.ts
@@ -1,0 +1,158 @@
+// Account deletion orchestrator — the one place that actually carries out a user's deletion request
+// across plugins, driven entirely by the account deletion registry.
+//
+// Two entry points:
+//   - `deleteServiceScopeData(slug, userId)` — delete just one plugin's data for this user.
+//   - `deleteAllAccountData(userId)` — delete every plugin's data for this user (whole account).
+//
+// Both run the registry-derived plan inside a single `withDbTransaction`, so a failure rolls the
+// whole thing back rather than leaving a user half-deleted. Each run records one
+// `account_deletion_events` row (the retained accountability record) and logs an audit line.
+//
+// Money is deliberately out of scope here. ServiceCredits wallets/ledgers are `retain` in the
+// registry and are settled by the existing reclaim flow (`markFullAccountDeletionRequested` →
+// `enqueueServiceCreditsDeletionReclaim` → the service-credits adapter outbox). The full-account
+// route calls that reclaim flow alongside this orchestrator; this file never moves credits.
+
+import type { PoolClient } from 'pg';
+import { withDbTransaction } from 'lib/db/postgres';
+import { logAccountAudit } from './audit';
+import {
+  accountDeletionRegistry,
+  getDeletionEntry,
+  type PluginDeletionEntry,
+} from './deletion-registry';
+import { executeEntry, type DeletionTableResult } from './deletion-engine';
+
+export type DeletionScope = 'service' | 'account';
+
+export type AccountDeletionResult = {
+  readonly ok: true;
+  readonly scope: DeletionScope;
+  /** Plugin slug for service scope; 'all-services' for account scope. */
+  readonly serviceName: string;
+  readonly status: 'completed';
+  readonly requestedAtIso: string;
+  /** Per-table row counts, for the caller and the audit record. */
+  readonly tables: readonly DeletionTableResult[];
+};
+
+/** Error thrown when a service-scope deletion targets a plugin that has no standalone delete. */
+export class ServiceScopeNotSupportedError extends Error {
+  constructor(public readonly slug: string) {
+    super(`Plugin "${slug}" does not support standalone service-scope deletion.`);
+    this.name = 'ServiceScopeNotSupportedError';
+  }
+}
+
+/** Insert the canonical account_deletion_events row inside the same transaction. */
+async function recordEvent(
+  client: PoolClient,
+  userId: string,
+  scope: DeletionScope,
+  serviceName: string,
+  tables: readonly DeletionTableResult[],
+): Promise<string> {
+  const summary = {
+    tables: tables.map((t) => ({ table: t.table, action: t.action, rowCount: t.rowCount })),
+  };
+  const inserted = await client.query<{ requested_at: Date }>(
+    `INSERT INTO account_deletion_events
+       (user_id, scope, service_name, requested_at, completed_at, status, summary)
+     VALUES ($1, $2, $3, NOW(), NOW(), 'completed', $4::jsonb)
+     RETURNING requested_at`,
+    [userId, scope, serviceName, JSON.stringify(summary)],
+  );
+  return inserted.rows[0].requested_at.toISOString();
+}
+
+/**
+ * Delete one plugin's data for a user. Throws `ServiceScopeNotSupportedError` if the plugin is not
+ * service-scoped (e.g. ServiceCredits, GDP, Weekly Performance), so callers can return a clear 4xx.
+ */
+export async function deleteServiceScopeData(
+  slug: string,
+  userId: string,
+): Promise<AccountDeletionResult> {
+  const entry = getDeletionEntry(slug);
+  if (!entry || !entry.serviceScopeSupported) {
+    throw new ServiceScopeNotSupportedError(slug);
+  }
+
+  try {
+    const { requestedAtIso, tables } = await withDbTransaction(async (client) => {
+      const tableResults = await executeEntry(client, entry, userId);
+      const iso = await recordEvent(client, userId, 'service', entry.slug, tableResults);
+      return { requestedAtIso: iso, tables: tableResults };
+    });
+
+    logAccountAudit({
+      command: 'account.data.delete.service',
+      actorId: userId,
+      status: 'allow',
+      reason: 'service_scope_confirmed',
+      scope: 'service',
+      serviceName: entry.slug,
+      result: 'success',
+      errorCategory: null,
+      metadata: { tableCount: tables.length },
+    });
+
+    return { ok: true, scope: 'service', serviceName: entry.slug, status: 'completed', requestedAtIso, tables };
+  } catch (error) {
+    logAccountAudit({
+      command: 'account.data.delete.service',
+      actorId: userId,
+      status: 'allow',
+      reason: 'service_scope_confirmed',
+      scope: 'service',
+      serviceName: entry.slug,
+      result: 'failure',
+      errorCategory: 'persistence_error',
+    });
+    throw error;
+  }
+}
+
+/**
+ * Delete every plugin's data for a user, in one transaction. Plugins are processed in registry
+ * order; within each plugin, tables run child-before-parent. Returns the combined per-table
+ * results. Money settlement (ServiceCredits reclaim) is handled separately by the caller.
+ */
+export async function deleteAllAccountData(userId: string): Promise<AccountDeletionResult> {
+  try {
+    const { requestedAtIso, tables } = await withDbTransaction(async (client) => {
+      const allResults: DeletionTableResult[] = [];
+      for (const entry of accountDeletionRegistry as readonly PluginDeletionEntry[]) {
+        const entryResults = await executeEntry(client, entry, userId);
+        allResults.push(...entryResults);
+      }
+      const iso = await recordEvent(client, userId, 'account', 'all-services', allResults);
+      return { requestedAtIso: iso, tables: allResults };
+    });
+
+    logAccountAudit({
+      command: 'account.data.delete.full',
+      actorId: userId,
+      status: 'allow',
+      reason: 'account_deletion_confirmed',
+      scope: 'account',
+      result: 'success',
+      errorCategory: null,
+      metadata: { tableCount: tables.length },
+    });
+
+    return { ok: true, scope: 'account', serviceName: 'all-services', status: 'completed', requestedAtIso, tables };
+  } catch (error) {
+    logAccountAudit({
+      command: 'account.data.delete.full',
+      actorId: userId,
+      status: 'allow',
+      reason: 'account_deletion_confirmed',
+      scope: 'account',
+      result: 'failure',
+      errorCategory: 'persistence_error',
+    });
+    throw error;
+  }
+}

--- a/ctf/packages/web/lib/account/deletion-orchestrator.ts
+++ b/ctf/packages/web/lib/account/deletion-orchestrator.ts
@@ -32,7 +32,10 @@ export type AccountDeletionResult = {
   /** Plugin slug for service scope; 'all-services' for account scope. */
   readonly serviceName: string;
   readonly status: 'completed';
+  /** When the deletion was requested. For a service delete this equals the completion time. */
   readonly requestedAtIso: string;
+  /** When the deletion finished (the row's `completed_at`). */
+  readonly completedAtIso: string;
   /** Per-table row counts, for the caller and the audit record. */
   readonly tables: readonly DeletionTableResult[];
 };
@@ -45,45 +48,90 @@ export class ServiceScopeNotSupportedError extends Error {
   }
 }
 
-/** Insert the canonical account_deletion_events row inside the same transaction. */
+/** Error thrown when a service-scope deletion targets a slug that is not in the registry at all. */
+export class UnknownServiceError extends Error {
+  constructor(public readonly slug: string) {
+    super(`Unknown service "${slug}".`);
+    this.name = 'UnknownServiceError';
+  }
+}
+
+/**
+ * Insert the canonical account_deletion_events row inside the same transaction.
+ *
+ * `requestedAtIso` is the real moment the deletion was requested — for a full-account deletion the
+ * caller passes the timestamp from `markFullAccountDeletionRequested`; for a standalone service
+ * delete there is no earlier request step, so it defaults to now. `completed_at` is always stamped
+ * `NOW()`. Returns both timestamps so the API can report them with correct semantics.
+ */
 async function recordEvent(
   client: PoolClient,
   userId: string,
   scope: DeletionScope,
   serviceName: string,
   tables: readonly DeletionTableResult[],
-): Promise<string> {
+  requestedAtIso?: string,
+): Promise<{ requestedAtIso: string; completedAtIso: string }> {
   const summary = {
     tables: tables.map((t) => ({ table: t.table, action: t.action, rowCount: t.rowCount })),
   };
-  const inserted = await client.query<{ requested_at: Date }>(
+  const inserted = await client.query<{ requested_at: Date; completed_at: Date }>(
     `INSERT INTO account_deletion_events
        (user_id, scope, service_name, requested_at, completed_at, status, summary)
-     VALUES ($1, $2, $3, NOW(), NOW(), 'completed', $4::jsonb)
-     RETURNING requested_at`,
-    [userId, scope, serviceName, JSON.stringify(summary)],
+     VALUES ($1, $2, $3, COALESCE($4::timestamptz, NOW()), NOW(), 'completed', $5::jsonb)
+     RETURNING requested_at, completed_at`,
+    [userId, scope, serviceName, requestedAtIso ?? null, JSON.stringify(summary)],
   );
-  return inserted.rows[0].requested_at.toISOString();
+  const row = inserted.rows[0];
+  return {
+    requestedAtIso: row.requested_at.toISOString(),
+    completedAtIso: row.completed_at.toISOString(),
+  };
 }
 
 /**
- * Delete one plugin's data for a user. Throws `ServiceScopeNotSupportedError` if the plugin is not
- * service-scoped (e.g. ServiceCredits, GDP, Weekly Performance), so callers can return a clear 4xx.
+ * Delete one plugin's data for a user. Throws `UnknownServiceError` if the slug is not in the
+ * registry at all, or `ServiceScopeNotSupportedError` if it is known but not service-scoped (e.g.
+ * ServiceCredits, GDP, Weekly Performance), so the route can map each to the right status. Both
+ * rejections are audited with `status: 'deny'` so denied attempts leave a trail.
  */
 export async function deleteServiceScopeData(
   slug: string,
   userId: string,
 ): Promise<AccountDeletionResult> {
   const entry = getDeletionEntry(slug);
-  if (!entry || !entry.serviceScopeSupported) {
+  if (!entry) {
+    logAccountAudit({
+      command: 'account.data.delete.service',
+      actorId: userId,
+      status: 'deny',
+      reason: 'unknown_service',
+      scope: 'service',
+      serviceName: slug,
+      result: 'failure',
+      errorCategory: 'not_found',
+    });
+    throw new UnknownServiceError(slug);
+  }
+  if (!entry.serviceScopeSupported) {
+    logAccountAudit({
+      command: 'account.data.delete.service',
+      actorId: userId,
+      status: 'deny',
+      reason: 'service_scope_not_supported',
+      scope: 'service',
+      serviceName: entry.slug,
+      result: 'failure',
+      errorCategory: 'policy_denied',
+    });
     throw new ServiceScopeNotSupportedError(slug);
   }
 
   try {
-    const { requestedAtIso, tables } = await withDbTransaction(async (client) => {
+    const { result, tables } = await withDbTransaction(async (client) => {
       const tableResults = await executeEntry(client, entry, userId);
-      const iso = await recordEvent(client, userId, 'service', entry.slug, tableResults);
-      return { requestedAtIso: iso, tables: tableResults };
+      const recorded = await recordEvent(client, userId, 'service', entry.slug, tableResults);
+      return { result: recorded, tables: tableResults };
     });
 
     logAccountAudit({
@@ -98,7 +146,15 @@ export async function deleteServiceScopeData(
       metadata: { tableCount: tables.length },
     });
 
-    return { ok: true, scope: 'service', serviceName: entry.slug, status: 'completed', requestedAtIso, tables };
+    return {
+      ok: true,
+      scope: 'service',
+      serviceName: entry.slug,
+      status: 'completed',
+      requestedAtIso: result.requestedAtIso,
+      completedAtIso: result.completedAtIso,
+      tables,
+    };
   } catch (error) {
     logAccountAudit({
       command: 'account.data.delete.service',
@@ -116,19 +172,25 @@ export async function deleteServiceScopeData(
 
 /**
  * Delete every plugin's data for a user, in one transaction. Plugins are processed in registry
- * order; within each plugin, tables run child-before-parent. Returns the combined per-table
- * results. Money settlement (ServiceCredits reclaim) is handled separately by the caller.
+ * order; within each plugin, tables run child-before-parent. The single transaction gives clean
+ * all-or-nothing semantics — a partial failure must not leave a user half-deleted, which matters
+ * more here than transaction length (each user's per-plugin footprint is small). Money settlement
+ * (ServiceCredits reclaim) is handled separately by the caller; `requestedAtIso` is the caller's
+ * original request time, stamped onto the event alongside the completion time.
  */
-export async function deleteAllAccountData(userId: string): Promise<AccountDeletionResult> {
+export async function deleteAllAccountData(
+  userId: string,
+  requestedAtIso?: string,
+): Promise<AccountDeletionResult> {
   try {
-    const { requestedAtIso, tables } = await withDbTransaction(async (client) => {
+    const { result, tables } = await withDbTransaction(async (client) => {
       const allResults: DeletionTableResult[] = [];
       for (const entry of accountDeletionRegistry as readonly PluginDeletionEntry[]) {
         const entryResults = await executeEntry(client, entry, userId);
         allResults.push(...entryResults);
       }
-      const iso = await recordEvent(client, userId, 'account', 'all-services', allResults);
-      return { requestedAtIso: iso, tables: allResults };
+      const recorded = await recordEvent(client, userId, 'account', 'all-services', allResults, requestedAtIso);
+      return { result: recorded, tables: allResults };
     });
 
     logAccountAudit({
@@ -142,7 +204,15 @@ export async function deleteAllAccountData(userId: string): Promise<AccountDelet
       metadata: { tableCount: tables.length },
     });
 
-    return { ok: true, scope: 'account', serviceName: 'all-services', status: 'completed', requestedAtIso, tables };
+    return {
+      ok: true,
+      scope: 'account',
+      serviceName: 'all-services',
+      status: 'completed',
+      requestedAtIso: result.requestedAtIso,
+      completedAtIso: result.completedAtIso,
+      tables,
+    };
   } catch (error) {
     logAccountAudit({
       command: 'account.data.delete.full',

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -14,6 +14,13 @@ CREATE SCHEMA IF NOT EXISTS demo;
 SET search_path = demo, public;
 
 -- Combined schema.sql for CTF (rewrite, no /platform)
+--
+-- Maintenance note (2026-05-31): seed scripts seedClicklog/seedGdp/seedMood/seedPeerProgramming
+-- were refactored to open their own `pg` Pool instead of importing the TypeScript
+-- `packages/web/lib/db/postgres.ts` (which plain Node cannot load on the Node 20 seed/provision
+-- workflows). This is a connection-boilerplate change only: no table, column, constraint, index,
+-- or seeded-row change. Recorded here to satisfy the seed/schema drift gate, which requires a
+-- schema.sql touch alongside any seed-script change.
 
 BEGIN;
 CREATE TABLE IF NOT EXISTS clicklog_incidents (
@@ -503,6 +510,32 @@ CREATE INDEX IF NOT EXISTS idx_skills_hunt_missions_round_status ON skills_hunt_
 CREATE INDEX IF NOT EXISTS idx_skills_hunt_mission_progress_user ON skills_hunt_mission_progress (user_id, completed_at, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_skills_hunt_mission_progress_mission ON skills_hunt_mission_progress (mission_id, completed_at);
 COMMIT;
+
+-- === account deletion events (cross-plugin orchestration log) ===
+-- One row per user-initiated deletion the orchestrator runs: a per-plugin "delete my data"
+-- (scope = 'service') or a whole-account deletion (scope = 'account'). This is the canonical,
+-- retained accountability record of what the orchestrator did — it is never itself deleted by a
+-- deletion. `summary` holds the per-table row counts the engine reported, for audit.
+CREATE TABLE IF NOT EXISTS account_deletion_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('service', 'account')),
+  -- For service scope this is the plugin slug; for account scope it is 'all-services'.
+  service_name TEXT NOT NULL,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  status TEXT NOT NULL CHECK (status IN ('requested', 'processing', 'completed', 'failed')),
+  summary JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS scope TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS service_name TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS requested_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS status TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS summary JSONB NOT NULL DEFAULT '{}'::jsonb;
+CREATE INDEX IF NOT EXISTS idx_account_deletion_events_user_scope
+  ON account_deletion_events(user_id, scope, requested_at DESC);
 
 -- === skills-hunt-service-credits ===
 CREATE TABLE IF NOT EXISTS skills_hunt_service_credits_transactions (

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -534,6 +534,42 @@ ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS requested
 ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
 ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS status TEXT;
 ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS summary JSONB NOT NULL DEFAULT '{}'::jsonb;
+-- Restore the CREATE TABLE guarantees on any drifted/legacy DB where the columns were added bare.
+-- Backfill nullable rows first so SET NOT NULL cannot fail, then re-assert defaults, NOT NULL, and
+-- the scope/status CHECK constraints (idempotently).
+UPDATE account_deletion_events SET summary = '{}'::jsonb WHERE summary IS NULL;
+UPDATE account_deletion_events SET requested_at = NOW() WHERE requested_at IS NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN scope SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN service_name SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN requested_at SET DEFAULT NOW();
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN requested_at SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN status SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN summary SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN summary SET NOT NULL;
+DO $account_deletion_events_scope_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'account_deletion_events_scope_check'
+  ) THEN
+    ALTER TABLE account_deletion_events
+      ADD CONSTRAINT account_deletion_events_scope_check CHECK (scope IN ('service', 'account'));
+  END IF;
+END
+$account_deletion_events_scope_check$;
+DO $account_deletion_events_status_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'account_deletion_events_status_check'
+  ) THEN
+    ALTER TABLE account_deletion_events
+      ADD CONSTRAINT account_deletion_events_status_check
+      CHECK (status IN ('requested', 'processing', 'completed', 'failed'));
+  END IF;
+END
+$account_deletion_events_status_check$;
 CREATE INDEX IF NOT EXISTS idx_account_deletion_events_user_scope
   ON account_deletion_events(user_id, scope, requested_at DESC);
 

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -513,6 +513,32 @@ CREATE INDEX IF NOT EXISTS idx_skills_hunt_mission_progress_user ON skills_hunt_
 CREATE INDEX IF NOT EXISTS idx_skills_hunt_mission_progress_mission ON skills_hunt_mission_progress (mission_id, completed_at);
 COMMIT;
 
+-- === account deletion events (cross-plugin orchestration log) ===
+-- One row per user-initiated deletion the orchestrator runs: a per-plugin "delete my data"
+-- (scope = 'service') or a whole-account deletion (scope = 'account'). This is the canonical,
+-- retained accountability record of what the orchestrator did — it is never itself deleted by a
+-- deletion. `summary` holds the per-table row counts the engine reported, for audit.
+CREATE TABLE IF NOT EXISTS account_deletion_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('service', 'account')),
+  -- For service scope this is the plugin slug; for account scope it is 'all-services'.
+  service_name TEXT NOT NULL,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  status TEXT NOT NULL CHECK (status IN ('requested', 'processing', 'completed', 'failed')),
+  summary JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS scope TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS service_name TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS requested_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS status TEXT;
+ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS summary JSONB NOT NULL DEFAULT '{}'::jsonb;
+CREATE INDEX IF NOT EXISTS idx_account_deletion_events_user_scope
+  ON account_deletion_events(user_id, scope, requested_at DESC);
+
 -- === skills-hunt-service-credits ===
 CREATE TABLE IF NOT EXISTS skills_hunt_service_credits_transactions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -536,6 +536,42 @@ ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS requested
 ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
 ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS status TEXT;
 ALTER TABLE IF EXISTS account_deletion_events ADD COLUMN IF NOT EXISTS summary JSONB NOT NULL DEFAULT '{}'::jsonb;
+-- Restore the CREATE TABLE guarantees on any drifted/legacy DB where the columns were added bare.
+-- Backfill nullable rows first so SET NOT NULL cannot fail, then re-assert defaults, NOT NULL, and
+-- the scope/status CHECK constraints (idempotently).
+UPDATE account_deletion_events SET summary = '{}'::jsonb WHERE summary IS NULL;
+UPDATE account_deletion_events SET requested_at = NOW() WHERE requested_at IS NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN scope SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN service_name SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN requested_at SET DEFAULT NOW();
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN requested_at SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN status SET NOT NULL;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN summary SET DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS account_deletion_events ALTER COLUMN summary SET NOT NULL;
+DO $account_deletion_events_scope_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'account_deletion_events_scope_check'
+  ) THEN
+    ALTER TABLE account_deletion_events
+      ADD CONSTRAINT account_deletion_events_scope_check CHECK (scope IN ('service', 'account'));
+  END IF;
+END
+$account_deletion_events_scope_check$;
+DO $account_deletion_events_status_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'account_deletion_events_status_check'
+  ) THEN
+    ALTER TABLE account_deletion_events
+      ADD CONSTRAINT account_deletion_events_status_check
+      CHECK (status IN ('requested', 'processing', 'completed', 'failed'));
+  END IF;
+END
+$account_deletion_events_status_check$;
 CREATE INDEX IF NOT EXISTS idx_account_deletion_events_user_scope
   ON account_deletion_events(user_id, scope, requested_at DESC);
 

--- a/ctf/scripts/check-deletion-engine.mjs
+++ b/ctf/scripts/check-deletion-engine.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+// Checks the account deletion engine's SQL generation without a database.
+//
+// The engine (`ctf/packages/web/lib/account/deletion-engine.ts`) is a pure translator from the
+// account deletion registry's three actions into SQL:
+//   - delete       → DELETE FROM <table> WHERE <userColumn> = $1
+//   - soft-delete  → UPDATE <table> SET <softDeleteColumn> = NOW()
+//                      WHERE <userColumn> = $1 AND <softDeleteColumn> IS NULL
+//   - retain       → (no statement)
+//
+// This script reads the registry source (the same single-quoted del()/soft()/retain() builder
+// calls that `check-deletion-registry.mjs` parses), reconstructs what the engine must produce for
+// each entry, and asserts a set of invariants. It is plain Node (no TypeScript import) so it runs on
+// any Node version, including the Node 20 CI runners. It fails closed: an unrecognized registry
+// shape stops the check rather than passing silently.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..');
+const registryPath = path.join(root, 'packages', 'web', 'lib', 'account', 'deletion-registry.ts');
+
+let failures = 0;
+function fail(message) {
+  console.error(`Deletion engine check failed: ${message}`);
+  failures += 1;
+}
+
+// Parse the registry's owned-table builder calls in source order. Mirrors the parser in
+// check-deletion-registry.mjs, and fails closed on shapes it does not understand.
+function parseOwnedTables(src) {
+  if (/\{\s*table\s*:/.test(src)) {
+    throw new Error(
+      'OwnedTable object literals are not supported by this check; use del()/soft()/retain() or extend the parser.',
+    );
+  }
+  if (/\b(?:del|soft|retain)\(\s*"/.test(src)) {
+    throw new Error(
+      'Double-quoted registry literals are not supported by this check; use single-quoted literals or extend the parser.',
+    );
+  }
+
+  // Walk every builder call in order so ordering invariants can be checked.
+  const callRe = /\b(del|soft|retain)\(\s*'([^']+)'(?:\s*,\s*'([^']+)')?(?:\s*,\s*'([^']+)')?/g;
+  const owned = [];
+  let m;
+  while ((m = callRe.exec(src)) !== null) {
+    const [, kind, a, b, c] = m;
+    if (kind === 'del') {
+      owned.push({ action: 'delete', table: a, userColumn: b });
+    } else if (kind === 'soft') {
+      owned.push({ action: 'soft-delete', table: a, userColumn: b, softDeleteColumn: c });
+    } else {
+      owned.push({ action: 'retain', table: a });
+    }
+  }
+  return owned;
+}
+
+// Reconstruct the SQL the engine must generate for one owned table (null for retain).
+function expectedSql(owned) {
+  if (owned.action === 'retain') return null;
+  if (owned.action === 'delete') {
+    return `DELETE FROM ${owned.table} WHERE ${owned.userColumn} = $1`;
+  }
+  return (
+    `UPDATE ${owned.table} SET ${owned.softDeleteColumn} = NOW() ` +
+    `WHERE ${owned.userColumn} = $1 AND ${owned.softDeleteColumn} IS NULL`
+  );
+}
+
+function main() {
+  if (!fs.existsSync(registryPath)) {
+    fail(`registry not found at ${registryPath}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  let owned;
+  try {
+    owned = parseOwnedTables(fs.readFileSync(registryPath, 'utf8'));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (owned.length === 0) {
+    fail('no owned tables parsed from the registry — parser or registry is broken.');
+    process.exitCode = 1;
+    return;
+  }
+
+  let statements = 0;
+  for (const entry of owned) {
+    const sql = expectedSql(entry);
+
+    if (entry.action === 'retain') {
+      if (sql !== null) fail(`retain table "${entry.table}" should produce no SQL.`);
+      continue;
+    }
+
+    statements += 1;
+
+    // Every non-retain statement must bind exactly the user id as $1 and no other parameter.
+    if (!sql.includes('$1')) {
+      fail(`table "${entry.table}" statement does not bind $1: ${sql}`);
+    }
+    if (sql.includes('$2')) {
+      fail(`table "${entry.table}" statement binds more than one parameter: ${sql}`);
+    }
+    // The user value must never be inlined — only ever the bound parameter.
+    if (!entry.userColumn || !sql.includes(`${entry.userColumn} = $1`)) {
+      fail(`table "${entry.table}" does not scope by its user column via $1: ${sql}`);
+    }
+
+    if (entry.action === 'delete' && !sql.startsWith(`DELETE FROM ${entry.table} `)) {
+      fail(`delete table "${entry.table}" produced unexpected SQL: ${sql}`);
+    }
+    if (entry.action === 'soft-delete') {
+      if (!entry.softDeleteColumn) {
+        fail(`soft-delete table "${entry.table}" has no soft-delete column.`);
+      } else if (!sql.includes(`SET ${entry.softDeleteColumn} = NOW()`)) {
+        fail(`soft-delete table "${entry.table}" does not stamp its soft-delete column: ${sql}`);
+      } else if (!sql.includes(`AND ${entry.softDeleteColumn} IS NULL`)) {
+        // Re-running a soft-delete must be a no-op for already-deleted rows.
+        fail(`soft-delete table "${entry.table}" is not idempotent (missing IS NULL guard): ${sql}`);
+      }
+    }
+  }
+
+  if (failures > 0) {
+    console.error(`Checked ${statements} generated statement(s); see failures above.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Deletion engine check passed: ${statements} generated statement(s) validated.`);
+}
+
+main();

--- a/ctf/scripts/check-deletion-engine.mjs
+++ b/ctf/scripts/check-deletion-engine.mjs
@@ -9,11 +9,13 @@
 //                      WHERE <userColumn> = $1 AND <softDeleteColumn> IS NULL
 //   - retain       → (no statement)
 //
-// This script reads the registry source (the same single-quoted del()/soft()/retain() builder
-// calls that `check-deletion-registry.mjs` parses), reconstructs what the engine must produce for
-// each entry, and asserts a set of invariants. It is plain Node (no TypeScript import) so it runs on
-// any Node version, including the Node 20 CI runners. It fails closed: an unrecognized registry
-// shape stops the check rather than passing silently.
+// To actually test the engine (not a re-implementation of it), this script extracts the two SQL
+// template literals straight from `deletion-engine.ts` source and renders them for every registry
+// entry. So if someone changes the engine's SQL — drops the `$1` binding, removes the soft-delete
+// `IS NULL` idempotency guard, inlines a value — the rendered output changes here and the invariant
+// assertions below fail. It is plain Node (no TypeScript import, which is unreliable across Node
+// versions) so it runs on the Node 20 CI runners, and it fails closed: an unrecognized registry or
+// engine shape stops the check rather than passing silently.
 
 import fs from 'fs';
 import path from 'path';
@@ -22,6 +24,7 @@ import { fileURLToPath } from 'url';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(here, '..');
 const registryPath = path.join(root, 'packages', 'web', 'lib', 'account', 'deletion-registry.ts');
+const enginePath = path.join(root, 'packages', 'web', 'lib', 'account', 'deletion-engine.ts');
 
 let failures = 0;
 function fail(message) {
@@ -43,7 +46,6 @@ function parseOwnedTables(src) {
     );
   }
 
-  // Walk every builder call in order so ordering invariants can be checked.
   const callRe = /\b(del|soft|retain)\(\s*'([^']+)'(?:\s*,\s*'([^']+)')?(?:\s*,\s*'([^']+)')?/g;
   const owned = [];
   let m;
@@ -60,28 +62,52 @@ function parseOwnedTables(src) {
   return owned;
 }
 
-// Reconstruct the SQL the engine must generate for one owned table (null for retain).
-function expectedSql(owned) {
-  if (owned.action === 'retain') return null;
-  if (owned.action === 'delete') {
-    return `DELETE FROM ${owned.table} WHERE ${owned.userColumn} = $1`;
+// Pull the two SQL template literals out of the engine source so this check renders the engine's
+// real SQL, not a copy. We look for the exact template-literal forms the engine uses and convert
+// the `${owned.X}` interpolations into a tiny render function. If the engine's SQL shape changes in
+// a way these patterns no longer match, the check fails closed (the engine must be re-read).
+function extractEngineTemplates(engineSrc) {
+  // delete: `DELETE FROM ${owned.table} WHERE ${owned.userColumn} = $1`
+  const deleteRe = /`(DELETE FROM \$\{owned\.table\} WHERE \$\{owned\.userColumn\} = \$1)`/;
+  // soft-delete is built by concatenating two template chunks; capture both and join them.
+  const softRe =
+    /`(UPDATE \$\{owned\.table\} SET \$\{owned\.softDeleteColumn\} = NOW\(\) )` \+\s*`(WHERE \$\{owned\.userColumn\} = \$1 AND \$\{owned\.softDeleteColumn\} IS NULL)`/;
+
+  const del = engineSrc.match(deleteRe);
+  const soft = engineSrc.match(softRe);
+  if (!del) {
+    throw new Error('could not find the engine DELETE template; the engine SQL shape changed — re-read deletion-engine.ts.');
   }
-  return (
-    `UPDATE ${owned.table} SET ${owned.softDeleteColumn} = NOW() ` +
-    `WHERE ${owned.userColumn} = $1 AND ${owned.softDeleteColumn} IS NULL`
-  );
+  if (!soft) {
+    throw new Error('could not find the engine soft-delete UPDATE template; the engine SQL shape changed — re-read deletion-engine.ts.');
+  }
+
+  const render = (tpl, owned) =>
+    tpl
+      .replaceAll('${owned.table}', owned.table)
+      .replaceAll('${owned.userColumn}', owned.userColumn ?? '')
+      .replaceAll('${owned.softDeleteColumn}', owned.softDeleteColumn ?? '');
+
+  return {
+    deleteSql: (owned) => render(del[1], owned),
+    softSql: (owned) => render(soft[1] + soft[2], owned),
+  };
 }
 
 function main() {
-  if (!fs.existsSync(registryPath)) {
-    fail(`registry not found at ${registryPath}`);
-    process.exitCode = 1;
-    return;
+  for (const [label, p] of [['registry', registryPath], ['engine', enginePath]]) {
+    if (!fs.existsSync(p)) {
+      fail(`${label} not found at ${p}`);
+      process.exitCode = 1;
+      return;
+    }
   }
 
   let owned;
+  let templates;
   try {
     owned = parseOwnedTables(fs.readFileSync(registryPath, 'utf8'));
+    templates = extractEngineTemplates(fs.readFileSync(enginePath, 'utf8'));
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;
@@ -96,13 +122,11 @@ function main() {
 
   let statements = 0;
   for (const entry of owned) {
-    const sql = expectedSql(entry);
-
     if (entry.action === 'retain') {
-      if (sql !== null) fail(`retain table "${entry.table}" should produce no SQL.`);
       continue;
     }
 
+    const sql = entry.action === 'delete' ? templates.deleteSql(entry) : templates.softSql(entry);
     statements += 1;
 
     // Every non-retain statement must bind exactly the user id as $1 and no other parameter.
@@ -137,7 +161,7 @@ function main() {
     process.exitCode = 1;
     return;
   }
-  console.log(`Deletion engine check passed: ${statements} generated statement(s) validated.`);
+  console.log(`Deletion engine check passed: ${statements} engine-rendered statement(s) validated.`);
 }
 
 main();


### PR DESCRIPTION
## Summary

Builds the executors on top of the account deletion registry (merged in #221), so a user's deletion request **actually removes their data** instead of only recording a request. This is the v2 "delete my account / delete my data" capability that v3 was missing.

Before this PR, `DELETE /api/account/full-account` wrote a request row and queued the ServiceCredits reclaim, but **never deleted any cross-plugin data**. That gap is now closed.

This is the **backend only**. The user-facing Account & Data UI that will call these routes is design-gated (Rule 127) and intentionally not built here.

## What this adds

**The engine** (`lib/account/deletion-engine.ts`) — a pure translator from a registry entry to SQL:
- `delete` → `DELETE FROM <table> WHERE <userColumn> = $1`
- `soft-delete` → an idempotent `UPDATE ... SET <col> = NOW() WHERE <userColumn> = $1 AND <col> IS NULL` (re-running is a no-op)
- `retain` → no statement (money ledgers, audit trails, shared content)

Identifiers come only from the registry (already validated against `schema.sql` in CI); the user id is always the bound parameter `$1`, never inlined. Because the planner is pure, its output is checked **without a database** by `scripts/check-deletion-engine.mjs`.

**The orchestrator** (`lib/account/deletion-orchestrator.ts`) — `deleteServiceScopeData(slug, userId)` and `deleteAllAccountData(userId)`. Each runs the registry-derived plan in a single `withDbTransaction` (a failure rolls back rather than half-deleting a user), records one `account_deletion_events` row, and logs an `[account.audit]` line.

**Money is never touched by the engine.** ServiceCredits and other ledgers are `retain` in the registry and are settled only by the existing reclaim flow (`markFullAccountDeletionRequested` → `enqueueServiceCreditsDeletionReclaim` → the service-credits adapter outbox). The full-account route runs that reclaim first, then the orchestrator.

**API routes:**
- `DELETE /api/account/services/:slug` — delete one plugin's data. The `:slug` is validated against the registry; non-service-scoped plugins (money/aggregate-only) return a clear 409 rather than a silent no-op. One generic route instead of 16 hand-written files.
- `DELETE /api/account/full-account` — now records the request, queues the ServiceCredits reclaim, **then** deletes data across every plugin.
- Both are self-service (caller's own rows only) and same-origin `x-ctf-csrf: 1` guarded, matching the existing per-plugin convention.

**Schema:** new `account_deletion_events` table (the retained accountability record: id, user_id, scope, service_name, requested_at, completed_at, status, summary), added with the `CREATE TABLE IF NOT EXISTS` + `ALTER ... ADD COLUMN IF NOT EXISTS` pattern. `schema.demo.sql` regenerated.

**CI:** `check-deletion-engine.mjs` wired into the Schema Drift Gate job next to the existing registry check. Both run on plain Node.

**Docs:** `ACCOUNT_DELETION_REGISTRY.md` and the non-plugin feature inventory updated to describe the engine, orchestrator, routes, and table.

## Why conservative

Deletion is irreversible and money-adjacent, so the engine deletes only what the registry marks `delete`/`soft-delete` and leaves every money/audit/shared table alone. The registry → engine → orchestrator split keeps each piece small and independently checkable, and the two plain-Node guards (registry-vs-schema, engine SQL generation) run in CI so neither can drift.

## Verification

- `node ctf/scripts/check-deletion-engine.mjs`: passes — 63 generated statements validated.
- `node ctf/scripts/check-deletion-registry.mjs`: passes — 84 references validated against `schema.sql`.
- `pnpm --dir ctf run typecheck`: passes (all packages).
- `check-eof-format.sh`, modularity governance, and the Schema Drift Gate all pass locally.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated account deletion registry documentation with new API routes and orchestration details

* **New Features**
  * Added self-service account data deletion endpoints
  * Users can delete their data by individual service or full account
  * CSRF protection implemented for account operations
  * All deletion requests recorded with audit logging for compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->