### PR TITLE
fix: serve sign-in from Clerk's hosted Account Portal

### DIFF
--- a/.github/instructions/123-environment-configuration-rules.mdc
+++ b/.github/instructions/123-environment-configuration-rules.mdc
@@ -52,9 +52,29 @@ The auth layer is provider-neutral (`lib/auth/provider-env.ts`); keys are not
 Clerk-name-specific:
 - `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`
 - `AUTH_SECRET_KEY`
-- `NEXT_PUBLIC_AUTH_SIGN_IN_URL`
+- `NEXT_PUBLIC_AUTH_SIGN_IN_URL` — **Clerk's hosted Account Portal sign-in URL**
+  (e.g. `https://accounts.<domain>/sign-in`), NOT `/sign-in` on the app's own
+  domain. See "Hosted sign-in" below.
 - `NEXT_PUBLIC_AUTH_PROVIDER` (the single provider-name variable; defaults to `clerk` if unset)
 - `CLERK_ENCRYPTION_KEY`
+
+### Hosted sign-in (Clerk Account Portal)
+
+Sign-in and sign-up run on **Clerk's own domains** (the hosted Account Portal —
+`https://accounts.<domain>` in production, `https://<slug>.accounts.dev` for a
+dev instance), not on a page rendered on the app's domain. The app redirects to
+the portal and Clerk redirects back when the flow completes.
+
+- `NEXT_PUBLIC_AUTH_SIGN_IN_URL` must therefore be the Account Portal URL. The
+  in-app `/sign-in` route is only a catch-all that forwards to that URL, so
+  pointing it back at the app's own host (`/sign-in` or
+  `https://<app-domain>/sign-in`) makes it redirect to itself forever
+  (`ERR_TOO_MANY_REDIRECTS`).
+- If the value is missing, relative, or same-host, the app self-corrects by
+  deriving the Account Portal from `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`
+  (`deriveAccountPortalOrigin` in `lib/auth/provider-env.ts`), and
+  `scripts/check-auth-env.mjs` prints a warning. Set the variable explicitly so
+  configuration matches behavior.
 
 ### Clerk Configuration Constraints
 - Do not share a Clerk instance across domains.

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,8 +20,13 @@ name: Build and push Docker images
 #   so the value is re-baked into a fresh image.
 #   NEXT_PUBLIC_APP_URL               — production URL, e.g. https://app.chargingthefuture.com
 #   NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY  — Clerk publishable key (pk_live_…); must match the domain the app is served on (Clerk production keys are domain-locked)
-#   NEXT_PUBLIC_AUTH_SIGN_IN_URL      — e.g. /sign-in
-#   NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL — e.g. /
+#   NEXT_PUBLIC_AUTH_SIGN_IN_URL      — Clerk hosted Account Portal sign-in URL,
+#       e.g. https://accounts.app.chargingthefuture.com/sign-in. Do NOT set this
+#       to /sign-in (or any URL on the app's own domain): the in-app /sign-in
+#       page only forwards to this URL, so a same-host value loops forever
+#       (ERR_TOO_MANY_REDIRECTS). If unset/misconfigured the app derives the
+#       Account Portal from the publishable key as a fallback.
+#   NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL — e.g. / (the app home page)
 #   NEXT_PUBLIC_AUTH_PROVIDER         — clerk
 #
 # OPTIONAL GITHUB SECRETS (enables auto-deploy to Render after image push):

--- a/ctf/docs/developer/AUTH_ARCHITECTURE.md
+++ b/ctf/docs/developer/AUTH_ARCHITECTURE.md
@@ -13,9 +13,38 @@ can be plugged in without touching consuming components.
 
 ## Current State
 
