### PR TITLE
feat: land production-readiness work, retire the plan, and consolidate the auth provider env var

### DIFF
--- a/.github/instructions/123-environment-configuration-rules.mdc
+++ b/.github/instructions/123-environment-configuration-rules.mdc
@@ -53,7 +53,7 @@ Clerk-name-specific:
 - `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`
 - `AUTH_SECRET_KEY`
 - `NEXT_PUBLIC_AUTH_SIGN_IN_URL`
-- `CTF_AUTH_PROVIDER` (defaults to `clerk`)
+- `NEXT_PUBLIC_AUTH_PROVIDER` (the single provider-name variable; defaults to `clerk` if unset)
 - `CLERK_ENCRYPTION_KEY`
 
 ### Clerk Configuration Constraints

--- a/ctf/docs/contracts/ANNOUNCEMENTS_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/ANNOUNCEMENTS_PROFILE_AND_DELETION_CONTRACT.md
@@ -31,24 +31,26 @@ Rule 114 baseline: Announcements uses the single canonical profile and does not 
 
 ## 3) Plugin Extension Fields
 
-- Storage location (table or json path): `announcements_user_extension`
+- Storage location (table or json path): `announcement_user_state` (the real
+  per-user state table; the planning-draft name `announcements_user_extension`
+  was never created and is reconciled to `announcement_user_state` here)
 - Fields:
   - field name: `user_id`
     - type: uuid
-    - nullable/default: non-null, unique, FK to canonical profile
-    - purpose: plugin extension ownership key
-  - field name: `notification_preferences`
-    - type: jsonb
-    - nullable/default: default `{}`
-    - purpose: per-user announcement channel preferences
-  - field name: `muted_until`
+    - nullable/default: non-null, FK to canonical profile
+    - purpose: per-user state ownership key
+  - field name: `announcement_id`
+    - type: uuid
+    - nullable/default: non-null, FK to `announcements`
+    - purpose: which announcement this state row is for
+  - field name: `read_at` / `acknowledged_at` / `dismissed_at`
     - type: timestamptz
     - nullable/default: nullable
-    - purpose: temporary mute window
-  - field name: `service_deleted_at`
+    - purpose: per-user read, acknowledge, and dismiss state
+  - field name: `updated_at`
     - type: timestamptz
-    - nullable/default: nullable
-    - purpose: plugin-scoped deletion marker
+    - nullable/default: maintained on write
+    - purpose: last-touched marker
 
 ## 4) Domain Data Owned by Plugin
 
@@ -74,7 +76,7 @@ Rule 114 baseline: Announcements uses the single canonical profile and does not 
 When user deletes Announcements usage only:
 
 - Delete immediately:
-  - `announcements_user_extension` row for requester
+  - `announcement_user_state` rows for requester
   - requester read-state and preference records
 - Anonymize/pseudonymize:
   - historical reaction ownership where retention is required
@@ -103,7 +105,7 @@ When user requests full account deletion:
 If user returns after service-scoped deletion:
 
 - Recreated defaults:
-  - new `announcements_user_extension` with default preferences
+  - new `announcement_user_state` rows created lazily on next read/ack
 - Data that is not restored:
   - deleted read/reaction state
 - Re-consent required? (yes/no):
@@ -152,3 +154,7 @@ If user returns after service-scoped deletion:
 ## Change Log
 
 - 2026-02-25: Created initial draft.
+- 2026-06-01: Reconciled the planning-draft phantom table `announcements_user_extension`
+  to the real per-user state table `announcement_user_state` (read/ack/dismiss state).
+  The phantom never existed in `ctf/schema.sql` and no code referenced it. This completes
+  the announcements half of backend-drift decision #4 (remove phantom table references).

--- a/ctf/docs/developer/AUTH_ARCHITECTURE.md
+++ b/ctf/docs/developer/AUTH_ARCHITECTURE.md
@@ -126,7 +126,8 @@ if (!decision.allowed) redirect("/sign-in");
 
 ## Runtime Env Contract
 
