### PR TITLE
fix: allow default feed targeting so chat and @comic posts save

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -189,7 +189,7 @@ Domain tables:
 **Existing (implemented):**
 
 1. `feed_items`
-2. `feed_item_targets`
+2. `feed_item_targets` — `target_role`/`target_plugin`/`target_region` are nullable, where `NULL` means "any" (read path treats `NULL` as a wildcard). Uniqueness is a `NULLS NOT DISTINCT` unique index on `(item_id, target_role, target_plugin, target_region)` rather than a primary key, because primary-key columns are implicitly `NOT NULL` and cannot hold the `NULL` wildcard used by default targeting.
 3. `feed_user_read_state`
 4. `feed_user_dismissals`
 5. `feed_render_config` — global singleton; columns include `is_public BOOLEAN NOT NULL DEFAULT TRUE` (publicly-viewable Hub channel flag).
@@ -270,6 +270,7 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 ## 11) Change Log
 
+- 2026-06-01: Fixed a posting failure that broke both community messages and @comic questions. `feed_item_targets` used a primary key over `(item_id, target_role, target_plugin, target_region)`, but default targeting writes `NULL` for plugin/region to mean "any" — and primary-key columns are implicitly `NOT NULL`, so every default-targeted insert threw a not-null violation, rolling back the whole post transaction and returning a generic 503. Replaced the primary key with a `NULLS NOT DISTINCT` unique index and made the three target columns nullable (guarded DDL repairs legacy databases). No application code change needed; verified against Postgres 16.
 - 2026-05-31: Feed-Announcements web pixel pass — aligned `live-feed-announcements.tsx` to canonical design mockup: accent color `#84CC16`, lucide icons throughout, removed "GetStream ⚡" badge, empty state matches mockup. Decomposed 712-line monolith into 7 sub-files per rule-116. Omitted mockup-only mock data (trending hashtags by count, top-engaged-today users) per real-data-only rule. Updated Web px ✅ and Gates ✅ in production readiness table. Typecheck, build, ESLint, EOF all pass.
 - 2026-05-18: Replaced "Web and Android Delivery Plan" with canonical "Web and Android Delivery Status" (`web+android complete`); removed web-first/Android-parity-pending framing. Removed stale Gaps entries that listed Questions/Community/Android as pending — these surfaces are shipped (`/api/feed/questions/*`, `/api/feed/community/*`, mobile FeedStream). Renamed "Gaps, Ambiguities, and Known Technical Debt (Current)" to canonical "Gaps and Known Technical Debt". Updated seed coverage to reference shipping script.
 - 2026-02-25: Added Rule 120 gaps section.

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -663,9 +663,23 @@ CREATE TABLE IF NOT EXISTS feed_item_targets (
   item_id UUID NOT NULL REFERENCES feed_items(id) ON DELETE CASCADE,
   target_role TEXT,
   target_plugin TEXT,
-  target_region TEXT,
-  PRIMARY KEY (item_id, target_role, target_plugin, target_region)
+  target_region TEXT
 );
+-- A NULL target_plugin/target_region means "any plugin / any region" — the read path
+-- treats NULL as a wildcard (see listFeedTimeline: "t.target_plugin IS NULL"). NULL
+-- cannot live in a PRIMARY KEY (PK columns are implicitly NOT NULL), so the old
+-- PRIMARY KEY (item_id, target_role, target_plugin, target_region) made every
+-- default-targeted feed item fail to insert — which broke posting community messages
+-- and @comic questions. Replace it with a unique index that treats NULLs as equal
+-- (NULLS NOT DISTINCT, Postgres 15+) so default targeting works and duplicate
+-- (item, role, plugin, region) rows are still de-duplicated. Guarded DDL repairs
+-- legacy databases that still carry the old primary key.
+ALTER TABLE IF EXISTS feed_item_targets DROP CONSTRAINT IF EXISTS feed_item_targets_pkey;
+ALTER TABLE IF EXISTS feed_item_targets ALTER COLUMN target_role DROP NOT NULL;
+ALTER TABLE IF EXISTS feed_item_targets ALTER COLUMN target_plugin DROP NOT NULL;
+ALTER TABLE IF EXISTS feed_item_targets ALTER COLUMN target_region DROP NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_item_targets_unique
+  ON feed_item_targets (item_id, target_role, target_plugin, target_region) NULLS NOT DISTINCT;
 CREATE TABLE IF NOT EXISTS feed_user_read_state (
   user_id TEXT NOT NULL,
   item_id UUID NOT NULL REFERENCES feed_items(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Symptom

Sending a message in hub chat — and asking an @comic question — failed with "Unable to send message." (HTTP 503).

## Root cause (reproduced on Postgres 16)

`feed_item_targets` declared:

```sql
PRIMARY KEY (item_id, target_role, target_plugin, target_region)
```

But default targeting writes `NULL` for `target_plugin`/`target_region` to mean "any plugin / any region" — and the read path relies on that (`... OR t.target_plugin IS NULL ...`). Primary-key columns are implicitly `NOT NULL`, so every default-targeted insert threw:

```
ERROR: null value in column "target_plugin" violates not-null constraint
```

That insert runs inside the same transaction as the post, so the whole post rolled back and the handler returned the generic 503. This hit **both** community messages and @comic questions, because both write feed targets through `upsertDefaultFeedTargets`.

## Fix

Replace the primary key with a `NULLS NOT DISTINCT` unique index (Postgres 15+) and make the three target columns nullable. Guarded DDL repairs legacy databases that still carry the old primary key. No application code change is needed — the existing upsert and read paths already use `NULL` as the wildcard. The demo schema is generated from `schema.sql`, so demo mode is covered too.

## Verification

Reproduced the failure and the fix against a fresh Postgres 16:
- before: default-target insert throws the not-null violation;
- after: the guarded migration repairs a legacy table, default-target inserts succeed, and duplicate `(item, role, plugin, region)` rows are still de-duplicated by the `NULLS NOT DISTINCT` index.

Also applied the full `schema.sql` to a fresh database and confirmed `feed_item_targets` ends up with nullable target columns and the unique index, and the real insert path succeeds.

Parity Status: web+android complete

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_