-Auth is a **no-op stub** until a real provider is wired in. The client context reports
-`isAuthenticated = false`, and the server auth layer treats requests with no resolved identity as
-anonymous and denies protected routes with `401 AUTH_UNAUTHORIZED`.
+**Clerk is the wired provider.** `app/layout.tsx` mounts `<ClerkProvider>`, `middleware.ts` runs
+`clerkMiddleware` (and translates the Clerk session into the generic `x-ctf-*` identity headers),
+and `lib/auth/client-context.tsx` derives the client session from Clerk's `useUser()` / `useAuth()`.
+When no Clerk env is configured the provider-neutral layer still resolves to the anonymous state, so
+the abstraction below remains intact.
+
+---
+
+## Hosted Sign-In (Clerk Account Portal)
+
+Sign-in and sign-up are served by **Clerk's hosted Account Portal on Clerk's own domains**
+(`https://accounts.<domain>` in production, `https://<slug>.accounts.dev` for a development
+instance) — not by a sign-in form rendered on the app's own domain. The app never mounts Clerk's
+`<SignIn />` / `<SignUp />` components; it redirects to the Account Portal and Clerk redirects back
+after a completed flow.
+
+- `lib/auth/provider-env.ts` resolves the hosted URLs:
+  - `getHostedSignInUrl()` — an explicitly external configured sign-in URL wins; otherwise the
+    Account Portal origin is **derived from the publishable key** (`deriveAccountPortalOrigin`) and
+    `/sign-in` is appended.
+  - `getHostedSignUpUrl()` / `getHostedAfterSignOutUrl()` — sign-up on the same portal; after
+    sign-out, the configured URL unless it would loop, else the app home page.
+- `app/layout.tsx` passes `signInUrl` / `signUpUrl` / `signInFallbackRedirectUrl` /
+  `signUpFallbackRedirectUrl` / `afterSignOutUrl` to `<ClerkProvider>`.
+- `app/sign-in/[[...sign-in]]/page.tsx` is a thin catch-all that forwards stray in-app `/sign-in`
+  links to the hosted portal (or home), and can never redirect to a `/sign-in` path on this host.
+
+**Redirect-loop pitfall (do not reintroduce):** `NEXT_PUBLIC_AUTH_SIGN_IN_URL` must be the Account
+Portal URL (e.g. `https://accounts.<domain>/sign-in`). Setting it to `/sign-in` — or any URL on the
+app's own host — makes the in-app `/sign-in` page redirect to itself forever
+(`ERR_TOO_MANY_REDIRECTS`). A same-host/relative value is ignored at runtime (the app falls back to
+the key-derived portal) and is flagged by `scripts/check-auth-env.mjs`.
 
 ---
 

--- a/ctf/packages/web/app/layout.tsx
+++ b/ctf/packages/web/app/layout.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
 import { AuthProvider } from '@/hooks/useAuth';
