### PR TITLE
fix: hub chat suggestion chips fill, focus, and scroll the composer

### DIFF
--- a/ctf/packages/web/app/apps/page.tsx
+++ b/ctf/packages/web/app/apps/page.tsx
@@ -5,7 +5,6 @@ import { evaluatePluginAccess } from '../../lib/auth/server-authz';
 import { getGdpShellStats } from '../../lib/gdp/repository';
 import { listPluginRegistry } from '../../lib/plugins/repository';
 import { getTrustUserExtension } from '../../lib/trust/repository';
-import { isDemoMode } from '../../lib/feature-flags/system';
 
 function buildShellUser(userId: string, username: string | null): ShellCurrentUser {
   const safeUsername = username && username !== 'guest' ? username : null;
@@ -34,14 +33,11 @@ export default async function AppsPage() {
   const pluginsPromise = listPluginRegistry();
   const shellStatsPromise = getGdpShellStats().catch(() => ({ memberCount: null, gdpValueUsd: null }));
   const authDecisionPromise = evaluatePluginAccess({ requireUsername: false }).catch(() => null);
-  // Chat suggestion chips are demo-only ("stage"); hidden in production.
-  const demoModePromise = isDemoMode().catch(() => false);
 
-  const [plugins, shellStats, authDecision, demoMode] = await Promise.all([
+  const [plugins, shellStats, authDecision] = await Promise.all([
     pluginsPromise,
     shellStatsPromise,
     authDecisionPromise,
-    demoModePromise,
   ]);
 
   const currentUser = authDecision && authDecision.allowed
@@ -59,7 +55,6 @@ export default async function AppsPage() {
       currentUser={currentUser}
       trust={trust}
       initialSection="apps"
-      showChatSuggestions={demoMode}
     />
   );
 }

--- a/ctf/packages/web/app/page.tsx
+++ b/ctf/packages/web/app/page.tsx
@@ -7,7 +7,6 @@ import { getGdpShellStats } from '../lib/gdp/repository';
 import { listPluginRegistry } from '../lib/plugins/repository';
 import { getTrustUserExtension } from '../lib/trust/repository';
 import { getHostedSignInUrl } from '../lib/auth/provider-env';
-import { isDemoMode } from '../lib/feature-flags/system';
 
 function buildShellUser(userId: string, username: string | null): ShellCurrentUser {
   const safeUsername = username && username !== 'guest' ? username : null;
@@ -36,15 +35,11 @@ export default async function HomePage() {
   const pluginsPromise = listPluginRegistry();
   const shellStatsPromise = getGdpShellStats().catch(() => ({ memberCount: null, gdpValueUsd: null }));
   const authDecisionPromise = evaluatePluginAccess({ requireUsername: false }).catch(() => null);
-  // The chat suggestion chips are unfinished; show them only to demo-mode users
-  // ("stage") and hide them in production. Defaults to hidden on any failure.
-  const demoModePromise = isDemoMode().catch(() => false);
 
-  const [plugins, shellStats, authDecision, demoMode] = await Promise.all([
+  const [plugins, shellStats, authDecision] = await Promise.all([
     pluginsPromise,
     shellStatsPromise,
     authDecisionPromise,
-    demoModePromise,
   ]);
 
   // `evaluatePluginAccess` denies an anonymous visitor with 401 (AUTH_UNAUTHORIZED)
@@ -79,7 +74,6 @@ export default async function HomePage() {
       trust={trust}
       isAuthenticated={isAuthenticated}
       signInUrl={signInUrl}
-      showChatSuggestions={demoMode}
     />
   );
 }

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -22,9 +22,6 @@ type CommunityShellProps = {
   initialSection?: ShellSection;
   isAuthenticated?: boolean;
   signInUrl?: string;
-  // Show the pre-selected chat suggestion chips. Hidden in production, on only in
-  // demo mode until their behavior is finished (tracked GitHub issue).
-  showChatSuggestions?: boolean;
 };
 
 type PluginsApiPayload = {
@@ -114,7 +111,7 @@ function sortPluginsForUi(
   });
 }
 
-export function CommunityShell({ initialPlugins, shellStats, currentUser, trust, initialSection = 'chat', isAuthenticated = false, signInUrl = '/sign-in', showChatSuggestions = false }: CommunityShellProps) {
+export function CommunityShell({ initialPlugins, shellStats, currentUser, trust, initialSection = 'chat', isAuthenticated = false, signInUrl = '/sign-in' }: CommunityShellProps) {
   const [section, setSection] = useState<ShellSection>(initialSection);
   const [query, setQuery] = useState('');
   const [plugins, setPlugins] = useState(initialPlugins);
@@ -324,7 +321,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
             <section className={styles.usernameAlert} role="alert">{loadError}</section>
           ) : null}
           {section === 'chat' ? (
-            <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} signInUrl={signInUrl} showSuggestions={showChatSuggestions} />
+            <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} signInUrl={signInUrl} />
           ) : (
             <ShellAppsPanel
               plugins={filteredPlugins}

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { AtSign } from 'lucide-react';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
 import type { ChatMessage, ComicStreamItem, ShellCurrentUser, ShellStats } from './shell-types';
@@ -39,7 +39,6 @@ type AuthenticatedChatPanelProps = {
   stats: ShellStats;
   plugins: PluginRegistryItem[];
   currentUser: ShellCurrentUser;
-  showSuggestions: boolean;
 };
 
 type ShellChatPanelProps = {
@@ -48,15 +47,11 @@ type ShellChatPanelProps = {
   currentUser: ShellCurrentUser;
   isAuthenticated?: boolean;
   signInUrl?: string;
-  // The pre-selected suggestion chips are hidden in production and shown only in
-  // demo mode while their behavior is finished — see GitHub issue tracked in the
-  // hub chat inventory. Defaults to hidden.
-  showSuggestions?: boolean;
 };
 
-export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = false, signInUrl = '/sign-in', showSuggestions = false }: ShellChatPanelProps) {
+export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = false, signInUrl = '/sign-in' }: ShellChatPanelProps) {
   if (isAuthenticated) {
-    return <AuthenticatedChatPanel stats={stats} plugins={plugins} currentUser={currentUser} showSuggestions={showSuggestions} />;
+    return <AuthenticatedChatPanel stats={stats} plugins={plugins} currentUser={currentUser} />;
   }
 
   const implementedCount = plugins.filter((plugin) => plugin.availabilityState === 'implemented_shell').length;
@@ -119,7 +114,7 @@ export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = 
   );
 }
 
-function AuthenticatedChatPanel({ stats, plugins, currentUser, showSuggestions }: AuthenticatedChatPanelProps) {
+function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedChatPanelProps) {
   const implementedCount = plugins.filter((plugin) => plugin.availabilityState === 'implemented_shell').length;
   const opportunityValue = Math.max(ECONOMY_TARGET_USD - (stats.gdpValueUsd ?? 0), 0);
   const {
@@ -139,6 +134,20 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser, showSuggestions }
     error,
   } = useHomeChat(currentUser);
   const supportStatus = isLive ? 'live support connected' : isLoading ? 'connecting live support…' : 'community support syncing';
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Tapping a suggestion chip fills the composer, then brings it into view and focuses it with the
+  // caret at the end — so the fill is visible even when the composer sits below the fold on mobile.
+  const selectSuggestion = (suggestion: string) => {
+    setInput(suggestion);
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      el.setSelectionRange(suggestion.length, suggestion.length);
+    });
+  };
 
   // Build the interleaved, time-ordered stream: tag hub messages and comic items with a numeric
   // epoch, then sort once so AI cards weave chronologically among community posts. `order` (source
