### PR TITLE
feat: hub peer posts lead with the author @username for members

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -445,6 +445,7 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 ### Change Log
 
+- 2026-06-02: Added `feed_community_posts.author_username` (nullable), captured from the poster's session when a community post is created (`createFeedCommunityPost` takes an `actorUsername`), and surfaced on the timeline as `FeedCommunityDetail.authorUsername`. Lets the Survivor Hub lead a peer post with the author's `@username` for signed-in members. Additive and forward-only — existing posts have a null username.
 - 2026-02-24: Created initial Feed rewrite checklist with approved web-first policy, central admin page decision, naming normalization/alias guidance, Postgres+Stream architecture controls, stream quota-impact gate, and schema drift predeployment evidence requirements.
 - 2026-03-02: Completed phase-0 implementation for combined feed+announcements stream, including migration, API routes, policy/audit guards, admin surface, seed fixtures, and quota-impact note.
 - 2026-04-05: Added Phase 4 (Questions + LLM), Phase 5 (Community Support), Phase 6 (Android Parity — required). Renumbered security/compliance to Phase 7. All commands now use unified `feed.*` namespace per FEED_PLUGIN_COMMAND_CONTRACTS.yaml.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -264,5 +264,6 @@ The Survivor Hub ⟵ Feed consolidation (2026-05-31) superseded the prior `hub_*
 
 ### Change Log
 
+- 2026-06-02: Hub peer posts now lead with the author's `@username` for signed-in members instead of the pseudonymous "Community member" label (official announcements/AI answers still show "Survivor Hub"). The Hub messages route is gated to signed-in members, so this only changes what authenticated members see; a future public Hub view would still show "Community member". Implemented Chyme-style: the poster's username is captured from their session and stored on `feed_community_posts.author_username` at post time, then surfaced through the Feed timeline. Forward-only — community posts created before this shipped have no stored username and keep showing "Community member".
 - 2026-05-12: Checklist re-scoped as a task list against the canonical inventory; rules 105, 107, 112, 120 referenced; pre-merge gates assert no cross-plugin imports/fetches; phased-rollout sections removed.
 - 2026-03-23: Initial checklist created under prior phase-based template.

--- a/ctf/packages/web/app/api/feed/community/posts/route.ts
+++ b/ctf/packages/web/app/api/feed/community/posts/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await createFeedCommunityPost(gate.auth.userId, input);
+    const result = await createFeedCommunityPost(gate.auth.userId, input, gate.auth.username ?? null);
     logFeedAudit({
       actorId: gate.auth.userId,
       pluginId: 'feed',

--- a/ctf/packages/web/app/api/hub/messages/route.ts
+++ b/ctf/packages/web/app/api/hub/messages/route.ts
@@ -126,15 +126,16 @@ export async function POST(request: Request) {
 
   try {
     // A message posted from the Hub input is a peer-to-peer community post.
-    const result = await createFeedCommunityPost(gate.auth.userId, input, gate.auth.username ?? null);
+    const authorUsername = gate.auth.username ?? null;
+    const result = await createFeedCommunityPost(gate.auth.userId, input, authorUsername);
 
     // Normalize to the same public author shape as mapTimelineItemToHubMessage so the
     // optimistic send and the next polled copy share a dedup key (from, senderLabel, text, time).
     const message: HubMessage = {
       id: result.postId,
       userId: gate.identity.userId,
-      username: null,
-      displayName: 'Community member',
+      username: authorUsername,
+      displayName: authorUsername ? `@${authorUsername}` : 'Community member',
       avatarUrl: null,
       text,
       sentAtIso: result.createdAtIso,

--- a/ctf/packages/web/app/api/hub/messages/route.ts
+++ b/ctf/packages/web/app/api/hub/messages/route.ts
@@ -19,7 +19,14 @@ import { ensureMutationCsrf } from '../../feed/_lib';
 function mapTimelineItemToHubMessage(item: FeedTimelineItem): HubMessage {
   const isCommunity = item.itemType === 'community';
   const authorUserId = isCommunity ? item.community?.authorUserId ?? 'hub-system' : 'hub-system';
-  const displayName = isCommunity ? 'Community member' : 'Survivor Hub';
+  // This route is gated to signed-in members, so a peer post leads with the
+  // author's @username when we captured it at post time. Posts created before
+  // usernames were stored (and official announcements/AI answers) fall back to
+  // the pseudonymous "Community member" / "Survivor Hub" labels.
+  const authorUsername = isCommunity ? item.community?.authorUsername ?? null : null;
+  const displayName = isCommunity
+    ? (authorUsername ? `@${authorUsername}` : 'Community member')
+    : 'Survivor Hub';
 
   // Announcements lead with their title; questions/community posts are body-only.
   const text = item.itemType === 'announcement' && item.title
@@ -29,7 +36,7 @@ function mapTimelineItemToHubMessage(item: FeedTimelineItem): HubMessage {
   return {
     id: item.id,
     userId: authorUserId,
-    username: null,
+    username: authorUsername,
     displayName,
     avatarUrl: null,
     text,
@@ -119,7 +126,7 @@ export async function POST(request: Request) {
 
   try {
     // A message posted from the Hub input is a peer-to-peer community post.
-    const result = await createFeedCommunityPost(gate.auth.userId, input);
+    const result = await createFeedCommunityPost(gate.auth.userId, input, gate.auth.username ?? null);
 
     // Normalize to the same public author shape as mapTimelineItemToHubMessage so the
     // optimistic send and the next polled copy share a dedup key (from, senderLabel, text, time).

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -115,6 +115,7 @@ type FeedAnswerRatingRow = {
 type FeedCommunityPostRow = {
   id: string;
   author_user_id: string;
+  author_username: string | null;
   body: string;
   category: FeedCommunityCategory;
   reply_count: number;
@@ -773,7 +774,7 @@ export async function listFeedTimeline(
       const [postRows, replyRows] = await Promise.all([
         client.query<FeedCommunityPostRow>(
           `