-import { getClerkRuntimeOptions } from '@/lib/auth/clerk-env';
+import {
+  getClerkRuntimeOptions,
+  getHostedSignInUrl,
+  getHostedSignUpUrl,
+  getHostedAfterSignOutUrl,
+  getAppUrl,
+} from '@/lib/auth/clerk-env';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -15,10 +21,27 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   const clerkOptions = getClerkRuntimeOptions();
+
+  // Point Clerk at its hosted Account Portal (accounts.<domain>) for sign-in and
+  // sign-up rather than a page rendered on this app's own domain. After a
+  // completed flow, Clerk returns the user to the app (signInFallbackRedirectUrl).
+  const signInUrl = getHostedSignInUrl();
+  const signUpUrl = getHostedSignUpUrl();
+  const afterSignOutUrl = getHostedAfterSignOutUrl();
+  const appHomeUrl = getAppUrl();
+
   return (
     <html lang="en">
       <body>
-        <ClerkProvider {...clerkOptions}>
+        <ClerkProvider
+          {...clerkOptions}
+          {...(signInUrl ? { signInUrl } : {})}
+          {...(signUpUrl ? { signUpUrl } : {})}
+          {...(appHomeUrl
+            ? { signInFallbackRedirectUrl: appHomeUrl, signUpFallbackRedirectUrl: appHomeUrl }
+            : {})}
+          {...(afterSignOutUrl ? { afterSignOutUrl } : {})}
+        >
           <AuthProvider>{children}</AuthProvider>
         </ClerkProvider>
       </body>

--- a/ctf/packages/web/app/page.tsx
+++ b/ctf/packages/web/app/page.tsx
@@ -5,7 +5,7 @@ import { evaluatePluginAccess } from '../lib/auth/server-authz';
 import { getGdpShellStats } from '../lib/gdp/repository';
 import { listPluginRegistry } from '../lib/plugins/repository';
 import { getTrustUserExtension } from '../lib/trust/repository';
-import { getConfiguredAuthProvider } from '../lib/auth/provider-env';
+import { getHostedSignInUrl } from '../lib/auth/provider-env';
 
 function buildShellUser(userId: string, username: string | null): ShellCurrentUser {
   const safeUsername = username && username !== 'guest' ? username : null;
@@ -51,8 +51,10 @@ export default async function HomePage() {
     ? await getTrustUserExtension(allowDecision.userId).catch(() => buildFallbackTrust(allowDecision.userId))
     : buildFallbackTrust(currentUser.userId);
 
-  const authProvider = getConfiguredAuthProvider();
-  const signInUrl = authProvider?.signInUrl || '/sign-in';
+  // Send "Sign In" straight to Clerk's hosted Account Portal. Falls back to the
+  // in-app `/sign-in` catch-all (which itself forwards to the portal) only when
+  // no hosted URL can be resolved.
+  const signInUrl = getHostedSignInUrl() ?? '/sign-in';
 
   return (
     <CommunityShell

--- a/ctf/packages/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/ctf/packages/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,13 +1,13 @@
 import { redirect } from 'next/navigation';
-import { getClerkSignInUrl } from 'lib/auth/clerk-env';
+import { getHostedSignInUrl } from 'lib/auth/clerk-env';
 
-// Sign-in is handled by the hosted account flow outside this app surface.
-// This page remains as a catch-all for legacy links or misconfigured redirects.
+// Sign-in is handled by Clerk's hosted Account Portal (accounts.<domain>), not
+// by a sign-in page rendered on this app's own domain. This catch-all only
+// exists to forward any legacy or in-app `/sign-in` link over to that hosted
+// portal. `getHostedSignInUrl()` only ever returns an Account Portal URL (a
+// different host) or `undefined`, so this can never redirect back to `/sign-in`
+// on this host — which is what previously caused an endless redirect loop
+// (ERR_TOO_MANY_REDIRECTS).
 export default function SignInPage() {
-  const signInUrl = getClerkSignInUrl();
-  if (signInUrl) {
-    redirect(signInUrl);
-  }
-
-  redirect('/');
+  redirect(getHostedSignInUrl() ?? '/');
 }

--- a/ctf/packages/web/lib/auth/clerk-env.ts
+++ b/ctf/packages/web/lib/auth/clerk-env.ts
@@ -4,7 +4,13 @@ import {
   isConfiguredAuthSignInExternal,
 } from './provider-env';
 
-export { getAppUrl } from './provider-env';
+export {
+  getAppUrl,
+  getHostedSignInUrl,
+  getHostedSignUpUrl,
+  getHostedAfterSignOutUrl,
+  getAccountPortalOrigin,
+} from './provider-env';
 
 export function getClerkPublishableKey(): string | undefined {
   return getConfiguredAuthProvider()?.publishableKey;

--- a/ctf/packages/web/lib/auth/client-context.tsx
+++ b/ctf/packages/web/lib/auth/client-context.tsx
@@ -8,7 +8,7 @@ import {
   useEffect,
 } from 'react';
 import { useUser, useAuth as useClerkAuth } from '@clerk/nextjs';
-import { getClerkSignInUrl } from './clerk-env';
+import { getHostedSignInUrl } from './clerk-env';
 
 /**
  * Provider-agnostic authentication context and types.
@@ -62,7 +62,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [clerkUser, isClerkLoaded]);
 
   const handleSignIn = async () => {
-    const signInUrl = getClerkSignInUrl();
+    const signInUrl = getHostedSignInUrl();
     if (signInUrl) {
       window.location.href = signInUrl;
     }

--- a/ctf/packages/web/lib/auth/provider-env.ts
+++ b/ctf/packages/web/lib/auth/provider-env.ts
@@ -164,3 +164,166 @@ export function isConfiguredAuthSignInExternal(): boolean {
     return false;
   }
 }
+
+/**
+ * Reports whether a candidate redirect URL would bounce the browser back to a
+ * `/sign-in` path on the app's own host.
+ *
+ * Sending someone to a `/sign-in` page that itself only redirects to a sign-in
+ * URL produces an endless loop (`ERR_TOO_MANY_REDIRECTS`). Any URL flagged here
+ * must be replaced with Clerk's hosted Account Portal (a different host) or the
+ * home page before it is used as a redirect target.
+ *
+ * @param value - The candidate path or absolute URL.
+ * @returns `true` when the target is a same-host `/sign-in` path.
+ */
+export function isLoopProneSignInTarget(value: string | undefined): boolean {
+  if (!value) return false;
+  const isSignInPath = (path: string): boolean =>
+    path === '/sign-in' || path.startsWith('/sign-in/') || path.startsWith('/sign-in?');
+
+  if (value.startsWith('/')) return isSignInPath(value);
+
+  try {
+    const parsed = new URL(value);
+    const appUrl = getAppUrl();
+    const sameHost = appUrl ? parsed.hostname === new URL(appUrl).hostname : false;
+    return sameHost && isSignInPath(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decodes the Clerk Frontend API host that is base64-encoded inside a Clerk
+ * publishable key.
+ *
+ * Clerk keys look like `pk_test_<base64>` / `pk_live_<base64>`, where the
+ * payload decodes to the Frontend API host followed by a `$` sentinel — e.g.
+ * `clerk.app.chargingthefuture.com$` or `sure-oarfish-90.clerk.accounts.dev$`.
+ *
+ * `atob` is used for decoding because it is available in browsers, the Next.js
+ * edge (middleware) runtime, and Node 18+ — the three runtimes this module is
+ * bundled into. The function is intentionally total: any malformed key returns
+ * `undefined` rather than throwing.
+ *
+ * @param publishableKey - The Clerk publishable key, if configured.
+ * @returns The decoded Frontend API host, or `undefined` when it can't be read.
+ */
+function decodeClerkFrontendApiHost(publishableKey: string | undefined): string | undefined {
+  if (!publishableKey) return undefined;
+  const match = /^pk_(?:test|live)_(.+)$/.exec(publishableKey.trim());
+  if (!match) return undefined;
+
+  let payload = match[1].replace(/-/g, '+').replace(/_/g, '/');
+  const remainder = payload.length % 4;
+  if (remainder === 1) return undefined;
+  if (remainder === 2) payload += '==';
+  else if (remainder === 3) payload += '=';
+
+  if (typeof atob !== 'function') return undefined;
+  let decoded: string;
+  try {
+    decoded = atob(payload);
+  } catch {
+    return undefined;
+  }
+
+  const host = decoded.replace(/\$+$/, '').trim();
+  return host.length > 0 ? host : undefined;
+}
+
+/**
+ * Derives the origin of Clerk's hosted Account Portal from a publishable key.
+ *
+ * This is how Clerk hosts sign-in/sign-up on its own domains instead of on the
+ * app's domain:
+ * - Production custom domain: Frontend API `clerk.<domain>` →
+ *   Account Portal `https://accounts.<domain>`.
+ * - Development instance: Frontend API `<slug>.clerk.accounts.dev` →
+ *   Account Portal `https://<slug>.accounts.dev`.
+ *
+ * @param publishableKey - The Clerk publishable key, if configured.
+ * @returns The Account Portal origin (no trailing slash), or `undefined`.
+ */
+export function deriveAccountPortalOrigin(publishableKey: string | undefined): string | undefined {
+  const frontendApiHost = decodeClerkFrontendApiHost(publishableKey);
+  if (!frontendApiHost) return undefined;
+
+  const devMatch = /^(.+)\.clerk\.(accounts(?:stage)?\.dev)$/i.exec(frontendApiHost);
+  if (devMatch) return `https://${devMatch[1]}.${devMatch[2]}`;
+
+  const prodMatch = /^clerk\.(.+)$/i.exec(frontendApiHost);
+  if (prodMatch) return `https://accounts.${prodMatch[1]}`;
+
+  return undefined;
+}
+
+/**
+ * Returns the Account Portal origin for the currently configured provider.
+ *
+ * @returns The hosted Account Portal origin, or `undefined` when no usable
+ *   publishable key is configured.
+ */
+export function getAccountPortalOrigin(): string | undefined {
+  return deriveAccountPortalOrigin(getConfiguredAuthProvider()?.publishableKey);
+}
+
+/**
+ * Resolves the sign-in URL the app should send people to.
+ *
+ * Order of precedence:
+ * 1. An explicitly external configured sign-in URL (absolute and on a different
+ *    host than the app) — an operator override, used as-is.
+ * 2. Clerk's hosted Account Portal derived from the publishable key
+ *    (`https://accounts.<domain>/sign-in`).
+ *
+ * A same-host or relative `/sign-in` value is deliberately ignored: it is the
+ * misconfiguration that causes the redirect loop, so we fall through to the
+ * hosted portal instead. Returns `undefined` only when neither source yields a
+ * usable URL, in which case callers fall back to the home page (never to
+ * `/sign-in`).
+ *
+ * @returns The hosted sign-in URL, or `undefined`.
+ */
+export function getHostedSignInUrl(): string | undefined {
+  if (isConfiguredAuthSignInExternal()) {
+    return getConfiguredAuthProvider()?.signInUrl;
+  }
+  const portalOrigin = getAccountPortalOrigin();
+  return portalOrigin ? `${portalOrigin}/sign-in` : undefined;
+}
+
+/**
+ * Resolves the sign-up URL on the same hosted Account Portal as
+ * {@link getHostedSignInUrl}.
+ *
+ * @returns The hosted sign-up URL, or `undefined` when sign-in is not hosted on
+ *   an absolute (different-host) URL.
+ */
+export function getHostedSignUpUrl(): string | undefined {
+  const signInUrl = getHostedSignInUrl();
+  if (!signInUrl) return undefined;
+  try {
+    return `${new URL(signInUrl).origin}/sign-up`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves where to send a user after they sign out.
+ *
+ * Honors a configured after-sign-out URL unless it would loop back into a
+ * same-host `/sign-in` page; in that case it falls back to the app home page so
+ * a freshly signed-out user is never trapped in a redirect loop.
+ *
+ * @returns The after-sign-out URL.
+ */
+export function getHostedAfterSignOutUrl(): string | undefined {
+  const configured = getConfiguredAuthProvider()?.afterSignOutUrl;
+  if (configured && !isLoopProneSignInTarget(configured)) {
+    return configured;
+  }
+  return getAppUrl() ?? '/';
+}

--- a/ctf/packages/web/scripts/check-auth-env.mjs
+++ b/ctf/packages/web/scripts/check-auth-env.mjs
@@ -41,13 +41,39 @@ requireAny('AUTH_SECRET_KEY or CLERK_SECRET_KEY', ['AUTH_SECRET_KEY', 'CLERK_SEC
 
 const signInUrl = getEnvValue('NEXT_PUBLIC_AUTH_SIGN_IN_URL', 'NEXT_PUBLIC_CLERK_SIGN_IN_URL');
 if (signInUrl) {
+  // A relative `/sign-in` value, or an absolute URL on the app's own host, is
+  // loop-prone: the in-app `/sign-in` page only forwards to the sign-in URL, so
+  // pointing it back at itself produces ERR_TOO_MANY_REDIRECTS. Sign-in must be
+  // hosted on Clerk's Account Portal (a different host, e.g.
+  // https://accounts.<domain>/sign-in). The app self-corrects by deriving the
+  // Account Portal from the publishable key, so this is a warning rather than a
+  // hard failure — but the value should be fixed so config matches behavior.
   const parsedApp = parseUrl(appUrl, 'NEXT_PUBLIC_APP_URL');
-  const parsedSignIn = parseUrl(signInUrl, 'NEXT_PUBLIC_AUTH_SIGN_IN_URL or NEXT_PUBLIC_CLERK_SIGN_IN_URL');
-  if (parsedApp && parsedSignIn && parsedSignIn.protocol !== parsedApp.protocol) {
-    console.error(
-      `Sign-in URL protocol mismatch. signIn=${parsedSignIn.protocol} app=${parsedApp.protocol}.`,
+
+  if (signInUrl.startsWith('/')) {
+    console.warn(
+      `Warning: NEXT_PUBLIC_AUTH_SIGN_IN_URL is a relative path ("${signInUrl}"). ` +
+        "Set it to Clerk's hosted Account Portal URL, e.g. https://accounts.<your-domain>/sign-in. " +
+        "The app will fall back to the Account Portal derived from the publishable key.",
     );
-    failed = true;
+  } else {
+    const parsedSignIn = parseUrl(
+      signInUrl,
+      'NEXT_PUBLIC_AUTH_SIGN_IN_URL or NEXT_PUBLIC_CLERK_SIGN_IN_URL',
+    );
+    if (parsedApp && parsedSignIn && parsedSignIn.protocol !== parsedApp.protocol) {
+      console.error(
+        `Sign-in URL protocol mismatch. signIn=${parsedSignIn.protocol} app=${parsedApp.protocol}.`,
+      );
+      failed = true;
+    }
+    if (parsedApp && parsedSignIn && parsedSignIn.hostname === parsedApp.hostname) {
+      console.warn(
+        `Warning: NEXT_PUBLIC_AUTH_SIGN_IN_URL ("${signInUrl}") is on the same host as ` +
+          `NEXT_PUBLIC_APP_URL ("${appUrl}"). Sign-in should be hosted on Clerk's Account Portal ` +
+          '(e.g. https://accounts.<your-domain>/sign-in) to avoid a redirect loop.',
+      );
+    }
   }
 }
 

--- a/render.yaml
+++ b/render.yaml
@@ -74,7 +74,11 @@ services:
       # they come from the GitHub Actions secrets passed as --build-arg in
       # build-images.yml (NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY,
       # NEXT_PUBLIC_AUTH_SIGN_IN_URL, NEXT_PUBLIC_AUTH_AFTER_SIGN_OUT_URL,
-      # NEXT_PUBLIC_AUTH_PROVIDER, NEXT_PUBLIC_APP_URL). Changing the publishable
+      # NEXT_PUBLIC_AUTH_PROVIDER, NEXT_PUBLIC_APP_URL). NEXT_PUBLIC_AUTH_SIGN_IN_URL
+      # must be Clerk's hosted Account Portal URL (e.g.
+      # https://accounts.<domain>/sign-in), NOT /sign-in on the app's own domain —
+      # a same-host value sends the in-app /sign-in page into an endless redirect
+      # loop. Changing the publishable
       # key in Infisical/Render has NO effect on the browser — you must update the
       # GitHub Actions secret and rebuild the image (build-images.yml) so the new
       # value is re-baked. Syncing a `NEXT_PUBLIC_*` value into Render at runtime


### PR DESCRIPTION
## Summary

Implements hosted sign-in via Clerk's Account Portal (`https://accounts.<domain>`) instead of rendering sign-in on the app's own domain. This prevents redirect loops and centralizes authentication on Clerk's infrastructure.

**Key changes:**
- Added `deriveAccountPortalOrigin()` to decode the Clerk Frontend API host from the publishable key and derive the Account Portal URL
- Added `getHostedSignInUrl()`, `getHostedSignUpUrl()`, and `getHostedAfterSignOutUrl()` to resolve hosted auth URLs with fallback logic
- Added `isLoopProneSignInTarget()` to detect and prevent same-host `/sign-in` redirects that cause `ERR_TOO_MANY_REDIRECTS`
- Updated `app/layout.tsx` to pass hosted URLs to `<ClerkProvider>`
- Updated `app/sign-in/[[...sign-in]]/page.tsx` to forward to the hosted portal (never loops back to itself)
- Enhanced `scripts/check-auth-env.mjs` to warn about misconfigured same-host sign-in URLs
- Updated documentation and deployment configs to clarify the hosted sign-in requirement

**Why:** A same-host `/sign-in` value (e.g., `NEXT_PUBLIC_AUTH_SIGN_IN_URL=/sign-in`) creates an infinite redirect loop: the in-app `/sign-in` page only forwards to the configured sign-in URL, so pointing it back at itself causes `ERR_TOO_MANY_REDIRECTS`. The app now self-corrects by deriving the Account Portal from the publishable key when the configured value is missing or misconfigured, and warns operators to fix the configuration.

## Parity

Parity Status: web+android complete

This is a web auth configuration/infrastructure fix (Clerk's hosted Account Portal plus the Next.js `/sign-in` redirect). There is no Android counterpart to build — the mobile app uses Clerk's own auth flow and has no equivalent `/sign-in` route — so there is no parity gap.

## Testing

- [x] Web tested — sign-in redirects to hosted Account Portal; `/sign-in` catch-all forwards correctly
- [x] Fallback tested — Account Portal origin correctly derived from publishable key when sign-in URL is missing
- [x] Loop prevention tested — same-host sign-in URLs are detected and rejected
- [x] Environment validation tested — `check-auth-env.mjs` warns on misconfigured values

## Compliance

- [x] Privacy/security impact reviewed — no sensitive data exposed; uses only public publishable key
- [x] No sensitive data exposed in logs/telemetry

## Modularity Governance

- [x] Changed files respect responsibility boundaries — auth resolution logic in `provider-env.ts`, Clerk integration in `clerk-env.ts` and `layout.tsx`, validation in `check-auth-env.mjs`
- [x] Complexity gates pass — helper functions are focused and under 50 lines; `decodeClerkFrontendApiHost()` includes defensive error handling
- [x] Tightly-coupled helpers justified — `decodeClerkFrontendApiHost()` is private to `provider-env.ts` because it's a Clerk-specific implementation detail not needed elsewhere

https://claude.ai/code/session_01KbZiSSFEKSfvbRc2n2LVeF