### PR TITLE
fix: tighten ServiceCredits parity guard, enforce SocketRelay price invariant, drop dead Trust prop

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
@@ -298,6 +298,7 @@ Android pixel pass (design `MobileSocketRelay.tsx`): `packages/mobile/src/featur
 
 ### Change Log
 
+- 2026-06-01: Enforced the SocketRelay price invariant at the DB level — added a guarded `socketrelay_requests_price_consistency_check` CHECK so a request either has no price (both NULL) or a positive amount in a named currency (the "Free = no price, never `$0`" rule). Follow-up to the #120 review.
 - 2026-06-01: Multi-currency (issue #120): added OPTIONAL `price_amount` + `price_currency` (FK → `currencies.code`) to `socketrelay_requests` and a `socketrelay_request_accepted_currencies` join. "Free" renders from the absence of a price, never `$0`. Documented the no-fiat-parity rule. Schema + inventory only; the currency UI is design-gated.
 
 - 2026-02-25: Created initial SocketRelay CTF rewrite checklist with web-first release gating, tracked Android deferrals, lifecycle requirements, and explicit mitigation gates for legacy-known risks.

--- a/ctf/packages/mobile/src/features/community/MockCommunity.tsx
+++ b/ctf/packages/mobile/src/features/community/MockCommunity.tsx
@@ -11,7 +11,7 @@ export const MockCommunity = () => (
     <Text style={styles.subtitle}>Mobile parity shell for peer posts, replies, and moderation-ready actions.</Text>
 
     {/* Trust Panel (Android parity) */}
-    <Trust compact />
+    <Trust />
 
     {posts.map((item) => (
       <React.Fragment>

--- a/ctf/packages/mobile/src/features/currency/assert.ts
+++ b/ctf/packages/mobile/src/features/currency/assert.ts
@@ -10,7 +10,7 @@
 // allowed (two distinct fields) and is not a parity claim — each field passes this guard on its own.
 
 function mentionsServiceCredits(lower: string): boolean {
-  return /servicecredits|\bsc\b|\bcredits?\b/.test(lower);
+  return /servicecredits|service[-\s]?credits|\bsc\b/.test(lower);
 }
 
 const EQUIVALENCE_CUE = /≈|~|=|\bequals?\b|\bworth\b/;

--- a/ctf/packages/mobile/src/features/directory/DirectoryProfile.tsx
+++ b/ctf/packages/mobile/src/features/directory/DirectoryProfile.tsx
@@ -14,7 +14,7 @@ export const DirectoryProfile = ({ profile }: { profile?: Profile }) => {
       <Text style={styles.desc}>{p.description}</Text>
 
       {/* Trust Panel (Android parity) */}
-      <Trust compact />
+      <Trust />
     </View>
   );
 };

--- a/ctf/packages/web/lib/currency/assert.ts
+++ b/ctf/packages/web/lib/currency/assert.ts
@@ -9,7 +9,7 @@
 // allowed (two distinct fields) and is not a parity claim — each field passes this guard on its own.
 
 function mentionsServiceCredits(lower: string): boolean {
-  return /servicecredits|\bsc\b|\bcredits?\b/.test(lower);
+  return /servicecredits|service[-\s]?credits|\bsc\b/.test(lower);
 }
 
 const EQUIVALENCE_CUE = /≈|~|=|\bequals?\b|\bworth\b/;

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2524,6 +2524,23 @@ ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS updated_at T
 -- never as $0. Accepted currencies (if any) live in socketrelay_request_accepted_currencies.
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS price_amount NUMERIC;
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS price_currency TEXT REFERENCES currencies(code);
+-- Enforce the "Free = no price, never $0" rule at the DB level (issue #120 follow-up): a request either
+-- has no price (both NULL) or a positive amount in a named currency. Guarded so it is added only once.
+DO $socketrelay_requests_price_consistency$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'socketrelay_requests_price_consistency_check'
+  ) THEN
+    ALTER TABLE socketrelay_requests
+      ADD CONSTRAINT socketrelay_requests_price_consistency_check
+      CHECK (
+        (price_amount IS NULL AND price_currency IS NULL) OR
+        (price_amount IS NOT NULL AND price_amount > 0 AND price_currency IS NOT NULL)
+      );
+  END IF;
+END
+$socketrelay_requests_price_consistency$;
 CREATE TABLE IF NOT EXISTS socketrelay_request_accepted_currencies (
   request_id UUID NOT NULL REFERENCES socketrelay_requests(id) ON DELETE CASCADE,
   currency_code TEXT NOT NULL REFERENCES currencies(code),


### PR DESCRIPTION
## What this does

Three small follow-up fixes. The first two address CodeRabbit's review of the now-merged #120 (PR #237); the third is a pre-existing type bug found during #184.

1. **`assertNoFiatParity` regex** (web `lib/currency/assert.ts` + mobile mirror): narrowed `mentionsServiceCredits` so it no longer matches generic "credits" (e.g. "carbon credits"), which could false-trigger a no-fiat-parity violation. Now matches only `servicecredits` / `service[-\s]?credits` / `\bsc\b`.
2. **SocketRelay price invariant** (`schema.sql`): added a guarded `socketrelay_requests_price_consistency_check` CHECK so a request is either free (`price_amount` and `price_currency` both NULL) or has a positive amount in a named currency — enforcing the "Free = no price, never `$0`" rule at the DB level.
3. **Dead `Trust` prop** (mobile): removed `compact` from `<Trust />` in `MockCommunity` and `DirectoryProfile`. `Trust` is `React.FC` with no props and no compact mode, so the prop was an ignored no-op that stricter TypeScript/React-types versions flag as an error.

## Verification
- Mobile typecheck is now clean (the `<Trust compact />` errors are resolved); web typecheck and the EOF check pass.
- The schema CHECK is additive, guarded DDL; existing rows (price columns all NULL) satisfy it.
- I intentionally did **not** change the seed script's `ssl: { rejectUnauthorized: false }` that CodeRabbit also flags elsewhere — every seed script in the repo uses that, so hardening TLS verification should be one repo-wide change, not a piecemeal divergence that could break the seed against the managed DB.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE2wfPhDmQMXoDpiNi5Lh9)_