### PR TITLE
feat: hide Live badge on available plugins; adopt tiered design strategy

### DIFF
--- a/.github/instructions/126-design-mockup-implementation-rules.mdc
+++ b/.github/instructions/126-design-mockup-implementation-rules.mdc
@@ -3,6 +3,9 @@
 ## Intent
 Ensure mockup implementations are grounded in existing features, preventing technical debt and scope creep caused by AI-generated designs that may include features not yet built.
 
+## Scope (production-era, 2026-06-05)
+This rule governs implementing a mockup for the **first build** of a surface — a net-new surface or a deliberate from-scratch redesign (the "design first" tier in rule `127-`). It does **not** govern iterating on an **already-shipped** screen: once a screen is live, the running screen is the source of truth and the agent changes it directly in code, without a mockup (see rule `127-` "Production-era policy" and rule `128-`). Reach for this rule when you are building from a mockup; ignore it when you are tweaking a screen that already ships.
+
 ## Core Rule: Existing Features Only
 - The Replit design submodule (`design/`) is produced by an AI agent. It frequently includes UI for features that **do not yet exist** in the codebase.
 - **Never implement UI, layout, or interactions for features that have no corresponding backend API, database table, or working server-side logic.**

--- a/.github/instructions/127-design-pass-gating-rules.mdc
+++ b/.github/instructions/127-design-pass-gating-rules.mdc
@@ -6,7 +6,36 @@ Stop AI implementation agents from building UI against an unlocked design. Repli
 
 Companion rule: `126-design-mockup-implementation-rules.mdc` covers what to do *after* a design exists. This rule (`127-`) covers what to do *before* one does.
 
-## The Design Submodule Is The Only Source Of Truth
+## Production-era policy (owner-directed, 2026-06-05): the gate is for new surfaces, not iteration on shipped screens
+
+The app is now in production with real users. That flips the cost/benefit of design-first. The
+mockup is a **pre-build** artifact, not a living mirror of the running app. Once a screen ships, the
+**production screen itself is the source of truth** for that screen, and changes to it are made
+directly in code — no design round-trip, and no keeping a mockup byte-identical to the code. The
+owner works on a phone with no local dev environment, so a forced mockup round-trip for every tweak
+is pure friction with no payoff once the screen exists.
+
+Apply this tiered test:
+
+- **Iterate in code now (NOT design-gated)** — any change to an **already-shipped** screen that does
+  not introduce a fundamentally new layout: removing/hiding an element, copy, color, spacing/density,
+  reordering, adding a missing state (empty/loading/error), small affordances, the
+  **mobile-responsive layout of an existing screen** (a shipped screen at a narrow width is the same
+  screen — front-end work, per rule `105-`), and all bug fixes. Make the change, ship it, update the
+  inventory. Do not stop for a design.
+- **Design first (still gated, per the rest of this rule)** — a **genuinely new surface** that does
+  not exist yet (a new plugin, a new page / modal / flow), **or a deliberate from-scratch redesign**
+  of an existing surface (a real rethink, not a tweak). Here a mockup is still the cheapest way to
+  explore the look before building, so the design agent leads and the checkpoint behavior below
+  applies.
+
+When a surface is in the "iterate in code" tier, treat it exactly like the "What The Gate Does Not
+Apply To" list — proceed end-to-end. The design submodule stays the authority for what does **not yet
+exist**; it is **not** the authority over what already ships. Do not re-mock a live screen to change
+it, and do not block a live-screen change waiting for a mockup. The `#312` design-prompt queue is
+therefore for genuinely new surfaces and redesigns only.
+
+## The Design Submodule Is The Source Of Truth For Not-Yet-Built Surfaces
 
 - Authoritative design location: the `design/` submodule at the root of this repo (`/design`). Submodule URL: `https://github.com/chargingthefuture/design`.
 - The Replit design agent commits designs **directly into that submodule** and pushes to its remote. There is no Figma file, no screenshot folder, no Slack thread, no Notion page that supersedes it. If it isn't in the `design/` submodule, it is not the design.