@@ -268,15 +277,13 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser, showSuggestions }
         })}
       </div>
 
-      {showSuggestions ? (
-        <div className={styles.chatSuggestions}>
-          {SUGGESTIONS.map((suggestion) => (
-            <button key={suggestion} type="button" className={styles.chatChip} onClick={() => setInput(suggestion)}>
-              {suggestion}
-            </button>
-          ))}
-        </div>
-      ) : null}
+      <div className={styles.chatSuggestions}>
+        {SUGGESTIONS.map((suggestion) => (
+          <button key={suggestion} type="button" className={styles.chatChip} onClick={() => selectSuggestion(suggestion)}>
+            {suggestion}
+          </button>
+        ))}
+      </div>
 
       {/* @comic mention affordance + helper copy (per the locked design / naming rules). */}
       <div className={styles.comicComposerHelper}>
@@ -291,6 +298,7 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser, showSuggestions }
       <div className={styles.chatInputWrap}>
         <label className={styles.visuallyHidden} htmlFor="chat-input">Share with the community, or type @comic to ask the AI Assistant</label>
         <input
+          ref={inputRef}
           id="chat-input"
           className={styles.chatInput}
           placeholder="Share with the community, or type @comic to ask…"


### PR DESCRIPTION
## What

Tapping a pre-selected suggestion chip on the Survivor Hub chat previously only filled the composer input (`setInput`). On mobile the composer sits below the fold, so the tap looked like it did nothing. As a stopgap the chips were hidden in production and shown only to demo-mode users.

This finishes the behavior and turns the chips back on for everyone:

- A chip tap now fills the composer, **focuses** it, **scrolls it into view**, and puts the caret at the end — so the fill is visible even when the composer is off-screen on mobile.
- Removes the demo-mode gate (`showChatSuggestions` / `isDemoMode`) and the now-dead plumbing through the home page, the apps page, and the community shell.

## Why

Resolves #256. The chips are a web-shell-only element (the React Native hub has no chips), so there is no Android surface to change.

## Checks

`@ctf/web` typecheck, ESLint on the changed files, and the EOF format check all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_