### PR TITLE
fix: use the single Exit Their Economy / Exit The Psyop loading screen everywhere

### DIFF
--- a/ctf/packages/web/components/directory/directory-loading-skeleton.tsx
+++ b/ctf/packages/web/components/directory/directory-loading-skeleton.tsx
@@ -1,72 +1,7 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/DirectoryLoading.tsx.
-import { BookOpen } from "lucide-react";
-import { BG, COLOR } from "./shared";
-
-const surface = "#161B27";
-const border = "#1E2A3A";
-
-function Sk({ w = "100%", h = 14, r = 6 }: { w?: string | number; h?: number; r?: number }) {
-  return <div style={{ width: w, height: h, borderRadius: r, background: "rgba(255,255,255,0.06)", flexShrink: 0 }} />;
-}
+// The Directory loading state is the single app-wide loading screen. The old
+// content skeleton was removed — see components/shared/app-loading.tsx.
+import { AppLoading } from "@/components/shared/app-loading";
 
 export function DirectoryLoadingSkeleton() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, fontFamily: "'Inter',system-ui", color: "#F9FAFB", overflow: "hidden" }}>
-      {/* Sidebar */}
-      <aside style={{ width: 320, borderRight: `1px solid ${border}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
-        <div style={{ padding: "16px 16px 12px", borderBottom: `1px solid ${border}` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
-            <BookOpen size={16} color={COLOR} /><Sk w={90} h={16} r={6} />
-          </div>
-          <Sk h={36} r={8} />
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 10 }}>
-            {[60, 80, 55, 70, 65, 75, 50].map((w, i) => <Sk key={i} w={w} h={24} r={12} />)}
-          </div>
-        </div>
-        <div style={{ padding: "10px 12px", borderBottom: `1px solid ${border}`, display: "flex", gap: 6 }}>
-          <Sk w={90} h={32} r={8} /><Sk w={90} h={32} r={8} />
-        </div>
-        <div style={{ flex: 1, padding: "12px", display: "flex", flexDirection: "column", gap: 10 }}>
-          {[{ from: "hub", w: 200 }, { from: "me", w: 160 }, { from: "hub", w: 220 }].map(({ from, w }, i) => (
-            <div key={i} style={{ display: "flex", justifyContent: from === "me" ? "flex-end" : "flex-start" }}>
-              <Sk w={w} h={44} r={10} />
-            </div>
-          ))}
-        </div>
-        <div style={{ padding: "12px", borderTop: `1px solid ${border}` }}>
-          <div style={{ display: "flex", gap: 8 }}><Sk h={40} r={8} /><Sk w={40} h={40} r={8} /></div>
-        </div>
-      </aside>
-
-      {/* Main — profile list */}
-      <main style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", background: surface }}>
-        <div style={{ height: 56, borderBottom: `1px solid ${border}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 12, flexShrink: 0 }}>
-          <Sk w={120} h={16} r={6} />
-          <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}><Sk w={100} h={32} r={8} /><Sk w={80} h={32} r={8} /></div>
-        </div>
-        <div style={{ flex: 1, overflowY: "auto", padding: "20px 24px", display: "flex", flexDirection: "column", gap: 12 }}>
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} style={{ borderRadius: 14, border: `1px solid ${border}`, padding: "16px 20px", display: "flex", gap: 16 }}>
-              <Sk w={56} h={56} r={28} />
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-                <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
-                  <Sk w={130} h={15} r={5} /><Sk w={70} h={20} r={10} />
-                </div>
-                <Sk w={160} h={12} r={4} />
-                <div style={{ display: "flex", gap: 6 }}>
-                  {[55, 45, 65].map((w, j) => <Sk key={j} w={w} h={22} r={11} />)}
-                </div>
-              </div>
-              <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
-                <Sk w={50} h={14} r={5} /><Sk w={80} h={32} r={8} />
-              </div>
-            </div>
-          ))}
-        </div>
-      </main>
-    </div>
-  );
+  return <AppLoading />;
 }

--- a/ctf/packages/web/components/foundation/foundation-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-shell.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { ChevronLeft, Hammer, Search } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { AppLoading } from "@/components/shared/app-loading";
 import { COLOR, FONT, type FoundationTab, type ProviderView, type QuoteView } from "./foundation-ui";
 import { IconRail, FilterSidebar, RightRail } from "./foundation-rails";
 import { BrowsePanel, QuotesPanel, ChatPanel } from "./foundation-panels";