@@ -15,15 +44,15 @@ Companion rule: `126-design-mockup-implementation-rules.mdc` covers what to do *
 
 ## When Stop-For-Design Is REQUIRED
 
-**No UI surface is design-skippable.** Every rendered surface — user-facing *and* admin/internal — requires a design pass before its UI is built. An agent must halt before writing any UI code if the change introduces or materially restructures:
+**A new or from-scratch-redesigned surface is design-skippable only by owner bypass.** This section applies to surfaces in the "design first" tier above — net-new surfaces and deliberate full redesigns. (Iterative changes to an already-shipped screen are *not* gated; see the production-era policy above and proceed in code.) An agent must halt before writing any UI code if the change introduces or materially restructures:
 
-1. A new user-facing page, route, modal, drawer, or component family.
+1. A new user-facing page, route, modal, drawer, or component family **that does not already exist**.
 2. A new plugin or major plugin rewrite (per the New Plugin Lifecycle Checklist in `CLAUDE.md`).
-3. A pinned, featured, or above-the-fold surface on a high-traffic page (Directory, Feed, Lighthouse, etc.).
-4. A change to existing user-facing UI that materially changes layout, information architecture, or interaction model (not just copy or color).
-5. Anything visible to the 5M-survivor audience that is not a copy-only or color-only tweak.
-6. Cross-plugin UI co-changes (e.g., Skills Hunt placing a reward card on Directory's public page).
-7. **Admin-only or internal tooling that renders a UI** — even surfaces only the owner uses. There is no "internal tooling" exemption from the design gate.
+3. A **brand-new** pinned, featured, or above-the-fold surface on a high-traffic page (Directory, Feed, Lighthouse, etc.) — adding a surface that isn't there yet, not restyling one that is.
+4. A deliberate from-scratch **redesign** of existing user-facing UI — a real rethink of layout, information architecture, or interaction model. (A small layout tweak, a removed element, or a responsive reflow of a shipped screen is *not* this — iterate in code.)
+5. A **new** surface visible to the 5M-survivor audience. (Copy-only, color-only, and small tweaks to existing surfaces are not gated.)
+6. Cross-plugin UI co-changes that add a **new** surface to another plugin (e.g., Skills Hunt placing a brand-new reward card on Directory's public page).
+7. **Admin-only or internal tooling that renders a brand-new UI surface** — even surfaces only the owner uses. There is no "internal tooling" exemption for net-new admin surfaces; but iterating on an already-shipped admin screen follows the "iterate in code" tier like any other shipped screen.
 
 In any of these cases, the agent must follow the **Required Checkpoint Behavior** below.
 
@@ -39,22 +68,31 @@ work. The standing workflow is therefore:
 This does **not** relax the gate: UI is still never written ahead of its design. It only clarifies
 that foundation work need not block on design, and that the UI pass is a deliberate later step.
 
-## What The Gate Does Not Apply To (no UI surface)
+## What The Gate Does Not Apply To
 
-These change types contain no rendered surface, so there is no design to wait on. They are not
-"UI skips" — they simply have no UI. An agent may proceed end-to-end:
+Two groups proceed end-to-end with no design wait.
+
+**No rendered surface at all** — there is simply no UI to design:
 
 1. Schema / database migration only.
 2. Library, utility, helper, or repository code with no UI surface.
 3. API routes whose only consumer is another agent or a server-side process (no rendered surface).
 4. Infra, configuration, CI/CD, or devcontainer changes.
-5. Bug fixes that change behavior but not layout, copy, or interaction model.
-6. Pure refactors with no observable user-visible effect.
-7. Type, lint, or test-only changes.
+5. Pure refactors with no observable user-visible effect.
+6. Type, lint, or test-only changes.
 
-If a change touches *any* rendered surface — including admin/internal pages — it is REQUIRED, not
-exempt. When in doubt, treat the change as REQUIRED. Cost of a false stop is one round-trip. Cost of
-a false start is rework.
+**Iteration on an already-shipped screen** (production-era policy above) — the screen exists, so the
+live screen is the design and the agent changes it directly:
+
+7. Bug fixes, including ones that change layout, copy, or interaction model on a shipped screen.
+8. Removing/hiding an element, copy, color, spacing/density, reordering, adding a missing
+   empty/loading/error state, small affordances.
+9. The mobile-responsive layout of a screen that already ships at desktop width (front-end work,
+   per rule `105-`).
+
+The line that still **requires** a design pass: introducing a **net-new** surface, or a deliberate
+**from-scratch redesign** of an existing one. When the choice is "tweak a shipped screen" vs. "design
+a new one," prefer iterating in code; only stop when the surface genuinely does not exist yet.
 
 ## Bypass Mechanism (User-Initiated)
 

--- a/.github/instructions/128-design-sync-workflow-rules.mdc
+++ b/.github/instructions/128-design-sync-workflow-rules.mdc
@@ -23,6 +23,17 @@ The app repo never writes back to the design repo. The design agent never reache
 business logic. This one-directional rule is what makes a sync safe: a sync is a *pull of a known
 pointer*, never a "make both sides match" reconciliation that could delete wanted work.
 
+## A mockup is a pre-build artifact, not a living mirror (production-era, 2026-06-05)
+
+A design sync feeds the **first build** of a surface. It is **not** a mandate to keep a shipped
+screen byte-identical to its mockup forever. Once a screen is in production, the **running screen is
+the source of truth** for that screen (see rule `127-` "Production-era policy"), and the owner / app
+agent iterates on it directly in code. The matching mockup is then effectively frozen — it will drift
+from the live screen, and that drift is **expected and fine**; do not "re-sync" a live screen back to
+its old mockup, and do not file design-queue prompts to make a mockup match a screen that already
+shipped. The sync mechanics below apply when adopting a **new** mockup (a net-new surface, or a
+deliberate from-scratch redesign), not for iterating on what already ships.
+
 ## How The App Consumes Designs: Submodule-Pin (NOT file-copy)
 
 This app does not copy mockup `.tsx` files into its own tree. There is no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,9 @@ asks for a plain restatement.
 
 ## Design Pass Gating (Critical — Read Before Touching UI)
 
-Before writing any UI — user-facing **or** admin/internal — for a new page, modal, plugin, featured surface, or material layout/IA change, you **must** verify a design exists in the `design/` submodule (canonical source; the only authoritative design location, remote: `https://github.com/chargingthefuture/design`). If no design exists for the feature, you **must** stop and announce `DESIGN PASS REQUIRED` per the protocol in `.github/instructions/127-design-pass-gating-rules.mdc`. No UI surface is skippable. Designs are produced in parallel by the Replit design agent; build non-UI foundation now and circle back for the UI once its design lands.
+**Production-era policy (2026-06-05): the gate is for new surfaces, not iteration on shipped screens.** The app is live. Once a screen ships, the **running screen is the source of truth** — change it directly in code, no mockup round-trip, and do not keep a mockup byte-identical to it. The gate applies only to a **net-new** surface (a new page, modal, plugin, or featured surface that does not exist yet) **or a deliberate from-scratch redesign** of an existing one. For those, verify a design exists in the `design/` submodule (canonical source; remote: `https://github.com/chargingthefuture/design`); if none exists, **stop** and announce `DESIGN PASS REQUIRED` per `.github/instructions/127-design-pass-gating-rules.mdc`. Designs are produced in parallel by the Replit design agent; build non-UI foundation now and circle back for the UI once its design lands.
 
-The gate only fails to apply to changes with no rendered surface: schema, libraries, server-only API routes, infra/CI, bug fixes, refactors, type/lint/test changes.
+Iterate in code (NOT gated): any change to an already-shipped screen that doesn't introduce a fundamentally new layout — removing/hiding an element, copy, color, spacing, reordering, adding an empty/loading/error state, the mobile-responsive layout of a shipped screen, and all bug fixes. Also never gated: changes with no rendered surface — schema, libraries, server-only API routes, infra/CI, refactors, type/lint/test changes.
 
 Owner-issued bypass keywords (must appear in the user's prompt): `bypass design`, `design done`, `hotfix`.
 

--- a/ctf/packages/web/components/community-shell/shell-apps-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-apps-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { PluginRegistryItem } from '../../lib/plugins/repository';
+import type { PluginAvailabilityState, PluginRegistryItem } from '../../lib/plugins/repository';
 import type { PluginSortMode } from './shell-types';
 import { getPluginVisuals } from './shell-plugin-config';
 import styles from './community-shell.module.css';
@@ -9,6 +9,15 @@ import styles from './community-shell.module.css';
 function getPluginHref(slug: string): string {
   return `/apps/${encodeURIComponent(slug)}`;
 }
+
+// Show a badge only when a plugin is NOT yet fully available, so the badge carries
+// information. A fully-shipped plugin (implemented_shell) gets no badge — labelling
+// every card "Live" is noise when nearly everything is live.
+const PLUGIN_BADGE_LABEL: Partial<Record<PluginAvailabilityState, string>> = {
+  planned: 'Coming soon',
+  alpha: 'Alpha',
+  beta: 'Beta',
+};
 
 type ShellAppsPanelProps = {
   plugins: PluginRegistryItem[];
@@ -70,8 +79,10 @@ export function ShellAppsPanel({ plugins, activeApp, onAppSelect, sortMode, onSo
                   {emoji}
                 </div>
                 <div className={styles.appCardBadges}>
-                  {plugin.availabilityState === 'implemented_shell' && (
-                    <span className={styles.appCardLive} style={{ color }}>Live</span>
+                  {PLUGIN_BADGE_LABEL[plugin.availabilityState] && (
+                    <span className={styles.appCardLive} style={{ color }}>
+                      {PLUGIN_BADGE_LABEL[plugin.availabilityState]}
+                    </span>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Live badge

The Apps grid labelled almost every plugin card "Live" (any plugin in the `implemented_shell` state). With nearly everything shipped, that badge was noise. Now:

- A fully-available plugin (`implemented_shell`) shows **no badge**.
- The badge appears only for not-yet-available states, where it carries information: `planned` → "Coming soon", `alpha` → "Alpha", `beta` → "Beta".

Android has no per-plugin availability badge (the "· Live" text there is a header subtitle, a different thing), so there is no parity change on mobile.

## Tiered design strategy (owner decision, production-era)

Now that the app is live, the running screen is the source of truth for a screen that already ships. The change in the rules:

- **Iterate on shipped screens directly in code** — no mockup round-trip, and no keeping a mockup byte-identical to the code. Covers removing/hiding elements, copy, color, spacing, reordering, missing states, the mobile-responsive layout of a shipped screen, and bug fixes.
- **The design gate now applies only to net-new surfaces or a deliberate from-scratch redesign** of an existing one.
- A mockup is a pre-build artifact, not a living mirror — expected to drift from the live screen after ship.

Encoded in `127-design-pass-gating-rules.mdc` (new production-era policy section + reworked "REQUIRED" / "does not apply" lists), `128-design-sync-workflow-rules.mdc` (mockups not kept in sync after ship), `126-design-mockup-implementation-rules.mdc` (scope note), and the `CLAUDE.md` gating summary.

A side effect: the mobile-responsive parity work (the D-gaps in #312) is no longer blocked on mobile mockups — those screens ship on desktop, so the phone layout is front-end work I can build directly.

Web typecheck and eslint pass. The badge change is the only behavior change; the rest is documentation.

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_