### PR TITLE
feat: add GDP currency rate-admin (view and revise USD factors)

### DIFF
--- a/ctf/docs/contracts/GDP_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/GDP_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -198,6 +198,51 @@ policies:
       - insufficient_role
 
   - pluginId: gross-domestic-product
+    command: admin.currency.rate.list
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+    consentRequirements:
+      scopes: []
+      fallbackLawfulBasis: public_interest_reporting
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - unauthenticated_actor
+      - insufficient_role
+
+  - pluginId: gross-domestic-product
+    command: admin.currency.rate.revise
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+    consentRequirements:
+      scopes: []
+      fallbackLawfulBasis: none
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - unauthenticated_actor
+      - insufficient_role
+      - csrf_validation_failed
+      - currency_not_found
+      - non_positive_rate
+
+  - pluginId: gross-domestic-product
     command: admin.backfill.run
     version: 1.0.0
     requiredRoles:

--- a/ctf/docs/contracts/GDP_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/GDP_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -239,6 +239,58 @@ contracts:
     idempotency: false
 
   - pluginId: gross-domestic-product
+    command: admin.currency.rate.list
+    version: 1.0.0
+    description: >-
+      List every active currency with its current USD factor (latest as_of row:
+      usd_rate, as_of, source) and its prior factors as history (newest first),
+      for the admin-only currency rate management surface. These factors only
+      estimate aggregate GDP and are never a per-wallet or redemption value.
+    inputSchema: {}
+    outputSchema:
+      currencies:
+        type: array
+    dataAccess:
+      - currency_usd_rates
+      - currencies
+    purpose: gdp_estimate_normalization
+    retentionClass: derived_medium_lived
+    idempotency: true
+
+  - pluginId: gross-domestic-product
+    command: admin.currency.rate.revise
+    version: 1.0.0
+    description: >-
+      Revise the owner-curated USD factor for a currency, used only to roll
+      multi-currency volume into the single USD-denominated GDP estimate.
+      Inserts a new dated currency_usd_rates row; revising the same as_of date
+      updates that row (ON CONFLICT (currency_code, as_of) DO UPDATE) so history
+      is preserved and the latest as_of stays the active factor. Admin-only.
+      This factor is never a per-wallet, per-price, or redemption value.
+    inputSchema:
+      currencyCode:
+        type: string
+        required: true
+      usdRate:
+        type: number
+        required: true
+      asOf:
+        type: string
+        required: false
+      source:
+        type: string
+        required: false
+    outputSchema:
+      rate:
+        type: object
+    dataAccess:
+      - currency_usd_rates
+      - currencies
+    purpose: gdp_estimate_normalization
+    retentionClass: audit_long_lived
+    idempotency: true
+
+  - pluginId: gross-domestic-product
     command: admin.backfill.run
     version: 1.0.0
     description: Run controlled historical GDP backfill to recompute aggregate snapshots.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -87,6 +87,20 @@ The plugin must provide equivalent core behavior across web and Android, with ph
 2. Validation queue for failed metric checks.
 3. Backfill and replay controls for historical periods.
 
+### 2.4 Currency Rate Factor Management (issue #312 P2)
+
+1. Admin-only view of the owner-curated USD factor for every active currency: current factor,
+   `as_of` date, and source label, plus the prior factors as history (newest first).
+2. Revise action that adds a new dated `currency_usd_rates` row (the latest `as_of` becomes the
+   active factor); revising the same day updates that day's row, never overwriting older history.
+3. These factors are used ONLY to roll multi-currency volume into the single USD-denominated GDP
+   estimate. The surface carries a calm disclaimer that the factors only estimate GDP and are
+   never a redemption rate, per-wallet conversion, or the price of ServiceCredits. Currencies are
+   shown by their label (e.g. "ServiceCredits", "United States Dollar"), never the bare code as a
+   value. United States Dollar is the fixed baseline and is not revisable.
+4. Web: `/admin/gdp/rates` (linked from `/admin/gdp`), desktop + mobile-responsive via
+   `useIsMobile()`. Android: a GDP Rate Admin screen gated on `user.isAdmin`.
+
 ### 2.3 Policy and Compliance Operations
 
 1. Access controls for administrative metric mutation commands.
@@ -135,6 +149,23 @@ Admin routes:
 - `POST /api/gross-domestic-product/admin/snapshots/publish`
 - `POST /api/gross-domestic-product/admin/backfill`
 - `GET /api/gross-domestic-product/admin/audit-events`
