### PR TITLE
docs: document the recurring PR title/parity CI failure and its fix

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -171,6 +171,27 @@ Use when Android parity is deferred; link to the tracking issue.
 
 All `.ts`, `.tsx`, `.js`, `.json`, `.yml`, `.yaml`, `.css` files must end with exactly one newline and no trailing blank lines. Validated by `ctf/scripts/check-eof-format.sh` on every PR.
 
+### Known: a freshly-opened PR fails "Semantic PR Title" and "PR Parity Status" — just fix it, don't re-diagnose
+
+PRs in this repo are usually opened from the Claude Code web UI, which auto-generates the title and
+description. That generated text does **not** follow the two conventions above, so the **Semantic PR
+Title** (`pr-title-semantic.yml`) and **PR Parity Status** (`pr-parity-status` in `ci.yml`) checks go
+red within seconds of the PR opening. **This is expected and well understood — do not spend tokens
+investigating why these two checks fail on a brand-new PR.** Fix the metadata directly:
+
+1. **Title** — edit it to a Conventional Commit (`feat:` / `fix:` / `chore:` / `refactor:` / `docs:` /
+   `ci:` / `perf:` / `test:` / `build:` / `style:` / `revert:`). Editing the title re-runs the
+   Semantic PR Title check automatically.
+2. **Description** — add a line that is *exactly* `Parity Status: web+android complete` (backend/infra,
+   or both web and Android shipped in this PR) **or** `Parity Ticket: #<issue>` (Android deferred).
+3. **Re-trigger parity** — the PR Parity Status check does **not** re-run on a description edit. Push
+   one empty commit to the PR branch to re-evaluate it:
+   `git commit --allow-empty -m "chore: re-trigger CI" && git push`.
+
+After that both go green. The whole fix costs about one title edit, one description edit, and one
+empty commit. If you can set the PR body at creation time, put the Conventional-Commit title and the
+`Parity Status:` line in up front so both pass on the first run and no empty commit is needed.
+
 ### CodeRabbit Review Labeling (self-triage)
 
 CodeRabbit auto-review is gated on the `coderabbit` label (see `.coderabbit.yaml`), and the


### PR DESCRIPTION
## Summary

Documents the recurring CI failure where a freshly-opened PR immediately fails the **Semantic PR Title** and **PR Parity Status** checks, because PRs created from the Claude Code web UI get an auto-generated title/body that don't follow the repo's conventions. Future agents kept re-investigating this and spending tokens; the note explains it is expected and exactly how to fix it (Conventional-Commit title, add the parity line, push one empty commit to re-trigger parity).

## Changes

- `.github/instructions/copilot-instructions.md`: new subsection under "Pull Request Conventions".

## Testing

- [x] Docs only; typecheck gate + pre-push build passed.

Parity Status: web+android complete

https://claude.ai/code/session_01KbZiSSFEKSfvbRc2n2LVeF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbZiSSFEKSfvbRc2n2LVeF)_