### PR TITLE
fix: log the real cause of unlock API 503s instead of swallowing it

### DIFF
--- a/ctf/packages/web/app/api/unlock/status/route.ts
+++ b/ctf/packages/web/app/api/unlock/status/route.ts
@@ -24,7 +24,10 @@ export async function GET() {
     });
 
     return NextResponse.json({ ok: true, status });
-  } catch {
+  } catch (error) {
+    // Surface the real cause in server logs (a swallowed error here made the 503
+    // undiagnosable). The client message stays generic so DB internals never leak.
+    console.error('[unlock] status query failed', error);
     return NextResponse.json({ ok: false, message: 'Unlock status unavailable.' }, { status: 503 });
   }
 }

--- a/ctf/packages/web/app/api/unlock/submission/route.ts
+++ b/ctf/packages/web/app/api/unlock/submission/route.ts
@@ -73,7 +73,10 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, submission }, { status: 201 });
-  } catch {
+  } catch (error) {
+    // Surface the real cause in server logs (a swallowed error here made the 503
+    // undiagnosable). The client message stays generic so DB internals never leak.
+    console.error('[unlock] submission failed', error);
     return unlockErrorResponse('Unlock submission unavailable.', 503);
   }
 }


### PR DESCRIPTION
## Summary

The unlock API routes (`/api/unlock/status` GET and `/api/unlock/submission` POST) caught every error with a bare `catch {}` and returned a generic 503, so the real cause never appeared anywhere — making the failure impossible to diagnose from logs.

Both routes now log the underlying error server-side (`console.error`) while keeping the client response generic, so no database internals leak to the browser. The actual cause (e.g. a missing table) now shows up in the server logs.

This is a **diagnosability** fix — it does not by itself resolve a 503. The likely current cause is the unlock tables being missing from the production database; `schema.sql` defines them correctly and is idempotent (`CREATE TABLE IF NOT EXISTS`), so applying it to prod (the "Update Neon DB with schema.sql" workflow, or `pnpm migrate:schema`) should create them.

## Changes

- `app/api/unlock/status/route.ts`: log the caught error before returning 503
- `app/api/unlock/submission/route.ts`: log the caught error before returning 503

## Parity

Parity Status: web+android complete

Backend-only change (server-side error logging in two API routes). No UI and no mobile counterpart.

## Testing

- [x] Typecheck + lint pass; pre-push verification (lint, typecheck, full web build) passed
- [x] Client response unchanged (still a generic 503 message); only server-side logging added

## Compliance

- [x] No sensitive data exposed to the client; the database error is logged server-side only (no credentials/secrets in the message)

https://claude.ai/code/session_01KbZiSSFEKSfvbRc2n2LVeF