### PR TITLE
ci: install matching PostgreSQL client for Formance backup/restore

### DIFF
--- a/.github/workflows/backup-formance-supabase.yml
+++ b/.github/workflows/backup-formance-supabase.yml
@@ -34,6 +34,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install PostgreSQL client 17
+        # The runner's bundled pg_dump may be missing or older than the
+        # Formance/Neon server (Postgres 16/17). pg_dump refuses to dump a
+        # server newer than itself, which fails the job in seconds. Install the
+        # client matching the newest server from the official PostgreSQL apt
+        # repository and put it first on PATH. A newer client dumps older
+        # servers fine.
+        run: |
+          set -e
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+
       - name: Run Formance backup script
         id: backup
         run: |

--- a/.github/workflows/restore-formance-supabase.yml
+++ b/.github/workflows/restore-formance-supabase.yml
@@ -50,8 +50,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Ensure pg_restore is available
-        run: command -v pg_restore >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y postgresql-client)
+      - name: Install PostgreSQL client 17
+        # Match the newest target server (Postgres 16/17). The runner's bundled
+        # client may be missing or too old, and pg_restore must be at least the
+        # server version. Install from the official PostgreSQL apt repository and
+        # put it first on PATH.
+        run: |
+          set -e
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
 
       - name: Run Formance restore script
         id: restore


### PR DESCRIPTION
## What was broken

The nightly "Backup Formance to Supabase" workflow has been failing every run, and it failed fast (12–26s — before any real dump ran).

Two causes:

1. **The backup workflow never made sure `pg_dump` was installed.** The restore workflow had a `command -v pg_restore || install` guard, but the backup workflow was missing the equivalent — so it relied on whatever the runner happened to ship.
2. **A version mismatch.** Even when a client is present, the runner's bundled `pg_dump` can be older than the Formance/Neon Postgres server (Formance is Postgres 16; Neon now defaults to 17). `pg_dump` refuses to dump a server newer than itself and exits 1 immediately, which matches the quick failures.

## The fix

Add a step to both the backup and restore workflows that installs the **PostgreSQL 17 client** from the official PostgreSQL apt repository and puts it first on `PATH`. A newer client backs up and restores older servers fine, so this is version-proof against both Postgres 16 and 17 servers.

This also replaces the restore workflow's weaker "install only if missing" guard, which could leave an out-of-date client in place.

## Testing notes

This is a CI/workflow-only change with no rendered surface, so the design gate does not apply. The real check is the next scheduled (or manually dispatched) run of "Backup Formance to Supabase" going green.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_014bGppHioeqkgNYVuc1fqDy)_