### PR TITLE
ci: extend drift inspector with directory_profiles health check

### DIFF
--- a/.github/workflows/inspect-schema-drift.yml
+++ b/.github/workflows/inspect-schema-drift.yml
@@ -58,4 +58,19 @@ jobs:
           JOIN pg_type tp ON tp.oid = af.atttypid
           WHERE c.contype = 'f' AND tc.typname <> tp.typname
           ORDER BY child_table, conname;
+
+          \echo '=== directory_profiles columns (clone) ==='
+          SELECT column_name, data_type
+          FROM information_schema.columns
+          WHERE table_schema = 'public' AND table_name = 'directory_profiles'
+          ORDER BY ordinal_position;
+
+          \echo '=== directory_profiles health counts (counts only, no row data) ==='
+          SELECT
+            count(*)                                                              AS total,
+            count(*) FILTER (WHERE claimed_by_user_id IS NULL)                    AS unclaimed,
+            count(*) FILTER (WHERE unclaimed_handle IS NOT NULL)                  AS with_handle,
+            count(*) FILTER (WHERE display_name IS NOT NULL AND display_name <> '') AS with_display_name,
+            count(*) FILTER (WHERE deleted_at IS NULL)                            AS not_deleted
+          FROM directory_profiles;
           SQL


### PR DESCRIPTION
Extends the read-only drift inspector with a `directory_profiles` health check: column list plus key counts (total, unclaimed, with_handle, with_display_name, not_deleted). This confirms the v2 directory data carried into the v3 schema correctly — in particular that `display_name` populated (vs defaulting to blank) and the unclaimed-handle backfill ran — before finalizing the directory migration. Counts only, no row data.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_