### PR TITLE
feat: show SocketRelay poster @username publicly, never Anonymous

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socketrelay-feature-inventory.md
@@ -105,7 +105,7 @@ Admin routes:
 Tables owned by this plugin:
 
 1. `socketrelay_user_extension` — Per-user profile extension fields.
-2. `socketrelay_requests` — Request lifecycle rows (status, ownership, repost lineage).
+2. `socketrelay_requests` — Request lifecycle rows (status, ownership, repost lineage). Includes a nullable `owner_username TEXT` column that captures the poster's chosen `@username` at request-creation time (denormalized from the Clerk session, exactly like `chyme_messages.username` and `feed_community_posts.author_username`), because v3 has no reliable server-side store of other users' usernames. This handle is surfaced in every view, including the not-signed-in / public projection — never "Anonymous" (owner decision, 2026-06-04).
 3. `socketrelay_request_events` — Event log for request state transitions.
 4. `socketrelay_fulfillments` — Fulfillment claims and outcomes per request.
 5. `socketrelay_fulfillment_participants` — Participant access records for fulfillment chats.
@@ -122,7 +122,7 @@ exists — never derived from `price_currency`. No ServiceCredits amount is show
 Storage and projection rules:
 
 1. Request and fulfillment status transitions are explicit and replay-safe via the `request_events` log.
-2. Public projection contracts are separated from authenticated/admin DTOs (privacy-minimized fields only on public routes).
+2. Public projection contracts are separated from authenticated/admin DTOs (privacy-minimized fields only on public routes). The public projection (`SocketRelayPublicRequest`, served by `GET /api/socketrelay/public` and `GET /api/socketrelay/public/:id`) now includes `ownerUsername` so the poster's `@username` is shown to signed-out visitors (owner decision, 2026-06-04). The authenticated `SocketRelayRequest` DTO also carries `ownerUsername`.
 3. Mutation operations enforce deterministic storage outcomes and audit-friendly metadata.
 
 ## 5) Security, Privacy, and Compliance Controls
