### PR TITLE
feat: add phone layouts for ServiceCredits and Peer Programming

### DIFF
--- a/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Users } from "lucide-react";
+import Link from "next/link";
+import { ChevronLeft, Users } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, type Message, type Room, type Tab } from "./pp-shared";
 import { PeerProgrammingLoading } from "./pp-loading";
 import { PeerProgrammingIconRail } from "./pp-icon-rail";
@@ -52,6 +54,7 @@ export function PeerProgrammingShell() {
   const [feedbackInput, setFeedbackInput] = useState("");
   const [feedbackSuccess, setFeedbackSuccess] = useState(false);
   const [feedbackError, setFeedbackError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -128,38 +131,71 @@ export function PeerProgrammingShell() {
 
   const participants = room?.participants ?? [];
 
+  const content = (
+    <>
+      {tab === "cohorts" && (
+        <PeerProgrammingCohortsTab
+          room={room}
+          participantCount={participants.length}
+          onJoinSession={() => setTab("session")}
+          feedback={{
+            value: feedbackInput,
+            onChange: setFeedbackInput,
+            onSubmit: (e) => void handleSubmitFeedback(e),
+            submitting,
+            success: feedbackSuccess,
+            error: feedbackError,
+          }}
+        />
+      )}
+      {tab === "session" && <PeerProgrammingSessionTab room={room} participants={participants} />}
+      {tab === "chat" && (
+        <PeerProgrammingChatTab
+          room={room}
+          messages={messages}
+          messageInput={messageInput}
+          onMessageInput={setMessageInput}
+          onSend={() => void handlePostMessage()}
+          submitting={submitting}
+        />
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    const tabs: { key: Tab; label: string }[] = [
+      { key: "cohorts", label: "Cohorts" },
+      { key: "session", label: "Session" },
+      { key: "chat", label: "Chat" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: "rgba(139,92,246,0.12)", border: "1px solid rgba(139,92,246,0.3)", display: "flex", alignItems: "center", justifyContent: "center", color: "#8B5CF6", textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Users size={18} style={{ color: "#8B5CF6", flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Peer Programming</span>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? "rgba(139,92,246,0.12)" : "transparent", border: `1px solid ${tab === key ? "rgba(139,92,246,0.4)" : "rgba(255,255,255,0.08)"}`, color: tab === key ? "#8B5CF6" : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+        </div>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       <PeerProgrammingIconRail tab={tab} onTab={setTab} />
       <PeerProgrammingSidebar />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <ShellHeader active={Boolean(room?.cohortId)} />
-        {tab === "cohorts" && (
-          <PeerProgrammingCohortsTab
-            room={room}
-            participantCount={participants.length}
-            onJoinSession={() => setTab("session")}
-            feedback={{
-              value: feedbackInput,
-              onChange: setFeedbackInput,
-              onSubmit: (e) => void handleSubmitFeedback(e),
-              submitting,
-              success: feedbackSuccess,
-              error: feedbackError,
-            }}
-          />
-        )}
-        {tab === "session" && <PeerProgrammingSessionTab room={room} participants={participants} />}
-        {tab === "chat" && (
-          <PeerProgrammingChatTab
-            room={room}
-            messages={messages}
-            messageInput={messageInput}
-            onMessageInput={setMessageInput}
-            onSend={() => void handlePostMessage()}
-            submitting={submitting}
-          />
-        )}
+        {content}
       </div>
       <PeerProgrammingRightPanel room={room} participants={participants} onJoinSession={() => setTab("session")} />
     </div>

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Coins } from "lucide-react";
+import Link from "next/link";
+import { ChevronLeft, Coins } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, COLOR, fmtCredits, type Tab, type WalletData } from "./sc-shared";
 import { ServiceCreditsIconRail } from "./sc-icon-rail";
 import { ServiceCreditsSidebar } from "./sc-sidebar";
@@ -39,6 +41,7 @@ export function ServiceCreditsShell() {
   const [error, setError] = useState<string | null>(null);
   const [wallet, setWallet] = useState<WalletData | null>(null);
   const [tab, setTab] = useState<Tab>("wallet");
+  const isMobile = useIsMobile();
 
   async function refreshWallet() {
     const res = await fetch("/api/service-credits/wallet");
@@ -65,15 +68,50 @@ export function ServiceCreditsShell() {
   const balance = wallet?.availableBalance ?? 0;
   const escrow = wallet?.escrowBalance ?? 0;
 
+  const content = (
+    <>
+      {tab === "wallet" && <ServiceCreditsWalletTab balance={balance} escrow={escrow} />}
+      {tab === "earn" && <ServiceCreditsEarnTab />}
+      {tab === "info" && <ServiceCreditsInfoTab />}
+    </>
+  );
+
+  if (isMobile) {
+    const tabs: { key: Tab; label: string }[] = [
+      { key: "wallet", label: "Wallet" },
+      { key: "earn", label: "Earn" },
+      { key: "info", label: "Info" },
+    ];
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Coins size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>ServiceCredits</span>
+            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{fmtCredits(balance)}</Badge>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+            {tabs.map(({ key, label }) => (
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+            ))}
+          </div>
+        </div>
+        {content}
+        <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} />
+      </div>
+    );
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       <ServiceCreditsIconRail tab={tab} onTab={setTab} />
       <ServiceCreditsSidebar />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <ShellHeader balance={balance} />
-        {tab === "wallet" && <ServiceCreditsWalletTab balance={balance} escrow={escrow} />}
-        {tab === "earn" && <ServiceCreditsEarnTab />}
-        {tab === "info" && <ServiceCreditsInfoTab />}
+        {content}
       </div>
       <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} />
     </div>


### PR DESCRIPTION
## What this does

Continues the per-plugin mobile pass. On phones, **ServiceCredits** and **Peer Programming** now use a single-column layout with a sticky top bar (back + title + tab switch) and full-width content; the icon rail and sidebar are hidden. Desktop (≥768px) is unchanged.

- **ServiceCredits:** Wallet / Earn / Info tab switch with the balance shown in the top bar. The send-credits panel is **kept** (stacked below the content) so sending still works on phones. Layout-only — no money/ledger logic changed.
- **Peer Programming:** Cohorts / Session / Chat tab switch; the right panel is hidden.

Both use the shared `useIsMobile` hook (768px).

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).

## Remaining

Still to do: Workforce, Skills Hunt, LevelUp, Weekly Performance, WhatWorks, Skills Taxonomy, Unlock.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_