### PR TITLE
fix: read NEXT_PUBLIC auth env vars statically so middleware gets the publishable key

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,8 @@ reviews:
   # PR thread. Real reviews (walkthrough + inline comments) still post when a review
   # actually runs; the skipped state remains visible as the CodeRabbit commit status.
   review_status: false
+  # Skip the whimsical poem at the end of the walkthrough comment.
+  poem: false
   auto_review:
     enabled: true
     # Never spend review credits on draft PRs.

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -123,13 +123,27 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID_WEB: ${{ secrets.RENDER_SERVICE_ID_WEB }}
         run: |
-          if [ -n "$RENDER_API_KEY" ] && [ -n "$RENDER_SERVICE_ID_WEB" ]; then
-            curl -sf -X POST \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{}' \
-              "https://api.render.com/v1/services/$RENDER_SERVICE_ID_WEB/deploys"
+          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_WEB" ]; then
+            echo "RENDER_API_KEY or RENDER_SERVICE_ID_WEB not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-web manually in Render)."
+            exit 0
           fi
+          # Do NOT use curl -f here: it exits 22 and hides the HTTP error. Capture
+          # the status code + body so a failed trigger is readable, and never fail
+          # the build on it — the image is already pushed and can be deployed
+          # manually in Render (Manual Deploy → Deploy latest reference).
+          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_WEB/deploys" || true)
+          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-web"
+          case "$http_status" in
+            2*) echo "Render deploy triggered for ctf-web." ;;
+            *)
+              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-web. The image is already pushed to GHCR — deploy manually (Manual Deploy → Deploy latest reference) and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_WEB. Response:"
+              cat /tmp/render-deploy.json 2>/dev/null || true
+              ;;
+          esac
 
   # ── ctf-ollama ──────────────────────────────────────────────────
   # Only rebuilds when the Dockerfile changes — model bake takes ~1 hour.
@@ -173,13 +187,24 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID_OLLAMA: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
         run: |
-          if [ -n "$RENDER_API_KEY" ] && [ -n "$RENDER_SERVICE_ID_OLLAMA" ]; then
-            curl -sf -X POST \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{}' \
-              "https://api.render.com/v1/services/$RENDER_SERVICE_ID_OLLAMA/deploys"
+          # See ctf-web for why curl -f is avoided; print status, never fail the build.
+          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_OLLAMA" ]; then
+            echo "RENDER_API_KEY or RENDER_SERVICE_ID_OLLAMA not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-ollama manually in Render)."
+            exit 0
           fi
+          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_OLLAMA/deploys" || true)
+          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-ollama"
+          case "$http_status" in
+            2*) echo "Render deploy triggered for ctf-ollama." ;;
+            *)
+              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-ollama. The image is already pushed to GHCR — deploy manually and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_OLLAMA. Response:"
+              cat /tmp/render-deploy.json 2>/dev/null || true
+              ;;
+          esac
 
   # ── ctf-rasa ────────────────────────────────────────────────────
   # Only rebuilds when ctf/ops/rasa/** changes — the NLU model is trained at build
@@ -224,13 +249,24 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID_RASA: ${{ secrets.RENDER_SERVICE_ID_RASA }}
         run: |
-          if [ -n "$RENDER_API_KEY" ] && [ -n "$RENDER_SERVICE_ID_RASA" ]; then
-            curl -sf -X POST \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{}' \
-              "https://api.render.com/v1/services/$RENDER_SERVICE_ID_RASA/deploys"
+          # See ctf-web for why curl -f is avoided; print status, never fail the build.
+          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_RASA" ]; then
+            echo "RENDER_API_KEY or RENDER_SERVICE_ID_RASA not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-rasa manually in Render)."
+            exit 0
           fi
+          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_RASA/deploys" || true)
+          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-rasa"
+          case "$http_status" in
+            2*) echo "Render deploy triggered for ctf-rasa." ;;
+            *)
+              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-rasa. The image is already pushed to GHCR — deploy manually and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_RASA. Response:"
+              cat /tmp/render-deploy.json 2>/dev/null || true
+              ;;
+          esac
 
   # ── ctf-formance-ledger ─────────────────────────────────────────
   build-formance-ledger:
@@ -272,10 +308,21 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID_FORMANCE: ${{ secrets.RENDER_SERVICE_ID_FORMANCE }}
         run: |
