### PR TITLE
feat: make the web app usable on phones

### DIFF
--- a/ctf/docs/developer/web-mobile-responsiveness-session-continuity.md
+++ b/ctf/docs/developer/web-mobile-responsiveness-session-continuity.md
@@ -1,0 +1,82 @@
+# Web mobile responsiveness — pragmatic reflow pass (session continuity)
+
+## What this is
+
+The v3 web app was built for desktop only. Its screens assume a wide window with a
+fixed multi-column layout — a 72px icon rail, a fixed-width sidebar, the main
+column, and a right rail. On a small phone screen (for example an iPhone SE at
+375px wide) that row ran off the side of the screen, and because the page also
+locked scrolling (`overflow: hidden` on `html, body`), the overflow was clipped
+and could not be reached. The app was effectively unusable on a phone.
+
+This pass makes the whole web app usable on a phone **without changing how it looks
+on desktop**.
+
+## Design-gate bypass (rule 127)
+
+Making the app adapt to small screens is a layout change to user-facing screens,
+which normally requires a design pass first (see
+`.github/instructions/127-design-pass-gating-rules.mdc`). The design submodule only
+holds desktop web designs; the narrow-screen `Mobile*` mockups there are scoped to
+the Android app, not the web (per `ctf/agents/design.agent.md`), so there is no
+authoritative responsive-web design to build against.
+
+The owner approved a bypass on 2026-06-01: do a pragmatic reflow now so they can
+test the app on their phone, keeping the existing desktop design and letting it
+adapt to small screens. This note records the bypass as the rule requires.
+
+Proper responsive-web designs from the Replit design agent remain a follow-up. When
+they land, the per-screen polish listed below should be implemented against them
+(see `.github/instructions/126-design-mockup-implementation-rules.mdc`).
+
+## What changed
+
+- `ctf/packages/web/app/globals.css`: on phones the document now scrolls normally
+  instead of being locked to the viewport height with hidden overflow. This single
+  change stops content from being clipped and unreachable. Desktop keeps the
+  locked-viewport behavior so each shell still manages its own internal scrolling.
+  A shared `.ctf-app-viewport` helper was added here too.
+- `ctf/packages/web/app/apps/layout.tsx` and
+  `ctf/packages/web/app/plugin/layout.tsx`: new wrappers that put every routed
+  plugin screen inside `.ctf-app-viewport`. On phones this drops each plugin
+  shell's fixed desktop row back to a normal vertical block, so the sections stack
+  one under another and the page scrolls. It works without editing all ~24 plugin
+  shells because a stylesheet rule marked `!important` overrides the plain inline
+  styles those shells use. Desktop is untouched.
+- `ctf/packages/web/components/community-shell/*`: the home screen and app launcher
+  (used at both `/` and `/apps`) previously hid its icon rail and sidebar on small
+  screens with nothing to replace them, leaving no way to navigate. It now shows a
+  top bar on phones with the brand, a Chat/Apps switch, and a sign-in button or
+  avatar, plus a menu button that slides the sidebar in as a drawer.
+
+## Breakpoint
+
+The phone treatment turns on below 768px wide. It is written with plain CSS media
+queries (not Tailwind utility classes), so it does not depend on the Tailwind
+version. The community shell keeps its existing 900px and 1280px breakpoints; its
+new mobile top bar shows at 900px and below, matching where its rails were already
+hidden.
+
+## Known limits / follow-ups (gated on a responsive-web design pass)
+
+These are intentionally left for a proper design pass rather than guessed at:
+
+- On phones, plugin screens stack their side rails (icon rail, filter sidebar,
+  right rail) above the main content, so you scroll past them to reach it.
+  Per-plugin polish — collapsing the rails, putting the main content first, and
+  placing right-rail content sensibly — needs a design.
+- The community shell's right rail (profile card, quote, member list) is hidden on
+  phones, as it already was below 1280px. Its key action (sign-in) is covered by
+  the new top bar.
+- Wide elements inside a plugin (for example data tables) may be clipped rather
+  than made horizontally scrollable. Giving those their own scroll containers is a
+  follow-up.
+
+## How a future session should start
+
+- Read `127-design-pass-gating-rules.mdc` and this note.
+- Check the design submodule for responsive-web mockups. If they exist, implement
+  the per-plugin mobile polish above against them.
+- The shared mobile fallback lives in `app/globals.css` (`.ctf-app-viewport` plus
+  the `html, body` media queries); the home-screen mobile nav lives in
+  `components/community-shell/`.