-            SELECT id, author_user_id, body, category, reply_count, created_at
+            SELECT id, author_user_id, author_username, body, category, reply_count, created_at
             FROM feed_community_posts
             WHERE id = ANY($1::uuid[])
           `,
@@ -809,6 +810,7 @@ export async function listFeedTimeline(
           body: row.body,
           category: row.category,
           authorUserId: row.author_user_id,
+          authorUsername: row.author_username,
           replyCount: row.reply_count,
           replies: repliesByPost.get(row.id) ?? [],
         });
@@ -1327,6 +1329,7 @@ export async function rateFeedAnswer(
 export async function createFeedCommunityPost(
   actorId: string,
   input: FeedCommunityPostInput,
+  actorUsername: string | null = null,
 ): Promise<{ postId: string; createdAtIso: string }> {
   return withDbTransaction(async (client) => {
     const body = normalizeText(input.body);
@@ -1348,11 +1351,11 @@ export async function createFeedCommunityPost(
 
     const inserted = await client.query<{ id: string; created_at: Date }>(
       `
-        INSERT INTO feed_community_posts (author_user_id, body, category, moderation_status)
-        VALUES ($1, $2, $3, 'accepted')
+        INSERT INTO feed_community_posts (author_user_id, author_username, body, category, moderation_status)
+        VALUES ($1, $2, $3, $4, 'accepted')
         RETURNING id, created_at
       `,
-      [actorId, body, category],
+      [actorId, actorUsername, body, category],
     );
 
     const postId = inserted.rows[0].id;

--- a/ctf/packages/web/lib/feed/types.ts
+++ b/ctf/packages/web/lib/feed/types.ts
@@ -58,6 +58,7 @@ export type FeedCommunityDetail = {
   body: string;
   category: FeedCommunityCategory;
   authorUserId: string;
+  authorUsername: string | null;
   replyCount: number;
   replies: FeedCommunityReply[];
 };

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -850,6 +850,7 @@ ALTER TABLE IF EXISTS llm_inference_log ADD COLUMN IF NOT EXISTS created_at TIME
 CREATE TABLE IF NOT EXISTS feed_community_posts (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   author_user_id TEXT NOT NULL,
+  author_username TEXT,
   body TEXT NOT NULL,
   category TEXT NOT NULL DEFAULT 'general',
   moderation_status TEXT NOT NULL DEFAULT 'accepted',
@@ -859,6 +860,7 @@ CREATE TABLE IF NOT EXISTS feed_community_posts (
 );
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS author_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS author_username TEXT;
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS body TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'general';
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS moderation_status TEXT NOT NULL DEFAULT 'accepted';

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -866,6 +866,7 @@ ALTER TABLE IF EXISTS llm_inference_log ADD COLUMN IF NOT EXISTS created_at TIME
 CREATE TABLE IF NOT EXISTS feed_community_posts (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   author_user_id TEXT NOT NULL,
+  author_username TEXT,
   body TEXT NOT NULL,
   category TEXT NOT NULL DEFAULT 'general',
   moderation_status TEXT NOT NULL DEFAULT 'accepted',
@@ -875,6 +876,7 @@ CREATE TABLE IF NOT EXISTS feed_community_posts (
 );
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS author_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS author_username TEXT;
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS body TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'general';
 ALTER TABLE IF EXISTS feed_community_posts ADD COLUMN IF NOT EXISTS moderation_status TEXT NOT NULL DEFAULT 'accepted';


### PR DESCRIPTION
Final item of removing the v2 `display_name` convention — the Survivor Hub author.

## What (owner-approved rule)
A Hub **peer post** now leads with the poster's `@username` for any **signed-in member**; official announcements / AI answers keep **"Survivor Hub"**; a peer post with no captured username falls back to **"Community member"**. The Hub messages route is already gated to signed-in members, so this only changes what authenticated members see (a future public Hub view would still show "Community member").

## Why it's built this way
v3 only knows the **current viewer's** username (from the Clerk session token) — another user's handle isn't stored anywhere server-side. So, exactly like **Chyme** already does, the author's username is **captured at write time**:

- `feed_community_posts` gains a nullable `author_username` (`schema.sql` + `schema.demo.sql`, additive ALTER — no separate migration).
- `createFeedCommunityPost` takes an `actorUsername` and stores it; both callers (the Feed community route and the Hub messages route) pass `gate.auth.username`.
- The Feed timeline selects `author_username` and exposes it as `FeedCommunityDetail.authorUsername`.
- The Hub messages mapper renders `@author_username` for peer posts, else "Community member".

## Forward-only
Community posts created before this ships have no stored username and keep showing "Community member"; only new posts show `@username`. (A broader Clerk→`users.username` sync — to resolve *any* user's handle, including old posts and claimed Directory profiles — would be a separate, larger effort; this is the lightweight Chyme-style approach you approved.)

## Verification
- `pnpm typecheck` + `eslint` (hub/feed) clean; the additive `FeedCommunityDetail` field broke no other construction site. EOF passes.
- Local `next build` fails only on the known Turbopack workspace-root quirk (environmental).

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community posts now display the author's actual username instead of a generic label, enabling better attribution and transparency. Pre-existing posts preserve their original display behavior.

* **Documentation**
  * Updated feature inventory documentation to reflect author username visibility for community posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->