### PR TITLE
feat: hide chat suggestion chips outside demo mode

### DIFF
--- a/ctf/packages/web/app/apps/page.tsx
+++ b/ctf/packages/web/app/apps/page.tsx
@@ -5,6 +5,7 @@ import { evaluatePluginAccess } from '../../lib/auth/server-authz';
 import { getGdpShellStats } from '../../lib/gdp/repository';
 import { listPluginRegistry } from '../../lib/plugins/repository';
 import { getTrustUserExtension } from '../../lib/trust/repository';
+import { isDemoMode } from '../../lib/feature-flags/system';
 
 function buildShellUser(userId: string, username: string | null): ShellCurrentUser {
   const safeUsername = username && username !== 'guest' ? username : null;
@@ -33,11 +34,14 @@ export default async function AppsPage() {
   const pluginsPromise = listPluginRegistry();
   const shellStatsPromise = getGdpShellStats().catch(() => ({ memberCount: null, gdpValueUsd: null }));
   const authDecisionPromise = evaluatePluginAccess({ requireUsername: false }).catch(() => null);
+  // Chat suggestion chips are demo-only ("stage"); hidden in production.
+  const demoModePromise = isDemoMode().catch(() => false);
 
-  const [plugins, shellStats, authDecision] = await Promise.all([
+  const [plugins, shellStats, authDecision, demoMode] = await Promise.all([
     pluginsPromise,
     shellStatsPromise,
     authDecisionPromise,
+    demoModePromise,
   ]);
 
   const currentUser = authDecision && authDecision.allowed
@@ -55,6 +59,7 @@ export default async function AppsPage() {
       currentUser={currentUser}
       trust={trust}
       initialSection="apps"
+      showChatSuggestions={demoMode}
     />
   );
 }

--- a/ctf/packages/web/app/page.tsx
+++ b/ctf/packages/web/app/page.tsx
@@ -7,6 +7,7 @@ import { getGdpShellStats } from '../lib/gdp/repository';
 import { listPluginRegistry } from '../lib/plugins/repository';
 import { getTrustUserExtension } from '../lib/trust/repository';
 import { getHostedSignInUrl } from '../lib/auth/provider-env';
+import { isDemoMode } from '../lib/feature-flags/system';
 
 function buildShellUser(userId: string, username: string | null): ShellCurrentUser {
   const safeUsername = username && username !== 'guest' ? username : null;
@@ -35,11 +36,15 @@ export default async function HomePage() {
   const pluginsPromise = listPluginRegistry();
   const shellStatsPromise = getGdpShellStats().catch(() => ({ memberCount: null, gdpValueUsd: null }));
   const authDecisionPromise = evaluatePluginAccess({ requireUsername: false }).catch(() => null);
+  // The chat suggestion chips are unfinished; show them only to demo-mode users
+  // ("stage") and hide them in production. Defaults to hidden on any failure.
+  const demoModePromise = isDemoMode().catch(() => false);
 
-  const [plugins, shellStats, authDecision] = await Promise.all([
+  const [plugins, shellStats, authDecision, demoMode] = await Promise.all([
     pluginsPromise,
     shellStatsPromise,
     authDecisionPromise,
+    demoModePromise,
   ]);
 
   // `evaluatePluginAccess` denies an anonymous visitor with 401 (AUTH_UNAUTHORIZED)
@@ -74,6 +79,7 @@ export default async function HomePage() {
       trust={trust}
       isAuthenticated={isAuthenticated}
       signInUrl={signInUrl}
+      showChatSuggestions={demoMode}
     />
   );
 }

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -22,6 +22,9 @@ type CommunityShellProps = {
   initialSection?: ShellSection;
   isAuthenticated?: boolean;
   signInUrl?: string;
+  // Show the pre-selected chat suggestion chips. Hidden in production, on only in
+  // demo mode until their behavior is finished (tracked GitHub issue).
+  showChatSuggestions?: boolean;
 };
 
 type PluginsApiPayload = {
@@ -111,7 +114,7 @@ function sortPluginsForUi(
   });
 }
 
-export function CommunityShell({ initialPlugins, shellStats, currentUser, trust, initialSection = 'chat', isAuthenticated = false, signInUrl = '/sign-in' }: CommunityShellProps) {
+export function CommunityShell({ initialPlugins, shellStats, currentUser, trust, initialSection = 'chat', isAuthenticated = false, signInUrl = '/sign-in', showChatSuggestions = false }: CommunityShellProps) {
   const [section, setSection] = useState<ShellSection>(initialSection);
   const [query, setQuery] = useState('');
   const [plugins, setPlugins] = useState(initialPlugins);
@@ -321,7 +324,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
             <section className={styles.usernameAlert} role="alert">{loadError}</section>
           ) : null}
           {section === 'chat' ? (
-            <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} signInUrl={signInUrl} />
+            <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} signInUrl={signInUrl} showSuggestions={showChatSuggestions} />
           ) : (
             <ShellAppsPanel
               plugins={filteredPlugins}

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -39,6 +39,7 @@ type AuthenticatedChatPanelProps = {
   stats: ShellStats;
   plugins: PluginRegistryItem[];
   currentUser: ShellCurrentUser;
+  showSuggestions: boolean;
 };
 
 type ShellChatPanelProps = {
@@ -47,11 +48,15 @@ type ShellChatPanelProps = {
   currentUser: ShellCurrentUser;
   isAuthenticated?: boolean;
   signInUrl?: string;
+  // The pre-selected suggestion chips are hidden in production and shown only in
+  // demo mode while their behavior is finished — see GitHub issue tracked in the
+  // hub chat inventory. Defaults to hidden.
+  showSuggestions?: boolean;
 };
 
-export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = false, signInUrl = '/sign-in' }: ShellChatPanelProps) {
+export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = false, signInUrl = '/sign-in', showSuggestions = false }: ShellChatPanelProps) {
   if (isAuthenticated) {
-    return <AuthenticatedChatPanel stats={stats} plugins={plugins} currentUser={currentUser} />;
+    return <AuthenticatedChatPanel stats={stats} plugins={plugins} currentUser={currentUser} showSuggestions={showSuggestions} />;
   }
 
   const implementedCount = plugins.filter((plugin) => plugin.availabilityState === 'implemented_shell').length;
@@ -114,7 +119,7 @@ export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = 
   );
 }
 
-function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedChatPanelProps) {
+function AuthenticatedChatPanel({ stats, plugins, currentUser, showSuggestions }: AuthenticatedChatPanelProps) {
   const implementedCount = plugins.filter((plugin) => plugin.availabilityState === 'implemented_shell').length;
   const opportunityValue = Math.max(ECONOMY_TARGET_USD - (stats.gdpValueUsd ?? 0), 0);
   const {
@@ -263,13 +268,15 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
         })}
       </div>
 
-      <div className={styles.chatSuggestions}>
-        {SUGGESTIONS.map((suggestion) => (
-          <button key={suggestion} type="button" className={styles.chatChip} onClick={() => setInput(suggestion)}>
-            {suggestion}
-          </button>
-        ))}
-      </div>
+      {showSuggestions ? (
+        <div className={styles.chatSuggestions}>
+          {SUGGESTIONS.map((suggestion) => (
+            <button key={suggestion} type="button" className={styles.chatChip} onClick={() => setInput(suggestion)}>
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      ) : null}
 
       {/* @comic mention affordance + helper copy (per the locked design / naming rules). */}
       <div className={styles.comicComposerHelper}>


### PR DESCRIPTION
## What

Hide the pre-selected chat suggestion chips in production; show them only to demo-mode users ("stage").

## Why

The chips only fill the composer input (`setInput`) — they don't send and don't scroll to / focus the input, so on mobile (input below the fold) a tap looks like it does nothing. They aren't needed for the initial release, so they're tabled and hidden from prod. Behavior fix and re-enable are tracked in #256.

## How

Gated on the existing `isDemoMode()` helper, threaded as `showChatSuggestions` from `app/page.tsx` and `app/apps/page.tsx` → `CommunityShell` → `ShellChatPanel`. Defaults to **hidden**, so any flag-eval failure also hides the chips. No new UI surface — an existing element is conditionally rendered.

## Checks

Typecheck, lint, and the EOF-format gate pass locally.

Parity Ticket: #256

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_