@@ -109,7 +110,7 @@ export function FoundationShell() {
   }, [loadQuotes]);
 
   if (loading) {
-    return <Centered color="#6B7280">Loading Foundation…</Centered>;
+    return <AppLoading />;
   }
 
   if (error) {

--- a/ctf/packages/web/components/lighthouse/lighthouse-loading-skeleton.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-loading-skeleton.tsx
@@ -1,61 +1,7 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/LightHouseLoading.tsx.
-import { Home } from "lucide-react";
-import { BG, COLOR } from "./shared";
-
-const surface = "#161B27";
-const border = "#1E2A3A";
-
-function Sk({ w = "100%", h = 14, r = 6 }: { w?: string | number; h?: number; r?: number }) {
-  return <div style={{ width: w, height: h, borderRadius: r, background: "rgba(255,255,255,0.06)", flexShrink: 0 }} />;
-}
+// The LightHouse loading state is the single app-wide loading screen. The old
+// content skeleton was removed — see components/shared/app-loading.tsx.
+import { AppLoading } from "@/components/shared/app-loading";
 
 export function LighthouseLoadingSkeleton() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, fontFamily: "'Inter',system-ui", color: "#F9FAFB", overflow: "hidden" }}>
-      <aside style={{ width: 72, background: "#090B0F", borderRight: `1px solid ${border}`, display: "flex", flexDirection: "column", alignItems: "center", padding: "16px 0", gap: 10, flexShrink: 0 }}>
-        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 8 }}>
-          <Home size={20} color={COLOR} />
-        </div>
-        {[1, 2, 3].map((i) => <Sk key={i} w={44} h={44} r={12} />)}
-      </aside>
-
-      <main style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", background: surface }}>
-        <div style={{ padding: "14px 24px", borderBottom: `1px solid ${border}`, display: "flex", gap: 10, flexShrink: 0 }}>
-          <Sk h={40} r={8} />
-          <Sk w={100} h={40} r={8} /><Sk w={100} h={40} r={8} /><Sk w={90} h={40} r={8} />
-          <Sk w={110} h={40} r={8} />
-        </div>
-        <div style={{ padding: "10px 24px", borderBottom: `1px solid ${border}`, display: "flex", gap: 12, flexShrink: 0 }}>
-          {[1, 2, 3, 4].map((i) => <Sk key={i} w={110} h={22} r={11} />)}
-          <div style={{ marginLeft: "auto" }}><Sk w={80} h={28} r={8} /></div>
-        </div>
-        <div style={{ flex: 1, overflowY: "auto", padding: "18px 24px", display: "flex", flexDirection: "column", gap: 14 }}>
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} style={{ borderRadius: 16, border: `1px solid ${border}`, display: "flex", overflow: "hidden" }}>
-              <Sk w={200} h={160} r={0} />
-              <div style={{ flex: 1, padding: "18px 20px", display: "flex", flexDirection: "column", gap: 10 }}>
-                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                  <Sk w={220} h={16} r={5} /><Sk w={70} h={22} r={11} />
-                </div>
-                <Sk w={140} h={12} r={4} />
-                <div style={{ display: "flex", gap: 8 }}>
-                  <Sk w={50} h={11} r={4} /><Sk w={50} h={11} r={4} /><Sk w={70} h={11} r={4} />
-                </div>
-                <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                  {[80, 90, 100, 75].map((w, j) => <Sk key={j} w={w} h={22} r={11} />)}
-                </div>
-                <div style={{ display: "flex", gap: 8, marginTop: "auto", alignItems: "center" }}>
-                  <Sk w={70} h={24} r={5} />
-                  <div style={{ marginLeft: "auto" }}><Sk w={100} h={36} r={8} /></div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </main>
-    </div>
-  );
+  return <AppLoading />;
 }

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ChevronLeft, Coins } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { AppLoading } from "@/components/shared/app-loading";
 import { BG, COLOR, fmtCredits, type Tab, type WalletData } from "./sc-shared";
 import { ServiceCreditsIconRail } from "./sc-icon-rail";
 import { ServiceCreditsSidebar } from "./sc-sidebar";
@@ -62,7 +63,7 @@ export function ServiceCreditsShell() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <CenteredNote color="#6B7280">Loading wallet…</CenteredNote>;
+  if (loading) return <AppLoading />;
   if (error) return <CenteredNote color="#EF4444">{error}</CenteredNote>;
 
   const balance = wallet?.availableBalance ?? 0;