-          if [ -n "$RENDER_API_KEY" ] && [ -n "$RENDER_SERVICE_ID_FORMANCE" ]; then
-            curl -sf -X POST \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{}' \
-              "https://api.render.com/v1/services/$RENDER_SERVICE_ID_FORMANCE/deploys"
+          # See ctf-web for why curl -f is avoided; print status, never fail the build.
+          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_FORMANCE" ]; then
+            echo "RENDER_API_KEY or RENDER_SERVICE_ID_FORMANCE not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-formance-ledger manually in Render)."
+            exit 0
           fi
+          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_FORMANCE/deploys" || true)
+          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-formance-ledger"
+          case "$http_status" in
+            2*) echo "Render deploy triggered for ctf-formance-ledger." ;;
+            *)
+              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-formance-ledger. The image is already pushed to GHCR — deploy manually and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_FORMANCE. Response:"
+              cat /tmp/render-deploy.json 2>/dev/null || true
+              ;;
+          esac

--- a/ctf/packages/web/lib/auth/provider-env.ts
+++ b/ctf/packages/web/lib/auth/provider-env.ts
@@ -1,5 +1,12 @@
 import { getEnvValue } from './env-utils.mjs';
 
+/**
+ * Resolved auth-provider configuration for the current runtime.
+ *
+ * `publishableKey`, `signInUrl`, `afterSignOutUrl` and `providerName` come from
+ * build-time-inlined `NEXT_PUBLIC_*` values; `secretKey` is a server-only
+ * runtime value and is never inlined into a client/edge bundle.
+ */
 export type AuthProviderRuntimeConfig = {
   providerName: string;
   publishableKey?: string;
@@ -8,9 +15,17 @@ export type AuthProviderRuntimeConfig = {
   afterSignOutUrl?: string;
 };
 
-// Returns the first non-empty, trimmed value. Used for the public env reads
-// below, which are passed as STATIC `process.env.NEXT_PUBLIC_*` expressions
-// (see getConfiguredAuthProvider for why static access matters).
+/**
+ * Returns the first value that is a non-empty string after trimming, or
+ * `undefined` if none qualify.
+ *
+ * Used for the public env reads below, which are passed as STATIC
+ * `process.env.NEXT_PUBLIC_*` expressions (see {@link getConfiguredAuthProvider}
+ * for why static access matters).
+ *
+ * @param values - Candidate values in priority order.
+ * @returns The first trimmed, non-empty value, or `undefined`.
+ */
 function firstNonEmptyTrimmed(...values: Array<string | undefined>): string | undefined {
   for (const value of values) {
     if (typeof value === 'string') {
@@ -21,6 +36,15 @@ function firstNonEmptyTrimmed(...values: Array<string | undefined>): string | un
   return undefined;
 }
 
+/**
+ * Normalizes a sign-in/redirect URL value.
+ *
+ * Relative paths (starting with `/`) are returned as-is; absolute URLs are
+ * parsed and re-serialized. Anything that fails to parse returns `undefined`.
+ *
+ * @param value - The raw URL or path, if any.
+ * @returns The normalized path/URL, or `undefined` when absent or invalid.
+ */
 function normalizeUrl(value: string | undefined): string | undefined {
   if (!value) return undefined;
   if (value.startsWith('/')) return value;
@@ -31,21 +55,36 @@ function normalizeUrl(value: string | undefined): string | undefined {
   }
 }
 
+/**
+ * Returns the configured public app URL (`NEXT_PUBLIC_APP_URL`), if set.
+ *
+ * Read as a static `process.env.NEXT_PUBLIC_*` expression so Next.js inlines it
+ * at build time into the client and edge bundles.
+ *
+ * @returns The app URL, or `undefined` when not configured.
+ */
 export function getAppUrl(): string | undefined {
-  // Static reference so Next.js inlines it at build time (see below).
   return firstNonEmptyTrimmed(process.env.NEXT_PUBLIC_APP_URL);
 }
 
+/**
+ * Resolves the active auth provider configuration from the environment.
+ *
+ * IMPORTANT: every `NEXT_PUBLIC_*` value must be read as a STATIC
+ * `process.env.NEXT_PUBLIC_FOO` member expression. Next.js only inlines public
+ * env vars at build time when they are referenced statically; reading them
+ * through a dynamic `process.env[key]` helper (`getEnvValue`) prevents the
+ * inlining. `NEXT_PUBLIC_*` vars are also not present in the edge (middleware)
+ * runtime's `process.env` at runtime, so a dynamic read leaves the publishable
+ * key undefined inside `clerkMiddleware` — which then throws
+ * "Missing publishableKey" and fails the health check. Reading them statically
+ * bakes the values into both the client and the edge bundle. The secret key is
+ * server-only and is read dynamically from the runtime environment so it is
+ * never inlined into a bundle.
+ *
+ * @returns The resolved provider config, or `null` when nothing is configured.
+ */
 export function getConfiguredAuthProvider(): AuthProviderRuntimeConfig | null {
-  // IMPORTANT: every `NEXT_PUBLIC_*` value must be read as a STATIC
-  // `process.env.NEXT_PUBLIC_FOO` member expression. Next.js only inlines
-  // public env vars at build time when they are referenced statically; reading
-  // them through a dynamic `process.env[key]` helper (getEnvValue) prevents the
-  // inlining. `NEXT_PUBLIC_*` vars are also not present in the edge (middleware)
-  // runtime's `process.env` at runtime, so a dynamic read leaves the publishable
-  // key undefined inside `clerkMiddleware` — which then throws
-  // "Missing publishableKey" and fails the health check. Reading them statically
-  // bakes the values into both the client and the edge bundle.
   const publishableKey = firstNonEmptyTrimmed(
     process.env.NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY,
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
@@ -83,6 +122,13 @@ export function getConfiguredAuthProvider(): AuthProviderRuntimeConfig | null {
   };
 }
 
+/**
+ * Returns just the publishable/secret keys for initializing the auth SDK
+ * (`ClerkProvider` and `clerkMiddleware`).
+ *
+ * @returns An object with `publishableKey`/`secretKey` when configured;
+ *   otherwise an empty object.
+ */
 export function getAuthRuntimeOptions(): {
   publishableKey?: string;
   secretKey?: string;
@@ -95,6 +141,15 @@ export function getAuthRuntimeOptions(): {
   };
 }
 
+/**
+ * Reports whether the configured sign-in URL points to a different host than
+ * the app itself (i.e. an externally hosted sign-in page).
+ *
+ * Relative sign-in paths are treated as internal. When no app URL is
+ * configured, an absolute sign-in URL is treated as external.
+ *
+ * @returns `true` when sign-in is hosted on a different host; otherwise `false`.
+ */
 export function isConfiguredAuthSignInExternal(): boolean {
   const provider = getConfiguredAuthProvider();
   const signInUrl = provider?.signInUrl;

--- a/ctf/packages/web/lib/auth/provider-env.ts
+++ b/ctf/packages/web/lib/auth/provider-env.ts
@@ -1,4 +1,3 @@
-import { firstNonEmpty } from './env-keys';
 import { getEnvValue } from './env-utils.mjs';
 
 export type AuthProviderRuntimeConfig = {
@@ -8,6 +7,19 @@ export type AuthProviderRuntimeConfig = {
   signInUrl?: string;
   afterSignOutUrl?: string;
 };
+
+// Returns the first non-empty, trimmed value. Used for the public env reads
+// below, which are passed as STATIC `process.env.NEXT_PUBLIC_*` expressions
+// (see getConfiguredAuthProvider for why static access matters).
+function firstNonEmptyTrimmed(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return undefined;
+}
 
 function normalizeUrl(value: string | undefined): string | undefined {
   if (!value) return undefined;
@@ -20,30 +32,47 @@ function normalizeUrl(value: string | undefined): string | undefined {
 }
 
 export function getAppUrl(): string | undefined {
-  return getEnvValue('NEXT_PUBLIC_APP_URL');
+  // Static reference so Next.js inlines it at build time (see below).
+  return firstNonEmptyTrimmed(process.env.NEXT_PUBLIC_APP_URL);
 }
 
 export function getConfiguredAuthProvider(): AuthProviderRuntimeConfig | null {
-  const publishableKey = getEnvValue(
-    'NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY',
-    'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  // IMPORTANT: every `NEXT_PUBLIC_*` value must be read as a STATIC
+  // `process.env.NEXT_PUBLIC_FOO` member expression. Next.js only inlines
+  // public env vars at build time when they are referenced statically; reading
+  // them through a dynamic `process.env[key]` helper (getEnvValue) prevents the
+  // inlining. `NEXT_PUBLIC_*` vars are also not present in the edge (middleware)
+  // runtime's `process.env` at runtime, so a dynamic read leaves the publishable
+  // key undefined inside `clerkMiddleware` — which then throws
+  // "Missing publishableKey" and fails the health check. Reading them statically
+  // bakes the values into both the client and the edge bundle.
+  const publishableKey = firstNonEmptyTrimmed(
+    process.env.NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY,
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
   );
-  const secretKey = getEnvValue('AUTH_SECRET_KEY', 'CLERK_SECRET_KEY');
   const signInUrl = normalizeUrl(
-    getEnvValue('NEXT_PUBLIC_AUTH_SIGN_IN_URL', 'NEXT_PUBLIC_CLERK_SIGN_IN_URL'),
+    firstNonEmptyTrimmed(
+      process.env.NEXT_PUBLIC_AUTH_SIGN_IN_URL,
+      process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,
+    ),
   );
   const afterSignOutUrl = normalizeUrl(
-    firstNonEmpty(
-      getEnvValue('NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL', 'NEXT_PUBLIC_CLERK_AFTER_SIGN_OUT_URL'),
+    firstNonEmptyTrimmed(
+      process.env.NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL,
+      process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_OUT_URL,
       signInUrl,
     ),
   );
+  const providerName = firstNonEmptyTrimmed(process.env.NEXT_PUBLIC_AUTH_PROVIDER) ?? 'clerk';
+
+  // The secret key is server-only and must NEVER be inlined into a client/edge
+  // bundle, so it is read dynamically from the runtime environment (non-public
+  // vars are available in `process.env` at runtime, including in middleware).
+  const secretKey = getEnvValue('AUTH_SECRET_KEY', 'CLERK_SECRET_KEY');
 
   if (!publishableKey && !secretKey && !signInUrl && !afterSignOutUrl) {
     return null;
   }
-
-  const providerName = getEnvValue('NEXT_PUBLIC_AUTH_PROVIDER') ?? 'clerk';
 
   return {
     providerName,


### PR DESCRIPTION
## The bug (primary fix)
The deployed `ctf-web` container's **middleware** throws on every request:
```
Error: @clerk/nextjs: Missing publishableKey
  at .next/server/edge/chunks/[root-of-the-server]…
```
That fails `/api/health`, so Render never promotes the deploy — which is why even manual redeploys of the same image keep failing (the image itself is unhealthy; re-running it reproduces the crash).

### Root cause
`getConfiguredAuthProvider()` read every value — including `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY` — through `getEnvValue(...)`, which does **dynamic** `process.env[key]` access. Next.js only inlines `NEXT_PUBLIC_*` values when they're referenced as **static** `process.env.NEXT_PUBLIC_FOO` expressions, and those vars are not present in the **edge (middleware) runtime's** `process.env` at runtime. So the publishable key was `undefined` inside `clerkMiddleware`. Server components still got it via runtime `process.env`, which is why the browser previously loaded a key (and showed the separate domain-lock error). Newly exposed by #232 (the old deployed image was 211 commits behind).

### The fix
Read the `NEXT_PUBLIC_*` values (publishable key, sign-in URL, after-sign-out URL, provider name, app URL) as **static** `process.env.NEXT_PUBLIC_*` expressions so Next.js bakes them into the client **and** edge bundles. The server-only **secret key stays a dynamic runtime read** so it is never inlined into a bundle. Module's public API is unchanged.

## Also in this PR: Render deploy step hardening (CI)
The four `Trigger Render deploy` steps used `curl -sf`, so a rejected trigger surfaced only as an opaque "exit code 22" and failed the whole build even though the image was already pushed. Each step (web/ollama/rasa/formance) now prints the actual HTTP status + response body, emits a `::warning::` with next steps on a non-2xx, and exits 0 so a trigger-only failure no longer blocks the build. (Merged latest `main` in, so #233's doc clarifications are included.)

## To take effect
Merging to `main` triggers `build-images.yml`, which re-bakes the image with the publishable key inlined into the edge bundle. **The GitHub Actions `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY` secret must hold the key** for the value to bake in (and use a Clerk key valid for the domain you're testing on). After the new image deploys, the health check should pass.

Parity Status: web+android complete

https://claude.ai/code/session_01WUG6boqjmNuV1XzzxZRg6d