### PR TITLE
fix: deploy to Render with only the API key so merged work reaches production

### DIFF
--- a/.github/scripts/render-deploy.sh
+++ b/.github/scripts/render-deploy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Tells Render to deploy the newest pre-built image for one service.
+#
+# How a deploy reaches production
+# ───────────────────────────────
+# GitHub Actions builds each image and pushes it to GHCR (…:latest). Render is
+# set to pull pre-built images, so it does NOT redeploy on its own when a new
+# image is pushed — something has to POST a deploy to the Render API. That is
+# what this script does.
+#
+# Finding the service without a second secret
+# ───────────────────────────────
+# The Render API needs the service's id (srv-…). Earlier this id lived in its
+# own GitHub secret (RENDER_SERVICE_ID_*), and when that secret was missing the
+# deploy silently skipped — the image shipped to GHCR but production stayed on
+# the old image. To remove that failure mode this script needs only the API
+# key: if no explicit id is given, it looks the service up by name. An explicit
+# id (RENDER_SERVICE_ID) is still honored as an override when present.
+#
+# Inputs (environment variables)
+#   RENDER_API_KEY        required — Render API key (rnd_…)
+#   RENDER_SERVICE_NAME   the service's name in Render, e.g. ctf-web
+#   RENDER_SERVICE_ID     optional — explicit srv-… id; skips the name lookup
+#
+# This never fails the build. The image is already in GHCR and can always be
+# deployed by hand (Render dashboard → the service → Manual Deploy → Deploy
+# latest reference). Any problem is reported as a GitHub Actions warning so the
+# build stays green while still flagging that production was not updated.
+set -uo pipefail
+
+name="${RENDER_SERVICE_NAME:-}"
+id="${RENDER_SERVICE_ID:-}"
+label="${name:-the service}"
+
+if [ -z "${RENDER_API_KEY:-}" ]; then
+  echo "RENDER_API_KEY not set — skipping auto-deploy (image is pushed to GHCR; deploy ${label} manually in Render)."
+  exit 0
+fi
+
+if [ -z "$name" ] && [ -z "$id" ]; then
+  echo "Neither RENDER_SERVICE_NAME nor RENDER_SERVICE_ID set — nothing to deploy."
+  exit 0
+fi
+
+# Look the service id up by name when one was not supplied explicitly. The id
+# itself is never printed (treated as opaque), only the human-readable name.
+if [ -z "$id" ]; then
+  echo "Looking up the Render service id for '${name}'…"
+  lookup_status=$(curl -s -o /tmp/render-services.json -w '%{http_code}' \
+    -H "Authorization: Bearer $RENDER_API_KEY" \
+    "https://api.render.com/v1/services?name=${name}&limit=100" || true)
+  case "$lookup_status" in
+    2*) ;;
+    *)
+      echo "::warning title=Render auto-deploy not triggered::Could not list Render services (HTTP ${lookup_status:-none}) to find '${name}'. The image is already pushed to GHCR — deploy it by hand (Manual Deploy → Deploy latest reference) and check RENDER_API_KEY (rnd_…, raw)."
+      exit 0
+      ;;
+  esac
+  id=$(jq -r --arg n "$name" 'map(.service) | map(select(.name == $n)) | .[0].id // empty' /tmp/render-services.json 2>/dev/null || true)
+fi
+
+if [ -z "$id" ]; then
+  echo "::warning title=Render auto-deploy not triggered::No Render service named '${name}' was found with this API key. The image is already pushed to GHCR — deploy it by hand (Manual Deploy → Deploy latest reference)."
+  exit 0
+fi
+
+# Do NOT use curl -f here (it exits 22 and hides the HTTP error). Capture the
+# status code and body so a failed trigger is readable, and never fail the build
+# on it — the image is already pushed and can be deployed manually in Render.
+deploy_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $RENDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  "https://api.render.com/v1/services/${id}/deploys" || true)
+echo "Render deploy API responded with HTTP ${deploy_status:-<none>} for ${name}"
+case "$deploy_status" in
+  2*) echo "Render deploy triggered for ${name}." ;;
+  *)
+    echo "::warning title=Render auto-deploy not triggered::HTTP ${deploy_status:-none} from Render for ${name}. The image is already pushed to GHCR — deploy it by hand (Manual Deploy → Deploy latest reference) and check RENDER_API_KEY (rnd_…, raw). Response:"
+    cat /tmp/render-deploy.json 2>/dev/null || true
+    ;;
+esac

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -30,11 +30,15 @@ name: Build and push Docker images
 #   NEXT_PUBLIC_AUTH_PROVIDER         — clerk
 #
 # OPTIONAL GITHUB SECRETS (enables auto-deploy to Render after image push):
