### PR TITLE
fix: directory page crash from sectors response shape

### DIFF
--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -43,7 +43,13 @@ export function DirectoryShell() {
       setMetaError(null);
       try {
         const res = await fetch("/api/directory/sectors");
-        if (res.ok) setSectors(await res.json() as Sector[]);
+        // The endpoint returns { items: Sector[] }; reading the body as a bare
+        // array left `sectors` holding an object, so `sectors.map(...)` during
+        // render threw and the whole Directory page failed to load.
+        if (res.ok) {
+          const data = await res.json() as { items?: Sector[] };
+          setSectors(data.items ?? []);
+        }
       } catch {
         setMetaError("Failed to load directory.");
       } finally {


### PR DESCRIPTION
## Symptom

`https://the-comic.com/apps/directory` does not load — blank page.

## Cause

`DirectoryShell` fetches `/api/directory/sectors` and does `setSectors(await res.json() as Sector[])`, treating the response body as a bare array. But the endpoint returns `{ items: Sector[] }`, so `sectors` ended up holding an object. On the next render `directory-shell.tsx` runs `["All", ...sectors.map((s) => s.name)]`, and `sectors.map` is not a function on an object — the render throws and the whole page fails to load.

## Fix

Read `data.items` from the response, matching the sibling members fetch right below it (which already reads `data.members`). One-line shape fix, no API change.

## Checks

Typecheck, lint, and the EOF-format gate pass locally.

Parity Status: web+android complete

(Web-only client parsing bug; the Android directory is a separate codebase and does not share this fetch.)

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_