### PR TITLE
chore: app-wide verbose error reporting to Sentry

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -585,3 +585,12 @@ known-open item — sign-in via Clerk (auth) — is owned by the owner's separat
   the feed/workforce reconciliations already done. **One known-open item:** sign-in via Clerk (auth),
   which the owner is fixing on a separate track — it does not block retirement of this build plan. The
   demo-tenant DB-scoping layer and the auth/public screens are carried into that auth/demo track.
+- 2026-06-01: Cross-cutting observability addendum (does not reopen the retired plan). Extended the
+  app-wide Sentry error reporting started in #267 to every remaining `ctf/packages/web/app/api/**/route.ts`:
+  each catch block handling an unexpected failure (5xx/persistence/swallowed) now calls the shared
+  `reportError(...)` reporter, tagged with the plugin slug (`area`) and a snake_case `op`, carrying only
+  non-sensitive context (userId and route ids — no tokens, secrets, amounts, bodies, or message text).
+  Expected client errors (400/401/403/404/429) stay unreported; branching catches report only on the 5xx
+  path. No API surface, schema, contract, or response behavior changed — this is reporting-only, so plugin
+  inventories' route maps and data models are unaffected. Gates: web `tsc --noEmit`, `eslint` on all changed
+  files, and EOF all pass.

--- a/ctf/docs/quota-impact/2026-06-01-app-wide-sentry-error-reporting.md
+++ b/ctf/docs/quota-impact/2026-06-01-app-wide-sentry-error-reporting.md
@@ -1,0 +1,33 @@
+# Stream Quota Impact Note
+
+## Summary
+- Feature/Change: App-wide verbose server-side error reporting to Sentry. Adds `reportError(...)` calls inside existing catch blocks across `ctf/packages/web/app/api/**/route.ts`. This note exists because one touched route path (`app/api/feed/stream/route.ts`) matches the Stream-change detector; the change itself adds no Stream usage.
+- PR: #273
+- Owner: platform-observability
+- Date: 2026-06-01
+
+## Stream Surfaces Affected
+- Chat / Activity Feeds / Video / AI Moderation: None. No Stream (getstream.io) API call is added, removed, or altered. The change only reports already-caught server errors to Sentry; request/response behavior, status codes, and Stream interactions are unchanged.
+
+## Estimated Monthly Impact
+- Chat MAU impact estimate: none.
+- Activity Feed API calls estimate: none.
+- Video participant-minutes estimate: none.
+- AI Moderation credits estimate: none.
+
+## Budget Threshold Risk
+- Expected threshold after rollout (Green/Yellow/Orange/Red): Green. No change to Stream consumption.
+- Peak scenario estimate: unchanged from current baseline; this change cannot increase Stream calls.
+
+## Fallback and Degradation Plan
+- What degrades first: nothing Stream-related. If Sentry is unreachable, `reportError` is a best-effort no-op and the original friendly error response is still returned to the user.
+- User-visible messaging behavior: unchanged — the same friendly error messages as before.
+- Kill switch / feature flag: governed by the existing `OBSERVABILITY_PROVIDER` setting; setting it away from `sentry` disables capture without code changes.
+
+## Observability
+- Metrics and alerts added/updated: caught 5xx/persistence failures across all API routes now reach Sentry, tagged with `area` (plugin slug) and `op` (snake_case operation), with non-sensitive context (userId and route ids only).
+- Dashboard link (if available): existing Sentry web project.
+
+## Validation
+- Tests added for degraded mode: none required; no behavior change. Verified with web-package `tsc --noEmit`, `eslint` on all changed files, and `check-eof-format.sh`.
+- Rollback strategy: revert the PR, or set `OBSERVABILITY_PROVIDER` away from `sentry`; either is config/code-only with no Stream impact.