-#   RENDER_API_KEY                    — Render API key
-#   RENDER_SERVICE_ID_WEB             — Render service ID for ctf-web
-#   RENDER_SERVICE_ID_OLLAMA          — Render service ID for ctf-ollama
-#   RENDER_SERVICE_ID_RASA            — Render service ID for ctf-rasa
-#   RENDER_SERVICE_ID_FORMANCE        — Render service ID for ctf-formance-ledger
+#   RENDER_API_KEY                    — Render API key. This ALONE is enough to
+#       deploy: after pushing an image, .github/scripts/render-deploy.sh asks the
+#       Render API for the service id by name and triggers the deploy. Without it
+#       the image still reaches GHCR, but production keeps running the OLD image
+#       until someone deploys by hand (Manual Deploy → Deploy latest reference).
+#   RENDER_SERVICE_ID_WEB             — optional: explicit ctf-web id, skips the name lookup
+#   RENDER_SERVICE_ID_OLLAMA          — optional: explicit ctf-ollama id
+#   RENDER_SERVICE_ID_RASA            — optional: explicit ctf-rasa id
+#   RENDER_SERVICE_ID_FORMANCE        — optional: explicit ctf-formance-ledger id
 
 on:
   push:
@@ -126,29 +130,10 @@ jobs:
       - name: Trigger Render deploy
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_WEB: ${{ secrets.RENDER_SERVICE_ID_WEB }}
-        run: |
-          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_WEB" ]; then
-            echo "RENDER_API_KEY or RENDER_SERVICE_ID_WEB not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-web manually in Render)."
-            exit 0
-          fi
-          # Do NOT use curl -f here: it exits 22 and hides the HTTP error. Capture
-          # the status code + body so a failed trigger is readable, and never fail
-          # the build on it — the image is already pushed and can be deployed
-          # manually in Render (Manual Deploy → Deploy latest reference).
-          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $RENDER_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d '{}' \
-            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_WEB/deploys" || true)
-          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-web"
-          case "$http_status" in
-            2*) echo "Render deploy triggered for ctf-web." ;;
-            *)
-              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-web. The image is already pushed to GHCR — deploy manually (Manual Deploy → Deploy latest reference) and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_WEB. Response:"
-              cat /tmp/render-deploy.json 2>/dev/null || true
-              ;;
-          esac
+          RENDER_SERVICE_NAME: ctf-web
+          # Optional explicit id; when unset the script finds it by name.
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_WEB }}
+        run: bash .github/scripts/render-deploy.sh
 
   # ── ctf-ollama ──────────────────────────────────────────────────
   # Only rebuilds when the Dockerfile changes — model bake takes ~1 hour.
@@ -190,26 +175,10 @@ jobs:
       - name: Trigger Render deploy
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_OLLAMA: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
-        run: |
-          # See ctf-web for why curl -f is avoided; print status, never fail the build.
-          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_OLLAMA" ]; then
-            echo "RENDER_API_KEY or RENDER_SERVICE_ID_OLLAMA not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-ollama manually in Render)."
-            exit 0
-          fi
-          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $RENDER_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d '{}' \
-            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_OLLAMA/deploys" || true)
-          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-ollama"
-          case "$http_status" in
-            2*) echo "Render deploy triggered for ctf-ollama." ;;
-            *)
-              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-ollama. The image is already pushed to GHCR — deploy manually and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_OLLAMA. Response:"
-              cat /tmp/render-deploy.json 2>/dev/null || true
-              ;;
-          esac
+          RENDER_SERVICE_NAME: ctf-ollama
+          # Optional explicit id; when unset the script finds it by name.
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
+        run: bash .github/scripts/render-deploy.sh
 
   # ── ctf-rasa ────────────────────────────────────────────────────
   # Only rebuilds when ctf/ops/rasa/** changes — the NLU model is trained at build
