### PR TITLE
feat: add phone layouts for Directory and SocketRelay

### DIFF
--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { BookOpen, Search, MessageSquare, Users, Bell, Settings } from "lucide-react";
+import { BookOpen, ChevronLeft, Search, MessageSquare, Users, Bell, Settings } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, COLOR, type Member, type Sector, type SkillsHuntRewardCard } from "./shared";
 import { DirectoryProfileDetail } from "./directory-profile-detail";
 import { DirectoryLoadingSkeleton } from "./directory-loading-skeleton";
@@ -36,6 +38,7 @@ export function DirectoryShell() {
   const [chatInput, setChatInput] = useState("");
   const [rewardCard, setRewardCard] = useState<SkillsHuntRewardCard | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     async function fetchMeta() {
@@ -133,6 +136,59 @@ export function DirectoryShell() {
     return <DirectoryProfileDetail member={selected} onBack={() => setSelected(null)} />;
   }
 
+  const content = tab === "browse" ? (
+    <DirectoryBrowse
+      rewardCard={rewardCard}
+      loadingMembers={loadingMembers}
+      members={members}
+      categories={sectors.map((s) => s.name)}
+      filtered={isFiltered}
+      onSelect={setSelected}
+      onClearFilters={clearFilters}
+    />
+  ) : (
+    <DirectoryChatTab
+      chatInput={chatInput}
+      onChatInputChange={setChatInput}
+      onBrowse={() => setTab("browse")}
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <BookOpen size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Directory</span>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {TABS.map(({ key }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer", textTransform: "capitalize" }}>{key}</button>
+            ))}
+          </div>
+          {tab === "browse" && (
+            <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
+              <div style={{ position: "relative" }}>
+                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
+                <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search providers…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+              </div>
+              <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
+                {sectorFilters.map((f) => (
+                  <button key={f} onClick={() => setActiveFilter(f)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: activeFilter === f ? `${COLOR}14` : "transparent", border: `1px solid ${activeFilter === f ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: activeFilter === f ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{f}</button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       {/* Icon rail */}
@@ -207,23 +263,7 @@ export function DirectoryShell() {
           </Badge>
         </header>
 
-        {tab === "browse" ? (
-          <DirectoryBrowse
-            rewardCard={rewardCard}
-            loadingMembers={loadingMembers}
-            members={members}
-            categories={sectors.map((s) => s.name)}
-            filtered={isFiltered}
-            onSelect={setSelected}
-            onClearFilters={clearFilters}
-          />
-        ) : (
-          <DirectoryChatTab
-            chatInput={chatInput}
-            onChatInputChange={setChatInput}
-            onBrowse={() => setTab("browse")}
-          />
-        )}
+        {content}
       </div>
 
       {/* Right panel */}

--- a/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { Share2 } from "lucide-react";
+import { ChevronLeft, Share2 } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import {
   BG,
+  CATEGORIES,
   COLOR,
   SUBTLE,
   TEXT,
@@ -69,6 +72,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
   const [chatCredentials, setChatCredentials] = useState<SrChatCredentials | null>(null);
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   const fetchData = useCallback(async (showLoading = true) => {
     if (showLoading) setLoading(true);
@@ -176,6 +180,78 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
     return true;
   });
 
+  const content = (
+    <>
+      {tab === "feed" && (
+        <SocketRelayFeed
+          requests={visible}
+          currentUserId={userId}
+          submitting={submitting}
+          onClaim={(id) => void handleClaim(id)}
+          onPost={() => setTab("post")}
+        />
+      )}
+      {tab === "post" && (
+        <SocketRelayPost
+          draft={draft}
+          onChange={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+          submitting={submitting}
+          error={postError}
+          success={postSuccess}
+          onSubmit={() => void handlePost()}
+        />
+      )}
+      {tab === "chat" && (
+        <SocketRelayChat
+          fulfillments={fulfillments}
+          selected={selectedFulfillment}
+          onSelect={(f) => void openFulfillmentChat(f)}
+          chatLoading={chatLoading}
+          chatError={chatError}
+          chatCredentials={chatCredentials}
+        />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    const tabs: { key: Tab; label: string }[] = [
+      { key: "feed", label: "Feed" },
+      { key: "post", label: "Post" },
+      { key: "chat", label: "Chat" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Share2 size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>SocketRelay</span>
+            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{openCount} open</Badge>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+          {tab === "feed" && (
+            <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
+              <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search requests…" style={{ width: "100%", padding: "8px 10px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+              <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
+                {CATEGORIES.map((c) => (
+                  <button key={c} onClick={() => setCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${COLOR}14` : "transparent", border: `1px solid ${category === c ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: category === c ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: "flex" }}>
       <SocketRelayIconRail tab={tab} onTab={setTab} />
@@ -201,35 +277,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
           </Badge>
         </header>
 
-        {tab === "feed" && (
-          <SocketRelayFeed
-            requests={visible}
-            currentUserId={userId}
-            submitting={submitting}
-            onClaim={(id) => void handleClaim(id)}
-            onPost={() => setTab("post")}
-          />
-        )}
-        {tab === "post" && (
-          <SocketRelayPost
-            draft={draft}
-            onChange={(patch) => setDraft((d) => ({ ...d, ...patch }))}
-            submitting={submitting}
-            error={postError}
-            success={postSuccess}
-            onSubmit={() => void handlePost()}
-          />
-        )}
-        {tab === "chat" && (
-          <SocketRelayChat
-            fulfillments={fulfillments}
-            selected={selectedFulfillment}
-            onSelect={(f) => void openFulfillmentChat(f)}
-            chatLoading={chatLoading}
-            chatError={chatError}
-            chatCredentials={chatCredentials}
-          />
-        )}
+        {content}
       </div>
 
       <SocketRelayRightPanel


### PR DESCRIPTION
## What this does

Continues the per-plugin mobile pass (batch 3, after #261 and #262). On phones, **Directory** and **SocketRelay** now use a single-column layout with a sticky top bar (back + title + tab switch) and full-width content; the icon rail, filter sidebar, and right panel are hidden. Desktop (≥768px) is unchanged.

- **Directory:** Browse / Chat tab switch, plus search and sector filter chips in the top bar.
- **SocketRelay:** Feed / Post / Chat tab switch, plus search and category chips in the top bar.

Both use the shared `useIsMobile` hook (768px).

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).
- Not device-tested — please screenshot anything off on your iPhone SE.

## Remaining

Still to do: TrustTransport, Workforce, Skills Hunt, Service Credits, LevelUp, Mood, GentlePulse, Peer Programming, Weekly Performance, WhatWorks, Foundation, ClickLog, Skills Taxonomy, Unlock.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_