--- a/ctf/packages/web/app/apps/layout.tsx
+++ b/ctf/packages/web/app/apps/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Wraps every routed `/apps/*` screen in the shared app viewport. On phones this
+ * lets each plugin shell's fixed desktop row fall back to a single scrolling
+ * column (see `.ctf-app-viewport` in `globals.css`); on desktop it is an inert
+ * full-width wrapper that changes nothing.
+ */
+export default function AppsLayout({ children }: { children: ReactNode }) {
+  return <div className="ctf-app-viewport">{children}</div>;
+}

--- a/ctf/packages/web/app/globals.css
+++ b/ctf/packages/web/app/globals.css
@@ -14,14 +14,69 @@ html,
 body {
   margin: 0;
   padding: 0;
-  height: 100vh;
-  overflow: hidden;
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
   background: #0b1020;
   color: #e5e7eb;
 }
 
+/*
+ * On desktop the viewport is locked so each shell manages its own internal
+ * scrolling (sidebars, chat panes, and so on). On small screens we let the
+ * whole document scroll instead — otherwise anything taller or wider than the
+ * screen gets clipped by `overflow: hidden` and becomes unreachable on a phone.
+ */
+@media (min-width: 768px) {
+  html,
+  body {
+    height: 100vh;
+    overflow: hidden;
+  }
+}
+
+@media (max-width: 767px) {
+  html,
+  body {
+    min-height: 100%;
+    overflow-x: hidden;
+  }
+}
+
 a {
   color: inherit;
   text-decoration: none;
+}
+
+/*
+ * Small-screen fallback for routed plugin/app screens.
+ *
+ * Most plugin shells are built as a fixed desktop row — a 72px icon rail, a
+ * fixed-width sidebar, the main column, and a right rail — using inline styles
+ * that media queries can't reach. On a phone that row runs off the side of the
+ * screen and, because the inline widths also set `flex-shrink: 0`, nothing
+ * reflows. Wrapping the routed screen lets us, on small screens only, drop the
+ * top-level row back to a normal vertical block so each section stacks and the
+ * page scrolls. A stylesheet rule marked `!important` overrides a plain inline
+ * style, so this reaches those inline layouts without editing every shell.
+ * Desktop rendering is left exactly as-is.
+ *
+ * A screen that already handles its own small-screen layout (the community
+ * shell) opts out with the `ctf-self-responsive` marker class so we don't
+ * fight its own flex layout.
+ */
+.ctf-app-viewport {
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  .ctf-app-viewport {
+    max-width: 100vw;
+    overflow-x: hidden;
+  }
+
+  .ctf-app-viewport > *:not(.ctf-self-responsive) {
+    display: block !important;
+    height: auto !important;
+    overflow: visible !important;
+    min-width: 0 !important;
+  }
 }

--- a/ctf/packages/web/app/plugin/layout.tsx
+++ b/ctf/packages/web/app/plugin/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Wraps every routed `/plugin/*` screen in the shared app viewport so plugin
+ * shells reflow to a single scrolling column on phones. On desktop it is an
+ * inert full-width wrapper. See `.ctf-app-viewport` in `globals.css`.
+ */
+export default function PluginLayout({ children }: { children: ReactNode }) {
+  return <div className="ctf-app-viewport">{children}</div>;
+}

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -950,6 +950,134 @@
   border: 0;
 }
 