@@ -252,26 +221,10 @@ jobs:
       - name: Trigger Render deploy
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_RASA: ${{ secrets.RENDER_SERVICE_ID_RASA }}
-        run: |
-          # See ctf-web for why curl -f is avoided; print status, never fail the build.
-          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_RASA" ]; then
-            echo "RENDER_API_KEY or RENDER_SERVICE_ID_RASA not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-rasa manually in Render)."
-            exit 0
-          fi
-          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $RENDER_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d '{}' \
-            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_RASA/deploys" || true)
-          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-rasa"
-          case "$http_status" in
-            2*) echo "Render deploy triggered for ctf-rasa." ;;
-            *)
-              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-rasa. The image is already pushed to GHCR — deploy manually and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_RASA. Response:"
-              cat /tmp/render-deploy.json 2>/dev/null || true
-              ;;
-          esac
+          RENDER_SERVICE_NAME: ctf-rasa
+          # Optional explicit id; when unset the script finds it by name.
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_RASA }}
+        run: bash .github/scripts/render-deploy.sh
 
   # ── ctf-formance-ledger ─────────────────────────────────────────
   build-formance-ledger:
@@ -311,23 +264,7 @@ jobs:
       - name: Trigger Render deploy
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_FORMANCE: ${{ secrets.RENDER_SERVICE_ID_FORMANCE }}
-        run: |
-          # See ctf-web for why curl -f is avoided; print status, never fail the build.
-          if [ -z "$RENDER_API_KEY" ] || [ -z "$RENDER_SERVICE_ID_FORMANCE" ]; then
-            echo "RENDER_API_KEY or RENDER_SERVICE_ID_FORMANCE not set — skipping auto-deploy (image is pushed to GHCR; deploy ctf-formance-ledger manually in Render)."
-            exit 0
-          fi
-          http_status=$(curl -s -o /tmp/render-deploy.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $RENDER_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d '{}' \
-            "https://api.render.com/v1/services/$RENDER_SERVICE_ID_FORMANCE/deploys" || true)
-          echo "Render deploy API responded with HTTP ${http_status:-<none>} for ctf-formance-ledger"
-          case "$http_status" in
-            2*) echo "Render deploy triggered for ctf-formance-ledger." ;;
-            *)
-              echo "::warning title=Render auto-deploy not triggered::HTTP ${http_status:-none} from Render for ctf-formance-ledger. The image is already pushed to GHCR — deploy manually and verify RENDER_API_KEY (rnd_…, raw) and RENDER_SERVICE_ID_FORMANCE. Response:"
-              cat /tmp/render-deploy.json 2>/dev/null || true
-              ;;
-          esac
+          RENDER_SERVICE_NAME: ctf-formance-ledger
+          # Optional explicit id; when unset the script finds it by name.
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_FORMANCE }}
+        run: bash .github/scripts/render-deploy.sh

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,10 +1,12 @@
 name: Render deploy
 
-# Redeploys a Render service without rebuilding the Docker image.
-# Use this to pick up new environment variables synced from Infisical,
-# or to restart a service after a config change.
+# Redeploys a Render service without rebuilding the Docker image (it re-pulls
+# the existing …:latest image from GHCR). Use this to ship images that were
+# already built — e.g. when the build ran but the deploy was never triggered —
+# or to pick up new environment variables synced from Infisical.
 #
-# Required secrets: RENDER_API_KEY + the service-specific RENDER_SERVICE_ID_*
+# Required secret: RENDER_API_KEY. The service id is looked up by name from the
+# Render API, so RENDER_SERVICE_ID_* secrets are an optional override only.
 
 on:
   workflow_dispatch:
