### PR TITLE
fix: rebuild drifted v2 socketrelay tables so schema apply completes

### DIFF
--- a/ctf/db/migrations/README.md
+++ b/ctf/db/migrations/README.md
@@ -39,3 +39,4 @@ up to the v3 spec: point the `DATABASE_URL` secret at the clone and run the work
 | File | When | Purpose |
 | --- | --- | --- |
 | `pre/0001_lighthouse_v2_to_v3_rebuild.sql` | pre | Drop the drifted v2 LightHouse tables (varchar ids) so `schema.sql` recreates them with uuid ids; drop the v2-only `lighthouse_announcements`. Guarded on the drift being present. |
+| `pre/0002_socketrelay_v2_to_v3_rebuild.sql` | pre | Drop the drifted v2 SocketRelay tables that `schema.sql` rebuilds (`socketrelay_requests`/`fulfillments`/`messages`, varchar ids) so they are recreated with uuid ids; the v2-only `socketrelay_profiles`/`socketrelay_announcements` are left untouched. Guarded on the drift being present. |

--- a/ctf/db/migrations/pre/0002_socketrelay_v2_to_v3_rebuild.sql
+++ b/ctf/db/migrations/pre/0002_socketrelay_v2_to_v3_rebuild.sql
@@ -1,0 +1,34 @@
+-- 0002_socketrelay_v2_to_v3_rebuild.sql  (pre-schema migration)
+--
+-- Why: same v2 -> v3 drift as lighthouse (0001). In the v2 database socketrelay_requests (and the
+-- tables schema.sql rebuilds around it) use varchar ids, but v3 adds
+-- socketrelay_request_accepted_currencies with a uuid foreign key to socketrelay_requests(id). A
+-- uuid foreign key cannot reference a varchar key, so applying schema.sql against a v2 database
+-- aborts there and leaves every table defined later in the file uncreated. The owner is treating the
+-- v2 SocketRelay data as disposable (handled/recreated before launch).
+--
+-- What: when (and only when) the drift is present, drop the schema.sql-managed drifted socketrelay
+-- tables so the canonical CREATE TABLE statements recreate them with uuid ids. CASCADE clears the
+-- old inter-table foreign keys. The v2-only socketrelay_profiles and socketrelay_announcements are
+-- not defined in schema.sql and do not block the apply, so they are left untouched.
+--
+-- Idempotent / safe to re-run: guarded on socketrelay_requests.id still being a non-uuid type. After
+-- this runs once the ids are uuid, so a second run is a no-op and never touches data. On a fresh
+-- database the tables do not exist yet, so this is also a no-op.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'socketrelay_requests'
+      AND column_name = 'id'
+      AND data_type <> 'uuid'
+  ) THEN
+    DROP TABLE IF EXISTS
+      socketrelay_messages,
+      socketrelay_fulfillments,
+      socketrelay_requests
+    CASCADE;
+  END IF;
+END $$;


### PR DESCRIPTION
## Why

Continues the v2 → v3 cutover. After the lighthouse fix, the schema apply hit the same drift in SocketRelay: in the v2 clone `socketrelay_requests` has a `varchar` id, but v3 adds `socketrelay_request_accepted_currencies` with a `uuid` foreign key to it, so the apply aborts there and leaves everything later in `schema.sql` (the comic tables) uncreated.

I enumerated the **entire** remaining collision set locally (stubbed every drifted parent table reported by the read-only drift inspector and ran `schema.sql` continuing past errors). Result: `socketrelay_requests` is the **only** remaining apply-blocker. So this should be the last rebuild migration needed to get the apply green.

## What

`pre/0002_socketrelay_v2_to_v3_rebuild.sql`: when the drift is present, drop the `schema.sql`-managed drifted socketrelay tables (`socketrelay_requests` / `fulfillments` / `messages`) so they are recreated with `uuid` ids; `CASCADE` clears the old inter-table foreign keys. The v2-only `socketrelay_profiles` / `socketrelay_announcements` are not defined in `schema.sql` and don't block the apply, so they're left untouched. Guarded on the drift being present, so it's a no-op once rebuilt or on a fresh database. Owner is treating the v2 SocketRelay data as disposable.

## Verification (local Postgres 16, full collision set)

Stubbed all ~55 drifted parent tables (the real clone state) and ran `pre/0001` + `pre/0002` → `schema.sql`: applies cleanly, `socketrelay_requests` becomes `uuid`, all three `*_accepted_currencies` tables and all five `comic_*` tables are created, and a re-run is a no-op.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_