+/* ─── Mobile top bar + nav drawer ────────────────────────────────────────── */
+/*
+ * On phones the icon rail and sidebar are replaced by a top bar (brand, section
+ * switch, sign-in/avatar) plus a menu button that slides the sidebar in as a
+ * drawer. These pieces stay hidden on desktop and are switched on inside the
+ * max-width: 900px block below, where the multi-column grid also collapses.
+ */
+.mobileBar {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  height: 52px;
+  padding: 0 12px;
+  background: #090B0F;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  flex-shrink: 0;
+}
+
+.mobileBarMenuBtn {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #9CA3AF;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.mobileBarBrand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.mobileBarLogo {
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: linear-gradient(135deg, #7C3AED 0%, #0EA5E9 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 800;
+  color: #fff;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.mobileBarTitle {
+  font-size: 14px;
+  font-weight: 700;
+  color: #F9FAFB;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mobileBarSections {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.mobileBarSectionBtn {
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: #6B7280;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mobileBarSectionBtnActive {
+  background: rgba(124, 58, 237, 0.2);
+  border-color: rgba(124, 58, 237, 0.4);
+  color: #A78BFA;
+}
+
+.mobileBarAuth {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.mobileBarAvatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7C3AED 0%, #0EA5E9 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: #fff;
+  user-select: none;
+}
+
+.mobileBarSignIn {
+  padding: 7px 14px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #7C3AED 0%, #0EA5E9 100%);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.mobileBackdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  background: rgba(8, 9, 13, 0.6);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 @media (max-width: 1280px) {
   .frame {
@@ -968,11 +1096,20 @@
 @media (max-width: 900px) {
   .shell {
     padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mobileBar {
+    display: flex;
   }
 
   .frame {
-    grid-template-columns: 1fr;
-    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    height: auto;
   }
 
   .iconRail,
@@ -982,6 +1119,24 @@
 
   .content {
     border-right: none;
+    flex: 1;
+    min-height: 0;
+  }
+
+  /* Sidebar slides in as a drawer when the menu button is pressed. */
+  .leftNav.leftNavMobileOpen {
+    display: flex;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(280px, 85vw);
+    z-index: 1000;
+    box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);
+  }
+
+  .mobileBackdrop {
+    display: block;
   }
 
   .heroBanner {

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Menu } from 'lucide-react';
 import type { TrustUserExtension } from '../../lib/trust/types';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
 import type { HubChannelInfo, HubDMInfo } from '../../lib/hub/types';
@@ -120,6 +122,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
   const [sortMode, setSortMode] = useState<PluginSortMode>('recent');
   const [recentPluginSlugs, setRecentPluginSlugs] = useState<string[]>([]);
   const [pluginUsageCounts, setPluginUsageCounts] = useState<Record<string, number>>({});
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -232,7 +235,49 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
     .slice(0, 5);
 
   return (
-    <div className={styles.shell}>
+    <div className={`${styles.shell} ctf-self-responsive`}>
+      <header className={styles.mobileBar}>
+        <button
+          type="button"
+          className={styles.mobileBarMenuBtn}
+          onClick={() => setMobileNavOpen((open) => !open)}
+          aria-label={mobileNavOpen ? 'Close navigation' : 'Open navigation'}
+          aria-expanded={mobileNavOpen}
+        >
+          <Menu size={18} />
+        </button>
+        <div className={styles.mobileBarBrand}>
+          <span className={styles.mobileBarLogo} aria-hidden="true">SH</span>
+          <span className={styles.mobileBarTitle}>Survivor Hub</span>
+        </div>
+        <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={section === 'chat'}
+            className={section === 'chat' ? `${styles.mobileBarSectionBtn} ${styles.mobileBarSectionBtnActive}` : styles.mobileBarSectionBtn}
+            onClick={() => setSection('chat')}
+          >
+            Chat
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={section === 'apps'}
+            className={section === 'apps' ? `${styles.mobileBarSectionBtn} ${styles.mobileBarSectionBtnActive}` : styles.mobileBarSectionBtn}
+            onClick={() => setSection('apps')}
+          >
+            Apps
+          </button>
+        </div>
+        <div className={styles.mobileBarAuth}>
+          {isAuthenticated ? (
+            <span className={styles.mobileBarAvatar} aria-hidden="true">{currentUser.initial}</span>
+          ) : (
+            <Link className={styles.mobileBarSignIn} href={signInUrl}>Sign in</Link>
+          )}
+        </div>
+      </header>
       <div className={styles.frame}>
         <ShellIconRail section={section} onSectionChange={setSection} initial={currentUser.initial} />
         <ShellSidebar
@@ -244,7 +289,17 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
           onAppSelect={handleAppSelect}
           query={query}
           onQueryChange={setQuery}
+          mobileOpen={mobileNavOpen}
+          onNavigate={() => setMobileNavOpen(false)}
         />
+        {mobileNavOpen ? (
+          <button
+            type="button"
+            className={styles.mobileBackdrop}
+            aria-label="Close navigation"
+            onClick={() => setMobileNavOpen(false)}
+          />
+        ) : null}
         <main className={`${styles.panel} ${styles.content}`}>
           {loadError ? (
             <section className={styles.usernameAlert} role="alert">{loadError}</section>

--- a/ctf/packages/web/components/community-shell/shell-sidebar.tsx
+++ b/ctf/packages/web/components/community-shell/shell-sidebar.tsx
@@ -16,6 +16,10 @@ type ShellSidebarProps = {
   onAppSelect: (slug: string | null) => void;
   query: string;
   onQueryChange: (q: string) => void;
+  // On phones the sidebar is a slide-in drawer; `mobileOpen` controls whether it
+  // is shown and `onNavigate` lets it close itself once a destination is picked.
+  mobileOpen?: boolean;
+  onNavigate?: () => void;
 };
 
 export function ShellSidebar({
@@ -27,9 +31,11 @@ export function ShellSidebar({
   onAppSelect,
   query,
   onQueryChange,
+  mobileOpen = false,
+  onNavigate,
 }: ShellSidebarProps) {
   return (
-    <aside className={`${styles.panel} ${styles.leftNav}`}>
+    <aside className={`${styles.panel} ${styles.leftNav}${mobileOpen ? ` ${styles.leftNavMobileOpen}` : ''}`}>
       <div className={styles.sidebarHeader}>
         <p className={styles.sectionTitle}>{section === 'chat' ? 'Channel' : 'Mini-Apps'}</p>
         {section === 'apps' ? (
@@ -51,7 +57,7 @@ export function ShellSidebar({
         {section === 'chat' ? (
           <>
             {channels.map((ch) => (
-              <Link key={ch.slug} href={`/apps/hub?channel=${encodeURIComponent(ch.slug)}`} className={styles.sidebarChannel}>
+              <Link key={ch.slug} href={`/apps/hub?channel=${encodeURIComponent(ch.slug)}`} className={styles.sidebarChannel} onClick={() => onNavigate?.()}>
                 <span className={styles.sidebarChannelHash}>#</span>
                 <span className={styles.sidebarChannelName}>{ch.slug}</span>
               </Link>
@@ -84,7 +90,10 @@ export function ShellSidebar({
                 type="button"
                 className={isActive ? `${styles.sidebarApp} ${styles.sidebarAppActive}` : styles.sidebarApp}
                 style={isActive ? { borderLeftColor: color, color } : undefined}
-                onClick={() => onAppSelect(isActive ? null : plugin.slug)}
+                onClick={() => {
+                  onAppSelect(isActive ? null : plugin.slug);
+                  onNavigate?.();
+                }}
               >
                 <span aria-hidden="true">{emoji}</span>
                 <span className={styles.sidebarAppName}>{plugin.name}</span>


### PR DESCRIPTION
## What this does

The web app was built for desktop. On a small phone screen (like an iPhone SE, 375px wide) the screens ran off the side and, because page scrolling was locked, the overflow was clipped and couldn't be reached — so the app was effectively unusable on a phone. This makes the whole web app usable on a phone **without changing how it looks on desktop**.

## Changes

- **Let the document scroll on phones.** Below 768px the page scrolls normally instead of being locked to the viewport with hidden overflow, so nothing is clipped. Desktop keeps its locked-viewport behaviour so each shell still manages its own internal scrolling. (`app/globals.css`)
- **Reflow plugin screens.** A shared wrapper (new `app/apps/layout.tsx` and `app/plugin/layout.tsx`) drops each plugin's fixed desktop row — icon rail, sidebar, main column, right rail — back to a single scrolling column on phones. It does this without editing all ~24 plugin shells, because those shells use inline styles and a stylesheet rule marked `!important` can override them.
- **Mobile navigation on the home screen.** The home screen and app launcher (used at `/` and `/apps`) previously hid its icon rail and sidebar on small screens with nothing to replace them, leaving no way to navigate. It now shows a phone top bar (brand, a Chat/Apps switch, and a sign-in button or avatar) plus a menu button that slides the sidebar in as a drawer. (`components/community-shell/*`)

## Design-gate note (please read)

Making the app responsive is a layout change to user-facing screens, which normally needs a design pass first (rule 127). The design submodule only has desktop web designs; the narrow-screen mockups there are scoped to the Android app, not the web. **The owner approved a bypass** to do a pragmatic reflow now so they can test on their phone. Proper responsive-web designs from the Replit design agent remain a follow-up; the per-screen polish is captured in `ctf/docs/developer/web-mobile-responsiveness-session-continuity.md`.

## Testing

- `pnpm typecheck` passes.
- `pnpm lint` is clean on the changed files (the 13 errors it reports are all pre-existing in files this PR doesn't touch).
- `pnpm build` compiles all routes successfully (a fresh container needed `turbopack.root` set to build; that was used only to validate and is **not** part of this PR).
- Not yet checked on a real device — the home-screen mobile nav and the per-plugin stacking would benefit from a quick look on your iPhone SE.

## Follow-ups (left for a responsive-web design pass)

- Per-plugin polish: collapse the stacked side rails, put the main content first, place right-rail content sensibly.
- Give wide elements (e.g. tables) their own horizontal scroll instead of clipping.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_