### PR TITLE
feat: add phone layouts for Mood and GentlePulse

### DIFF
--- a/ctf/packages/web/components/gentlepulse/gentlepulse-shell.tsx
+++ b/ctf/packages/web/components/gentlepulse/gentlepulse-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { Heart } from "lucide-react";
+import { ChevronLeft, Heart } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, COLOR, FAINT, type Session, type Tab } from "./gp-shared";
 import { GentlePulseLoading } from "./gp-loading";
 import { GentlePulseIconRail } from "./gp-icon-rail";
@@ -25,6 +27,7 @@ export function GentlePulseShell() {
   const [chatInput, setChatInput] = useState("");
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [submitting, setSubmitting] = useState(false);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -93,6 +96,68 @@ export function GentlePulseShell() {
   const filtered = category === "All" ? sessions : sessions.filter((s) => s.category === category);
   const playingSession = playing ? sessions.find((s) => s.id === playing) ?? null : null;
 
+  const content = (
+    <>
+      {tab === "sessions" && (
+        <GentlePulseSessions
+          sessions={sessions}
+          filtered={filtered}
+          favorites={favorites}
+          submitting={submitting}
+          onPlay={(id) => void handlePlay(id)}
+          onToggleFavorite={(id, isFav) => void handleFavorite(id, isFav)}
+        />
+      )}
+      {tab === "playing" && (
+        <GentlePulsePlayer
+          session={playingSession}
+          isPaused={isPaused}
+          progress={progress}
+          onTogglePause={() => setIsPaused((p) => !p)}
+          onClose={() => setTab("sessions")}
+          onBrowse={() => setTab("sessions")}
+        />
+      )}
+      {tab === "chat" && (
+        <GentlePulseChat chatInput={chatInput} onChatInput={setChatInput} onBrowse={() => setTab("sessions")} />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    const tabs: { key: Tab; label: string }[] = [
+      { key: "sessions", label: "Sessions" },
+      { key: "chat", label: "Chat" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#080D0C", borderBottom: "1px solid rgba(20,184,166,0.1)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Heart size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>GentlePulse</span>
+            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>✓ Safe</Badge>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+          {tab === "sessions" && (
+            <div style={{ display: "flex", gap: 6, padding: "0 12px 10px", overflowX: "auto" }}>
+              {categories.map((c) => (
+                <button key={c} onClick={() => setCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${COLOR}14` : "transparent", border: `1px solid ${category === c ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: category === c ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
+              ))}
+            </div>
+          )}
+        </div>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       <GentlePulseIconRail tab={tab} onTab={setTab} />
@@ -116,29 +181,7 @@ export function GentlePulseShell() {
           </Badge>
         </header>
 
-        {tab === "sessions" && (
-          <GentlePulseSessions
-            sessions={sessions}
-            filtered={filtered}
-            favorites={favorites}
-            submitting={submitting}
-            onPlay={(id) => void handlePlay(id)}
-            onToggleFavorite={(id, isFav) => void handleFavorite(id, isFav)}
-          />
-        )}
-        {tab === "playing" && (
-          <GentlePulsePlayer
-            session={playingSession}
-            isPaused={isPaused}
-            progress={progress}
-            onTogglePause={() => setIsPaused((p) => !p)}
-            onClose={() => setTab("sessions")}
-            onBrowse={() => setTab("sessions")}
-          />
-        )}
-        {tab === "chat" && (
-          <GentlePulseChat chatInput={chatInput} onChatInput={setChatInput} onBrowse={() => setTab("sessions")} />
-        )}
+        {content}
       </div>
 
       <GentlePulseRightPanel sessions={sessions} onPlay={(id) => void handlePlay(id)} />

--- a/ctf/packages/web/components/mood/mood-shell.tsx
+++ b/ctf/packages/web/components/mood/mood-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { Smile } from "lucide-react";
+import { ChevronLeft, Smile } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { COLOR, getMoodClientId, type MoodEligibility, type Tab } from "./mood-shared";
 import { MoodLoading } from "./mood-loading";
 import { MoodIconRail } from "./mood-icon-rail";
@@ -21,6 +23,7 @@ export default function MoodShell() {
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const id = getMoodClientId();
@@ -67,6 +70,51 @@ export default function MoodShell() {
 
   if (loading) return <MoodLoading />;
 
+  const content = tab === "checkin" ? (
+    <MoodCheckin
+      eligibility={eligibility}
+      selected={selected}
+      onSelect={setSelected}
+      note={note}
+      onNoteChange={setNote}
+      submitting={submitting}
+      submitted={submitted}
+      error={error}
+      onSubmit={() => void handleSubmit()}
+      onViewCommunity={() => setTab("community")}
+    />
+  ) : (
+    <MoodCommunity />
+  );
+
+  if (isMobile) {
+    const tabs: { key: Tab; label: string }[] = [
+      { key: "checkin", label: "Check-in" },
+      { key: "community", label: "Community" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: "#0F1117", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Smile size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Mood</span>
+            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>🔒 Anonymous</Badge>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+        </div>
+        {content}
+        <MoodCrisisRail />
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       <MoodIconRail tab={tab} onTab={setTab} />
@@ -82,22 +130,7 @@ export default function MoodShell() {
           <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>🔒 Anonymous</Badge>
         </header>
 
-        {tab === "checkin" ? (
-          <MoodCheckin
-            eligibility={eligibility}
-            selected={selected}
-            onSelect={setSelected}
-            note={note}
-            onNoteChange={setNote}
-            submitting={submitting}
-            submitted={submitted}
-            error={error}
-            onSubmit={() => void handleSubmit()}
-            onViewCommunity={() => setTab("community")}
-          />
-        ) : (
-          <MoodCommunity />
-        )}
+        {content}
       </div>
 
       <MoodCrisisRail />


### PR DESCRIPTION
## What this does

Continues the per-plugin mobile pass. On phones, **Mood** and **GentlePulse** now use a single-column layout with a sticky top bar (back + title + tab switch) and full-width content; the icon rail and sidebar are hidden. Desktop (≥768px) is unchanged.

- **Mood:** Check-in / Community tab switch. The crisis-support rail is **kept** (stacked below the content) so safety resources stay reachable on phones.
- **GentlePulse:** Sessions / Chat tab switch plus category chips; the right panel is hidden.

Both use the shared `useIsMobile` hook (768px).

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).

## Remaining

Still to do: TrustTransport, Workforce, Skills Hunt, Service Credits, LevelUp, Peer Programming, Weekly Performance, WhatWorks, Foundation, ClickLog, Skills Taxonomy, Unlock.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_