### PR TITLE
feat: read Clerk first and last name into request identity

### DIFF
--- a/ctf/packages/web/lib/auth/request-identity.ts
+++ b/ctf/packages/web/lib/auth/request-identity.ts
@@ -8,6 +8,8 @@ export type RequestIdentity = {
   authProvider: string | null;
   userId: string | null;
   username: string | null;
+  firstName: string | null;
+  lastName: string | null;
   role: string | null;
   isAdmin: boolean;
   isApproved: boolean;
@@ -72,6 +74,8 @@ export async function resolveRequestIdentity(): Promise<RequestIdentity> {
   );
   const isAuthenticated = explicitAuthenticationState ?? authResult.isAuthenticated;
   const username = readIdentityValue('x-ctf-username', 'ctf_username', headerStore, cookieStore);
+  const firstName = readIdentityValue('x-ctf-first-name', 'ctf_first_name', headerStore, cookieStore);
+  const lastName = readIdentityValue('x-ctf-last-name', 'ctf_last_name', headerStore, cookieStore);
   const role = normalizeRole(
     readIdentityValue('x-ctf-user-role', 'ctf_user_role', headerStore, cookieStore),
   );
@@ -84,6 +88,8 @@ export async function resolveRequestIdentity(): Promise<RequestIdentity> {
     authProvider: provider,
     userId: isAuthenticated ? authResult.userId || userId : null,
     username: isAuthenticated ? username : null,
+    firstName: isAuthenticated ? firstName : null,
+    lastName: isAuthenticated ? lastName : null,
     role: isAuthenticated ? role : null,
     isAdmin: isAuthenticated ? role === 'admin' : false,
     isApproved: isAuthenticated ? isApproved : false,
@@ -115,4 +121,25 @@ export function buildIdentityDisplayName(username: string | null, userId: string
   }
 
   return `user-${userId.slice(0, 8)}`;
+}
+
+// Render a person's name for surfaces that lead with the real name (e.g. the
+// Directory): "First Last", or just whichever of the two is present. Falls back
+// to `@username` and finally to the anonymous identity, so the value is never
+// empty. Pure — safe to import on the client.
+export function buildPersonName(
+  firstName: string | null,
+  lastName: string | null,
+  username: string | null,
+  userId: string | null = null,
+): string {
+  const parts = [firstName, lastName]
+    .map((part) => (typeof part === 'string' ? part.trim() : ''))
+    .filter((part) => part.length > 0);
+
+  if (parts.length > 0) {
+    return parts.join(' ');
+  }
+
+  return buildIdentityDisplayName(username, userId);
 }

--- a/ctf/packages/web/middleware.ts
+++ b/ctf/packages/web/middleware.ts
@@ -12,6 +12,8 @@ const MANAGED_IDENTITY_HEADERS = [
   'x-ctf-auth-provider',
   'x-ctf-user-id',
   'x-ctf-username',
+  'x-ctf-first-name',
+  'x-ctf-last-name',
   'x-ctf-user-role',
 ];
 
@@ -25,19 +27,48 @@ function claimString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-// Clerk does NOT include the username or public metadata in the session token by
-// default, so these reads return `undefined` until the session token is
-// customized. To populate them, in the Clerk dashboard go to
+// Clerk does NOT include the username, first/last name, or public metadata in the
+// session token by default, so these reads return `undefined` until the session
+// token is customized. To populate them, in the Clerk dashboard go to
 // Configure → Sessions → "Customize session token" and add:
-//   { "username": "{{user.username}}", "metadata": "{{user.public_metadata}}" }
+//   {
+//     "username": "{{user.username}}",
+//     "first_name": "{{user.first_name}}",
+//     "last_name": "{{user.last_name}}",
+//     "metadata": "{{user.public_metadata}}"
+//   }
 // and store roles in the user's public metadata (e.g. { "role": "admin" }).
-// Until then the app falls back to the anonymous display name and no role — no
-// regression. Both the flat (`username`/`role`) and nested-in-`metadata`
-// shapes are accepted so either claim mapping works.
+// Until then the app falls back to the username/anonymous identity and no role —
+// no regression. Both the flat (`username`/`first_name`/`last_name`/`role`) and
+// nested-in-`metadata` shapes are accepted so either claim mapping works.
 function extractUsername(claims: unknown): string | undefined {
   const root = asRecord(claims);
   if (!root) return undefined;
   return claimString(root.username) ?? claimString(asRecord(root.metadata)?.username);
+}
+
+function extractFirstName(claims: unknown): string | undefined {
+  const root = asRecord(claims);
+  if (!root) return undefined;
+  const metadata = asRecord(root.metadata);
+  return (
+    claimString(root.first_name) ??
+    claimString(root.firstName) ??
+    claimString(metadata?.first_name) ??
+    claimString(metadata?.firstName)
+  );
+}
+
+function extractLastName(claims: unknown): string | undefined {
+  const root = asRecord(claims);
+  if (!root) return undefined;
+  const metadata = asRecord(root.metadata);
+  return (
+    claimString(root.last_name) ??
+    claimString(root.lastName) ??
+    claimString(metadata?.last_name) ??
+    claimString(metadata?.lastName)
+  );
 }
 
 function extractRole(claims: unknown): string | undefined {
@@ -63,6 +94,16 @@ export default clerkMiddleware(async (auth, request) => {
     const username = extractUsername(sessionClaims);
     if (username) {
       requestHeaders.set('x-ctf-username', username);
+    }
+
+    const firstName = extractFirstName(sessionClaims);
+    if (firstName) {
+      requestHeaders.set('x-ctf-first-name', firstName);
+    }
+
+    const lastName = extractLastName(sessionClaims);
+    if (lastName) {
+      requestHeaders.set('x-ctf-last-name', lastName);
     }
 
     const role = extractRole(sessionClaims);


### PR DESCRIPTION
First step of removing the v2 `display_name` convention from v3 and sourcing identity from Clerk. This one is foundational and server-only — no UI, no schema change.

## Why
Identity flows from the Clerk session token → middleware → request headers (`x-ctf-username`, etc.). Today only `username` and `role` are pulled. To show honest, per-plugin identity (Directory leads with a real first + last name; Chyme with `@username`), the app first needs the user's first and last name available the same way the username already is.

## What
- `middleware.ts`: read `first_name` / `last_name` from the customized Clerk session claims (flat or nested in `metadata`) and set `x-ctf-first-name` / `x-ctf-last-name`. Updated the dashboard session-token instructions accordingly.
- `request-identity.ts`: expose `firstName` / `lastName` on `RequestIdentity`, gated on authentication like `username`.
- Add `buildPersonName(firstName, lastName, username, userId)` — a pure helper that renders "First Last", falling back to `@username` then the anonymous identity, so name-led surfaces never render empty.

## Owner action
In the Clerk dashboard session-token customization (where `username` is already added), also add `first_name` and `last_name`. Until then these read as absent with **no regression**.

## Verification
- `pnpm typecheck` clean, `eslint` clean on the changed files, EOF check passes.

Next PRs migrate the actual surfaces: Directory → first/last name (supersedes #289), then Chyme/Hub → `@username`, then the remaining person surfaces, then non-person `display_name` labels → `name`.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User identity system now captures and displays first and last names from authenticated sessions
  * Added consistent formatting for user name display across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->