### PR TITLE
feat: add phone layouts for Chyme and Feed

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
+++ b/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
@@ -2,6 +2,7 @@
 
 import type { RefObject } from 'react';
 import { Hash, Send } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { BORDER, PRIMARY } from './chyme-shared';
 import type { ChymeMessage } from 'lib/chyme/types';
 
@@ -22,14 +23,15 @@ export function ChymeChatPanel({
   sending: boolean;
   messagesEndRef: RefObject<HTMLDivElement | null>;
 }) {
+  const isMobile = useIsMobile();
   return (
-    <div style={{ width: 300, borderLeft: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', background: '#030d05', flexShrink: 0 }}>
+    <div style={{ width: isMobile ? '100%' : 300, borderLeft: isMobile ? 'none' : `1px solid ${BORDER}`, borderTop: isMobile ? `1px solid ${BORDER}` : undefined, display: 'flex', flexDirection: 'column', background: '#030d05', flexShrink: 0 }}>
       <div style={{ padding: '14px 16px', borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', gap: 8 }}>
         <Hash size={14} style={{ color: PRIMARY }} />
         <span style={{ fontSize: 14, fontWeight: 600, color: '#F0FDF4' }}>Room Chat</span>
         <span style={{ marginLeft: 'auto', background: `${PRIMARY}15`, color: PRIMARY, border: `1px solid ${PRIMARY}25`, fontSize: 10, padding: '2px 8px', borderRadius: 12 }}>Encrypted</span>
       </div>
-      <div style={{ flex: 1, overflowY: 'auto', padding: '12px 14px' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '12px 14px', minHeight: isMobile ? 220 : undefined }}>
         {messages.length === 0 ? (
           <div style={{ color: '#4B5563', fontSize: 13 }}>No messages yet.</div>
         ) : (

--- a/ctf/packages/web/components/chyme/chyme-controls.tsx
+++ b/ctf/packages/web/components/chyme/chyme-controls.tsx
@@ -2,6 +2,7 @@
 
 import type { CSSProperties } from 'react';
 import { Hand, Mic, MicOff, Phone, Volume2 } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { BORDER, PRIMARY } from './chyme-shared';
 
 function toggleButtonStyle(active: boolean, activeBg: string, activeBorder: string, activeColor: string): CSSProperties {
@@ -39,9 +40,10 @@ export function ChymeControls({
     ? toggleButtonStyle(true, 'rgba(239,68,68,0.15)', 'rgba(239,68,68,0.4)', '#F87171')
     : toggleButtonStyle(true, `${PRIMARY}18`, `${PRIMARY}40`, PRIMARY);
   const handStyle = toggleButtonStyle(handRaised, 'rgba(234,179,8,0.15)', 'rgba(234,179,8,0.4)', '#FDE047');
+  const isMobile = useIsMobile();
 
   return (
-    <div style={{ padding: '16px 24px', borderTop: `1px solid ${BORDER}`, background: '#030d05', display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
+    <div style={{ padding: '16px 24px', borderTop: `1px solid ${BORDER}`, background: '#030d05', display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0, flexWrap: isMobile ? 'wrap' : undefined }}>
       <button onClick={onToggleMute} style={muteStyle}>
         {muted ? <MicOff size={16} /> : <Mic size={16} />}
         {muted ? 'Unmute' : 'Mute'}

--- a/ctf/packages/web/components/chyme/chyme-live-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-live-shell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Radio } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { DARK_BG, PRIMARY, type CurrentUser, requestJson } from './chyme-shared';
 import { ChymeHeader } from './chyme-header';
 import { ChymeSidebar } from './chyme-sidebar';
@@ -25,6 +26,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
   const [handRaised, setHandRaised] = useState(false);
   const [showChat, setShowChat] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     let active = true;
@@ -103,7 +105,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
         onRefresh={() => void refreshMessages()}
       />
 
-      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: isMobile ? 'column' : 'row', overflow: isMobile ? 'visible' : 'hidden' }}>
         <ChymeSidebar
           loading={loading}
           room={room}
@@ -111,7 +113,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
           onJoin={() => void handleJoin()}
         />
 
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: isMobile ? 'visible' : 'hidden' }}>
           {error && (
             <div style={{ padding: '12px 24px', background: '#2b0b0b', border: `1px solid #7f1d1d`, color: '#fecaca', fontSize: 13, margin: 16, borderRadius: 12 }}>
               {error}

--- a/ctf/packages/web/components/chyme/chyme-room-view.tsx
+++ b/ctf/packages/web/components/chyme/chyme-room-view.tsx
@@ -2,6 +2,7 @@
 
 import type { RefObject } from 'react';
 import { Lock, MessageSquare } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { BORDER, PRIMARY, type CurrentUser } from './chyme-shared';
 import { ChymeStage } from './chyme-stage';
 import { ChymeChatPanel } from './chyme-chat-panel';
@@ -30,6 +31,7 @@ export type ChymeRoomViewProps = {
 
 export function ChymeRoomView(props: ChymeRoomViewProps) {
   const { room, currentUser, showChat, onToggleChat } = props;
+  const isMobile = useIsMobile();
   return (
     <>
       <div style={{ padding: '20px 24px 16px', borderBottom: `1px solid ${BORDER}`, flexShrink: 0 }}>
@@ -55,7 +57,7 @@ export function ChymeRoomView(props: ChymeRoomViewProps) {
         </div>
       </div>
 
-      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: isMobile ? 'column' : 'row', overflow: isMobile ? 'visible' : 'hidden' }}>
         <ChymeStage
           room={room}
           currentUserId={currentUser.userId}

--- a/ctf/packages/web/components/chyme/chyme-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-shell.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { ChevronLeft, Radio } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { ChymeLiveShell } from '@/components/chyme/chyme-live-shell';
 
 type ChymeShellProps = {
@@ -13,6 +14,31 @@ type ChymeShellProps = {
 };
 
 export function ChymeShell({ currentUser }: ChymeShellProps) {
+  const isMobile = useIsMobile();
+
+  // Phones: drop the 72px side rail for a compact sticky top bar (back + brand)
+  // and let the live shell fill the width and stack its panes vertically.
+  if (isMobile) {
+    return (
+      <div style={{ minHeight: '100vh', background: '#021006' }}>
+        <div style={{ position: 'sticky', top: 0, zIndex: 20, display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: '#030d05', borderBottom: '1px solid #052e16' }}>
+          <Link
+            href="/apps"
+            aria-label="Back to apps"
+            style={{ width: 38, height: 38, borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#22C55E', textDecoration: 'none', flexShrink: 0 }}
+          >
+            <ChevronLeft size={20} />
+          </Link>
+          <div style={{ width: 32, height: 32, borderRadius: 9, background: 'rgba(34,197,94,0.15)', border: '1px solid rgba(34,197,94,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#22C55E', flexShrink: 0 }}>
+            <Radio size={18} />
+          </div>
+          <span style={{ fontSize: 15, fontWeight: 700, color: '#F0FDF4' }}>Chyme</span>
+        </div>
+        <ChymeLiveShell currentUser={currentUser} />
+      </div>
+    );
+  }
+
   return (
     <div style={{ display: 'flex', minHeight: '100vh', background: '#021006' }}>
       {/* Left navigation rail */}

--- a/ctf/packages/web/components/chyme/chyme-sidebar.tsx
+++ b/ctf/packages/web/components/chyme/chyme-sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Mic, Users } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { BORDER, PRIMARY } from './chyme-shared';
 import type { ChymeRoomResponse } from 'lib/chyme/types';
 
@@ -17,10 +18,11 @@ export function ChymeSidebar({
   joinState: JoinState;
   onJoin: () => void;
 }) {
+  const isMobile = useIsMobile();
   const joinLabel = joinState === 'joining' ? 'Joining…' : joinState === 'ready' ? '✓ Joined' : 'Join Room';
 
   return (
-    <aside style={{ width: 300, borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', flexShrink: 0, background: '#030d05' }}>
+    <aside style={{ width: isMobile ? '100%' : 300, borderRight: isMobile ? 'none' : `1px solid ${BORDER}`, borderBottom: isMobile ? `1px solid ${BORDER}` : undefined, display: 'flex', flexDirection: 'column', flexShrink: 0, background: '#030d05' }}>
       <div style={{ padding: '16px 16px 12px' }}>
         <button
           onClick={onJoin}

--- a/ctf/packages/web/components/feed/live-feed-announcements.tsx
+++ b/ctf/packages/web/components/feed/live-feed-announcements.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { Megaphone, RefreshCw } from 'lucide-react';
+import { ChevronLeft, Megaphone, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { StreamChatPanel } from '../shared/stream-chat-panel';
 import { FeedAnnouncementsIconRail } from './feed-announcements-icon-rail';
 import { FeedAnnouncementsSidebar } from './feed-announcements-sidebar';
@@ -276,19 +277,70 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
     setShowPostForm(enabledChannels.includes('community') ? 'community' : 'question');
   }, [enabledChannels]);
 
-  return (
-    <div style={{ width: '100%', height: '100%', minHeight: '100vh', background: FEED_BG, fontFamily: "'Inter', system-ui, sans-serif", color: '#E8EAF0', display: 'flex' }}>
-      <FeedAnnouncementsIconRail uiTab={uiTab} onTabChange={setUiTab} unreadCount={unreadCount} />
+  const isMobile = useIsMobile();
+  const mobileTabs: { key: 'feed' | 'chat' | 'admin'; label: string }[] = [
+    { key: 'feed', label: 'Feed' },
+    { key: 'chat', label: 'Chat' },
+    ...(isAdmin ? [{ key: 'admin' as const, label: 'Admin' }] : []),
+  ];
+  const mobileFilters: { key: FeedFilter; label: string }[] = [
+    { key: 'all', label: 'All' },
+    ...enabledChannels.map((channel) => ({ key: channel as FeedFilter, label: channel.charAt(0).toUpperCase() + channel.slice(1) })),
+    { key: 'unread', label: unreadCount > 0 ? `Unread (${unreadCount})` : 'Unread' },
+  ];
 
-      <FeedAnnouncementsSidebar
-        filter={filter}
-        onFilterChange={setFilter}
-        unreadCount={unreadCount}
-        enabledChannels={enabledChannels}
-      />
+  return (
+    <div style={{ width: '100%', height: '100%', minHeight: '100vh', background: FEED_BG, fontFamily: "'Inter', system-ui, sans-serif", color: '#E8EAF0', display: 'flex', flexDirection: isMobile ? 'column' : 'row' }}>
+      {!isMobile && <FeedAnnouncementsIconRail uiTab={uiTab} onTabChange={setUiTab} unreadCount={unreadCount} />}
+
+      {!isMobile && (
+        <FeedAnnouncementsSidebar
+          filter={filter}
+          onFilterChange={setFilter}
+          unreadCount={unreadCount}
+          enabledChannels={enabledChannels}
+        />
+      )}
+
+      {isMobile && (
+        <div style={{ position: 'sticky', top: 0, zIndex: 20, background: FEED_BG, borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${FEED_COLOR}14`, border: `1px solid ${FEED_COLOR}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: FEED_COLOR, textDecoration: 'none', flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Megaphone size={18} style={{ color: FEED_COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: '#F9FAFB', flex: 1 }}>Feed</span>
+            <button onClick={openNewPost} style={{ padding: '8px 14px', borderRadius: 9, background: `${FEED_COLOR}1A`, border: `1px solid ${FEED_COLOR}40`, color: FEED_COLOR, fontSize: 13, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>New post</button>
+          </div>
+          <div style={{ display: 'flex', gap: 6, padding: '0 12px 8px' }}>
+            {mobileTabs.map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setUiTab(key)}
+                style={{ flex: 1, padding: '8px 0', borderRadius: 8, background: uiTab === key ? `${FEED_COLOR}1A` : 'transparent', border: `1px solid ${uiTab === key ? FEED_COLOR + '40' : 'rgba(255,255,255,0.08)'}`, color: uiTab === key ? FEED_COLOR : '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {uiTab === 'feed' && (
+            <div style={{ display: 'flex', gap: 6, padding: '0 12px 10px', overflowX: 'auto' }}>
+              {mobileFilters.map(({ key, label }) => (
+                <button
+                  key={key}
+                  onClick={() => setFilter(key)}
+                  style={{ whiteSpace: 'nowrap', padding: '5px 12px', borderRadius: 14, background: filter === key ? `${FEED_COLOR}14` : 'transparent', border: `1px solid ${filter === key ? FEED_COLOR + '50' : 'rgba(255,255,255,0.1)'}`, color: filter === key ? FEED_COLOR : '#9CA3AF', fontSize: 12, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-        <FeedAnnouncementsHeader onNewPost={openNewPost} />
+        {!isMobile && <FeedAnnouncementsHeader onNewPost={openNewPost} />}
 
         {uiTab === 'feed' && (
           <FeedTab
@@ -339,7 +391,7 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
             {chatLoading && <div style={{ color: '#9CA3AF', fontSize: 14 }}>Loading chat…</div>}
             {chatError && <div style={{ color: '#EF4444', fontSize: 14 }}>{chatError}</div>}
             {chatCredentials && (
-              <div style={{ flex: 1, borderRadius: 14, overflow: 'hidden', border: `1px solid ${FEED_COLOR}20` }}>
+              <div style={{ flex: 1, borderRadius: 14, overflow: 'hidden', border: `1px solid ${FEED_COLOR}20`, minHeight: isMobile ? '65vh' : undefined }}>
                 <StreamChatPanel
                   streamApiKey={chatCredentials.streamApiKey}
                   streamToken={chatCredentials.streamToken}
@@ -361,13 +413,15 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
         )}
       </div>
 
-      <FeedAnnouncementsRightPanel
-        items={items}
-        alertCount={alertCount}
-        questionCount={questionCount}
-        communityCount={communityCount}
-        unreadCount={unreadCount}
-      />
+      {!isMobile && (
+        <FeedAnnouncementsRightPanel
+          items={items}
+          alertCount={alertCount}
+          questionCount={questionCount}
+          communityCount={communityCount}
+          unreadCount={unreadCount}
+        />
+      )}
     </div>
   );
 }

--- a/ctf/packages/web/hooks/use-is-mobile.ts
+++ b/ctf/packages/web/hooks/use-is-mobile.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+/**
+ * Returns true when the viewport is narrower than the phone breakpoint (768px).
+ *
+ * Mirrors the design system's `use-mobile` hook so web shells can switch to the
+ * single-column phone layout shown in the `Mobile*` mockups. Starts false so the
+ * server renders the desktop layout; the client corrects it on mount.
+ */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const update = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    update();
+    query.addEventListener('change', update);
+    return () => query.removeEventListener('change', update);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## What this does

The previous responsive change (#247) made plugins *reachable* on a phone but not good to look at — multi-pane screens stacked into thin orphaned rails and big empty voids (you saw this on Chyme and Feed). This gives **Chyme** and **Feed** real single-column phone layouts that match the `Mobile*` mockups in the `design/` submodule, while leaving the desktop view exactly as it was.

These are the first two of the per-plugin passes — the goal is to confirm the pattern looks right on your phone before rolling it out to the rest.

## Changes

- **Shared `useIsMobile` hook** (`hooks/use-is-mobile.ts`, 768px) mirroring the design system's own `use-mobile` hook, so shells can switch to the phone layout.
- **Chyme:** drops the 72px side rail for a compact sticky top bar (back + brand). The rooms list, audio room, chat, and controls now stack full-width and scroll, instead of three cramped side-by-side columns running off the screen.
- **Feed:** hides the desktop icon rail / filter sidebar / right panel; adds a compact sticky header with a **Feed / Chat / Admin** switch and a horizontal **filter chip** row (All · Announcements · Questions · Community · Unread). The post list fills the width.

Desktop (≥768px) renders exactly as before.

## Why per-plugin (not a global rule)

A single global CSS rule can only stack the top-level columns; plugins like Chyme nest their real layout two or three levels deep, so the global fallback can't reach them. Each multi-pane plugin needs its own phone layout. I'm matching the existing mobile mockups, so this is implementing your design system, not inventing new design.

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (a fresh container needs `turbopack.root` set to build — used only to validate, not part of this PR).
- Not yet checked on a real device — please look at **Chyme** and **Feed** on your iPhone SE. If the pattern is right, I'll apply the same to the other ~18 plugins.

## Follow-ups

- The remaining plugins (LightHouse, GDP, Directory, SocketRelay, etc.) still use the global stacking fallback and need the same per-plugin treatment.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_