### PR TITLE
feat: add Account & Data privacy and deletion surface (web + Android)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -36,13 +36,38 @@
   deletion in a single transaction, records one `account_deletion_events` row, logs an
   `[account.audit]` line. Money is settled only by the existing ServiceCredits reclaim flow, never
   hard-deleted here.
-- API: `DELETE /api/account/services/:slug` (one plugin) and `DELETE /api/account/full-account`
-  (every plugin + ServiceCredits reclaim). Both are self-service (caller's own rows only) and
-  same-origin CSRF-guarded.
+- API:
+  - `GET /api/account/services` — read-only projection of the deletion registry for the Account &
+    Data UI. Returns `{ ok, deletable[], retained[], counts }`, where each entry is
+    `{ slug, name, summary, serviceScopeSupported }` taken straight from the registry (no copy is
+    stored in the route or the UI). `deletable` = `serviceScopeSupported === true`; `retained` =
+    `false` (ServiceCredits wallet/ledger kept for financial integrity, settled at full-account
+    deletion; GDP / Weekly Performance hold only community-wide aggregate totals). Gated by
+    `requireAccountAccess` (any signed-in identity, read-only — no CSRF needed).
+  - `DELETE /api/account/services/:slug` (one plugin) and `DELETE /api/account/full-account`
+    (every plugin + ServiceCredits reclaim). Both are self-service (caller's own rows only) and
+    same-origin CSRF-guarded (`x-ctf-csrf: 1`).
 - Data model: `account_deletion_events` (id, user_id, scope, service_name, requested_at,
-  completed_at, status, summary).
-- The user-facing Account & Data UI that calls these routes is design-gated (Rule 127) and not yet
-  built.
+  completed_at, status, summary). The `GET /api/account/services` projection adds no tables — it
+  reads only the in-code registry.
+- The user-facing Account & Data surface is now built (PR `feat/account-data-privacy-deletion-ui`):
+  - Web: `ctf/packages/web/app/account/data/page.tsx` (auth-gated, same posture as
+    `requireAccountAccess`) renders `ctf/packages/web/components/account-data/account-data-shell.tsx`.
+    One responsive component set switches desktop/mobile on `useIsMobile()` (768px), with loading,
+    empty, populated, and confirm-delete states matching the survivor-hub mockups. Per-service delete
+    uses a two-step confirm; full-account delete requires typing the exact phrase `delete my account`.
+    Reached from the community shell icon rail (the previously-disabled settings slot now links to
+    `/account/data`).
+  - Android: `ctf/packages/mobile/src/features/account-data/` (`AccountData.tsx` + `api.ts`),
+    registered in `ctf/packages/mobile/App.tsx`, binding to the same three endpoints.
+  - Not added to `ctf/config/plugin-parity-contracts.json`: that file is keyed to the **plugin**
+    registry (`lib/plugins/repository.ts`), and `check-web-android-parity.mjs` fails any contract
+    slug with no matching registry entry. Account & Data is a non-plugin account surface, so its
+    Android parity is satisfied by the real feature directory + `App.tsx` registration, not a plugin
+    parity contract row.
+  - Omitted vs. mockups (no backing API; real-data-only rule 126): "Export all data" and "Deactivate
+    account instead" controls, the static encryption badges, and the icon rail's export/notification
+    stubs.
 
 ### 1.3 Pricing Tier and Payment Admin (API/Control Contract Only)
 

--- a/ctf/packages/mobile/App.tsx
+++ b/ctf/packages/mobile/App.tsx
@@ -22,6 +22,7 @@ import { ServiceCredits } from './src/features/service-credits';
 import { Levelup } from './src/features/levelup';
 import { Unlock } from './src/features/unlock';
 import { SkillsTaxonomy } from './src/features/skills-taxonomy';
+import { AccountData } from './src/features/account-data';
 import { AuthProvider } from './src/features/trusttransport/auth-context';
 
 type FeatureKey =
@@ -44,6 +45,7 @@ type FeatureKey =
   | 'service-credits'
   | 'levelup'
   | 'unlock'
+  | 'account-data'
   | 'comic-review';
 
 const featureOrder: Array<{ key: FeatureKey; label: string }> = [
@@ -66,6 +68,7 @@ const featureOrder: Array<{ key: FeatureKey; label: string }> = [
   { key: 'service-credits', label: 'Service Credits' },
   { key: 'levelup', label: 'LevelUp' },
   { key: 'unlock', label: 'Unlock' },
+  { key: 'account-data', label: 'Account & Data' },
   { key: 'comic-review', label: 'AI Review' },
 ];
 
@@ -117,6 +120,8 @@ export default function App() {
         return <Levelup />;
       case 'unlock':
         return <Unlock />;
+      case 'account-data':
+        return <AccountData />;
       case 'comic-review':
         return <ComicReviewConsole />;
       default:

--- a/ctf/packages/mobile/src/features/account-data/AccountData.tsx
+++ b/ctf/packages/mobile/src/features/account-data/AccountData.tsx
@@ -197,24 +197,28 @@ export function AccountData() {
                   const isPending = pendingSlug === service.slug;
                   const error = rowError?.slug === service.slug ? rowError.message : null;
                   return (
-                    <View key={service.slug} style={[s.row, error ? s.rowError : null, isPending && s.rowPending]}>
-                      <View style={s.rowGlyph}>
-                        <Text style={s.rowGlyphText}>{glyph(service.slug)}</Text>
+                    // key goes on the Fragment, not the View: @types/react 19.2 rejects `key`
+                    // on class-based host components like View ("does not exist on ViewProps").
+                    <React.Fragment key={service.slug}>
+                      <View style={[s.row, error ? s.rowError : null, isPending && s.rowPending]}>
+                        <View style={s.rowGlyph}>
+                          <Text style={s.rowGlyphText}>{glyph(service.slug)}</Text>
+                        </View>
+                        <View style={s.rowBody}>
+                          <Text style={s.rowName}>{service.name}</Text>
+                          <Text style={[s.rowSummary, error ? s.rowSummaryError : null]}>{error ?? service.summary}</Text>
+                        </View>
+                        <TouchableOpacity
+                          onPress={() => handleDeleteService(service)}
+                          disabled={isPending}
+                          style={s.deleteBtn}
+                          accessibilityRole="button"
+                          accessibilityLabel={`Delete your ${service.name} data`}
+                        >
+                          {isPending ? <ActivityIndicator color={DANGER} size="small" /> : <Text style={s.deleteBtnText}>🗑</Text>}
+                        </TouchableOpacity>
                       </View>
-                      <View style={s.rowBody}>
-                        <Text style={s.rowName}>{service.name}</Text>
-                        <Text style={[s.rowSummary, error ? s.rowSummaryError : null]}>{error ?? service.summary}</Text>
-                      </View>
-                      <TouchableOpacity
-                        onPress={() => handleDeleteService(service)}
-                        disabled={isPending}
-                        style={s.deleteBtn}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Delete your ${service.name} data`}
-                      >
-                        {isPending ? <ActivityIndicator color={DANGER} size="small" /> : <Text style={s.deleteBtnText}>🗑</Text>}
-                      </TouchableOpacity>
-                    </View>
+                    </React.Fragment>
                   );
                 })}
               </View>
@@ -224,18 +228,20 @@ export function AccountData() {
                   <Text style={s.sectionLabel}>Always retained — {retained.length} {retained.length === 1 ? 'service' : 'services'}</Text>
                   <View style={s.list}>
                     {retained.map((service) => (
-                      <View key={service.slug} style={s.retainedRow}>
-                        <View style={s.retainedGlyph}>
-                          <Text style={s.rowGlyphText}>{glyph(service.slug)}</Text>
-                        </View>
-                        <View style={s.rowBody}>
-                          <View style={s.retainedNameRow}>
-                            <Text style={s.retainedName}>{service.name}</Text>
-                            <Text style={s.lockGlyph}>🔒</Text>
+                      <React.Fragment key={service.slug}>
+                        <View style={s.retainedRow}>
+                          <View style={s.retainedGlyph}>
+                            <Text style={s.rowGlyphText}>{glyph(service.slug)}</Text>
                           </View>
-                          <Text style={s.retainedReason}>{service.summary}</Text>
+                          <View style={s.rowBody}>
+                            <View style={s.retainedNameRow}>
+                              <Text style={s.retainedName}>{service.name}</Text>
+                              <Text style={s.lockGlyph}>🔒</Text>
+                            </View>
+                            <Text style={s.retainedReason}>{service.summary}</Text>
+                          </View>
                         </View>
-                      </View>
+                      </React.Fragment>
                     ))}
                   </View>
                 </>
@@ -285,10 +291,12 @@ function DangerZone({ serviceCount, onContinue }: { serviceCount: number; onCont
         Removes your profile and all personal data across all {serviceCount} services. Your ServiceCredits are settled — not destroyed. Some audit records are retained by design.
       </Text>
       {points.map((p, i) => (
-        <View key={i} style={s.bulletRow}>
-          <View style={[s.bulletDot, { backgroundColor: p.warn ? DANGER : '#4B5563' }]} />
-          <Text style={[s.bulletText, p.warn ? s.bulletTextWarn : null]}>{p.t}</Text>
-        </View>
+        <React.Fragment key={i}>
+          <View style={s.bulletRow}>
+            <View style={[s.bulletDot, { backgroundColor: p.warn ? DANGER : '#4B5563' }]} />
+            <Text style={[s.bulletText, p.warn ? s.bulletTextWarn : null]}>{p.t}</Text>
+          </View>
+        </React.Fragment>
       ))}
       <TouchableOpacity style={s.dangerBtn} onPress={onContinue} accessibilityRole="button">
         <Text style={s.dangerBtnText}>Continue to confirmation</Text>
@@ -355,10 +363,12 @@ function ConfirmDelete({ serviceCount, onCancel }: { serviceCount: number; onCan
         <View style={s.confirmInfo}>
           <Text style={s.confirmInfoTitle}>Delete your entire account</Text>
           {points.map((p, i) => (
-            <View key={i} style={s.bulletRow}>
-              <Text style={[s.confirmBulletGlyph, { color: p.warn ? DANGER : SUBTLE }]}>{p.warn ? '🗑' : '🔒'}</Text>
-              <Text style={s.confirmBulletText}>{p.t}</Text>
-            </View>
+            <React.Fragment key={i}>
+              <View style={s.bulletRow}>
+                <Text style={[s.confirmBulletGlyph, { color: p.warn ? DANGER : SUBTLE }]}>{p.warn ? '🗑' : '🔒'}</Text>
+                <Text style={s.confirmBulletText}>{p.t}</Text>
+              </View>
+            </React.Fragment>
           ))}
         </View>
 

--- a/ctf/packages/mobile/src/features/account-data/AccountData.tsx
+++ b/ctf/packages/mobile/src/features/account-data/AccountData.tsx
@@ -1,0 +1,493 @@
+// Real Account & Data screen — pixel-pass to
+// design/artifacts/mockup-sandbox/src/components/mockups/survivor-hub/MobileAccountData.tsx
+// (plus MobileAccountDataEmpty / MobileAccountDataConfirmDelete states).
+//
+// API bindings: GET /api/account/services, DELETE /api/account/services/:slug,
+// DELETE /api/account/full-account. Service names and summaries come from the live registry
+// projection — never hardcoded here.
+//
+// Omissions vs mockup (no backing API): "Export your data" and "Deactivate instead" controls are
+// not rendered — there is no export or deactivate endpoint, and the real-data-only rule forbids
+// dead buttons.
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  fetchAccountServices,
+  deleteServiceData,
+  deleteFullAccount,
+  type AccountService,
+} from './api';
+
+const BRAND = '#E91E8C';
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+const DANGER = '#EF4444';
+
+const CONFIRM_PHRASE = 'delete my account';
+
+const SERVICE_GLYPH: Record<string, string> = {
+  chyme: '💬', directory: '📇', 'feed-announcements': '📣', foundation: '🪛', mood: '🌿',
+  gentlepulse: '🎵', 'peer-programming': '👥', lighthouse: '🏠', socketrelay: '🔂',
+  trusttransport: '📦', trust: '🛡️', workforce: '💼', 'skills-hunt': '🎯',
+  'skills-taxonomy': '🗂️', unlock: '🔓', levelup: '🚀', clicklog: '🚨', comic: '🤖',
+  feedback: '💬', 'service-credits': '⚙️', 'gross-domestic-product': '📊', 'weekly-performance': '📊',
+};
+
+function glyph(slug: string): string {
+  return SERVICE_GLYPH[slug] ?? '📁';
+}
+
+type Tab = 'data' | 'danger';
+
+export function AccountData() {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [deletable, setDeletable] = useState<AccountService[]>([]);
+  const [retained, setRetained] = useState<AccountService[]>([]);
+  const [deletedSlugs, setDeletedSlugs] = useState<string[]>([]);
+  const [pendingSlug, setPendingSlug] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<{ slug: string; message: string } | null>(null);
+  const [tab, setTab] = useState<Tab>('data');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setLoadError(false);
+    fetchAccountServices()
+      .then((data) => {
+        setDeletable(data.deletable ?? []);
+        setRetained(data.retained ?? []);
+      })
+      .catch(() => setLoadError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const remaining = useMemo(
+    () => deletable.filter((s) => !deletedSlugs.includes(s.slug)),
+    [deletable, deletedSlugs],
+  );
+  const totalServices = deletable.length + retained.length;
+
+  const handleDeleteService = useCallback((service: AccountService) => {
+    Alert.alert(
+      `Delete your ${service.name} data?`,
+      `${service.summary}\n\nThis is permanent and cannot be undone. Some audit records may be retained for platform integrity. Your account stays open.`,
+      [
+        { text: 'Keep my data', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            setPendingSlug(service.slug);
+            setRowError(null);
+            try {
+              await deleteServiceData(service.slug);
+              setDeletedSlugs((prev) => (prev.includes(service.slug) ? prev : [...prev, service.slug]));
+            } catch (e) {
+              setRowError({ slug: service.slug, message: e instanceof Error ? e.message : 'Unable to delete this data.' });
+            } finally {
+              setPendingSlug(null);
+            }
+          },
+        },
+      ],
+    );
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={[s.root, s.center]}>
+        <ActivityIndicator color={BRAND} />
+      </View>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <View style={[s.root, s.center]}>
+        <Text style={s.errTitle}>We couldn&apos;t load your data</Text>
+        <Text style={s.errSub}>Please try again.</Text>
+        <TouchableOpacity style={s.retryBtn} onPress={load} accessibilityRole="button">
+          <Text style={s.retryText}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (confirmOpen) {
+    return (
+      <ConfirmDelete
+        serviceCount={totalServices}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    );
+  }
+
+  const isEmpty = remaining.length === 0;
+
+  return (
+    <View style={s.root}>
+      {/* Header */}
+      <View style={s.header}>
+        <View style={s.headerRow}>
+          <View style={s.headerIcon}>
+            <Text style={s.headerIconText}>🛡</Text>
+          </View>
+          <View>
+            <Text style={s.headerTitle}>Account &amp; Data</Text>
+            <Text style={s.headerSub}>{totalServices} services · your control</Text>
+          </View>
+        </View>
+        <View style={s.tabRow}>
+          {(['data', 'danger'] as Tab[]).map((t) => {
+            const active = tab === t;
+            const danger = t === 'danger';
+            return (
+              <TouchableOpacity
+                key={t}
+                onPress={() => setTab(t)}
+                style={[
+                  s.tab,
+                  active && (danger ? s.tabDangerActive : s.tabActive),
+                ]}
+                accessibilityRole="tab"
+                accessibilityState={{ selected: active }}
+              >
+                <Text style={[s.tabText, active && (danger ? s.tabTextDangerActive : s.tabTextActive)]}>
+                  {t === 'data' ? 'Your Data' : '⚠️ Danger Zone'}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
+
+      <ScrollView style={s.scroll} contentContainerStyle={s.scrollContent}>
+        {tab === 'data' ? (
+          isEmpty ? (
+            <EmptyState hasRetained={retained.length > 0} />
+          ) : (
+            <>
+              <View style={s.notice}>
+                <Text style={s.noticeText}>
+                  Deleting from a service is permanent. Some audit records are retained for platform integrity.
+                </Text>
+              </View>
+
+              <Text style={s.sectionLabel}>Personal data — {remaining.length} {remaining.length === 1 ? 'service' : 'services'}</Text>
+              <View style={s.list}>
+                {remaining.map((service) => {
+                  const isPending = pendingSlug === service.slug;
+                  const error = rowError?.slug === service.slug ? rowError.message : null;
+                  return (
+                    <View key={service.slug} style={[s.row, error ? s.rowError : null, isPending && s.rowPending]}>
+                      <View style={s.rowGlyph}>
+                        <Text style={s.rowGlyphText}>{glyph(service.slug)}</Text>
+                      </View>
+                      <View style={s.rowBody}>
+                        <Text style={s.rowName}>{service.name}</Text>
+                        <Text style={[s.rowSummary, error ? s.rowSummaryError : null]}>{error ?? service.summary}</Text>
+                      </View>
+                      <TouchableOpacity
+                        onPress={() => handleDeleteService(service)}
+                        disabled={isPending}
+                        style={s.deleteBtn}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Delete your ${service.name} data`}
+                      >
+                        {isPending ? <ActivityIndicator color={DANGER} size="small" /> : <Text style={s.deleteBtnText}>🗑</Text>}
+                      </TouchableOpacity>
+                    </View>
+                  );
+                })}
+              </View>
+
+              {retained.length > 0 ? (
+                <>
+                  <Text style={s.sectionLabel}>Always retained — {retained.length} {retained.length === 1 ? 'service' : 'services'}</Text>
+                  <View style={s.list}>
+                    {retained.map((service) => (
+                      <View key={service.slug} style={s.retainedRow}>
+                        <View style={s.retainedGlyph}>
+                          <Text style={s.rowGlyphText}>{glyph(service.slug)}</Text>
+                        </View>
+                        <View style={s.rowBody}>
+                          <View style={s.retainedNameRow}>
+                            <Text style={s.retainedName}>{service.name}</Text>
+                            <Text style={s.lockGlyph}>🔒</Text>
+                          </View>
+                          <Text style={s.retainedReason}>{service.summary}</Text>
+                        </View>
+                      </View>
+                    ))}
+                  </View>
+                </>
+              ) : null}
+            </>
+          )
+        ) : (
+          <DangerZone serviceCount={totalServices} onContinue={() => setConfirmOpen(true)} />
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+function EmptyState({ hasRetained }: { hasRetained: boolean }) {
+  return (
+    <View style={s.emptyWrap}>
+      <View style={s.emptyAnchor}>
+        <Text style={s.emptyAnchorText}>🛡</Text>
+      </View>
+      <Text style={s.emptyTitle}>No personal data stored yet</Text>
+      <Text style={s.emptySub}>
+        As you use Survivor Hub apps, any personal data they hold will appear here for you to see and delete.
+      </Text>
+      {hasRetained ? (
+        <View style={s.notice}>
+          <Text style={s.noticeText}>
+            ServiceCredits ledger and community totals are always retained for financial integrity. They hold no personal identifiers.
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function DangerZone({ serviceCount, onContinue }: { serviceCount: number; onContinue: () => void }) {
+  const points: Array<{ t: string; warn: boolean }> = [
+    { t: 'All personal data permanently deleted', warn: true },
+    { t: 'ServiceCredits settled via standard process', warn: false },
+    { t: 'Audit records retained (by design)', warn: false },
+    { t: 'Profile removed from all directories', warn: true },
+  ];
+  return (
+    <View style={s.dangerCard}>
+      <Text style={s.dangerTitle}>⚠️ Delete Entire Account</Text>
+      <Text style={s.dangerBody}>
+        Removes your profile and all personal data across all {serviceCount} services. Your ServiceCredits are settled — not destroyed. Some audit records are retained by design.
+      </Text>
+      {points.map((p, i) => (
+        <View key={i} style={s.bulletRow}>
+          <View style={[s.bulletDot, { backgroundColor: p.warn ? DANGER : '#4B5563' }]} />
+          <Text style={[s.bulletText, p.warn ? s.bulletTextWarn : null]}>{p.t}</Text>
+        </View>
+      ))}
+      <TouchableOpacity style={s.dangerBtn} onPress={onContinue} accessibilityRole="button">
+        <Text style={s.dangerBtnText}>Continue to confirmation</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function ConfirmDelete({ serviceCount, onCancel }: { serviceCount: number; onCancel: () => void }) {
+  const [input, setInput] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const ready = input.toLowerCase().trim() === CONFIRM_PHRASE && status !== 'submitting';
+
+  const handleConfirm = useCallback(async () => {
+    if (input.toLowerCase().trim() !== CONFIRM_PHRASE || status === 'submitting') return;
+    setStatus('submitting');
+    setErrorMessage(null);
+    try {
+      await deleteFullAccount();
+      setStatus('done');
+    } catch (e) {
+      setStatus('error');
+      setErrorMessage(e instanceof Error ? e.message : 'Unable to complete deletion.');
+    }
+  }, [input, status]);
+
+  if (status === 'done') {
+    return (
+      <View style={[s.root, s.center]}>
+        <Text style={s.doneGlyph}>✅</Text>
+        <Text style={s.doneTitle}>Deletion queued</Text>
+        <Text style={s.doneSub}>
+          Your request has been received. Your personal data is being removed across all services, and your ServiceCredits balance will be settled through the standard process. Some audit records are retained for platform integrity.
+        </Text>
+      </View>
+    );
+  }
+
+  const points: Array<{ t: string; warn: boolean }> = [
+    { t: `All personal data deleted across ${serviceCount} services`, warn: true },
+    { t: 'ServiceCredits balance settled via standard process — not destroyed', warn: false },
+    { t: 'Some audit records retained for platform integrity — intentional', warn: false },
+    { t: 'Your profile and username removed from all directories', warn: true },
+  ];
+
+  return (
+    <View style={s.root}>
+      <View style={s.confirmHeader}>
+        <View style={s.confirmHeaderIcon}>
+          <Text style={s.confirmHeaderIconText}>⚠️</Text>
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text style={s.headerTitle}>Confirm Deletion</Text>
+          <Text style={s.headerSub}>Full account · permanent</Text>
+        </View>
+        <TouchableOpacity onPress={onCancel} style={s.confirmClose} accessibilityRole="button" accessibilityLabel="Cancel">
+          <Text style={s.confirmCloseText}>✕</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView style={s.scroll} contentContainerStyle={s.scrollContent}>
+        <View style={s.confirmInfo}>
+          <Text style={s.confirmInfoTitle}>Delete your entire account</Text>
+          {points.map((p, i) => (
+            <View key={i} style={s.bulletRow}>
+              <Text style={[s.confirmBulletGlyph, { color: p.warn ? DANGER : SUBTLE }]}>{p.warn ? '🗑' : '🔒'}</Text>
+              <Text style={s.confirmBulletText}>{p.t}</Text>
+            </View>
+          ))}
+        </View>
+
+        <View style={s.confirmFieldWrap}>
+          <Text style={s.confirmFieldLabel}>
+            Type <Text style={s.confirmPhrase}>{CONFIRM_PHRASE}</Text> to confirm.
+          </Text>
+          <TextInput
+            value={input}
+            onChangeText={setInput}
+            placeholder={CONFIRM_PHRASE}
+            placeholderTextColor="#4B5563"
+            autoCapitalize="none"
+            autoCorrect={false}
+            style={[s.confirmInput, ready && s.confirmInputReady]}
+          />
+        </View>
+
+        {status === 'error' && errorMessage ? (
+          <View style={s.confirmErrorBox}>
+            <Text style={s.confirmErrorText}>{errorMessage}</Text>
+          </View>
+        ) : null}
+
+        <TouchableOpacity
+          onPress={handleConfirm}
+          disabled={!ready}
+          style={[s.confirmDeleteBtn, ready ? s.confirmDeleteBtnReady : null]}
+          accessibilityRole="button"
+        >
+          {status === 'submitting' ? (
+            <ActivityIndicator color={DANGER} size="small" />
+          ) : (
+            <Text style={[s.confirmDeleteText, ready ? s.confirmDeleteTextReady : null]}>🗑 Delete permanently</Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={onCancel}
+          disabled={status === 'submitting'}
+          style={s.keepBtn}
+          accessibilityRole="button"
+        >
+          <Text style={s.keepText}>Keep my data</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: BG },
+  center: { alignItems: 'center', justifyContent: 'center', padding: 32 },
+  header: { paddingHorizontal: 16, paddingTop: 14, paddingBottom: 10, borderBottomWidth: 1, borderBottomColor: BORDER },
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
+  headerIcon: { width: 34, height: 34, borderRadius: 9, backgroundColor: `${BRAND}20`, borderWidth: 1, borderColor: `${BRAND}35`, alignItems: 'center', justifyContent: 'center' },
+  headerIconText: { fontSize: 16, color: BRAND },
+  headerTitle: { fontSize: 16, fontWeight: '700', color: TEXT },
+  headerSub: { fontSize: 11, color: SUBTLE },
+  tabRow: { flexDirection: 'row', gap: 4 },
+  tab: { flex: 1, paddingVertical: 7, borderRadius: 8, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center' },
+  tabActive: { backgroundColor: `${BRAND}18`, borderColor: `${BRAND}40` },
+  tabDangerActive: { backgroundColor: 'rgba(239,68,68,0.12)', borderColor: 'rgba(239,68,68,0.4)' },
+  tabText: { fontSize: 12, color: SUBTLE },
+  tabTextActive: { color: BRAND, fontWeight: '700' },
+  tabTextDangerActive: { color: DANGER, fontWeight: '700' },
+  scroll: { flex: 1 },
+  scrollContent: { padding: 16, paddingBottom: 28 },
+  notice: { padding: 12, borderRadius: 10, backgroundColor: `${BRAND}0D`, borderWidth: 1, borderColor: `${BRAND}25`, marginBottom: 16 },
+  noticeText: { fontSize: 12, color: '#9CA3AF', lineHeight: 18 },
+  sectionLabel: { fontSize: 12, fontWeight: '700', color: SUBTLE, textTransform: 'uppercase', letterSpacing: 0.7, marginBottom: 10 },
+  list: { gap: 7, marginBottom: 22 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 10, padding: 11, borderRadius: 12, backgroundColor: SURFACE, borderWidth: 1, borderColor: BORDER },
+  rowError: { borderColor: 'rgba(239,68,68,0.35)' },
+  rowPending: { opacity: 0.7 },
+  rowGlyph: { width: 30, height: 30, borderRadius: 8, backgroundColor: `${BRAND}10`, borderWidth: 1, borderColor: `${BRAND}20`, alignItems: 'center', justifyContent: 'center' },
+  rowGlyphText: { fontSize: 14 },
+  rowBody: { flex: 1 },
+  rowName: { fontSize: 13, fontWeight: '600', color: TEXT },
+  rowSummary: { fontSize: 11, color: '#4B5563', lineHeight: 15, marginTop: 1 },
+  rowSummaryError: { color: '#F87171' },
+  deleteBtn: { paddingVertical: 6, paddingHorizontal: 10, borderRadius: 7, backgroundColor: 'rgba(239,68,68,0.06)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.2)', minWidth: 36, alignItems: 'center' },
+  deleteBtnText: { color: DANGER, fontSize: 13 },
+  retainedRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, padding: 11, borderRadius: 12, backgroundColor: 'rgba(255,255,255,0.01)', borderWidth: 1, borderColor: BORDER },
+  retainedGlyph: { width: 30, height: 30, borderRadius: 8, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center', justifyContent: 'center' },
+  retainedNameRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 3 },
+  retainedName: { fontSize: 13, fontWeight: '600', color: SUBTLE },
+  lockGlyph: { fontSize: 10 },
+  retainedReason: { fontSize: 11, color: '#4B5563', lineHeight: 15 },
+  emptyWrap: { alignItems: 'center', paddingVertical: 24 },
+  emptyAnchor: { width: 56, height: 56, borderRadius: 16, backgroundColor: `${BRAND}14`, borderWidth: 1, borderColor: `${BRAND}30`, borderStyle: 'dashed', alignItems: 'center', justifyContent: 'center', marginBottom: 16 },
+  emptyAnchorText: { fontSize: 24 },
+  emptyTitle: { fontSize: 19, fontWeight: '800', color: TEXT, marginBottom: 8, textAlign: 'center' },
+  emptySub: { fontSize: 13, color: SUBTLE, lineHeight: 20, textAlign: 'center', marginBottom: 20 },
+  dangerCard: { padding: 18, borderRadius: 14, backgroundColor: 'rgba(239,68,68,0.04)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.18)' },
+  dangerTitle: { fontSize: 15, fontWeight: '700', color: TEXT, marginBottom: 10 },
+  dangerBody: { fontSize: 13, color: '#9CA3AF', lineHeight: 20, marginBottom: 14 },
+  bulletRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 8, marginBottom: 7 },
+  bulletDot: { width: 4, height: 4, borderRadius: 2, marginTop: 6 },
+  bulletText: { flex: 1, fontSize: 12, color: '#9CA3AF', lineHeight: 17 },
+  bulletTextWarn: { color: '#F87171' },
+  dangerBtn: { marginTop: 8, paddingVertical: 11, borderRadius: 10, backgroundColor: 'rgba(239,68,68,0.1)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.35)', alignItems: 'center' },
+  dangerBtnText: { color: DANGER, fontSize: 14, fontWeight: '700' },
+  confirmHeader: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 16, paddingTop: 14, paddingBottom: 14, borderBottomWidth: 1, borderBottomColor: BORDER },
+  confirmHeaderIcon: { width: 34, height: 34, borderRadius: 9, backgroundColor: 'rgba(239,68,68,0.12)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.25)', alignItems: 'center', justifyContent: 'center' },
+  confirmHeaderIconText: { fontSize: 16 },
+  confirmClose: { width: 30, height: 30, borderRadius: 8, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center', justifyContent: 'center' },
+  confirmCloseText: { color: SUBTLE, fontSize: 14 },
+  confirmInfo: { padding: 16, borderRadius: 14, backgroundColor: 'rgba(239,68,68,0.05)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.18)', marginBottom: 18 },
+  confirmInfoTitle: { fontSize: 14, fontWeight: '700', color: TEXT, marginBottom: 12 },
+  confirmBulletGlyph: { fontSize: 13, marginTop: 1 },
+  confirmBulletText: { flex: 1, fontSize: 12, color: '#9CA3AF', lineHeight: 18 },
+  confirmFieldWrap: { padding: 14, borderRadius: 12, backgroundColor: SURFACE, borderWidth: 1, borderColor: BORDER, marginBottom: 18 },
+  confirmFieldLabel: { fontSize: 13, color: '#9CA3AF', marginBottom: 10, lineHeight: 19 },
+  confirmPhrase: { color: DANGER, fontWeight: '700' },
+  confirmInput: { paddingVertical: 11, paddingHorizontal: 12, backgroundColor: BG, borderWidth: 1, borderColor: BORDER, borderRadius: 9, fontSize: 14, color: TEXT },
+  confirmInputReady: { borderColor: 'rgba(239,68,68,0.5)', color: DANGER },
+  confirmErrorBox: { padding: 12, borderRadius: 8, backgroundColor: 'rgba(239,68,68,0.08)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.3)', marginBottom: 16 },
+  confirmErrorText: { color: '#F87171', fontSize: 13, lineHeight: 18 },
+  confirmDeleteBtn: { paddingVertical: 14, borderRadius: 12, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center', marginBottom: 10 },
+  confirmDeleteBtnReady: { backgroundColor: 'rgba(239,68,68,0.14)', borderColor: 'rgba(239,68,68,0.45)' },
+  confirmDeleteText: { color: '#374151', fontSize: 15, fontWeight: '700' },
+  confirmDeleteTextReady: { color: DANGER },
+  keepBtn: { paddingVertical: 14, borderRadius: 12, backgroundColor: `${BRAND}12`, borderWidth: 1, borderColor: `${BRAND}30`, alignItems: 'center' },
+  keepText: { color: BRAND, fontSize: 15, fontWeight: '600' },
+  doneGlyph: { fontSize: 48, marginBottom: 18 },
+  doneTitle: { fontSize: 20, fontWeight: '800', color: TEXT, marginBottom: 10, textAlign: 'center' },
+  doneSub: { fontSize: 13, color: SUBTLE, lineHeight: 21, textAlign: 'center' },
+  errTitle: { fontSize: 16, fontWeight: '700', color: TEXT, marginBottom: 8, textAlign: 'center' },
+  errSub: { fontSize: 13, color: '#9CA3AF', textAlign: 'center', marginBottom: 16 },
+  retryBtn: { paddingVertical: 10, paddingHorizontal: 24, borderRadius: 10, backgroundColor: `${BRAND}15`, borderWidth: 1, borderColor: `${BRAND}30` },
+  retryText: { color: BRAND, fontSize: 14, fontWeight: '600' },
+});

--- a/ctf/packages/mobile/src/features/account-data/api.ts
+++ b/ctf/packages/mobile/src/features/account-data/api.ts
@@ -8,6 +8,25 @@
 
 const API_BASE = process.env.EXPO_PUBLIC_API_BASE || 'https://api.chargingthefuture.com';
 
+// Bound every request so a stalled connection can't trap the screen in a loading or
+// submitting state forever. Aborts after the timeout and reports a clear "network_timeout".
+const REQUEST_TIMEOUT_MS = 15000;
+
+async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error('network_timeout');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export type AccountService = {
   slug: string;
   name: string;
@@ -23,7 +42,7 @@ export type AccountServicesResponse = {
 };
 
 export async function fetchAccountServices(): Promise<AccountServicesResponse> {
-  const res = await fetch(`${API_BASE}/api/account/services`, { credentials: 'include' });
+  const res = await fetchWithTimeout(`${API_BASE}/api/account/services`, { credentials: 'include' });
   if (!res.ok) {
     throw new Error(`account_services_fetch_failed:${res.status}`);
   }
@@ -31,7 +50,7 @@ export async function fetchAccountServices(): Promise<AccountServicesResponse> {
 }
 
 export async function deleteServiceData(slug: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/account/services/${encodeURIComponent(slug)}`, {
+  const res = await fetchWithTimeout(`${API_BASE}/api/account/services/${encodeURIComponent(slug)}`, {
     method: 'DELETE',
     credentials: 'include',
     headers: {
@@ -46,7 +65,7 @@ export async function deleteServiceData(slug: string): Promise<void> {
 }
 
 export async function deleteFullAccount(): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/account/full-account`, {
+  const res = await fetchWithTimeout(`${API_BASE}/api/account/full-account`, {
     method: 'DELETE',
     credentials: 'include',
     headers: {

--- a/ctf/packages/mobile/src/features/account-data/api.ts
+++ b/ctf/packages/mobile/src/features/account-data/api.ts
@@ -1,0 +1,61 @@
+// Account & Data API client — binds to the same live backend the web surface uses.
+// GET    /api/account/services           → AccountServicesResponse (read-only registry projection)
+// DELETE /api/account/services/:slug      → per-service deletion
+// DELETE /api/account/full-account        → whole-account deletion
+//
+// Mutations send the same-origin CSRF header (`x-ctf-csrf: 1`) and JSON content type that the
+// account routes require.
+
+const API_BASE = process.env.EXPO_PUBLIC_API_BASE || 'https://api.chargingthefuture.com';
+
+export type AccountService = {
+  slug: string;
+  name: string;
+  summary: string;
+  serviceScopeSupported: boolean;
+};
+
+export type AccountServicesResponse = {
+  ok: boolean;
+  deletable: AccountService[];
+  retained: AccountService[];
+  counts: { deletable: number; retained: number; total: number };
+};
+
+export async function fetchAccountServices(): Promise<AccountServicesResponse> {
+  const res = await fetch(`${API_BASE}/api/account/services`, { credentials: 'include' });
+  if (!res.ok) {
+    throw new Error(`account_services_fetch_failed:${res.status}`);
+  }
+  return res.json() as Promise<AccountServicesResponse>;
+}
+
+export async function deleteServiceData(slug: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/account/services/${encodeURIComponent(slug)}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-ctf-csrf': '1',
+    },
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { message?: string; code?: string };
+    throw new Error(body.message ?? body.code ?? `service_delete_failed:${res.status}`);
+  }
+}
+
+export async function deleteFullAccount(): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/account/full-account`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-ctf-csrf': '1',
+    },
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { message?: string; code?: string };
+    throw new Error(body.message ?? body.code ?? `full_account_delete_failed:${res.status}`);
+  }
+}

--- a/ctf/packages/mobile/src/features/account-data/index.ts
+++ b/ctf/packages/mobile/src/features/account-data/index.ts
@@ -1,0 +1,1 @@
+export { AccountData } from './AccountData';

--- a/ctf/packages/web/app/account/data/page.tsx
+++ b/ctf/packages/web/app/account/data/page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { AccountDataShell } from '@/components/account-data/account-data-shell';
+
+// Account & Data surface: the signed-in user can see the personal data the platform holds per
+// service, delete that data one service at a time, or delete their whole account. Auth posture
+// matches the account deletion API (`requireAccountAccess`): any signed-in identity, including
+// unlock-pending users, may exercise their right to be forgotten — so deletion is never gated by
+// approval state. The mutations themselves run through the live DELETE routes under /api/account/**.
+export default async function AccountDataPage() {
+  const decision = await evaluatePluginAccess({
+    requireUsername: false,
+    requireApprovedUserOrAdmin: false,
+    allowUnlockSupportOnly: true,
+  });
+
+  if (!decision.allowed) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-12 space-y-4">
+        <h1 className="text-2xl font-semibold tracking-tight">Sign in to manage your data</h1>
+        <p className="text-sm text-muted-foreground">
+          You need to be signed in to see and delete the data the platform holds for you.
+        </p>
+        <p className="text-sm">
+          <Link className="underline underline-offset-4" href="/">Return to home</Link>
+        </p>
+      </main>
+    );
+  }
+
+  return <AccountDataShell />;
+}

--- a/ctf/packages/web/app/api/account/services/route.ts
+++ b/ctf/packages/web/app/api/account/services/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { requireAccountAccess } from '../_lib';
+import { accountDeletionRegistry } from 'lib/account/deletion-registry';
+
+// Read-only projection of the account deletion registry for the Account & Data UI.
+//
+// The registry (`lib/account/deletion-registry.ts`) is the single source of truth for which
+// services hold a user's data, their human-readable names, the one-line data summary shown to the
+// user, and whether each service can be deleted on its own ("service" scope). This endpoint simply
+// surfaces that — it stores no copy of its own and performs no deletion. The actual deletes happen
+// through `DELETE /api/account/services/:slug` and `DELETE /api/account/full-account`.
+//
+// Services split into two lists for the UI:
+//   - `deletable`  — `serviceScopeSupported === true`; the user can delete this data independently.
+//   - `retained`   — `serviceScopeSupported === false`; honestly shown as "kept by design" with the
+//                    registry's own reason (money/ledger integrity for ServiceCredits; aggregate-only
+//                    community totals for GDP / Weekly Performance).
+//
+// GET /api/account/services
+export async function GET() {
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const deletable = accountDeletionRegistry
+    .filter((entry) => entry.serviceScopeSupported)
+    .map((entry) => ({
+      slug: entry.slug,
+      name: entry.name,
+      summary: entry.dataSummary,
+      serviceScopeSupported: true as const,
+    }));
+
+  const retained = accountDeletionRegistry
+    .filter((entry) => !entry.serviceScopeSupported)
+    .map((entry) => ({
+      slug: entry.slug,
+      name: entry.name,
+      summary: entry.dataSummary,
+      serviceScopeSupported: false as const,
+    }));
+
+  return NextResponse.json(
+    {
+      ok: true,
+      deletable,
+      retained,
+      counts: {
+        deletable: deletable.length,
+        retained: retained.length,
+        total: deletable.length + retained.length,
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
+++ b/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState } from 'react';
+import { Trash2, Lock, CheckCircle, X, Loader2 } from 'lucide-react';
+import {
+  BRAND, BG, BORDER, TEXT, SUBTLE, FULL_ACCOUNT_CONFIRM_PHRASE,
+} from './account-data-shared';
+
+type ConfirmStatus = 'idle' | 'submitting' | 'done' | 'error';
+
+type ConfirmProps = {
+  serviceCount: number;
+  isMobile: boolean;
+  onCancel: () => void;
+  // Performs the live DELETE /api/account/full-account call. Resolves on success, rejects on failure.
+  onConfirm: () => Promise<void>;
+};
+
+// Full-account deletion confirmation. Requires the user to type the exact phrase
+// ("delete my account") before the delete button is enabled — an intentional gesture, matching
+// AccountDataConfirmDelete.tsx / MobileAccountDataConfirmDelete.tsx. On success it shows the
+// "Deletion queued" acknowledgement; the parent decides where to send the user next.
+export function AccountDataConfirmDelete({ serviceCount, isMobile, onCancel, onConfirm }: ConfirmProps) {
+  const [input, setInput] = useState('');
+  const [status, setStatus] = useState<ConfirmStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const ready = input.toLowerCase().trim() === FULL_ACCOUNT_CONFIRM_PHRASE && status !== 'submitting';
+
+  async function handleConfirm() {
+    if (input.toLowerCase().trim() !== FULL_ACCOUNT_CONFIRM_PHRASE || status === 'submitting') {
+      return;
+    }
+    setStatus('submitting');
+    setErrorMessage(null);
+    try {
+      await onConfirm();
+      setStatus('done');
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to complete deletion. Please try again.');
+    }
+  }
+
+  if (status === 'done') {
+    return (
+      <div style={{ position: 'fixed', inset: 0, zIndex: 60, background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0 32px' }}>
+        <div style={{ textAlign: 'center', maxWidth: 440 }}>
+          <div style={{ width: 64, height: 64, borderRadius: '50%', background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 20px' }}>
+            <CheckCircle size={30} color="#22C55E" />
+          </div>
+          <div style={{ fontSize: 22, fontWeight: 800, color: TEXT, marginBottom: 10 }}>Deletion queued</div>
+          <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
+            Your request has been received. Your personal data is being removed across all services, and your ServiceCredits balance will be settled through the standard process. Some audit records are retained for platform integrity.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const panelWidth = isMobile ? '100%' : 560;
+
+  return (
+    <div style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(9,11,15,0.78)', fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: 'flex', alignItems: isMobile ? 'flex-start' : 'center', justifyContent: 'center', padding: isMobile ? '16px' : '24px', overflowY: 'auto' }}>
+      <div style={{ width: panelWidth, maxWidth: 560, borderRadius: 22, background: '#0D0F14', border: '1px solid rgba(239,68,68,0.3)', boxShadow: '0 28px 72px rgba(0,0,0,0.65)', overflow: 'hidden' }}>
+        {/* Header band */}
+        <div style={{ padding: '24px 26px 18px', background: 'linear-gradient(135deg,rgba(239,68,68,0.1),rgba(233,30,140,0.04))', borderBottom: '1px solid rgba(239,68,68,0.12)', display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+          <div style={{ width: 46, height: 46, borderRadius: 13, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <Trash2 size={21} color="#EF4444" />
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 18, fontWeight: 800, color: TEXT }}>Delete your entire account</div>
+            <div style={{ fontSize: 13, color: '#EF4444', marginTop: 2 }}>Permanent — this cannot be reversed.</div>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Cancel"
+            style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE, flexShrink: 0 }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: '22px 26px' }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 12 }}>What will happen</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 22 }}>
+            {([
+              { t: `All personal data deleted across ${serviceCount} services`, Icon: Trash2, c: '#EF4444' },
+              { t: 'ServiceCredits balance settled via standard process — not destroyed', Icon: CheckCircle, c: '#9CA3AF' },
+              { t: 'Some audit records retained for platform integrity — this is intentional', Icon: Lock, c: '#9CA3AF' },
+              { t: 'Your profile and username removed from all directories', Icon: Trash2, c: '#EF4444' },
+            ]).map(({ t, Icon, c }, i) => (
+              <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                <Icon size={14} color={c} style={{ flexShrink: 0, marginTop: 2 }} />
+                <span style={{ fontSize: 13, color: '#9CA3AF', lineHeight: 1.55 }}>{t}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Confirm field */}
+          <div style={{ padding: '16px', borderRadius: 12, background: 'rgba(239,68,68,0.04)', border: '1px solid rgba(239,68,68,0.14)', marginBottom: 18 }}>
+            <label htmlFor="account-delete-confirm" style={{ display: 'block', fontSize: 13, color: '#9CA3AF', marginBottom: 10, lineHeight: 1.5 }}>
+              To confirm, type{' '}
+              <span style={{ color: '#EF4444', fontWeight: 700, fontFamily: 'monospace' }}>{FULL_ACCOUNT_CONFIRM_PHRASE}</span>{' '}
+              in the field below.
+            </label>
+            <input
+              id="account-delete-confirm"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder={FULL_ACCOUNT_CONFIRM_PHRASE}
+              autoComplete="off"
+              style={{ width: '100%', padding: '10px 12px', background: BG, border: `1px solid ${ready ? 'rgba(239,68,68,0.5)' : BORDER}`, borderRadius: 8, fontSize: 14, color: ready ? '#EF4444' : TEXT, outline: 'none', fontFamily: 'monospace', boxSizing: 'border-box' }}
+            />
+          </div>
+
+          {status === 'error' && errorMessage ? (
+            <div style={{ padding: '10px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.3)', color: '#F87171', fontSize: 13, marginBottom: 16, lineHeight: 1.5 }}>
+              {errorMessage}
+            </div>
+          ) : null}
+
+          {/* Actions */}
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={!ready}
+              style={{ flex: 1, padding: '13px', borderRadius: 11, background: ready ? 'rgba(239,68,68,0.14)' : 'rgba(255,255,255,0.04)', border: `1px solid ${ready ? 'rgba(239,68,68,0.45)' : BORDER}`, color: ready ? '#EF4444' : '#374151', fontSize: 14, fontWeight: 700, cursor: ready ? 'pointer' : 'not-allowed', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
+            >
+              {status === 'submitting' ? <><Loader2 size={15} className="account-data-spin" /> Deleting…</> : <><Trash2 size={15} /> Delete permanently</>}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={status === 'submitting'}
+              style={{ padding: '13px 22px', borderRadius: 11, background: `${BRAND}12`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 14, fontWeight: 600, cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}
+            >
+              Keep my data
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
+++ b/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
@@ -74,9 +74,11 @@ export function AccountDataConfirmDelete({ serviceCount, isMobile, onCancel, onC
           </div>
           <button
             type="button"
-            onClick={onCancel}
+            onClick={() => { if (status !== 'submitting') onCancel(); }}
+            disabled={status === 'submitting'}
+            aria-disabled={status === 'submitting'}
             aria-label="Cancel"
-            style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: SUBTLE, flexShrink: 0 }}
+            style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: status === 'submitting' ? 'not-allowed' : 'pointer', color: SUBTLE, flexShrink: 0 }}
           >
             <X size={14} />
           </button>

--- a/ctf/packages/web/components/account-data/account-data-desktop.tsx
+++ b/ctf/packages/web/components/account-data/account-data-desktop.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import {
+  Shield, Database, Trash2, Lock, AlertTriangle, Info, Loader2,
+} from 'lucide-react';
+import {
+  BRAND, BG, SURFACE, BORDER, TEXT, SUBTLE,
+  glyphForService, type AccountService,
+} from './account-data-shared';
+
+type View = 'data' | 'danger';
+
+type DesktopProps = {
+  view: View;
+  onViewChange: (v: View) => void;
+  deletable: AccountService[];
+  retained: AccountService[];
+  deletedSlugs: string[];
+  pendingSlug: string | null;
+  rowError: { slug: string; message: string } | null;
+  onDeleteService: (service: AccountService) => void;
+  onOpenAccountDelete: () => void;
+};
+
+// Desktop (>=768px) Account & Data layout. Matches AccountData.tsx / AccountDataEmpty.tsx.
+export function AccountDataDesktop({
+  view, onViewChange, deletable, retained, deletedSlugs, pendingSlug, rowError,
+  onDeleteService, onOpenAccountDelete,
+}: DesktopProps) {
+  const remaining = deletable.filter((s) => !deletedSlugs.includes(s.slug));
+  const isEmpty = remaining.length === 0;
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: 'hidden' }}>
+      {/* Left sidebar */}
+      <aside style={{ width: 240, background: '#0D0F14', borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+        <div style={{ padding: '20px 16px 12px' }}>
+          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: SUBTLE, textTransform: 'uppercase', marginBottom: 4 }}>🔒 Account &amp; Data</div>
+          <div style={{ fontSize: 12, color: '#4B5563', lineHeight: 1.5 }}>Your data — transparent, under your control</div>
+        </div>
+        <div style={{ padding: '0 12px', flex: 1 }}>
+          {([
+            { label: 'Your Data', key: 'data' as const, Icon: Database },
+            { label: 'Danger Zone', key: 'danger' as const, Icon: AlertTriangle },
+          ]).map(({ label, key, Icon }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onViewChange(key)}
+              style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: '9px 10px', borderRadius: 8, marginBottom: 2, cursor: 'pointer', background: view === key ? `${BRAND}15` : 'transparent', borderLeft: view === key ? `2px solid ${BRAND}` : '2px solid transparent', color: view === key ? TEXT : SUBTLE, fontSize: 13, border: 'none', textAlign: 'left' }}
+            >
+              <Icon size={15} />
+              {label}
+            </button>
+          ))}
+          <div style={{ margin: '16px 0 8px', fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: '#4B5563', textTransform: 'uppercase' }}>Summary</div>
+          {([
+            { l: 'Services with your data', v: `${remaining.length} of ${deletable.length}` },
+            { l: 'Always retained', v: `${retained.length}` },
+            { l: 'Deleted this session', v: `${deletedSlugs.length}` },
+          ]).map(({ l, v }) => (
+            <div key={l} style={{ padding: '5px 2px', fontSize: 12, color: SUBTLE }}>
+              {l}: <span style={{ color: TEXT, fontWeight: 600 }}>{v}</span>
+            </div>
+          ))}
+        </div>
+        <div style={{ padding: 12, borderTop: `1px solid ${BORDER}` }}>
+          <div style={{ fontSize: 11, color: '#4B5563', lineHeight: 1.5 }}>🔒 Deletions are permanent and cannot be undone.</div>
+        </div>
+      </aside>
+
+      {/* Main */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+        <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: '#0D0F14', flexShrink: 0 }}>
+          <Shield size={18} color={BRAND} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>Your Data &amp; Privacy</div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>See and delete the data Survivor Hub holds across all services</div>
+          </div>
+        </header>
+
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '28px 40px' }}>
+          {view === 'data' ? (
+            isEmpty ? (
+              <EmptyState retained={retained} />
+            ) : (
+              <DataView
+                remaining={remaining}
+                retained={retained}
+                pendingSlug={pendingSlug}
+                rowError={rowError}
+                onDeleteService={onDeleteService}
+              />
+            )
+          ) : (
+            <DangerZone serviceCount={deletable.length} onOpenAccountDelete={onOpenAccountDelete} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DataView({
+  remaining, retained, pendingSlug, rowError, onDeleteService,
+}: {
+  remaining: AccountService[];
+  retained: AccountService[];
+  pendingSlug: string | null;
+  rowError: { slug: string; message: string } | null;
+  onDeleteService: (service: AccountService) => void;
+}) {
+  return (
+    <>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 16px', borderRadius: 12, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 24 }}>
+        <Info size={15} color={BRAND} style={{ flexShrink: 0, marginTop: 1 }} />
+        <div style={{ fontSize: 13, color: '#9CA3AF', lineHeight: 1.6 }}>
+          Deleting data from a service removes your records from that service permanently. Some audit records may be retained for platform integrity. Deleting from one service does not close your account.
+        </div>
+      </div>
+
+      <div style={{ fontSize: 14, fontWeight: 700, color: TEXT, marginBottom: 14 }}>
+        Personal data — {remaining.length} {remaining.length === 1 ? 'service' : 'services'}
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginBottom: 32 }}>
+        {remaining.map((service) => {
+          const isPending = pendingSlug === service.slug;
+          const error = rowError?.slug === service.slug ? rowError.message : null;
+          return (
+            <div key={service.slug} style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '13px 16px', borderRadius: 12, background: SURFACE, border: `1px solid ${error ? 'rgba(239,68,68,0.35)' : BORDER}`, opacity: isPending ? 0.7 : 1 }}>
+              <div style={{ width: 34, height: 34, borderRadius: 9, background: `${BRAND}10`, border: `1px solid ${BRAND}20`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14, flexShrink: 0 }}>
+                {glyphForService(service.slug)}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{service.name}</div>
+                <div style={{ fontSize: 12, color: error ? '#F87171' : SUBTLE, lineHeight: 1.4 }}>
+                  {error ?? service.summary}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => onDeleteService(service)}
+                disabled={isPending}
+                style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 5, padding: '5px 11px', borderRadius: 7, background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.2)', color: '#EF4444', fontSize: 12, fontWeight: 600, cursor: isPending ? 'not-allowed' : 'pointer' }}
+              >
+                {isPending ? <><Loader2 size={12} className="account-data-spin" /> Deleting…</> : <><Trash2 size={12} /> Delete this data</>}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <RetainedList retained={retained} />
+    </>
+  );
+}
+
+function RetainedList({ retained }: { retained: AccountService[] }) {
+  if (retained.length === 0) return null;
+  return (
+    <>
+      <div style={{ fontSize: 14, fontWeight: 700, color: TEXT, marginBottom: 6 }}>Always retained — {retained.length} {retained.length === 1 ? 'service' : 'services'}</div>
+      <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 14 }}>These cannot be deleted independently. See each reason below.</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+        {retained.map((service) => (
+          <div key={service.slug} style={{ display: 'flex', alignItems: 'flex-start', gap: 14, padding: '13px 16px', borderRadius: 12, background: 'rgba(255,255,255,0.01)', border: `1px solid ${BORDER}` }}>
+            <div style={{ width: 34, height: 34, borderRadius: 9, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14, flexShrink: 0 }}>
+              {glyphForService(service.slug)}
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                <span style={{ fontSize: 13, fontWeight: 600, color: SUBTLE }}>{service.name}</span>
+                <span style={{ fontSize: 10, fontWeight: 600, padding: '1px 6px', borderRadius: 4, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, color: '#4B5563' }}>Retained by design</span>
+              </div>
+              <div style={{ fontSize: 12, color: '#4B5563', lineHeight: 1.5 }}>{service.summary}</div>
+            </div>
+            <Lock size={13} color="#374151" style={{ flexShrink: 0, marginTop: 3 }} />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function EmptyState({ retained }: { retained: AccountService[] }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '40px 24px', textAlign: 'center', minHeight: '60vh' }}>
+      <div style={{ width: 64, height: 64, borderRadius: 20, background: `${BRAND}08`, border: `1px dashed ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 20 }}>
+        <Shield size={28} color={`${BRAND}50`} />
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 800, color: TEXT, marginBottom: 8 }}>No personal data stored yet</div>
+      <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7, maxWidth: 480, marginBottom: 28 }}>
+        As you use Survivor Hub apps, any personal data they hold will appear here — where you can see it and delete it on your own terms.
+      </div>
+      {retained.length > 0 ? (
+        <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 16px', borderRadius: 12, background: `${BRAND}05`, border: `1px solid ${BRAND}15`, maxWidth: 560, width: '100%', textAlign: 'left' }}>
+          <Info size={14} color={BRAND} style={{ flexShrink: 0, marginTop: 1 }} />
+          <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.6 }}>
+            ServiceCredits ledger and community totals are always retained for financial integrity and platform accuracy. They hold no personal identifiers.
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DangerZone({ serviceCount, onOpenAccountDelete }: { serviceCount: number; onOpenAccountDelete: () => void }) {
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <div style={{ padding: '22px 24px', borderRadius: 16, background: 'rgba(239,68,68,0.04)', border: '1px solid rgba(239,68,68,0.18)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+          <AlertTriangle size={18} color="#EF4444" />
+          <span style={{ fontSize: 16, fontWeight: 700, color: TEXT }}>Delete Entire Account</span>
+        </div>
+        <div style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.7, marginBottom: 16 }}>
+          This removes your profile and all personal data across all {serviceCount} services. Your ServiceCredits balance is settled via the standard process — not silently destroyed. Some audit records are retained for platform integrity.
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginBottom: 18 }}>
+          {([
+            { t: `All personal data across ${serviceCount} services permanently deleted`, warn: true },
+            { t: 'ServiceCredits balance settled via standard process — not destroyed', warn: false },
+            { t: 'Some audit records retained for platform integrity (by design)', warn: false },
+            { t: 'Profile and username removed from all directories', warn: true },
+          ]).map(({ t, warn }, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 9, fontSize: 13 }}>
+              <div style={{ width: 5, height: 5, borderRadius: '50%', background: warn ? '#EF4444' : '#4B5563', flexShrink: 0, marginTop: 6 }} />
+              <span style={{ color: warn ? '#F87171' : '#9CA3AF', lineHeight: 1.5 }}>{t}</span>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={onOpenAccountDelete}
+          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '10px 20px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.35)', color: '#EF4444', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}
+        >
+          <AlertTriangle size={15} /> Continue to confirmation →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export { type View as AccountDataView };

--- a/ctf/packages/web/components/account-data/account-data-mobile.tsx
+++ b/ctf/packages/web/components/account-data/account-data-mobile.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import {
+  Shield, Trash2, Lock, AlertTriangle, Info, ChevronRight, Loader2,
+} from 'lucide-react';
+import {
+  BRAND, BG, SURFACE, BORDER, TEXT, SUBTLE,
+  glyphForService, type AccountService,
+} from './account-data-shared';
+import type { AccountDataView } from './account-data-desktop';
+
+type MobileProps = {
+  view: AccountDataView;
+  onViewChange: (v: AccountDataView) => void;
+  deletable: AccountService[];
+  retained: AccountService[];
+  deletedSlugs: string[];
+  pendingSlug: string | null;
+  rowError: { slug: string; message: string } | null;
+  onDeleteService: (service: AccountService) => void;
+  onOpenAccountDelete: () => void;
+};
+
+// Mobile (<768px) Account & Data layout. Matches MobileAccountData.tsx / MobileAccountDataEmpty.tsx.
+export function AccountDataMobile({
+  view, onViewChange, deletable, retained, deletedSlugs, pendingSlug, rowError,
+  onDeleteService, onOpenAccountDelete,
+}: MobileProps) {
+  const remaining = deletable.filter((s) => !deletedSlugs.includes(s.slug));
+  const isEmpty = remaining.length === 0;
+
+  return (
+    <div style={{ minHeight: '100vh', background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Header */}
+      <div style={{ padding: '14px 16px 10px', borderBottom: `1px solid ${BORDER}`, flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+          <div style={{ width: 34, height: 34, borderRadius: 9, background: `${BRAND}20`, border: `1px solid ${BRAND}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Shield size={16} color={BRAND} />
+          </div>
+          <div>
+            <div style={{ fontSize: 16, fontWeight: 700 }}>Account &amp; Data</div>
+            <div style={{ fontSize: 11, color: SUBTLE }}>{deletable.length + retained.length} services · your control</div>
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {(['data', 'danger'] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => onViewChange(t)}
+              style={{ flex: 1, padding: '7px', borderRadius: 8, background: view === t ? (t === 'danger' ? 'rgba(239,68,68,0.12)' : `${BRAND}18`) : 'rgba(255,255,255,0.04)', border: `1px solid ${view === t ? (t === 'danger' ? 'rgba(239,68,68,0.4)' : `${BRAND}40`) : BORDER}`, color: view === t ? (t === 'danger' ? '#EF4444' : BRAND) : SUBTLE, fontSize: 12, fontWeight: view === t ? 700 : 400, cursor: 'pointer' }}
+            >
+              {t === 'data' ? 'Your Data' : '⚠️ Danger Zone'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '14px 16px 24px' }}>
+        {view === 'data' ? (
+          isEmpty ? (
+            <MobileEmpty retained={retained} />
+          ) : (
+            <MobileDataView
+              remaining={remaining}
+              retained={retained}
+              pendingSlug={pendingSlug}
+              rowError={rowError}
+              onDeleteService={onDeleteService}
+            />
+          )
+        ) : (
+          <MobileDanger serviceCount={deletable.length} onOpenAccountDelete={onOpenAccountDelete} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MobileDataView({
+  remaining, retained, pendingSlug, rowError, onDeleteService,
+}: {
+  remaining: AccountService[];
+  retained: AccountService[];
+  pendingSlug: string | null;
+  rowError: { slug: string; message: string } | null;
+  onDeleteService: (service: AccountService) => void;
+}) {
+  return (
+    <>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 10, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 16 }}>
+        <Info size={13} color={BRAND} style={{ flexShrink: 0, marginTop: 1 }} />
+        <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.5 }}>Deleting from a service is permanent. Some audit records are retained for platform integrity.</div>
+      </div>
+
+      <div style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 10 }}>Personal data — {remaining.length} {remaining.length === 1 ? 'service' : 'services'}</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginBottom: 24 }}>
+        {remaining.map((service) => {
+          const isPending = pendingSlug === service.slug;
+          const error = rowError?.slug === service.slug ? rowError.message : null;
+          return (
+            <div key={service.slug} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '11px 12px', borderRadius: 12, background: SURFACE, border: `1px solid ${error ? 'rgba(239,68,68,0.35)' : BORDER}`, opacity: isPending ? 0.7 : 1 }}>
+              <div style={{ width: 30, height: 30, borderRadius: 8, background: `${BRAND}10`, border: `1px solid ${BRAND}20`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, flexShrink: 0 }}>
+                {glyphForService(service.slug)}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: TEXT }}>{service.name}</div>
+                <div style={{ fontSize: 11, color: error ? '#F87171' : '#4B5563', lineHeight: 1.3, marginTop: 1 }}>{error ?? service.summary}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => onDeleteService(service)}
+                disabled={isPending}
+                aria-label={`Delete your ${service.name} data`}
+                style={{ flexShrink: 0, padding: '5px 8px', borderRadius: 7, background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.2)', color: '#EF4444', fontSize: 11, fontWeight: 700, cursor: isPending ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center' }}
+              >
+                {isPending ? <Loader2 size={12} className="account-data-spin" /> : <Trash2 size={12} />}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {retained.length > 0 ? (
+        <>
+          <div style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 10 }}>Always retained — {retained.length} {retained.length === 1 ? 'service' : 'services'}</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+            {retained.map((service) => (
+              <div key={service.slug} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '11px 12px', borderRadius: 12, background: 'rgba(255,255,255,0.01)', border: `1px solid ${BORDER}` }}>
+                <div style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, flexShrink: 0 }}>{glyphForService(service.slug)}</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: SUBTLE }}>{service.name}</span>
+                    <Lock size={10} color="#374151" />
+                  </div>
+                  <div style={{ fontSize: 11, color: '#4B5563', lineHeight: 1.4 }}>{service.summary}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+function MobileEmpty({ retained }: { retained: AccountService[] }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '24px 4px', textAlign: 'center' }}>
+      <div style={{ width: 56, height: 56, borderRadius: 16, background: `${BRAND}08`, border: `1px dashed ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>
+        <Shield size={24} color={`${BRAND}50`} />
+      </div>
+      <div style={{ fontSize: 19, fontWeight: 800, color: TEXT, marginBottom: 8 }}>No personal data stored yet</div>
+      <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6, marginBottom: 20 }}>
+        As you use Survivor Hub apps, any personal data they hold will appear here for you to see and delete.
+      </div>
+      {retained.length > 0 ? (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '12px', borderRadius: 12, background: `${BRAND}05`, border: `1px solid ${BRAND}15`, width: '100%', textAlign: 'left' }}>
+          <Info size={13} color={BRAND} style={{ flexShrink: 0, marginTop: 1 }} />
+          <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>
+            ServiceCredits ledger and community totals are always retained for financial integrity. They hold no personal identifiers.
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MobileDanger({ serviceCount, onOpenAccountDelete }: { serviceCount: number; onOpenAccountDelete: () => void }) {
+  return (
+    <div>
+      <div style={{ padding: '18px', borderRadius: 14, background: 'rgba(239,68,68,0.04)', border: '1px solid rgba(239,68,68,0.18)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+          <AlertTriangle size={16} color="#EF4444" />
+          <span style={{ fontSize: 15, fontWeight: 700, color: TEXT }}>Delete Entire Account</span>
+        </div>
+        <div style={{ fontSize: 13, color: '#9CA3AF', lineHeight: 1.6, marginBottom: 14 }}>
+          Removes your profile and all personal data across all {serviceCount} services. Your ServiceCredits are settled — not destroyed. Some audit records are retained by design.
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginBottom: 14 }}>
+          {([
+            { t: 'All personal data permanently deleted', warn: true },
+            { t: 'ServiceCredits settled via standard process', warn: false },
+            { t: 'Audit records retained (by design)', warn: false },
+            { t: 'Profile removed from all directories', warn: true },
+          ]).map(({ t, warn }, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 8, fontSize: 12 }}>
+              <div style={{ width: 4, height: 4, borderRadius: '50%', background: warn ? '#EF4444' : '#4B5563', flexShrink: 0, marginTop: 5 }} />
+              <span style={{ color: warn ? '#F87171' : '#9CA3AF', lineHeight: 1.4 }}>{t}</span>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={onOpenAccountDelete}
+          style={{ width: '100%', padding: '11px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.35)', color: '#EF4444', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
+        >
+          <AlertTriangle size={14} /> Continue to confirmation <ChevronRight size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/account-data/account-data-shared.ts
+++ b/ctf/packages/web/components/account-data/account-data-shared.ts
@@ -1,0 +1,63 @@
+// Shared design tokens and types for the Account & Data surface.
+//
+// Tokens mirror the survivor-hub mockups exactly (BRAND `#E91E8C`, bg `#0F1117`, surface `#161B27`,
+// border `#1E2A3A`, text `#F9FAFB`, subtle `#6B7280`). The shell uses inline styles to match the
+// mockup conventions for this surface.
+
+export const BRAND = '#E91E8C';
+export const BG = '#0F1117';
+export const SURFACE = '#161B27';
+export const BORDER = '#1E2A3A';
+export const TEXT = '#F9FAFB';
+export const SUBTLE = '#6B7280';
+
+// One service entry as returned by GET /api/account/services. Names and summaries come straight
+// from the deletion registry — never hardcoded in the components.
+export type AccountService = {
+  slug: string;
+  name: string;
+  summary: string;
+  serviceScopeSupported: boolean;
+};
+
+export type AccountServicesResponse = {
+  ok: boolean;
+  deletable: AccountService[];
+  retained: AccountService[];
+  counts: { deletable: number; retained: number; total: number };
+};
+
+// Per-service emoji glyphs, keyed by registry slug. Purely decorative; the registry has no icon
+// field, so these live here to match the mockup's per-row glyph. A missing slug falls back to a
+// neutral folder glyph.
+const SERVICE_GLYPH: Record<string, string> = {
+  chyme: '💬',
+  directory: '📇',
+  'feed-announcements': '📣',
+  foundation: '🪛',
+  mood: '🌿',
+  gentlepulse: '🎵',
+  'peer-programming': '👥',
+  lighthouse: '🏠',
+  socketrelay: '🔂',
+  trusttransport: '📦',
+  trust: '🛡️',
+  workforce: '💼',
+  'skills-hunt': '🎯',
+  'skills-taxonomy': '🗂️',
+  unlock: '🔓',
+  levelup: '🚀',
+  clicklog: '🚨',
+  comic: '🤖',
+  feedback: '💬',
+  'service-credits': '⚙️',
+  'gross-domestic-product': '📊',
+  'weekly-performance': '📊',
+};
+
+export function glyphForService(slug: string): string {
+  return SERVICE_GLYPH[slug] ?? '📁';
+}
+
+// The exact phrase the user must type to confirm full-account deletion (matches the mockup).
+export const FULL_ACCOUNT_CONFIRM_PHRASE = 'delete my account';

--- a/ctf/packages/web/components/account-data/account-data-shell.tsx
+++ b/ctf/packages/web/components/account-data/account-data-shell.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import { BG, TEXT } from './account-data-shared';
+import type { AccountService, AccountServicesResponse } from './account-data-shared';
+import { AccountDataDesktop, type AccountDataView } from './account-data-desktop';
+import { AccountDataMobile } from './account-data-mobile';
+import { AccountDataConfirmDelete } from './account-data-confirm-delete';
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+// Account & Data surface. Fetches the live service list from GET /api/account/services (a read-only
+// projection of the deletion registry), lets the user delete one service at a time via
+// DELETE /api/account/services/:slug, and delete the whole account via DELETE /api/account/full-account.
+// Desktop and mobile share this state; the layout switches on useIsMobile().
+export function AccountDataShell() {
+  const isMobile = useIsMobile();
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [deletable, setDeletable] = useState<AccountService[]>([]);
+  const [retained, setRetained] = useState<AccountService[]>([]);
+  const [view, setView] = useState<AccountDataView>('data');
+  const [deletedSlugs, setDeletedSlugs] = useState<string[]>([]);
+  const [pendingSlug, setPendingSlug] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<{ slug: string; message: string } | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      setLoadState('loading');
+      try {
+        const res = await fetch('/api/account/services', { signal: controller.signal });
+        if (controller.signal.aborted) return;
+        if (!res.ok) {
+          setLoadState('error');
+          return;
+        }
+        const data = (await res.json()) as AccountServicesResponse;
+        setDeletable(data.deletable ?? []);
+        setRetained(data.retained ?? []);
+        setLoadState('ready');
+      } catch {
+        if (!controller.signal.aborted) setLoadState('error');
+      }
+    }
+    void load();
+    return () => controller.abort();
+  }, []);
+
+  const handleDeleteService = useCallback(async (service: AccountService) => {
+    // Two-step confirm gesture for a single service: the browser confirm dialog states exactly what
+    // is removed before any request is sent. (Full-account deletion uses the stronger type-the-phrase
+    // gesture in the modal.)
+    const ok = window.confirm(
+      `Delete your ${service.name} data?\n\n${service.summary}\n\nThis is permanent and cannot be undone. Some audit records may be retained for platform integrity. Your account stays open.`,
+    );
+    if (!ok) return;
+
+    setPendingSlug(service.slug);
+    setRowError(null);
+    try {
+      const res = await fetch(`/api/account/services/${encodeURIComponent(service.slug)}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+      });
+      if (!res.ok) {
+        let message = 'Unable to delete this data. Please try again.';
+        try {
+          const body = (await res.json()) as { message?: string };
+          if (body.message) message = body.message;
+        } catch {
+          // keep default message
+        }
+        setRowError({ slug: service.slug, message });
+        return;
+      }
+      setDeletedSlugs((prev) => (prev.includes(service.slug) ? prev : [...prev, service.slug]));
+    } catch {
+      setRowError({ slug: service.slug, message: 'Network error. Please try again.' });
+    } finally {
+      setPendingSlug(null);
+    }
+  }, []);
+
+  const handleConfirmFullAccount = useCallback(async () => {
+    const res = await fetch('/api/account/full-account', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+    });
+    if (!res.ok) {
+      let message = 'Unable to complete full-account deletion. Please try again.';
+      try {
+        const body = (await res.json()) as { message?: string };
+        if (body.message) message = body.message;
+      } catch {
+        // keep default message
+      }
+      throw new Error(message);
+    }
+  }, []);
+
+  if (loadState === 'loading') {
+    return <AccountDataLoadingState />;
+  }
+
+  if (loadState === 'error') {
+    return <AccountDataErrorState />;
+  }
+
+  const layout = isMobile ? (
+    <AccountDataMobile
+      view={view}
+      onViewChange={setView}
+      deletable={deletable}
+      retained={retained}
+      deletedSlugs={deletedSlugs}
+      pendingSlug={pendingSlug}
+      rowError={rowError}
+      onDeleteService={handleDeleteService}
+      onOpenAccountDelete={() => setConfirmOpen(true)}
+    />
+  ) : (
+    <AccountDataDesktop
+      view={view}
+      onViewChange={setView}
+      deletable={deletable}
+      retained={retained}
+      deletedSlugs={deletedSlugs}
+      pendingSlug={pendingSlug}
+      rowError={rowError}
+      onDeleteService={handleDeleteService}
+      onOpenAccountDelete={() => setConfirmOpen(true)}
+    />
+  );
+
+  return (
+    <>
+      <style>{'@keyframes account-data-spin{to{transform:rotate(360deg)}}.account-data-spin{animation:account-data-spin 0.8s linear infinite}'}</style>
+      {layout}
+      {confirmOpen ? (
+        <AccountDataConfirmDelete
+          serviceCount={deletable.length + retained.length}
+          isMobile={isMobile}
+          onCancel={() => setConfirmOpen(false)}
+          onConfirm={handleConfirmFullAccount}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function AccountDataLoadingState() {
+  return (
+    <div style={{ display: 'flex', height: '100vh', background: BG, alignItems: 'center', justifyContent: 'center', fontFamily: "'Inter',system-ui" }}>
+      <div style={{ textAlign: 'center', padding: '0 32px' }}>
+        <div style={{ fontSize: 11, letterSpacing: '0.18em', color: 'rgba(255,255,255,0.22)', textTransform: 'uppercase', fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>EXIT THEIR ECONOMY</div>
+        <div style={{ fontSize: 11, letterSpacing: '0.18em', color: 'rgba(255,255,255,0.22)', textTransform: 'uppercase', fontWeight: 500, lineHeight: 2 }}>EXIT THE PSYOP</div>
+      </div>
+    </div>
+  );
+}
+
+function AccountDataErrorState() {
+  return (
+    <div style={{ display: 'flex', height: '100vh', background: BG, color: TEXT, alignItems: 'center', justifyContent: 'center', fontFamily: "'Inter',system-ui", padding: '0 32px' }}>
+      <div style={{ textAlign: 'center', maxWidth: 420 }}>
+        <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 10 }}>We couldn&apos;t load your data right now</div>
+        <div style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.6 }}>Please refresh the page to try again. Your data and deletion controls will be here.</div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { MessageSquare, Zap, Bell, Settings } from 'lucide-react';
+import Link from 'next/link';
+import { MessageSquare, Zap, Bell, Shield } from 'lucide-react';
 import type { ShellSection } from './shell-types';
 import styles from './community-shell.module.css';
 
@@ -48,16 +49,14 @@ export function ShellIconRail({ section, onSectionChange, initial = 'S' }: IconR
         <Bell size={18} />
       </button>
 
-      <button
-        type="button"
-        className={`${styles.iconRailBtn} ${styles.iconRailBtnDisabled}`}
-        aria-label="Settings coming soon"
-        aria-disabled="true"
-        disabled
-        title="Settings are coming soon"
+      <Link
+        href="/account/data"
+        className={styles.iconRailBtn}
+        aria-label="Account and data"
+        title="Account & Data — see and delete your data"
       >
-        <Settings size={18} />
-      </button>
+        <Shield size={18} />
+      </Link>
 
       <div className={styles.iconRailAvatar} aria-hidden="true">{initial}</div>
     </aside>


### PR DESCRIPTION
Implements **P3 from #312** — the user-facing **Account & Data** (privacy & deletion) surface — on top of the already-live deletion backend. No backend logic, schema, or the deletion orchestrator was touched; this adds a read-only projection endpoint and the UI.

## What a user can do
See the personal data the platform holds for them per service, delete that data one service at a time, or delete their whole account. Calm, trauma-informed copy.

## Backend binding (no stub data — rule 126)
- **New** `GET /api/account/services` — a read-only projection of `accountDeletionRegistry`: every service's slug, name, one-line summary, and whether it's independently deletable. Split into `deletable` (19) and `retained` (3 — ServiceCredits, GDP, Weekly Performance, shown honestly as "kept by design"). All copy comes from the registry, not the component.
- Per-service delete → `DELETE /api/account/services/:slug`; full-account delete → `DELETE /api/account/full-account`. Both send `x-ctf-csrf: '1'`.

## UI
- Web: one responsive component set under `components/account-data/` (desktop + mobile via `useIsMobile()`), states loading/empty/populated + confirm-delete. Page at `app/account/data/page.tsx`, auth posture matching `requireAccountAccess`. Reached from the shell icon rail (the old disabled "Settings coming soon" icon now opens Account & Data).
- Android: `src/features/account-data/` (screen + API client), registered in `App.tsx`.

## Confirm gestures
- Per-service: a confirm dialog stating exactly what is removed (account stays open), then the DELETE.
- Full-account: a modal that requires typing `delete my account` before the destructive button enables, then a "Deletion queued" acknowledgement. Both state what is deleted vs retained (ServiceCredits settled, audit records kept).

## Decisions worth a look
- **Retained count is 3, not 2.** The mockup hardcodes "2" and merges GDP + Weekly Performance; the registry has three non-deletable entries, so the UI renders all three and derives every count from live data.
- **Unbacked mockup controls omitted** (Export all data, Deactivate-instead, static encryption badges) — no backend, so not rendered (rule 126).
- **Not added to `plugin-parity-contracts.json`** — that check fails any slug without a matching plugin-registry entry, and this is a non-plugin account surface. Android parity is met by the real feature dir + `App.tsx` registration; rationale documented in the inventory. The parity check passes.

## Verification
Web typecheck + eslint, mobile typecheck + eslint, EOF check, and `check-web-android-parity.mjs` all pass. `next build` not run (Turbopack workspace-root failure is environmental in this container).

Parity Status: web+android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Account & Data" feature allowing users to view and manage personal data linked across services
  * Users can delete individual service data with confirmation, with some data permanently retained by the system
  * Users can delete their entire account using a typed confirmation phrase for enhanced security
  * Feature is available on both web and mobile platforms
  * Added navigation entry point to access account and data management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->