### PR TITLE
fix: make What Works suggest form fit phones and stop the mobile layout flash

### DIFF
--- a/ctf/packages/web/components/whatworks/ww-suggest-guidance.tsx
+++ b/ctf/packages/web/components/whatworks/ww-suggest-guidance.tsx
@@ -2,6 +2,7 @@
 
 // Static "what makes a good entry" guidance from design/.../survivor-hub/WhatWorksEmpty.tsx.
 import { ShieldCheck } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { BRAND, BORDER, SURFACE, SUBTLE, TEXT } from './ww-shared';
 
 const ENTRY_TIPS = [
@@ -12,8 +13,9 @@ const ENTRY_TIPS = [
 ];
 
 export function WhatWorksSuggestGuidance() {
+  const isMobile = useIsMobile();
   return (
-    <div style={{ width: 300, flexShrink: 0 }}>
+    <div style={{ width: isMobile ? '100%' : 300, maxWidth: isMobile ? 540 : undefined, flexShrink: 0 }}>
       <div style={{ padding: '20px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 16 }}>
         <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>What makes a good entry</div>
         {ENTRY_TIPS.map((tip) => (

--- a/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
+++ b/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
@@ -5,6 +5,7 @@
 // review-honest (the mockup's "added" framing assumes immediate publish).
 import { useState, type CSSProperties, type ReactNode } from 'react';
 import { ListChecks, Plus, ExternalLink, Send, CheckCircle, Tag, ChevronDown, ChevronLeft } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { BG, BRAND, BORDER, SUBTLE, TEXT, type SuggestDraft, type WhatWorksProblemOption } from './ww-shared';
 import { WhatWorksSuggestGuidance } from './ww-suggest-guidance';
 
@@ -38,6 +39,7 @@ export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: P
   const [submitting, setSubmitting] = useState(false);
   const [added, setAdded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   const ready = problemId.trim() && name.trim() && link.trim();
 
@@ -97,7 +99,7 @@ export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: P
         ) : null}
       </div>
 
-      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, display: 'flex', alignItems: 'flex-start', justifyContent: 'center', padding: '44px 64px', gap: 44 }}>
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, display: 'flex', flexWrap: isMobile ? 'wrap' : 'nowrap', alignItems: 'flex-start', justifyContent: 'center', padding: isMobile ? '24px 16px' : '44px 64px', gap: isMobile ? 24 : 44 }}>
         <div style={{ flex: 1, maxWidth: 540 }}>
           <div style={{ marginBottom: 26 }}>
             <div style={{ width: 56, height: 56, borderRadius: 16, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>

--- a/ctf/packages/web/hooks/use-is-mobile.ts
+++ b/ctf/packages/web/hooks/use-is-mobile.ts
@@ -1,26 +1,33 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 const MOBILE_BREAKPOINT = 768;
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const query = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+  query.addEventListener('change', callback);
+  return () => query.removeEventListener('change', callback);
+}
+
+function getSnapshot(): boolean {
+  return window.innerWidth < MOBILE_BREAKPOINT;
+}
+
+// The server has no viewport, so it always renders the desktop layout; the client
+// then takes over with the real size.
+function getServerSnapshot(): boolean {
+  return false;
+}
 
 /**
  * Returns true when the viewport is narrower than the phone breakpoint (768px).
  *
- * Mirrors the design system's `use-mobile` hook so web shells can switch to the
- * single-column phone layout shown in the `Mobile*` mockups. Starts false so the
- * server renders the desktop layout; the client corrects it on mount.
+ * Backed by `useSyncExternalStore` so the client uses the real viewport size from
+ * its very first render after hydration — no post-mount flip from the desktop
+ * layout to the mobile one (which showed up as a visible flash on load).
  */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const query = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const update = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    update();
-    query.addEventListener('change', update);
-    return () => query.removeEventListener('change', update);
-  }, []);
-
-  return isMobile;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## What this fixes

Two issues you caught on the phone:

1. **What Works "suggest a tool" form overflowed.** When the list is empty (or you tap Suggest), What Works shows a different screen — a two-column desktop form (the form + a "What makes a good entry" guidance panel) that I hadn't made responsive, so it ran off the side of a phone. The two columns now wrap to a stack and use phone padding, and the guidance panel goes full-width.

2. **Layout flash on load.** Every plugin briefly rendered the desktop layout and then snapped to the mobile one a moment later ("text jumps to the top"). The cause was the `useIsMobile` hook starting at `false` and flipping after mount. It now reads the viewport through React's `useSyncExternalStore`, so the client uses the real size from its first render after hydration — no post-mount flip. This applies to **all** plugins, not just What Works.

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).
- Please re-check What Works (open it with an empty list / tap Suggest) and watch the load on a couple of plugins for the flash.

Parity Status: web+android complete

(Web-only change. The Android app is native, so there is no deferred Android work.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_