### PR TITLE
feat: GDP multi-currency recognition foundation (issue #121)

### DIFF
--- a/ctf/config/canonical_metrics.yaml
+++ b/ctf/config/canonical_metrics.yaml
@@ -96,7 +96,7 @@ canonical_metrics:
 
   - id: gdp_total_revenue
     name: GDP Total Revenue
-    description: Total GDP revenue (services plus goods/local economy), USD-normalized from multi-currency transaction volume via the currency_usd_rates factors in the GDP estimation layer. A morale/transparency estimate, not an accounting figure (issue #121).
+    description: Total GDP revenue (services plus goods/local economy), per the projection formula below; reported as a USD estimate (issue #121). Multi-currency transaction volume is normalized to USD via the currency_usd_rates factors only as live recognition is wired in — the GDP feature inventory documents that mechanism; the authoritative calculation here remains the projection.
     owner: economics-team@chargingthefuture.org
     data_type: currency
     unit: USD

--- a/ctf/config/canonical_metrics.yaml
+++ b/ctf/config/canonical_metrics.yaml
@@ -96,7 +96,7 @@ canonical_metrics:
 
   - id: gdp_total_revenue
     name: GDP Total Revenue
-    description: Total annual GDP revenue (services plus goods/local economy).
+    description: Total GDP revenue (services plus goods/local economy), USD-normalized from multi-currency transaction volume via the currency_usd_rates factors in the GDP estimation layer. A morale/transparency estimate, not an accounting figure (issue #121).
     owner: economics-team@chargingthefuture.org
     data_type: currency
     unit: USD

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -160,13 +160,14 @@ Extension entity:
 
 Domain tables:
 
-1. `gdp_metric_snapshots`
+1. `gdp_metric_snapshots` — per-metric weekly snapshot. Carries `is_estimate` (issue #121): TRUE for USD-normalized aggregates such as `gdp_total_revenue`, so the UI can label them estimates.
 2. `gdp_category_breakdowns`
 3. `gdp_provider_tier_snapshots`
 4. `gdp_rollout_targets`
 5. `gdp_rollout_actuals`
 6. `gdp_metric_definition_events`
 7. `gdp_publish_events`
+8. `currency_usd_rates` — notional USD conversion factor per currency (`currency_code` FK → `currencies.code`, plus `usd_rate`, `as_of`, `source`). Used ONLY by the GDP estimation layer to roll multi-currency transaction volume into the single USD-denominated GDP estimate; the most recent `as_of` per currency is the active rate. LEGAL GUARDRAIL: never surfaced as a per-wallet or per-price "ServiceCredits = fiat" equivalence.
 
 ### 4.3 Lifecycle and Storage Constraints
 
@@ -189,6 +190,7 @@ Domain tables:
 1. Account-deletion treasury returns are reserve reallocations and MUST NOT be recognized as GDP.
 2. GDP recognition occurs on eligible spend events only, per canonical metric definitions.
 3. Reclaim/finalization events from deletion workflows are excluded from GDP numerator calculations and tracked as accounting-state movements.
+4. Multi-currency normalization (issue #121): the platform transacts in ServiceCredits, fiat, barter, and crypto. GDP rolls all eligible volume into one USD-denominated ESTIMATE using the `currency_usd_rates` factors, applied only in the GDP estimation layer (`ctf/packages/web/lib/gdp/recognition.ts`). The figure is labeled an estimate (`gdp_metric_snapshots.is_estimate`); small drift is acceptable because GDP is a morale/transparency metric, not an accounting ledger. The ServiceCredits→USD factor is confined to this aggregate and is never shown as a per-wallet or per-price fiat equivalence (the no-fiat-parity line from issue #120). Account-deletion reclaim stays a reserve reallocation per point 1 above — it is not recognized as GDP.
 
 ---
 
@@ -287,6 +289,7 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 
 ## 10) Change Log
 
+- 2026-06-01: Multi-currency recognition foundation (issue #121): added the `currency_usd_rates` table (notional USD factor per currency, FK → `currencies.code`, with `as_of`) + `seedCurrencyUsdRates.mjs`; an `is_estimate` flag on `gdp_metric_snapshots`; and the GDP estimation-layer helper `ctf/packages/web/lib/gdp/recognition.ts` that rolls multi-currency volume into one USD estimate (the FX factor lives only here, never a per-wallet/per-price parity). Seeded `gdp_total_revenue` as an estimate. Documented the model and the no-fiat-parity guardrail; reconciled with the account-deletion-reclaim non-recognition rule (§4.4). The live automated rollup across plugin transaction tables, the admin rate-management UI, and the in-product estimate label remain next steps (the last two are design-gated).
 - 2026-05-31: Android pixel pass — rewrote `Gdp.tsx` to match `MobileGDP.tsx` / `MobileGDPEmpty.tsx` / `MobileGDPLoading.tsx` / `MobileGDPPublic.tsx` design mockups using React Native primitives (exact colors, spacing, type, layout). Created real `api.ts` bound to `GET /api/gdp/report/current`. Real metric bindings: `gdp_total_revenue` (hero), `weekly_active_users` (chip). Omissions per real-data-only rule: sector breakdown, country breakdown, per-user contribution, weekly trend series, $300B target progress. Loading/empty/public/error states all covered. MockGdp.tsx retained as dead file (no import). No schema/route/contract changes.
 - 2026-05-31: Seed runtime fix. `seedGdp.mjs` now opens its own `pg` Pool and defines a local `queryDb` helper instead of importing the TypeScript `packages/web/lib/db/postgres.ts`, which plain Node (e.g. the Node 20 seed/provision workflows) cannot load. Added `pool.end()` teardown. No change to seeded rows, schema, or API.
 - 2026-05-30: Web pixel pass — aligned the shell to `design/.../survivor-hub/GDP.tsx` and decomposed the 210-line / complexity-29 monolith into modular sub-components (`gdp-shared.ts`, `gdp-loading.tsx`, `gdp-icon-rail`, `gdp-sidebar`, `gdp-dashboard` with Hero/Sectors/Countries, `gdp-map`, thin shell) within rule-116 limits. Added a real loading splash and aria-labels on the icon-only rail buttons; removed the sidebar's "By Phase" filter (a banned term absent from the design mockup). Per real-data-only, all figures derive from `/api/gdp/report/current`; the design's mock contribution/live-feed/trend/chat content stays omitted. Dropped the unused `isAdmin` prop at the call site. No schema/route/contract changes.

--- a/ctf/package.json
+++ b/ctf/package.json
@@ -12,6 +12,7 @@
     "verify:pre-push": "pnpm run verify:web && pnpm run verify:mobile",
     "test": "pnpm -r --if-present run test",
     "seed:currencies": "node ./scripts/seedCurrenciesPhase0.mjs",
+    "seed:currency-usd-rates": "node ./scripts/seedCurrencyUsdRates.mjs",
     "seed:skills-taxonomy": "node ./scripts/seedSkillsTaxonomy.mjs",
     "seed:directory": "node ./scripts/seedDirectory.mjs",
     "seed:feed-announcements": "node ./scripts/seedFeedAnnouncements.mjs",

--- a/ctf/packages/web/lib/gdp/recognition.ts
+++ b/ctf/packages/web/lib/gdp/recognition.ts
@@ -1,0 +1,69 @@
+import { queryDb } from 'lib/db/postgres';
+
+// Multi-currency GDP recognition (issue #121). This module is the GDP "estimation layer": the ONLY
+// place the notional USD conversion factors from currency_usd_rates are applied. It rolls
+// multi-currency transaction volume into the single, estimate-labeled GDP figure.
+//
+// LEGAL GUARDRAIL: these factors must never be surfaced as a per-wallet or per-price
+// "ServiceCredits = fiat" equivalence. A user never sees "your N ServiceCredits = $X". The only place
+// a USD-normalized ServiceCredits value appears is inside the aggregate, estimate-labeled GDP total.
+
+/** A single-currency transaction volume to recognize into the USD GDP estimate. */
+export interface CurrencyVolume {
+  amount: number;
+  currencyCode: string;
+}
+
+/** The result of rolling multi-currency volume into one USD estimate. */
+export interface UsdEstimate {
+  /** USD-denominated estimate (not an accounting figure; small drift is acceptable and disclosed). */
+  usdEstimate: number;
+  /** Currency codes that had no active rate and were therefore excluded (surfaced, never silently dropped). */
+  unratedCurrencies: string[];
+}
+
+/**
+ * The active USD conversion factor per currency: the most recent `as_of` row per `currency_code` in
+ * `currency_usd_rates`. `1` unit of the currency is worth `usd_rate` USD (a notional estimate the owner
+ * curates). Returns a map keyed by currency code.
+ */
+export async function getActiveUsdRates(): Promise<Map<string, number>> {
+  const result = await queryDb<{ currency_code: string; usd_rate: string }>(
+    `SELECT DISTINCT ON (currency_code) currency_code, usd_rate::text AS usd_rate
+       FROM currency_usd_rates
+       ORDER BY currency_code, as_of DESC`,
+  );
+  const rates = new Map<string, number>();
+  for (const row of result.rows) {
+    rates.set(row.currency_code, Number(row.usd_rate));
+  }
+  return rates;
+}
+
+/**
+ * Roll a set of multi-currency volumes into one USD-denominated estimate using the active rates.
+ * A currency with no active rate is excluded and reported in `unratedCurrencies` rather than being
+ * treated as zero-value without surfacing it. The output is an ESTIMATE, labeled as such in-product.
+ */
+export function normalizeVolumesToUsd(
+  volumes: CurrencyVolume[],
+  rates: Map<string, number>,
+): UsdEstimate {
+  let usdEstimate = 0;
+  const unrated = new Set<string>();
+  for (const volume of volumes) {
+    const rate = rates.get(volume.currencyCode);
+    if (rate === undefined) {
+      unrated.add(volume.currencyCode);
+      continue;
+    }
+    usdEstimate += volume.amount * rate;
+  }
+  return { usdEstimate, unratedCurrencies: [...unrated] };
+}
+
+/** Convenience: load the active rates and normalize in one call (server-side only). */
+export async function recognizeUsdEstimate(volumes: CurrencyVolume[]): Promise<UsdEstimate> {
+  const rates = await getActiveUsdRates();
+  return normalizeVolumesToUsd(volumes, rates);
+}

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2672,7 +2672,7 @@ ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS created_at 
 CREATE TABLE IF NOT EXISTS currency_usd_rates (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   currency_code TEXT NOT NULL REFERENCES currencies(code),
-  usd_rate NUMERIC NOT NULL,
+  usd_rate NUMERIC NOT NULL CHECK (usd_rate > 0),
   as_of DATE NOT NULL,
   source TEXT NOT NULL DEFAULT 'owner',
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2634,6 +2634,13 @@ ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS dp_suppresse
 ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS lawful_basis TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS source_plugin TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency GDP recognition (issue #121): mark metrics that are USD-normalized ESTIMATES (e.g.
+-- gdp_total_revenue, which rolls multi-currency volume into USD via currency_usd_rates). The in-product
+-- "estimate" label reads this flag; small drift is acceptable and disclosed, since GDP is a morale/
+-- transparency figure, not an accounting ledger.
+ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS is_estimate BOOLEAN NOT NULL DEFAULT FALSE;
+-- Mark the USD-normalized aggregate(s) as estimates for any rows that predate the column.
+UPDATE gdp_metric_snapshots SET is_estimate = TRUE WHERE metric_key = 'gdp_total_revenue' AND is_estimate = FALSE;
 
 CREATE TABLE IF NOT EXISTS gdp_admin_audit_trail (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -2655,6 +2662,29 @@ ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS target_type
 ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS target_id TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Multi-currency GDP recognition (issue #121). The notional USD conversion factor per currency, used
+-- ONLY by the GDP estimation layer to roll multi-currency transaction volume into the single,
+-- estimate-labeled GDP figure. LEGAL GUARDRAIL: this rate is NEVER surfaced as a per-wallet or
+-- per-price "ServiceCredits = fiat" equivalence; a user never sees "your N ServiceCredits = $X". The
+-- only place a USD-normalized ServiceCredits value appears is inside the aggregate GDP estimate. The
+-- owner curates rates over time; the most recent as_of per currency_code is the active rate.
+CREATE TABLE IF NOT EXISTS currency_usd_rates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  currency_code TEXT NOT NULL REFERENCES currencies(code),
+  usd_rate NUMERIC NOT NULL,
+  as_of DATE NOT NULL,
+  source TEXT NOT NULL DEFAULT 'owner',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (currency_code, as_of)
+);
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS currency_code TEXT;
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS usd_rate NUMERIC;
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS as_of DATE;
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'owner';
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE INDEX IF NOT EXISTS idx_currency_usd_rates_code_asof ON currency_usd_rates(currency_code, as_of DESC);
 
 -- === MOOD MODULE ===
 CREATE TABLE IF NOT EXISTS mood_submissions (

--- a/ctf/scripts/seedCurrencyUsdRates.mjs
+++ b/ctf/scripts/seedCurrencyUsdRates.mjs
@@ -1,0 +1,73 @@
+import { Pool } from 'pg';
+
+// Seed the `currency_usd_rates` table (issue #121). These are the notional USD conversion factors the
+// GDP estimation layer uses to roll multi-currency transaction volume into one USD-denominated
+// estimate. They are owner-curated estimates, not market quotes, and are revised over time (a new row
+// per currency_code with a later `as_of` becomes the active rate).
+//
+// LEGAL GUARDRAIL: these factors are used ONLY inside the aggregate, estimate-labeled GDP figure. They
+// are NEVER shown as a per-wallet or per-price "ServiceCredits = fiat" equivalence. The ServiceCredits
+// factor in particular is a non-binding morale-estimate input, NOT a redemption rate.
+const AS_OF = '2026-01-01';
+const SOURCE = 'owner-seed';
+
+// 1 unit of <code> is counted as <usdRate> USD inside the GDP estimate. Approximate, owner-revisable.
+const RATES = [
+  { code: 'USD', usdRate: 1 },
+  { code: 'EUR', usdRate: 1.08 },
+  { code: 'JPY', usdRate: 0.0067 },
+  { code: 'GBP', usdRate: 1.27 },
+  { code: 'CHF', usdRate: 1.12 },
+  { code: 'CAD', usdRate: 0.73 },
+  { code: 'AUD', usdRate: 0.66 },
+  { code: 'CNY', usdRate: 0.14 },
+  { code: 'INR', usdRate: 0.012 },
+  { code: 'BRL', usdRate: 0.18 },
+  { code: 'BTC', usdRate: 65000 },
+  // ServiceCredits: a non-binding morale-estimate factor for GDP only, never a redemption rate. The
+  // owner sets the real notional value; this placeholder simply lets the estimate include SC volume.
+  { code: 'SC', usdRate: 0.1 },
+];
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+async function seed() {
+  const pool = new Pool({
+    connectionString: requireEnv('DATABASE_URL'),
+    ssl: { rejectUnauthorized: false },
+  });
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    try {
+      for (const rate of RATES) {
+        await client.query(
+          `INSERT INTO currency_usd_rates (currency_code, usd_rate, as_of, source)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (currency_code, as_of) DO UPDATE SET usd_rate = EXCLUDED.usd_rate, source = EXCLUDED.source`,
+          [rate.code, rate.usdRate, AS_OF, SOURCE],
+        );
+      }
+      await client.query('COMMIT');
+      console.log(`Seeded ${RATES.length} currency_usd_rates (as_of ${AS_OF}).`);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    }
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/ctf/scripts/seedGdp.mjs
+++ b/ctf/scripts/seedGdp.mjs
@@ -50,7 +50,14 @@ async function seed() {
         `INSERT INTO gdp_metric_snapshots
          (id, week_start_date, metric_key, metric_value, dp_suppressed, lawful_basis, source_plugin, is_estimate)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-         ON CONFLICT (id) DO UPDATE SET is_estimate = EXCLUDED.is_estimate`,
+         ON CONFLICT (id) DO UPDATE SET
+           week_start_date = EXCLUDED.week_start_date,
+           metric_key = EXCLUDED.metric_key,
+           metric_value = EXCLUDED.metric_value,
+           dp_suppressed = EXCLUDED.dp_suppressed,
+           lawful_basis = EXCLUDED.lawful_basis,
+           source_plugin = EXCLUDED.source_plugin,
+           is_estimate = EXCLUDED.is_estimate`,
         [
           id,
           WEEK_START,

--- a/ctf/scripts/seedGdp.mjs
+++ b/ctf/scripts/seedGdp.mjs
@@ -26,11 +26,15 @@ async function queryDb(text, values = []) {
 const WEEK_START = '2026-05-19';
 
 const METRICS = [
-  { key: 'users.active', value: 1250, source: 'directory' },
-  { key: 'posts.created', value: 342, source: 'feed' },
-  { key: 'connections.initiated', value: 89, source: 'foundation' },
-  { key: 'skills.matched', value: 156, source: 'skills-hunt' },
-  { key: 'workforce.placements', value: 23, source: 'workforce' },
+  { key: 'users.active', value: 1250, source: 'directory', isEstimate: false },
+  { key: 'posts.created', value: 342, source: 'feed', isEstimate: false },
+  { key: 'connections.initiated', value: 89, source: 'foundation', isEstimate: false },
+  { key: 'skills.matched', value: 156, source: 'skills-hunt', isEstimate: false },
+  { key: 'workforce.placements', value: 23, source: 'workforce', isEstimate: false },
+  // The USD-normalized GDP total (issue #121): one estimate rolled from multi-currency transaction
+  // volume via currency_usd_rates in the GDP estimation layer. isEstimate = true so the UI can label
+  // it an estimate. The value here is a deterministic placeholder the owner/recognition layer revises.
+  { key: 'gdp_total_revenue', value: 12500, source: 'gdp', isEstimate: true },
 ];
 
 function deterministicId(weekDate, metricKey, sourcePlugin) {
@@ -44,9 +48,9 @@ async function seed() {
       const id = deterministicId(WEEK_START, metric.key, metric.source);
       await queryDb(
         `INSERT INTO gdp_metric_snapshots
-         (id, week_start_date, metric_key, metric_value, dp_suppressed, lawful_basis, source_plugin)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
-         ON CONFLICT (id) DO NOTHING`,
+         (id, week_start_date, metric_key, metric_value, dp_suppressed, lawful_basis, source_plugin, is_estimate)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (id) DO UPDATE SET is_estimate = EXCLUDED.is_estimate`,
         [
           id,
           WEEK_START,
@@ -55,6 +59,7 @@ async function seed() {
           false,
           'service-delivery',
           metric.source,
+          metric.isEstimate,
         ]
       );
     }


### PR DESCRIPTION
## What this does

Foundation layer for issue #121 — normalizing multi-currency transaction volume into the single, USD-denominated GDP estimate. Builds on the `currencies` model merged in #120.

You chose the **foundation-layer** scope (GDP metrics are currently seeded, not produced by a live pipeline), so this delivers the rate table, the normalization layer, the estimate flag, and the docs — and explicitly leaves the live automated rollup as a documented next step.

### Schema (`ctf/schema.sql`, additive/idempotent)
- `currency_usd_rates` — the notional USD conversion factor per currency (FK → `currencies.code`, with `usd_rate`, `as_of`, `source`). The most recent `as_of` per currency is the active rate.
- `gdp_metric_snapshots.is_estimate` — TRUE for USD-normalized aggregates (e.g. `gdp_total_revenue`), so the UI can label them estimates; a backfill marks pre-existing rows.

**Legal guardrail:** the ServiceCredits→USD (and every) factor is used ONLY inside the aggregate, estimate-labeled GDP figure. It is never surfaced as a per-wallet or per-price "ServiceCredits = fiat" equivalence (the no-fiat-parity line from #120).

### Library
`ctf/packages/web/lib/gdp/recognition.ts` — `getActiveUsdRates`, `normalizeVolumesToUsd`, `recognizeUsdEstimate`. The single place the factors are applied; a currency with no rate is surfaced, never silently treated as zero-value.

### Seeds & docs
- `seedCurrencyUsdRates.mjs` (+ a `seed:currency-usd-rates` script) seeds owner-revisable estimates.
- `seedGdp.mjs` now seeds `gdp_total_revenue` as an estimate.
- GDP inventory + `canonical_metrics.yaml` updated; reconciled with the existing account-deletion-reclaim non-recognition rule (§4.4).

## Deferred (documented, not in this PR)
- The **live automated rollup** that scans plugin transaction tables and writes weekly `gdp_metric_snapshots` (needs product decisions on which sources count and how ServiceCredits volume is valued).
- The **admin rate-management UI** and the **in-product "estimate" label** — both design-gated (rule 127).

## Notes
- Web typecheck passes and the EOF check is clean. I could not run the full `pnpm build` in this environment, but the new TypeScript compiles under the web typecheck and the SQL is additive, guarded DDL (the schema-drift gate validates in CI).
- The seeded `currency_usd_rates` values (especially the ServiceCredits factor) are owner-revisable placeholders, not market quotes.

Part of #121 (foundation layer); the live pipeline + admin UI remain for follow-up.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE2wfPhDmQMXoDpiNi5Lh9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-currency support for GDP metrics with automatic USD normalization from transaction volumes.
  * GDP metrics now explicitly marked as estimates rather than accounting figures for improved transparency.

* **Documentation**
  * Enhanced GDP metric descriptions to clarify USD-normalized calculation from multi-currency data.
  * Updated GDP plugin documentation with currency handling mechanics and legal guardrails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->