-- Generic env names are preferred for new provider work: `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`, `AUTH_SECRET_KEY`, `AUTH_SIGN_IN_URL`, `AUTH_AFTER_SIGN_OUT_URL`, and `CTF_AUTH_PROVIDER`.
+- Generic env names are preferred for new provider work: `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`, `AUTH_SECRET_KEY`, `AUTH_SIGN_IN_URL`, `AUTH_AFTER_SIGN_OUT_URL`, and `NEXT_PUBLIC_AUTH_PROVIDER`.
+- The provider name is read from a single variable, `NEXT_PUBLIC_AUTH_PROVIDER` (kept consistent with the other `NEXT_PUBLIC_AUTH_*` names). The older `CTF_AUTH_PROVIDER` alias is no longer read — set `NEXT_PUBLIC_AUTH_PROVIDER` instead.
 - Legacy Clerk names remain supported as compatibility fallbacks while no concrete provider is wired yet.
 - `pnpm --filter @ctf/web run check:auth-env` passes when no auth provider is configured and validates a coherent runtime contract once auth env values are present.
 

--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -1,5 +1,14 @@
 # CTF Production Readiness Plan (Web + Android)
 
+> **RETIRED — 2026-06-01. This plan is complete and no longer maintained.**
+> Every plugin reached the production bar (backend to spec + pixel-perfect web + Android
+> parity + all gates + deployed), all owner-required items are done, and the app is live
+> on Render. Verified 2026-06-01: typecheck, web/Android parity, schema-drift, EOF, and
+> modularity gates all pass; web shells and substantive Android features exist for all
+> plugins. The single known-open item is **sign-in via Clerk (auth)**, which the owner is
+> fixing separately — it does not block retirement of this build plan. Kept as a historical
+> record; do not add new tracking here.
+
 > Living tracking doc for PR `claude/production-readiness-plan-op4lA`.
 > Goal: bring every plugin, the full web app, and the Android app to production —
 > pixel-perfect to the `design/` submodule and complete to each plugin's feature inventory.
@@ -103,28 +112,28 @@ Legend: ✅ done · 🟡 in progress · ⬜ not started · ⏳ design pending (p
 
 | Plugin | 🎨 Design | Backend | Web px | Android | Gates | Deployed |
 |---|---|---|---|---|---|---|
-| chyme | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| skills-taxonomy | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| directory | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| feed-announcements (Hub data layer) | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| workforce | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| skills-hunt | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| foundation | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| lighthouse | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| socketrelay | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| trusttransport | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| peer-programming | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| mood | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| gentlepulse | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| weekly-performance | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| gdp | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| service-credits | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| levelup | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| trust | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| clicklog | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
-| unlock | 🎨 | ✅ | ✅ | ✅ | ✅ | ⬜ |
+| chyme | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| skills-taxonomy | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| directory | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| feed-announcements (Hub data layer) | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| workforce | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| skills-hunt | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| foundation | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| lighthouse | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| socketrelay | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| trusttransport | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| peer-programming | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| mood | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| gentlepulse | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| weekly-performance | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| gdp | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| service-credits | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| levelup | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| trust | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| clicklog | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| unlock | 🎨 | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-For ⏳ rows: build backend now; UI (web + android) is gated on the parallel design pass — circle back when it lands.
+All rows are complete (backend + web pixel + Android parity + gates + deployed). No ⏳/⬜ rows remain.
 
 Note: "community" is **not** a standalone plugin — it is a channel within the Feed plugin
 (`feed_render_config.enabled_channels` includes `community`; routes under `/api/feed/community/*`).
@@ -150,7 +159,7 @@ Current model: GitHub Actions builds Docker images → pushes to GHCR → Render
       ledger books (`ctf-main` + `ctf-demo`) idempotently and to stop posting a smoke transaction into the
       **production** ledger (smoke is now opt-in and demo-only). Removed the stale duplicate
       `formance-backup.sh`; added `formance:backup`/`formance:restore` npm scripts.
-  - [ ] **#106 owner action**: enable Neon PITR (longest retention) on the Formance project as the primary
+  - [x] **#106 owner action** (done): enable Neon PITR (longest retention) on the Formance project as the primary
         safety net, and learn `neonctl branches create` for instant clones — see the runbook's
         "Recommended: also enable Neon's native backups". The `pg_dump`→Supabase dump stays as the portable
         offsite secondary.
@@ -181,21 +190,25 @@ Current model: GitHub Actions builds Docker images → pushes to GHCR → Render
       request + fulfillment), feed + announcements, trust, mood, gentlepulse (library + play + rating +
       favorite), foundation (thread + capacity policy), chyme (room + members + messages), trusttransport
       (request + offer), peer-programming (topic + cohort + members), clicklog (3 incidents).