@@ -298,7 +298,8 @@ Android pixel pass (design `MobileSocketRelay.tsx`): `packages/mobile/src/featur
 
 ### Change Log
 
-- 2026-06-04: Owner decision — SocketRelay is **not anonymous**. A request poster / chat participant is identified by their **`@username`** (the unique handle they chose at sign-up), and that `@username` is what's shown **even in the not-signed-in / public view** (a chosen handle, not a real name, so it is safe to surface publicly). This supersedes the design mockups' "Anonymous" poster treatment (design catch-up tracked as gap D5 in the design-prompt issue #312). Implementation note: the public request projection must surface the poster's `@username`; since usernames are not reliably stored server-side, this needs the username captured/denormalized at request time (same pattern as Chyme/Feed) — tracked as follow-up.
+- 2026-06-04: Owner decision — SocketRelay is **not anonymous**. A request poster / chat participant is identified by their **`@username`** (the unique handle they chose at sign-up), and that `@username` is what's shown **even in the not-signed-in / public view** (a chosen handle, not a real name, so it is safe to surface publicly). This supersedes the design mockups' "Anonymous" poster treatment (design catch-up tracked as gap D5 in the design-prompt issue #312).
+- 2026-06-04: Implemented the public `@username`. Added a nullable `owner_username TEXT` column to `socketrelay_requests` that captures the poster's username at request-creation time (denormalized from the Clerk session, like `chyme_messages.username` and `feed_community_posts.author_username`); the create function writes `gate.auth.username`. Both the authenticated `SocketRelayRequest` DTO and the public `SocketRelayPublicRequest` projection now carry `ownerUsername`. Web (`sr-feed` request cards) and Android (`SocketRelay` feed cards) render `@username` with a neutral `user-<id>` fallback when no username was captured. Schema (`schema.sql` + `schema.demo.sql`, additive `ALTER TABLE … ADD COLUMN IF NOT EXISTS`), repository, types, create route, and both client surfaces updated.
 - 2026-06-02: Removed the unused `display_name` column from `socketrelay_user_extension` (and the `displayName` field from `SocketRelayProfile`/`SocketRelayProfileInput`, the profile route parser, and the repository reads/writes). Nothing rendered it; SocketRelay identifies people by their Clerk `@username` (built in the relay/chat routes), so the stored display name was dead. Dropped via `db/migrations/post/0003_socketrelay_drop_display_name.sql` (guarded, re-runnable). Part of removing the v2 "display name" convention from v3.
 - 2026-06-01: Enforced the SocketRelay price invariant at the DB level — added a guarded `socketrelay_requests_price_consistency_check` CHECK so a request either has no price (both NULL) or a positive amount in a named currency (the "Free = no price, never `$0`" rule). Follow-up to the #120 review.
 - 2026-06-01: Multi-currency (issue #120): added OPTIONAL `price_amount` + `price_currency` (FK → `currencies.code`) to `socketrelay_requests` and a `socketrelay_request_accepted_currencies` join. "Free" renders from the absence of a price, never `$0`. Documented the no-fiat-parity rule. Schema + inventory only; the currency UI is design-gated.

--- a/ctf/packages/mobile/src/features/socketrelay/SocketRelay.tsx
+++ b/ctf/packages/mobile/src/features/socketrelay/SocketRelay.tsx
@@ -13,6 +13,7 @@ import {
   createRequest,
   listRequests,
   fulfillRequest,
+  socketRelayHandle,
   type SocketRelayRequest,
 } from './api';
 import { SocketRelayLoading } from './SocketRelayLoading';
@@ -144,6 +145,10 @@ export function SocketRelay() {
                     {r.details}
                   </Text>
                 ) : null}
+
+                <Text style={styles.cardPoster}>
+                  {socketRelayHandle(r.ownerUsername, r.id)}
+                </Text>
 
                 <Text style={styles.cardMeta}>
                   {r.city ? `📍 ${r.city} · ` : ''}
@@ -394,6 +399,7 @@ const styles = StyleSheet.create({
     lineHeight: 20,
   },
   cardDetails: { fontSize: 12, color: '#9CA3AF', marginBottom: 6, lineHeight: 18 },
+  cardPoster: { fontSize: 12, color: COLOR, fontWeight: '600', marginBottom: 4 },
   cardMeta: { fontSize: 11, color: '#6B7280', marginBottom: 10 },
   helpBtn: {
     paddingVertical: 8,

--- a/ctf/packages/mobile/src/features/socketrelay/api.ts
+++ b/ctf/packages/mobile/src/features/socketrelay/api.ts
@@ -10,6 +10,7 @@ export type SocketRelayRequestStatus = 'open' | 'claimed' | 'closed' | 'cancelle
 export type SocketRelayRequest = {
   id: string;
   ownerUserId: string;
+  ownerUsername: string | null;
   title: string;
   details: string;
   category: string;
@@ -29,6 +30,15 @@ export type SocketRelayRequestInput = {
   city: string | null;
   isPublic: boolean;
 };
+
+// Poster handle: show the chosen @username (owner decision: shown publicly, never "Anonymous").
+// When no username was captured, fall back to a neutral short id — mirrors Chyme's chymeHandle.
+export function socketRelayHandle(
+  username: string | null,
+  id: string,
+): string {
+  return username ? `@${username}` : `user-${id.slice(0, 8)}`;
+}
 
 export type ListRequestsResponse = {
   ok: boolean;

--- a/ctf/packages/web/app/api/socketrelay/requests/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/requests/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: Request) {
     : `${gate.auth.userId}:${Date.now()}`;
 
   try {
-    const item = await createRequest(gate.auth.userId, input, idempotencyKey);
+    const item = await createRequest(gate.auth.userId, gate.auth.username ?? null, input, idempotencyKey);
     return NextResponse.json({ ok: true, item }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'socketrelay', op: 'requests' });

--- a/ctf/packages/web/components/socketrelay/sr-feed.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-feed.tsx
@@ -3,7 +3,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
 import { MapPin, Share2 } from "lucide-react";
-import { COLOR, FAINT, SUBTLE, timeAgo, type SrRequest } from "./sr-shared";
+import { COLOR, FAINT, SUBTLE, srHandle, timeAgo, type SrRequest } from "./sr-shared";
 
 function CardAction({ open, isOwn, submitting, onClaim }: { open: boolean; isOwn: boolean; submitting: boolean; onClaim: () => void }) {
   if (!open) return <div style={{ fontSize: 12, color: "#22C55E", fontWeight: 600 }}>✓ closed</div>;
@@ -43,6 +43,7 @@ function RequestCard({
           <div style={{ fontSize: 14, fontWeight: 600, color: "#F9FAFB", marginBottom: 4, lineHeight: 1.4 }}>{r.title}</div>
           {r.details && <div style={{ fontSize: 13, color: "#9CA3AF", marginBottom: 6, lineHeight: 1.5 }}>{r.details}</div>}
           <div style={{ display: "flex", gap: 12, fontSize: 12, color: SUBTLE, flexWrap: "wrap" }}>
+            <span style={{ color: COLOR, fontWeight: 600 }}>{srHandle(r.ownerUsername, r.id)}</span>
             {r.city && <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><MapPin size={11} /> {r.city}</span>}
             <span>· {timeAgo(r.createdAtIso)}</span>
           </div>

--- a/ctf/packages/web/components/socketrelay/sr-shared.ts
+++ b/ctf/packages/web/components/socketrelay/sr-shared.ts
@@ -17,6 +17,7 @@ export type SrRequestStatus = "open" | "claimed" | "closed" | "cancelled";
 export type SrRequest = {
   id: string;
   ownerUserId: string;
+  ownerUsername: string | null;
   title: string;
   details: string;
   category: string;
@@ -64,4 +65,10 @@ export function timeAgo(iso: string): string {
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs} hr ago`;
   return `${Math.floor(hrs / 24)}d ago`;
