### PR TITLE
feat: add phone layouts for LightHouse and GDP

### DIFF
--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Globe } from "lucide-react";
+import Link from "next/link";
+import { ChevronLeft, Globe } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, COLOR, type GdpMetrics, type GdpReport, type GdpTab } from "./gdp-shared";
 import { GdpLoading } from "./gdp-loading";
 import { GdpIconRail } from "./gdp-icon-rail";
@@ -63,6 +65,7 @@ export default function GdpShell() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [report, setReport] = useState<GdpReport | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -90,6 +93,33 @@ export default function GdpShell() {
   const sectors = report?.sectors ?? [];
   const countries = report?.countries ?? [];
   const metrics = report?.metrics ?? {};
+
+  if (isMobile) {
+    const tabs: { key: GdpTab; label: string }[] = [
+      { key: "dashboard", label: "Dashboard" },
+      { key: "map", label: "Map" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "Inter, system-ui, sans-serif", color: "#E8EAF0", display: "flex", flexDirection: "column" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Globe size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>GDP</span>
+            <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>↑ Live</Badge>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+        </div>
+        <GdpContent error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} />
+      </div>
+    );
+  }
 
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "Inter, system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>

--- a/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ChevronLeft, Search } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, COLOR, type ChatCredentials, type Match, type Profile, type Property, type Tab } from "./shared";
 import { LighthouseIconRail } from "./lighthouse-icon-rail";
 import { LighthouseFilterSidebar, type ListingFilter, filterProperties } from "./lighthouse-filter-sidebar";
@@ -26,6 +29,7 @@ export function LighthouseShell() {
   const [chatCredentials, setChatCredentials] = useState<ChatCredentials | null>(null);
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     async function fetchAll() {
@@ -107,6 +111,79 @@ export function LighthouseShell() {
     setSaved((s) => (s.includes(id) ? s.filter((x) => x !== id) : [...s, id]));
   }
 
+  const content = (
+    <>
+      {tab === "browse" && (
+        <LighthouseBrowse
+          properties={visibleProperties}
+          totalCount={properties.length}
+          creditsCount={creditsCount}
+          saved={saved}
+          onToggleSave={toggleSave}
+          onSelect={setSelectedProperty}
+        />
+      )}
+      {tab === "matches" && (
+        <LighthouseMatches matches={matches} properties={properties} onSelectProperty={setSelectedProperty} />
+      )}
+      {tab === "chat" && (
+        <LighthouseChat
+          matches={matches}
+          selectedMatch={selectedMatch}
+          onSelectMatch={setSelectedMatch}
+          chatLoading={chatLoading}
+          chatError={chatError}
+          chatCredentials={chatCredentials}
+        />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    const tabs: { key: Tab; label: string }[] = [
+      { key: "browse", label: "Browse" },
+      { key: "matches", label: "Matches" },
+      { key: "chat", label: "Chat" },
+    ];
+    const filters: { key: ListingFilter; label: string }[] = [
+      { key: "all", label: "All" },
+      { key: "available", label: "Available" },
+      { key: "credits", label: "Credits" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>🏠 LightHouse</span>
+            <span style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>✓ Private</span>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+          {tab === "browse" && (
+            <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
+              <div style={{ position: "relative" }}>
+                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
+                <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="City or neighborhood…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+              </div>
+              <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
+                {filters.map(({ key, label }) => (
+                  <button key={key} onClick={() => setFilter(key)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: filter === key ? `${COLOR}14` : "transparent", border: `1px solid ${filter === key ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: filter === key ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{label}</button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       <LighthouseIconRail tab={tab} onTab={setTab} />
@@ -122,29 +199,7 @@ export function LighthouseShell() {
         </header>
 
         <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflowY: "auto" }}>
-          {tab === "browse" && (
-            <LighthouseBrowse
-              properties={visibleProperties}
-              totalCount={properties.length}
-              creditsCount={creditsCount}
-              saved={saved}
-              onToggleSave={toggleSave}
-              onSelect={setSelectedProperty}
-            />
-          )}
-          {tab === "matches" && (
-            <LighthouseMatches matches={matches} properties={properties} onSelectProperty={setSelectedProperty} />
-          )}
-          {tab === "chat" && (
-            <LighthouseChat
-              matches={matches}
-              selectedMatch={selectedMatch}
-              onSelectMatch={setSelectedMatch}
-              chatLoading={chatLoading}
-              chatError={chatError}
-              chatCredentials={chatCredentials}
-            />
-          )}
+          {content}
         </div>
       </div>
 


### PR DESCRIPTION
## What this does

Continues the per-plugin mobile pass (after Chyme + Feed in #261). On phones, **LightHouse** and **GDP** now use a single-column layout with a sticky top bar (back + title + tab switch) and full-width content, matching the pattern you already merged. Desktop (≥768px) is unchanged.

- **LightHouse:** Browse / Matches / Chat tab switch, plus a search box and filter chips (All · Available · Credits) in the top bar — the desktop filter sidebar and right panel are hidden on phones.
- **GDP:** Dashboard / Map tab switch; the icon rail and sidebar are hidden on phones, dashboard/map fill the width.

Both use the shared `useIsMobile` hook (768px) added in #261.

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not part of this PR).
- Not device-tested — please check LightHouse and GDP on your iPhone SE and screenshot anything off.

## Remaining

Still to do (next batches): Directory, SocketRelay, TrustTransport, Workforce, Skills Hunt, Service Credits, LevelUp, Mood, GentlePulse, Peer Programming, Weekly Performance, WhatWorks, Foundation, ClickLog, Skills Taxonomy, Unlock.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_