### PR TITLE
feat: add phone layout for Skills Taxonomy

### DIFF
--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { BG, TEXT, type StSector } from "./st-shared";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { BG, BORDER, BRAND, TEXT, type StSector } from "./st-shared";
 import { SkillsTaxonomyIconRail } from "./st-icon-rail";
 import { SkillsTaxonomySectorsColumn } from "./st-sectors-column";
 import { SkillsTaxonomyTitlesColumn } from "./st-titles-column";
@@ -16,6 +19,8 @@ export function SkillsTaxonomyBrowser({ isAdmin }: { isAdmin: boolean }) {
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
+  const [mobileView, setMobileView] = useState<"sectors" | "titles" | "skills">("sectors");
 
   useEffect(() => {
     let cancelled = false;
@@ -42,6 +47,59 @@ export function SkillsTaxonomyBrowser({ isAdmin }: { isAdmin: boolean }) {
 
   if (loading) return <SkillsTaxonomyLoading />;
   if (!error && sectors.length === 0) return <SkillsTaxonomyEmptyState isAdmin={isAdmin} />;
+
+  // Phones can't fit three columns side by side, so the hierarchy becomes a
+  // drill-down: sectors → job titles → skills, one level at a time with a
+  // back button. The column components go full-width on small screens.
+  if (isMobile) {
+    const backTarget = mobileView === "skills" ? "titles" : "sectors";
+    const backLabel = mobileView === "skills" ? "Job titles" : "Sectors";
+    return (
+      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: `1px solid ${BORDER}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, display: "flex", alignItems: "center", justifyContent: "center", color: BRAND, textDecoration: "none", flexShrink: 0 }}>
+              <ChevronLeft size={20} />
+            </Link>
+            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>Skills Taxonomy</span>
+          </div>
+          {mobileView !== "sectors" && (
+            <div style={{ padding: "0 12px 10px" }}>
+              <button type="button" onClick={() => setMobileView(backTarget)} style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", padding: "8px 12px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, color: "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
+                <ChevronLeft size={14} /> {backLabel}
+              </button>
+            </div>
+          )}
+        </div>
+        {error ? (
+          <div style={{ padding: 24, color: "#F87171", fontSize: 14 }}>{error}</div>
+        ) : mobileView === "sectors" ? (
+          <SkillsTaxonomySectorsColumn
+            sectors={sectors}
+            selectedSectorId={selectedSectorId}
+            onSelect={(id) => { setSelectedSectorId(id); setSelectedJobTitleId(null); setSearch(""); setMobileView("titles"); }}
+            isAdmin={isAdmin}
+          />
+        ) : mobileView === "titles" ? (
+          <SkillsTaxonomyTitlesColumn
+            sector={selectedSector}
+            selectedJobTitleId={selectedJobTitleId}
+            onSelect={(id) => { setSelectedJobTitleId(id); setSearch(""); setMobileView("skills"); }}
+            isAdmin={isAdmin}
+          />
+        ) : (
+          <SkillsTaxonomySkillsDetail
+            sector={selectedSector}
+            jobTitle={selectedJobTitle}
+            skills={visibleSkills}
+            search={search}
+            onSearch={setSearch}
+            isAdmin={isAdmin}
+          />
+        )}
+      </div>
+    );
+  }
 
   return (
     <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>

--- a/ctf/packages/web/components/skills-taxonomy/st-sectors-column.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-sectors-column.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Plus } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BORDER, FAINT, SUBTLE, TEXT, countLabel, sectorColor, type StSector } from "./st-shared";
 
 export function SkillsTaxonomySectorsColumn({
@@ -14,8 +15,9 @@ export function SkillsTaxonomySectorsColumn({
   onSelect: (sectorId: string) => void;
   isAdmin: boolean;
 }) {
+  const isMobile = useIsMobile();
   return (
-    <aside style={{ width: 240, background: "#0D0F14", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
+    <aside style={{ width: isMobile ? "100%" : 240, background: "#0D0F14", borderRight: isMobile ? "none" : `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
       <div style={{ padding: "20px 16px 12px" }}>
         <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 4 }}>📚 Skills Taxonomy</div>
         <div style={{ fontSize: 12, color: FAINT, lineHeight: 1.5 }}>3-level hierarchy browser</div>

--- a/ctf/packages/web/components/skills-taxonomy/st-titles-column.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-titles-column.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Briefcase, Plus } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BORDER, BRAND, SUBTLE, TEXT, countLabel, type StJobTitle, type StSector } from "./st-shared";
 
 export function SkillsTaxonomyTitlesColumn({
@@ -15,8 +16,9 @@ export function SkillsTaxonomyTitlesColumn({
   isAdmin: boolean;
 }) {
   const jobTitles: StJobTitle[] = sector?.jobTitles ?? [];
+  const isMobile = useIsMobile();
   return (
-    <aside style={{ width: 260, background: "#0D0F14", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
+    <aside style={{ width: isMobile ? "100%" : 260, background: "#0D0F14", borderRight: isMobile ? "none" : `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
       <div style={{ padding: "20px 16px 12px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <div>
           <div style={{ fontSize: 14, fontWeight: 700, color: TEXT }}>Job Titles</div>


### PR DESCRIPTION
## What this does

The final plugin in the per-plugin mobile pass. **Skills Taxonomy** is a 3-column sector → job-title → skill browser that can't fit a phone, so on small screens it becomes a **drill-down**: pick a sector, then a job title, then see its skills, with a back button to step up a level. The sector and job-title list columns go full-width on phones; the skills view fills the width. Desktop (≥768px) is unchanged.

Uses the shared `useIsMobile` hook (768px).

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).

## This completes the mobile pass

With this, the whole web app is phone-ready: the home shell, the AI-consent modal fix, and all ~20 plugins now have phone layouts. 🎉

Parity Status: web+android complete

(Web-only change. The Android app is already a native mobile experience, so there is no deferred Android work to track.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_