### PR TITLE
feat: add phone layouts for Workforce and Skills Hunt

### DIFF
--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Search } from "lucide-react";
+import Link from "next/link";
+import { Bell, ChevronLeft, Search } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import {
   BG, COLOR, TABS, type Tab,
   type SkillsHuntRound, type SkillsHuntLeaderboardItem, type SkillsHuntAchievement,
@@ -109,6 +111,7 @@ export function SkillsHuntShell({
   const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
   const [loadingFinds, setLoadingFinds] = useState(false);
   const [globalError, setGlobalError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   const { form, submitted, resetForm } = useNominationForm(activeRound);
 
@@ -236,6 +239,44 @@ export function SkillsHuntShell({
   const { currentUserEntry, noActiveRound, unreadCount } = deriveShellState({ leaderboard, serverCurrentUserEntry, userId, rounds, notifications });
   const showModeratorTools = isAdmin || isModerator;
 
+  const content = (
+    <ShellContent
+      tab={tab} setTab={setTab} noActiveRound={noActiveRound} submitted={submitted} form={form} resetForm={resetForm}
+      loadingLeaderboard={loadingLeaderboard} leaderboard={leaderboard} userId={userId}
+      loadingMissions={loadingMissions} missions={missions}
+      loadingFinds={loadingFinds} myFinds={myFinds}
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}1A`, border: `1px solid ${COLOR}40`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <Search size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Skills Hunt</span>
+            <button type="button" onClick={() => setNotifOpen((o) => !o)} aria-label="Notifications" style={{ position: "relative", width: 38, height: 38, borderRadius: 10, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", color: "#9CA3AF", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0 }}>
+              <Bell size={18} />
+              {unreadCount > 0 && <span style={{ position: "absolute", top: 5, right: 5, width: 8, height: 8, borderRadius: "50%", background: "#EF4444" }} />}
+            </button>
+          </div>
+          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px", overflowX: "auto" }}>
+            {TABS.map((t) => (
+              <button key={t.key} onClick={() => setTab(t.key)} style={{ whiteSpace: "nowrap", padding: "6px 12px", borderRadius: 8, background: tab === t.key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === t.key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === t.key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{t.label}</button>
+            ))}
+          </div>
+        </div>
+        {notifOpen && (
+          <SkillsHuntNotifications notifications={notifications} onClose={() => setNotifOpen(false)} onMarkRead={(id) => void markRead(id)} />
+        )}
+        <div style={{ padding: 16 }}>{content}</div>
+      </div>
+    );
+  }
+
   return (
     <div style={{ position: "relative", width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
       <SkillsHuntIconRail tab={tab} onTab={setTab} notifOpen={notifOpen} onToggleNotif={() => setNotifOpen((o) => !o)} unreadCount={unreadCount} />
@@ -246,12 +287,7 @@ export function SkillsHuntShell({
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <ShellHeader activeRound={activeRound} />
         <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
-          <ShellContent
-            tab={tab} setTab={setTab} noActiveRound={noActiveRound} submitted={submitted} form={form} resetForm={resetForm}
-            loadingLeaderboard={loadingLeaderboard} leaderboard={leaderboard} userId={userId}
-            loadingMissions={loadingMissions} missions={missions}
-            loadingFinds={loadingFinds} myFinds={myFinds}
-          />
+          {content}
         </div>
       </div>
       <SkillsHuntRightPanel currentUserEntry={currentUserEntry} achievements={achievements} showModeratorTools={showModeratorTools} />

--- a/ctf/packages/web/components/workforce/workforce-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-shell.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { BarChart2, Target, Plus } from 'lucide-react';
+import Link from 'next/link';
+import { BarChart2, ChevronLeft, Target, Plus } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import type { WorkforceDashboard, WorkforceGroupedReportItem, WorkforceProfile } from '../../lib/workforce/types';
 import { WorkforceIconRail } from './workforce-icon-rail';
 import { WorkforceSidebar } from './workforce-sidebar';
@@ -217,6 +219,7 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     skillItems: [],
     profile: null,
   });
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -295,6 +298,46 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     );
   }
 
+  const content = (
+    <WorkforceDashboardContent
+      dashboard={dashboard}
+      sectorItems={sectorItems}
+      skillItems={skillItems}
+      activeView={view}
+    />
+  );
+
+  if (isMobile) {
+    const views: { key: SidebarView; label: string }[] = [
+      { key: 'overview', label: 'Overview' },
+      { key: 'sector', label: 'Sectors' },
+      { key: 'skill-level', label: 'Skill Level' },
+    ];
+    // ctf-self-responsive opts out of the global mobile de-flex so this flex
+    // column keeps a real height — the dashboard's ScrollArea needs it to scroll.
+    return (
+      <div className="ctf-self-responsive" style={{ height: '100vh', display: 'flex', flexDirection: 'column', background: '#0F1117', fontFamily: "'Inter', system-ui, sans-serif", color: '#E8EAF0' }}>
+        <div style={{ background: '#0D0F14', borderBottom: '1px solid rgba(255,255,255,0.06)', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}20`, border: `1px solid ${COLOR}40`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: COLOR, textDecoration: 'none', flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <BarChart2 size={18} style={{ color: COLOR, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: '#F9FAFB', flex: 1 }}>Workforce</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6, padding: '0 12px 8px', overflowX: 'auto' }}>
+            {views.map(({ key, label }) => (
+              <button key={key} onClick={() => setView(key)} style={{ whiteSpace: 'nowrap', padding: '6px 12px', borderRadius: 8, background: view === key ? `${COLOR}20` : 'transparent', border: `1px solid ${view === key ? COLOR + '40' : 'rgba(255,255,255,0.08)'}`, color: view === key ? COLOR : '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>{label}</button>
+            ))}
+          </div>
+        </div>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+          {content}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       style={{
@@ -342,12 +385,7 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
           </div>
         </header>
 
-        <WorkforceDashboardContent
-          dashboard={dashboard}
-          sectorItems={sectorItems}
-          skillItems={skillItems}
-          activeView={view}
-        />
+        {content}
       </div>
 
       <WorkforceProfilePanel profile={profile} loading={loading} />


### PR DESCRIPTION
## What this does

Continues the per-plugin mobile pass. On phones, **Workforce** and **Skills Hunt** now use a single-column layout with a sticky top bar and full-width content; the icon rail, sidebar, and right panel are hidden. Desktop (≥768px) is unchanged.

- **Workforce:** Overview / Sectors / Skill Level view switch in the top bar; the dashboard fills the width. (Uses a controlled flex height so the dashboard's scroll area still works on a phone.)
- **Skills Hunt:** Scout / Leaderboard / Missions / My Finds tab switch, plus a notifications bell that opens the existing notifications panel.

Both use the shared `useIsMobile` hook (768px).

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).

## Remaining

Last ones: WhatWorks, Skills Taxonomy, Unlock (Unlock looks already phone-friendly).

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_