### PR TITLE
ci: surface Formance backup/restore failure reason in the job log

### DIFF
--- a/.github/workflows/backup-formance-supabase.yml
+++ b/.github/workflows/backup-formance-supabase.yml
@@ -56,10 +56,14 @@ jobs:
         id: backup
         run: |
           set -e
-          node ctf/scripts/backupFormanceToSupabase.mjs 2> backup-error.log || {
-            echo "Backup script failed. See backup-error.log." >&2
+          # Capture stderr to a file AND print it to the console on failure, so
+          # the real reason shows up directly in the job log (not only in the
+          # uploaded artifact, which needs a separate download to read).
+          if ! node ctf/scripts/backupFormanceToSupabase.mjs 2> backup-error.log; then
+            echo "::error::Formance backup failed. Error output from the backup script:"
+            cat backup-error.log >&2
             exit 1
-          }
+          fi
 
       - name: Upload failure logs (if present)
         if: failure() && steps.backup.outcome == 'failure' && hashFiles('backup-error.log') != ''

--- a/.github/workflows/restore-formance-supabase.yml
+++ b/.github/workflows/restore-formance-supabase.yml
@@ -70,10 +70,14 @@ jobs:
         id: restore
         run: |
           set -e
-          node ctf/scripts/restoreFormanceFromSupabase.mjs 2> restore-error.log || {
-            echo "Restore script failed. See restore-error.log." >&2
+          # Capture stderr to a file AND print it to the console on failure, so
+          # the real reason shows up directly in the job log (not only in the
+          # uploaded artifact, which needs a separate download to read).
+          if ! node ctf/scripts/restoreFormanceFromSupabase.mjs 2> restore-error.log; then
+            echo "::error::Formance restore failed. Error output from the restore script:"
+            cat restore-error.log >&2
             exit 1
-          }
+          fi
 
       - name: Upload failure logs (if present)
         if: failure() && steps.restore.outcome == 'failure' && hashFiles('restore-error.log') != ''


### PR DESCRIPTION
## What this does

When the nightly "Backup Formance to Supabase" job failed, the run log showed only:

```
Backup script failed. See backup-error.log.
Error: Process completed with exit code 1
```

…and nothing about *why*. The script's error output was redirected into `backup-error.log` and only uploaded as an artifact, which has to be downloaded separately to read. On a phone (or anywhere) you just saw "failed, no reason."

This prints the captured error output straight to the job log on failure (with a `::error::` annotation), in both the backup and restore workflows, while still uploading the artifact. The real reason now appears inline in the run.

## Context — the backup itself is now working

The actual cause of the repeated failures was a missing / too-old `pg_dump` on the runner, fixed in #271 (install the PostgreSQL 17 client). I dispatched this branch's backup workflow against the live secrets to confirm: it succeeded — `pg_dump` ran, the dump uploaded to Supabase, and the script's upload verification passed (run 26804884979, all steps green, the failure-log upload step skipped because there was no failure).

This PR is the follow-up so that if a backup ever fails again, the reason is visible immediately instead of hidden.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_014bGppHioeqkgNYVuc1fqDy)_