### PR TITLE
fix: propagate Clerk username and role into request identity

### DIFF
--- a/.github/instructions/123-environment-configuration-rules.mdc
+++ b/.github/instructions/123-environment-configuration-rules.mdc
@@ -81,6 +81,22 @@ the portal and Clerk redirects back when the flow completes.
 - The Clerk instance's redirect URIs must exactly match the production domain.
 - Session/auth failures often indicate a Clerk domain mismatch.
 
+### Clerk session token claims (username + role)
+
+`middleware.ts` reads the signed-in user's username and role from the Clerk
+**session token claims** and forwards them as `x-ctf-username` / `x-ctf-user-role`.
+Clerk does not include these by default, so the session token must be customized
+(Clerk dashboard → Configure → Sessions → "Customize session token"):
+
+```json
+{ "username": "{{user.username}}", "metadata": "{{user.public_metadata}}" }
+```
+
+Roles live in the user's **public metadata** (e.g. `{ "role": "admin" }`). Without
+this configuration the app falls back to an anonymous display name and no role
+(no regression), but username-gated routes deny with `missing_username` and admin
+checks fail. Approval is not in the token — it comes from the database unlock tier.
+
 ## Environment Variable Contract
 
 ### Infisical is the single source of truth

--- a/ctf/docs/developer/AUTH_ARCHITECTURE.md
+++ b/ctf/docs/developer/AUTH_ARCHITECTURE.md
@@ -48,6 +48,41 @@ the key-derived portal) and is flagged by `scripts/check-auth-env.mjs`.
 
 ---
 
+## Identity Propagation (username + role)
+
+`middleware.ts` is the only place that writes the `x-ctf-*` identity headers, and
+`lib/auth/request-identity.ts` reads them. The middleware always sets `x-ctf-user-id` from the
+verified Clerk `userId`, and additionally sets:
+
+- `x-ctf-username` — the Clerk username, when present.
+- `x-ctf-user-role` — the user's role (e.g. `admin`), when present.
+
+These come from the **Clerk session token claims** (`sessionClaims`), which is fast (no extra
+Clerk API call per request — the values ride along in the session JWT).
+
+**Required Clerk dashboard configuration** (without it, `username`/`role` stay null and the app
+falls back to the anonymous display name with no role — no regression, but Chyme shows
+`user-<id>` instead of `@username`, and `requireUsername` routes like Foundation deny with
+`missing_username`):
+
+1. **Customize the session token** — Clerk dashboard → Configure → Sessions → "Customize session
+   token", add:
+
+   ```json
+   { "username": "{{user.username}}", "metadata": "{{user.public_metadata}}" }
+   ```
+
+2. **Store roles in public metadata** — for an admin, set the user's Public metadata to
+   `{ "role": "admin" }` (Clerk dashboard → Users → [user] → Metadata → Public).
+
+The middleware accepts either a flat claim (`username` / `role`) or one nested under `metadata`, so
+both common claim mappings work. Session tokens refresh about every minute, so after changing the
+config a signed-in user picks up the new claims on the next refresh (or after signing out and back
+in). Approval (`isApproved`) is **not** sourced from Clerk — it comes from the database unlock tier
+(`isUserUnlocked`), so it is intentionally left out of the session claims.
+
+---
+
 ## Files
 
 | File                           | Purpose                                                                                                                                     |

--- a/ctf/packages/web/middleware.ts
+++ b/ctf/packages/web/middleware.ts
@@ -11,10 +11,44 @@ const MANAGED_IDENTITY_HEADERS = [
   'x-ctf-authenticated',
   'x-ctf-auth-provider',
   'x-ctf-user-id',
+  'x-ctf-username',
+  'x-ctf-user-role',
 ];
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined;
+}
+
+function claimString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+// Clerk does NOT include the username or public metadata in the session token by
+// default, so these reads return `undefined` until the session token is
+// customized. To populate them, in the Clerk dashboard go to
+// Configure → Sessions → "Customize session token" and add:
+//   { "username": "{{user.username}}", "metadata": "{{user.public_metadata}}" }
+// and store roles in the user's public metadata (e.g. { "role": "admin" }).
+// Until then the app falls back to the anonymous display name and no role — no
+// regression. Both the flat (`username`/`role`) and nested-in-`metadata`
+// shapes are accepted so either claim mapping works.
+function extractUsername(claims: unknown): string | undefined {
+  const root = asRecord(claims);
+  if (!root) return undefined;
+  return claimString(root.username) ?? claimString(asRecord(root.metadata)?.username);
+}
+
+function extractRole(claims: unknown): string | undefined {
+  const root = asRecord(claims);
+  if (!root) return undefined;
+  const metadata = asRecord(root.metadata) ?? asRecord(root.public_metadata);
+  return claimString(root.role) ?? claimString(metadata?.role);
+}
+
 export default clerkMiddleware(async (auth, request) => {
-  const { userId } = await auth();
+  const { userId, sessionClaims } = await auth();
 
   const requestHeaders = new Headers(request.headers);
   for (const header of MANAGED_IDENTITY_HEADERS) {
@@ -25,6 +59,16 @@ export default clerkMiddleware(async (auth, request) => {
   requestHeaders.set('x-ctf-auth-provider', 'clerk');
   if (userId) {
     requestHeaders.set('x-ctf-user-id', userId);
+
+    const username = extractUsername(sessionClaims);
+    if (username) {
+      requestHeaders.set('x-ctf-username', username);
+    }
+
+    const role = extractRole(sessionClaims);
+    if (role) {
+      requestHeaders.set('x-ctf-user-role', role);
+    }
   }
 
   return NextResponse.next({ request: { headers: requestHeaders } });


### PR DESCRIPTION
## Summary

Extends identity propagation in `middleware.ts` to extract and forward the signed-in user's username and role from the Clerk session token claims as `x-ctf-username` and `x-ctf-user-role` headers. Adds helpers to safely read these from either a flat or a nested (`metadata`) claim shape, so both common Clerk claim mappings work.

Includes documentation of the required Clerk dashboard configuration (session token customization + public metadata) in `AUTH_ARCHITECTURE.md` and the environment configuration rules.

## Changes

- **middleware.ts**: added `extractUsername()` / `extractRole()` to parse session claims; the middleware now reads `sessionClaims` and sets the new headers when present (added to the managed, client-cleared header set so they can't be spoofed)
- **AUTH_ARCHITECTURE.md**: new "Identity Propagation" section (feature, required Clerk config, fallback behavior)
- **123-environment-configuration-rules.mdc**: new "Clerk session token claims" subsection with setup steps

## Parity

Parity Status: web+android complete

Web-specific auth infrastructure (the Next.js middleware that sets server-side identity headers). React Native has no equivalent middleware and mobile auth is handled separately, so there is no mobile counterpart to build.

## Testing

- [x] Typecheck + lint pass; pre-push verification (lint, typecheck, full web build) passed
- [x] No regression: missing claims fall back to the anonymous display name and no role
- [x] Behavior is gated on Clerk dashboard config (session-token claims + public-metadata role), documented in the PR and the auth docs

## Compliance

- [x] Privacy/security: claims are read from the verified Clerk JWT; the new headers are cleared from client input before being set, so they can't be spoofed
- [x] No sensitive data exposed

## Modularity Governance

- [x] Helpers (`asRecord`, `claimString`, `extractUsername`, `extractRole`) are tightly coupled to middleware claim parsing; kept in-file to avoid over-engineering a single-use module
- [x] Low complexity; no gates exceeded
- [x] Middleware remains the sole writer of identity headers

https://claude.ai/code/session_01KbZiSSFEKSfvbRc2n2LVeF