### PR TITLE
feat: model multi-currency value fields across plugins (issue #120)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
@@ -66,6 +66,13 @@ Foundation-owned domain entities (canonical in `ctf/schema.sql`):
 9. `foundation_rate_limit_counters` — Per-command rate limiting state.
 10. `foundation_capacity_policies` — Admin-configured capacity limits and thresholds.
 11. `foundation_admin_audit_trail` — Admin action audit log.
+12. `foundation_provider_accepted_currencies` — join (`user_id`, `currency_code` FK → `currencies.code`) for the currencies a provider accepts.
+
+Multi-currency (issue #120): a provider can list a service rate on their profile — `foundation_user_extension`
+gains `rate_amount` + `rate_currency` (FK → `currencies.code`). The quote process stays free-text/manual this
+version (no structured quote amount, so no price fields on `foundation_quote_requests`). "Accepts ServiceCredits"
+is true only when a `foundation_provider_accepted_currencies` row with `currency_code='SC'` exists — never
+derived from `rate_currency`. No ServiceCredits amount is shown at a fiat equivalent.
 
 Quota threshold level (green/yellow/orange/red) is derived at evaluation time from the capacity policy and rate-limit counters; it is not a stored table (there is no `foundation_quota_threshold_states`).
 
@@ -118,6 +125,7 @@ Seeded content (deterministic):
 
 ## Change Log
 
+- 2026-06-01: Multi-currency (issue #120): added `rate_amount` + `rate_currency` (FK → `currencies.code`) to `foundation_user_extension` (provider rate on the profile) and a `foundation_provider_accepted_currencies` join. The quote process stays free-text/manual (no price fields on quotes). Documented the no-fiat-parity rule. Schema + inventory only; the currency UI is design-gated.
 - 2026-06-01: Fixed the demo seed (`ctf/scripts/seedDemo.mjs`) so it can be re-run for a different demo participant. The Foundation connection thread row uses a fixed demo id but a `thread_key` derived from the owner; the insert previously only handled a `thread_key` conflict, so re-seeding with a new owner hit an unhandled primary-key collision and aborted the whole seed. The insert now upserts on the primary key and refreshes `thread_key`. No schema change — same table, same columns.
 - 2026-05-31: Web pixel pass. Rebuilt `FoundationShell` to match the canonical `survivor-hub/Foundation` design mockup and bind to real API contracts only. Fixed three pre-existing data bugs: provider search now reads `{ items }` (was treating the response as a raw array), quote history now calls `GET /api/foundation/quotes/history` (was calling the GET-less `/api/foundation/quotes`), and "Request Quote" now performs the real two-step flow (POST `/connections/threads` then POST `/quotes` with `x-ctf-csrf: 1`) instead of posting an unsupported `{ providerId, description }` body. Decomposed the shell into five Rule-116-compliant files. Dropped mockup fields with no backing API (rating, jobs, price, availability, hard-coded platform stats). Web px flipped to ✅ in the readiness table.
 - 2026-05-31: Android pixel pass complete. Mobile feature rewritten to `MobileFoundation*.tsx` mockup spec. Real API bindings for provider search, quote history, and two-step quote creation (thread + quote POST, both with CSRF header). `MockFoundation.tsx` retired. Omitted mockup-only fields (rating, price, availability, credits, job count, platform stats) — no backing API field. Gates passed: tsc (pre-existing expo/tsconfig.base constraint noted), EOF clean, parity check green.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-levelup-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-levelup-feature-inventory.md
@@ -60,6 +60,11 @@ Core tables:
 13. `levelup_audit_events`
 14. `levelup_policy_config`
 
+Multi-currency (issue #120): `levelup_cohorts` carries `stipend_currency` and `microgrant_currency`
+(FK → `currencies.code`), naming the currency of `stipend_amount_per_payout` and `microgrant_amount`.
+Both default to ServiceCredits (code `SC`) — these are internal token payouts. No surface renders a
+ServiceCredits amount at a fiat equivalent (the no-fiat-parity rule from issue #120).
+
 External value movement dependencies:
 
 - `service_credits_wallets`
@@ -106,6 +111,7 @@ list endpoint); active-enrollment banner (no user-enrollment GET endpoint yet).
 
 ## Change Log
 
+- 2026-06-01: Multi-currency (issue #120): added `stipend_currency` and `microgrant_currency` (FK → `currencies.code`, default ServiceCredits) to `levelup_cohorts`. Documented the no-fiat-parity rule. Schema + inventory only; the currency UI is design-gated.
 - 2026-05-31: Android pixel pass — rewrote `ctf/packages/mobile/src/features/levelup/Levelup.tsx` to the design mockup (loading/empty/main states). Created real `api.ts` bound to `GET /api/levelup/cohorts` and `GET /api/service-credits/wallet`. Retired `MockLevelup.tsx`. Omitted unbacked fields: trainerName, tags, milestoneCount (not in cohorts list endpoint), active-enrollment banner (no user enrollment GET route). EOF, parity, and tsc gates all green.
 - 2026-05-30: Web pixel pass — rebuilt the web shell to the design mockup and decomposed the 520-line `levelup-shell.tsx` monolith into modular sub-components (`lu-shared.ts`, `lu-loading.tsx`, `lu-sidebar.tsx`, `lu-cohort-card.tsx`, `lu-browse.tsx`, `lu-progress.tsx`, `lu-right-panel.tsx`, thin shell) within rule-116 limits. Removed 6 dead unreferenced components (AdminPanel, CohortDetail, CohortList, EnrollModal, TrainerDashboard, UserDashboard). Shell binds real routes (cohorts, service-credits wallet, enroll, milestone validate); unbacked mockup figures omitted. No schema/route/contract changes.
 - 2026-05-17: Updated inventory to enforce Rule 105 parity baseline and Rule 120 living-snapshot model. Removed Android parity deferral language; confirmed web+android complete delivery status. Clarified technical debt (attachment storage) as genuine limitation, not unimplemented feature.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
@@ -111,6 +111,13 @@ Tables owned by this plugin:
 5. `socketrelay_fulfillment_participants` — Participant access records for fulfillment chats.
 6. `socketrelay_messages` — Participant-only chat messages on a fulfillment. The chat is transaction-scoped: after the fulfillment reaches a terminal state no new rows may be added; existing rows become read-only for the two participants for a limited window and are retained server-side for moderation/abuse evidence per the deletion contract (platform rule 100).
 7. `socketrelay_admin_audit_trail` — Audit log for admin mutations.
+8. `socketrelay_request_accepted_currencies` — join (`request_id`, `currency_code` FK → `currencies.code`) for any currencies an offered reward accepts.
+
+Multi-currency (issue #120): SocketRelay is mutual aid and posts are free, so `socketrelay_requests`
+gains OPTIONAL `price_amount` + `price_currency` (FK → `currencies.code`) for the rare case a reward is
+offered. "Free" renders from the ABSENCE of a price (NULL `price_amount`), never as `$0`. "Accepts
+ServiceCredits" is true only when a `socketrelay_request_accepted_currencies` row with `currency_code='SC'`
+exists — never derived from `price_currency`. No ServiceCredits amount is shown at a fiat equivalent.
 
 Storage and projection rules:
 
@@ -290,6 +297,8 @@ Android pixel pass (design `MobileSocketRelay.tsx`): `packages/mobile/src/featur
     - Removed scope is date-stamped and not silently deleted.
 
 ### Change Log
+
+- 2026-06-01: Multi-currency (issue #120): added OPTIONAL `price_amount` + `price_currency` (FK → `currencies.code`) to `socketrelay_requests` and a `socketrelay_request_accepted_currencies` join. "Free" renders from the absence of a price, never `$0`. Documented the no-fiat-parity rule. Schema + inventory only; the currency UI is design-gated.
 
 - 2026-02-25: Created initial SocketRelay CTF rewrite checklist with web-first release gating, tracked Android deferrals, lifecycle requirements, and explicit mitigation gates for legacy-known risks.
 - 2026-05-31: Documented the transaction-scoped messaging lifecycle per platform rule 100 ("Messaging Scope and Lifecycle"): the per-fulfillment 1:1 chat closes on terminal fulfillment state (read-only window + `socketrelay_messages` retained for moderation/abuse evidence); no messaging outside an active fulfillment. Aligning the deletion contract to mirror this retention is a tracked follow-up.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trusttransport-feature-inventory.md
@@ -203,6 +203,13 @@ Tables owned by this plugin:
 11. `trusttransport_market_config` — Region/service-zone/fee/commission/capacity configuration.
 12. `trusttransport_admin_audit_trail` — Admin mutation audit log.
 
+Multi-currency (issue #120): `trusttransport_payout_requests` and `trusttransport_earnings_ledger` gain
+`price_currency` (FK → `currencies.code`), the admin-curated, referenced settlement currency that supersedes
+the legacy free-text `currency` column (the GDP estimation layer in issue #121 reads `price_currency`).
+Existing rows are backfilled from `currency` only where it already matches a known code; unknown legacy values
+are left for manual reconciliation so no money data is overwritten. No surface renders a ServiceCredits amount
+at a fiat equivalent.
+
 ### 4.3 Lifecycle and Storage Constraints
 
 1. Immutable event log for status transitions.
@@ -244,6 +251,8 @@ Tables owned by this plugin:
 3. Command contract complexity should be monitored to prevent drift from UI flow logic.
 
 ## Change Log
+
+- 2026-06-01: Multi-currency (issue #120): added `price_currency` (FK → `currencies.code`) to `trusttransport_payout_requests` and `trusttransport_earnings_ledger`, superseding the legacy free-text `currency` column, with a safe backfill that never overwrites money data. Documented the no-fiat-parity rule. The GDP estimation layer (issue #121) reads `price_currency`.
 
 - 2026-05-31: Android pixel pass — rewrote `TrustTransport.tsx` to align with `design/.../survivor-hub/MobileTrustTransport*.tsx` (main, empty, loading, public states). Binds real `/api/trusttransport/requests` (list + create). Omits unbacked mockup elements (Nearby Drivers list, driver ratings/ETAs/vehicle info, online driver count) per real-data-only rule. Retired `MockTrustTransport.tsx` (cleared). `AuthProvider` + `TrustTransport` exports preserved. No schema/route/contract changes.
 - 2026-05-30: Web pixel pass — aligned the shell to `design/.../survivor-hub/TrustTransport.tsx` and decomposed the 358-line / complexity-28 monolith into modular sub-components (`tt-shared.ts`, `tt-loading.tsx`, `tt-icon-rail`, `tt-sidebar`, `tt-book-tab`, `tt-tracking-tab`, `tt-chat-tab`, `tt-right-panel`, thin shell) within rule-116 limits. Per real-data-only, stripped remaining unbacked values (hardcoded "Safety Rating 4.9" and "Safety Incidents 0 today") and aligned GetStream-branded copy to the design's "End-to-end encrypted" / "All comms encrypted" wording (Stream chat integration unchanged). Dropped the unused `userId`/`isAdmin` props at the call site. No schema/route/contract changes.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -95,6 +95,10 @@ Admin page:
 2. `unlock_verification_submissions`
 3. `unlock_audit_log`
 
+Multi-currency (issue #120): `unlock_runtime_config` carries `incentive_currency` (FK → `currencies.code`),
+naming the currency of `incentive_amount`. It defaults to ServiceCredits (code `SC`) — the approval
+incentive is an internal token grant. No surface renders a ServiceCredits amount at a fiat equivalent.
+
 ### 4.2 Stored State
 
 1. review status: `pending | approved | rejected | spam`
@@ -238,5 +242,7 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 - [ ] Dynamic incentive amount source of truth (runtime config vs policy constant).
 
 ### Change Log
+
+- 2026-06-01: Multi-currency (issue #120): added `incentive_currency` (FK → `currencies.code`, default ServiceCredits) to `unlock_runtime_config`, naming the currency of `incentive_amount`. Documented the no-fiat-parity rule. Schema + inventory only; the currency UI is design-gated.
 
 - 2026-03-25: Created initial Unlock rewrite checklist with contracts, schema, submission/moderation, incentive, and access-tier enforcement phases.

--- a/ctf/packages/mobile/src/features/currency/assert.ts
+++ b/ctf/packages/mobile/src/features/currency/assert.ts
@@ -1,0 +1,38 @@
+// No-fiat-parity guard (issue #120 — the legal line). Mobile mirror of
+// ctf/packages/web/lib/currency/assert.ts — keep the two in sync.
+//
+// ServiceCredits is a utility token with no fiat redemption path. A *single* ServiceCredits value
+// must NEVER be rendered as a fiat equivalent (e.g. "2,420 credits ≈ $242 USD", "purchasing power",
+// "real monetary value"). This guard detects that pattern in a single value/label string.
+//
+// IMPORTANT: apply this to an individual rendered value or label, NOT to a whole composed view.
+// A compact layout that shows a fiat price field AND a separate "Accepts ServiceCredits" badge is
+// allowed (two distinct fields) and is not a parity claim — each field passes this guard on its own.
+
+function mentionsServiceCredits(lower: string): boolean {
+  return /servicecredits|\bsc\b|\bcredits?\b/.test(lower);
+}
+
+const EQUIVALENCE_CUE = /≈|~|=|\bequals?\b|\bworth\b/;
+const FIAT_FIGURE =
+  /[$€£¥₹₿]\s?\d|\b\d[\d,. ]*\s?(usd|eur|gbp|jpy|chf|cad|aud|cny|inr|brl|btc|dollars?|euros?)\b/;
+
+/** True if `text` pegs a ServiceCredits value to a fiat/external-money equivalent. */
+export function isFiatParityWithServiceCredits(text: string): boolean {
+  const lower = text.toLowerCase();
+  if (!mentionsServiceCredits(lower)) return false;
+  if (/purchasing power|monetary value/.test(lower)) return true;
+  return EQUIVALENCE_CUE.test(lower) && FIAT_FIGURE.test(lower);
+}
+
+/** Returns `text` unchanged, or throws if it claims a ServiceCredits↔fiat parity. */
+export function assertNoFiatParity(text: string): string {
+  if (isFiatParityWithServiceCredits(text)) {
+    throw new Error(
+      `No-fiat-parity violation: a ServiceCredits value must not be shown at a fiat equivalent. Offending text: ${JSON.stringify(
+        text,
+      )}`,
+    );
+  }
+  return text;
+}

--- a/ctf/packages/mobile/src/features/currency/format.ts
+++ b/ctf/packages/mobile/src/features/currency/format.ts
@@ -1,0 +1,49 @@
+// Mobile mirror of ctf/packages/web/lib/currency/format.ts (issue #120) — keep the two in sync.
+import type { Currency } from './types';
+import { SERVICE_CREDITS_LABEL } from './types';
+
+/**
+ * Sort currencies so ServiceCredits is always first (the platform's preferred currency wherever
+ * multiple options appear), then by sort_order, then code.
+ */
+export function sortPreferred(currencies: Currency[]): Currency[] {
+  return [...currencies].sort((a, b) => {
+    if (a.isServiceCredits !== b.isServiceCredits) return a.isServiceCredits ? -1 : 1;
+    return a.sortOrder - b.sortOrder || a.code.localeCompare(b.code);
+  });
+}
+
+function labelOf(currency: Currency): string {
+  return currency.isServiceCredits ? SERVICE_CREDITS_LABEL : currency.label;
+}
+
+/**
+ * Format a single listed price in its own currency. ServiceCredits renders as "N ServiceCredits"
+ * (never a fiat symbol). Barter / amount-less currencies render their label only.
+ */
+export function formatPrice(amount: number | null, currency: Currency): string {
+  if (currency.kind === 'barter' || !currency.requiresAmount || amount === null) {
+    return labelOf(currency);
+  }
+  const formatted = amount.toLocaleString('en-US', {
+    minimumFractionDigits: currency.decimalPlaces,
+    maximumFractionDigits: currency.decimalPlaces,
+  });
+  if (currency.isServiceCredits) {
+    return `${formatted} ${SERVICE_CREDITS_LABEL}`;
+  }
+  return currency.symbol ? `${currency.symbol}${formatted}` : `${formatted} ${currency.code}`;
+}
+
+/**
+ * Compact-view label for an accepted-currencies set: ServiceCredits first, then a capped remainder
+ * (e.g. "Accepts ServiceCredits +2"). Full set belongs in the detail view.
+ */
+export function formatAcceptedCurrencies(currencies: Currency[], maxVisible = 1): string {
+  if (currencies.length === 0) return '';
+  const sorted = sortPreferred(currencies);
+  const visible = sorted.slice(0, Math.max(1, maxVisible));
+  const remainder = sorted.length - visible.length;
+  const head = `Accepts ${visible.map(labelOf).join(', ')}`;
+  return remainder > 0 ? `${head} +${remainder}` : head;
+}

--- a/ctf/packages/mobile/src/features/currency/index.ts
+++ b/ctf/packages/mobile/src/features/currency/index.ts
@@ -1,0 +1,5 @@
+// Mobile currency mirror (issue #120). No DB repository here — the mobile app receives currency
+// rows from the API; pure types/format/guard logic mirrors ctf/packages/web/lib/currency.
+export * from './types';
+export * from './format';
+export * from './assert';

--- a/ctf/packages/mobile/src/features/currency/types.ts
+++ b/ctf/packages/mobile/src/features/currency/types.ts
@@ -1,0 +1,29 @@
+// Currency model shared across value-bearing plugins (issue #120). Mobile mirror of
+// ctf/packages/web/lib/currency/types.ts — keep the two in sync.
+// ServiceCredits is the platform utility token. Its technical code is 'SC', but UI must always
+// render the label 'ServiceCredits' and must never show a ServiceCredits amount at a fiat equivalent.
+
+export type CurrencyKind = 'token' | 'fiat' | 'crypto' | 'barter';
+
+export interface Currency {
+  code: string;
+  label: string;
+  kind: CurrencyKind;
+  isServiceCredits: boolean;
+  symbol: string | null;
+  decimalPlaces: number;
+  requiresAmount: boolean;
+  isActive: boolean;
+  sortOrder: number;
+}
+
+/** Technical code of the platform utility token. Internal only — never render it in UI. */
+export const SERVICE_CREDITS_CODE = 'SC';
+/** The only user-facing name for the token. */
+export const SERVICE_CREDITS_LABEL = 'ServiceCredits';
+
+/** A listed price: an amount in a single currency (amount is null for barter / amount-less rows). */
+export interface PricedValue {
+  amount: number | null;
+  currencyCode: string;
+}

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -969,6 +969,9 @@ ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS submission_
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS reminder_schedule_hours INTEGER[] NOT NULL DEFAULT ARRAY[0,24,72,168];
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS incentive_amount TEXT NOT NULL DEFAULT '100';
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS support_only_after_expiry BOOLEAN NOT NULL DEFAULT TRUE;
+-- Multi-currency (issue #120): the verification incentive is an internal ServiceCredits payout.
+-- incentive_currency names the currency of incentive_amount; it defaults to ServiceCredits (code 'SC').
+ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS incentive_currency TEXT NOT NULL DEFAULT 'SC' REFERENCES currencies(code);
 
 -- === levelup_enrollments table (guarded DDL, schema drift prevention) ===
 CREATE TABLE IF NOT EXISTS levelup_enrollments (
@@ -1151,6 +1154,17 @@ CREATE TABLE IF NOT EXISTS trusttransport_earnings_ledger (
   metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+-- Multi-currency (issue #120): model the settlement currency as an admin-curated, referenced code.
+-- The legacy free-text `currency` column is superseded by `price_currency` (FK -> currencies.code), which
+-- the GDP estimation layer (issue #121) reads. Existing rows are backfilled from `currency` only where it
+-- already matches a known code; unknown legacy values are left for manual reconciliation so no money data
+-- is overwritten. This never asserts a ServiceCredits<->fiat parity.
+ALTER TABLE IF EXISTS trusttransport_payout_requests ADD COLUMN IF NOT EXISTS price_currency TEXT REFERENCES currencies(code);
+ALTER TABLE IF EXISTS trusttransport_earnings_ledger ADD COLUMN IF NOT EXISTS price_currency TEXT REFERENCES currencies(code);
+UPDATE trusttransport_payout_requests SET price_currency = currency
+  WHERE price_currency IS NULL AND currency IN (SELECT code FROM currencies);
+UPDATE trusttransport_earnings_ledger SET price_currency = currency
+  WHERE price_currency IS NULL AND currency IN (SELECT code FROM currencies);
 CREATE TABLE IF NOT EXISTS trusttransport_admin_audit_trail (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   actor_id TEXT NOT NULL,
@@ -2085,6 +2099,11 @@ ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS policy_json JSONB
 ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS created_by_user_id TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency (issue #120): LevelUp stipends and microgrants are internal ServiceCredits payouts.
+-- stipend_currency / microgrant_currency name the currency of stipend_amount_per_payout / microgrant_amount;
+-- both default to ServiceCredits (code 'SC').
+ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS stipend_currency TEXT NOT NULL DEFAULT 'SC' REFERENCES currencies(code);
+ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS microgrant_currency TEXT NOT NULL DEFAULT 'SC' REFERENCES currencies(code);
 
 CREATE TABLE IF NOT EXISTS levelup_curriculum_items (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -2396,6 +2415,20 @@ ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS accessi
 ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS trauma_informed_defaults JSONB NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS service_deleted_at TIMESTAMPTZ;
 ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency (issue #120): a Foundation provider can list a service rate on their profile.
+-- rate_amount is the listed amount; rate_currency names its currency (FK -> currencies.code). The quote
+-- process stays free-text/manual this version (no structured quote amount). "Accepts ServiceCredits" is a
+-- separate field in foundation_provider_accepted_currencies, never derived from rate_currency.
+ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS rate_amount NUMERIC;
+ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS rate_currency TEXT REFERENCES currencies(code);
+CREATE TABLE IF NOT EXISTS foundation_provider_accepted_currencies (
+  user_id TEXT NOT NULL REFERENCES foundation_user_extension(user_id) ON DELETE CASCADE,
+  currency_code TEXT NOT NULL REFERENCES currencies(code),
+  PRIMARY KEY (user_id, currency_code)
+);
+ALTER TABLE IF EXISTS foundation_provider_accepted_currencies ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE IF EXISTS foundation_provider_accepted_currencies ADD COLUMN IF NOT EXISTS currency_code TEXT;
+CREATE INDEX IF NOT EXISTS idx_foundation_provider_accepted_currencies_user ON foundation_provider_accepted_currencies(user_id);
 
 CREATE TABLE IF NOT EXISTS foundation_call_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -2486,6 +2519,19 @@ ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS claimed_fulf
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS idempotency_key TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency (issue #120): SocketRelay is mutual aid and posts are free. These OPTIONAL columns let a
+-- request name an offered reward when one exists; "Free" must render from the ABSENCE of a price (NULL),
+-- never as $0. Accepted currencies (if any) live in socketrelay_request_accepted_currencies.
+ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS price_amount NUMERIC;
+ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS price_currency TEXT REFERENCES currencies(code);
+CREATE TABLE IF NOT EXISTS socketrelay_request_accepted_currencies (
+  request_id UUID NOT NULL REFERENCES socketrelay_requests(id) ON DELETE CASCADE,
+  currency_code TEXT NOT NULL REFERENCES currencies(code),
+  PRIMARY KEY (request_id, currency_code)
+);
+ALTER TABLE IF EXISTS socketrelay_request_accepted_currencies ADD COLUMN IF NOT EXISTS request_id UUID;
+ALTER TABLE IF EXISTS socketrelay_request_accepted_currencies ADD COLUMN IF NOT EXISTS currency_code TEXT;
+CREATE INDEX IF NOT EXISTS idx_socketrelay_request_accepted_currencies_request ON socketrelay_request_accepted_currencies(request_id);
 
 CREATE TABLE IF NOT EXISTS socketrelay_request_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## What this does

Completes the app-wide multi-currency value-field retrofit for issue #120. The shared `currencies` table, the web `lib/currency` library (with the `assertNoFiatParity` guard), the seed, and the LightHouse retrofit already landed; this finishes the remaining in-scope plugins and adds the mobile mirror.

### Schema (`ctf/schema.sql`) — additive and idempotent
Every currency column is a foreign key to `currencies(code)`. All changes use `ADD COLUMN IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS`, so both fresh and existing databases stay in step.

- **Unlock**: `unlock_runtime_config.incentive_currency` (defaults to ServiceCredits).
- **LevelUp**: `levelup_cohorts.stipend_currency` and `microgrant_currency` (default ServiceCredits).
- **TrustTransport**: `price_currency` added to `trusttransport_payout_requests` and `trusttransport_earnings_ledger`, superseding the legacy free-text `currency` column. The backfill copies `currency` into `price_currency` **only where it already matches a known code**, so no money record is ever overwritten.
- **Foundation**: `rate_amount` + `rate_currency` on `foundation_user_extension` (a provider's rate on their profile) plus a `foundation_provider_accepted_currencies` join. Quotes stay free-text/manual.
- **SocketRelay**: optional `price_amount` + `price_currency` on `socketrelay_requests` plus a `socketrelay_request_accepted_currencies` join. "Free" renders from the absence of a price, never `$0`.

### Mobile mirror
`ctf/packages/mobile/src/features/currency/` mirrors `lib/currency` (types, formatting, the no-fiat-parity guard) for React Native — dependency-free pure TypeScript.

### Docs
Updated the Unlock, LevelUp, TrustTransport, Foundation, and SocketRelay inventories (Data Model sections + change logs) per the inventory sync policy, including the rule that a ServiceCredits amount is never shown at a fiat equivalent.

## Not in this change
- The currency **UI** is design-gated (rule 127) and comes after this lands.
- **GDP multi-currency recognition / USD normalization** is its own follow-up, issue #121.
- A unit test for `assertNoFiatParity`: the web package has no test runner configured today, so adding one is out of scope here; the guard is applied by the shared formatters.

## Notes for the reviewer
- This branch is based one commit behind the current `main`; it can be rebased before merge.
- I could not run `pnpm build` in this environment (the workspace root `ctf/node_modules` isn't installed). The changes are schema + docs + dependency-free TypeScript that mirrors an already-compiling library; the EOF format check passes.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE2wfPhDmQMXoDpiNi5Lh9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-currency support added across Foundation, LevelUp, SocketRelay, TrustTransport, and Unlock plugins, with ServiceCredits as the default platform token.
  * New mobile currency formatting and validation capabilities for handling multiple currency types.

* **Documentation**
  * Updated feature inventories documenting multi-currency schema and handling rules across all affected plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->