### PR TITLE
chore: enforce plain-voice rule with a Stop hook

### DIFF
--- a/.claude/hooks/check-no-pleasantries.mjs
+++ b/.claude/hooks/check-no-pleasantries.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Stop hook: enforce the plain-voice rule (see CLAUDE.md "Voice — no pleasantries, no feelings").
+// If the assistant's last reply contains a pleasantry, sign-off, or first-person feeling word, block
+// the stop and ask for a plain restatement. Defensive by design: any error -> allow (never break a
+// session or hard-fail). Loop-safe: if we are already in a stop-hook continuation, do not re-block.
+import { readFileSync } from 'node:fs';
+
+// Tight list — clear pleasantries / sign-offs / feeling words. "appreciate" is matched only in the
+// "I/we appreciate" form so it does not trip on finance text like "the rate appreciates".
+const BANNED = [
+  /\bthanks\b/i,
+  /\bthank you\b/i,
+  /\byou(?:'|’| a)?re welcome\b/i,
+  /\bno problem\b/i,
+  /\bmy pleasure\b/i,
+  /\bglad\b/i,
+  /\bhappy to\b/i,
+  /\bexcited\b/i,
+  /\bdelighted\b/i,
+  /\bsorry\b/i,
+  /\bapolog(?:y|ies|ize|ise|izing|ising)\b/i,
+  /\bcheers\b/i,
+  /\bcongrat(?:s|ulations)\b/i,
+  /\b(?:i|we) (?:really |truly )?appreciate\b/i,
+  /\bhope (?:this|that|you|it)\b/i,
+  /\bfeel free\b/i,
+  /\b(?:warm|best|kind)(?:est)? regards\b/i,
+  /\blooking forward\b/i,
+];
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function lastAssistantText(transcriptPath) {
+  const raw = readFileSync(transcriptPath, 'utf8');
+  const lines = raw.split('\n').filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    let entry;
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+    if (entry.type !== 'assistant') continue;
+    const content = entry.message && entry.message.content;
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      return content
+        .filter((part) => part && part.type === 'text' && typeof part.text === 'string')
+        .map((part) => part.text)
+        .join('\n');
+    }
+    return '';
+  }
+  return '';
+}
+
+try {
+  const input = JSON.parse(readStdin() || '{}');
+  if (input.stop_hook_active) process.exit(0); // already retrying; do not loop
+  const text = input.transcript_path ? lastAssistantText(input.transcript_path) : '';
+  const match = BANNED.map((re) => text.match(re)).find(Boolean);
+  if (match) {
+    process.stdout.write(
+      JSON.stringify({
+        decision: 'block',
+        reason:
+          `The reply contains a banned pleasantry/feeling/sign-off ("${match[0]}"). ` +
+          'Restate the result in plain, factual language — no thanks, apologies, well-wishes, ' +
+          'sign-offs, jargon, or first-person feeling words — then stop.',
+      }),
+    );
+  }
+} catch {
+  // Never block on error.
+}
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,17 @@
     "additionalDirectories": [
       "/workspaces/chargingthefuture/ctf/packages/web"
     ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-no-pleasantries.mjs\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,15 @@ Commit messages must end with the active session URL on its own line:
 https://claude.ai/code/session_<id>
 ```
 
+## Voice — no pleasantries, no feelings (Critical — every reply, all agents)
+
+Do not address the user with thanks, apologies, congratulations, well-wishes, encouragement, or
+closing sign-offs. Do not use first-person feeling words (e.g. glad, happy, excited, delighted,
+sorry, "hope this helps", "I appreciate"). You have no feelings; do not perform them. No jargon, no
+buzzwords. State the result or the next step in plain words, then stop. This is enforced by the Stop
+hook `.claude/hooks/check-no-pleasantries.mjs`, which blocks a reply that contains a banned term and
+asks for a plain restatement.
+
 ## Design Pass Gating (Critical — Read Before Touching UI)
 
 Before writing any UI — user-facing **or** admin/internal — for a new page, modal, plugin, featured surface, or material layout/IA change, you **must** verify a design exists in the `design/` submodule (canonical source; the only authoritative design location, remote: `https://github.com/chargingthefuture/design`). If no design exists for the feature, you **must** stop and announce `DESIGN PASS REQUIRED` per the protocol in `.github/instructions/127-design-pass-gating-rules.mdc`. No UI surface is skippable. Designs are produced in parallel by the Replit design agent; build non-UI foundation now and circle back for the UI once its design lands.


### PR DESCRIPTION
Add a Stop hook that blocks any reply containing a pleasantry, sign-off,
or first-person feeling word and asks for a plain restatement. Wire it
into .claude/settings.json and document the rule in CLAUDE.md.

The hook is defensive (any error lets the stop through, so it can never
break a session) and loop-safe (it does nothing when already retrying a
blocked stop). The "appreciate" check only matches the "I/we appreciate"
form so finance copy like "the rate appreciates" is not flagged.

https://claude.ai/code/session_01VE2wfPhDmQMXoDpiNi5Lh9