### PR TITLE
fix: tie mobile detection to the CSS breakpoint and set an explicit viewport

### DIFF
--- a/ctf/packages/web/app/layout.tsx
+++ b/ctf/packages/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
 import { AuthProvider } from '@/hooks/useAuth';
 import {
@@ -13,6 +13,13 @@ import './globals.css';
 export const metadata: Metadata = {
   title: 'CTF Survivor Hub',
   description: 'Dark theme plugin-first community shell for survivor-centered support.',
+};
+
+// Explicit phone viewport so the page lays out at device width (not a ~980px
+// desktop fallback), which the mobile breakpoint depends on.
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/ctf/packages/web/hooks/use-is-mobile.ts
+++ b/ctf/packages/web/hooks/use-is-mobile.ts
@@ -3,30 +3,37 @@
 import { useSyncExternalStore } from 'react';
 
 const MOBILE_BREAKPOINT = 768;
+// Same query the CSS uses to switch to the phone layout. Reading the breakpoint
+// through matchMedia (rather than window.innerWidth) keeps the JS check and the
+// CSS in lock-step — on some browsers innerWidth reported a desktop width even at
+// phone size, which left every plugin stuck on its desktop layout.
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
 function subscribe(callback: () => void): () => void {
-  if (typeof window === 'undefined') return () => {};
-  const query = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+  const query = window.matchMedia(MOBILE_QUERY);
   query.addEventListener('change', callback);
   return () => query.removeEventListener('change', callback);
 }
 
 function getSnapshot(): boolean {
-  return window.innerWidth < MOBILE_BREAKPOINT;
+  return window.matchMedia(MOBILE_QUERY).matches;
 }
 
 // The server has no viewport, so it always renders the desktop layout; the client
-// then takes over with the real size.
+// takes over with the real media-query result after hydration.
 function getServerSnapshot(): boolean {
   return false;
 }
 
 /**
- * Returns true when the viewport is narrower than the phone breakpoint (768px).
+ * Returns true when the viewport matches the phone breakpoint (max-width: 767px).
  *
- * Backed by `useSyncExternalStore` so the client uses the real viewport size from
- * its very first render after hydration — no post-mount flip from the desktop
- * layout to the mobile one (which showed up as a visible flash on load).
+ * Backed by `useSyncExternalStore` + `matchMedia` so the client uses the correct
+ * value from its first render after hydration (no desktop-to-mobile flash) and
+ * stays exactly in sync with the CSS breakpoint.
  */
 export function useIsMobile(): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);


### PR DESCRIPTION
## What this fixes (root cause of every "plugin not responsive on my phone" report)

The per-plugin mobile layouts were never actually activating on real phones — Foundation, GentlePulse, What Works, etc. all rendered their desktop layout (you've been seeing the rough global column‑stacking, not the intended mobile top‑bar layouts).

**Why:** `useIsMobile` decided "mobile" from `window.innerWidth < 768`. On mobile Safari (and DuckDuckGo, in both mobile and desktop toggles) that value comes back as a **desktop width** — the page "shrink‑to‑fits" when content overflows and there's no explicit viewport scale — so `isMobile` was `false` and every `if (isMobile)` branch was skipped, even though the page was at phone width and the CSS media queries were matching.

**The fix:**
- `useIsMobile` now reads the **same `(max-width: 767px)` media query the CSS uses**, via `window.matchMedia(...)`. The JS check and the CSS breakpoint can no longer disagree, so the mobile layouts activate exactly when the page is at phone width.
- The root layout now declares an **explicit viewport** (`width=device-width, initial-scale=1`) so the page lays out at device width instead of a ~980px desktop fallback.

This is a 2‑file change but it flips on the mobile layout for **all** plugins at once.

## Testing

- `pnpm typecheck` ✅ · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).
- After it deploys, re-check Foundation, GentlePulse, and What Works on your phone — they should show the mobile top‑bar layout, not the desktop rail.

Parity Status: web+android complete

(Web-only change. The Android app is native, so there is no deferred Android work.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_