### PR TITLE
docs: clarify NEXT_PUBLIC_* auth vars are baked at build time, not read from Render

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,9 +10,16 @@ name: Build and push Docker images
 #   Package settings → Change visibility → Public.
 #   This lets Render pull images without registry credentials.
 #
-# REQUIRED GITHUB SECRETS:
+# REQUIRED GITHUB SECRETS (baked into the client bundle at build time):
+#   These NEXT_PUBLIC_* values are read ONLY here, at image build time. Next.js
+#   inlines every `NEXT_PUBLIC_*` value into the client JavaScript when the image
+#   is built, so this workflow's GitHub Actions secrets — NOT Render/Infisical —
+#   are the source of truth for what the browser loads. Updating the same key in
+#   Infisical/Render at runtime does NOTHING for the client; to change any of
+#   these you must update the GitHub Actions secret here and re-run this workflow
+#   so the value is re-baked into a fresh image.
 #   NEXT_PUBLIC_APP_URL               — production URL, e.g. https://app.chargingthefuture.com
-#   NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY  — Clerk publishable key (pk_live_…)
+#   NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY  — Clerk publishable key (pk_live_…); must match the domain the app is served on (Clerk production keys are domain-locked)
 #   NEXT_PUBLIC_AUTH_SIGN_IN_URL      — e.g. /sign-in
 #   NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL — e.g. /
 #   NEXT_PUBLIC_AUTH_PROVIDER         — clerk
@@ -100,6 +107,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=ctf-web
           cache-to: type=gha,scope=ctf-web,mode=max
+          # These NEXT_PUBLIC_* build-args are inlined into the client bundle now,
+          # at build time. They are the ONLY source of the browser's Clerk config —
+          # Render/Infisical runtime env does not change them. Re-run this workflow
+          # after updating a secret so the new value is re-baked.
           build-args: |
             NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }}
             NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY }}

--- a/render.yaml
+++ b/render.yaml
@@ -57,16 +57,28 @@ services:
       # Observability — enables Sentry cron check-ins for workforce-incremental-sync
       - key: OBSERVABILITY_PROVIDER
         value: sentry
-      # All remaining secrets are synced automatically by Infisical → Render Sync:
+      # Server-side (runtime) secrets are synced automatically by Infisical →
+      # Render Sync. These are read by the running container at request time:
       #   AUTH_SECRET_KEY               — Clerk secret key (sk_test_… / sk_live_…)
       #   CLERK_ENCRYPTION_KEY          — random 32-char string (openssl rand -hex 16); required when secretKey is passed dynamically
-      #   NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY — Clerk publishable key (pk_…)
       #   DATABASE_URL                  — Neon Postgres connection string
       #   STREAM_API_KEY / STREAM_API_SECRET — Stream Chat
       #   SENTRY_DSN / SENTRY_AUTH_TOKEN
       #   CRON_SECRET
       #   INFISICAL_CLIENT_ID / INFISICAL_CLIENT_SECRET
       #   FORMANCE_POSTGRES_URI         — Neon Postgres URI for Formance ledger
+      #
+      # IMPORTANT — the browser-side Clerk values are NOT in this list and are
+      # NOT read from Render/Infisical at runtime. Next.js inlines every
+      # `NEXT_PUBLIC_*` value into the client JavaScript bundle at BUILD time, so
+      # they come from the GitHub Actions secrets passed as --build-arg in
+      # build-images.yml (NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY,
+      # NEXT_PUBLIC_AUTH_SIGN_IN_URL, NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL,
+      # NEXT_PUBLIC_AUTH_PROVIDER, NEXT_PUBLIC_APP_URL). Changing the publishable
+      # key in Infisical/Render has NO effect on the browser — you must update the
+      # GitHub Actions secret and rebuild the image (build-images.yml) so the new
+      # value is re-baked. Syncing a `NEXT_PUBLIC_*` value into Render at runtime
+      # is a no-op for the client; do not rely on it.
 
   # ── PM MCP Server — intentionally NOT a Render service ───────────
   # ctf/packages/pm-mcp-server is a stdio MCP server (StdioServerTransport).


### PR DESCRIPTION
## What and why
Fixes the misleading comments that caused a real debugging dead-end: `render.yaml` listed `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY` among the secrets "synced by Infisical → Render," implying the browser's Clerk key is read at runtime. It is not — Next.js inlines every `NEXT_PUBLIC_*` value into the client bundle at **image build time**, so the browser's Clerk config comes from the GitHub Actions build-args in `build-images.yml`. Syncing those keys into Render at runtime is a no-op for the client.

## Changes (comment-only)
- **render.yaml**: removed the publishable key from the Infisical-synced list; added an explicit note that `NEXT_PUBLIC_*` are baked at build time and that changing the key requires updating the GitHub Actions secret **and** rebuilding the image.
- **build-images.yml**: header + build-args step now state these `NEXT_PUBLIC_*` values are the only source of the browser's Clerk config, and that Clerk production keys are domain-locked.

## Safety
Strictly comment-only — no service config, image URL, env var, or build step is changed. Render Blueprint sync sees no configuration diff, so **no service redeploys** and there is no impact on the running apps. The next image build produces an identical image. YAML validated; EOF and typecheck gates pass.

Parity Status: web+android complete

https://claude.ai/code/session_01WUG6boqjmNuV1XzzxZRg6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUG6boqjmNuV1XzzxZRg6d)_