### PR TITLE
feat: build real Weekly-Performance admin UI (web + Android)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
@@ -54,13 +54,20 @@ Command groups:
 
 ### 2.2 HTTP Projection Routes
 
-Admin routes:
+The route set below is the **shipped** surface (the earlier draft above named a
+different, never-built `/admin/weeks/:weekStart/...` shape; the routes that
+actually exist are listed here).
 
-- `GET /api/weekly-performance/admin/weeks`
-- `GET /api/weekly-performance/admin/weeks/:weekStart`
-- `GET /api/weekly-performance/admin/weeks/:weekStart/metrics`
-- `GET /api/weekly-performance/admin/weeks/:weekStart/comparison`
-- `POST /api/weekly-performance/admin/weeks/:weekStart/export`
+Read routes (admin or approved user):
+
+- `GET /api/weekly-performance/weeks` — tracked weeks (most recent 52).
+- `GET /api/weekly-performance/current-week` — current week plus active-user count (last 7 days).
+- `GET /api/weekly-performance/metrics?weekStartDate=...[&compareWeekStartDate=...]` — week metrics, or a week-over-week comparison when `compareWeekStartDate` is supplied.
+
+Admin-only routes:
+
+- `PUT /api/weekly-performance/admin/week-selection` — marks a week active (body `{ weekStartDate }`); requires the `x-ctf-csrf: '1'` header and writes a `weekly-performance.admin.week.select` audit row.
+- `GET /api/weekly-performance/export?weekStartDate=...` — export gate (admin-only, additionally guarded by the `WEEKLY_PERFORMANCE_EXPORT_ENABLED` environment flag).
 
 ## 3) Data Dependencies and Contracts
 
@@ -85,6 +92,8 @@ Admin routes:
 
 Web pixel pass (design `c5d83c0`): the user-facing shell is rebuilt to `design/.../survivor-hub/WeeklyPerformance.tsx` and its Empty/Loading states — icon rail, week-history sidebar, metric cards, a this-week-vs-last-week comparison chart, and a week-summary right rail. Week selection drives `GET /api/weekly-performance/weeks`, `/current-week`, and `/metrics` (with `compareWeekStartDate` for per-metric deltas); admin export opens `GET /api/weekly-performance/export`. Real data only — the mockup's fabricated daily series became a real per-metric current-vs-compare chart scaled relative to the max value in view, metric labels are humanized from `metric_key` (no label column exists), and the unbacked "Top Apps" widget was omitted rather than faked. Decomposed into modular sub-components within the rule-116 limits.
 
+Admin surface (2026-06-06): the admin page `app/admin/weekly-performance/page.tsx` was a thin server stub (it printed only the current week and the tracked-week count). It is now a real, mobile-responsive admin UI. The server page keeps the same admin gate as the other `app/admin/<plugin>/page.tsx` pages (`evaluatePluginAccess({ requireApprovedUserOrAdmin: true })`, then `redirect('/apps/weekly-performance')` when `!decision.isAdmin`) and renders a new client shell `components/weekly-performance/wp-admin-shell.tsx`. The shell uses `useIsMobile()` so the owner can run it on iOS: it lists tracked weeks and the current week, lets the admin pick a week and **set it active** (`PUT /api/weekly-performance/admin/week-selection` with `x-ctf-csrf: '1'`), shows that week's metrics, and offers the export action (`GET /api/weekly-performance/export`). Loading, empty, populated, and success/error feedback states are all handled. A matching Android admin screen (`packages/mobile/src/features/weekly-performance/AdminWeeklyPerformance.tsx`, design `MobileWeeklyPerformanceAdminView.tsx`) was added and registered in `App.tsx`; it is admin-gated client-side (`useAuth().user.isAdmin`), binds to the same routes via a new `selectActiveWeek` helper in `api.ts`, and keeps the Metrics and History tabs. The mockup's fabricated plugin-breakdown and daily bar chart are omitted (no backing API field), per real-data-only policy.
+
 Android pixel pass (design `MobileWeeklyPerformance.tsx`, 2026-05-31): the mobile screen (`packages/mobile/src/features/weekly-performance/WeeklyPerformance.tsx`) is fully rewritten to align with the canonical mockup. A new `api.ts` is introduced, binding to the same three read routes used by web (`GET /api/weekly-performance/weeks`, `/current-week`, `/metrics`). Four states are implemented: Loading (brand phrases centered), Public/unauthenticated (blurred metric preview with lock overlay and sign-in CTA), Empty (week in progress with placeholder cards), and Populated (metrics grid + history tab). Metric cards are driven by known `metricKey` values (`member_count`, `signups`, `engagements`, `gdp_delta`); the mockup's "Daily Engagements" bar chart has no backing API field (metrics are weekly aggregates only) and is omitted per real-data-only policy. The admin Export action is not surfaced on mobile (admin-only server gate exists on web; mobile surfaces the admin badge and export hint in the history tab). All mock data retired. Export `WeeklyPerformance` preserved.
 
 ## 6) Seed Coverage Status
