### PR TITLE
feat: add phone layouts for What Works and Unlock

### DIFF
--- a/ctf/packages/web/components/unlock/unlock-status-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-status-view.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Unlock as UnlockIcon } from "lucide-react";
+import Link from "next/link";
+import { ChevronLeft, Unlock as UnlockIcon } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, BORDER, STATUS_CONFIG, SUBTLE, TEXT, type DisplayStatus } from "./unlock-shared";
 import { UnlockIconRail } from "./unlock-icon-rail";
 import { UnlockSidebar } from "./unlock-sidebar";
@@ -24,6 +26,38 @@ export function UnlockStatusView({
 }) {
   const cfg = STATUS_CONFIG[status];
   const Icon = cfg.icon;
+  const isMobile = useIsMobile();
+
+  const content = (
+    <UnlockStatusCard
+      status={status}
+      resubmitUrl={resubmitUrl}
+      onResubmitUrlChange={onResubmitUrlChange}
+      onResubmit={onResubmit}
+      submitting={submitting}
+      error={error}
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: `1px solid ${BORDER}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${cfg.color}1A`, border: `1px solid ${cfg.color}40`, display: "flex", alignItems: "center", justifyContent: "center", color: cfg.color, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <UnlockIcon size={18} color={cfg.color} style={{ flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>Verification Status</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "4px 10px", borderRadius: 20, background: cfg.bg, border: `1px solid ${cfg.color}30`, fontSize: 11, fontWeight: 600, color: cfg.color, flexShrink: 0 }}>
+              <Icon size={11} /> {cfg.label}
+            </div>
+          </div>
+        </div>
+        <div style={{ padding: "16px" }}>{content}</div>
+      </div>
+    );
+  }
 
   return (
     <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
@@ -43,14 +77,7 @@ export function UnlockStatusView({
         </header>
 
         <div style={{ flex: 1, overflowY: "auto", padding: "40px 64px" }}>
-          <UnlockStatusCard
-            status={status}
-            resubmitUrl={resubmitUrl}
-            onResubmitUrlChange={onResubmitUrlChange}
-            onResubmit={onResubmit}
-            submitting={submitting}
-            error={error}
-          />
+          {content}
         </div>
       </div>
 

--- a/ctf/packages/web/components/unlock/unlock-submission-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-submission-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CheckCircle, ExternalLink, Send, Shield, Unlock as UnlockIcon } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BG, BORDER, BRAND, SUBTLE, SURFACE, TEXT } from "./unlock-shared";
 
 const WHY = [
@@ -25,6 +26,7 @@ export function UnlockSubmissionView({
   error: string | null;
 }) {
   const canSubmit = url.trim().length > 0 && !submitting;
+  const isMobile = useIsMobile();
   return (
     <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter',system-ui", color: TEXT, display: "flex", flexDirection: "column" }}>
       <div style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 28px", gap: 12, background: "#0D0F14", flexShrink: 0 }}>
@@ -35,8 +37,8 @@ export function UnlockSubmissionView({
         </div>
       </div>
 
-      <div style={{ flex: 1, display: "flex", alignItems: "flex-start", justifyContent: "center", padding: "48px 64px", gap: 40, flexWrap: "wrap" }}>
-        <div style={{ flex: 1, maxWidth: 520, minWidth: 320 }}>
+      <div style={{ flex: 1, display: "flex", alignItems: "flex-start", justifyContent: "center", padding: isMobile ? "24px 16px" : "48px 64px", gap: isMobile ? 24 : 40, flexWrap: "wrap" }}>
+        <div style={{ flex: 1, maxWidth: 520, minWidth: isMobile ? 0 : 320 }}>
           <div style={{ marginBottom: 28 }}>
             <div style={{ fontSize: 26, fontWeight: 800, color: TEXT, marginBottom: 10 }}>Submit your Quora profile URL</div>
             <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
@@ -75,7 +77,7 @@ export function UnlockSubmissionView({
           </div>
         </div>
 
-        <div style={{ width: 300, flexShrink: 0 }}>
+        <div style={{ width: isMobile ? "100%" : 300, flexShrink: 0 }}>
           <div style={{ padding: "20px", borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 16 }}>
             <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>Why we verify via Quora</div>
             {WHY.map(({ icon, t, d }) => (

--- a/ctf/packages/web/components/whatworks/whatworks-shell.tsx
+++ b/ctf/packages/web/components/whatworks/whatworks-shell.tsx
@@ -5,7 +5,8 @@
 // Layout + tokens are matched to design/.../survivor-hub/WhatWorks.tsx.
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { ListChecks, Search, ShieldCheck } from 'lucide-react';
+import { ChevronLeft, ListChecks, Search, ShieldCheck } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import {
   BG, BRAND, BORDER, SUBTLE, TEXT,
   type SuggestDraft, type WhatWorksListResponse, type WhatWorksProblem,
@@ -55,6 +56,7 @@ export function WhatWorksShell() {
   const [showSuggest, setShowSuggest] = useState(false);
   const [busyProductId, setBusyProductId] = useState<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+  const isMobile = useIsMobile();
 
   async function loadList(): Promise<void> {
     setError(null);
@@ -174,6 +176,66 @@ export function WhatWorksShell() {
     );
   }
 
+  const content = (
+    <>
+      <WhatWorksHero stats={stats} />
+      {error ? (
+        <div style={{ marginBottom: 20, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 13 }}>{error}</div>
+      ) : null}
+      {visibleProblems.length === 0 ? (
+        <div style={{ fontSize: 14, color: SUBTLE, padding: '24px 0' }}>No tools or problems match “{query}”.</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+          {visibleProblems.map((problem) => (
+            <WhatWorksProblemSection
+              key={problem.id}
+              problem={problem}
+              busyProductId={busyProductId}
+              onToggleHelpful={(product) => void toggleHelpful(product)}
+              sectionRef={(node) => { sectionRefs.current[problem.id] = node; }}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <div style={{ minHeight: '100vh', background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
+        <div style={{ position: 'sticky', top: 0, zIndex: 20, background: '#0D0F14', borderBottom: `1px solid ${BORDER}` }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: BRAND, textDecoration: 'none', flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <ListChecks size={18} color={BRAND} style={{ flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>What Works</span>
+            {isAdmin ? (
+              <Link href="/admin/whatworks" aria-label="Admin" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '7px 10px', borderRadius: 9, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 12, fontWeight: 700, textDecoration: 'none', flexShrink: 0 }}>
+                <ShieldCheck size={13} /> Admin
+              </Link>
+            ) : null}
+          </div>
+          <div style={{ padding: '0 12px 10px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', borderRadius: 9, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}` }}>
+              <Search size={14} color={SUBTLE} />
+              <input
+                aria-label="Search tools or problems"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search tools or problems…"
+                style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 13, color: TEXT, fontFamily: 'inherit' }}
+              />
+            </div>
+          </div>
+        </div>
+        <div style={{ padding: '16px' }}>
+          <div style={{ maxWidth: 760, margin: '0 auto' }}>{content}</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div style={{ display: 'flex', height: '100vh', maxHeight: '100%', background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: 'hidden' }}>
       <WhatWorksIconRail />
@@ -210,25 +272,7 @@ export function WhatWorksShell() {
 
         <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '28px 40px 48px' }}>
           <div style={{ maxWidth: 760, margin: '0 auto' }}>
-            <WhatWorksHero stats={stats} />
-            {error ? (
-              <div style={{ marginBottom: 20, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 13 }}>{error}</div>
-            ) : null}
-            {visibleProblems.length === 0 ? (
-              <div style={{ fontSize: 14, color: SUBTLE, padding: '24px 0' }}>No tools or problems match “{query}”.</div>
-            ) : (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
-                {visibleProblems.map((problem) => (
-                  <WhatWorksProblemSection
-                    key={problem.id}
-                    problem={problem}
-                    busyProductId={busyProductId}
-                    onToggleHelpful={(product) => void toggleHelpful(product)}
-                    sectionRef={(node) => { sectionRefs.current[problem.id] = node; }}
-                  />
-                ))}
-              </div>
-            )}
+            {content}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What this does

Continues the per-plugin mobile pass. On phones, **What Works** and **Unlock** now adapt cleanly. Desktop (≥768px) is unchanged.

- **What Works:** a sticky top bar (back + title + admin link + search) replaces the icon rail and problem sidebar; the verified-tools list fills the width and the right rail is hidden.
- **Unlock:** the submission view no longer overflows on a phone (its form had a 320px min-width inside wide padding — now relaxed on small screens), and the verification-status view gets the same top-bar treatment with the rails hidden.

Uses the shared `useIsMobile` hook (768px).

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).

## Remaining

Just **Skills Taxonomy** left — the 3-column drill-down browser. That one needs its column components reworked for a phone (one column at a time), so it's coming as its own PR next.

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_