--- a/ctf/packages/web/app/api/account/chyme-profile/route.ts
+++ b/ctf/packages/web/app/api/account/chyme-profile/route.ts
@@ -3,6 +3,7 @@ import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { markServiceDeletion } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
+import { reportError } from 'lib/observability/report';
 
 export async function DELETE() {
   const decision = await evaluatePluginAccess({
@@ -31,7 +32,8 @@ export async function DELETE() {
     });
 
     return NextResponse.json(deletion, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'account', op: 'delete_chyme_service', extra: { userId: decision.userId } });
     logChymeAudit({
       pluginId: 'chyme',
       command: 'chyme.profile.delete.service',

--- a/ctf/packages/web/app/api/account/full-account/route.ts
+++ b/ctf/packages/web/app/api/account/full-account/route.ts
@@ -3,6 +3,7 @@ import { markFullAccountDeletionRequested } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
 import { deleteAllAccountData } from 'lib/account/deletion-orchestrator';
+import { reportError } from 'lib/observability/report';
 import { requireAccountAccess, ensureMutationCsrf } from '../_lib';
 
 export async function DELETE(request: Request) {
@@ -56,7 +57,8 @@ export async function DELETE(request: Request) {
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'account', op: 'delete_full_account', extra: { userId } });
     logChymeAudit({
       pluginId: 'chyme',
       command: 'account.profile.delete.full',

--- a/ctf/packages/web/app/api/account/services/[slug]/route.ts
+++ b/ctf/packages/web/app/api/account/services/[slug]/route.ts
@@ -7,6 +7,7 @@ import {
   ServiceScopeNotSupportedError,
   UnknownServiceError,
 } from 'lib/account/deletion-orchestrator';
+import { reportError } from 'lib/observability/report';
 
 // Generic per-plugin "delete my data for this service" endpoint.
 //
@@ -81,6 +82,7 @@ export async function DELETE(request: Request, context: { params: Promise<{ slug
       );
     }
 
+    reportError(error, { area: 'account', op: 'delete_service_scope', extra: { userId: gate.auth.userId, slug } });
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/account/skills-hunt-profile/route.ts
+++ b/ctf/packages/web/app/api/account/skills-hunt-profile/route.ts
@@ -7,6 +7,7 @@ import { rebuildLeaderboard } from 'lib/skills-hunt/repository';
 import { recomputeMissionProgressForUser } from 'lib/skills-hunt/missions';
 import { logSkillsHuntAudit } from 'lib/skills-hunt/audit';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 
 // GDPR soft-delete entry point for Skills Hunt.
 //
@@ -51,7 +52,8 @@ export async function DELETE(request: Request) {
     });
 
     return NextResponse.json({ ok: true, deleted: result.deleted }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'account', op: 'delete_skills_hunt_profile', extra: { userId: decision.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete profile.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/announcements/[announcementId]/dismiss/route.ts
+++ b/ctf/packages/web/app/api/announcements/[announcementId]/dismiss/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedReadAccess } from '../../../feed/_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { dismissAnnouncement } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{
@@ -49,7 +50,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, announcementId }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'announcements', op: 'dismiss', extra: { userId: gate.auth.userId, announcementId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to dismiss announcement.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/announcements/[announcementId]/read/route.ts
+++ b/ctf/packages/web/app/api/announcements/[announcementId]/read/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedReadAccess } from '../../../feed/_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { markAnnouncementRead } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{
@@ -38,7 +39,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, announcementId }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'announcements', op: 'mark_read', extra: { userId: gate.auth.userId, announcementId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to mark announcement as read.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/announcements/admin/[announcementId]/archive/route.ts
+++ b/ctf/packages/web/app/api/announcements/admin/[announcementId]/archive/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../../feed/_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { archiveAnnouncement } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ announcementId: string }>;
@@ -27,6 +28,10 @@ export async function POST(request: Request, { params }: RouteParams) {
     const message = error instanceof Error ? error.message : 'error';
     const status = message === 'announcement_not_found' ? 404 : 503;
     const code = message === 'announcement_not_found' ? FEED_ERROR_CODE.notFound : FEED_ERROR_CODE.persistenceUnavailable;
+
+    if (message !== 'announcement_not_found') {
+      reportError(error, { area: 'announcements', op: 'archive', extra: { userId: gate.auth.userId, announcementId } });
+    }
 
     return NextResponse.json(
       { ok: false, code, message: 'Unable to archive announcement.' },

--- a/ctf/packages/web/app/api/announcements/admin/[announcementId]/publish/route.ts
+++ b/ctf/packages/web/app/api/announcements/admin/[announcementId]/publish/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../../feed/_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { publishAnnouncement } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ announcementId: string }>;
@@ -27,6 +28,10 @@ export async function POST(request: Request, { params }: RouteParams) {
     const message = error instanceof Error ? error.message : 'error';
     const status = message === 'announcement_not_found' ? 404 : 503;
     const code = message === 'announcement_not_found' ? FEED_ERROR_CODE.notFound : FEED_ERROR_CODE.persistenceUnavailable;
+
+    if (message !== 'announcement_not_found') {
+      reportError(error, { area: 'announcements', op: 'publish', extra: { userId: gate.auth.userId, announcementId } });
+    }
 
     return NextResponse.json(
       { ok: false, code, message: 'Unable to publish announcement.' },

--- a/ctf/packages/web/app/api/announcements/admin/drafts/[draftId]/route.ts
+++ b/ctf/packages/web/app/api/announcements/admin/drafts/[draftId]/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../../feed/_li
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { updateAnnouncementDraft, validateAnnouncementDraftInput } from 'lib/feed/repository';
 import type { AnnouncementDraftInput } from 'lib/feed/types';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ draftId: string }>;
@@ -60,6 +61,10 @@ export async function PUT(request: Request, { params }: RouteParams) {
     const message = error instanceof Error ? error.message : 'error';
     const status = message === 'announcement_not_found' ? 404 : 503;
     const code = message === 'announcement_not_found' ? FEED_ERROR_CODE.notFound : FEED_ERROR_CODE.persistenceUnavailable;
+
+    if (message !== 'announcement_not_found') {
+      reportError(error, { area: 'announcements', op: 'update_draft', extra: { userId: gate.auth.userId, draftId } });
+    }
 
     return NextResponse.json(
       { ok: false, code, message: 'Unable to update draft.' },

--- a/ctf/packages/web/app/api/announcements/admin/drafts/route.ts
+++ b/ctf/packages/web/app/api/announcements/admin/drafts/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../feed/_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { createAnnouncementDraft, validateAnnouncementDraftInput } from 'lib/feed/repository';
 import type { AnnouncementDraftInput } from 'lib/feed/types';
+import { reportError } from 'lib/observability/report';
 
 type DraftBody = Partial<AnnouncementDraftInput>;
 
@@ -50,7 +51,8 @@ export async function POST(request: Request) {
   try {
     const announcement = await createAnnouncementDraft(gate.auth.userId, input);
     return NextResponse.json({ ok: true, announcement }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'announcements', op: 'create_draft', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create draft.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/announcements/membership/events/route.ts
+++ b/ctf/packages/web/app/api/announcements/membership/events/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../feed/_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { emitMembershipEvent } from 'lib/feed/repository';
 import type { MembershipEventType } from 'lib/feed/types';
+import { reportError } from 'lib/observability/report';
 
 type MembershipBody = {
   userId?: string;
@@ -64,7 +65,12 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, streamEmitted: result.streamEmitted }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'announcements',
+      op: 'emit_membership_event',
+      extra: { userId: gate.auth.userId, targetUserId: input.userId, pluginId: input.pluginId },
+    });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to emit membership event.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/announcements/route.ts
+++ b/ctf/packages/web/app/api/announcements/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireFeedReadAccess } from '../feed/_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { listAnnouncements } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireFeedReadAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const announcements = await listAnnouncements(false);
     return NextResponse.json({ items: announcements }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'announcements', op: 'list_announcements', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch announcements.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/chyme/service-credits/route.ts
+++ b/ctf/packages/web/app/api/chyme/service-credits/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireChymeAccess } from '../_lib';
 import { sendServiceCredits } from 'lib/chyme/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request) {
   const gate = await requireChymeAccess();
@@ -23,6 +24,11 @@ export async function POST(request: Request) {
     const tx = await sendServiceCredits(gate.identity.userId, body.toUserId, body.amount, body.message);
     return NextResponse.json({ ok: true, transaction: tx }, { status: 200 });
   } catch (error) {
+    reportError(error, {
+      area: 'chyme',
+      op: 'send_service_credits',
+      extra: { userId: gate.identity.userId, toUserId: body.toUserId },
+    });
     return NextResponse.json({ ok: false, message: (error as Error).message }, { status: 500 });
   }
 }

--- a/ctf/packages/web/app/api/comic/answers/[turnId]/rate/route.ts
+++ b/ctf/packages/web/app/api/comic/answers/[turnId]/rate/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireComicReadAccess } from '../../../_lib';
 import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { logComicAudit } from 'lib/comic/audit';
 import { isValidComicAnswerRating, rateComicAnswer } from 'lib/comic/repository';
+import { reportError } from 'lib/observability/report';
 
 type RateBody = {
   rating?: string;
@@ -74,6 +75,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
+    reportError(error, { area: 'comic', op: 'post_rate_answer', extra: { userId: gate.auth.userId, turnId } });
     return NextResponse.json(
       { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to rate AI Assistant answer.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/comic/conversation/route.ts
+++ b/ctf/packages/web/app/api/comic/conversation/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireComicReadAccess } from '../_lib';
 import { COMIC_ASKER_STREAM_LIMIT, COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { listComicAskerStream } from 'lib/comic/repository';
+import { reportError } from 'lib/observability/report';
 
 // Asker-facing read of the current user's own @comic Q&A history. Returns answered AI cards
 // (approved/corrected only) and pending "Reviewing for safety" items. The repository enforces the
@@ -20,7 +21,8 @@ export async function GET(request: Request) {
   try {
     const result = await listComicAskerStream(gate.auth.userId, limit);
     return NextResponse.json({ ok: true, items: result.items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'comic', op: 'get_asker_conversation', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to load AI Assistant conversation.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/comic/message/route.ts
+++ b/ctf/packages/web/app/api/comic/message/route.ts
@@ -4,6 +4,7 @@ import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { logComicAudit } from 'lib/comic/audit';
 import { routeComicMessage, validateComicMessageInput } from 'lib/comic/repository';
 import type { ComicMessageInput } from 'lib/comic/types';
+import { reportError } from 'lib/observability/report';
 
 type MessageBody = Partial<ComicMessageInput>;
 
@@ -129,6 +130,7 @@ export async function POST(request: Request) {
       );
     }
 
+    reportError(error, { area: 'comic', op: 'post_route_message', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to route message to the AI Assistant.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/comic/review/[turnId]/resolve/route.ts
+++ b/ctf/packages/web/app/api/comic/review/[turnId]/resolve/route.ts
@@ -4,6 +4,7 @@ import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { logComicAudit } from 'lib/comic/audit';
 import { resolveComicReview } from 'lib/comic/repository';
 import type { ComicReviewResolveInput } from 'lib/comic/types';
+import { reportError } from 'lib/observability/report';
 
 type ResolveBody = Partial<ComicReviewResolveInput>;
 
@@ -120,6 +121,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ tur
       );
     }
 
+    reportError(error, { area: 'comic', op: 'post_resolve_review', extra: { userId: gate.auth.userId, reviewId } });
     return NextResponse.json(
       { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to resolve review item.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/comic/review/route.ts
+++ b/ctf/packages/web/app/api/comic/review/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireComicAdminAccess } from '../_lib';
 import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { listPendingComicReviews } from 'lib/comic/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: Request) {
   const gate = await requireComicAdminAccess();
@@ -20,7 +21,8 @@ export async function GET(request: Request) {
     );
 
     return NextResponse.json({ ok: true, items: result.items, pagination: result.pagination }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'comic', op: 'get_review_queue', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to load the review queue.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/comic/training/export/route.ts
+++ b/ctf/packages/web/app/api/comic/training/export/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireComicAdminAccess } from '../../_lib';
 import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { exportComicTrainingExamples } from 'lib/comic/repository';
+import { reportError } from 'lib/observability/report';
 
 function escapeRasaExample(text: string): string {
   return text.replace(/[\\`*_{}[\]()#+\-.!]/g, '\\$&').replace(/\n/g, ' ').trim();
@@ -52,7 +53,8 @@ export async function GET(request: Request) {
         'X-Total-Examples': String(totalExamples),
       },
     });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'comic', op: 'get_export_training', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to export training examples.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/admin/announcements/[id]/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/announcements/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireDirectoryAdminAccess } from '../../../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { deactivateAnnouncement, updateAnnouncement, validateAnnouncementInput } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 import type { DirectoryAnnouncementInput } from 'lib/directory/types';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -59,7 +60,8 @@ export async function PUT(request: Request, { params }: RouteParams) {
     }
 
     return NextResponse.json({ ok: true, announcement }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'update_announcement', extra: { userId: gate.auth.userId, announcementId: id } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update announcement.' },
       { status: 503 },
@@ -90,7 +92,8 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     }
 
     return NextResponse.json({ ok: true }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'deactivate_announcement', extra: { userId: gate.auth.userId, announcementId: id } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to deactivate announcement.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/admin/announcements/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/announcements/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireDirectoryAdminAccess } from '../../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { createAnnouncement, listDirectoryAnnouncements, validateAnnouncementInput } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 import type { DirectoryAnnouncementInput } from 'lib/directory/types';
 
 type AnnouncementBody = Partial<DirectoryAnnouncementInput>;
@@ -25,7 +26,8 @@ export async function GET() {
   try {
     const items = await listDirectoryAnnouncements(false);
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'list_admin_announcements', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to list announcements.' },
       { status: 503 },
@@ -65,7 +67,8 @@ export async function POST(request: Request) {
   try {
     const announcement = await createAnnouncement(gate.auth.userId, input);
     return NextResponse.json({ ok: true, announcement }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'create_announcement', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to create announcement.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/admin/profiles/[id]/assign/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/profiles/[id]/assign/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireDirectoryAdminAccess } from '../../../../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { assignAdminProfile } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -50,7 +51,8 @@ export async function PUT(request: Request, { params }: RouteParams) {
     }
 
     return NextResponse.json({ ok: true, profile }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'assign_admin_profile', extra: { userId: gate.auth.userId, id, assigneeUserId: userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to assign profile.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/admin/profiles/[id]/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/profiles/[id]/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireDirectoryAdminAccess } from '../../../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { deleteAdminProfile, updateAdminProfile, validateProfileInput } from 'lib/directory/repository';
 import { logDirectoryAudit } from 'lib/directory/audit';
+import { reportError } from 'lib/observability/report';
 import type { DirectoryProfileInput } from 'lib/directory/types';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -67,6 +68,10 @@ export async function PUT(request: Request, { params }: RouteParams) {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown';
     const isValidation = message.includes('_not_found');
+
+    if (!isValidation) {
+      reportError(error, { area: 'directory', op: 'update_admin_profile', extra: { userId: gate.auth.userId, id } });
+    }
 
     return NextResponse.json(
       {
@@ -135,7 +140,8 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'delete_admin_profile', extra: { userId: gate.auth.userId, id } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete profile.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/admin/profiles/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/profiles/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireDirectoryAdminAccess } from '../../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { createAdminProfile, listAdminProfiles, parsePaginationParams, validateProfileInput } from 'lib/directory/repository';
 import { logDirectoryAudit } from 'lib/directory/audit';
+import { reportError } from 'lib/observability/report';
 import type { DirectoryProfileInput } from 'lib/directory/types';
 
 type AdminProfileBody = Partial<DirectoryProfileInput>;
@@ -33,7 +34,8 @@ export async function GET(request: Request) {
   try {
     const payload = await listAdminProfiles(pagination, includeInactive);
     return NextResponse.json(payload, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'list_admin_profiles', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to list admin profiles.' },
       { status: 503 },
@@ -88,6 +90,10 @@ export async function POST(request: Request) {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown';
     const isValidation = message.includes('_not_found');
+
+    if (!isValidation) {
+      reportError(error, { area: 'directory', op: 'create_admin_profile', extra: { userId: gate.auth.userId } });
+    }
 
     logDirectoryAudit({
       actorId: gate.auth.userId,

--- a/ctf/packages/web/app/api/directory/admin/skills/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/skills/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireDirectoryAdminAccess } from '../../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { listTaxonomyJobTitles, listTaxonomySectors, listTaxonomySkills } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireDirectoryAdminAccess();
@@ -29,7 +30,8 @@ export async function GET() {
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'list_skills_compatibility', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch skills compatibility.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/announcements/route.ts
+++ b/ctf/packages/web/app/api/directory/announcements/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireDirectoryReadAccess } from '../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { listDirectoryAnnouncements } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireDirectoryReadAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const items = await listDirectoryAnnouncements(true);
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'list_announcements', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch announcements.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/job-titles/route.ts
+++ b/ctf/packages/web/app/api/directory/job-titles/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireDirectoryReadAccess } from '../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { listTaxonomyJobTitles } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: Request) {
   const gate = await requireDirectoryReadAccess();
@@ -14,7 +15,8 @@ export async function GET(request: Request) {
   try {
     const items = await listTaxonomyJobTitles(sectorId);
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'list_job_titles', extra: { userId: gate.auth.userId, sectorId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch job titles.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/directory/skills/route.ts
+++ b/ctf/packages/web/app/api/directory/skills/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireDirectoryReadAccess } from '../_lib';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
 import { listTaxonomySkills } from 'lib/directory/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: Request) {
   const gate = await requireDirectoryReadAccess();
@@ -14,7 +15,8 @@ export async function GET(request: Request) {
   try {
     const items = await listTaxonomySkills(jobTitleId);
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'directory', op: 'list_skills', extra: { userId: gate.auth.userId, jobTitleId } });
     return NextResponse.json(
       { ok: false, code: DIRECTORY_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch skills.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/admin/announcements/[announcementId]/archive/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/announcements/[announcementId]/archive/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { archiveAnnouncement } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ announcementId: string }>;
@@ -39,6 +40,10 @@ export async function POST(request: Request, { params }: RouteParams) {
     const message = error instanceof Error ? error.message : 'error';
     const status = message === 'announcement_not_found' ? 404 : 503;
     const code = message === 'announcement_not_found' ? FEED_ERROR_CODE.notFound : FEED_ERROR_CODE.persistenceUnavailable;
+
+    if (message !== 'announcement_not_found') {
+      reportError(error, { area: 'feed', op: 'archive_announcement', extra: { userId: gate.auth.userId, announcementId } });
+    }
 
     return NextResponse.json(
       { ok: false, code, message: 'Unable to archive announcement.' },

--- a/ctf/packages/web/app/api/feed/admin/announcements/[announcementId]/publish/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/announcements/[announcementId]/publish/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { publishAnnouncement } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ announcementId: string }>;
@@ -39,6 +40,10 @@ export async function POST(request: Request, { params }: RouteParams) {
     const message = error instanceof Error ? error.message : 'error';
     const status = message === 'announcement_not_found' ? 404 : 503;
     const code = message === 'announcement_not_found' ? FEED_ERROR_CODE.notFound : FEED_ERROR_CODE.persistenceUnavailable;
+
+    if (message !== 'announcement_not_found') {
+      reportError(error, { area: 'feed', op: 'publish_announcement', extra: { userId: gate.auth.userId, announcementId } });
+    }
 
     return NextResponse.json(
       { ok: false, code, message: 'Unable to publish announcement.' },

--- a/ctf/packages/web/app/api/feed/admin/announcements/[announcementId]/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/announcements/[announcementId]/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { updateAnnouncementDraft, validateAnnouncementDraftInput } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 import type { AnnouncementDraftInput } from 'lib/feed/types';
 
 type RouteParams = {
@@ -72,6 +73,10 @@ export async function PUT(request: Request, { params }: RouteParams) {
     const message = error instanceof Error ? error.message : 'error';
     const status = message === 'announcement_not_found' ? 404 : 503;
     const code = message === 'announcement_not_found' ? FEED_ERROR_CODE.notFound : FEED_ERROR_CODE.persistenceUnavailable;
+
+    if (message !== 'announcement_not_found') {
+      reportError(error, { area: 'feed', op: 'update_announcement_draft', extra: { userId: gate.auth.userId, announcementId } });
+    }
 
     return NextResponse.json(
       { ok: false, code, message: 'Unable to update announcement draft.' },

--- a/ctf/packages/web/app/api/feed/admin/announcements/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/announcements/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { createAnnouncementDraft, listAnnouncements, validateAnnouncementDraftInput } from 'lib/feed/repository';
 import { logFeedAudit } from 'lib/feed/audit';
+import { reportError } from 'lib/observability/report';
 import type { AnnouncementDraftInput } from 'lib/feed/types';
 
 type AnnouncementBody = Partial<AnnouncementDraftInput>;
@@ -28,7 +29,8 @@ export async function GET() {
   try {
     const announcements = await listAnnouncements(true);
     return NextResponse.json({ items: announcements }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'list_announcements', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to list announcements.' },
       { status: 503 },
@@ -79,7 +81,8 @@ export async function POST(request: Request) {
       errorCategory: null,
     });
     return NextResponse.json({ ok: true, announcement }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'create_announcement_draft', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create announcement draft.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/admin/config/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/config/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../_lib';
 import { FEED_ALLOWED_CHANNELS, FEED_ERROR_CODE } from 'lib/feed/constants';
 import { getFeedConfig, updateFeedConfig, validateFeedConfigInput } from 'lib/feed/repository';
 import { logFeedAudit } from 'lib/feed/audit';
+import { reportError } from 'lib/observability/report';
 import type { FeedConfigInput } from 'lib/feed/types';
 
 type ConfigBody = Partial<FeedConfigInput>;
@@ -29,7 +30,8 @@ export async function GET() {
   try {
     const config = await getFeedConfig();
     return NextResponse.json({ config }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'get_admin_feed_config', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch feed config.' },
       { status: 503 },
@@ -84,7 +86,8 @@ export async function PUT(request: Request) {
     });
 
     return NextResponse.json({ ok: true, config }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'update_feed_config', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to update feed config.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/admin/questions/[questionId]/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/questions/[questionId]/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedAdminAccess } from '../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { relabelQuestionCategory, isValidFeedQuestionCategory } from 'lib/feed/repository';
 import { logFeedAudit } from 'lib/feed/audit';
+import { reportError } from 'lib/observability/report';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ questionId: string }> }) {
   const gate = await requireFeedAdminAccess();
@@ -63,6 +64,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ qu
         { status: 404 },
       );
     }
+    reportError(error, { area: 'feed', op: 'relabel_question_category', extra: { userId: gate.auth.userId, questionId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to relabel question.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/admin/questions/export/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/questions/export/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireFeedAdminAccess } from '../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { exportQuestionsForRasa } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 import type { FeedQuestionCategory } from 'lib/feed/types';
 
 function escapeRasaExample(text: string): string {
@@ -62,7 +63,8 @@ export async function GET(request: Request) {
         'X-Total-Questions': String(totalQuestions),
       },
     });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'export_questions', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to export questions.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/admin/questions/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/questions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireFeedAdminAccess } from '../../_lib';
 import { FEED_ERROR_CODE, FEED_DEFAULT_PAGE, FEED_DEFAULT_PAGE_SIZE, FEED_MAX_PAGE_SIZE, FEED_QUESTION_CATEGORIES } from 'lib/feed/constants';
 import { listAdminQuestions, isValidFeedQuestionCategory } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 import type { FeedQuestionCategory } from 'lib/feed/types';
 
 export async function GET(request: Request) {
@@ -39,7 +40,8 @@ export async function GET(request: Request) {
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'list_admin_questions', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to list questions.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/answers/[answerId]/rate/route.ts
+++ b/ctf/packages/web/app/api/feed/answers/[answerId]/rate/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedReadAccess } from '../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { isValidAnswerRating, rateFeedAnswer } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RateBody = {
   rating?: string;
@@ -70,6 +71,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
+    reportError(error, { area: 'feed', op: 'rate_answer', extra: { userId: gate.auth.userId, answerId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to rate answer.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/community/posts/[postId]/reply/route.ts
+++ b/ctf/packages/web/app/api/feed/community/posts/[postId]/reply/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedReadAccess } from '../../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { replyToFeedCommunityPost, validateFeedCommunityReplyBody } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type ReplyBody = {
   body?: string;
@@ -86,6 +87,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
+    reportError(error, { area: 'feed', op: 'community_post_reply', extra: { userId: gate.auth.userId, postId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create community reply.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/community/posts/route.ts
+++ b/ctf/packages/web/app/api/feed/community/posts/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedReadAccess } from '../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { createFeedCommunityPost, validateFeedCommunityPostInput } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 import type { FeedCommunityPostInput } from 'lib/feed/types';
 
 type CommunityBody = Partial<FeedCommunityPostInput>;
@@ -74,6 +75,7 @@ export async function POST(request: Request) {
       );
     }
 
+    reportError(error, { area: 'feed', op: 'community_post_create', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create community post.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/config/route.ts
+++ b/ctf/packages/web/app/api/feed/config/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireFeedReadAccess } from '../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { getFeedConfig } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireFeedReadAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const config = await getFeedConfig();
     return NextResponse.json({ config }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'get_feed_config', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to load feed config.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/items/[itemId]/dismiss/route.ts
+++ b/ctf/packages/web/app/api/feed/items/[itemId]/dismiss/route.ts
@@ -3,6 +3,7 @@ import { requireFeedReadAccess, ensureMutationCsrf } from '../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { dismissFeedItem } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{
@@ -49,7 +50,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, itemId }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'dismiss_item', extra: { userId: gate.auth.userId, itemId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to dismiss feed item.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/items/[itemId]/read/route.ts
+++ b/ctf/packages/web/app/api/feed/items/[itemId]/read/route.ts
@@ -3,6 +3,7 @@ import { requireFeedReadAccess, ensureMutationCsrf } from '../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { markFeedItemRead } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{
@@ -38,7 +39,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, itemId }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'read_item', extra: { userId: gate.auth.userId, itemId } });
     logFeedAudit({
       actorId: gate.auth.userId,
       pluginId: 'feed',

--- a/ctf/packages/web/app/api/feed/items/route.ts
+++ b/ctf/packages/web/app/api/feed/items/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireFeedReadAccess } from '../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { isValidFeedChannel, listFeedTimeline, parsePaginationParams } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: Request) {
   const gate = await requireFeedReadAccess();
@@ -30,7 +31,8 @@ export async function GET(request: Request) {
     );
 
     return NextResponse.json(payload, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'list_feed_timeline', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch feed timeline.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/membership/events/route.ts
+++ b/ctf/packages/web/app/api/feed/membership/events/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFeedAdminAccess } from '../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { emitMembershipEvent } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 import type { MembershipEventType } from 'lib/feed/types';
 
 type MembershipBody = {
@@ -64,7 +65,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, streamEmitted: result.streamEmitted }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'emit_membership_event', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to emit membership event.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/questions/[questionId]/answer/route.ts
+++ b/ctf/packages/web/app/api/feed/questions/[questionId]/answer/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedReadAccess } from '../../../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { generateFeedQuestionAnswer } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 
 
 
@@ -66,6 +67,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ que
       );
     }
 
+    reportError(error, { area: 'feed', op: 'answer_question', extra: { userId: gate.auth.userId, questionId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.llmUnavailable, message: 'Unable to generate an assisted answer right now.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/questions/route.ts
+++ b/ctf/packages/web/app/api/feed/questions/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireFeedReadAccess } from '../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
 import { logFeedAudit } from 'lib/feed/audit';
 import { createFeedQuestion, validateFeedQuestionInput } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
 import type { FeedQuestionInput } from 'lib/feed/types';
 
 type QuestionBody = Partial<FeedQuestionInput>;
@@ -83,6 +84,7 @@ export async function POST(request: Request) {
       );
     }
 
+    reportError(error, { area: 'feed', op: 'submit_question', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to submit question.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/feed/stream/route.ts
+++ b/ctf/packages/web/app/api/feed/stream/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getFeedStreamCredentials } from 'lib/feed/stream';
 import { requireFeedReadAccess } from '../_lib';
 import { buildIdentityDisplayName } from 'lib/auth/request-identity';
+import { reportError } from 'lib/observability/report';
 
 export async function POST() {
   const gate = await requireFeedReadAccess();
@@ -18,7 +19,8 @@ export async function POST() {
       return NextResponse.json({ ok: false, message: 'Stream service is not configured.' }, { status: 503 });
     }
     return NextResponse.json({ ok: true, ...credentials }, { status: 200 });
-  } catch (e) {
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'stream_credentials', extra: { userId: gate.auth.userId } });
     return NextResponse.json({ ok: false, message: 'Unable to fetch Stream credentials.' }, { status: 500 });
   }
 }

--- a/ctf/packages/web/app/api/foundation/admin/audit-events/route.ts
+++ b/ctf/packages/web/app/api/foundation/admin/audit-events/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireFoundationAdminAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { listFoundationAuditEvents } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireFoundationAdminAccess();
@@ -14,6 +15,7 @@ export async function GET(request: NextRequest) {
     const events = await listFoundationAuditEvents(limit);
     return NextResponse.json({ ok: true, items: events }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'admin_audit_events_list', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Audit events list failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Audit event listing unavailable.' },

--- a/ctf/packages/web/app/api/foundation/admin/capacity-policy/route.ts
+++ b/ctf/packages/web/app/api/foundation/admin/capacity-policy/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationAdminAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { getCapacityPolicy, insertFoundationAudit, updateCapacityPolicy } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireFoundationAdminAccess();
@@ -13,6 +14,7 @@ export async function GET() {
     const policy = await getCapacityPolicy();
     return NextResponse.json({ ok: true, policy }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'admin_capacity_policy_read', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Capacity policy read failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Capacity policy unavailable.' },
@@ -99,6 +101,7 @@ export async function PUT(request: Request) {
 
     return NextResponse.json({ ok: true, policy }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'admin_capacity_policy_update', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Capacity policy update failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Capacity policy update unavailable.' },

--- a/ctf/packages/web/app/api/foundation/admin/rate-limits/evaluate/route.ts
+++ b/ctf/packages/web/app/api/foundation/admin/rate-limits/evaluate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationAdminAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { evaluateRateLimitCommand, insertFoundationAudit } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -51,6 +52,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, ...evaluation }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'admin_rate_limit_evaluate', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Rate-limit evaluation failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Rate-limit evaluation unavailable.' },

--- a/ctf/packages/web/app/api/foundation/connections/history/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/history/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { insertFoundationAudit, listConnectionHistory } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireFoundationReadAccess();
@@ -40,6 +41,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ ok: true, ...history }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'connection_history_list', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Connection history list failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Connection history unavailable.' },

--- a/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/calls/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/calls/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_CALL_MODALITIES, FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { createCallSession, insertFoundationAudit } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request, context: { params: Promise<{ threadId: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -72,6 +73,7 @@ export async function POST(request: Request, context: { params: Promise<{ thread
       );
     }
 
+    reportError(error, { area: 'foundation', op: 'connection_call_session_create', extra: { userId: gate.auth.userId, threadId } });
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Call session unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/messages/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/messages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { insertFoundationAudit, sendMessageToThread } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request, context: { params: Promise<{ threadId: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -74,6 +75,7 @@ export async function POST(request: Request, context: { params: Promise<{ thread
       );
     }
 
+    reportError(error, { area: 'foundation', op: 'connection_message_send', extra: { userId: gate.auth.userId, threadId } });
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Message send unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/foundation/connections/threads/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/threads/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { createConnectionThread, insertFoundationAudit } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -84,6 +85,7 @@ export async function POST(request: Request) {
       );
     }
 
+    reportError(error, { area: 'foundation', op: 'connection_thread_create', extra: { userId: gate.auth.userId, providerId } });
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Thread create unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/foundation/notifications/[notificationEventId]/ack/route.ts
+++ b/ctf/packages/web/app/api/foundation/notifications/[notificationEventId]/ack/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { ackNotificationEvent, insertFoundationAudit } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request, context: { params: Promise<{ notificationEventId: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -47,6 +48,7 @@ export async function POST(request: Request, context: { params: Promise<{ notifi
 
     return NextResponse.json({ ok: true, notification: updated }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'notification_event_ack', extra: { userId: gate.auth.userId, notificationEventId } });
     console.error('[Foundation] Notification ack failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Notification ack unavailable.' },

--- a/ctf/packages/web/app/api/foundation/notifications/preferences/route.ts
+++ b/ctf/packages/web/app/api/foundation/notifications/preferences/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { insertFoundationAudit, upsertNotificationPreferences } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function PUT(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -52,6 +53,7 @@ export async function PUT(request: Request) {
 
     return NextResponse.json({ ok: true, ...preferences }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'notification_preferences_update', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Notification preferences update failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Notification preferences unavailable.' },

--- a/ctf/packages/web/app/api/foundation/notifications/route.ts
+++ b/ctf/packages/web/app/api/foundation/notifications/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { listNotificationEvents } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireFoundationReadAccess();
@@ -14,6 +15,7 @@ export async function GET(request: NextRequest) {
     const notifications = await listNotificationEvents(gate.auth.userId, unreadOnly);
     return NextResponse.json({ ok: true, items: notifications }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'notifications_list', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Notifications list failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Notifications unavailable.' },

--- a/ctf/packages/web/app/api/foundation/providers/search/route.ts
+++ b/ctf/packages/web/app/api/foundation/providers/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { insertFoundationAudit, searchProviders } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireFoundationReadAccess();
@@ -29,6 +30,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ ok: true, ...providers }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'provider_search', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Provider search failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Provider search unavailable.' },

--- a/ctf/packages/web/app/api/foundation/quotes/[quoteRequestId]/state/route.ts
+++ b/ctf/packages/web/app/api/foundation/quotes/[quoteRequestId]/state/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE, FOUNDATION_QUOTE_STATES } from 'lib/foundation/constants';
 import { insertFoundationAudit, updateQuoteRequestState } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 import type { FoundationQuoteState } from 'lib/foundation/types';
 
 export async function POST(request: Request, context: { params: Promise<{ quoteRequestId: string }> }) {
@@ -79,6 +80,7 @@ export async function POST(request: Request, context: { params: Promise<{ quoteR
       );
     }
 
+    reportError(error, { area: 'foundation', op: 'quote_request_state_update', extra: { userId: gate.auth.userId, quoteRequestId } });
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Quote transition unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/foundation/quotes/history/route.ts
+++ b/ctf/packages/web/app/api/foundation/quotes/history/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { insertFoundationAudit, listQuoteHistory } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 import type { FoundationQuoteState } from 'lib/foundation/types';
 
 export async function GET(request: NextRequest) {
@@ -40,6 +41,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ ok: true, ...history }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'quote_request_history_list', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Quote history list failed:', error);
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Quote history unavailable.' },

--- a/ctf/packages/web/app/api/foundation/quotes/route.ts
+++ b/ctf/packages/web/app/api/foundation/quotes/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireFoundationReadAccess } from 'lib/foundation/_lib';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { createQuoteRequest, insertFoundationAudit } from 'lib/foundation/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -77,6 +78,7 @@ export async function POST(request: Request) {
       );
     }
 
+    reportError(error, { area: 'foundation', op: 'quote_request_create', extra: { userId: gate.auth.userId, threadId } });
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Quote create unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/foundation/service-credits/route.ts
+++ b/ctf/packages/web/app/api/foundation/service-credits/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireFoundationReadAccess, ensureMutationCsrf } from '../_lib';
 import { createTransfer } from 'lib/service-credits/repository';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
+import { reportError } from 'lib/observability/report';
 
 type FoundationServiceCreditsSendInput = {
   toUserId: string;
@@ -49,6 +50,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, transaction: tx }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'foundation', op: 'service_credits_transfer_send', extra: { userId: gate.auth.userId } });
     console.error('[Foundation] Service credits transfer failed:', error);
     return NextResponse.json({ ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Unable to send service credits.' }, { status: 503 });
   }

--- a/ctf/packages/web/app/api/hub/bots/route.ts
+++ b/ctf/packages/web/app/api/hub/bots/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { HubBotsResponse } from 'lib/hub/types';
+import { reportError } from 'lib/observability/report';
 import { requireHubAccess } from '../_lib';
 
 export async function GET() {
@@ -18,7 +19,8 @@ export async function GET() {
     };
 
     return NextResponse.json(response, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'hub', op: 'list_bots', extra: { userId: gate.identity.userId } });
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/hub/channels/route.ts
+++ b/ctf/packages/web/app/api/hub/channels/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { HubChannelsResponse } from 'lib/hub/types';
+import { reportError } from 'lib/observability/report';
 import { requireHubAccess } from '../_lib';
 
 export async function GET() {
@@ -25,7 +26,8 @@ export async function GET() {
     };
 
     return NextResponse.json(response, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'hub', op: 'list_channels', extra: { userId: gate.identity.userId } });
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/hub/dms/route.ts
+++ b/ctf/packages/web/app/api/hub/dms/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { HubDMsResponse } from 'lib/hub/types';
+import { reportError } from 'lib/observability/report';
 import { requireHubAccess } from '../_lib';
 
 export async function GET() {
@@ -18,7 +19,8 @@ export async function GET() {
     };
 
     return NextResponse.json(response, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'hub', op: 'list_dms', extra: { userId: gate.identity.userId } });
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/hub/join/route.ts
+++ b/ctf/packages/web/app/api/hub/join/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { HubJoinResponse } from 'lib/hub/types';
+import { reportError } from 'lib/observability/report';
 import { requireHubAccess } from '../_lib';
 
 export async function POST() {
@@ -22,7 +23,8 @@ export async function POST() {
     };
 
     return NextResponse.json(response, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'hub', op: 'join', extra: { userId: gate.identity.userId } });
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/internal/product-update/route.ts
+++ b/ctf/packages/web/app/api/internal/product-update/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAnnouncementDraft, publishAnnouncement } from 'lib/feed/repository';
 import { logFeedAudit } from 'lib/feed/audit';
+import { reportError } from 'lib/observability/report';
 
 const CI_ACTOR_ID = 'ci-product-update';
 
@@ -45,8 +46,9 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json({ id: announcement.id, status: 'published' }, { status: 201 });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'unknown';
+  } catch (error) {
+    reportError(error, { area: 'internal', op: 'post_product_update_publish', extra: { actorId: CI_ACTOR_ID } });
+    const message = error instanceof Error ? error.message : 'unknown';
     return NextResponse.json({ error: 'Failed to publish', detail: message }, { status: 503 });
   }
 }

--- a/ctf/packages/web/app/api/internal/service-credits/accounts/[accountId]/deletion-reclaims/[deletionRequestId]/execute/route.ts
+++ b/ctf/packages/web/app/api/internal/service-credits/accounts/[accountId]/deletion-reclaims/[deletionRequestId]/execute/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { executeDeletionReclaim, insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 
 type ReclaimBody = {
   treasuryUserId?: string;
@@ -78,6 +79,9 @@ export async function POST(request: Request, context: ReclaimParams) {
 
     return NextResponse.json({ ok: true, reclaim }, { status: 200 });
   } catch (error) {
+    if (!(error instanceof Error && (error.message === 'insufficient_balance' || error.message === 'invalid_payload'))) {
+      reportError(error, { area: 'internal', op: 'post_deletion_reclaim_execute', extra: { accountId, deletionRequestId, requestId: body.requestId, traceId: body.traceId } });
+    }
     return serviceCreditsErrorResponse(error, 'Account deletion reclaim unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/admin/adjust-credits/route.ts
+++ b/ctf/packages/web/app/api/levelup/admin/adjust-credits/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { adminAdjustCredits, insertLevelupAudit } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupAdminAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 const adjustSchema = z.object({
   targetUserId: z.string().min(1),
@@ -55,6 +56,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, adjustment }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_admin_adjust_credits', extra: { userId: gate.auth.userId, targetUserId: parsed.data.targetUserId } });
     return levelupErrorResponse(error, 'Admin credit adjustment unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/cohorts/route.ts
+++ b/ctf/packages/web/app/api/levelup/cohorts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { createCohort, insertLevelupAudit, listCohorts } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupAdminAccess, requireLevelupReadAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 const querySchema = z.object({
   track: z.string().optional(),
@@ -120,6 +121,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, cohortId: created.cohortId }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_create_cohort', extra: { userId: gate.auth.userId } });
     return levelupErrorResponse(error, 'Create cohort unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/disputes/[disputeId]/resolve/route.ts
+++ b/ctf/packages/web/app/api/levelup/disputes/[disputeId]/resolve/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { insertLevelupAudit, resolveDispute } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupReadAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ disputeId: string }>;
@@ -75,6 +76,7 @@ export async function POST(request: Request, { params }: RouteProps) {
 
     return NextResponse.json({ ok: true, resolution }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_resolve_dispute', extra: { userId: gate.auth.userId, disputeId: resolvedParams.disputeId } });
     return levelupErrorResponse(error, 'Resolve dispute unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/disputes/route.ts
+++ b/ctf/packages/web/app/api/levelup/disputes/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { insertLevelupAudit, openDispute } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupReadAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 const disputeSchema = z.object({
   enrollmentId: z.string().uuid(),
@@ -53,6 +54,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, disputeId: dispute.disputeId }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_open_dispute', extra: { userId: gate.auth.userId, enrollmentId: parsed.data.enrollmentId } });
     return levelupErrorResponse(error, 'Open dispute unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/enroll/route.ts
+++ b/ctf/packages/web/app/api/levelup/enroll/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { enrollInCohort, insertLevelupAudit } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupReadAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 const enrollSchema = z.object({
   cohortId: z.string().uuid(),
@@ -55,6 +56,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, enrollment }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_enroll_cohort', extra: { userId: gate.auth.userId, cohortId: parsed.data.cohortId } });
     return levelupErrorResponse(error, 'Enrollment unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/milestones/[milestoneId]/release/route.ts
+++ b/ctf/packages/web/app/api/levelup/milestones/[milestoneId]/release/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { insertLevelupAudit, isTrainerForCohort, releaseMilestoneCredits } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupReadAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ milestoneId: string }>;
@@ -69,6 +70,7 @@ export async function POST(request: Request, { params }: RouteProps) {
 
     return NextResponse.json({ ok: true, release }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_milestone_release', extra: { userId: gate.auth.userId, milestoneId: resolvedParams.milestoneId, enrollmentId: parsed.data.enrollmentId } });
     return levelupErrorResponse(error, 'Milestone release unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/milestones/[milestoneId]/validate/route.ts
+++ b/ctf/packages/web/app/api/levelup/milestones/[milestoneId]/validate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { insertLevelupAudit, isTrainerForCohort, validateMilestone } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupReadAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ milestoneId: string }>;
@@ -68,6 +69,7 @@ export async function POST(request: Request, { params }: RouteProps) {
 
     return NextResponse.json({ ok: true, validation }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_milestone_validate', extra: { userId: gate.auth.userId, milestoneId: resolvedParams.milestoneId, enrollmentId: parsed.data.enrollmentId } });
     return levelupErrorResponse(error, 'Milestone validation unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/levelup/transfers/route.ts
+++ b/ctf/packages/web/app/api/levelup/transfers/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { insertLevelupAudit, transferCreditsForLevelup } from 'lib/levelup/repository';
 import { ensureMutationCsrf, levelupErrorResponse, requireLevelupReadAccess } from 'lib/levelup/_lib';
+import { reportError } from 'lib/observability/report';
 
 const transferSchema = z.object({
   recipientUserId: z.string().min(1),
@@ -51,6 +52,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, transfer }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'levelup', op: 'post_transfer_credits', extra: { userId: gate.auth.userId } });
     return levelupErrorResponse(error, 'Transfer unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/admin/announcements/[announcementId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/announcements/[announcementId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
+import { reportError } from 'lib/observability/report';
 import {
   deleteLighthouseAdminAnnouncement,
   insertLighthouseAudit,
@@ -69,7 +70,8 @@ export async function PUT(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, announcement }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_announcement_update', extra: { userId: gate.auth.userId, announcementId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin announcement update unavailable.' },
       { status: 503 },
@@ -102,7 +104,8 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, announcement }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_announcement_delete', extra: { userId: gate.auth.userId, announcementId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin announcement delete unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/announcements/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/announcements/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
+import { reportError } from 'lib/observability/report';
 import {
   createLighthouseAdminAnnouncement,
   insertLighthouseAudit,
@@ -31,7 +32,8 @@ export async function GET() {
   try {
     const items = await listLighthouseAdminAnnouncements();
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_announcement_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin announcement listing unavailable.' },
       { status: 503 },
@@ -80,7 +82,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, announcement }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_announcement_create', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin announcement create unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/audit-events/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/audit-events/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listLighthouseAuditEvents } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireLighthouseAdminAccess();
@@ -14,7 +15,8 @@ export async function GET(request: NextRequest) {
   try {
     const items = await listLighthouseAuditEvents(limit);
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_audit_event_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin audit event listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/hosts/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/hosts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listLighthouseProfiles } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireLighthouseAdminAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const items = await listLighthouseProfiles('host');
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_host_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Host listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/matches/[matchId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/matches/[matchId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { insertLighthouseAudit, updateMatch, validateMatchUpdateInput } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 import type { LighthouseMatchUpdateInput } from 'lib/lighthouse/types';
 
 type RouteParams = {
@@ -77,6 +78,7 @@ export async function PUT(request: Request, { params }: RouteParams) {
       );
     }
 
+    reportError(error, { area: 'lighthouse', op: 'admin_match_update', extra: { userId: gate.auth.userId, matchId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin match update unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/matches/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/matches/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listLighthouseMatchesAdmin } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireLighthouseAdminAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const items = await listLighthouseMatchesAdmin();
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_match_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin match listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/profiles/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/profiles/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listLighthouseProfiles } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireLighthouseAdminAccess();
@@ -20,7 +21,8 @@ export async function GET(request: NextRequest) {
   try {
     const items = await listLighthouseProfiles(rawType === 'seeker' || rawType === 'host' ? rawType : undefined);
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_profile_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Profile listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/properties/[propertyId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/properties/[propertyId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { insertLighthouseAudit, updateProperty, validatePropertyInput } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 import type { LighthousePropertyInput } from 'lib/lighthouse/types';
 
 type RouteParams = {
@@ -85,6 +86,7 @@ export async function PUT(request: Request, { params }: RouteParams) {
       );
     }
 
+    reportError(error, { area: 'lighthouse', op: 'admin_property_update', extra: { userId: gate.auth.userId, propertyId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin property update unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/properties/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/properties/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listLighthousePropertiesAdmin } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireLighthouseAdminAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const items = await listLighthousePropertiesAdmin();
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_property_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin property listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/seekers/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/seekers/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listLighthouseProfiles } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireLighthouseAdminAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const items = await listLighthouseProfiles('seeker');
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_seeker_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Seeker listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/admin/stats/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/stats/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireLighthouseAdminAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { getLighthouseAdminStats } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireLighthouseAdminAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const stats = await getLighthouseAdminStats();
     return NextResponse.json({ ok: true, stats }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'admin_stats', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Admin stats unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/announcements/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/announcements/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireLighthouseReadAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listAnnouncementsForLighthouseUser } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 function parsePositiveInt(value: string | null, fallback: number): number {
   const parsed = Number.parseInt(value ?? '', 10);
@@ -26,7 +27,8 @@ export async function GET(request: NextRequest) {
     });
 
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'announcement_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Announcement listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/blocks/[blockedUserId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/blocks/[blockedUserId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireLighthouseReadAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { insertLighthouseAudit, removeBlock } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ blockedUserId: string }>;
@@ -39,7 +40,8 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'block_delete', extra: { userId: gate.auth.userId, blockedUserId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Block remove unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/blocks/check/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/blocks/check/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireLighthouseReadAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { isBlockedPair } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireLighthouseReadAccess();
@@ -20,7 +21,8 @@ export async function GET(request: NextRequest) {
   try {
     const blocked = await isBlockedPair(gate.auth.userId, blockedUserId);
     return NextResponse.json({ ok: true, blocked }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'block_check', extra: { userId: gate.auth.userId, blockedUserId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Block check unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/blocks/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/blocks/route.ts
@@ -2,11 +2,32 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireLighthouseReadAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { createBlock, insertLighthouseAudit, listBlocks } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 type CreateBlockBody = {
   blockedUserId?: string;
   reason?: string;
 };
+
+// Error messages the repository throws to signal an expected client error (4xx/409),
+// handled by lighthouseErrorResponse. Anything else falls through to a 503 and is an
+// unexpected server failure worth reporting to Sentry.
+const LIGHTHOUSE_EXPECTED_ERROR_MESSAGES = new Set([
+  'profile_not_found',
+  'property_not_found',
+  'match_not_found',
+  'block_not_found',
+  'not_owner',
+  'policy_denied',
+  'blocked_pair',
+  'self_block',
+  'duplicate_match',
+  'invalid payload',
+]);
+
+function isUnexpectedLighthouseError(error: unknown): boolean {
+  return !(error instanceof Error && LIGHTHOUSE_EXPECTED_ERROR_MESSAGES.has(error.message));
+}
 
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
@@ -97,6 +118,9 @@ export async function GET() {
     const items = await listBlocks(gate.auth.userId);
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'block_list', extra: { userId: gate.auth.userId } });
+    }
     return lighthouseErrorResponse(error, 'Block listing unavailable.');
   }
 }
@@ -144,6 +168,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, block }, { status: 201 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'block_create', extra: { userId: gate.auth.userId, blockedUserId } });
+    }
     return lighthouseErrorResponse(error, 'Block create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/matches/[matchId]/chat/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/[matchId]/chat/route.ts
@@ -3,6 +3,7 @@ import { ensureLighthouseMatchChannel, createLighthouseParticipantToken } from '
 import { requireLighthouseReadAccess } from 'lib/lighthouse/_lib';
 import { listMatches } from 'lib/lighthouse/repository';
 import { buildIdentityDisplayName } from 'lib/auth/request-identity';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(_request: Request, { params }: { params: Promise<{ matchId: string }> }) {
   const { matchId } = await params;
@@ -43,7 +44,9 @@ export async function POST(_request: Request, { params }: { params: Promise<{ ma
       return NextResponse.json({ ok: false, message: 'Unable to create participant token' }, { status: 500 });
     }
     return NextResponse.json({ ok: true, channelId, ...credentials });
-  } catch (e: any) {
-    return NextResponse.json({ ok: false, message: e.message || 'Error creating chat channel' }, { status: 500 });
+  } catch (e) {
+    reportError(e, { area: 'lighthouse', op: 'match_chat_channel_create', extra: { userId, matchId } });
+    const message = e instanceof Error ? e.message : '';
+    return NextResponse.json({ ok: false, message: message || 'Error creating chat channel' }, { status: 500 });
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/matches/[matchId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/[matchId]/route.ts
@@ -3,12 +3,33 @@ import { ensureMutationCsrf, requireLighthouseReadAccess } from 'lib/lighthouse/
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { insertLighthouseAudit, updateMatch, validateMatchUpdateInput } from 'lib/lighthouse/repository';
 import type { LighthouseMatchUpdateInput } from 'lib/lighthouse/types';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ matchId: string }>;
 };
 
 type MatchBody = Partial<LighthouseMatchUpdateInput>;
+
+// Error messages the repository throws to signal an expected client error (4xx/409),
+// handled by lighthouseErrorResponse. Anything else falls through to a 503 and is an
+// unexpected server failure worth reporting to Sentry.
+const LIGHTHOUSE_EXPECTED_ERROR_MESSAGES = new Set([
+  'profile_not_found',
+  'property_not_found',
+  'match_not_found',
+  'block_not_found',
+  'not_owner',
+  'policy_denied',
+  'blocked_pair',
+  'self_block',
+  'duplicate_match',
+  'invalid payload',
+]);
+
+function isUnexpectedLighthouseError(error: unknown): boolean {
+  return !(error instanceof Error && LIGHTHOUSE_EXPECTED_ERROR_MESSAGES.has(error.message));
+}
 
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
@@ -147,6 +168,9 @@ export async function PUT(request: Request, { params }: RouteParams) {
 
     return NextResponse.json({ ok: true, match }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'match_update', extra: { userId: gate.auth.userId, matchId } });
+    }
     return lighthouseErrorResponse(error, 'Match update unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/matches/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/route.ts
@@ -8,8 +8,29 @@ import {
   validateMatchCreateInput,
 } from 'lib/lighthouse/repository';
 import type { LighthouseMatchCreateInput } from 'lib/lighthouse/types';
+import { reportError } from 'lib/observability/report';
 
 type MatchBody = Partial<LighthouseMatchCreateInput> & { idempotencyKey?: string };
+
+// Error messages the repository throws to signal an expected client error (4xx/409),
+// handled by lighthouseErrorResponse. Anything else falls through to a 503 and is an
+// unexpected server failure worth reporting to Sentry.
+const LIGHTHOUSE_EXPECTED_ERROR_MESSAGES = new Set([
+  'profile_not_found',
+  'property_not_found',
+  'match_not_found',
+  'block_not_found',
+  'not_owner',
+  'policy_denied',
+  'blocked_pair',
+  'self_block',
+  'duplicate_match',
+  'invalid payload',
+]);
+
+function isUnexpectedLighthouseError(error: unknown): boolean {
+  return !(error instanceof Error && LIGHTHOUSE_EXPECTED_ERROR_MESSAGES.has(error.message));
+}
 
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
@@ -100,6 +121,9 @@ export async function GET() {
     const items = await listMatches(gate.auth.userId);
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'match_list', extra: { userId: gate.auth.userId } });
+    }
     return lighthouseErrorResponse(error, 'Match listing unavailable.');
   }
 }
@@ -162,6 +186,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, ...created }, { status: 201 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'match_request_create', extra: { userId: gate.auth.userId, propertyId: input.propertyId } });
+    }
     return lighthouseErrorResponse(error, 'Match create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/my-properties/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/my-properties/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireLighthouseReadAccess } from 'lib/lighthouse/_lib';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 import { listMyProperties } from 'lib/lighthouse/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireLighthouseReadAccess();
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const items = await listMyProperties(gate.auth.userId);
     return NextResponse.json({ ok: true, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'my_property_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'My property listing unavailable.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/lighthouse/profile/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/profile/route.ts
@@ -9,8 +9,29 @@ import {
   validateProfileInput,
 } from 'lib/lighthouse/repository';
 import type { LighthouseProfileInput } from 'lib/lighthouse/types';
+import { reportError } from 'lib/observability/report';
 
 type ProfileBody = Partial<LighthouseProfileInput>;
+
+// Error messages the repository throws to signal an expected client error (4xx/409),
+// handled by lighthouseErrorResponse. Anything else falls through to a 503 and is an
+// unexpected server failure worth reporting to Sentry.
+const LIGHTHOUSE_EXPECTED_ERROR_MESSAGES = new Set([
+  'profile_not_found',
+  'property_not_found',
+  'match_not_found',
+  'block_not_found',
+  'not_owner',
+  'policy_denied',
+  'blocked_pair',
+  'self_block',
+  'duplicate_match',
+  'invalid payload',
+]);
+
+function isUnexpectedLighthouseError(error: unknown): boolean {
+  return !(error instanceof Error && LIGHTHOUSE_EXPECTED_ERROR_MESSAGES.has(error.message));
+}
 
 function parseProfileInput(body: ProfileBody): LighthouseProfileInput {
   return {
@@ -150,6 +171,9 @@ async function upsertProfileHandler(request: Request) {
 
     return NextResponse.json({ ok: true, profile }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'profile_upsert', extra: { userId: gate.auth.userId } });
+    }
     return lighthouseErrorResponse(error, 'Profile upsert unavailable.');
   }
 }
@@ -171,6 +195,9 @@ export async function GET() {
 
     return NextResponse.json({ ok: true, profile }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'profile_get', extra: { userId: gate.auth.userId } });
+    }
     return lighthouseErrorResponse(error, 'Profile lookup unavailable.');
   }
 }
@@ -207,6 +234,9 @@ export async function DELETE(request: Request) {
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'profile_delete', extra: { userId: gate.auth.userId } });
+    }
     return lighthouseErrorResponse(error, 'Profile delete unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/properties/[propertyId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/properties/[propertyId]/route.ts
@@ -9,12 +9,33 @@ import {
   validatePropertyInput,
 } from 'lib/lighthouse/repository';
 import type { LighthousePropertyInput } from 'lib/lighthouse/types';
+import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
   params: Promise<{ propertyId: string }>;
 };
 
 type PropertyBody = Partial<LighthousePropertyInput>;
+
+// Error messages the repository throws to signal an expected client error (4xx/409),
+// handled by lighthouseErrorResponse. Anything else falls through to a 503 and is an
+// unexpected server failure worth reporting to Sentry.
+const LIGHTHOUSE_EXPECTED_ERROR_MESSAGES = new Set([
+  'profile_not_found',
+  'property_not_found',
+  'match_not_found',
+  'block_not_found',
+  'not_owner',
+  'policy_denied',
+  'blocked_pair',
+  'self_block',
+  'duplicate_match',
+  'invalid payload',
+]);
+
+function isUnexpectedLighthouseError(error: unknown): boolean {
+  return !(error instanceof Error && LIGHTHOUSE_EXPECTED_ERROR_MESSAGES.has(error.message));
+}
 
 function parsePropertyInput(body: PropertyBody): LighthousePropertyInput {
   return {
@@ -135,6 +156,9 @@ export async function GET(_: Request, { params }: RouteParams) {
 
     return NextResponse.json({ ok: true, property }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'property_get', extra: { userId: gate.auth.userId, propertyId } });
+    }
     return lighthouseErrorResponse(error, 'Property lookup unavailable.');
   }
 }
@@ -183,6 +207,9 @@ export async function PUT(request: Request, { params }: RouteParams) {
 
     return NextResponse.json({ ok: true, property }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'property_update', extra: { userId: gate.auth.userId, propertyId } });
+    }
     return lighthouseErrorResponse(error, 'Property update unavailable.');
   }
 }
@@ -220,6 +247,9 @@ export async function DELETE(request: Request, { params }: RouteParams) {
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'property_delete', extra: { userId: gate.auth.userId, propertyId } });
+    }
     return lighthouseErrorResponse(error, 'Property delete unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/properties/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/properties/route.ts
@@ -8,8 +8,29 @@ import {
   validatePropertyInput,
 } from 'lib/lighthouse/repository';
 import type { LighthousePropertyInput } from 'lib/lighthouse/types';
+import { reportError } from 'lib/observability/report';
 
 type PropertyBody = Partial<LighthousePropertyInput>;
+
+// Error messages the repository throws to signal an expected client error (4xx/409),
+// handled by lighthouseErrorResponse. Anything else falls through to a 503 and is an
+// unexpected server failure worth reporting to Sentry.
+const LIGHTHOUSE_EXPECTED_ERROR_MESSAGES = new Set([
+  'profile_not_found',
+  'property_not_found',
+  'match_not_found',
+  'block_not_found',
+  'not_owner',
+  'policy_denied',
+  'blocked_pair',
+  'self_block',
+  'duplicate_match',
+  'invalid payload',
+]);
+
+function isUnexpectedLighthouseError(error: unknown): boolean {
+  return !(error instanceof Error && LIGHTHOUSE_EXPECTED_ERROR_MESSAGES.has(error.message));
+}
 
 function parsePositiveInt(value: string | null, fallback: number): number {
   const parsed = Number.parseInt(value ?? '', 10);
@@ -141,6 +162,9 @@ export async function GET(request: NextRequest) {
     const result = await listProperties({ page, pageSize, country, city, onlyActive });
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'property_list', extra: { userId: gate.auth.userId } });
+    }
     return lighthouseErrorResponse(error, 'Property listing unavailable.');
   }
 }
@@ -187,6 +211,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, property }, { status: 201 });
   } catch (error) {
+    if (isUnexpectedLighthouseError(error)) {
+      reportError(error, { area: 'lighthouse', op: 'property_create', extra: { userId: gate.auth.userId } });
+    }
     return lighthouseErrorResponse(error, 'Property create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/service-credits/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/service-credits/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireLighthouseReadAccess, ensureMutationCsrf } from 'lib/lighthouse/_lib';
 import { createTransfer } from 'lib/service-credits/repository';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
+import { reportError } from 'lib/observability/report';
 
 type LighthouseServiceCreditsSendInput = {
   toUserId: string;
@@ -48,7 +49,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, transaction: tx }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'lighthouse', op: 'service_credits_send', extra: { userId: gate.auth.userId } });
     return NextResponse.json({ ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: 'Unable to send service credits.' }, { status: 503 });
   }
 }

--- a/ctf/packages/web/app/api/mood/eligibility/route.ts
+++ b/ctf/packages/web/app/api/mood/eligibility/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireMoodAccess, moodErrorResponse } from 'lib/mood/_lib';
 import { getMoodEligibility } from 'lib/mood/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: NextRequest) {
   const gate = await requireMoodAccess();
@@ -17,6 +18,9 @@ export async function GET(request: NextRequest) {
     const eligibility = await getMoodEligibility({ clientId });
     return NextResponse.json({ ok: true, ...eligibility }, { status: 200 });
   } catch (error) {
+    if (!(error instanceof Error && error.message === 'eligibility_not_found')) {
+      reportError(error, { area: 'mood', op: 'get_eligibility', extra: { userId: gate.auth.userId, clientId } });
+    }
     return moodErrorResponse(error, 'Mood eligibility unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/mood/submissions/route.ts
+++ b/ctf/packages/web/app/api/mood/submissions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createMoodSubmission } from 'lib/mood/repository';
 import { ensureMutationCsrf, moodErrorResponse, requireMoodAccess } from 'lib/mood/_lib';
+import { reportError } from 'lib/observability/report';
 
 type SubmissionBody = {
   clientId?: string;
@@ -40,6 +41,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, submission }, { status: 201 });
   } catch (error) {
+    if (!(error instanceof Error && error.message === 'eligibility_not_found')) {
+      reportError(error, { area: 'mood', op: 'post_submission', extra: { userId: gate.auth.userId, clientId: body.clientId } });
+    }
     return moodErrorResponse(error, 'Mood submission unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/peer-programming/admin/assignments/run/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/admin/assignments/run/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, peerProgrammingErrorResponse, requirePeerProgrammingAdminAccess } from 'lib/peer-programming/_lib';
 import { insertPeerProgrammingAudit, runWeeklyAssignment } from 'lib/peer-programming/repository';
 import { getActiveUserIdsLastDays } from 'lib/engagement/login-activity';
+import { reportError } from 'lib/observability/report';
 
 type AssignmentBody = {
   activeUserIds?: string[];
@@ -46,6 +47,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
+    if ((error instanceof Error ? error.message : '') !== 'assignment_not_found') {
+      reportError(error, {
+        area: 'peer-programming',
+        op: 'run_weekly_assignment',
+        extra: { userId: gate.auth.userId },
+      });
+    }
     return peerProgrammingErrorResponse(error, 'Weekly cohort assignment unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/peer-programming/admin/topics/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/admin/topics/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ensureMutationCsrf, peerProgrammingErrorResponse, requirePeerProgrammingAdminAccess } from 'lib/peer-programming/_lib';
 import { getPublishedWeeklyTopic, insertPeerProgrammingAudit, upsertWeeklyTopic } from 'lib/peer-programming/repository';
+import { reportError } from 'lib/observability/report';
 
 type TopicBody = {
   weekStartDate?: string;
@@ -20,6 +21,13 @@ export async function GET() {
     const topic = await getPublishedWeeklyTopic();
     return NextResponse.json({ ok: true, topic }, { status: 200 });
   } catch (error) {
+    if ((error instanceof Error ? error.message : '') !== 'assignment_not_found') {
+      reportError(error, {
+        area: 'peer-programming',
+        op: 'get_published_topic',
+        extra: { userId: gate.auth.userId },
+      });
+    }
     return peerProgrammingErrorResponse(error, 'Topic retrieval unavailable.');
   }
 }
@@ -68,6 +76,13 @@ export async function PUT(request: NextRequest) {
 
     return NextResponse.json({ ok: true, topic }, { status: 200 });
   } catch (error) {
+    if ((error instanceof Error ? error.message : '') !== 'assignment_not_found') {
+      reportError(error, {
+        area: 'peer-programming',
+        op: 'upsert_topic',
+        extra: { userId: gate.auth.userId },
+      });
+    }
     return peerProgrammingErrorResponse(error, 'Topic upsert unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/peer-programming/feedback/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/feedback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, peerProgrammingErrorResponse, requirePeerProgrammingReadAccess } from 'lib/peer-programming/_lib';
 import { insertPeerProgrammingAudit, submitFeedback } from 'lib/peer-programming/repository';
+import { reportError } from 'lib/observability/report';
 
 type FeedbackBody = {
   cohortId?: string | null;
@@ -53,6 +54,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (error) {
+    if ((error instanceof Error ? error.message : '') !== 'assignment_not_found') {
+      reportError(error, {
+        area: 'peer-programming',
+        op: 'submit_feedback',
+        extra: { userId: gate.auth.userId },
+      });
+    }
     return peerProgrammingErrorResponse(error, 'Feedback submission unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/peer-programming/messages/[messageId]/replies/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/messages/[messageId]/replies/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createMessage, insertPeerProgrammingAudit } from 'lib/peer-programming/repository';
 import { ensureMutationCsrf, peerProgrammingErrorResponse, requirePeerProgrammingReadAccess } from 'lib/peer-programming/_lib';
+import { reportError } from 'lib/observability/report';
 
 type ReplyBody = {
   cohortId?: string;
@@ -54,6 +55,13 @@ export async function POST(request: Request, context: { params: Promise<{ messag
 
     return NextResponse.json({ ok: true, reply }, { status: 201 });
   } catch (error) {
+    if ((error instanceof Error ? error.message : '') !== 'assignment_not_found') {
+      reportError(error, {
+        area: 'peer-programming',
+        op: 'create_reply',
+        extra: { userId: gate.auth.userId, messageId },
+      });
+    }
     return peerProgrammingErrorResponse(error, 'Reply creation unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/peer-programming/messages/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/messages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, peerProgrammingErrorResponse, requirePeerProgrammingReadAccess } from 'lib/peer-programming/_lib';
 import { createMessage, insertPeerProgrammingAudit } from 'lib/peer-programming/repository';
 import type { PeerProgrammingTier } from 'lib/peer-programming/types';
+import { reportError } from 'lib/observability/report';
 
 type CreateMessageBody = {
   cohortId?: string;
@@ -50,6 +51,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, message }, { status: 201 });
   } catch (error) {
+    if ((error instanceof Error ? error.message : '') !== 'assignment_not_found') {
+      reportError(error, {
+        area: 'peer-programming',
+        op: 'create_message',
+        extra: { userId: gate.auth.userId },
+      });
+    }
     return peerProgrammingErrorResponse(error, 'Message creation unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/peer-programming/room/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/room/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requirePeerProgrammingReadAccess, peerProgrammingErrorResponse } from 'lib/peer-programming/_lib';
 import { getMyCohort, getPublishedWeeklyTopic, listMessages } from 'lib/peer-programming/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requirePeerProgrammingReadAccess();
@@ -24,6 +25,13 @@ export async function GET() {
       fallbackOpen: cohort?.fallbackOpen ?? true,
     });
   } catch (error) {
+    if ((error instanceof Error ? error.message : '') !== 'assignment_not_found') {
+      reportError(error, {
+        area: 'peer-programming',
+        op: 'get_room',
+        extra: { userId: gate.auth.userId },
+      });
+    }
     return peerProgrammingErrorResponse(error, 'Peer programming room unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/plugins/route.ts
+++ b/ctf/packages/web/app/api/plugins/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
 import { listPluginRegistryWithSummary } from 'lib/plugins/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   try {
     const { plugins, summary } = await listPluginRegistryWithSummary();
     return NextResponse.json({ plugins, summary }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'plugins', op: 'get_plugin_registry' });
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/service-credits/admin/disputes/adjustments/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/disputes/adjustments/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { applyDisputeAdjustment, insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { ensureMutationCsrf, requireServiceCreditsAdminAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 
 type DisputeAdjustmentBody = {
   disputeCaseId?: string;
@@ -70,6 +71,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, adjustment }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_dispute_adjustment', extra: { userId: gate.auth.userId, disputeCaseId: body.disputeCaseId } });
     return serviceCreditsErrorResponse(error, 'Dispute adjustment unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/service-credits/admin/governance/burns/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/governance/burns/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireServiceCreditsAdminAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 import { burnCredits, insertServiceCreditsAudit } from 'lib/service-credits/repository';
 
 type BurnBody = {
@@ -57,6 +58,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, burn }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_governance_burn', extra: { userId: gate.auth.userId, targetUserId: body.targetUserId } });
     return serviceCreditsErrorResponse(error, 'Governance burn unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/service-credits/admin/governance/mint-grants/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/governance/mint-grants/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireServiceCreditsAdminAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 import { insertServiceCreditsAudit, mintGrant } from 'lib/service-credits/repository';
 
 type MintBody = {
@@ -57,6 +58,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, grant }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_governance_mint_grant', extra: { userId: gate.auth.userId, targetUserId: body.targetUserId } });
     return serviceCreditsErrorResponse(error, 'Governance mint grant unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/service-credits/admin/treasury/fees/collect/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/treasury/fees/collect/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { collectTreasuryFee, insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { ensureMutationCsrf, requireServiceCreditsAdminAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 
 type TreasuryFeeBody = {
   sourceUserId?: string;
@@ -71,6 +72,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, collection }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_treasury_fee_collect', extra: { userId: gate.auth.userId, sourceUserId: body.sourceUserId, treasuryUserId: body.treasuryUserId } });
     return serviceCreditsErrorResponse(error, 'Treasury fee collection unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/service-credits/escrows/[escrowId]/refund/route.ts
+++ b/ctf/packages/web/app/api/service-credits/escrows/[escrowId]/refund/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { insertServiceCreditsAudit, refundEscrow } from 'lib/service-credits/repository';
 import { ensureMutationCsrf, requireServiceCreditsReadAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 
 type EscrowParams = {
   params: Promise<{ escrowId: string }>;
@@ -60,6 +61,7 @@ export async function POST(request: Request, context: EscrowParams) {
 
     return NextResponse.json({ ok: true, refund }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_escrow_refund', extra: { userId: gate.auth.userId, escrowId } });
     return serviceCreditsErrorResponse(error, 'Escrow refund unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/service-credits/escrows/[escrowId]/release/route.ts
+++ b/ctf/packages/web/app/api/service-credits/escrows/[escrowId]/release/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { insertServiceCreditsAudit, releaseEscrow } from 'lib/service-credits/repository';
 import { ensureMutationCsrf, requireServiceCreditsReadAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 
 type EscrowParams = {
   params: Promise<{ escrowId: string }>;
@@ -62,6 +63,7 @@ export async function POST(request: Request, context: EscrowParams) {
 
     return NextResponse.json({ ok: true, release }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_escrow_release', extra: { userId: gate.auth.userId, escrowId } });
     return serviceCreditsErrorResponse(error, 'Escrow release unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/service-credits/escrows/route.ts
+++ b/ctf/packages/web/app/api/service-credits/escrows/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createEscrowHold, insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { ensureMutationCsrf, requireServiceCreditsReadAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 
 type EscrowHoldBody = {
   escrowId?: string;
@@ -65,6 +66,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, escrow }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_escrow_hold_create', extra: { userId: gate.auth.userId } });
     return serviceCreditsErrorResponse(error, 'Escrow hold unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/service-credits/transfers/route.ts
+++ b/ctf/packages/web/app/api/service-credits/transfers/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createTransfer, insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { ensureMutationCsrf, requireServiceCreditsReadAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
+import { reportError } from 'lib/observability/report';
 
 type TransferBody = {
   recipientUserId?: string;
@@ -59,6 +60,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, transfer }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'service-credits', op: 'post_transfer_create', extra: { userId: gate.auth.userId } });
     return serviceCreditsErrorResponse(error, 'Transfer unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/skills-hunt/achievements/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/achievements/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireSkillsHuntReadAccess } from '../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { listAchievements } from 'lib/skills-hunt/repository';
 
 export async function GET() {
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const achievements = await listAchievements(gate.auth.userId);
     return NextResponse.json({ achievements }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_achievements', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load achievements.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/audit-events/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/audit-events/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireSkillsHuntAdminAccess } from '../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { listSkillsHuntAuditEvents } from 'lib/skills-hunt/repository';
 
 export async function GET(request: Request) {
@@ -15,7 +16,8 @@ export async function GET(request: Request) {
   try {
     const events = await listSkillsHuntAuditEvents(limit);
     return NextResponse.json({ events }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_audit_events', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch audit events.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/feature-reward-card/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/feature-reward-card/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { insertSkillsHuntAudit, updateFeatureRewardCard, validateFeatureRewardCardInput } from 'lib/skills-hunt/repository';
 import type { SkillsHuntFeatureRewardCardInput } from 'lib/skills-hunt/types';
 
@@ -58,7 +59,8 @@ export async function PUT(request: Request) {
     });
 
     return NextResponse.json({ ok: true, card }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'update_feature_reward_card', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to update feature reward card.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/notifications/round-ending-soon/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/notifications/round-ending-soon/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../../_lib'
 import { withDbTransaction } from 'lib/db/postgres';
 import { notifyRoundsEndingSoon } from 'lib/skills-hunt/notifications';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 
 // Round-ending-24h notification cron entry point.
 // Idempotent: notifyRoundsEndingSoon checks per (user, round) for an existing
@@ -22,7 +23,8 @@ export async function POST(request: Request) {
   try {
     const result = await withDbTransaction((client) => notifyRoundsEndingSoon(client));
     return NextResponse.json({ ok: true, emitted: result.emitted }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'notify_rounds_ending_soon', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to run round-ending-soon notifications.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/reports/[reportId]/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/reports/[reportId]/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../../_lib'
 import { withDbTransaction } from 'lib/db/postgres';
 import { resolveReport, type ResolveReportInput } from 'lib/skills-hunt/moderation';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ reportId: string }> }) {
   const gate = await requireSkillsHuntAdminAccess();
@@ -61,7 +62,8 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ re
       );
     }
     return NextResponse.json({ ok: true, report }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'resolve_report', extra: { userId: gate.auth.userId, reportId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to resolve report.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/reports/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/reports/route.ts
@@ -3,6 +3,7 @@ import { requireSkillsHuntAdminAccess } from '../../_lib';
 import { withDbTransaction } from 'lib/db/postgres';
 import { listOpenReports } from 'lib/skills-hunt/moderation';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import type { SkillsHuntSubmissionReportStatus } from 'lib/skills-hunt/types';
 
 function parseStatus(value: string | null): SkillsHuntSubmissionReportStatus | null {
@@ -30,7 +31,8 @@ export async function GET(request: Request) {
   try {
     const items = await withDbTransaction((client) => listOpenReports(client, status));
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_reports', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load reports.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/missions/[missionId]/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/missions/[missionId]/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../../../..
 import { withDbTransaction } from 'lib/db/postgres';
 import { archiveMission, getMissionById, updateMission, type MissionUpdateInput } from 'lib/skills-hunt/missions';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 
 // All operations on a mission must scope by both roundId AND missionId so
 // callers from one round cannot read/write missions belonging to another
@@ -33,7 +34,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ rou
       );
     }
     return NextResponse.json({ mission }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'get_mission', extra: { userId: gate.auth.userId, roundId, missionId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load mission.' },
       { status: 503 },
@@ -80,7 +82,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ roun
       );
     }
     return NextResponse.json({ ok: true, mission }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'update_mission', extra: { userId: gate.auth.userId, roundId, missionId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to update mission.' },
       { status: 503 },
@@ -118,7 +121,8 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ r
       );
     }
     return NextResponse.json({ ok: true, mission }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'archive_mission', extra: { userId: gate.auth.userId, roundId, missionId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to archive mission.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/missions/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/missions/route.ts
@@ -8,6 +8,7 @@ import {
   type MissionCreateInput,
 } from 'lib/skills-hunt/missions';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ roundId: string }> }) {
   const gate = await requireSkillsHuntAdminAccess();
@@ -20,7 +21,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ rou
   try {
     const items = await withDbTransaction((client) => listMissionsForAdmin(client, roundId));
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_admin_missions', extra: { userId: gate.auth.userId, roundId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load missions.' },
       { status: 503 },
@@ -113,7 +115,8 @@ export async function POST(request: Request, { params }: { params: Promise<{ rou
   try {
     const mission = await withDbTransaction((client) => createMission(client, gate.auth.userId, input));
     return NextResponse.json({ ok: true, mission }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'create_mission', extra: { userId: gate.auth.userId, roundId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to create mission.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { insertSkillsHuntAudit, updateRound, validateRoundInput } from 'lib/skills-hunt/repository';
 import type { SkillsHuntRoundInput } from 'lib/skills-hunt/types';
 
@@ -67,7 +68,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ roun
     });
 
     return NextResponse.json({ ok: true, round }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'update_round', extra: { userId: gate.auth.userId, roundId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to update round.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/submissions/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/submissions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireSkillsHuntModeratorAccess } from '../../../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { listSubmissions, parsePaginationParams } from 'lib/skills-hunt/repository';
 
 export async function GET(request: Request, { params }: { params: Promise<{ roundId: string }> }) {
@@ -19,7 +20,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ roun
       isModeratorOrAdmin: true,
     });
     return NextResponse.json(result, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_admin_submissions', extra: { userId: gate.auth.userId, roundId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to list submissions.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { createRound, insertSkillsHuntAudit, listRounds, validateRoundInput } from 'lib/skills-hunt/repository';
 import type { SkillsHuntRoundInput } from 'lib/skills-hunt/types';
 
@@ -26,7 +27,8 @@ export async function GET() {
   try {
     const rounds = await listRounds(null);
     return NextResponse.json({ rounds }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_admin_rounds', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to list rounds.' },
       { status: 503 },
@@ -76,7 +78,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, round }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'create_round', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to create round.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/admin/submissions/[submissionId]/generate-directory-profile/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/submissions/[submissionId]/generate-directory-profile/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSkillsHuntModeratorAccess } from '../../../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { generateDirectoryProfileFromAcceptedSubmission, insertSkillsHuntAudit } from 'lib/skills-hunt/repository';
 
 type GenerateBody = {
@@ -70,6 +71,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ sub
       status = 404;
       code = SKILLS_HUNT_ERROR_CODE.submissionNotFound;
       responseMessage = 'Accepted submission not found.';
+    }
+
+    if (status >= 500) {
+      reportError(error, { area: 'skills-hunt', op: 'generate_directory_profile', extra: { userId: gate.auth.userId, submissionId } });
     }
 
     return NextResponse.json({ ok: false, code, message: responseMessage }, { status });

--- a/ctf/packages/web/app/api/skills-hunt/admin/submissions/[submissionId]/review/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/submissions/[submissionId]/review/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSkillsHuntModeratorAccess } from '../../../../_lib';
 import { logSkillsHuntAudit } from 'lib/skills-hunt/audit';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { insertSkillsHuntAudit, reviewSubmission, validateReviewInput } from 'lib/skills-hunt/repository';
 import type { SkillsHuntSubmissionReviewInput } from 'lib/skills-hunt/types';
 
@@ -76,6 +77,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ sub
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown';
     const isNotFound = message === 'skills_hunt_submission_not_found';
+
+    if (!isNotFound) {
+      reportError(error, { area: 'skills-hunt', op: 'review_submission', extra: { userId: gate.auth.userId, submissionId } });
+    }
 
     logSkillsHuntAudit({
       actorId: gate.auth.userId,

--- a/ctf/packages/web/app/api/skills-hunt/feature-reward-card/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/feature-reward-card/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireSkillsHuntReadAccess } from '../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { getFeatureRewardCard } from 'lib/skills-hunt/repository';
 
 export async function GET() {
@@ -19,7 +20,8 @@ export async function GET() {
     }
 
     return NextResponse.json({ card }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'get_feature_reward_card', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load feature reward card.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/notifications/[notificationId]/read/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/notifications/[notificationId]/read/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSkillsHuntReadAccess } from '../../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { markNotificationRead } from 'lib/skills-hunt/repository';
 
 export async function POST(request: Request, { params }: { params: Promise<{ notificationId: string }> }) {
@@ -26,7 +27,8 @@ export async function POST(request: Request, { params }: { params: Promise<{ not
     }
 
     return NextResponse.json({ ok: true, notification }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'mark_notification_read', extra: { userId: gate.auth.userId, notificationId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to acknowledge notification.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/notifications/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireSkillsHuntReadAccess } from '../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { listNotifications } from 'lib/skills-hunt/repository';
 
 export async function GET(request: Request) {
@@ -14,7 +15,8 @@ export async function GET(request: Request) {
   try {
     const notifications = await listNotifications(gate.auth.userId, unreadOnly);
     return NextResponse.json({ notifications }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_notifications', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load notifications.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/leaderboard/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/leaderboard/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireSkillsHuntReadAccess } from '../../../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { listAllTimeLeaderboard, listLeaderboard } from 'lib/skills-hunt/repository';
 import type { SkillsHuntLeaderboardMode } from 'lib/skills-hunt/types';
 
@@ -36,7 +37,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ roun
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'get_leaderboard', extra: { userId: gate.auth.userId, roundId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load leaderboard.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/missions/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/missions/route.ts
@@ -3,6 +3,7 @@ import { requireSkillsHuntReadAccess } from '../../../_lib';
 import { withDbTransaction } from 'lib/db/postgres';
 import { listMissionsForRoundWithProgress } from 'lib/skills-hunt/missions';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ roundId: string }> }) {
   const gate = await requireSkillsHuntReadAccess();
@@ -17,7 +18,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ rou
       listMissionsForRoundWithProgress(client, roundId, gate.auth.userId),
     );
     return NextResponse.json({ items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_round_missions', extra: { userId: gate.auth.userId, roundId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load missions.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/submissions/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/submissions/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireSkillsHuntReadAccess, requireSkillsHuntSubmi
 import { isReservedUsername } from 'lib/auth/username-policy';
 import { logSkillsHuntAudit } from 'lib/skills-hunt/audit';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { createSubmission, listSubmissions, validateSubmissionInput } from 'lib/skills-hunt/repository';
 import type { SkillsHuntSubmissionInput } from 'lib/skills-hunt/types';
 
@@ -40,7 +41,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ rou
       { userId: gate.auth.userId, isModeratorOrAdmin: false },
     );
     return NextResponse.json({ items: result.items, total: result.total }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_round_submissions', extra: { userId: gate.auth.userId, roundId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load submissions.' },
       { status: 503 },
@@ -141,6 +143,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ rou
       status = 400;
       code = SKILLS_HUNT_ERROR_CODE.urlValidationFailed;
       responseMessage = 'This Quora profile URL appears to be removed or unreachable. Please verify and try again.';
+    }
+
+    if (status >= 500) {
+      reportError(error, { area: 'skills-hunt', op: 'create_submission', extra: { userId: gate.auth.userId, roundId } });
     }
 
     logSkillsHuntAudit({

--- a/ctf/packages/web/app/api/skills-hunt/rounds/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/rounds/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireSkillsHuntReadAccess } from '../_lib';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import { listRounds } from 'lib/skills-hunt/repository';
 import type { SkillsHuntRoundStatus } from 'lib/skills-hunt/types';
 
@@ -27,7 +28,8 @@ export async function GET(request: Request) {
   try {
     const rounds = await listRounds(status);
     return NextResponse.json({ rounds }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'list_rounds', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load rounds.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-hunt/service-credits/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/service-credits/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireSkillsHuntReadAccess, ensureMutationCsrf } from '../_lib';
 import { createTransfer } from 'lib/service-credits/repository';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 import type { SkillsHuntServiceCreditsTransactionInput } from 'lib/skills-hunt/types';
 
 export async function POST(request: Request) {
@@ -42,7 +43,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, transaction: tx }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'send_service_credits', extra: { userId: gate.auth.userId } });
     return NextResponse.json({ ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to send service credits.' }, { status: 503 });
   }
 }

--- a/ctf/packages/web/app/api/skills-hunt/submissions/[submissionId]/report/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/submissions/[submissionId]/report/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireSkillsHuntReadAccess } from '../../../_lib';
 import { withDbTransaction } from 'lib/db/postgres';
 import { createReport, validateCreateReportInput, type CreateReportInput } from 'lib/skills-hunt/moderation';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request, { params }: { params: Promise<{ submissionId: string }> }) {
   const gate = await requireSkillsHuntReadAccess();
@@ -47,7 +48,8 @@ export async function POST(request: Request, { params }: { params: Promise<{ sub
       createReport(client, gate.auth.userId, gate.auth.username, input),
     );
     return NextResponse.json({ ok: true, report }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'create_report', extra: { userId: gate.auth.userId, submissionId } });
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to file report.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/dependency-impact/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/dependency-impact/route.ts
@@ -3,6 +3,7 @@ import { requireTaxonomyAdminAccess } from '../../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
 import { previewDependencyImpact, validateDependencyPreviewInput } from 'lib/skills-taxonomy/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET(request: Request) {
   const gate = await requireTaxonomyAdminAccess();
@@ -67,6 +68,12 @@ export async function GET(request: Request) {
         { status: 404 },
       );
     }
+
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_dependency_impact_preview',
+      extra: { userId: gate.auth.userId, targetType, targetId },
+    });
 
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to preview dependency impact.' },

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/flattened/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/flattened/route.ts
@@ -3,6 +3,7 @@ import { requireTaxonomyAdminAccess } from '../../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { getFlattened } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 function parseBooleanParam(url: string, name: string): boolean {
   return new URL(url).searchParams.get(name) === 'true';
@@ -36,7 +37,13 @@ export async function GET(request: Request) {
     });
 
     return NextResponse.json({ items, generatedAt: new Date().toISOString() }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_admin_flattened',
+      extra: { userId: gate.auth.userId },
+    });
+
     logSkillsTaxonomyAudit({
       pluginId: 'skills-taxonomy',
       command: 'skills-taxonomy.flattened.get',

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/hierarchy/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/hierarchy/route.ts
@@ -3,6 +3,7 @@ import { requireTaxonomyAdminAccess } from '../../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { getHierarchy } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 function parseIncludeInactive(url: string): boolean {
   return new URL(url).searchParams.get('includeInactive') !== 'false';
@@ -34,7 +35,13 @@ export async function GET(request: Request) {
     });
 
     return NextResponse.json({ items, generatedAt: new Date().toISOString() }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_admin_hierarchy',
+      extra: { userId: gate.auth.userId },
+    });
+
     logSkillsTaxonomyAudit({
       pluginId: 'skills-taxonomy',
       command: 'skills-taxonomy.hierarchy.get',

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/[id]/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/[id]/route.ts
@@ -9,6 +9,7 @@ import {
   validateJobTitleUpdateInput,
 } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 type JobTitleUpdateBody = {
   sectorId?: unknown;
@@ -39,7 +40,13 @@ export async function GET(_request: Request, context: { params: Promise<{ id: st
     }
 
     return NextResponse.json(jobTitle, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_job_title',
+      extra: { userId: gate.auth.userId, id },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to read job title.' },
       { status: 503 },
@@ -128,6 +135,12 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
       );
     }
 
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'update_job_title',
+      extra: { userId: gate.auth.userId, id },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update job title.' },
       { status: 503 },
@@ -209,6 +222,12 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
         { status: 409 },
       );
     }
+
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'delete_job_title',
+      extra: { userId: gate.auth.userId, id },
+    });
 
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete job title.' },

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireTaxonomyAdminAccess } from '../../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { createJobTitle, listJobTitles, validateJobTitleCreateInput } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 type JobTitleCreateBody = {
   sectorId?: unknown;
@@ -23,7 +24,13 @@ export async function GET(request: Request) {
   try {
     const jobTitles = await listJobTitles(parseIncludeInactive(request.url));
     return NextResponse.json({ items: jobTitles }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'list_job_titles',
+      extra: { userId: gate.auth.userId },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to list job titles.' },
       { status: 503 },
@@ -100,6 +107,12 @@ export async function POST(request: Request) {
         { status: 404 },
       );
     }
+
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'create_job_title',
+      extra: { userId: gate.auth.userId, sectorId: input.sectorId },
+    });
 
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to create job title.' },

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/sectors/[id]/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/sectors/[id]/route.ts
@@ -9,6 +9,7 @@ import {
   validateSectorUpdateInput,
 } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 type SectorUpdateBody = {
   name?: unknown;
@@ -39,7 +40,13 @@ export async function GET(_request: Request, context: { params: Promise<{ id: st
     }
 
     return NextResponse.json(sector, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_sector',
+      extra: { userId: gate.auth.userId, id },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to read sector.' },
       { status: 503 },
@@ -106,7 +113,13 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
     });
 
     return NextResponse.json({ ok: true, sector }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'update_sector',
+      extra: { userId: gate.auth.userId, id },
+    });
+
     logSkillsTaxonomyAudit({
       pluginId: 'skills-taxonomy',
       command: 'skills-taxonomy.sector.update',
@@ -199,6 +212,12 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
         { status: 409 },
       );
     }
+
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'delete_sector',
+      extra: { userId: gate.auth.userId, id },
+    });
 
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete sector.' },

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/sectors/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/sectors/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireTaxonomyAdminAccess } from '../../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { createSector, listSectors, validateSectorCreateInput } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 type SectorCreateBody = {
   name?: unknown;
@@ -23,7 +24,13 @@ export async function GET(request: Request) {
   try {
     const sectors = await listSectors(parseIncludeInactive(request.url));
     return NextResponse.json({ items: sectors }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'list_sectors',
+      extra: { userId: gate.auth.userId },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to list sectors.' },
       { status: 503 },
@@ -80,7 +87,13 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, sector }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'create_sector',
+      extra: { userId: gate.auth.userId },
+    });
+
     logSkillsTaxonomyAudit({
       pluginId: 'skills-taxonomy',
       command: 'skills-taxonomy.sector.create',

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/skills/[id]/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/skills/[id]/route.ts
@@ -9,6 +9,7 @@ import {
   validateSkillUpdateInput,
 } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 type SkillUpdateBody = {
   jobTitleId?: unknown;
@@ -40,7 +41,13 @@ export async function GET(_request: Request, context: { params: Promise<{ id: st
     }
 
     return NextResponse.json(skill, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_skill',
+      extra: { userId: gate.auth.userId, id },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to read skill.' },
       { status: 503 },
@@ -130,6 +137,12 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
       );
     }
 
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'update_skill',
+      extra: { userId: gate.auth.userId, id },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update skill.' },
       { status: 503 },
@@ -211,6 +224,12 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
         { status: 409 },
       );
     }
+
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'delete_skill',
+      extra: { userId: gate.auth.userId, id },
+    });
 
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete skill.' },

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/skills/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/skills/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireTaxonomyAdminAccess } from '../../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { createSkill, listSkills, validateSkillCreateInput } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 type SkillCreateBody = {
   jobTitleId?: unknown;
@@ -24,7 +25,13 @@ export async function GET(request: Request) {
   try {
     const skills = await listSkills(parseIncludeInactive(request.url));
     return NextResponse.json({ items: skills }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'list_skills',
+      extra: { userId: gate.auth.userId },
+    });
+
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to list skills.' },
       { status: 503 },
@@ -102,6 +109,12 @@ export async function POST(request: Request) {
         { status: 404 },
       );
     }
+
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'create_skill',
+      extra: { userId: gate.auth.userId, jobTitleId: input.jobTitleId },
+    });
 
     return NextResponse.json(
       { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to create skill.' },

--- a/ctf/packages/web/app/api/skills-taxonomy/flattened/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/flattened/route.ts
@@ -3,6 +3,7 @@ import { requireTaxonomyReadAccess } from '../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { getFlattened } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 function parseBooleanParam(url: string, name: string): boolean {
   return new URL(url).searchParams.get(name) === 'true';
@@ -41,7 +42,13 @@ export async function GET(request: Request) {
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_flattened',
+      extra: { userId: gate.auth.userId },
+    });
+
     logSkillsTaxonomyAudit({
       pluginId: 'skills-taxonomy',
       command: 'skills-taxonomy.flattened.get',

--- a/ctf/packages/web/app/api/skills-taxonomy/hierarchy/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/hierarchy/route.ts
@@ -3,6 +3,7 @@ import { requireTaxonomyReadAccess } from '../_lib';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { getHierarchy } from 'lib/skills-taxonomy/repository';
 import { logSkillsTaxonomyAudit } from 'lib/skills-taxonomy/audit';
+import { reportError } from 'lib/observability/report';
 
 function parseIncludeInactive(url: string): boolean {
   return new URL(url).searchParams.get('includeInactive') === 'true';
@@ -37,7 +38,13 @@ export async function GET(request: Request) {
       },
       { status: 200 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'skills-taxonomy',
+      op: 'get_hierarchy',
+      extra: { userId: gate.auth.userId },
+    });
+
     logSkillsTaxonomyAudit({
       pluginId: 'skills-taxonomy',
       command: 'skills-taxonomy.hierarchy.get',

--- a/ctf/packages/web/app/api/socketrelay/admin/announcements/[id]/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/admin/announcements/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { ensureMutationCsrf, requireSocketRelayAdminAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { deleteSocketRelayAdminAnnouncement, updateSocketRelayAdminAnnouncement, validateAnnouncementInput } from 'lib/socketrelay/repository';
 import type { SocketRelayAnnouncementInput } from 'lib/socketrelay/types';
@@ -62,6 +63,7 @@ export async function PUT(request: Request, { params }: RouteProps) {
     const announcement = await updateSocketRelayAdminAnnouncement(gate.auth.userId, id, input);
     return NextResponse.json({ ok: true, announcement }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'admin_announcement_update', extra: { userId: gate.auth.userId, id } });
     return socketRelayErrorResponse(error, 'Admin announcement update unavailable.');
   }
 }
@@ -82,6 +84,7 @@ export async function DELETE(request: Request, { params }: RouteProps) {
     const announcement = await deleteSocketRelayAdminAnnouncement(gate.auth.userId, id);
     return NextResponse.json({ ok: true, announcement }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'admin_announcement_delete', extra: { userId: gate.auth.userId, id } });
     return socketRelayErrorResponse(error, 'Admin announcement delete unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/admin/announcements/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/admin/announcements/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayAdminAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { createSocketRelayAdminAnnouncement, listSocketRelayAdminAnnouncements, validateAnnouncementInput } from 'lib/socketrelay/repository';
 import type { SocketRelayAnnouncementInput } from 'lib/socketrelay/types';
@@ -25,6 +26,7 @@ export async function GET() {
     const items = await listSocketRelayAdminAnnouncements();
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'admin_announcements_list', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Admin announcements unavailable.');
   }
 }
@@ -62,6 +64,7 @@ export async function POST(request: Request) {
     const announcement = await createSocketRelayAdminAnnouncement(gate.auth.userId, input);
     return NextResponse.json({ ok: true, announcement }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'admin_announcement_create', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Admin announcement create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/admin/fulfillments/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/admin/fulfillments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireSocketRelayAdminAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { listAdminFulfillments } from 'lib/socketrelay/repository';
 
 export async function GET() {
@@ -12,6 +13,7 @@ export async function GET() {
     const items = await listAdminFulfillments();
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'admin_fulfillments_list', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Admin fulfillments unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/admin/requests/[id]/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/admin/requests/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayAdminAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { adminDeleteRequest, insertSocketRelayAudit } from 'lib/socketrelay/repository';
 
 type RouteProps = {
@@ -31,6 +32,7 @@ export async function DELETE(request: Request, { params }: RouteProps) {
     });
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'admin_request_delete', extra: { userId: gate.auth.userId, id } });
     return socketRelayErrorResponse(error, 'Admin delete unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/admin/requests/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/admin/requests/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { parsePositiveInteger, requireSocketRelayAdminAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_DEFAULT_PAGE, SOCKETRELAY_DEFAULT_PAGE_SIZE } from 'lib/socketrelay/constants';
 import { listAdminRequests } from 'lib/socketrelay/repository';
 
@@ -16,6 +17,7 @@ export async function GET(request: Request) {
     const response = await listAdminRequests({ page, pageSize });
     return NextResponse.json({ ok: true, ...response }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'admin_requests_list', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Admin requests unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/announcements/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/announcements/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { parsePositiveInteger, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_DEFAULT_PAGE, SOCKETRELAY_DEFAULT_PAGE_SIZE } from 'lib/socketrelay/constants';
 import { listAnnouncementsForSocketRelayUser } from 'lib/socketrelay/repository';
 
@@ -23,6 +24,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json({ ok: true, ...response }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'announcements_list', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Announcements unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/chat/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { reportError } from 'lib/observability/report';
 import { ensureSocketRelayFulfillmentChannel, createSocketRelayParticipantToken } from 'lib/socketrelay/stream';
 import { requireSocketRelayReadAccess } from 'lib/socketrelay/_lib';
 import { getFulfillmentById } from 'lib/socketrelay/repository';
@@ -42,6 +43,7 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
     }
     return NextResponse.json({ ok: true, channelId, ...credentials });
   } catch (error: unknown) {
+    reportError(error, { area: 'socketrelay', op: 'fulfillment_chat_channel_create', extra: { userId, fulfillmentId: fulfillment.id } });
     const message = error instanceof Error ? error.message : 'Error creating chat channel';
     return NextResponse.json({ ok: false, message }, { status: 500 });
   }

--- a/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/close/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/close/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { closeFulfillment } from 'lib/socketrelay/repository';
 
 type RouteProps = {
@@ -30,6 +31,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     const item = await closeFulfillment(id, gate.auth.userId, gate.auth.isAdmin, reason);
     return NextResponse.json({ ok: true, item }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'fulfillment_close', extra: { userId: gate.auth.userId, fulfillmentId: id } });
     return socketRelayErrorResponse(error, 'Fulfillment close unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/messages/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/messages/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { listFulfillmentMessages, sendFulfillmentMessage, validateMessageInput } from 'lib/socketrelay/repository';
 
@@ -19,6 +20,7 @@ export async function GET(_: Request, { params }: RouteProps) {
     const items = await listFulfillmentMessages(id, gate.auth.userId, gate.auth.isAdmin);
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'fulfillment_messages_list', extra: { userId: gate.auth.userId, fulfillmentId: id } });
     return socketRelayErrorResponse(error, 'Fulfillment messages unavailable.');
   }
 }
@@ -62,6 +64,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     const item = await sendFulfillmentMessage(id, gate.auth.userId, gate.auth.isAdmin, messageText, clientMessageId);
     return NextResponse.json({ ok: true, item }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'fulfillment_message_send', extra: { userId: gate.auth.userId, fulfillmentId: id } });
     return socketRelayErrorResponse(error, 'Message send unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { getFulfillmentById } from 'lib/socketrelay/repository';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 
@@ -34,6 +35,7 @@ export async function GET(_: Request, { params }: RouteProps) {
 
     return NextResponse.json({ ok: true, item }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'fulfillment_get', extra: { userId: gate.auth.userId, fulfillmentId: id } });
     return socketRelayErrorResponse(error, 'Fulfillment lookup unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/my-fulfillments/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/my-fulfillments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { listMyFulfillments } from 'lib/socketrelay/repository';
 
 export async function GET() {
@@ -12,6 +13,7 @@ export async function GET() {
     const items = await listMyFulfillments(gate.auth.userId);
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'my_fulfillments_list', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'My fulfillments unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/my-requests/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/my-requests/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { parsePositiveInteger, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_DEFAULT_PAGE, SOCKETRELAY_DEFAULT_PAGE_SIZE } from 'lib/socketrelay/constants';
 import { listRequests } from 'lib/socketrelay/repository';
 
@@ -22,6 +23,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json({ ok: true, ...response }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'my_requests_list', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'My requests listing unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/profile/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/profile/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { deleteProfile, getProfile, insertSocketRelayAudit, upsertProfile, validateProfileInput } from 'lib/socketrelay/repository';
 import type { SocketRelayProfileInput } from 'lib/socketrelay/types';
@@ -57,6 +58,7 @@ async function upsertHandler(request: Request) {
 
     return NextResponse.json({ ok: true, profile }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'profile_upsert', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Profile upsert unavailable.');
   }
 }
@@ -78,6 +80,7 @@ export async function GET() {
 
     return NextResponse.json({ ok: true, profile }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'profile_get', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Profile lookup unavailable.');
   }
 }
@@ -113,6 +116,7 @@ export async function DELETE(request: Request) {
     });
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'profile_delete', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Profile delete unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/public/[id]/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/public/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { getPublicRequestById } from 'lib/socketrelay/repository';
 
@@ -21,6 +22,7 @@ export async function GET(_: Request, { params }: RouteProps) {
 
     return NextResponse.json({ ok: true, item }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'public_request_get', extra: { id } });
     return socketRelayErrorResponse(error, 'Public request lookup unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/public/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/public/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { parsePositiveInteger, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_DEFAULT_PAGE, SOCKETRELAY_DEFAULT_PAGE_SIZE } from 'lib/socketrelay/constants';
 import { listPublicRequests } from 'lib/socketrelay/repository';
 
@@ -11,6 +12,7 @@ export async function GET(request: Request) {
     const response = await listPublicRequests({ page, pageSize });
     return NextResponse.json({ ok: true, ...response }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'public_requests_list' });
     return socketRelayErrorResponse(error, 'Public requests unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/requests/[id]/fulfill/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/requests/[id]/fulfill/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { claimRequest } from 'lib/socketrelay/repository';
 
 type RouteProps = {
@@ -23,6 +24,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     const created = await claimRequest(id, gate.auth.userId);
     return NextResponse.json({ ok: true, ...created }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'request_fulfill_claim', extra: { userId: gate.auth.userId, requestId: id } });
     return socketRelayErrorResponse(error, 'Fulfillment claim unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/requests/[id]/repost/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/requests/[id]/repost/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { repostRequest } from 'lib/socketrelay/repository';
 
 type RouteProps = {
@@ -23,6 +24,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     const item = await repostRequest(id, gate.auth.userId, gate.auth.isAdmin);
     return NextResponse.json({ ok: true, item }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'request_repost', extra: { userId: gate.auth.userId, requestId: id } });
     return socketRelayErrorResponse(error, 'Request repost unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/requests/[id]/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/requests/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { getRequestById, updateRequest, validateRequestInput } from 'lib/socketrelay/repository';
 import type { SocketRelayRequestInput } from 'lib/socketrelay/types';
@@ -45,6 +46,7 @@ export async function GET(_: Request, { params }: RouteProps) {
 
     return NextResponse.json({ ok: true, item }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'request_get', extra: { userId: gate.auth.userId, requestId: id } });
     return socketRelayErrorResponse(error, 'Request lookup unavailable.');
   }
 }
@@ -84,6 +86,7 @@ export async function PUT(request: Request, { params }: RouteProps) {
     const item = await updateRequest(id, gate.auth.userId, gate.auth.isAdmin, input);
     return NextResponse.json({ ok: true, item }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'request_update', extra: { userId: gate.auth.userId, requestId: id } });
     return socketRelayErrorResponse(error, 'Request update unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/requests/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/requests/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, parsePositiveInteger, requireSocketRelayReadAccess, socketRelayErrorResponse } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { SOCKETRELAY_DEFAULT_PAGE, SOCKETRELAY_DEFAULT_PAGE_SIZE, SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { createRequest, listRequests, validateRequestInput } from 'lib/socketrelay/repository';
 import type { SocketRelayRequestInput } from 'lib/socketrelay/types';
@@ -27,6 +28,7 @@ export async function GET(request: Request) {
     const response = await listRequests({ page, pageSize });
     return NextResponse.json({ ok: true, ...response }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'requests_list', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Request listing unavailable.');
   }
 }
@@ -68,6 +70,7 @@ export async function POST(request: Request) {
     const item = await createRequest(gate.auth.userId, input, idempotencyKey);
     return NextResponse.json({ ok: true, item }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'request_create', extra: { userId: gate.auth.userId } });
     return socketRelayErrorResponse(error, 'Request create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/socketrelay/service-credits/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/service-credits/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireSocketRelayReadAccess, ensureMutationCsrf } from 'lib/socketrelay/_lib';
+import { reportError } from 'lib/observability/report';
 import { createTransfer } from 'lib/service-credits/repository';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 
@@ -48,7 +49,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, transaction: tx }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'socketrelay', op: 'service_credits_send', extra: { userId: gate.auth.userId } });
     return NextResponse.json({ ok: false, code: SOCKETRELAY_ERROR_CODE.persistenceUnavailable, message: 'Unable to send service credits.' }, { status: 503 });
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/admin/accounts/[userId]/restore/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/admin/accounts/[userId]/restore/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportAdminAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { insertTrustTransportAudit, restoreAccount } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ userId: string }>;
@@ -31,6 +32,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     });
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'admin_account_restore', extra: { userId: gate.auth.userId, targetUserId: userId } });
     return trustTransportErrorResponse(error, 'Account restore unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/admin/accounts/[userId]/restrict/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/admin/accounts/[userId]/restrict/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportAdminAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { insertTrustTransportAudit, restrictAccount } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ userId: string }>;
@@ -39,6 +40,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     });
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'admin_account_restrict', extra: { userId: gate.auth.userId, targetUserId: userId } });
     return trustTransportErrorResponse(error, 'Account restrict unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/admin/audit-events/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/admin/audit-events/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireTrustTransportAdminAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { listAuditEvents } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireTrustTransportAdminAccess();
@@ -12,6 +13,7 @@ export async function GET() {
     const items = await listAuditEvents();
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'admin_audit_events_list', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Audit events unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/admin/incidents/[incidentId]/resolve/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/admin/incidents/[incidentId]/resolve/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportAdminAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { insertTrustTransportAudit, resolveIncident } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ incidentId: string }>;
@@ -40,6 +41,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     });
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'admin_incident_resolve', extra: { userId: gate.auth.userId, incidentId } });
     return trustTransportErrorResponse(error, 'Incident resolve unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/admin/incidents/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/admin/incidents/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireTrustTransportAdminAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { listIncidents } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireTrustTransportAdminAccess();
@@ -12,6 +13,7 @@ export async function GET() {
     const items = await listIncidents();
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'admin_incidents_list', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Incident listing unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/admin/market-config/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/admin/market-config/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, requireTrustTransportAdminAccess, trustTransportErr
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { getMarketConfig, insertTrustTransportAudit, updateMarketConfig } from 'lib/trusttransport/repository';
 import type { TrustTransportMarketConfig } from 'lib/trusttransport/types';
+import { reportError } from 'lib/observability/report';
 
 function parseMarketConfig(body: Record<string, unknown>): TrustTransportMarketConfig {
   return {
@@ -22,6 +23,7 @@ export async function GET() {
     const config = await getMarketConfig();
     return NextResponse.json({ ok: true, config }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'admin_market_config_get', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Market config unavailable.');
   }
 }
@@ -62,6 +64,7 @@ export async function PUT(request: Request) {
     });
     return NextResponse.json({ ok: true, config }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'admin_market_config_update', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Market config update unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/offers/[offerId]/accept/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/offers/[offerId]/accept/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { acceptOffer } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ offerId: string }>;
@@ -46,6 +47,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     const result = await acceptOffer(requestId, offerId, gate.auth.userId, idempotencyKey);
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'offer_accept', extra: { userId: gate.auth.userId, offerId, requestId } });
     return trustTransportErrorResponse(error, 'Offer accept unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/orders/[orderId]/cancel/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/orders/[orderId]/cancel/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { cancelOrder } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ orderId: string }>;
@@ -30,6 +31,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     await cancelOrder(orderId, gate.auth.userId, gate.auth.isAdmin, reason);
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'order_cancel', extra: { userId: gate.auth.userId, orderId } });
     return trustTransportErrorResponse(error, 'Order cancel unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/orders/[orderId]/rating/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/orders/[orderId]/rating/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { submitOrderRating } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ orderId: string }>;
@@ -36,6 +37,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     await submitOrderRating(orderId, gate.auth.userId, gate.auth.isAdmin, { score, feedback });
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'order_rating_submit', extra: { userId: gate.auth.userId, orderId } });
     return trustTransportErrorResponse(error, 'Rating submit unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/payouts/requests/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/payouts/requests/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportProviderAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { requestPayout } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -33,6 +34,7 @@ export async function POST(request: Request) {
     const payout = await requestPayout(gate.auth.userId, amount, idempotencyKey);
     return NextResponse.json({ ok: true, payout }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'payout_request', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Payout request unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/payouts/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/payouts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireTrustTransportProviderAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { listMyPayouts } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function GET() {
   const gate = await requireTrustTransportProviderAccess();
@@ -12,6 +13,7 @@ export async function GET() {
     const items = await listMyPayouts(gate.auth.userId);
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'payouts_list', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Payout listing unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/requests/[requestId]/offers/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/requests/[requestId]/offers/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { getRequestById, listOffersForRequest } from 'lib/trusttransport/repository';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ requestId: string }>;
@@ -34,6 +35,7 @@ export async function GET(_: Request, { params }: RouteProps) {
     const items = await listOffersForRequest(requestId);
     return NextResponse.json({ ok: true, items }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'request_offers_list', extra: { userId: gate.auth.userId, requestId } });
     return trustTransportErrorResponse(error, 'Offer listing unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/requests/[requestId]/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/requests/[requestId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { getRequestById } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ requestId: string }>;
@@ -33,6 +34,7 @@ export async function GET(_: Request, { params }: RouteProps) {
 
     return NextResponse.json({ ok: true, item }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'request_lookup', extra: { userId: gate.auth.userId, requestId } });
     return trustTransportErrorResponse(error, 'Request lookup unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/requests/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/requests/route.ts
@@ -3,6 +3,7 @@ import { ensureMutationCsrf, parsePositiveInteger, requireTrustTransportReadAcce
 import { TRUSTTRANSPORT_DEFAULT_PAGE, TRUSTTRANSPORT_DEFAULT_PAGE_SIZE, TRUSTTRANSPORT_ERROR_CODE, TRUSTTRANSPORT_MODES } from 'lib/trusttransport/constants';
 import { createRequest, listRequests, validateRequestInput } from 'lib/trusttransport/repository';
 import type { TrustTransportMode, TrustTransportRequestInput } from 'lib/trusttransport/types';
+import { reportError } from 'lib/observability/report';
 
 function parseRequestInput(body: Record<string, unknown>): TrustTransportRequestInput {
   const modeValue = typeof body.mode === 'string' ? body.mode : 'ride';
@@ -34,6 +35,7 @@ export async function GET(request: Request) {
     const response = await listRequests({ page, pageSize, requesterUserId: gate.auth.userId });
     return NextResponse.json({ ok: true, ...response }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'requests_list', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Request listing unavailable.');
   }
 }
@@ -75,6 +77,7 @@ export async function POST(request: Request) {
     const item = await createRequest(gate.auth.userId, input, idempotencyKey);
     return NextResponse.json({ ok: true, item }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'request_create', extra: { userId: gate.auth.userId } });
     return trustTransportErrorResponse(error, 'Request create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/service-credits/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/service-credits/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireTrustTransportReadAccess, ensureMutationCsrf } from 'lib/trusttransport/_lib';
 import { createTransfer } from 'lib/service-credits/repository';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
+import { reportError } from 'lib/observability/report';
 
 type TrustTransportServiceCreditsSendInput = {
   toUserId: string;
@@ -48,7 +49,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, transaction: tx }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'service_credits_transfer', extra: { userId: gate.auth.userId } });
     return NextResponse.json({ ok: false, code: TRUSTTRANSPORT_ERROR_CODE.persistenceUnavailable, message: 'Unable to send service credits.' }, { status: 503 });
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/trips/[tripId]/chat/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/trips/[tripId]/chat/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureTrustTransportTripChannel, createTrustTransportParticipantToken } from 'lib/trusttransport/stream';
 import { requireTrustTransportReadAccess } from 'lib/trusttransport/_lib';
 import { getTripById } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 export async function POST(_request: Request, { params }: { params: Promise<{ tripId: string }> }) {
   const { tripId } = await params;
@@ -35,7 +36,9 @@ export async function POST(_request: Request, { params }: { params: Promise<{ tr
       return NextResponse.json({ ok: false, message: 'Unable to create participant token' }, { status: 500 });
     }
     return NextResponse.json({ ok: true, channelId, ...credentials });
-  } catch (e: any) {
-    return NextResponse.json({ ok: false, message: e.message || 'Error creating chat channel' }, { status: 500 });
+  } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'trip_chat_channel', extra: { userId, tripId } });
+    const message = error instanceof Error ? error.message : '';
+    return NextResponse.json({ ok: false, message: message || 'Error creating chat channel' }, { status: 500 });
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/trips/[tripId]/emergency-stop/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/trips/[tripId]/emergency-stop/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { triggerEmergencyStop } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ tripId: string }>;
@@ -30,6 +31,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     const result = await triggerEmergencyStop(tripId, gate.auth.userId, gate.auth.isAdmin, notes);
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'trip_emergency_stop', extra: { userId: gate.auth.userId, tripId } });
     return trustTransportErrorResponse(error, 'Emergency stop unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/trips/[tripId]/proof/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/trips/[tripId]/proof/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { captureTripProof } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
   params: Promise<{ tripId: string }>;
@@ -44,6 +45,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     await captureTripProof(tripId, gate.auth.userId, gate.auth.isAdmin, artifactType as 'photo' | 'code' | 'note', artifactRedacted);
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'trip_proof_capture', extra: { userId: gate.auth.userId, tripId } });
     return trustTransportErrorResponse(error, 'Trip proof capture unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/trusttransport/trips/[tripId]/status/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/trips/[tripId]/status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trusttransport/_lib';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { updateTripStatus } from 'lib/trusttransport/repository';
+import { reportError } from 'lib/observability/report';
 import type { TrustTransportTripStatus } from 'lib/trusttransport/types';
 
 type RouteProps = {
@@ -55,6 +56,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     const result = await updateTripStatus(tripId, gate.auth.userId, gate.auth.isAdmin, nextStatus as TrustTransportTripStatus, note);
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
+    reportError(error, { area: 'trusttransport', op: 'trip_status_update', extra: { userId: gate.auth.userId, tripId } });
     return trustTransportErrorResponse(error, 'Trip status update unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireUnlockAdminAccess, unlockErrorResponse } from 'lib/unlock/_lib';
+import { reportError } from 'lib/observability/report';
 import { getUnlockRuntimeConfig, insertUnlockAudit, markUnlockIncentiveGranted, reviewUnlockSubmission } from 'lib/unlock/repository';
 import { insertServiceCreditsAudit, mintGrant } from 'lib/service-credits/repository';
 import { grantUnleashFlagForUser } from 'lib/feature-flags/unleash-admin';
@@ -104,7 +105,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     }
 
     return NextResponse.json({ ok: true, submission });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'unlock', op: 'post_admin_submission_review', extra: { userId: gate.auth.userId, submissionId } });
     return unlockErrorResponse('Unlock submission review unavailable.', 503);
   }
 }

--- a/ctf/packages/web/app/api/unlock/admin/submissions/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireUnlockAdminAccess, unlockErrorResponse } from 'lib/unlock/_lib';
+import { reportError } from 'lib/observability/report';
 import { insertUnlockAudit, listUnlockSubmissions } from 'lib/unlock/repository';
 import type { UnlockAccessTier, UnlockReviewStatus } from 'lib/unlock/types';
 
@@ -45,7 +46,8 @@ export async function GET(request: Request) {
     });
 
     return NextResponse.json({ ok: true, submissions });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'unlock', op: 'get_admin_submissions', extra: { userId: gate.auth.userId } });
     return unlockErrorResponse('Unlock submission queue unavailable.', 503);
   }
 }

--- a/ctf/packages/web/app/api/unlock/status/route.ts
+++ b/ctf/packages/web/app/api/unlock/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireUnlockUserAccess } from 'lib/unlock/_lib';
+import { reportError } from 'lib/observability/report';
 import { getUnlockStatusForUser, insertUnlockAudit } from 'lib/unlock/repository';
 
 export async function GET() {
@@ -25,6 +26,7 @@ export async function GET() {
 
     return NextResponse.json({ ok: true, status });
   } catch (error) {
+    reportError(error, { area: 'unlock', op: 'get_status', extra: { userId: gate.auth.userId } });
     // Surface the real cause in server logs (a swallowed error here made the 503
     // undiagnosable). The client message stays generic so DB internals never leak.
     console.error('[unlock] status query failed', error);

--- a/ctf/packages/web/app/api/unlock/submission/route.ts
+++ b/ctf/packages/web/app/api/unlock/submission/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireUnlockUserAccess, unlockErrorResponse } from 'lib/unlock/_lib';
+import { reportError } from 'lib/observability/report';
 import { createOrUpdateUnlockSubmission, insertUnlockAudit } from 'lib/unlock/repository';
 
 type SubmissionBody = {
@@ -74,6 +75,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, submission }, { status: 201 });
   } catch (error) {
+    reportError(error, { area: 'unlock', op: 'post_submission', extra: { userId: gate.auth.userId } });
     // Surface the real cause in server logs (a swallowed error here made the 503
     // undiagnosable). The client message stays generic so DB internals never leak.
     console.error('[unlock] submission failed', error);

--- a/ctf/packages/web/app/api/weekly-performance/admin/week-selection/route.ts
+++ b/ctf/packages/web/app/api/weekly-performance/admin/week-selection/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWeeklyPerformanceAdminAccess } from 'lib/weekly-performance/_lib';
+import { reportError } from 'lib/observability/report';
 import { insertWeeklyPerformanceAudit, selectWeek } from 'lib/weekly-performance/repository';
 
 type SelectionBody = {
@@ -46,6 +47,7 @@ export async function PUT(request: Request) {
       return NextResponse.json({ ok: false, code: 'weekly_performance_week_not_found', message: 'Week not found.' }, { status: 404 });
     }
 
+    reportError(error, { area: 'weekly-performance', op: 'put_admin_week_select', extra: { userId: gate.auth.userId } });
     return NextResponse.json({ ok: false, code: 'weekly_performance_unavailable', message: 'Week selection unavailable.' }, { status: 503 });
   }
 }

--- a/ctf/packages/web/app/api/whatworks/problems/route.ts
+++ b/ctf/packages/web/app/api/whatworks/problems/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { listActiveProblems } from 'lib/whatworks/repository';
 import { requireWhatWorksAccess, whatworksError } from '../_lib';
+import { reportError } from 'lib/observability/report';
 
 // Active problems for the suggest form. Members may only attach a tool to an existing
 // problem; new problems are admin-curated to avoid duplicate categories.
@@ -21,7 +22,12 @@ export async function GET() {
         context: problem.context,
       })),
     });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'whatworks',
+      op: 'list_active_problems',
+      extra: { userId: gate.auth.userId },
+    });
     return whatworksError('Problems are unavailable right now.', 'whatworks_problems_unavailable', 500);
   }
 }

--- a/ctf/packages/web/app/api/whatworks/products/route.ts
+++ b/ctf/packages/web/app/api/whatworks/products/route.ts
@@ -16,6 +16,7 @@ import {
   requireWhatWorksAccess,
   whatworksError,
 } from '../_lib';
+import { reportError } from 'lib/observability/report';
 
 // A survivor suggests a tool. It lands as `pending` for admin review before it joins
 // the shared list, and the suggester is auto-recorded as its first verifier.
@@ -86,6 +87,11 @@ export async function POST(request: Request) {
     });
     return NextResponse.json({ ok: true, productId: product.id, status: product.status }, { status: 201 });
   } catch (error) {
+    reportError(error, {
+      area: 'whatworks',
+      op: 'suggest_product',
+      extra: { userId: gate.auth.userId, problemId },
+    });
     console.error('whatworks: failed to save product suggestion', error);
     return whatworksError('We could not save your suggestion. Try again.', 'whatworks_suggest_failed', 500);
   }

--- a/ctf/packages/web/app/api/whatworks/public/route.ts
+++ b/ctf/packages/web/app/api/whatworks/public/route.ts
@@ -5,6 +5,7 @@ import {
   PUBLIC_PREVIEW_PRODUCTS_PER_PROBLEM,
 } from 'lib/whatworks/constants';
 import { whatworksError } from '../_lib';
+import { reportError } from 'lib/observability/report';
 
 // Public, sign-in-free projection: the list is readable by anyone, but only a teaser
 // slice is returned and submitter identity is never exposed. Full browse is sign-in gated.
@@ -16,7 +17,11 @@ export async function GET() {
       products: problem.products.slice(0, PUBLIC_PREVIEW_PRODUCTS_PER_PROBLEM),
     }));
     return NextResponse.json({ ok: true, problems, stats: list.stats });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'whatworks',
+      op: 'get_public_preview',
+    });
     return whatworksError('What Works preview is unavailable right now.', 'whatworks_public_unavailable', 500);
   }
 }

--- a/ctf/packages/web/app/api/whatworks/route.ts
+++ b/ctf/packages/web/app/api/whatworks/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getReaderList } from 'lib/whatworks/repository';
 import { requireWhatWorksAccess, whatworksError } from './_lib';
+import { reportError } from 'lib/observability/report';
 
 // Full shared list for an authenticated survivor, with per-row endorsement state.
 export async function GET() {
@@ -11,7 +12,12 @@ export async function GET() {
   try {
     const list = await getReaderList(gate.auth.userId);
     return NextResponse.json({ ok: true, ...list, viewer: { isAdmin: gate.auth.isAdmin } });
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      area: 'whatworks',
+      op: 'get_reader_list',
+      extra: { userId: gate.auth.userId },
+    });
     return whatworksError('What Works is unavailable right now.', 'whatworks_unavailable', 500);
   }
 }

--- a/ctf/packages/web/app/api/workforce/admin/announcements/[id]/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/announcements/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { deactivateAnnouncement, insertWorkforceAdminAudit, updateAnnouncement, validateAnnouncementInput } from 'lib/workforce/repository';
 import type { WorkforceAnnouncementInput } from 'lib/workforce/types';
 
@@ -69,7 +70,8 @@ export async function PUT(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, announcement }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_announcement_update', extra: { userId: gate.auth.userId, id } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to update announcement.' },
       { status: 503 },
@@ -109,7 +111,8 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, id }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_announcement_deactivate', extra: { userId: gate.auth.userId, id } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to deactivate announcement.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/admin/announcements/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/announcements/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { createAnnouncement, insertWorkforceAdminAudit, listAnnouncements, validateAnnouncementInput } from 'lib/workforce/repository';
 import type { WorkforceAnnouncementInput } from 'lib/workforce/types';
 
@@ -24,7 +25,8 @@ export async function GET() {
   try {
     const announcements = await listAnnouncements(false);
     return NextResponse.json({ announcements }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_announcements_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch announcements.' },
       { status: 503 },
@@ -74,7 +76,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, announcement }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_announcement_create', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to create announcement.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/admin/audit-events/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/audit-events/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { listAdminAuditEvents, parsePaginationParams } from 'lib/workforce/repository';
 
 export async function GET(request: Request) {
@@ -13,7 +14,8 @@ export async function GET(request: Request) {
     const pagination = parsePaginationParams(request.url);
     const result = await listAdminAuditEvents(pagination);
     return NextResponse.json(result, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_audit_events_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch audit events.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/admin/config/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/config/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { insertWorkforceAdminAudit, getWorkforceConfig, updateWorkforceConfig, validateConfigInput } from 'lib/workforce/repository';
 import { logWorkforceAudit } from 'lib/workforce/audit';
 import type { WorkforceConfigInput } from 'lib/workforce/types';
@@ -25,7 +26,8 @@ export async function GET() {
   try {
     const config = await getWorkforceConfig();
     return NextResponse.json({ config }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_config_get', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch workforce config.' },
       { status: 503 },
@@ -87,7 +89,8 @@ export async function PUT(request: Request) {
     });
 
     return NextResponse.json({ ok: true, config }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_config_update', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to update config.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/admin/occupations/[id]/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/occupations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { deleteOccupation, insertWorkforceAdminAudit, updateOccupation, validateOccupationInput } from 'lib/workforce/repository';
 import type { WorkforceOccupationInput } from 'lib/workforce/types';
 
@@ -68,7 +69,8 @@ export async function PUT(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, occupation }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_occupation_update', extra: { userId: gate.auth.userId, id } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to update occupation.' },
       { status: 503 },
@@ -108,7 +110,8 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json({ ok: true, id }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_occupation_delete', extra: { userId: gate.auth.userId, id } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete occupation.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/admin/occupations/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/occupations/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { createOccupation, insertWorkforceAdminAudit, listOccupations, parsePaginationParams, validateOccupationInput } from 'lib/workforce/repository';
 import type { WorkforceOccupationInput } from 'lib/workforce/types';
 
@@ -24,7 +25,8 @@ export async function GET(request: Request) {
     const pagination = parsePaginationParams(request.url);
     const result = await listOccupations(pagination, true);
     return NextResponse.json(result, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_occupations_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch occupations.' },
       { status: 503 },
@@ -74,7 +76,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, occupation }, { status: 201 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_occupation_create', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to create occupation.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/admin/recompute/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/recompute/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { enqueueRecruitedRecompute } from 'lib/workforce/repository';
 
 export async function POST(request: Request) {
@@ -17,7 +18,8 @@ export async function POST(request: Request) {
   try {
     const result = await enqueueRecruitedRecompute(gate.auth.userId);
     return NextResponse.json({ ok: true, ...result }, { status: 202 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_recompute_enqueue', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to enqueue recompute.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/admin/sync/route.ts
+++ b/ctf/packages/web/app/api/workforce/admin/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { runIncrementalRecruitedSync } from 'lib/workforce/repository';
 
 type SyncBody = {
@@ -32,7 +33,8 @@ export async function POST(request: Request) {
     });
 
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'admin_sync_run', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to run incremental sync.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/announcements/route.ts
+++ b/ctf/packages/web/app/api/workforce/announcements/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { listAnnouncements } from 'lib/workforce/repository';
 
 export async function GET() {
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const announcements = await listAnnouncements(true);
     return NextResponse.json({ announcements }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'announcements_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch announcements.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/dashboard/route.ts
+++ b/ctf/packages/web/app/api/workforce/dashboard/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { getDashboard } from 'lib/workforce/repository';
 
 export async function GET() {
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const dashboard = await getDashboard();
     return NextResponse.json({ dashboard }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'dashboard_get', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to load dashboard.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/export/jobs/[jobId]/result/route.ts
+++ b/ctf/packages/web/app/api/workforce/export/jobs/[jobId]/result/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { getExportJobById } from 'lib/workforce/repository';
 
 type RouteParams = {
@@ -35,7 +36,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
       },
       { status: 501 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'export_job_result_get', extra: { userId: gate.auth.userId, jobId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch export result.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/export/jobs/[jobId]/route.ts
+++ b/ctf/packages/web/app/api/workforce/export/jobs/[jobId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { getExportJobById } from 'lib/workforce/repository';
 
 type RouteParams = {
@@ -27,7 +28,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     return NextResponse.json({ job }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'export_job_get', extra: { userId: gate.auth.userId, jobId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch export job.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/export/jobs/route.ts
+++ b/ctf/packages/web/app/api/workforce/export/jobs/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceAdminAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { createDeferredExportJob, insertWorkforceAdminAudit } from 'lib/workforce/repository';
 
 type ExportBody = {
@@ -52,7 +53,8 @@ export async function POST(request: Request) {
       },
       { status: 501 },
     );
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'export_job_create', extra: { userId: gate.auth.userId, exportType } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to create export job.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/internal/sync/route.ts
+++ b/ctf/packages/web/app/api/workforce/internal/sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { getObservabilityReporter } from 'lib/observability/provider';
 import { runIncrementalRecruitedSync } from 'lib/workforce/repository';
 
@@ -64,7 +65,8 @@ export async function POST(request: Request) {
       });
 
       return NextResponse.json({ ok: true, ...result }, { status: 200 });
-    } catch {
+    } catch (error) {
+      reportError(error, { area: 'workforce', op: 'internal_sync_run' });
       await reporter.captureCronCheckIn({
         monitorSlug: WORKFORCE_INCREMENTAL_SYNC_MONITOR_SLUG,
         status: 'error',
@@ -76,7 +78,8 @@ export async function POST(request: Request) {
         { status: 503 },
       );
     }
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'internal_sync_checkin' });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to run internal incremental sync.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/occupations/[id]/route.ts
+++ b/ctf/packages/web/app/api/workforce/occupations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { getOccupationById } from 'lib/workforce/repository';
 
 type RouteParams = {
@@ -27,7 +28,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     return NextResponse.json({ occupation }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'occupation_get', extra: { userId: gate.auth.userId, id } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch occupation.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/occupations/route.ts
+++ b/ctf/packages/web/app/api/workforce/occupations/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { listOccupations, parsePaginationParams } from 'lib/workforce/repository';
 
 export async function GET(request: Request) {
@@ -14,7 +15,8 @@ export async function GET(request: Request) {
     const includeInactive = new URL(request.url).searchParams.get('includeInactive') === 'true' && gate.auth.isAdmin;
     const result = await listOccupations(pagination, includeInactive);
     return NextResponse.json(result, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'occupations_list', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch occupations.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/profile/route.ts
+++ b/ctf/packages/web/app/api/workforce/profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureMutationCsrf, requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { logWorkforceAudit } from 'lib/workforce/audit';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { deleteOwnWorkforceProfile, getOwnProfile, upsertOwnProfile, validateProfileInput } from 'lib/workforce/repository';
 import type { WorkforceProfileInput } from 'lib/workforce/types';
 
@@ -26,7 +27,8 @@ export async function GET() {
   try {
     const profile = await getOwnProfile(gate.auth.userId);
     return NextResponse.json({ profile }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'profile_get', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch profile.' },
       { status: 503 },
@@ -93,6 +95,10 @@ async function handleUpsert(request: Request) {
       errorCategory: isOccupationNotFound ? 'validation' : 'persistence_error',
     });
 
+    if (!isOccupationNotFound) {
+      reportError(error, { area: 'workforce', op: 'profile_upsert', extra: { userId: gate.auth.userId } });
+    }
+
     return NextResponse.json(
       {
         ok: false,
@@ -138,7 +144,8 @@ export async function DELETE(request: Request) {
     });
 
     return NextResponse.json({ ok: true, scope: 'service', status: 'completed', requestedAtIso: deletion.requestedAtIso }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'profile_delete_service', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete workforce profile.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/reports/sector/[sector]/route.ts
+++ b/ctf/packages/web/app/api/workforce/reports/sector/[sector]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { fetchSectorReport } from 'lib/workforce/repository';
 
 
@@ -18,7 +19,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ sec
     const normalizedSector = sector.toLowerCase();
     const bucket = items.find((item) => item.bucket.toLowerCase() === normalizedSector) ?? null;
     return NextResponse.json({ bucket, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'report_sector_get', extra: { userId: gate.auth.userId, sector } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch sector report.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/reports/skill-level/[skillLevel]/route.ts
+++ b/ctf/packages/web/app/api/workforce/reports/skill-level/[skillLevel]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { fetchSkillLevelReport } from 'lib/workforce/repository';
 
 
@@ -17,7 +18,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ ski
     const items = await fetchSkillLevelReport();
     const bucket = items.find((item) => item.bucket === skillLevel.toLowerCase()) ?? null;
     return NextResponse.json({ bucket, items }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'report_skill_level_get', extra: { userId: gate.auth.userId, skillLevel } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch skill-level report.' },
       { status: 503 },

--- a/ctf/packages/web/app/api/workforce/reports/summary/route.ts
+++ b/ctf/packages/web/app/api/workforce/reports/summary/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
+import { reportError } from 'lib/observability/report';
 import { fetchSummaryReport } from 'lib/workforce/repository';
 
 export async function GET() {
@@ -12,7 +13,8 @@ export async function GET() {
   try {
     const summary = await fetchSummaryReport();
     return NextResponse.json({ summary }, { status: 200 });
-  } catch {
+  } catch (error) {
+    reportError(error, { area: 'workforce', op: 'report_summary_get', extra: { userId: gate.auth.userId } });
     return NextResponse.json(
       { ok: false, code: WORKFORCE_ERROR_CODE.persistenceUnavailable, message: 'Unable to fetch summary report.' },
       { status: 503 },


### PR DESCRIPTION
## What

Adds verbose server-side error reporting to Sentry across every remaining `ctf/packages/web/app/api/**/route.ts`.

API routes that catch their own errors return a friendly message and a generic 5xx, but the underlying cause never reaches Sentry — only unhandled exceptions do, via the Next.js `onRequestError` hook. That left every swallowed persistence/5xx failure invisible (the same blind spot that made the feed bug expensive to find).

## How

- Calls the shared reporter `lib/observability/report.ts` (`reportError(error, { area, op, extra })`) in the unexpected-failure catch block of each route, tagging with the plugin slug as `area` and a snake_case `op`.
- `extra` carries only non-sensitive context: `userId` and route ids. No tokens, secrets, transaction amounts, request bodies, or message text.
- Expected client errors (400/401/403/404/429) are left unreported. Catch blocks that branch validation → 4xx else → 5xx only report on the 5xx path.
- Friendly responses, status codes, and logic are unchanged.
- Routes already covered in #267 (hub/messages; chyme room/join/messages; directory sectors/list/profile) are untouched.
- Two pre-existing `catch (…: any)` chat routes were converted to the codebase-standard `unknown` + `instanceof Error` guard so the changed files stay lint-clean; the response strings are identical.

## Verification

- `pnpm exec tsc --noEmit` on the web package: clean (the root `pnpm run typecheck` fails only on a pre-existing TypeScript 6.0.3 `baseUrl` deprecation in `packages/shared`, unrelated to this change).
- `eslint` on all 217 changed route files: clean.
- `bash ctf/scripts/check-eof-format.sh`: passes.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLyoHNSJ6Eugw31dgUrvJD)_