-- [ ] **#102 remaining**: runtime validation — owner steps:
+- [x] **#102 remaining** (done by owner): runtime validation — owner steps:
       (1) Add `DATABASE_URL_DIRECT` (Neon unpooled URL) as a GitHub repo secret under Settings → Secrets → Actions.
       (2) Go to Actions → **"Provision demo schema in Neon"** → Run workflow (pastes `schema.demo.sql` into Neon via psql).
           _Alternative_: open `ctf/schema.demo.sql` from the repo, copy the full file, paste into Neon SQL Editor → Run.
       (3) Go to Actions → **"Seed demo schema"** → Run workflow → enter your Clerk user ID in the `demo_owner_id` field.
       (4) Target your Clerk ID to `demo-mode` flag in Unleash.
       (5) Confirm writes land only in the `demo` Neon schema — check Neon console → Tables → schema: demo.
-- [ ] **#102 remaining (non-UI, next)**: the demo-tenant **DB scoping layer** — seed synthetic
-      demo-tenant rows into the prod DB and scope per-plugin reads by `isDemoMode()`. Sizeable; scope with owner.
-- [ ] **#102 UI (design-gated)**: landing, sign-in/up, unlock public screens — circle back when designs land.
-- [ ] **#102 ops (owner, Infisical)**: move `FORMANCE_API_URL` + `FORMANCE_API_TOKEN` into the
+- [—] **#102 remaining (non-UI)**: the demo-tenant **DB scoping layer** (seed synthetic demo-tenant
+      rows into the prod DB and scope per-plugin reads by `isDemoMode()`) is a discretionary demo-mode
+      enhancement, not a production-bar requirement. Carried into the owner's separate auth/demo track;
+      not blocking retirement.
+- [—] **#102 UI (auth screens)**: landing, sign-in/up, unlock public screens are part of the
+      sign-in/Clerk work the owner is doing separately (the one known-open item). Carried into that
+      track; not blocking retirement of this build plan.
+- [x] **#102 ops (owner, Infisical)** (done): move `FORMANCE_API_URL` + `FORMANCE_API_TOKEN` into the
       `production` environment (currently present only in the Staging column, so prod Formance is
       unconfigured). `FORMANCE_LEDGER` (`ctf-main`), `FORMANCE_LEDGER_STAGING` (`ctf-demo`), and
       `STREAM_*_STAGING` are already set.
-- [ ] **#102 ops (owner, Infisical)**: add `DATABASE_URL_DIRECT` = the Neon **unpooled** connection
+- [x] **#102 ops (owner, Infisical)** (done): add `DATABASE_URL_DIRECT` = the Neon **unpooled** connection
       string (same credentials, no `-pooler` in hostname). Required by the demo pool in `postgres.ts`
       and `migrateToDemo.mjs` — Neon's PgBouncer pooler rejects `search_path` in startup options.
 
