### PR TITLE
chore: remove dead Foundation mobile mock and reconcile inventory status

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
@@ -88,7 +88,7 @@ Cross-plugin read dependencies (read-only):
 ## Web and Android Delivery Status
 
 - **Web:** delivered. `FoundationShell` (`ctf/packages/web/components/foundation/`) renders the survivor-facing experience against the live Foundation API — provider search/browse (`displayName`, `headline`, `bio`), provider profile, real two-step quote request (open connection thread → create quote on it), and quote history with lifecycle status. Decomposed under Rule 116 into `foundation-ui`, `foundation-rails`, `foundation-panels`, `foundation-profile`, and the orchestrating `foundation-shell`. Aligned to the canonical `survivor-hub/Foundation` design mockup; mockup-only fields with no backing API (star rating, job counts, hourly price, availability, inflated platform stats) are intentionally omitted rather than mocked, per the real-data-only rule.
-- **Android:** pending UI circle-back; tracked in the readiness table (Android ⬜).
+- **Android:** delivered (pixel pass, 2026-05-31). The mobile feature binds the real Foundation API — see below.
 
 Android pixel pass delivered 2026-05-31. Mobile feature (`ctf/packages/mobile/src/features/foundation/`) rewritten to match the `MobileFoundation*.tsx` mockup. Real backend bindings mirror the merged web shell (PR #182):
 
@@ -98,7 +98,7 @@ Android pixel pass delivered 2026-05-31. Mobile feature (`ctf/packages/mobile/sr
 
 Omitted (no backing field): trade filter chips, star ratings, price/rate, job count, availability dot, credits badge, platform stats. These are mockup fixtures only; no real API field exists for them.
 
-`MockFoundation.tsx` is retired (no longer imported or used).
+`MockFoundation.tsx` has been removed (it was an unused placeholder; the real screens are `Foundation` / `FoundationLoading` / `FoundationEmpty` / `FoundationPublic`).
 
 ## Seed Coverage Status
 

--- a/ctf/packages/mobile/src/features/foundation/Foundation.tsx
+++ b/ctf/packages/mobile/src/features/foundation/Foundation.tsx
@@ -27,7 +27,7 @@ type Tab = 'browse' | 'quotes';
  * Foundation main screen — mirrors MobileFoundation.tsx mockup.
  * Binds real backend data: providers from /api/foundation/providers/search,
  * quote history from /api/foundation/quotes/history.
- * MockFoundation is retired; this is the sole exported screen.
+ * This is the sole exported screen (the earlier placeholder mock was removed).
  *
  * Omitted (no backing field): trade filter chips, star ratings, price/rate,
  * job count, availability dot, credits badge, platform stats. All are

--- a/ctf/packages/mobile/src/features/foundation/MockFoundation.tsx
+++ b/ctf/packages/mobile/src/features/foundation/MockFoundation.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-
-export const MockFoundation = () => (
-  <View style={styles.container}><Text style={styles.title}>Foundation (mock)</Text><Text>Core foundation features (mock)</Text></View>
-);
-const styles = StyleSheet.create({container:{flex:1,padding:12},title:{fontSize:18,fontWeight:'700',marginBottom:12}});


### PR DESCRIPTION
## What this does

Final housekeeping for the Foundation Android parity work (issue #183), which already shipped to `main` in #196.

- Removes `ctf/packages/mobile/src/features/foundation/MockFoundation.tsx`. It was an unused placeholder — never imported, and not exported from the feature's `index.ts` (which exports only `Foundation` / `FoundationLoading` / `FoundationEmpty` / `FoundationPublic`). Dead-code removal, no behavior change.
- Fixes a stale line in the Foundation feature inventory that still read "Android: pending UI circle-back" even though the change log directly below it records the 2026-05-31 Android pixel pass as complete.
- Updates the inventory note and one code comment to say the mock was removed rather than just retired.

Nothing imported the deleted file, so there is no functional change.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE2wfPhDmQMXoDpiNi5Lh9)_