### PR TITLE
feat: app-wide loading screen

### DIFF
--- a/ctf/packages/web/app/loading.module.css
+++ b/ctf/packages/web/app/loading.module.css
@@ -1,0 +1,28 @@
+/* App-wide loading state. Canonical design: design/ submodule HubLoading.tsx
+   (every per-surface *Loading mockup shares this exact treatment). */
+.screen {
+  display: flex;
+  height: 100vh;
+  background: #0F1117;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.inner {
+  text-align: center;
+  padding: 0 32px;
+}
+
+.line {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.22);
+  text-transform: uppercase;
+  font-weight: 500;
+  line-height: 2;
+}
+
+.lineLead {
+  margin-bottom: 16px;
+}

--- a/ctf/packages/web/app/loading.tsx
+++ b/ctf/packages/web/app/loading.tsx
@@ -1,0 +1,14 @@
+import styles from './loading.module.css';
+
+// App-wide loading screen shown while any route segment streams. Matches the
+// canonical loading design in the design/ submodule (HubLoading.tsx).
+export default function Loading() {
+  return (
+    <div className={styles.screen}>
+      <div className={styles.inner}>
+        <div className={`${styles.line} ${styles.lineLead}`}>Exit Their Economy</div>
+        <div className={styles.line}>Exit The Psyop</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Add an app-wide loading screen so every route shows one consistent state while it streams: centered **EXIT THEIR ECONOMY / EXIT THE PSYOP** on `#0F1117`.

## Why

There was no root loading UI, so loading was inconsistent across the app. This adds a single `app/loading.tsx` (Next.js App Router root loading boundary) that applies universally.

## Design

Matches the canonical design in the `design/` submodule — `HubLoading.tsx`, whose treatment is shared by every per-surface `*Loading` mockup (same copy, color `rgba(255,255,255,0.22)`, 0.18em letter-spacing, uppercase, `#0F1117` background). Design pass satisfied (design exists; not a new undesigned surface).

## Files

- `app/loading.tsx` — root loading component.
- `app/loading.module.css` — styling matching the mockup.

## Checks

Typecheck, lint, and the EOF-format gate pass locally.

Parity Ticket: #259

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_