### PR TITLE
fix: match Render service-id secret names to the actual repo secrets

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -35,10 +35,10 @@ name: Build and push Docker images
 #       Render API for the service id by name and triggers the deploy. Without it
 #       the image still reaches GHCR, but production keeps running the OLD image
 #       until someone deploys by hand (Manual Deploy → Deploy latest reference).
-#   RENDER_SERVICE_ID_CT_WEB             — optional: explicit ctf-web id, skips the name lookup
-#   RENDER_SERVICE_ID_CT_OLLAMA          — optional: explicit ctf-ollama id
-#   RENDER_SERVICE_ID_CT_RASA            — optional: explicit ctf-rasa id
-#   RENDER_SERVICE_ID_CT_FORMANCE        — optional: explicit ctf-formance-ledger id
+#   RENDER_SERVICE_ID_CTF_WEB             — optional: explicit ctf-web id, skips the name lookup
+#   RENDER_SERVICE_ID_OLLAMA          — optional: explicit ctf-ollama id
+#   RENDER_SERVICE_ID_CTF_RASA            — optional: explicit ctf-rasa id
+#   RENDER_SERVICE_ID_CTF_FORMANCE        — optional: explicit ctf-formance-ledger id
 
 on:
   push:
@@ -132,7 +132,7 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_NAME: ctf-web
           # Optional explicit id; when unset the script finds it by name.
-          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CT_WEB }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CTF_WEB }}
         run: bash .github/scripts/render-deploy.sh
 
   # ── ctf-ollama ──────────────────────────────────────────────────
@@ -177,7 +177,7 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_NAME: ctf-ollama
           # Optional explicit id; when unset the script finds it by name.
-          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CT_OLLAMA }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
         run: bash .github/scripts/render-deploy.sh
 
   # ── ctf-rasa ────────────────────────────────────────────────────
@@ -223,7 +223,7 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_NAME: ctf-rasa
           # Optional explicit id; when unset the script finds it by name.
-          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CT_RASA }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CTF_RASA }}
         run: bash .github/scripts/render-deploy.sh
 
   # ── ctf-formance-ledger ─────────────────────────────────────────
@@ -266,5 +266,5 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_NAME: ctf-formance-ledger
           # Optional explicit id; when unset the script finds it by name.
-          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CT_FORMANCE }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CTF_FORMANCE }}
         run: bash .github/scripts/render-deploy.sh

--- a/.github/workflows/render-debug-agent.yml
+++ b/.github/workflows/render-debug-agent.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       service_id:
-        description: 'Render service ID to debug (e.g. srv-xxx). Leave blank to use RENDER_SERVICE_ID_CT_WEB secret.'
+        description: 'Render service ID to debug (e.g. srv-xxx). Leave blank to use RENDER_SERVICE_ID_CTF_WEB secret.'
         required: false
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
         id: debug
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID: ${{ inputs.service_id || secrets.RENDER_SERVICE_ID_CT_WEB }}
+          RENDER_SERVICE_ID: ${{ inputs.service_id || secrets.RENDER_SERVICE_ID_CTF_WEB }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod +x ctf/scripts/render-debug-agent.sh

--- a/.github/workflows/render-deploy-watch.yml
+++ b/.github/workflows/render-deploy-watch.yml
@@ -11,9 +11,9 @@ name: Render Deploy Watch
 #
 # To watch another service:
 #   1. add a matrix entry with its name (e.g. - name: ctf-worker);
-#   2. add a static env line below: RENDER_SERVICE_ID_CT_WORKER: ${{ secrets.RENDER_SERVICE_ID_CT_WORKER }};
+#   2. add a static env line below: RENDER_SERVICE_ID_CTF_WORKER: ${{ secrets.RENDER_SERVICE_ID_CTF_WORKER }};
 #   3. add a case branch mapping that name to that env var;
-#   4. add the RENDER_SERVICE_ID_CT_WORKER repo secret.
+#   4. add the RENDER_SERVICE_ID_CTF_WORKER repo secret.
 # Secrets are referenced statically on purpose — dynamic secrets[...] indexing
 # would expose the whole secrets context to the runner.
 
@@ -45,7 +45,7 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           # One static line per watched service (pattern: RENDER_SERVICE_ID_<NAME>).
-          RENDER_SERVICE_ID_CT_WEB: ${{ secrets.RENDER_SERVICE_ID_CT_WEB }}
+          RENDER_SERVICE_ID_CTF_WEB: ${{ secrets.RENDER_SERVICE_ID_CTF_WEB }}
           SERVICE_NAME: ${{ matrix.service.name }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
@@ -53,7 +53,7 @@ jobs:
 
           # Map this matrix service to its statically-provided id env var.
           case "$SERVICE_NAME" in
-            ctf-web) RENDER_SERVICE_ID="${RENDER_SERVICE_ID_CT_WEB:-}" ;;
+            ctf-web) RENDER_SERVICE_ID="${RENDER_SERVICE_ID_CTF_WEB:-}" ;;
             *) echo "::error::Unknown service '${SERVICE_NAME}' — add its secret env mapping in the workflow."; exit 1 ;;
           esac
 

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Trigger Render deploy(s)
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_ID_CT_WEB: ${{ secrets.RENDER_SERVICE_ID_CT_WEB }}
-          RENDER_SERVICE_ID_CT_OLLAMA: ${{ secrets.RENDER_SERVICE_ID_CT_OLLAMA }}
-          RENDER_SERVICE_ID_CT_FORMANCE: ${{ secrets.RENDER_SERVICE_ID_CT_FORMANCE }}
+          RENDER_SERVICE_ID_CTF_WEB: ${{ secrets.RENDER_SERVICE_ID_CTF_WEB }}
+          RENDER_SERVICE_ID_OLLAMA: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
+          RENDER_SERVICE_ID_CTF_FORMANCE: ${{ secrets.RENDER_SERVICE_ID_CTF_FORMANCE }}
           SERVICE: ${{ inputs.service }}
         run: |
           deploy() {
@@ -42,12 +42,12 @@ jobs:
           }
 
           case "$SERVICE" in