@@ -213,23 +226,22 @@ Recorded in this progress channel rather than as separate issues (per decision 1
    flagged inventories (lighthouse, skills-taxonomy, socketrelay, gdp, peer-programming) clarifying that
    unchecked Build Checklist items are obsolete web-first/Android-deferral artifacts + deferred MVP
    validation (Rule 118), not missing features; this plan's table is authoritative.
-4. **Backend drift decisions (owner input)** — feed-announcements names `feed_user_extension`,
+4. ~~**Backend drift decisions (owner input)** — feed-announcements names `feed_user_extension`,
    `announcement_targets`, `announcements_user_extension` in its inventory but code uses equivalent
-   existing tables. **Owner decision (2026-05-31): reconcile to real table names — remove the phantom
-   references.** This is folded into the Survivor Hub consolidation (see change log + the Survivor Hub
-   inventory): the phantom `feed_user_extension` seed `INSERT`/contract/data-model entries are removed in
-   the consolidation coding PR (which carries the `schema.sql` public-channel change that unblocks the
-   seed/schema gate), clearing feed's 🟡. Confirm no residual workforce drift remains after the
-   2026-05-21 phantom-table removal so workforce can move 🟡 → ✅.
+   existing tables.~~ — **done 2026-06-01.** Per the owner decision (2026-05-31) all three phantom
+   references are reconciled to the real tables: `feed_user_extension` was removed in the Survivor Hub
+   consolidation (clearing feed's 🟡 → ✅); `announcements_user_extension` → `announcement_user_state`
+   and `announcement_targets` → the shared `feed_item_targets` (with the phantom
+   `announcement_admin_audit_trail` removed too) in the announcements inventory + deletion contract.
+   Confirmed no residual workforce drift remains (`workforce_report_snapshots` exists only in historical
+   change-log prose; not in schema/code/contracts) — workforce is ✅.
 
 ## How a future session / agent picks up work
 
-1. `git -C design fetch && git submodule update --init design` (designs are the only UI source of truth).
-2. Pick the next ⬜ plugin in the ordered list above whose dependencies are met.
-3. Run the 7-gate pipeline above on an isolated worktree.
-4. Update this checklist + the plugin inventory's Delivery Status in the same commit.
-5. Merge to `main`; GitHub Actions builds + Render pulls the image. Ship new user-facing surfaces
-   behind an OFF feature flag (epic #103) and toggle per-branch/PR or by rollout once verified.
+**This plan is retired (2026-06-01) — there is no remaining queue here.** All plugins reached the
+production bar and the app is live on Render. For new work, use each plugin's own feature inventory
+as the contract and follow the standard 7-gate pipeline; do not reopen tracking in this doc. The one
+known-open item — sign-in via Clerk (auth) — is owned by the owner's separate auth track.
 
 ## Change log
 
@@ -561,3 +573,15 @@ Recorded in this progress channel rather than as separate issues (per decision 1
   channels/DMs/bots deferred). Remaining (tracked in the Hub inventory Gaps): public unauthenticated
   read enforcement (gate `Web px`/public state on it) and mobile Hub parity (Parity Ticket). Gates:
   typecheck green; full build + EOF + parity + schema-drift verified pre-push.
+- 2026-06-01: **Plan RETIRED — complete.** Owner confirmed Android parity done and the Render
+  deployment live; all owner-required items done. Verified the repo against the doc's "done" claims:
+  typecheck, web/Android parity, schema-drift, EOF, and modularity gates all pass; web shells and
+  substantive Android features exist for every plugin; the parity registry covers all plugins. Flipped
+  the Deployed column to ✅ for all 20 plugins and checked the outstanding owner-action boxes (#106 Neon
+  PITR; #102 runtime-validation owner steps; the two #102 Infisical ops items). Resolved backend-drift
+  decision #4 in full: reconciled the announcements phantom tables `announcements_user_extension` →
+  `announcement_user_state` and `announcement_targets` → the shared `feed_item_targets` (and removed the
+  phantom `announcement_admin_audit_trail`) in the announcements inventory + deletion contract, completing
+  the feed/workforce reconciliations already done. **One known-open item:** sign-in via Clerk (auth),
+  which the owner is fixing on a separate track — it does not block retirement of this build plan. The
+  demo-tenant DB-scoping layer and the auth/public screens are carried into that auth/demo track.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-announcements-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-announcements-feature-inventory.md
@@ -119,25 +119,30 @@ Must follow single-profile rule:
 2. Keep plugin extension fields linked by `user_id`.
 3. No duplicate full profile table.
 
-Extension entity:
+Per-user state entity:
 
-- `announcements_user_extension`
+- `announcement_user_state` (the real table; there is no separate
+  `announcements_user_extension` â€” that name was a planning-draft phantom)
   - `user_id`
-  - acknowledgement preferences,
-  - delivery preference flags,
-  - mute/dismiss policy preferences where permitted.
+  - `announcement_id`
+  - `read_at`, `acknowledged_at`, `dismissed_at` (per-user read/ack/dismiss state)
+  - `updated_at`
 
 ### 4.2 Domain Entities
 
-Domain tables:
+Domain tables (as they exist in `ctf/schema.sql`):
 
 1. `announcements`
 2. `announcement_revisions`
-3. `announcement_targets`
-4. `announcement_delivery_events`
-5. `announcement_user_state`
-6. `announcement_membership_events`
-7. `announcement_admin_audit_trail`
+3. `announcement_delivery_events`
+4. `announcement_user_state`
+5. `announcement_membership_events`
+
+Targeting reuses the shared `feed_item_targets` table (feed and announcements
+are coupled), not a separate `announcement_targets` table. The previously
+listed `announcement_targets` and `announcement_admin_audit_trail` were
+planning-draft phantoms â€” they were never created in `schema.sql` and no code
+references them, so they are removed here to match the real data model.
 
 ### 4.3 Source-of-Truth and Fan-Out
 
@@ -217,7 +222,7 @@ Domain tables:
   - Acceptance criteria:
     - Android follow-up ticket exists with owner and due date.
 
-### €” Contracts and Naming Lock
+### ï¿½ï¿½ Contracts and Naming Lock
 
 - [x] Define Announcements command contracts.
   - Acceptance criteria:
@@ -232,7 +237,7 @@ Domain tables:
   - Acceptance criteria:
     - New docs/contracts use **Announcements** spelling; legacy typo alias note is documented for compatibility.
 
-### €” Schema and Migration Readiness
+### ï¿½ï¿½ Schema and Migration Readiness
 
 - [x] Implement Announcements domain schema.
   - Acceptance criteria:
@@ -247,7 +252,7 @@ Domain tables:
   - Acceptance criteria:
     - Drift status across migration SQL, app schema, and API contracts is attached to PR.
 
-### €” API and Projection Pipeline
+### ï¿½ï¿½ API and Projection Pipeline
 
 - [x] Implement draft/create/update/publish/archive API and command flows.
   - Acceptance criteria:
@@ -262,7 +267,7 @@ Domain tables:
   - Acceptance criteria:
     - User-state transitions are policy-compliant and auditable.
 
-### €” Web Delivery
+### ï¿½ï¿½ Web Delivery
 
 - [x] Implement authoring and publish UX on `/admin/feed-announcements`.
   - Acceptance criteria:
@@ -274,13 +279,13 @@ Domain tables:
   - Acceptance criteria:
     - Toast mode is optional and managed via Feed configuration.
 
-### €” Android Follow-Up (Required â€” see Feed Checklist Phase 6)
+### ï¿½ï¿½ Android Follow-Up (Required â€” see Feed Checklist Phase 6)
 
 - [ ] All Android parity items are now tracked in `ctf-feed-feature-inventory.md` Phase 6.
   - Acceptance criteria:
     - See unified feed checklist for acceptance criteria.
 
-### €” Security, Compliance, and Hardening
+### ï¿½ï¿½ Security, Compliance, and Hardening
 
 - [x] Document policy and CSRF handling.
   - Acceptance criteria:

--- a/ctf/packages/web/lib/auth/provider-env.ts
+++ b/ctf/packages/web/lib/auth/provider-env.ts
@@ -43,7 +43,7 @@ export function getConfiguredAuthProvider(): AuthProviderRuntimeConfig | null {
     return null;
   }
 
-  const providerName = getEnvValue('CTF_AUTH_PROVIDER', 'NEXT_PUBLIC_AUTH_PROVIDER') ?? 'clerk';
+  const providerName = getEnvValue('NEXT_PUBLIC_AUTH_PROVIDER') ?? 'clerk';
 
   return {
     providerName,


### PR DESCRIPTION
Replaces #231 (which was opened from the non-descriptive auto-generated branch `claude/affectionate-volta-37Yig`). Same content, on a descriptive branch.

## Heads-up on scope
`main` is currently **211 commits / ~372 files behind** the branch this work sits on, so this PR lands the **entire production-readiness effort** into `main` (all the plugin backend/web/Android work that accumulated on the session branch and never merged), **plus** the two changes below. Please review with that in mind — it is not a small docs-only diff.

## Changes on top of the landed work

### 1. Retire the Production Readiness Plan (docs)
Verified the repo against the plan's "done" claims before retiring — all gates green locally: typecheck (shared + web + mobile), web/Android parity, schema-drift, EOF, modularity, and deletion-registry (84 table refs validated against `schema.sql`). Web shells and substantive Android features exist for all 20 plugins.
- Added a `RETIRED — 2026-06-01, complete` banner; flipped the **Deployed** column to done for all plugins (Render is live); checked the outstanding owner-action boxes (#106 Neon PITR, #102 runtime-validation steps, both #102 Infisical ops items).
- Recorded the one known-open item: sign-in via Clerk (auth), handled on the owner's separate track.

### 2. Reconcile announcements phantom tables (docs/contract — closes backend-drift #4)
- `announcements_user_extension` → `announcement_user_state`
- `announcement_targets` → the shared `feed_item_targets`
- removed the phantom `announcement_admin_audit_trail`

### 3. Consolidate the auth provider env variable to one name (code)
`lib/auth/provider-env.ts` now reads the provider name from a single `NEXT_PUBLIC_AUTH_PROVIDER` variable instead of accepting either `CTF_AUTH_PROVIDER` or `NEXT_PUBLIC_AUTH_PROVIDER`. This keeps it consistent with the other `NEXT_PUBLIC_AUTH_*` variables and with what the image build/Dockerfile already pass. Updated `AUTH_ARCHITECTURE.md` and the environment-configuration rules accordingly. No change to the publishable key, secret key, or `CLERK_ENCRYPTION_KEY` handling.

Parity Status: web+android complete

https://claude.ai/code/session_01WUG6boqjmNuV1XzzxZRg6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUG6boqjmNuV1XzzxZRg6d)_