### PR TITLE
fix: correct devcontainer DB password extraction in setup.sh

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -82,7 +82,7 @@ pnpm --filter "@ctf/agent-mcp-server" build || {
 if [ "$FAST_MODE" != "1" ] && [ -n "$DATABASE_URL" ]; then
   echo "Applying ctf/schema.sql to Neon DB at DATABASE_URL..."
   if command -v psql &> /dev/null; then
-    PGPASSWORD="$(echo $DATABASE_URL | sed -n 's/.*:.*:\/\/(.*):(.*)@.*/\2/p')" \
+    PGPASSWORD="$(echo "$DATABASE_URL" | sed -En 's/.*:\/\/[^:]+:([^@]+)@.*/\1/p')" \
     psql "$DATABASE_URL" -f /workspaces/chargingthefuture/ctf/schema.sql || {
       echo "Failed to apply schema.sql to Neon DB. Check your DATABASE_URL and schema file.";
       exit 1;


### PR DESCRIPTION
## Summary

Salvages the one still-relevant change from the stale tracking PR #119 (which can now be closed — see below) and applies it cleanly on top of current `main`.

The devcontainer schema-apply step in `.devcontainer/setup.sh` built `PGPASSWORD` with `sed -n` using a BRE pattern that contained ERE-style groups — unescaped `(` `)` plus a `\2` back-reference. In BRE mode that errors (`sed: invalid reference \2 on 's' command's RHS`) and yields an **empty password**, so when a container starts with a `DATABASE_URL` set, the schema-apply step silently runs without a password.

### The fix

```diff
- PGPASSWORD="$(echo $DATABASE_URL | sed -n 's/.*:.*:\/\/(.*):(.*)@.*/\2/p')" \
+ PGPASSWORD="$(echo "$DATABASE_URL" | sed -En 's/.*:\/\/[^:]+:([^@]+)@.*/\1/p')" \
```

`sed -En` (extended regex) with a single capture group that takes everything between the first `:` after the userinfo and the `@`. Also quotes `$DATABASE_URL`.

### Verified

For `postgresql://myuser:s3cr3tP%40ss@host/db?sslmode=require`:
- New pattern extracts `s3cr3tP%40ss` correctly (including the percent-encoded char).
- Old pattern errors and returns empty — confirming the latent bug.

Typecheck and EOF gates pass.

## Why this exists / relation to #119

PR #119 was an umbrella "UI circle-back" tracking PR from 2026-05-28. Its per-plugin pixel work has all since landed via individual merged PRs — the four plugins it still listed (skills-taxonomy, weekly-performance, clicklog, unlock) are already `Web px ✅` on `main`, and `main` carries newer shell implementations. The only change in #119 not already on `main` was this one-line `setup.sh` fix, salvaged here. #119 can be closed in favor of following `PRODUCTION_READINESS_PLAN.md`.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgyaKSChDch8Mr798bbXWS)_