-            ctf-web)             deploy ctf-web             "$RENDER_SERVICE_ID_CT_WEB" ;;
-            ctf-ollama)          deploy ctf-ollama          "$RENDER_SERVICE_ID_CT_OLLAMA" ;;
-            ctf-formance-ledger) deploy ctf-formance-ledger "$RENDER_SERVICE_ID_CT_FORMANCE" ;;
+            ctf-web)             deploy ctf-web             "$RENDER_SERVICE_ID_CTF_WEB" ;;
+            ctf-ollama)          deploy ctf-ollama          "$RENDER_SERVICE_ID_OLLAMA" ;;
+            ctf-formance-ledger) deploy ctf-formance-ledger "$RENDER_SERVICE_ID_CTF_FORMANCE" ;;
             all)
-              deploy ctf-web             "$RENDER_SERVICE_ID_CT_WEB"
-              deploy ctf-ollama          "$RENDER_SERVICE_ID_CT_OLLAMA"
-              deploy ctf-formance-ledger "$RENDER_SERVICE_ID_CT_FORMANCE"
+              deploy ctf-web             "$RENDER_SERVICE_ID_CTF_WEB"
+              deploy ctf-ollama          "$RENDER_SERVICE_ID_OLLAMA"
+              deploy ctf-formance-ledger "$RENDER_SERVICE_ID_CTF_FORMANCE"
               ;;
           esac


### PR DESCRIPTION
## What this fixes

The workflows referenced Render service-id secret names that **don't exist** in the repository secrets, so the explicit-id path never matched and every deploy quietly fell back to the Render API name lookup. The `render-deploy-watch.yml` watcher has **no** fallback, so it silently skipped (green, but never confirmed a deploy).

This points every reference at the **actual** secret names (confirmed from the repo Settings → Secrets):

| Service | Secret name (actual) |
|---|---|
| web | `RENDER_SERVICE_ID_CTF_WEB` |
| ollama | `RENDER_SERVICE_ID_OLLAMA` (no prefix) |
| rasa | `RENDER_SERVICE_ID_CTF_RASA` |
| formance | `RENDER_SERVICE_ID_CTF_FORMANCE` |

## Background

PR #304 changed these to a `CT_` spelling based on an early mis-typed name. No secrets are being renamed, so this restores the names that actually exist. Deploys were never blocked (the name lookup added in #303 covered the gap), but now the explicit id resolves directly and the **web deploy-watch will actually confirm deploys** instead of skipping.

Touches `.github/workflows/**` only — no app/schema/contract changes, and merging it doesn't trigger a build (path-filtered to `ctf/**`).

Parity Status: web+android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01YU7ir9k83V7HjMSokT9Uoo)_