@@ -24,6 +26,8 @@ jobs:
     name: Redeploy ${{ inputs.service }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Trigger Render deploy(s)
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
@@ -33,27 +37,17 @@ jobs:
           SERVICE: ${{ inputs.service }}
         run: |
           deploy() {
-            local id="$1" name="$2"
-            if [ -z "$id" ]; then
-              echo "SKIP $name — service ID secret not set"
-              return
-            fi
-            echo "Deploying $name ($id)..."
-            curl -sf -X POST \
-              -H "Authorization: Bearer $RENDER_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{}' \
-              "https://api.render.com/v1/services/$id/deploys"
-            echo " done"
+            # $1 = service name (used to find the id), $2 = optional explicit id.
+            RENDER_SERVICE_NAME="$1" RENDER_SERVICE_ID="$2" bash .github/scripts/render-deploy.sh
           }
 
           case "$SERVICE" in
-            ctf-web)            deploy "$RENDER_SERVICE_ID_WEB"     "ctf-web" ;;
-            ctf-ollama)         deploy "$RENDER_SERVICE_ID_OLLAMA"   "ctf-ollama" ;;
-            ctf-formance-ledger) deploy "$RENDER_SERVICE_ID_FORMANCE" "ctf-formance-ledger" ;;
+            ctf-web)             deploy ctf-web             "$RENDER_SERVICE_ID_WEB" ;;
+            ctf-ollama)          deploy ctf-ollama          "$RENDER_SERVICE_ID_OLLAMA" ;;
+            ctf-formance-ledger) deploy ctf-formance-ledger "$RENDER_SERVICE_ID_FORMANCE" ;;
             all)
-              deploy "$RENDER_SERVICE_ID_WEB"     "ctf-web"
-              deploy "$RENDER_SERVICE_ID_OLLAMA"  "ctf-ollama"
-              deploy "$RENDER_SERVICE_ID_FORMANCE" "ctf-formance-ledger"
+              deploy ctf-web             "$RENDER_SERVICE_ID_WEB"
+              deploy ctf-ollama          "$RENDER_SERVICE_ID_OLLAMA"
+              deploy ctf-formance-ledger "$RENDER_SERVICE_ID_FORMANCE"
               ;;
           esac


### PR DESCRIPTION
## What was broken

Every merge to `main` builds the web image and pushes it to GHCR, and CI goes green — but the changes never reached https://the-comic.com. That is why the responsive per-plugin layouts and the unified loading screen, though merged, were still showing the old desktop pages on phones.

Render is set to **pull** pre-built images; it does **not** redeploy on its own when a new image is pushed. Something has to POST a deploy to the Render API. That POST was guarded by a `RENDER_SERVICE_ID_WEB` secret that is **not set**, so the step printed `RENDER_API_KEY or RENDER_SERVICE_ID_WEB not set — skipping auto-deploy` and exited. The image sat in GHCR while production kept serving the old one. The manual "Render deploy" workflow skipped for the same reason (last successful run: May 25).

Confirmed in the build log for the #298 merge: `RENDER_API_KEY: ***` (set) but `RENDER_SERVICE_ID_WEB:` (empty).

## The fix

Stop depending on that second secret. A new shared script — `.github/scripts/render-deploy.sh` — needs only `RENDER_API_KEY` (which is set): when no explicit service id is given, it looks the service up **by name** through the Render API, then triggers the deploy. An explicit `RENDER_SERVICE_ID_*` is still honored as an override if anyone sets it.

- All four build jobs in `build-images.yml` and every branch of the manual `render-deploy.yml` now call the one script — the deploy logic lives in a single place (was ~25 duplicated lines × 5).
- The script **never fails the build**: a missing key or a failed API call prints a GitHub Actions warning and exits cleanly, because the image is already in GHCR and can be deployed by hand.
- The service id is never printed to logs (only the human-readable name).

## After this merges

Because this PR only touches `.github/**`, merging it will not itself rebuild or deploy the web image (the build is path-filtered to `ctf/**`). To push the already-built responsive work live immediately, I will run the manual `render-deploy.yml` (service `ctf-web`) once it is on `main`. From then on, every merge that touches `ctf/**` will deploy automatically.

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_