@@ -96,9 +105,11 @@ Weekly performance metrics are derived from upstream plugin tables (workforce, s
 1. Non-financial metric dictionary and formulas live in code; no canonical governance document captures the dictionary outside the implementation.
 2. Authorized non-admin read-only access is not surfaced; all read paths require admin role.
 3. Mood-related comparison fields are excluded from the current dictionary; whether to reintroduce them is an outstanding product question.
+4. Contract gap: the shipped `PUT /api/weekly-performance/admin/week-selection` route (audit command `weekly-performance.admin.week.select`) is not represented in `docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml`, which lists only `week.list`, `week.get`, `metrics.get`, `comparison.get`, and `report.export`. The week-selection command should be added to the command/access/audit contracts.
 
 ## 8) Change Log
 
+- 2026-06-06: Turned the Weekly Performance admin page from a thin stub into a real, mobile-responsive admin UI and added an Android admin screen. Web: `app/admin/weekly-performance/page.tsx` now renders the new client shell `components/weekly-performance/wp-admin-shell.tsx` (same admin gate as the other admin pages; `useIsMobile()` responsive); surfaces week selection (`PUT /api/weekly-performance/admin/week-selection`, CSRF header), the selected week's metrics (`GET /api/weekly-performance/metrics`), and export (`GET /api/weekly-performance/export`), with loading/empty/populated and success/error states. Android: added `AdminWeeklyPerformance.tsx` (design `MobileWeeklyPerformanceAdminView.tsx`), admin-gated and registered in `App.tsx`, with a `selectActiveWeek` helper added to `api.ts`. Fabricated plugin breakdown and daily bar chart from the mockup omitted (no backing API field). Noted the week-selection command/contract gap (section 7). No schema change.
 - 2026-05-31: Android pixel pass (design `MobileWeeklyPerformance.tsx`). Rewrote `packages/mobile/src/features/weekly-performance/WeeklyPerformance.tsx` to align with canonical mockup; introduced `api.ts` binding to real routes (`/weeks`, `/current-week`, `/metrics`). Four states: Loading, Public, Empty, Populated. Metric cards keyed on real `metricKey` fields. Daily chart omitted (no backing API field). Mock data retired. No schema/API/contract change.
 - 2026-05-29: Web UI circle-back (design `c5d83c0`; unblocked by the design re-pin). Rebuilt the user-facing weekly-performance shell from the baseline server summary to the full client dashboard in `WeeklyPerformance.tsx` (+ Empty/Loading), wired to the documented read routes and the admin export. Decomposed into modular sub-components (`wp-shared`, `wp-loading`, `wp-icon-rail`, `wp-sidebar`, `wp-metric-cards`, `wp-comparison-chart`, `wp-empty-main`, `wp-dashboard-main`, `wp-right-rail`, plus the shell). Real data only; the dummy daily chart became a real this-week-vs-last-week per-metric comparison and the unbacked "Top Apps" widget was omitted. No schema/API change.
 - 2026-05-18: Replaced "Web and Android Parity Notes" with canonical "Web and Android Delivery Status" (`web+android complete`). Renamed "Open Decisions" to canonical "Gaps and Known Technical Debt" and removed Android-parity-milestone entry per Rule 105.

--- a/ctf/packages/mobile/App.tsx
+++ b/ctf/packages/mobile/App.tsx
@@ -16,7 +16,7 @@ import { TrustTransport } from './src/features/trusttransport';
 import { PeerProgramming, AdminPeerProgramming } from './src/features/peer-programming';
 import { Mood } from './src/features/mood';
 import { GentlePulse } from './src/features/gentlepulse';
-import { WeeklyPerformance } from './src/features/weekly-performance';
+import { WeeklyPerformance, AdminWeeklyPerformance } from './src/features/weekly-performance';
 import { Gdp } from './src/features/gdp';
 import { ServiceCredits } from './src/features/service-credits';
 import { Levelup } from './src/features/levelup';
@@ -41,6 +41,7 @@ type FeatureKey =
   | 'mood'
   | 'gentlepulse'
   | 'weekly-performance'
+  | 'weekly-performance-admin'
   | 'gdp'
   | 'service-credits'
   | 'levelup'
@@ -65,6 +66,7 @@ const featureOrder: Array<{ key: FeatureKey; label: string }> = [
   { key: 'mood', label: 'Mood' },
   { key: 'gentlepulse', label: 'GentlePulse' },
   { key: 'weekly-performance', label: 'Weekly Performance' },
+  { key: 'weekly-performance-admin', label: 'Weekly Performance Admin' },
   { key: 'gdp', label: 'GDP' },
   { key: 'service-credits', label: 'Service Credits' },
   { key: 'levelup', label: 'LevelUp' },
@@ -114,6 +116,8 @@ export default function App() {
         return <GentlePulse />;
       case 'weekly-performance':
         return <WeeklyPerformance />;
+      case 'weekly-performance-admin':
+        return <AdminWeeklyPerformance />;
       case 'gdp':
         return <Gdp />;
       case 'service-credits':

--- a/ctf/packages/mobile/src/features/weekly-performance/AdminWeeklyPerformance.tsx
+++ b/ctf/packages/mobile/src/features/weekly-performance/AdminWeeklyPerformance.tsx
@@ -1,0 +1,397 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
+import { useAuth } from '../../hooks/useAuth';
+import {
+  fetchCurrentWeek,
+  fetchWeekMetrics,
+  fetchWeeks,
+  selectActiveWeek,
+  WeekMetric,
+  WeekRow,
+} from './api';
+
+// Admin surface for Weekly Performance, aligned to
+// design/.../survivor-hub/MobileWeeklyPerformanceAdminView.tsx.
+// Real endpoints only: the mockup's fabricated plugin-breakdown and daily bar
+// chart are omitted (no backing API field). Tabs: Metrics, History.
+// Actions: set the active week (PUT /api/weekly-performance/admin/week-selection).
+
+const BRAND = '#F59E0B';
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+const STATUS_BG = '#090B0F';
+
+const METRIC_CONFIG: Record<string, { label: string; color: string }> = {
+  member_count: { label: 'Members', color: '#A78BFA' },
+  signups: { label: 'Sign-ups', color: '#22C55E' },
+  engagements: { label: 'Engagements', color: BRAND },
+  gdp_delta: { label: 'GDP Delta', color: '#06B6D4' },
+};
+
+type Tab = 'metrics' | 'history';
+
+type Feedback = { kind: 'success' | 'error'; text: string } | null;
+
+function statusColor(status: WeekRow['status']): string {
+  if (status === 'open') return '#22C55E';
+  if (status === 'published') return '#06B6D4';
+  return SUBTLE;
+}
+
+function NotAdmin() {
+  return (
+    <View style={styles.centerRoot}>
+      <Text style={styles.notAdminTitle}>Admin access required</Text>
+      <Text style={styles.notAdminSub}>
+        The Weekly Performance admin view is available to administrators only.
+      </Text>
+    </View>
+  );
+}
+
+export const AdminWeeklyPerformance: React.FC = () => {
+  const { isAuthenticated, isLoading: authLoading, user } = useAuth();
+  const isAdmin = !!user?.isAdmin;
+
+  const [tab, setTab] = useState<Tab>('metrics');
+  const [weeks, setWeeks] = useState<WeekRow[]>([]);
+  const [currentWeekStart, setCurrentWeekStart] = useState<string | null>(null);
+  const [selectedWeek, setSelectedWeek] = useState<WeekRow | null>(null);
+  const [metrics, setMetrics] = useState<WeekMetric[]>([]);
+  const [dataLoading, setDataLoading] = useState(false);
+  const [metricsLoading, setMetricsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [selecting, setSelecting] = useState(false);
+
+  const loadWeeks = useCallback(() => {
+    setDataLoading(true);
+    setError(null);
+    return Promise.all([fetchWeeks(), fetchCurrentWeek()])
+      .then(([weeksRes, currentRes]) => {
+        const loadedWeeks = weeksRes.weeks ?? [];
+        const current = currentRes.currentWeek ?? null;
+        setWeeks(loadedWeeks);
+        setCurrentWeekStart(current?.weekStartDate ?? null);
+        setSelectedWeek((prev) => prev ?? current ?? loadedWeeks[0] ?? null);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : 'Failed to load data');
+      })
+      .finally(() => setDataLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated || !isAdmin) return;
+    void loadWeeks();
+  }, [isAuthenticated, isAdmin, loadWeeks]);
+
+  useEffect(() => {
+    if (!selectedWeek) {
+      setMetrics([]);
+      return;
+    }
+    let active = true;
+    setMetricsLoading(true);
+    fetchWeekMetrics(selectedWeek.weekStartDate)
+      .then((res) => {
+        if (active) setMetrics(res.metrics ?? []);
+      })
+      .catch(() => {
+        if (active) setMetrics([]);
+      })
+      .finally(() => {
+        if (active) setMetricsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selectedWeek]);
+
+  function onSelectActiveWeek() {
+    if (!selectedWeek || selecting) return;
+    setSelecting(true);
+    setFeedback(null);
+    selectActiveWeek(selectedWeek.weekStartDate)
+      .then((res) => {
+        setFeedback({ kind: 'success', text: `Active week set to ${res.selectedWeek?.weekStartDate ?? selectedWeek.weekStartDate}.` });
+        return loadWeeks();
+      })
+      .catch((e: unknown) => {
+        setFeedback({ kind: 'error', text: e instanceof Error ? e.message : 'Could not set the active week.' });
+      })
+      .finally(() => setSelecting(false));
+  }
+
+  if (authLoading) {
+    return (
+      <View style={styles.centerRoot}>
+        <ActivityIndicator size="large" color={BRAND} />
+      </View>
+    );
+  }
+  if (!isAuthenticated || !isAdmin) return <NotAdmin />;
+
+  const knownMetrics = metrics.filter((m) => m.metricKey in METRIC_CONFIG);
+
+  return (
+    <View style={styles.root}>
+      {/* Header */}
+      <View style={styles.header}>
+        <View style={styles.headerIconWrap}>
+          <Text style={styles.headerIconText}>📊</Text>
+        </View>
+        <View style={styles.headerTextWrap}>
+          <Text style={styles.headerTitle}>Weekly Performance</Text>
+          <Text style={styles.headerSub}>Admin view</Text>
+        </View>
+        <View style={styles.adminBadge}>
+          <Text style={styles.adminBadgeText}>ADMIN</Text>
+        </View>
+      </View>
+
+      {/* Tab bar */}
+      <View style={styles.tabBar}>
+        {(['metrics', 'history'] as const).map((t) => (
+          <TouchableOpacity
+            key={t}
+            style={[styles.tabBtn, tab === t && styles.tabBtnActive]}
+            onPress={() => setTab(t)}
+            accessibilityRole="tab"
+          >
+            <Text style={[styles.tabBtnText, tab === t && styles.tabBtnTextActive]}>
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+      <ScrollView style={styles.scrollArea} contentContainerStyle={styles.scrollContent}>
+        {/* Active-week selection control (shown on both tabs) */}
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Active week</Text>
+          <Text style={styles.cardSub}>
+            Current week: {currentWeekStart ?? 'not set'} · Tracked weeks: {weeks.length}
+          </Text>
+          {selectedWeek ? (
+            <Text style={styles.selectedLabel}>
+              Selected: {selectedWeek.weekStartDate} – {selectedWeek.weekEndDate}
+            </Text>
+          ) : null}
+          <TouchableOpacity
+            style={[styles.primaryBtn, (selecting || !selectedWeek) && styles.primaryBtnDisabled]}
+            onPress={onSelectActiveWeek}
+            disabled={selecting || !selectedWeek}
+            accessibilityRole="button"
+          >
+            <Text style={styles.primaryBtnText}>
+              {selecting ? 'Setting…' : 'Set selected week as active'}
+            </Text>
+          </TouchableOpacity>
+          {feedback ? (
+            <Text style={[styles.feedbackText, feedback.kind === 'success' ? styles.feedbackOk : styles.feedbackErr]}>
+              {feedback.text}
+            </Text>
+          ) : null}
+        </View>
+
+        {dataLoading ? (
+          <ActivityIndicator size="large" color={BRAND} style={styles.spinner} />
+        ) : weeks.length === 0 ? (
+          <Text style={styles.noDataText}>No weeks are tracked yet.</Text>
+        ) : tab === 'metrics' ? (
+          metricsLoading ? (
+            <ActivityIndicator size="large" color={BRAND} style={styles.spinner} />
+          ) : knownMetrics.length === 0 ? (
+            <Text style={styles.noDataText}>No metric data available for this week.</Text>
+          ) : (
+            <View style={styles.metricsGrid}>
+              {knownMetrics.map((m) => {
+                const cfg = METRIC_CONFIG[m.metricKey];
+                const displayValue =
+                  m.metricUnit === 'USD'
+                    ? `$${m.metricValue.toLocaleString()}`
+                    : m.metricValue.toLocaleString();
+                return (
+                  <React.Fragment key={m.metricKey}>
+                    <View style={[styles.metricCard, { borderColor: `${cfg.color}20` }]}>
+                      <Text style={styles.metricCardLabel}>{cfg.label}</Text>
+                      <Text style={[styles.metricCardValue, { color: cfg.color }]}>{displayValue}</Text>
+                    </View>
+                  </React.Fragment>
+                );
+              })}
+            </View>
+          )
+        ) : (
+          <View style={styles.historyList}>
+            {weeks.map((w) => {
+              const isSelected = w.weekStartDate === selectedWeek?.weekStartDate;
+              const isCurrent = w.weekStartDate === currentWeekStart;
+              return (
+                <TouchableOpacity
+                  key={w.weekStartDate}
+                  style={[styles.historyItem, isSelected && styles.historyItemSelected]}
+                  onPress={() => {
+                    setSelectedWeek(w);
+                    setFeedback(null);
+                    setTab('metrics');
+                  }}
+                  accessibilityRole="button"
+                >
+                  <View style={styles.historyItemContent}>
+                    <Text style={styles.historyItemLabel}>
+                      {w.weekStartDate} – {w.weekEndDate}
+                    </Text>
+                    <Text style={[styles.historyItemStatus, { color: statusColor(w.status) }]}>{w.status}</Text>
+                  </View>
+                  {isCurrent ? <Text style={styles.currentBadge}>CURRENT</Text> : null}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: BG },
+  centerRoot: { flex: 1, backgroundColor: BG, alignItems: 'center', justifyContent: 'center', padding: 24 },
+  notAdminTitle: { fontSize: 18, fontWeight: '800', color: TEXT, marginBottom: 8 },
+  notAdminSub: { fontSize: 13, color: SUBTLE, textAlign: 'center', lineHeight: 20, maxWidth: 300 },
+
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    paddingBottom: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+    backgroundColor: STATUS_BG,
+  },
+  headerIconWrap: {
+    width: 34,
+    height: 34,
+    borderRadius: 9,
+    backgroundColor: `${BRAND}20`,
+    borderWidth: 1,
+    borderColor: `${BRAND}35`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 8,
+  },
+  headerIconText: { fontSize: 16 },
+  headerTextWrap: { flex: 1 },
+  headerTitle: { fontSize: 16, fontWeight: '700', color: TEXT },
+  headerSub: { fontSize: 11, color: SUBTLE, marginTop: 1 },
+  adminBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+    backgroundColor: 'rgba(99,102,241,0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(99,102,241,0.3)',
+  },
+  adminBadgeText: { fontSize: 9, fontWeight: '700', color: '#818CF8' },
+
+  tabBar: {
+    flexDirection: 'row',
+    gap: 4,
+    padding: 8,
+    backgroundColor: STATUS_BG,
+    borderBottomWidth: 1,
+    borderBottomColor: BORDER,
+  },
+  tabBtn: {
+    flex: 1,
+    paddingVertical: 7,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: BORDER,
+    alignItems: 'center',
+  },
+  tabBtnActive: { backgroundColor: `${BRAND}20`, borderColor: `${BRAND}40` },
+  tabBtnText: { fontSize: 12, fontWeight: '400', color: SUBTLE },
+  tabBtnTextActive: { fontWeight: '700', color: BRAND },
+
+  scrollArea: { flex: 1 },
+  scrollContent: { padding: 14, paddingBottom: 32, gap: 12 },
+
+  card: {
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: SURFACE,
+    borderWidth: 1,
+    borderColor: BORDER,
+  },
+  cardTitle: { fontSize: 13, fontWeight: '700', color: TEXT, marginBottom: 4 },
+  cardSub: { fontSize: 12, color: SUBTLE, marginBottom: 8 },
+  selectedLabel: { fontSize: 12, color: TEXT, marginBottom: 10 },
+  primaryBtn: {
+    paddingVertical: 11,
+    borderRadius: 8,
+    backgroundColor: BRAND,
+    alignItems: 'center',
+  },
+  primaryBtnDisabled: { backgroundColor: `${BRAND}60` },
+  primaryBtnText: { fontSize: 13, fontWeight: '700', color: '#0F1117' },
+  feedbackText: { fontSize: 12, marginTop: 10 },
+  feedbackOk: { color: '#22C55E' },
+  feedbackErr: { color: '#EF4444' },
+
+  metricsGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
+  metricCard: {
+    width: '47%',
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: SURFACE,
+    borderWidth: 1,
+  },
+  metricCardLabel: { fontSize: 10, color: SUBTLE, marginBottom: 6 },
+  metricCardValue: { fontSize: 22, fontWeight: '800' },
+  noDataText: { fontSize: 14, color: SUBTLE, textAlign: 'center', marginTop: 24 },
+
+  historyList: { gap: 8 },
+  historyItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: SURFACE,
+    borderWidth: 1,
+    borderColor: BORDER,
+  },
+  historyItemSelected: { borderColor: BRAND },
+  historyItemContent: { flex: 1 },
+  historyItemLabel: { fontSize: 13, fontWeight: '600', color: TEXT },
+  historyItemStatus: { fontSize: 11, marginTop: 2, textTransform: 'capitalize' },
+  currentBadge: {
+    fontSize: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+    fontWeight: '700',
+    overflow: 'hidden',
+    backgroundColor: `${BRAND}15`,
+    color: BRAND,
+  },
+
+  spinner: { marginTop: 24 },
+  errorText: { color: '#EF4444', fontSize: 13, textAlign: 'center', padding: 12 },
+});

--- a/ctf/packages/mobile/src/features/weekly-performance/api.ts
+++ b/ctf/packages/mobile/src/features/weekly-performance/api.ts
@@ -53,3 +53,27 @@ export async function fetchWeekMetrics(weekStartDate: string): Promise<MetricsRe
   if (!res.ok) throw new Error('Failed to fetch metrics');
   return res.json() as Promise<MetricsResponse>;
 }
+
+export interface WeekSelectionResponse {
+  ok: boolean;
+  selectedWeek?: WeekRow;
+  message?: string;
+}
+
+// Admin-only: mark a week active. The server enforces the admin gate and the
+// CSRF confirmation header; this mirrors the web admin's PUT call.
+export async function selectActiveWeek(weekStartDate: string): Promise<WeekSelectionResponse> {
+  const res = await fetch(`${API_BASE}/admin/week-selection`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-ctf-csrf': '1',
+    },
+    body: JSON.stringify({ weekStartDate }),
+  });
+  const data = (await res.json()) as WeekSelectionResponse;
+  if (!res.ok || !data.ok) {
+    throw new Error(data.message ?? `week_selection_failed:${res.status}`);
+  }
+  return data;
+}

--- a/ctf/packages/mobile/src/features/weekly-performance/index.ts
+++ b/ctf/packages/mobile/src/features/weekly-performance/index.ts
@@ -1,1 +1,2 @@
 export { WeeklyPerformance } from './WeeklyPerformance';
+export { AdminWeeklyPerformance } from './AdminWeeklyPerformance';

--- a/ctf/packages/web/app/admin/weekly-performance/page.tsx
+++ b/ctf/packages/web/app/admin/weekly-performance/page.tsx
@@ -1,9 +1,8 @@
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { WeeklyPerformanceAdminShell } from 'components/weekly-performance/wp-admin-shell';
 
 export const dynamic = 'force-dynamic';
-import { getCurrentWeek, listWeeks } from 'lib/weekly-performance/repository';
 
 export default async function WeeklyPerformanceAdminPage() {
   const decision = await evaluatePluginAccess({ requireApprovedUserOrAdmin: true, requireUsername: false });
@@ -11,23 +10,5 @@ export default async function WeeklyPerformanceAdminPage() {
     redirect('/apps/weekly-performance');
   }
 
-  const [currentWeek, weeks] = await Promise.all([getCurrentWeek(), listWeeks()]);
-
-  return (
-    <main className="mx-auto max-w-4xl px-6 py-10 space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Weekly Performance Admin</h1>
-        <p className="text-sm text-muted-foreground">Week selection, guardrails, and export gate administration.</p>
-      </header>
-
-      <section className="rounded-lg border bg-card p-5 text-sm space-y-2">
-        <p>Current week: {currentWeek?.weekStartDate ?? 'n/a'}</p>
-        <p>Tracked weeks: {weeks.length}</p>
-      </section>
-
-      <p className="text-sm">
-        <Link className="underline underline-offset-4" href="/apps/weekly-performance">Open plugin shell</Link>
-      </p>
-    </main>
-  );
+  return <WeeklyPerformanceAdminShell />;
 }

--- a/ctf/packages/web/components/weekly-performance/wp-admin-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-admin-shell.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { BarChart2, ChevronLeft, Download } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import {
+  BG,
+  BORDER,
+  BRAND,
+  SUBTLE,
+  SURFACE,
+  TEXT,
+  formatMetricValue,
+  formatWeekRange,
+  humanizeMetricKey,
+  type CurrentWeekResponse,
+  type MetricsResponse,
+  type WeekSelectionResponse,
+  type WeeksResponse,
+  type WpMetric,
+  type WpWeek,
+} from "./wp-shared";
+
+// Web admin surface for Weekly Performance.
+// Real endpoints only (rule 126):
+//   GET  /api/weekly-performance/weeks          — tracked weeks
+//   GET  /api/weekly-performance/current-week    — current week + active-user count
+//   GET  /api/weekly-performance/metrics         — metrics for a week
+//   PUT  /api/weekly-performance/admin/week-selection (CSRF) — mark a week active
+//   GET  /api/weekly-performance/export          — export gate (admin, env-flagged)
+
+type Feedback = { kind: "success" | "error"; text: string } | null;
+
+function statusColor(status: WpWeek["status"]): string {
+  if (status === "open") return "#22C55E";
+  if (status === "published") return "#06B6D4";
+  return SUBTLE;
+}
+
+export function WeeklyPerformanceAdminShell() {
+  const isMobile = useIsMobile();
+  const [loading, setLoading] = useState(true);
+  const [weeks, setWeeks] = useState<WpWeek[]>([]);
+  const [currentWeekStart, setCurrentWeekStart] = useState<string | null>(null);
+  const [selectedWeekStart, setSelectedWeekStart] = useState<string | null>(null);
+  const [metrics, setMetrics] = useState<WpMetric[]>([]);
+  const [metricsLoading, setMetricsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [selecting, setSelecting] = useState(false);
+
+  const loadWeeks = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const [weeksRes, currentRes] = await Promise.all([
+        fetch("/api/weekly-performance/weeks", { cache: "no-store" }),
+        fetch("/api/weekly-performance/current-week", { cache: "no-store" }),
+      ]);
+      if (!weeksRes.ok) throw new Error("Could not load tracked weeks.");
+      const weeksData = (await weeksRes.json()) as WeeksResponse;
+      const currentData = currentRes.ok ? ((await currentRes.json()) as CurrentWeekResponse) : null;
+      const current = currentData?.currentWeek?.weekStartDate ?? null;
+      setWeeks(weeksData.weeks);
+      setCurrentWeekStart(current);
+      setSelectedWeekStart((prev) => prev ?? current ?? weeksData.weeks[0]?.weekStartDate ?? null);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Could not load Weekly Performance admin data.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadWeeks();
+  }, [loadWeeks]);
+
+  useEffect(() => {
+    if (!selectedWeekStart) {
+      setMetrics([]);
+      return;
+    }
+    let active = true;
+    setMetricsLoading(true);
+    fetch(`/api/weekly-performance/metrics?weekStartDate=${encodeURIComponent(selectedWeekStart)}`, { cache: "no-store" })
+      .then((res) => (res.ok ? (res.json() as Promise<MetricsResponse>) : Promise.resolve({ ok: false, metrics: [] } as MetricsResponse)))
+      .then((data) => {
+        if (active) setMetrics(data.metrics ?? []);
+      })
+      .catch(() => {
+        if (active) setMetrics([]);
+      })
+      .finally(() => {
+        if (active) setMetricsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selectedWeekStart]);
+
+  const selectedWeek = weeks.find((w) => w.weekStartDate === selectedWeekStart) ?? null;
+
+  async function selectActiveWeek() {
+    if (!selectedWeekStart || selecting) return;
+    setSelecting(true);
+    setFeedback(null);
+    try {
+      const res = await fetch("/api/weekly-performance/admin/week-selection", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({ weekStartDate: selectedWeekStart }),
+      });
+      const data = (await res.json()) as WeekSelectionResponse;
+      if (!res.ok || !data.ok) {
+        throw new Error(data.message ?? "Could not set the active week.");
+      }
+      setFeedback({ kind: "success", text: `Active week set to ${data.selectedWeek ? formatWeekRange(data.selectedWeek) : selectedWeekStart}.` });
+      await loadWeeks();
+    } catch (e) {
+      setFeedback({ kind: "error", text: e instanceof Error ? e.message : "Could not set the active week." });
+    } finally {
+      setSelecting(false);
+    }
+  }
+
+  function exportSelected() {
+    if (selectedWeekStart) {
+      window.open(`/api/weekly-performance/export?weekStartDate=${encodeURIComponent(selectedWeekStart)}`, "_blank");
+    }
+  }
+
+  const cardStyle: React.CSSProperties = {
+    padding: 16,
+    borderRadius: 12,
+    background: SURFACE,
+    border: `1px solid ${BORDER}`,
+  };
+
+  const header = (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 20 }}>
+      <Link
+        href="/apps/weekly-performance"
+        aria-label="Back to plugin"
+        style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, display: "flex", alignItems: "center", justifyContent: "center", color: BRAND, textDecoration: "none", flexShrink: 0 }}
+      >
+        <ChevronLeft size={20} />
+      </Link>
+      <div style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}20`, border: `1px solid ${BRAND}35`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+        <BarChart2 size={18} color={BRAND} />
+      </div>
+      <div style={{ flex: 1 }}>
+        <h1 style={{ fontSize: isMobile ? 16 : 20, fontWeight: 800, margin: 0, color: TEXT }}>Weekly Performance Admin</h1>
+        <div style={{ fontSize: 12, color: SUBTLE }}>Set the active week and review its metrics.</div>
+      </div>
+      <span style={{ padding: "3px 8px", borderRadius: 6, background: "rgba(99,102,241,0.15)", border: "1px solid rgba(99,102,241,0.3)", fontSize: 11, color: "#818CF8", fontWeight: 700, flexShrink: 0 }}>ADMIN</span>
+    </div>
+  );
+
+  let body: React.ReactNode;
+  if (loading) {
+    body = <div style={{ ...cardStyle, color: SUBTLE, fontSize: 13 }}>Loading weeks…</div>;
+  } else if (loadError) {
+    body = <div style={{ ...cardStyle, color: "#F87171", fontSize: 13 }}>{loadError}</div>;
+  } else if (weeks.length === 0) {
+    body = <div style={{ ...cardStyle, color: SUBTLE, fontSize: 13 }}>No weeks are tracked yet. Weeks appear once upstream metrics are recorded.</div>;
+  } else {
+    body = (
+      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        {/* Week selection control */}
+        <section style={cardStyle}>
+          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 4, color: TEXT }}>Active week</div>
+          <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 12 }}>
+            Current week: {currentWeekStart ? currentWeekStart : "not set"}. Tracked weeks: {weeks.length}.
+          </div>
+          <div style={{ display: "flex", flexDirection: isMobile ? "column" : "row", gap: 10, alignItems: isMobile ? "stretch" : "center" }}>
+            <select
+              value={selectedWeekStart ?? ""}
+              onChange={(e) => {
+                setSelectedWeekStart(e.target.value);
+                setFeedback(null);
+              }}
+              style={{ flex: 1, padding: "9px 11px", background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, borderRadius: 8, color: TEXT, fontSize: 13 }}
+            >
+              {weeks.map((w) => (
+                <option key={w.weekStartDate} value={w.weekStartDate}>
+                  {formatWeekRange(w)} · {w.status}
+                  {w.weekStartDate === currentWeekStart ? " (current)" : ""}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={() => void selectActiveWeek()}
+              disabled={selecting || !selectedWeekStart}
+              style={{ padding: "9px 16px", borderRadius: 8, background: selecting ? `${BRAND}60` : BRAND, border: "none", color: "#0F1117", fontSize: 13, fontWeight: 700, cursor: selecting ? "default" : "pointer", flexShrink: 0 }}
+            >
+              {selecting ? "Setting…" : "Set as active week"}
+            </button>
+          </div>
+          {feedback && (
+            <div style={{ marginTop: 10, fontSize: 12, color: feedback.kind === "success" ? "#22C55E" : "#F87171" }}>{feedback.text}</div>
+          )}
+        </section>
+
+        {/* Selected week summary + export */}
+        {selectedWeek && (
+          <section style={cardStyle}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, fontWeight: 700, color: TEXT }}>{formatWeekRange(selectedWeek)}</div>
+                <div style={{ fontSize: 12, color: statusColor(selectedWeek.status), fontWeight: 600, textTransform: "capitalize" }}>{selectedWeek.status}</div>
+              </div>
+              <button
+                onClick={exportSelected}
+                style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 12px", borderRadius: 8, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}
+              >
+                <Download size={14} />
+                Export
+              </button>
+            </div>
+            {metricsLoading ? (
+              <div style={{ fontSize: 13, color: SUBTLE }}>Loading metrics…</div>
+            ) : metrics.length === 0 ? (
+              <div style={{ fontSize: 13, color: SUBTLE }}>No metrics recorded for this week yet.</div>
+            ) : (
+              <div style={{ display: "grid", gridTemplateColumns: isMobile ? "1fr 1fr" : "repeat(auto-fill, minmax(150px, 1fr))", gap: 10 }}>
+                {metrics.map((m) => (
+                  <div key={m.metricKey} style={{ padding: "12px 14px", borderRadius: 10, background: BG, border: `1px solid ${BORDER}` }}>
+                    <div style={{ fontSize: 11, color: SUBTLE, marginBottom: 4 }}>{humanizeMetricKey(m.metricKey)}</div>
+                    <div style={{ fontSize: 20, fontWeight: 800, color: BRAND }}>{formatMetricValue(m.metricValue, m.metricUnit)}</div>
+                    <div style={{ fontSize: 10, color: SUBTLE, marginTop: 2 }}>{m.sourcePlugin}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: BG,
+        color: TEXT,
+        fontFamily: "'Inter', system-ui, sans-serif",
+        padding: isMobile ? 16 : 32,
+      }}
+    >
+      <div style={{ maxWidth: 880, margin: "0 auto" }}>
+        {header}
+        {body}
+      </div>
+    </main>
+  );
+}

--- a/ctf/packages/web/components/weekly-performance/wp-shared.ts
+++ b/ctf/packages/web/components/weekly-performance/wp-shared.ts
@@ -42,6 +42,7 @@ export type CurrentWeekResponse = {
 export type WeeksResponse = { ok: boolean; weeks: WpWeek[] };
 export type MetricsResponse = { ok: boolean; metrics: WpMetric[] };
 export type ComparisonResponse = { ok: boolean; comparison: WpComparison };
+export type WeekSelectionResponse = { ok: boolean; selectedWeek?: WpWeek; message?: string };
 
 // A week is "live" while open; locked/published weeks are closed.
 export function isLiveWeek(week: WpWeek | null): boolean {


### PR DESCRIPTION
Reconciliation: the **Weekly-Performance admin page** was a thin stub (current week + tracked-weeks count). Now a real, mobile-responsive admin UI on web plus an Android admin screen, binding existing endpoints only.

## Wired (existing endpoints, rule 126)
- `GET /api/weekly-performance/weeks` — tracked weeks.
- `GET /api/weekly-performance/current-week` — current week.
- `GET /api/weekly-performance/metrics?weekStartDate=…` — selected-week metrics.
- `PUT /api/weekly-performance/admin/week-selection` (`x-ctf-csrf: '1'`) — primary action: "Set as active week".
- `GET /api/weekly-performance/export?weekStartDate=…` — export button.

The mockup's fabricated plugin-breakdown and daily bar chart were omitted (no backing field).

## Web / Android
- Web `app/admin/weekly-performance/page.tsx` renders `wp-admin-shell`, `useIsMobile()` responsive, admin gate unchanged.
- New `AdminWeeklyPerformance.tsx` Android screen (registered in `App.tsx`), same endpoints, admin-gated.

## Notes
- No `key` on host components (keys on `TouchableOpacity` / `React.Fragment`).
- Inventory updated; flagged that the shipped `week-selection` route isn't yet in the command-contract YAML (pre-existing gap, noted not invented).
- Web + mobile typecheck, eslint, EOF pass. `next build` not run (environmental).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_