+
+Implemented admin routes (currency rate factors, issue #312 P2):
+
+- `GET /api/gdp/admin/currency-rates` — admin-only. For each active currency returns
+  `code`, `label`, `symbol`, `isServiceCredits`, `decimalPlaces`, `sortOrder`, its current
+  factor (`current`: the latest `as_of` row's `usdRate`, `asOf`, `source`, or `null` when none
+  set) and its prior factors (`history`, newest first). Gated by `requireGdpAdminAccess()`.
+  Command contract: `admin.currency.rate.list`.
+- `POST /api/gdp/admin/currency-rates` — admin-only revise. Body
+  `{ currencyCode, usdRate, asOf?, source? }`. Inserts a `currency_usd_rates` row with
+  `ON CONFLICT (currency_code, as_of) DO UPDATE`, so revising the same `as_of` date updates that
+  row instead of failing the UNIQUE constraint; any other date adds a new history row and leaves
+  prior rows intact. `asOf` defaults to today; `source` defaults to `owner`. Validates
+  `usdRate > 0` and that `currencyCode` is an active currency. Requires the `x-ctf-csrf: 1`
+  header. Audited via `gdp_admin_audit_trail` (`gdp.currency-rate.revise`, allow + deny on
+  unknown currency). Command contract: `admin.currency.rate.revise`. LEGAL GUARDRAIL: these
+  factors only estimate aggregate GDP — never a per-wallet, per-price, or redemption value.
 
 ---
 
@@ -257,6 +288,16 @@ Web pixel pass complete: the shell (`gdp-shell.tsx` + `gdp-*` sub-components) is
 
 Android pixel pass complete (2026-05-31): `Gdp.tsx` rewritten to match `design/.../survivor-hub/MobileGDP.tsx` (+ Empty/Loading/Public states) using React Native primitives. Real `api.ts` created, bound exclusively to `GET /api/gdp/report/current`. Metric bindings: `gdp_total_revenue` (hero value) and `weekly_active_users` (active-users chip). Omissions per real-data-only rule: sector breakdown, country breakdown, per-user contribution, weekly trend series, and $300B target progress (none backed by an API field). `MockGdp.tsx` retained as dead code but no longer imported. Export `Gdp` preserved; `App.tsx` unchanged.
 
+Currency rate admin shipped (2026-06-06, issue #312 P2, surface 1): an admin-only screen to view
+and revise the owner-curated USD factors used only to roll multi-currency volume into the single
+USD-denominated GDP estimate. Web `/admin/gdp/rates` (`components/gdp/gdp-rate-admin.tsx`, desktop +
+mobile-responsive via `useIsMobile()`, linked from `/admin/gdp`) and Android (`GdpRateAdmin.tsx` +
+`rateAdminApi.ts`, gated on `user.isAdmin`) both bind to `GET`/`POST /api/gdp/admin/currency-rates`.
+Matches `design/.../survivor-hub/GDPRateAdmin.tsx` and `MobileGDPRateAdmin.tsx`. The hard legal line
+is honored everywhere: a calm disclaimer that these factors only estimate aggregate GDP and are never
+a redemption rate, per-wallet conversion, or the price of ServiceCredits; currencies are shown by
+label, never as a per-wallet "N ServiceCredits = $X" equivalence.
+
 Estimate treatment shipped (2026-06-06, issue #312 P2): the headline GDP figure and the sidebar USD aggregate now show an understated "Estimate" chip plus a short footnote on web (`gdp-dashboard.tsx` hero — desktop and the mobile-responsive layout — and `gdp-sidebar.tsx` Live Ticker) and Android (`Gdp.tsx` overview hero), driven by the `isEstimate` flag the report projection surfaces off `gdp_metric_snapshots.is_estimate`. The chip/footnote render only where the data is flagged an estimate. Copy describes a community-wide normalized USD estimate (a morale/transparency metric, not a ledger), never a per-user redemption value, honoring the no-fiat-parity line.
 
 ---
@@ -292,6 +333,27 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 
 ## 10) Change Log
 
+- 2026-06-06: GDP currency rate admin shipped (issue #312, prompt P2, surface 1). New admin-only
+  endpoints `GET`/`POST /api/gdp/admin/currency-rates` (`app/api/gdp/admin/currency-rates/route.ts`),
+  gated by `requireGdpAdminAccess()` with the GDP CSRF helper (`x-ctf-csrf: 1`) on the mutation.
+  `GET` returns each active currency with its current factor (latest `as_of`) and history (older
+  rows, newest first); `POST` revises by inserting a `currency_usd_rates` row with
+  `ON CONFLICT (currency_code, as_of) DO UPDATE` (same-day revise updates that row, preserving older
+  history; latest `as_of` stays active), `asOf` defaulting to today and `source` to `owner`,
+  validating `usdRate > 0` and that the currency exists. DB work added to `lib/gdp/repository.ts`
+  (`listCurrencyRateAdmin`, `currencyExists`, `upsertCurrencyUsdRate`); audited via
+  `gdp_admin_audit_trail` (`gdp.currency-rate.revise`). Web: `components/gdp/gdp-rate-admin.tsx`
+  client surface + `/admin/gdp/rates` page (admin-gated, linked from `/admin/gdp`), desktop and
+  mobile-responsive (`useIsMobile()`), states loading/empty/populated/saved, bound to the GET (no stub
+  data). Android: `packages/mobile/src/features/gdp/GdpRateAdmin.tsx` + `rateAdminApi.ts`, gated on
+  `user.isAdmin`, registered in `App.tsx`. Command + access-policy contracts added
+  (`admin.currency.rate.list`, `admin.currency.rate.revise`). Matches `GDPRateAdmin.tsx` /
+  `MobileGDPRateAdmin.tsx`. No schema change (`currency_usd_rates` already existed). LEGAL HARD LINE:
+  these factors only estimate aggregate GDP — never a per-wallet, per-price, or redemption
+  "ServiceCredits = fiat" value; currencies are shown by label. Mockup control omitted for lack of
+  backend: the mockup's editable `as_of` field is not exposed in the revise form (the endpoint accepts
+  an optional `asOf` but the UI always revises as of today, matching the "new dated row with today's
+  date" copy); no other controls omitted.
 - 2026-06-06: GDP "Estimate" treatment shipped (issue #312, prompt P2). Surfaced the existing `gdp_metric_snapshots.is_estimate` flag through the report read path: `lib/gdp/repository.ts` `mapMetric` now selects and maps `is_estimate` → `isEstimate`, and `GET /api/gdp/report/current` returns it per metric. Web (`gdp-shell.tsx` derives the headline-metric estimate flag; `gdp-dashboard.tsx` hero and `gdp-sidebar.tsx` Live Ticker render an understated "Estimate" chip + footnote on the GDP/USD-aggregate figures, desktop and mobile-responsive) and Android (`Gdp.tsx` overview hero + `api.ts` `pickMetricIsEstimate`) now show the chip/footnote only where the data is flagged an estimate, matching `design/.../survivor-hub/GDP.tsx`, `GDPPublic.tsx`, `MobileGDP.tsx`, `MobileGDPPublic.tsx`. Copy reads as a community-wide normalized USD estimate (a morale/transparency metric, not a ledger or redemption value); the ServiceCredits→USD factor stays confined to the aggregate, never a per-wallet/per-price fiat equivalence. No schema change (the column already existed). Read-only projection change, not design-gated.
 - 2026-06-01: GDP recognition pipeline (issue #121 follow-up): added an extensible source registry in `recognition.ts` (`RecognitionSource` + `recognizeGdpVolumeUsd`) and the `scripts/recognizeGdp.mjs` rollup job (`pnpm gdp:recognize`) that recognizes actual multi-currency volume into the `gdp_recognized_volume_usd` estimate metric, ALONGSIDE the projection target. First source: TrustTransport completed-task earnings (`credit`/`release`), normalized via `currency_usd_rates`; other plugins register as the owner approves them. Registered the metric in `canonical_metrics.yaml`. The rate-admin screen and the in-product "estimate" label stay design-gated (no mockup yet); their design brief is handed to the owner directly rather than committed (prompts are one-time, not kept in the repo). No schema change (reuses `gdp_metric_snapshots` + `currency_usd_rates`).
 - 2026-06-01: Multi-currency recognition foundation (issue #121): added the `currency_usd_rates` table (notional USD factor per currency, FK → `currencies.code`, with `as_of`) + `seedCurrencyUsdRates.mjs`; an `is_estimate` flag on `gdp_metric_snapshots`; and the GDP estimation-layer helper `ctf/packages/web/lib/gdp/recognition.ts` that rolls multi-currency volume into one USD estimate (the FX factor lives only here, never a per-wallet/per-price parity). Seeded `gdp_total_revenue` as an estimate. Documented the model and the no-fiat-parity guardrail; reconciled with the account-deletion-reclaim non-recognition rule (§4.4). The live automated rollup across plugin transaction tables, the admin rate-management UI, and the in-product estimate label remain next steps (the last two are design-gated).

--- a/ctf/packages/mobile/App.tsx
+++ b/ctf/packages/mobile/App.tsx
@@ -17,7 +17,7 @@ import { PeerProgramming, AdminPeerProgramming } from './src/features/peer-progr
 import { Mood } from './src/features/mood';
 import { GentlePulse } from './src/features/gentlepulse';
 import { WeeklyPerformance, AdminWeeklyPerformance } from './src/features/weekly-performance';
-import { Gdp } from './src/features/gdp';
+import { Gdp, GdpRateAdmin } from './src/features/gdp';
 import { ServiceCredits } from './src/features/service-credits';
 import { Levelup } from './src/features/levelup';
 import { Unlock } from './src/features/unlock';
@@ -44,6 +44,7 @@ type FeatureKey =
   | 'weekly-performance'
   | 'weekly-performance-admin'
   | 'gdp'
+  | 'gdp-rate-admin'
   | 'service-credits'
   | 'levelup'
   | 'unlock'
@@ -74,6 +75,7 @@ const featureOrder: Array<{ key: FeatureKey; label: string }> = [
   { key: 'weekly-performance', label: 'Weekly Performance' },
   { key: 'weekly-performance-admin', label: 'Weekly Performance Admin' },
   { key: 'gdp', label: 'GDP' },
+  { key: 'gdp-rate-admin', label: 'GDP Rate Admin' },
   { key: 'service-credits', label: 'Service Credits' },
   { key: 'levelup', label: 'LevelUp' },
   { key: 'unlock', label: 'Unlock' },
@@ -132,6 +134,8 @@ export default function App() {
         return <AdminWeeklyPerformance />;
       case 'gdp':
         return <Gdp />;
+      case 'gdp-rate-admin':
+        return <GdpRateAdmin />;
       case 'service-credits':
         return <ServiceCredits />;
       case 'levelup':

--- a/ctf/packages/mobile/src/features/gdp/GdpRateAdmin.tsx
+++ b/ctf/packages/mobile/src/features/gdp/GdpRateAdmin.tsx
@@ -1,0 +1,520 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
+import { useAuth } from '../../auth/auth-context';
+import {
+  CurrencyRateEntry,
+  fetchCurrencyRates,
+  reviseCurrencyRate,
+  isFixedBaseline,
+  formatFactor,
+} from './rateAdminApi';
+
+// Admin-only GDP currency rate-admin (issue #312 P2), mirrors
+// design/.../survivor-hub/MobileGDPRateAdmin.tsx. These factors exist solely to
+// estimate aggregate GDP — never a redemption rate or per-wallet conversion.
+
+const COLOR = '#06B6D4';
+const BG = '#0F1117';
+const BG_DARK = '#0D0F14';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const MUTED = '#9CA3AF';
+const SUBTLE = '#6B7280';
+
+const DISCLAIMER =
+  'These factors exist solely to estimate aggregate GDP. They are never a redemption rate or per-wallet conversion.';
+
+export const GdpRateAdmin = () => {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const isAdmin = Boolean(user?.isAdmin);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currencies, setCurrencies] = useState<CurrencyRateEntry[]>([]);
+
+  const [editing, setEditing] = useState<CurrencyRateEntry | null>(null);
+  const [newRate, setNewRate] = useState('');
+  const [newSource, setNewSource] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await fetchCurrencyRates();
+      setCurrencies(rows);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load currency factors.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated || !isAdmin) return;
+    void load();
+  }, [isAuthenticated, isAdmin, load]);
+
+  const openEdit = (c: CurrencyRateEntry) => {
+    setEditing(c);
+    setNewRate(c.current ? String(c.current.usdRate) : '');
+    setNewSource('');
+    setSaved(false);
+    setSaveError(null);
+  };
+
+  const closeEdit = () => {
+    setEditing(null);
+    setSaved(false);
+    setSaveError(null);
+  };
+
+  const canSave = newRate.trim() !== '' && newSource.trim() !== '' && !saving;
+
+  const save = async () => {
+    if (!editing || !canSave) return;
+    const rateNum = Number(newRate);
+    if (!Number.isFinite(rateNum) || rateNum <= 0) {
+      setSaveError('Factor must be a number greater than zero.');
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await reviseCurrencyRate({ currencyCode: editing.code, usdRate: rateNum, source: newSource.trim() });
+      setSaved(true);
+      await load();
+      setTimeout(() => {
+        setSaved(false);
+        setEditing(null);
+      }, 2200);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : 'Failed to save the new factor.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Gating states ──────────────────────────────────────────────────────────
+  if (authLoading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={COLOR} size="large" />
+      </View>
+    );
+  }
+  if (!isAuthenticated || !isAdmin) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.gateTitle}>Admin only</Text>
+        <Text style={styles.gateDesc}>
+          The GDP currency rate admin is available to administrators only.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.root}>
+      {/* Header */}
+      <View style={styles.header}>
+        {editing && !saved ? (
+          <TouchableOpacity onPress={closeEdit} style={styles.backBtn} accessibilityRole="button" accessibilityLabel="Back">
+            <Text style={styles.backChevron}>‹</Text>
+          </TouchableOpacity>
+        ) : null}
+        <Text style={styles.headerGlobe}>🌐</Text>
+        <View style={styles.headerTextWrap}>
+          <Text style={styles.headerTitle}>GDP Rate Admin</Text>
+          <Text style={styles.headerSub}>
+            {editing ? `Revising — ${editing.label}` : 'GDP estimate factors only'}
+          </Text>
+        </View>
+        <View style={styles.adminChip}>
+          <Text style={styles.adminChipText}>Admin only</Text>
+        </View>
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color={COLOR} />
+          <Text style={styles.loadingText}>Loading currency factors…</Text>
+        </View>
+      ) : error ? (
+        <View style={styles.center}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      ) : (
+        <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollPad}>
+          {editing ? (
+            <RevisePanel
+              editing={editing}
+              saved={saved}
+              saving={saving}
+              newRate={newRate}
+              newSource={newSource}
+              saveError={saveError}
+              canSave={canSave}
+              onChangeRate={setNewRate}
+              onChangeSource={setNewSource}
+              onSave={save}
+            />
+          ) : (
+            <CurrencyList currencies={currencies} onRevise={openEdit} />
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+};
+
+function Disclaimer() {
+  return (
+    <View style={styles.disclaimer}>
+      <Text style={styles.disclaimerIcon}>⚠</Text>
+      <Text style={styles.disclaimerText}>{DISCLAIMER}</Text>
+    </View>
+  );
+}
+
+function CurrencyList({
+  currencies,
+  onRevise,
+}: {
+  currencies: CurrencyRateEntry[];
+  onRevise: (_c: CurrencyRateEntry) => void;
+}) {
+  return (
+    <>
+      <Disclaimer />
+      {currencies.length === 0 ? (
+        <View style={styles.emptyCard}>
+          <Text style={styles.emptyText}>No active currencies to manage yet.</Text>
+        </View>
+      ) : (
+        currencies.map((c) => {
+          const fixed = isFixedBaseline(c);
+          return (
+            <React.Fragment key={c.code}>
+              <View style={styles.currencyCard}>
+                <View style={styles.currencyTopRow}>
+                  <View style={[styles.currencyBadge, c.isServiceCredits && styles.currencyBadgeSc]}>
+                    <Text style={[styles.currencyBadgeText, c.isServiceCredits && styles.currencyBadgeTextSc]}>
+                      {c.symbol ?? c.code}
+                    </Text>
+                  </View>
+                  <View style={styles.currencyInfo}>
+                    <Text style={styles.currencyLabel}>{c.label}</Text>
+                    <Text style={styles.currencyAsOf}>
+                      {c.current ? `as of ${c.current.asOf}` : 'no factor set'}
+                    </Text>
+                  </View>
+                  <Text style={[styles.currencyFactor, fixed && styles.currencyFactorFixed]}>
+                    {formatFactor(c)}
+                  </Text>
+                </View>
+                <Text style={styles.currencySource}>
+                  {c.current ? `Source: ${c.current.source}` : 'No factor recorded yet'}
+                </Text>
+                {!fixed ? (
+                  <TouchableOpacity style={styles.reviseBtn} onPress={() => onRevise(c)} accessibilityRole="button">
+                    <Text style={styles.reviseBtnText}>Revise</Text>
+                  </TouchableOpacity>
+                ) : (
+                  <Text style={styles.fixedNote}>Fixed baseline — no revision needed</Text>
+                )}
+              </View>
+            </React.Fragment>
+          );
+        })
+      )}
+    </>
+  );
+}
+
+function RevisePanel({
+  editing,
+  saved,
+  saving,
+  newRate,
+  newSource,
+  saveError,
+  canSave,
+  onChangeRate,
+  onChangeSource,
+  onSave,
+}: {
+  editing: CurrencyRateEntry;
+  saved: boolean;
+  saving: boolean;
+  newRate: string;
+  newSource: string;
+  saveError: string | null;
+  canSave: boolean;
+  onChangeRate: (_v: string) => void;
+  onChangeSource: (_v: string) => void;
+  onSave: () => void;
+}) {
+  if (saved) {
+    return (
+      <View style={styles.savedWrap}>
+        <View style={styles.savedCircle}>
+          <Text style={styles.savedCheck}>✓</Text>
+        </View>
+        <Text style={styles.savedTitle}>Factor saved</Text>
+        <Text style={styles.savedDesc}>New row added with today&apos;s date. Prior values preserved as history.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <View style={styles.disclaimer}>
+        <Text style={styles.disclaimerIcon}>⚠</Text>
+        <Text style={styles.disclaimerText}>
+          GDP estimate factor only — never a redemption rate or per-wallet value.
+        </Text>
+      </View>
+
+      <Text style={styles.fieldLabel}>New USD factor *</Text>
+      <View style={styles.rateInputWrap}>
+        <Text style={styles.rateDollar}>$</Text>
+        <TextInput
+          value={newRate}
+          onChangeText={onChangeRate}
+          keyboardType="decimal-pad"
+          placeholder="0.00000"
+          placeholderTextColor={SUBTLE}
+          style={styles.rateInput}
+        />
+        {editing.symbol ? <Text style={styles.rateUnit}>/ {editing.symbol}</Text> : null}
+      </View>
+
+      <Text style={styles.fieldLabel}>Source / note *</Text>
+      <TextInput
+        value={newSource}
+        onChangeText={onChangeSource}
+        placeholder="e.g. Owner — quarterly review"
+        placeholderTextColor={SUBTLE}
+        style={styles.sourceInput}
+      />
+
+      {saveError ? <Text style={styles.errorText}>{saveError}</Text> : null}
+
+      <TouchableOpacity
+        style={[styles.saveBtn, !canSave && styles.saveBtnDisabled]}
+        onPress={onSave}
+        disabled={!canSave}
+        accessibilityRole="button"
+      >
+        <Text style={[styles.saveBtnText, !canSave && styles.saveBtnTextDisabled]}>
+          {saving ? 'Saving…' : 'Save new factor'}
+        </Text>
+      </TouchableOpacity>
+
+      {editing.history.length > 0 ? (
+        <>
+          <Text style={styles.priorLabel}>Prior values</Text>
+          {editing.history.map((h) => (
+            <React.Fragment key={`${h.asOf}-${h.usdRate}`}>
+              <View style={styles.priorCard}>
+                <View style={styles.priorTopRow}>
+                  <Text style={styles.priorRate}>
+                    ${h.usdRate}{editing.symbol ? ` / ${editing.symbol}` : ''}
+                  </Text>
+                  <Text style={styles.priorDate}>{h.asOf}</Text>
+                </View>
+                <Text style={styles.priorSource}>{h.source}</Text>
+              </View>
+            </React.Fragment>
+          ))}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: BG },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, backgroundColor: BG },
+  loadingText: { color: SUBTLE, fontSize: 13, marginTop: 12 },
+  errorText: { color: '#EF4444', fontSize: 13, textAlign: 'center', marginVertical: 8 },
+  gateTitle: { color: TEXT, fontSize: 18, fontWeight: '800', marginBottom: 8 },
+  gateDesc: { color: SUBTLE, fontSize: 13, textAlign: 'center', lineHeight: 20 },
+  // Header
+  header: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: BG_DARK,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  backBtn: { paddingRight: 4 },
+  backChevron: { color: COLOR, fontSize: 26, lineHeight: 26, fontWeight: '700' },
+  headerGlobe: { fontSize: 17 },
+  headerTextWrap: { flex: 1 },
+  headerTitle: { fontSize: 15, fontWeight: '700', color: TEXT },
+  headerSub: { fontSize: 11.5, color: SUBTLE },
+  adminChip: {
+    paddingHorizontal: 9,
+    paddingVertical: 3,
+    borderRadius: 20,
+    backgroundColor: `${COLOR}12`,
+    borderWidth: 1,
+    borderColor: `${COLOR}30`,
+  },
+  adminChipText: { fontSize: 10.5, fontWeight: '700', color: COLOR },
+  // Scroll
+  scroll: { flex: 1 },
+  scrollPad: { padding: 16 },
+  // Disclaimer
+  disclaimer: {
+    padding: 13,
+    borderRadius: 11,
+    backgroundColor: 'rgba(234,179,8,0.05)',
+    borderWidth: 1,
+    borderColor: 'rgba(234,179,8,0.18)',
+    marginBottom: 18,
+    flexDirection: 'row',
+    gap: 9,
+  },
+  disclaimerIcon: { color: '#EAB308', fontSize: 13, marginTop: 1 },
+  disclaimerText: { flex: 1, fontSize: 11.5, color: MUTED, lineHeight: 18 },
+  // Currency card
+  emptyCard: {
+    padding: 24,
+    borderRadius: 13,
+    backgroundColor: SURFACE,
+    borderWidth: 1,
+    borderColor: BORDER,
+    alignItems: 'center',
+  },
+  emptyText: { color: SUBTLE, fontSize: 13 },
+  currencyCard: {
+    padding: 14,
+    borderRadius: 13,
+    backgroundColor: SURFACE,
+    borderWidth: 1,
+    borderColor: BORDER,
+    marginBottom: 10,
+  },
+  currencyTopRow: { flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 8 },
+  currencyBadge: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: BORDER,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  currencyBadgeSc: { backgroundColor: `${COLOR}15`, borderColor: `${COLOR}30` },
+  currencyBadgeText: { fontSize: 12, fontWeight: '800', color: SUBTLE },
+  currencyBadgeTextSc: { color: COLOR },
+  currencyInfo: { flex: 1, minWidth: 0 },
+  currencyLabel: { fontSize: 13.5, fontWeight: '700', color: TEXT },
+  currencyAsOf: { fontSize: 11, color: SUBTLE, marginTop: 2 },
+  currencyFactor: { fontSize: 15, fontWeight: '800', color: COLOR },
+  currencyFactorFixed: { color: SUBTLE },
+  currencySource: { fontSize: 11, color: SUBTLE, marginBottom: 10 },
+  reviseBtn: {
+    paddingVertical: 9,
+    borderRadius: 9,
+    backgroundColor: `${COLOR}12`,
+    borderWidth: 1,
+    borderColor: `${COLOR}30`,
+    alignItems: 'center',
+  },
+  reviseBtnText: { color: COLOR, fontSize: 13, fontWeight: '700' },
+  fixedNote: { textAlign: 'center', fontSize: 12, color: SUBTLE },
+  // Revise form
+  fieldLabel: { fontSize: 12.5, fontWeight: '600', color: MUTED, marginBottom: 6 },
+  rateInputWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 13,
+    paddingVertical: 11,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: BORDER,
+    borderRadius: 11,
+    gap: 8,
+    marginBottom: 14,
+  },
+  rateDollar: { fontSize: 13, color: SUBTLE },
+  rateInput: { flex: 1, fontSize: 14, color: TEXT, padding: 0 },
+  rateUnit: { fontSize: 12, color: SUBTLE },
+  sourceInput: {
+    paddingHorizontal: 13,
+    paddingVertical: 11,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: BORDER,
+    borderRadius: 11,
+    fontSize: 13,
+    color: TEXT,
+    marginBottom: 20,
+  },
+  saveBtn: {
+    paddingVertical: 13,
+    borderRadius: 11,
+    backgroundColor: COLOR,
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  saveBtnDisabled: { backgroundColor: 'rgba(255,255,255,0.06)' },
+  saveBtnText: { fontSize: 14.5, fontWeight: '700', color: '#0A0E06' },
+  saveBtnTextDisabled: { color: SUBTLE },
+  // Saved confirmation
+  savedWrap: { alignItems: 'center', paddingTop: 48 },
+  savedCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: `${COLOR}15`,
+    borderWidth: 1,
+    borderColor: `${COLOR}30`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 14,
+  },
+  savedCheck: { color: COLOR, fontSize: 30, fontWeight: '800' },
+  savedTitle: { fontSize: 20, fontWeight: '800', color: TEXT, marginBottom: 8 },
+  savedDesc: { fontSize: 13, color: SUBTLE, lineHeight: 20, textAlign: 'center' },
+  // Prior values
+  priorLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: SUBTLE,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  priorCard: {
+    padding: 12,
+    borderRadius: 10,
+    backgroundColor: SURFACE,
+    borderWidth: 1,
+    borderColor: BORDER,
+    marginBottom: 8,
+  },
+  priorTopRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 3 },
+  priorRate: { fontSize: 12, fontWeight: '700', color: MUTED },
+  priorDate: { fontSize: 11, color: SUBTLE },
+  priorSource: { fontSize: 11, color: SUBTLE },
+});

--- a/ctf/packages/mobile/src/features/gdp/index.ts
+++ b/ctf/packages/mobile/src/features/gdp/index.ts
@@ -1,1 +1,2 @@
 export { Gdp } from './Gdp';
+export { GdpRateAdmin } from './GdpRateAdmin';

--- a/ctf/packages/mobile/src/features/gdp/rateAdminApi.ts
+++ b/ctf/packages/mobile/src/features/gdp/rateAdminApi.ts
@@ -1,0 +1,80 @@
+// GDP currency rate-admin API client for mobile (issue #312 P2).
+// Mirrors GET/POST /api/gdp/admin/currency-rates. These factors exist ONLY to roll
+// multi-currency volume into the single USD-denominated GDP estimate — never a
+// per-wallet or redemption "ServiceCredits = fiat" value.
+
+import { Platform } from 'react-native';
+
+const API_BASE: string =
+  Platform.OS === 'android'
+    ? 'http://10.0.2.2:3000/api/gdp/admin/currency-rates'
+    : 'http://localhost:3000/api/gdp/admin/currency-rates';
+
+export type CurrencyRateFactor = { usdRate: number; asOf: string; source: string };
+
+export type CurrencyRateEntry = {
+  code: string;
+  label: string;
+  symbol: string | null;
+  isServiceCredits: boolean;
+  decimalPlaces: number;
+  sortOrder: number;
+  current: CurrencyRateFactor | null;
+  history: CurrencyRateFactor[];
+};
+
+type ListResponse = {
+  ok: boolean;
+  currencies?: CurrencyRateEntry[];
+  code?: string;
+  message?: string;
+};
+
+type ReviseResponse = {
+  ok: boolean;
+  rate?: { currencyCode: string; usdRate: number; asOf: string; source: string };
+  code?: string;
+  message?: string;
+};
+
+export async function fetchCurrencyRates(): Promise<CurrencyRateEntry[]> {
+  const res = await fetch(API_BASE, { headers: { 'Content-Type': 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`gdp_currency_rates_fetch_failed:${res.status}`);
+  }
+  const json: ListResponse = await res.json();
+  if (json.ok && json.currencies) {
+    return json.currencies;
+  }
+  throw new Error(json.message ?? 'Failed to load currency factors.');
+}
+
+export async function reviseCurrencyRate(input: {
+  currencyCode: string;
+  usdRate: number;
+  source: string;
+}): Promise<void> {
+  const res = await fetch(API_BASE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+    body: JSON.stringify(input),
+  });
+  const json: ReviseResponse = await res.json().catch(() => ({ ok: false }) as ReviseResponse);
+  if (res.ok && json.ok) {
+    return;
+  }
+  throw new Error(json.message ?? 'Failed to save the new factor.');
+}
+
+// United States Dollar is the baseline; its factor is fixed at 1 and not revised.
+export function isFixedBaseline(entry: CurrencyRateEntry): boolean {
+  return entry.code === 'USD';
+}
+
+export function formatFactor(entry: CurrencyRateEntry): string {
+  if (isFixedBaseline(entry)) return '1 : 1';
+  if (!entry.current) return 'Not set';
+  const r = entry.current.usdRate;
+  const d = r < 0.001 ? 5 : r < 0.1 ? 4 : 3;
+  return `$${r.toFixed(d)}`;
+}

--- a/ctf/packages/web/app/admin/gdp/page.tsx
+++ b/ctf/packages/web/app/admin/gdp/page.tsx
@@ -25,6 +25,17 @@ export default async function GdpAdminPage() {
         <p>Metrics in report: {report?.metrics.length ?? 0}</p>
       </section>
 
+      <section className="rounded-lg border bg-card p-5 text-sm space-y-2">
+        <h2 className="font-medium">Currency rate factors</h2>
+        <p className="text-muted-foreground">
+          Review and revise the owner-curated USD factors used only to roll multi-currency volume into the
+          single USD-denominated GDP estimate. These are not per-wallet or redemption values.
+        </p>
+        <p>
+          <Link className="underline underline-offset-4" href="/admin/gdp/rates">Open currency rate admin</Link>
+        </p>
+      </section>
+
       <p className="text-sm">
         <Link className="underline underline-offset-4" href="/apps/gdp">Open plugin shell</Link>
       </p>

--- a/ctf/packages/web/app/admin/gdp/rates/page.tsx
+++ b/ctf/packages/web/app/admin/gdp/rates/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import GdpRateAdmin from '@/components/gdp/gdp-rate-admin';
+
+export const dynamic = 'force-dynamic';
+
+export default async function GdpRateAdminPage() {
+  const decision = await evaluatePluginAccess({ requireApprovedUserOrAdmin: true, requireUsername: false });
+  if (!decision.allowed || !decision.isAdmin) {
+    redirect('/apps/gdp');
+  }
+
+  return <GdpRateAdmin />;
+}

--- a/ctf/packages/web/app/api/gdp/admin/currency-rates/route.ts
+++ b/ctf/packages/web/app/api/gdp/admin/currency-rates/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from 'next/server';
+import { ensureMutationCsrf, requireGdpAdminAccess } from 'lib/gdp/_lib';
+import {
+  currencyExists,
+  insertGdpAudit,
+  listCurrencyRateAdmin,
+  upsertCurrencyUsdRate,
+} from 'lib/gdp/repository';
+
+// Admin-only currency USD-rate management (issue #312 P2). These factors exist
+// ONLY to roll multi-currency volume into the single USD-denominated GDP estimate.
+// LEGAL GUARDRAIL: never a per-wallet, per-price, or redemption "ServiceCredits = fiat" value.
+
+export async function GET() {
+  const gate = await requireGdpAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const currencies = await listCurrencyRateAdmin();
+  return NextResponse.json({ ok: true, currencies }, { status: 200 });
+}
+
+type ReviseBody = {
+  currencyCode?: string;
+  usdRate?: number | string;
+  asOf?: string;
+  source?: string;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function POST(request: Request) {
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireGdpAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  let body: ReviseBody;
+  try {
+    body = (await request.json()) as ReviseBody;
+  } catch {
+    return NextResponse.json({ ok: false, code: 'gdp_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const currencyCode = typeof body.currencyCode === 'string' ? body.currencyCode.trim().toUpperCase() : '';
+  if (!currencyCode) {
+    return NextResponse.json(
+      { ok: false, code: 'gdp_invalid_payload', message: 'currencyCode is required.' },
+      { status: 400 },
+    );
+  }
+
+  const usdRate = typeof body.usdRate === 'string' ? Number(body.usdRate) : body.usdRate;
+  if (typeof usdRate !== 'number' || !Number.isFinite(usdRate) || usdRate <= 0) {
+    return NextResponse.json(
+      { ok: false, code: 'gdp_invalid_rate', message: 'usdRate must be a number greater than zero.' },
+      { status: 400 },
+    );
+  }
+
+  const asOf = typeof body.asOf === 'string' && body.asOf.trim() ? body.asOf.trim() : todayIso();
+  if (!ISO_DATE.test(asOf)) {
+    return NextResponse.json(
+      { ok: false, code: 'gdp_invalid_date', message: 'asOf must be an ISO date (YYYY-MM-DD).' },
+      { status: 400 },
+    );
+  }
+
+  const source = typeof body.source === 'string' && body.source.trim() ? body.source.trim() : 'owner';
+
+  const exists = await currencyExists(currencyCode);
+  if (!exists) {
+    await insertGdpAudit({
+      actorId: gate.auth.userId,
+      command: 'gdp.currency-rate.revise',
+      policyStatus: 'deny',
+      reason: 'currency_not_found',
+      targetType: 'currency_usd_rate',
+      targetId: currencyCode,
+      metadata: { currencyCode, asOf },
+    });
+    return NextResponse.json(
+      { ok: false, code: 'gdp_currency_not_found', message: 'Unknown or inactive currency code.' },
+      { status: 404 },
+    );
+  }
+
+  const rate = await upsertCurrencyUsdRate({ currencyCode, usdRate, asOf, source });
+
+  await insertGdpAudit({
+    actorId: gate.auth.userId,
+    command: 'gdp.currency-rate.revise',
+    policyStatus: 'allow',
+    reason: 'ok',
+    targetType: 'currency_usd_rate',
+    targetId: `${currencyCode}:${asOf}`,
+    metadata: { currencyCode, usdRate, asOf, source },
+  });
+
+  return NextResponse.json({ ok: true, rate }, { status: 201 });
+}

--- a/ctf/packages/web/components/gdp/gdp-rate-admin.tsx
+++ b/ctf/packages/web/components/gdp/gdp-rate-admin.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+// Admin-only currency USD-rate management for the aggregate GDP estimate (issue #312 P2).
+// These factors exist SOLELY to normalize multi-currency volume into one USD-denominated
+// GDP estimate (a morale/transparency metric). LEGAL HARD LINE: never rendered as a
+// per-wallet / per-price "ServiceCredits = fiat" equivalence or a redemption value.
+// Mirrors design/.../survivor-hub/GDPRateAdmin.tsx + MobileGDPRateAdmin.tsx.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Globe, ShieldCheck, Clock, CheckCircle, Edit2, AlertTriangle } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+
+const COLOR = "#06B6D4";
+const bg = "#0F1117";
+const surface = "#161B27";
+const border = "#1E2A3A";
+const text = "#F9FAFB";
+const subtle = "#6B7280";
+
+type RateFactor = { usdRate: number; asOf: string; source: string };
+
+type CurrencyEntry = {
+  code: string;
+  label: string;
+  symbol: string | null;
+  isServiceCredits: boolean;
+  decimalPlaces: number;
+  sortOrder: number;
+  current: RateFactor | null;
+  history: RateFactor[];
+};
+
+// United States Dollar is the baseline; its factor is fixed at 1 and not revised.
+function isFixedBaseline(c: CurrencyEntry): boolean {
+  return c.code === "USD";
+}
+
+function fmtFactor(c: CurrencyEntry): string {
+  if (isFixedBaseline(c)) return "—";
+  if (!c.current) return "Not set";
+  const r = c.current.usdRate;
+  const d = r < 0.001 ? 5 : r < 0.1 ? 4 : 3;
+  return `$${r.toFixed(d)}${c.symbol ? ` / ${c.symbol}` : ""}`;
+}
+
+function symbolGlyph(c: CurrencyEntry): string {
+  return c.symbol ?? c.code;
+}
+
+const DISCLAIMER =
+  "These factors exist solely to normalize multi-currency activity into one aggregate GDP estimate — a morale and transparency metric. They are never a redemption rate, per-wallet conversion, or the price of ServiceCredits. Revising adds a new dated row; all prior values are preserved as history.";
+
+export default function GdpRateAdmin() {
+  const isMobile = useIsMobile();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currencies, setCurrencies] = useState<CurrencyEntry[]>([]);
+
+  const [editingCode, setEditingCode] = useState<string | null>(null);
+  const [newRate, setNewRate] = useState("");
+  const [newSource, setNewSource] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/gdp/admin/currency-rates", { signal });
+      if (!res.ok) throw new Error("Failed to load currency factors");
+      const data = (await res.json()) as { ok: boolean; currencies?: CurrencyEntry[] };
+      if (!signal?.aborted) setCurrencies(data.currencies ?? []);
+    } catch (e: unknown) {
+      if (signal?.aborted) return;
+      setError(e instanceof Error ? e.message : "Failed to load currency factors.");
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  const editing = useMemo(
+    () => currencies.find((c) => c.code === editingCode) ?? null,
+    [currencies, editingCode],
+  );
+
+  const openEdit = (c: CurrencyEntry) => {
+    setEditingCode(c.code);
+    setNewRate(c.current ? String(c.current.usdRate) : "");
+    setNewSource("");
+    setSaved(false);
+    setSaveError(null);
+  };
+
+  const closeEdit = () => {
+    setEditingCode(null);
+    setSaved(false);
+    setSaveError(null);
+  };
+
+  const canSave = newRate.trim() !== "" && newSource.trim() !== "" && !saving;
+
+  const save = async () => {
+    if (!editing || !canSave) return;
+    const rateNum = Number(newRate);
+    if (!Number.isFinite(rateNum) || rateNum <= 0) {
+      setSaveError("Factor must be a number greater than zero.");
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch("/api/gdp/admin/currency-rates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({ currencyCode: editing.code, usdRate: rateNum, source: newSource.trim() }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new Error(data?.message ?? "Failed to save the new factor.");
+      }
+      setSaved(true);
+      await load();
+      setTimeout(() => {
+        setSaved(false);
+        setEditingCode(null);
+      }, 2200);
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : "Failed to save the new factor.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const activeCount = currencies.filter((c) => !isFixedBaseline(c)).length;
+
+  // ── Shared sub-blocks ──────────────────────────────────────────────────────
+  function Disclaimer() {
+    return (
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10, padding: "13px 16px", borderRadius: 12, background: "rgba(234,179,8,0.05)", border: "1px solid rgba(234,179,8,0.18)", marginBottom: 20 }}>
+        <AlertTriangle size={14} color="#EAB308" style={{ flexShrink: 0, marginTop: 2 }} />
+        <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.65 }}>{DISCLAIMER}</div>
+      </div>
+    );
+  }
+
+  function ReviseForm() {
+    if (!editing) return null;
+    if (saved) {
+      return (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 14, padding: "28px 0", textAlign: "center" }}>
+          <div style={{ width: 56, height: 56, borderRadius: "50%", background: `${COLOR}15`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <CheckCircle size={28} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 17, fontWeight: 700 }}>Factor saved</div>
+          <div style={{ fontSize: 12, color: subtle, lineHeight: 1.6 }}>
+            New row added with today&apos;s date.<br />Prior values preserved as history.
+          </div>
+        </div>
+      );
+    }
+    return (
+      <>
+        <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 3 }}>Revise — {editing.label}</div>
+        <div style={{ fontSize: 12, color: subtle, marginBottom: 20 }}>Creates a new dated row. History is preserved.</div>
+
+        <div style={{ marginBottom: 14 }}>
+          <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>New USD factor *</label>
+          <div style={{ display: "flex", alignItems: "center", padding: "10px 13px", background: "rgba(255,255,255,0.04)", border: `1px solid ${newRate ? COLOR + "50" : border}`, borderRadius: 10, gap: 8 }}>
+            <span style={{ fontSize: 13, color: subtle }}>$</span>
+            <input value={newRate} onChange={(e) => setNewRate(e.target.value)} inputMode="decimal" style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: text }} placeholder="0.00000" />
+            {editing.symbol ? <span style={{ fontSize: 12, color: subtle }}>/ {editing.symbol}</span> : null}
+          </div>
+          <div style={{ fontSize: 10.5, color: subtle, marginTop: 5, lineHeight: 1.5 }}>GDP estimate factor only — not a redemption or per-user rate.</div>
+        </div>
+
+        <div style={{ marginBottom: 20 }}>
+          <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>Source / note *</label>
+          <input value={newSource} onChange={(e) => setNewSource(e.target.value)} style={{ width: "100%", boxSizing: "border-box", padding: "10px 13px", background: "rgba(255,255,255,0.04)", border: `1px solid ${newSource ? COLOR + "50" : border}`, borderRadius: 10, fontSize: 13, color: text, outline: "none" }} placeholder="e.g. Owner — quarterly review" />
+        </div>
+
+        {saveError ? (
+          <div style={{ fontSize: 12, color: "#EF4444", marginBottom: 12 }}>{saveError}</div>
+        ) : null}
+
+        <div style={{ display: "flex", gap: 10 }}>
+          <button onClick={closeEdit} style={{ flex: 1, padding: "10px", borderRadius: 9, background: "rgba(255,255,255,0.05)", border: `1px solid ${border}`, color: subtle, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>Cancel</button>
+          <button onClick={() => void save()} disabled={!canSave} style={{ flex: 2, padding: "10px", borderRadius: 9, background: canSave ? COLOR : "rgba(255,255,255,0.06)", border: "none", color: canSave ? "#0A0E06" : subtle, fontSize: 13, fontWeight: 700, cursor: canSave ? "pointer" : "default" }}>{saving ? "Saving…" : "Save new factor"}</button>
+        </div>
+
+        {editing.history.length > 0 ? (
+          <div style={{ marginTop: 24 }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: subtle, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 12 }}>Prior values</div>
+            {editing.history.map((h) => (
+              <div key={`${h.asOf}-${h.usdRate}`} style={{ padding: "10px 14px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${border}`, marginBottom: 8 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 3 }}>
+                  <span style={{ fontSize: 12, fontWeight: 700, color: "#9CA3AF" }}>${h.usdRate}{editing.symbol ? ` / ${editing.symbol}` : ""}</span>
+                  <span style={{ fontSize: 11, color: subtle }}>{h.asOf}</span>
+                </div>
+                <div style={{ fontSize: 11, color: subtle }}>{h.source}</div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </>
+    );
+  }
+
+  function CurrencyList() {
+    return (
+      <>
+        <div style={{ fontSize: 11, fontWeight: 700, color: subtle, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 14 }}>
+          Active factors · {activeCount} {activeCount === 1 ? "currency" : "currencies"}
+        </div>
+        {currencies.length === 0 ? (
+          <div style={{ padding: "28px 20px", borderRadius: 14, background: surface, border: `1px solid ${border}`, textAlign: "center", color: subtle, fontSize: 13 }}>
+            No active currencies to manage yet.
+          </div>
+        ) : (
+          currencies.map((c) => {
+            const fixed = isFixedBaseline(c);
+            const active = c.code === editingCode;
+            return (
+              <div key={c.code} style={{ padding: isMobile ? "14px 16px" : "16px 20px", borderRadius: 14, background: surface, border: `1px solid ${active ? COLOR + "40" : border}`, marginBottom: 10, display: "flex", flexDirection: isMobile ? "column" : "row", alignItems: isMobile ? "stretch" : "center", gap: isMobile ? 10 : 16 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: isMobile ? 12 : 16, flex: 1, minWidth: 0 }}>
+                  <div style={{ width: 44, height: 44, borderRadius: 12, background: c.isServiceCredits ? `${COLOR}15` : "rgba(255,255,255,0.04)", border: `1px solid ${c.isServiceCredits ? COLOR + "30" : border}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 13, fontWeight: 800, color: c.isServiceCredits ? COLOR : subtle, flexShrink: 0 }}>
+                    {symbolGlyph(c)}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 700 }}>{c.label}</div>
+                    <div style={{ fontSize: 11.5, color: subtle, display: "flex", gap: 14, marginTop: 3, flexWrap: "wrap" }}>
+                      <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                        <Clock size={10} />{c.current ? `as of ${c.current.asOf}` : "no factor set"}
+                      </span>
+                      {c.current ? <span>Source: {c.current.source}</span> : null}
+                    </div>
+                  </div>
+                  {!isMobile ? (
+                    <div style={{ textAlign: "right", flexShrink: 0, minWidth: 140 }}>
+                      <div style={{ fontSize: 16, fontWeight: 800, color: fixed ? subtle : COLOR }}>{fmtFactor(c)}</div>
+                      <div style={{ fontSize: 11, color: subtle }}>GDP estimate factor</div>
+                    </div>
+                  ) : null}
+                </div>
+                {isMobile ? (
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <div style={{ fontSize: 15, fontWeight: 800, color: fixed ? subtle : COLOR }}>{fmtFactor(c)}</div>
+                    {!fixed ? (
+                      <button onClick={() => openEdit(c)} style={{ padding: "7px 16px", borderRadius: 9, background: `${COLOR}12`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 700, cursor: "pointer", display: "flex", alignItems: "center", gap: 6 }}>
+                        <Edit2 size={12} /> Revise
+                      </button>
+                    ) : (
+                      <span style={{ fontSize: 12, color: subtle }}>Fixed baseline</span>
+                    )}
+                  </div>
+                ) : !fixed ? (
+                  <button onClick={() => openEdit(c)} style={{ padding: "7px 16px", borderRadius: 9, background: `${COLOR}12`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 700, cursor: "pointer", display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+                    <Edit2 size={12} /> Revise
+                  </button>
+                ) : (
+                  <div style={{ padding: "7px 14px", borderRadius: 9, background: "rgba(255,255,255,0.03)", border: `1px solid ${border}`, color: subtle, fontSize: 12, flexShrink: 0 }}>Fixed</div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </>
+    );
+  }
+
+  function InfoPanel() {
+    return (
+      <div style={{ padding: "20px", borderRadius: 16, background: `${COLOR}06`, border: `1px solid ${COLOR}20` }}>
+        <div style={{ fontSize: 14, fontWeight: 700, color: COLOR, marginBottom: 12 }}>About these factors</div>
+        <div style={{ fontSize: 13, color: subtle, lineHeight: 1.7 }}>
+          These USD factors normalize multi-currency activity into a single GDP estimate. They are a morale and transparency metric — never a ledger, redemption offer, or indication of what ServiceCredits are worth to any individual.
+        </div>
+        <div style={{ marginTop: 16, padding: "12px 14px", borderRadius: 10, background: "rgba(255,255,255,0.03)", border: `1px solid ${border}` }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: "#9CA3AF", marginBottom: 6 }}>Revision protocol</div>
+          <div style={{ fontSize: 12, color: subtle, lineHeight: 1.65 }}>Revising any currency creates a new dated row. Prior rows are never overwritten — the most recent row is always the active factor.</div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Header ─────────────────────────────────────────────────────────────────
+  function Header() {
+    return (
+      <div style={{ height: 56, borderBottom: `1px solid ${border}`, display: "flex", alignItems: "center", padding: isMobile ? "0 16px" : "0 28px", gap: 12, background: "#0D0F14", flexShrink: 0 }}>
+        <Globe size={18} color={COLOR} />
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>GDP — Currency Rate Admin</div>
+          {!isMobile ? (
+            <div style={{ fontSize: 12, color: subtle }}>Factors used only to estimate aggregate GDP — not per-wallet values</div>
+          ) : null}
+        </div>
+        <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "center", gap: 5, fontSize: 11, fontWeight: 700, color: COLOR, padding: "4px 11px", borderRadius: 20, background: `${COLOR}12`, border: `1px solid ${COLOR}30`, flexShrink: 0 }}>
+          <ShieldCheck size={12} /> Admin only
+        </span>
+      </div>
+    );
+  }
+
+  function Body() {
+    if (loading) {
+      return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: subtle, fontSize: 14, padding: 24 }}>Loading currency factors…</div>;
+    }
+    if (error) {
+      return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF4444", fontSize: 14, padding: 24 }}>{error}</div>;
+    }
+
+    if (isMobile) {
+      return (
+        <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: 16 }}>
+          {editing ? (
+            <ReviseForm />
+          ) : (
+            <>
+              <Disclaimer />
+              <CurrencyList />
+            </>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div style={{ flex: 1, overflowY: "auto", minHeight: 0, display: "flex", gap: 28, padding: "28px 36px", alignItems: "flex-start" }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <Disclaimer />
+          <CurrencyList />
+        </div>
+        <div style={{ width: 340, flexShrink: 0 }}>
+          {editing ? (
+            <div style={{ padding: 20, borderRadius: 16, background: surface, border: `1px solid ${COLOR}30` }}>
+              <ReviseForm />
+            </div>
+          ) : (
+            <InfoPanel />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh", background: bg, fontFamily: "'Inter',system-ui", color: text }}>
+      <Header />
+      <Body />
+    </div>
+  );
+}

--- a/ctf/packages/web/lib/gdp/repository.ts
+++ b/ctf/packages/web/lib/gdp/repository.ts
@@ -116,6 +116,108 @@ export async function getGdpShellStats(): Promise<{ memberCount: number | null; 
   };
 }
 
+// === Currency USD rate admin (issue #312 P2) ===
+// The owner curates a notional USD factor per currency, used ONLY to roll
+// multi-currency volume into the single USD-denominated GDP estimate. The most
+// recent as_of row per currency is the active factor; older rows are history.
+// LEGAL GUARDRAIL: never a per-wallet or per-price "ServiceCredits = fiat" value.
+
+type CurrencyRateHistoryRow = {
+  usd_rate: string;
+  as_of: string;
+  source: string;
+};
+
+export type CurrencyRateAdminEntry = {
+  code: string;
+  label: string;
+  symbol: string | null;
+  isServiceCredits: boolean;
+  decimalPlaces: number;
+  sortOrder: number;
+  current: { usdRate: number; asOf: string; source: string } | null;
+  history: { usdRate: number; asOf: string; source: string }[];
+};
+
+type CurrencyMetaRow = {
+  code: string;
+  label: string;
+  symbol: string | null;
+  is_service_credits: boolean;
+  decimal_places: number;
+  sort_order: number;
+};
+
+// Build the full rate-admin view: every active currency with its current factor
+// (latest as_of) and its prior factors (newest first).
+export async function listCurrencyRateAdmin(): Promise<CurrencyRateAdminEntry[]> {
+  const currencyResult = await queryDb<CurrencyMetaRow>(
+    `SELECT code, label, symbol, is_service_credits, decimal_places, sort_order
+     FROM currencies
+     WHERE is_active = TRUE
+     ORDER BY sort_order ASC, code ASC`,
+  );
+
+  const rateResult = await queryDb<CurrencyRateHistoryRow & { currency_code: string }>(
+    `SELECT currency_code, usd_rate::text, as_of::text, source
+     FROM currency_usd_rates
+     ORDER BY currency_code ASC, as_of DESC`,
+  );
+
+  const ratesByCurrency = new Map<string, { usdRate: number; asOf: string; source: string }[]>();
+  for (const row of rateResult.rows) {
+    const list = ratesByCurrency.get(row.currency_code) ?? [];
+    list.push({ usdRate: Number(row.usd_rate), asOf: row.as_of, source: row.source });
+    ratesByCurrency.set(row.currency_code, list);
+  }
+
+  return currencyResult.rows.map((c) => {
+    const ordered = ratesByCurrency.get(c.code) ?? [];
+    const current = ordered[0] ?? null;
+    const history = ordered.slice(1);
+    return {
+      code: c.code,
+      label: c.label,
+      symbol: c.symbol,
+      isServiceCredits: c.is_service_credits,
+      decimalPlaces: c.decimal_places,
+      sortOrder: c.sort_order,
+      current,
+      history,
+    };
+  });
+}
+
+export async function currencyExists(code: string): Promise<boolean> {
+  const result = await queryDb<{ code: string }>(
+    `SELECT code FROM currencies WHERE code = $1 AND is_active = TRUE LIMIT 1`,
+    [code],
+  );
+  return result.rows.length > 0;
+}
+
+// Insert a new dated factor row. Revising the same as_of date updates that row
+// (ON CONFLICT (currency_code, as_of) DO UPDATE) instead of failing the UNIQUE
+// constraint; any other date adds a new history row and leaves prior rows intact.
+export async function upsertCurrencyUsdRate(input: {
+  currencyCode: string;
+  usdRate: number;
+  asOf: string;
+  source: string;
+}): Promise<{ currencyCode: string; usdRate: number; asOf: string; source: string }> {
+  const result = await queryDb<{ currency_code: string; usd_rate: string; as_of: string; source: string }>(
+    `INSERT INTO currency_usd_rates (currency_code, usd_rate, as_of, source)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (currency_code, as_of)
+     DO UPDATE SET usd_rate = EXCLUDED.usd_rate, source = EXCLUDED.source
+     RETURNING currency_code, usd_rate::text, as_of::text, source`,
+    [input.currencyCode, input.usdRate, input.asOf, input.source],
+  );
+
+  const row = result.rows[0];
+  return { currencyCode: row.currency_code, usdRate: Number(row.usd_rate), asOf: row.as_of, source: row.source };
+}
+
 export async function insertGdpAudit(input: {
   actorId: string;
   command: string;


### PR DESCRIPTION
Implements **P2, surface 1 from #312** — the admin screen to view and revise the owner-curated USD factors that roll multi-currency volume into the single USD GDP estimate. This was the missing half of P2 (the estimate label shipped in #324).

## API (admin-only, new)
- `GET /api/gdp/admin/currency-rates` — per active currency: code, label, symbol, the current factor (latest `as_of` row: rate/as_of/source) and its history (older rows, newest first).
- `POST /api/gdp/admin/currency-rates` — revise: `INSERT … ON CONFLICT (currency_code, as_of) DO UPDATE`. A new `as_of` adds a history row (latest = active); same-day revise updates that day's row instead of erroring on the `UNIQUE(currency_code, as_of)` constraint. Validates `usdRate > 0` and a known/active currency. Gated by `requireGdpAdminAccess()` + CSRF (`x-ctf-csrf: '1'`).
- New commands added to `GDP_PLUGIN_COMMAND_CONTRACTS.yaml` + `GDP_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml`. No schema change (`currency_usd_rates`/`currencies` already exist).

## UI (web desktop + mobile-responsive + Android)
Currency list with current factor + as_of + source, a **Revise** action (new dated row, prior values shown as history), loading/empty/populated/saved states, and a calm disclaimer. Reached from `/admin/gdp` → `/admin/gdp/rates`. Android screen mirrors it; both admin-gated (server is the real authority).

## Legal line honored
Admin-only; framed as "the notional factor used to estimate community-wide GDP," never "what your ServiceCredits are worth." No ServiceCredits→fiat per-wallet/per-price equivalence anywhere. Currencies shown by label ("ServiceCredits", "United States Dollar"), never the bare code. USD is the fixed, non-revisable baseline.

## Notes
- Mobile list keys are on `React.Fragment` (CI `@types/react` 19.2 rejects `key` on host components).
- The mockup has no editable date field (revise = today); matched that, though the endpoint accepts an optional `asOf`.
- Web + mobile typecheck, eslint, EOF, YAML all pass. `next build` not run (environmental).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_