### PR TITLE
chore: ignore Claude Code agent worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ ctf/packages/mobile/.env.local
 .refact/
 .ai/
 .claude/settings.local.json
+
+# Claude Code agent worktrees (transient, per-agent isolated checkouts)
+.claude/worktrees/


### PR DESCRIPTION
Adds `.claude/worktrees/` to `.gitignore`. When a code-writing sub-agent runs in an isolated git worktree, the harness creates a transient checkout under `.claude/worktrees/`. That directory showed up as untracked in the main checkout; it is per-agent scratch space and should never be committed.

Documentation/infra only — no code or behavior change.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_