--- a/ctf/packages/web/components/shared/app-loading.tsx
+++ b/ctf/packages/web/components/shared/app-loading.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties } from 'react';
+
+// The single app-wide loading screen ("Exit Their Economy / Exit The Psyop").
+// Every surface's loading state renders this — there is intentionally no other
+// loading variant anywhere in the app. Canonical design: the design/ submodule
+// HubLoading.tsx (mirrors app/loading.tsx / loading.module.css).
+const lineStyle: CSSProperties = {
+  fontSize: 11,
+  letterSpacing: '0.18em',
+  color: 'rgba(255, 255, 255, 0.22)',
+  textTransform: 'uppercase',
+  fontWeight: 500,
+  lineHeight: 2,
+};
+
+export function AppLoading() {
+  return (
+    <div style={{ display: 'flex', height: '100vh', width: '100%', background: '#0F1117', alignItems: 'center', justifyContent: 'center', fontFamily: "'Inter', system-ui, sans-serif" }}>
+      <div style={{ textAlign: 'center', padding: '0 32px' }}>
+        <div style={{ ...lineStyle, marginBottom: 16 }}>Exit Their Economy</div>
+        <div style={lineStyle}>Exit The Psyop</div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Bell, ChevronLeft, Search } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { AppLoading } from "@/components/shared/app-loading";
 import {
   BG, COLOR, TABS, type Tab,
   type SkillsHuntRound, type SkillsHuntLeaderboardItem, type SkillsHuntAchievement,
@@ -233,7 +234,7 @@ export function SkillsHuntShell({
     } catch { /* swallow — UX falls through to next poll */ }
   }
 
-  if (loadingRounds) return <CenteredNote color="#6B7280">Loading Skills Hunt…</CenteredNote>;
+  if (loadingRounds) return <AppLoading />;
   if (globalError) return <CenteredNote color="#EF4444">{globalError}</CenteredNote>;
 
   const { currentUserEntry, noActiveRound, unreadCount } = deriveShellState({ leaderboard, serverCurrentUserEntry, userId, rounds, notifications });

--- a/ctf/packages/web/components/workforce/workforce-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-shell.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { BarChart2, ChevronLeft, Target, Plus } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useIsMobile } from '@/hooks/use-is-mobile';
+import { AppLoading } from '@/components/shared/app-loading';
 import type { WorkforceDashboard, WorkforceGroupedReportItem, WorkforceProfile } from '../../lib/workforce/types';
 import { WorkforceIconRail } from './workforce-icon-rail';
 import { WorkforceSidebar } from './workforce-sidebar';
@@ -26,33 +27,7 @@ interface WorkforceData {
 }
 
 function WorkforceLoadingState() {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        height: '100vh',
-        background: '#0F1117',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontFamily: "'Inter', system-ui, sans-serif",
-      }}
-    >
-      <div style={{ textAlign: 'center', padding: '0 32px' }}>
-        <div
-          style={{
-            fontSize: 11,
-            letterSpacing: '0.18em',
-            color: 'rgba(255,255,255,0.22)',
-            textTransform: 'uppercase',
-            fontWeight: 500,
-            lineHeight: 2,
-          }}
-        >
-          Loading workforce data…
-        </div>
-      </div>
-    </div>
-  );
+  return <AppLoading />;
 }
 
 function WorkforceEmptyState() {


### PR DESCRIPTION
## What this does

Every loading state now shows the single app-wide **"Exit Their Economy / Exit The Psyop"** screen — there's intentionally no other loading variant.

What was wrong and is now removed:
- **Directory** and **LightHouse** rendered content **skeletons** (the "old loading screen" you kept seeing) — deleted.
- **Workforce**, **Foundation**, **Skills Hunt**, and **Service Credits** showed "Loading X…" text — replaced.

All six now render a new shared `components/shared/app-loading.tsx` (`AppLoading`), which mirrors the canonical `app/loading.tsx` / `loading.module.css`. The other plugins already used this screen.

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` clean on changed files · `pnpm build` compiles all routes ✅ (fresh container needs `turbopack.root` set to build — used only to validate, not in this PR).

Parity Status: web+android complete

(Web-only change. The Android app is native, so there is no deferred Android work.)

https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_