### PR TITLE
fix: stack the What Works suggest form as a column on phones

### DIFF
--- a/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
+++ b/ctf/packages/web/components/whatworks/ww-suggest-panel.tsx
@@ -99,7 +99,7 @@ export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: P
         ) : null}
       </div>
 
-      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, display: 'flex', flexWrap: isMobile ? 'wrap' : 'nowrap', alignItems: 'flex-start', justifyContent: 'center', padding: isMobile ? '24px 16px' : '44px 64px', gap: isMobile ? 24 : 44 }}>
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, display: 'flex', flexDirection: isMobile ? 'column' : 'row', alignItems: isMobile ? 'stretch' : 'flex-start', justifyContent: isMobile ? 'flex-start' : 'center', padding: isMobile ? '24px 16px' : '44px 64px', gap: isMobile ? 24 : 44 }}>
         <div style={{ flex: 1, maxWidth: 540 }}>
           <div style={{ marginBottom: 26 }}>
             <div style={{ width: 56, height: 56, borderRadius: 16, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>


### PR DESCRIPTION
## What this fixes

The What Works "suggest a tool" screen (`/apps/whatworks` with an empty list) was still overflowing on a phone after #293.

**Why #293 didn't fix it:** that change used `flex-wrap`, but the right-hand guidance panel is `flex-shrink: 0` with `width: 100%`. In a wrap row, a no-shrink, full-width item still packs onto the **same line** as the form instead of wrapping below it — so the two columns stayed side by side and ran off the screen exactly as before.

**This fix:** the content row now uses `flex-direction: column` (with `align-items: stretch`) on phones, so the form and the guidance panel stack vertically, each full-width — no horizontal overflow. Desktop keeps the side-by-side row.

One-line change.

## Testing

- `pnpm typecheck` ✅ · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).
- Reasoned through the render: column + stretch forces both children to full container width, which can't overflow horizontally.

Parity Status: web+android complete

(Web-only CSS change. The Android app is native, so there is no deferred Android work.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_