### PR TITLE
fix: keep the general channel in-shell instead of 404ing

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -159,11 +159,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
   padding: 8px 10px;
+  border: none;
   border-radius: 8px;
+  background: transparent;
   cursor: pointer;
   color: #9CA3AF;
   font-size: 14px;
+  text-align: left;
   text-decoration: none;
   transition: background 0.1s;
 }
@@ -171,6 +175,15 @@
 .sidebarChannel:hover {
   background: rgba(255, 255, 255, 0.04);
   color: #E8EAF0;
+}
+
+.sidebarChannelActive {
+  background: rgba(124, 58, 237, 0.16);
+  color: #E8EAF0;
+}
+
+.sidebarChannelActive .sidebarChannelHash {
+  color: #A78BFA;
 }
 
 .sidebarChannelHash {

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -116,6 +116,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
   const [query, setQuery] = useState('');
   const [plugins, setPlugins] = useState(initialPlugins);
   const [channels, setChannels] = useState<HubChannelInfo[]>([]);
+  const [activeChannel, setActiveChannel] = useState<string | null>(null);
   const [dms, setDms] = useState<HubDMInfo[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [activeApp, setActiveApp] = useState<string | null>(null);
@@ -172,7 +173,11 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
         if (channelsRes.ok) {
           const channelsPayload = (await channelsRes.json()) as { channels: HubChannelInfo[] };
           if (!cancelled) {
-            setChannels(channelsPayload.channels ?? []);
+            const loadedChannels = channelsPayload.channels ?? [];
+            setChannels(loadedChannels);
+            // Default the open channel to the first one (general) so the sidebar
+            // shows which channel the chat panel is already displaying.
+            setActiveChannel((current) => current ?? loadedChannels[0]?.slug ?? null);
           }
         }
 
@@ -221,6 +226,15 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
       window.localStorage.setItem(PLUGIN_USAGE_COUNTS_STORAGE_KEY, JSON.stringify(next));
       return next;
     });
+  };
+
+  // Channels live inside the chat panel of this single-page shell, so selecting
+  // one just keeps the user in the chat section and marks it active — it must not
+  // navigate to a separate route (there is no per-channel page; doing so 404s).
+  const handleChannelSelect = (slug: string) => {
+    setActiveChannel(slug);
+    setSection('chat');
+    setActiveApp(null);
   };
 
   const handleSortModeChange = (mode: PluginSortMode) => {
@@ -285,6 +299,8 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
           channels={channels}
           dms={dms}
           plugins={filteredPlugins}
+          activeChannel={activeChannel}
+          onChannelSelect={handleChannelSelect}
           activeApp={activeApp}
           onAppSelect={handleAppSelect}
           query={query}

--- a/ctf/packages/web/components/community-shell/shell-sidebar.tsx
+++ b/ctf/packages/web/components/community-shell/shell-sidebar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import type { ShellSection } from './shell-types';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
 import type { HubChannelInfo, HubDMInfo } from '../../lib/hub/types';
@@ -12,6 +11,8 @@ type ShellSidebarProps = {
   channels: HubChannelInfo[];
   dms: HubDMInfo[];
   plugins: PluginRegistryItem[];
+  activeChannel: string | null;
+  onChannelSelect: (slug: string) => void;
   activeApp: string | null;
   onAppSelect: (slug: string | null) => void;
   query: string;
@@ -27,6 +28,8 @@ export function ShellSidebar({
   channels,
   dms,
   plugins,
+  activeChannel,
+  onChannelSelect,
   activeApp,
   onAppSelect,
   query,
@@ -56,12 +59,24 @@ export function ShellSidebar({
       <div className={styles.sidebarBody}>
         {section === 'chat' ? (
           <>
-            {channels.map((ch) => (
-              <Link key={ch.slug} href={`/apps/hub?channel=${encodeURIComponent(ch.slug)}`} className={styles.sidebarChannel} onClick={() => onNavigate?.()}>
-                <span className={styles.sidebarChannelHash}>#</span>
-                <span className={styles.sidebarChannelName}>{ch.slug}</span>
-              </Link>
-            ))}
+            {channels.map((ch) => {
+              const isActive = activeChannel === ch.slug;
+              return (
+                <button
+                  key={ch.slug}
+                  type="button"
+                  className={isActive ? `${styles.sidebarChannel} ${styles.sidebarChannelActive}` : styles.sidebarChannel}
+                  aria-current={isActive ? 'true' : undefined}
+                  onClick={() => {
+                    onChannelSelect(ch.slug);
+                    onNavigate?.();
+                  }}
+                >
+                  <span className={styles.sidebarChannelHash}>#</span>
+                  <span className={styles.sidebarChannelName}>{ch.slug}</span>
+                </button>
+              );
+            })}
             <p className={styles.sidebarGroupLabel}>Direct Messages</p>
             {dms.map((dm) => (
               <button


### PR DESCRIPTION
## What was wrong

Tapping the `# general` channel in the community shell sidebar opened a "404 — This page could not be found" screen, even though the user was already viewing the general channel.

The sidebar channel item was a link to `/apps/hub?channel=<slug>`. There is no `/apps/hub` page and no `hub` plugin, so the dynamic plugin route (`app/apps/[pluginSlug]/page.tsx`) resolved the slug `hub`, found nothing, and called `notFound()` → 404.

## Fix

Channels live inside the single-page community shell — the chat panel already renders the channel content inline. So selecting a channel now:

- marks it active in the sidebar,
- switches to the chat section, and
- closes the mobile drawer,

instead of navigating to a separate (nonexistent) route. The open channel defaults to the first channel (general) so the sidebar reflects what the chat panel is already showing. The channel item changed from a link to a button, with an active-state highlight.

## Files

- `components/community-shell/shell-sidebar.tsx` — channel item is now a button calling `onChannelSelect`; added `activeChannel`/`onChannelSelect` props.
- `components/community-shell/community-shell.tsx` — added `activeChannel` state, default to first channel on load, and the select handler.
- `components/community-shell/community-shell.module.css` — button reset on `.sidebarChannel` plus a `.sidebarChannelActive` highlight.

## Checks

Typecheck, lint, and the EOF-format gate all pass locally.

Parity Status: web+android complete

(Web-only bug: the 404 came from Next.js route resolution. The mobile app does not use this routing, so there is no Android counterpart to change.)

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_