+}
+
+// Poster handle: show the chosen @username (owner decision: shown publicly, never "Anonymous").
+// When no username was captured, fall back to a neutral short id — mirrors Chyme's chymeHandle.
+export function srHandle(username: string | null, id: string): string {
+  return username ? `@${username}` : `user-${id.slice(0, 8)}`;
 }

--- a/ctf/packages/web/lib/socketrelay/repository.ts
+++ b/ctf/packages/web/lib/socketrelay/repository.ts
@@ -42,6 +42,7 @@ type ProfileRow = {
 type RequestRow = {
   id: string;
   owner_user_id: string;
+  owner_username: string | null;
   title: string;
   details: string;
   category: string;
@@ -126,6 +127,7 @@ function mapRequestRow(row: RequestRow): SocketRelayRequest {
   return {
     id: row.id,
     ownerUserId: row.owner_user_id,
+    ownerUsername: row.owner_username,
     title: row.title,
     details: row.details,
     category: row.category,
@@ -142,6 +144,7 @@ function mapRequestRow(row: RequestRow): SocketRelayRequest {
 function mapPublicRequestRow(row: RequestRow): SocketRelayPublicRequest {
   return {
     id: row.id,
+    ownerUsername: row.owner_username,
     title: row.title,
     category: row.category,
     city: row.city,
@@ -299,10 +302,10 @@ export async function deleteProfile(userId: string): Promise<void> {
   );
 }
 
-export async function createRequest(actorUserId: string, input: SocketRelayRequestInput, idempotencyKey: string): Promise<SocketRelayRequest> {
+export async function createRequest(actorUserId: string, actorUsername: string | null, input: SocketRelayRequestInput, idempotencyKey: string): Promise<SocketRelayRequest> {
   return withDbTransaction(async (client) => {
     const existing = await client.query<RequestRow>(
-      `SELECT id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
+      `SELECT id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
        FROM socketrelay_requests
        WHERE owner_user_id = $1 AND idempotency_key = $2
        LIMIT 1`,
@@ -315,11 +318,12 @@ export async function createRequest(actorUserId: string, input: SocketRelayReque
 
     const created = await client.query<RequestRow>(
       `INSERT INTO socketrelay_requests (
-         owner_user_id, title, details, category, city, is_public, status, idempotency_key
-       ) VALUES ($1, $2, $3, $4, $5, $6, 'open', $7)
-       RETURNING id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
+         owner_user_id, owner_username, title, details, category, city, is_public, status, idempotency_key
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'open', $8)
+       RETURNING id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
       [
         actorUserId,
+        normalizeNullableText(actorUsername),
         normalizeText(input.title),
         normalizeText(input.details),
         normalizeText(input.category),
@@ -363,7 +367,7 @@ export async function listRequests(options?: {
   const total = Number.parseInt(count.rows[0]?.total ?? '0', 10);
 
   const result = await queryDb<RequestRow>(
-    `SELECT id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
+    `SELECT id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
      FROM socketrelay_requests
      WHERE ($1::text IS NULL OR owner_user_id = $1)
        AND ($2::boolean = FALSE OR is_public = TRUE)
@@ -382,7 +386,7 @@ export async function listRequests(options?: {
 
 export async function getRequestById(requestId: string): Promise<SocketRelayRequest | null> {
   const result = await queryDb<RequestRow>(
-    `SELECT id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
+    `SELECT id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
      FROM socketrelay_requests
      WHERE id = $1::uuid
      LIMIT 1`,
@@ -415,7 +419,7 @@ export async function updateRequest(requestId: string, actorUserId: string, isAd
          is_public = $6,
          updated_at = NOW()
      WHERE id = $1::uuid
-     RETURNING id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
+     RETURNING id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
     [
       requestId,
       normalizeText(input.title),
@@ -446,7 +450,7 @@ export async function repostRequest(requestId: string, actorUserId: string, isAd
          claimed_fulfillment_id = NULL,
          updated_at = NOW()
      WHERE id = $1::uuid
-     RETURNING id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
+     RETURNING id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
     [requestId],
   );
 
@@ -456,7 +460,7 @@ export async function repostRequest(requestId: string, actorUserId: string, isAd
 export async function claimRequest(requestId: string, actorUserId: string): Promise<{ request: SocketRelayRequest; fulfillment: SocketRelayFulfillment }> {
   const created = await withDbTransaction(async (client) => {
     const requestResult = await client.query<RequestRow>(
-      `SELECT id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
+      `SELECT id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
        FROM socketrelay_requests
        WHERE id = $1::uuid
        LIMIT 1
@@ -496,7 +500,7 @@ export async function claimRequest(requestId: string, actorUserId: string): Prom
       `UPDATE socketrelay_requests
        SET status = 'claimed', claimed_fulfillment_id = $2::uuid, updated_at = NOW()
        WHERE id = $1::uuid
-       RETURNING id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
+       RETURNING id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
       [requestId, fulfillment.rows[0].id],
     );
 
@@ -654,7 +658,7 @@ export async function listPublicRequests(options?: { page?: number; pageSize?: n
   const total = Number.parseInt(count.rows[0]?.total ?? '0', 10);
 
   const result = await queryDb<RequestRow>(
-    `SELECT id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
+    `SELECT id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
      FROM socketrelay_requests
      WHERE is_public = TRUE AND status <> 'cancelled'
      ORDER BY created_at DESC
@@ -672,7 +676,7 @@ export async function listPublicRequests(options?: { page?: number; pageSize?: n
 
 export async function getPublicRequestById(requestId: string): Promise<SocketRelayPublicRequest | null> {
   const result = await queryDb<RequestRow>(
-    `SELECT id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
+    `SELECT id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at
      FROM socketrelay_requests
      WHERE id = $1::uuid AND is_public = TRUE AND status <> 'cancelled'
      LIMIT 1`,
@@ -704,7 +708,7 @@ export async function adminDeleteRequest(requestId: string): Promise<void> {
   const result = await queryDb<RequestRow>(
     `DELETE FROM socketrelay_requests
      WHERE id = $1::uuid
-     RETURNING id, owner_user_id, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
+     RETURNING id, owner_user_id, owner_username, title, details, category, city, is_public, status, reopened_count, claimed_fulfillment_id, created_at, updated_at`,
     [requestId],
   );
 

--- a/ctf/packages/web/lib/socketrelay/types.ts
+++ b/ctf/packages/web/lib/socketrelay/types.ts
@@ -18,6 +18,7 @@ export type SocketRelayRequestStatus = 'open' | 'claimed' | 'closed' | 'cancelle
 export type SocketRelayRequest = {
   id: string;
   ownerUserId: string;
+  ownerUsername: string | null;
   title: string;
   details: string;
   category: string;
@@ -62,6 +63,7 @@ export type SocketRelayMessage = {
 
 export type SocketRelayPublicRequest = {
   id: string;
+  ownerUsername: string | null;
   title: string;
   category: string;
   city: string | null;

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -2455,6 +2455,7 @@ ALTER TABLE IF EXISTS socketrelay_user_extension ADD COLUMN IF NOT EXISTS update
 CREATE TABLE IF NOT EXISTS socketrelay_requests (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   owner_user_id TEXT NOT NULL,
+  owner_username TEXT,
   title TEXT NOT NULL,
   details TEXT NOT NULL,
   category TEXT NOT NULL,
@@ -2470,6 +2471,7 @@ CREATE TABLE IF NOT EXISTS socketrelay_requests (
 );
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS id UUID;
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS owner_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS owner_username TEXT;
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS details TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT '';

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2506,6 +2506,7 @@ ALTER TABLE IF EXISTS socketrelay_user_extension ADD COLUMN IF NOT EXISTS update
 CREATE TABLE IF NOT EXISTS socketrelay_requests (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   owner_user_id TEXT NOT NULL,
+  owner_username TEXT,
   title TEXT NOT NULL,
   details TEXT NOT NULL,
   category TEXT NOT NULL,
@@ -2521,6 +2522,7 @@ CREATE TABLE IF NOT EXISTS socketrelay_requests (
 );
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS id UUID;
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS owner_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS owner_username TEXT;
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS details TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
Owner decision (2026-06-04): SocketRelay is not anonymous. A request poster is identified by the `@username` they chose at sign-up, and that handle is shown to everyone — including people who are not signed in (the public view). It is never "Anonymous".

## What changed

- **Schema** (`ctf/schema.sql`, `ctf/schema.demo.sql`): added a nullable `owner_username TEXT` column to `socketrelay_requests`, both in the `CREATE TABLE` block and as an idempotent `ALTER TABLE IF EXISTS … ADD COLUMN IF NOT EXISTS`. Additive only — the Update-Neon-DB workflow applies the column.
- **Repository** (`lib/socketrelay/repository.ts`): the request row type and every relevant `SELECT`/`RETURNING` carry `owner_username`; both the authenticated mapper and the public mapper set `ownerUsername`; `createRequest` now takes the poster's username and writes it.
- **Why store it:** v3 has no reliable server-side store of other users' usernames — identity comes from the Clerk session per request. So the username is captured at request-creation time, the same pattern Chyme (`chyme_messages.username`) and Feed (`feed_community_posts.author_username`) already use.
- **Create route** (`app/api/socketrelay/requests/route.ts`): passes `gate.auth.username` into `createRequest`.
- **Web** (`sr-feed.tsx`, `sr-shared.ts`): a new `srHandle(username, id)` helper renders `@username`, with a neutral `user-<id8>` fallback when no username was captured. Shown on each request card.
- **Android** (`SocketRelay.tsx`, `api.ts`): same handle rendered on each feed card.
- Inventory updated (data model, public projection, Change Log).

## Notes

- The one remaining "Anonymous" string in `SocketRelayEmpty.tsx` is feature copy ("Anonymous posting always available") about posting being open, not a poster-identity label — left as-is.
- Web typecheck, eslint, EOF check, and mobile typecheck/eslint all pass. The repo's `next build` (Turbopack) and `packages/shared` typecheck fail the same way on a clean tree — environmental, unrelated to this change.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Socket Relay request feed cards now display the poster's username publicly on both web and mobile platforms.
  * Automatic fallback identifier provided when a poster's username is unavailable.

* **Updates**
  * Backend infrastructure updated to capture and store poster information at request creation time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->