### PR TITLE
feat: add phone layouts for TrustTransport, Foundation, and ClickLog

### DIFF
--- a/ctf/packages/web/components/clicklog/clicklog-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-shell.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import type { ClicklogIncident } from "../../lib/clicklog/types";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, BORDER, BRAND, SUBTLE, TEXT, deriveClicklogStats } from "./clicklog-shared";
 import { ClicklogIconRail } from "./clicklog-icon-rail";
 import { ClicklogSidebar } from "./clicklog-sidebar";
@@ -10,7 +12,7 @@ import { ClicklogLogPanel } from "./clicklog-log-panel";
 import { ClicklogIncidentList } from "./clicklog-incident-list";
 import { ClicklogEmptyState } from "./clicklog-empty-state";
 import { ClicklogLoading } from "./clicklog-loading";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, ChevronLeft } from "lucide-react";
 
 type Geo = { latitude?: number; longitude?: number };
 
@@ -23,6 +25,7 @@ export function ClicklogShell() {
   const [note, setNote] = useState("");
   const [geo, setGeo] = useState<Geo>({});
   const [logged, setLogged] = useState(false);
+  const isMobile = useIsMobile();
 
   async function fetchIncidents(initial = false): Promise<void> {
     if (initial) setLoading(true);
@@ -101,6 +104,53 @@ export function ClicklogShell() {
 
   const stats = deriveClicklogStats(incidents);
 
+  const content = (
+    <>
+      {error && (
+        <div style={{ marginBottom: 16, padding: "10px 14px", borderRadius: 10, background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)", color: "#fecaca", fontSize: 13 }}>
+          {error}
+        </div>
+      )}
+
+      <ClicklogLogPanel
+        logged={logged}
+        showForm={showForm}
+        note={note}
+        submitting={busy}
+        locationAdded={typeof geo.latitude === "number"}
+        onToggleForm={() => setShowForm((s) => !s)}
+        onNoteChange={setNote}
+        onAddLocation={addLocation}
+        onSubmit={() => void postIncident({ ...geo, notes: note })}
+        onCancel={() => { setShowForm(false); setNote(""); setGeo({}); }}
+      />
+
+      {incidents.length > 0 && (
+        <ClicklogIncidentList incidents={incidents} onDelete={(id) => void handleDelete(id)} />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: `1px solid ${BORDER}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}20`, border: `1px solid ${BRAND}40`, display: "flex", alignItems: "center", justifyContent: "center", color: BRAND, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <AlertTriangle size={18} color={BRAND} style={{ flexShrink: 0 }} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 15, fontWeight: 700, color: TEXT }}>Incident Log</div>
+              <div style={{ fontSize: 11, color: SUBTLE }}>{stats.total} incidents total</div>
+            </div>
+          </div>
+        </div>
+        <div style={{ padding: 16 }}>{content}</div>
+      </div>
+    );
+  }
+
   return (
     <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
       <ClicklogIconRail />
@@ -116,28 +166,7 @@ export function ClicklogShell() {
         </header>
 
         <div style={{ flex: 1, overflowY: "auto", padding: "32px 48px" }}>
-          {error && (
-            <div style={{ marginBottom: 16, padding: "10px 14px", borderRadius: 10, background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)", color: "#fecaca", fontSize: 13 }}>
-              {error}
-            </div>
-          )}
-
-          <ClicklogLogPanel
-            logged={logged}
-            showForm={showForm}
-            note={note}
-            submitting={busy}
-            locationAdded={typeof geo.latitude === "number"}
-            onToggleForm={() => setShowForm((s) => !s)}
-            onNoteChange={setNote}
-            onAddLocation={addLocation}
-            onSubmit={() => void postIncident({ ...geo, notes: note })}
-            onCancel={() => { setShowForm(false); setNote(""); setGeo({}); }}
-          />
-
-          {incidents.length > 0 && (
-            <ClicklogIncidentList incidents={incidents} onDelete={(id) => void handleDelete(id)} />
-          )}
+          {content}
         </div>
       </div>
 

--- a/ctf/packages/web/components/foundation/foundation-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-shell.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Hammer } from "lucide-react";
+import Link from "next/link";
+import { ChevronLeft, Hammer, Search } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { COLOR, FONT, type FoundationTab, type ProviderView, type QuoteView } from "./foundation-ui";
 import { IconRail, FilterSidebar, RightRail } from "./foundation-rails";
 import { BrowsePanel, QuotesPanel, ChatPanel } from "./foundation-panels";
@@ -30,6 +32,7 @@ export function FoundationShell() {
   const [submitting, setSubmitting] = useState(false);
   const [quoteError, setQuoteError] = useState<string | null>(null);
   const [quoteSuccess, setQuoteSuccess] = useState(false);
+  const isMobile = useIsMobile();
 
   // Trade filter has no client-side field to match on; it scopes the server search query.
   const searchTerm = [trade === "All Trades" ? "" : trade, query].filter(Boolean).join(" ").trim();
@@ -126,6 +129,56 @@ export function FoundationShell() {
     );
   }
 
+  const content = (
+    <>
+      {tab === "browse" && <BrowsePanel providers={providers} onSelect={setSelected} />}
+      {tab === "quotes" && <QuotesPanel quotes={quotes} onBrowse={() => setTab("browse")} />}
+      {tab === "chat" && (
+        <ChatPanel
+          input={chatInput}
+          onInput={setChatInput}
+          onSend={() => setChatInput("")}
+          onBrowse={() => setTab("browse")}
+        />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    const tabs: { key: FoundationTab; label: string }[] = [
+      { key: "browse", label: "Browse" },
+      { key: "quotes", label: "Quotes" },
+      { key: "chat", label: "Chat" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: "#0F1117", fontFamily: FONT, color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Hammer size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Foundation</span>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+          {tab === "browse" && (
+            <div style={{ padding: "0 12px 10px" }}>
+              <div style={{ position: "relative" }}>
+                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
+                <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search trade providers…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+              </div>
+            </div>
+          )}
+        </div>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: FONT, color: "#E8EAF0", display: "flex" }}>
       <IconRail tab={tab} onTab={setTab} />
@@ -138,16 +191,7 @@ export function FoundationShell() {
             <div style={{ fontSize: 12, color: "#6B7280" }}>Vetted providers · Background-checked · Safe</div>
           </div>
         </header>
-        {tab === "browse" && <BrowsePanel providers={providers} onSelect={setSelected} />}
-        {tab === "quotes" && <QuotesPanel quotes={quotes} onBrowse={() => setTab("browse")} />}
-        {tab === "chat" && (
-          <ChatPanel
-            input={chatInput}
-            onInput={setChatInput}
-            onSend={() => setChatInput("")}
-            onBrowse={() => setTab("browse")}
-          />
-        )}
+        {content}
       </div>
       <RightRail providers={providers} quoteCount={quotes.length} onBrowse={() => setTab("browse")} onSelect={setSelected} />
     </div>

--- a/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
+++ b/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Car } from "lucide-react";
+import Link from "next/link";
+import { Car, ChevronLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, deriveRideTypes, type ChatCreds, type Mode, type Tab, type TripRequest } from "./tt-shared";
 import { TrustTransportLoading } from "./tt-loading";
 import { TrustTransportIconRail } from "./tt-icon-rail";
@@ -46,6 +48,7 @@ export function TrustTransportShell() {
   // Tracks the most recently requested chat trip so a slower earlier response
   // can't overwrite the credentials for a trip the user has since switched to.
   const activeChatReqRef = useRef<string | null>(null);
+  const isMobile = useIsMobile();
 
   async function fetchRequests() {
     const res = await fetch("/api/trusttransport/requests");
@@ -125,42 +128,75 @@ export function TrustTransportShell() {
 
   const rideTypes = deriveRideTypes(modes);
 
+  const content = (
+    <>
+      {tab === "book" && (
+        <TrustTransportBookTab
+          rideTypes={rideTypes}
+          rideType={rideType}
+          onRideType={setRideType}
+          from={from}
+          to={to}
+          onFrom={setFrom}
+          onTo={setTo}
+          bookingError={bookingError}
+          booked={booked}
+          submitting={submitting}
+          onBook={() => void handleBook()}
+          onReset={() => { setBooked(false); setFrom(""); setTo(""); }}
+        />
+      )}
+      {tab === "tracking" && (
+        <TrustTransportTrackingTab requests={requests} onBook={() => setTab("book")} onChat={openChat} />
+      )}
+      {tab === "chat" && (
+        <TrustTransportChatTab
+          requests={requests}
+          selectedRequest={selectedRequest}
+          chatCredentials={chatCredentials}
+          chatLoading={chatLoading}
+          chatError={chatError}
+          onSelect={(r) => void fetchChatForRequest(r)}
+          onBook={() => setTab("book")}
+        />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    const tabs: { key: Tab; label: string }[] = [
+      { key: "book", label: "Book" },
+      { key: "tracking", label: "Tracking" },
+      { key: "chat", label: "Chat" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: "rgba(249,115,22,0.12)", border: "1px solid rgba(249,115,22,0.3)", display: "flex", alignItems: "center", justifyContent: "center", color: "#F97316", textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Car size={18} style={{ color: "#F97316", flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>TrustTransport</span>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? "rgba(249,115,22,0.12)" : "transparent", border: `1px solid ${tab === key ? "rgba(249,115,22,0.4)" : "rgba(255,255,255,0.08)"}`, color: tab === key ? "#F97316" : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+        </div>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       <TrustTransportIconRail tab={tab} onTab={setTab} />
       <TrustTransportSidebar rideTypes={rideTypes} rideType={rideType} onRideType={setRideType} requests={requests} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <ShellHeader />
-        {tab === "book" && (
-          <TrustTransportBookTab
-            rideTypes={rideTypes}
-            rideType={rideType}
-            onRideType={setRideType}
-            from={from}
-            to={to}
-            onFrom={setFrom}
-            onTo={setTo}
-            bookingError={bookingError}
-            booked={booked}
-            submitting={submitting}
-            onBook={() => void handleBook()}
-            onReset={() => { setBooked(false); setFrom(""); setTo(""); }}
-          />
-        )}
-        {tab === "tracking" && (
-          <TrustTransportTrackingTab requests={requests} onBook={() => setTab("book")} onChat={openChat} />
-        )}
-        {tab === "chat" && (
-          <TrustTransportChatTab
-            requests={requests}
-            selectedRequest={selectedRequest}
-            chatCredentials={chatCredentials}
-            chatLoading={chatLoading}
-            chatError={chatError}
-            onSelect={(r) => void fetchChatForRequest(r)}
-            onBook={() => setTab("book")}
-          />
-        )}
+        {content}
       </div>
       <TrustTransportRightPanel requestCount={requests.length} modeCount={modes.length || rideTypes.length} onBook={() => setTab("book")} />
     </div>


### PR DESCRIPTION
## What this does

Continues the per-plugin mobile pass. On phones, **TrustTransport**, **Foundation**, and **ClickLog** now use a single-column layout with a sticky top bar and full-width content; the icon rail, sidebar, and right rail are hidden. Desktop (≥768px) is unchanged.

- **TrustTransport:** Book / Tracking / Chat tab switch.
- **Foundation:** Browse / Quotes / Chat tab switch plus a provider search box.
- **ClickLog:** no tabs, so the bar is just back + title; the incident log and "log incident" form fill the width.

All use the shared `useIsMobile` hook (768px).

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).

## Remaining

Still to do: Workforce, Skills Hunt, Service Credits, LevelUp, Peer Programming, Weekly Performance, WhatWorks, Skills Taxonomy, Unlock.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_