### PR TITLE
chore: report Chyme and Directory errors to Sentry

### DIFF
--- a/ctf/packages/web/app/api/chyme/join/route.ts
+++ b/ctf/packages/web/app/api/chyme/join/route.ts
@@ -3,6 +3,7 @@ import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
 import { createStreamJoinCredentials } from 'lib/chyme/stream';
 import { getRoomState, markRoomCallJoined } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
+import { reportError } from 'lib/observability/report';
 import { requireChymeAccess } from '../_lib';
 
 export async function POST() {
@@ -66,7 +67,8 @@ export async function POST() {
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'chyme', op: 'call_join', extra: { userId: gate.auth.userId } });
     logChymeAudit({
       pluginId: 'chyme',
       command: 'chyme.call.join',

--- a/ctf/packages/web/app/api/chyme/messages/route.ts
+++ b/ctf/packages/web/app/api/chyme/messages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { CHYME_DEFAULT_MESSAGES_LIMIT, CHYME_ERROR_CODE } from 'lib/chyme/constants';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { listRoomMessages, sendRoomMessage, validateMessageInput } from 'lib/chyme/repository';
+import { reportError } from 'lib/observability/report';
 import { requireChymeAccess } from '../_lib';
 
 function parseLimit(url: string): number {
@@ -47,7 +48,8 @@ export async function GET(request: Request) {
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'chyme', op: 'messages_list', extra: { userId: gate.auth.userId } });
     logChymeAudit({
       pluginId: 'chyme',
       command: 'chyme.messages.list',
@@ -138,7 +140,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, message }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'chyme', op: 'message_send', extra: { userId: gate.auth.userId } });
     logChymeAudit({
       pluginId: 'chyme',
       command: 'chyme.message.send',

--- a/ctf/packages/web/app/api/chyme/room/route.ts
+++ b/ctf/packages/web/app/api/chyme/room/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { getRoomState } from 'lib/chyme/repository';
+import { reportError } from 'lib/observability/report';
 import { requireChymeAccess } from '../_lib';
 
 export async function GET() {
@@ -27,7 +28,8 @@ export async function GET() {
     });
 
     return NextResponse.json(room, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'chyme', op: 'room_state_fetch', extra: { userId: gate.auth.userId } });
     logChymeAudit({
       pluginId: 'chyme',
       command: 'chyme.room.state.fetch',

--- a/ctf/packages/web/app/api/directory/list/route.ts
+++ b/ctf/packages/web/app/api/directory/list/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireDirectoryReadAccess } from '../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { listDirectoryForMember, parsePaginationParams } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 
 function getFilters(url: string) {
   const params = new URL(url).searchParams;
@@ -39,6 +40,7 @@ export async function GET(request: Request) {
       );
     }
 
+    reportError(error, { area: 'directory', op: 'list_members', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch directory list.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/profile/route.ts
+++ b/ctf/packages/web/app/api/directory/profile/route.ts
@@ -3,6 +3,7 @@ import { requireDirectoryReadAccess } from '../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { deleteOwnDirectoryProfile, getOwnProfile, upsertOwnProfile, validateProfileInput } from 'lib/directory/repository';
 import { logDirectoryAudit } from 'lib/directory/audit';
+import { reportError } from 'lib/observability/report';
 import type { DirectoryProfileInput } from 'lib/directory/types';
 
 type ProfileBody = Partial<DirectoryProfileInput>;
@@ -34,7 +35,8 @@ export async function GET() {
   try {
     const profile = await getOwnProfile(gate.auth.userId);
     return NextResponse.json({ profile }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'get_own_profile', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch profile.' },
       { status: 503 },
@@ -96,6 +98,12 @@ async function handleUpsert(request: Request) {
     const message = error instanceof Error ? error.message : 'unknown';
     const isSelectorIssue = message.includes('directory_') && message.endsWith('_not_found');
 
+    // A selector-not-found is a client validation problem; anything else is an
+    // unexpected server/persistence failure worth reporting.
+    if (!isSelectorIssue) {
+      reportError(error, { area: 'directory', op: 'upsert_own_profile', extra: { userId: gate.auth.userId } });
+    }
+
     logDirectoryAudit({
       actorId: gate.auth.userId,
       command: 'directory.profile.upsert',
@@ -150,7 +158,8 @@ export async function DELETE() {
       { ok: true, scope: 'service', status: 'completed', requestedAtIso: deletion.requestedAtIso },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'delete_own_profile', extra: { userId: gate.auth.userId } });
     logDirectoryAudit({
       actorId: gate.auth.userId,
       command: 'directory.profile.delete.service',

--- a/ctf/packages/web/app/api/directory/sectors/route.ts
+++ b/ctf/packages/web/app/api/directory/sectors/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireDirectoryReadAccess } from '../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { listTaxonomySectors } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireDirectoryReadAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const items = await listTaxonomySectors();
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'list_sectors', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch sectors.' },
       { status: 503 },

--- a/ctf/packages/web/components/chyme/chyme-audio-room.tsx
+++ b/ctf/packages/web/components/chyme/chyme-audio-room.tsx
@@ -15,6 +15,7 @@ import {
 import { Mic } from 'lucide-react';
 import { BORDER, PRIMARY, initials, type CurrentUser } from './chyme-shared';
 import { ChymeControls } from './chyme-controls';
+import { reportError } from 'lib/observability/report';
 import type { ChymeJoinResponse } from 'lib/chyme/types';
 
 // Chyme is open social audio (early-Clubhouse style): everyone who joins can
@@ -72,6 +73,17 @@ export function ChymeAudioRoom({ joinInfo, currentUser, showChat, chatPanel, isM
         setStatus('joined');
       } catch (error) {
         if (cancelled) return;
+        // Surface the real Stream error verbatim in the UI and report it to Sentry
+        // with the call coordinates so a failed join is diagnosable without a repro.
+        reportError(error, {
+          area: 'chyme',
+          op: 'audio_join',
+          extra: {
+            callType: CALL_TYPE,
+            callId: toCallId(joinInfo.streamChannelId),
+            streamUserId: joinInfo.streamUserId,
+          },
+        });
         setErrorMessage(error instanceof Error ? error.message : 'Could not connect to the audio room.');
         setStatus('error');
       }

--- a/ctf/packages/web/lib/observability/report.ts
+++ b/ctf/packages/web/lib/observability/report.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/nextjs';
+
+type ReportContext = {
+  // Coarse grouping for the error (e.g. 'chyme', 'directory', 'hub').
+  area: string;
+  // The specific operation that failed (e.g. 'join', 'list_members', 'send_message').
+  op: string;
+  // Extra non-sensitive context to make the error debuggable without reproducing
+  // it: ids, status codes, filters, etc. NEVER put secrets, tokens, or API keys here.
+  extra?: Record<string, unknown>;
+};
+
+// Report a caught error to Sentry with debugging context.
+//
+// Caught errors do not reach Sentry on their own — only unhandled exceptions do,
+// via the Next.js onRequestError hook. Routes and client surfaces that catch their
+// own errors (to return a friendly message) therefore hide the real cause. Call
+// this in those catch blocks so the underlying error, tagged and annotated, shows
+// up in Sentry. Works on both the server and the client (@sentry/nextjs).
+export function reportError(error: unknown, context: ReportContext): void {
+  Sentry.captureException(error, {
+    tags: { area: context.area, op: context.op },
+    ...(context.extra ? { extra: context.extra } : {}),
+  });
+}


### PR DESCRIPTION
## What

Make the surfaces from this session's work report their swallowed errors to Sentry, verbosely.

## Why

The Chyme and Directory routes caught their errors in bare `catch {}` blocks and returned a generic 5xx; the Chyme audio client only showed "Could not connect." None of it reached Sentry, so a failure couldn't be diagnosed without reproducing it — the same blind spot that made the feed bug expensive to find.

## How

- New shared reporter `lib/observability/report.ts`: `reportError(error, { area, op, extra })` → `Sentry.captureException` with grouping tags and non-sensitive context (ids; never tokens/secrets). Works server and client.
- Wired into the catch blocks of: Chyme `room` / `join` / `messages` routes, the Chyme audio-room join failure (also tags the call type/id), and Directory `sectors` / `list` / `profile` routes.

Friendly client responses are unchanged; the real cause is now visible in Sentry. (The hub messages route already reported to Sentry from #254.)

Parity Status: web+android complete

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_