### PR TITLE
fix: stack the AI consent modal buttons on phones

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1612,3 +1612,24 @@
   font-weight: 600;
   cursor: pointer;
 }
+
+/* ─── AI consent modal — small-screen action layout ──────────────────────── */
+/*
+ * On phones the two action buttons sat side by side, which left the long
+ * "I understand — turn it on" label cramped against the confirm button's edges.
+ * Stack them full-width instead so each button has even padding and room.
+ */
+@media (max-width: 767px) {
+  .comicConsentActions {
+    flex-direction: column;
+  }
+
+  .comicConsentConfirm {
+    flex: none;
+    width: 100%;
+  }
+
+  .comicConsentDismiss {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## What this fixes

You flagged the padding around the **"I understand — turn it on"** button on the AI Assistant consent modal. On a phone the modal's two actions sat side by side, so the long confirm label was cramped against the button edges next to "Not now."

Below 768px the two buttons now **stack full-width** with even padding (desktop keeps the side-by-side layout). One small CSS-module change; no markup or behavior change.

## Testing

- `pnpm build` compiles all routes ✅ · EOF check ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).
- Please confirm on your iPhone SE once deployed.

Parity Status: web+android complete

(Web-only CSS change. The Android app is native, so there is no deferred Android work.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_