### PR TITLE
feat: comic theme foundation with persistent per-user toggle

### DIFF
--- a/ctf/packages/web/app/api/account/ui-preferences/route.ts
+++ b/ctf/packages/web/app/api/account/ui-preferences/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { requireAccountAccess, ensureMutationCsrf } from '../_lib';
+import { getUserTheme, setUserTheme } from 'lib/account/ui-preferences-repository';
+import { normalizeTheme } from 'lib/theme/theme-tokens';
+
+// Per-user UI theme preference. Auth posture matches the other /api/account routes:
+// any signed-in identity (including unlock-pending) may read and set its own theme.
+// The choice is non-sensitive, scoped to the caller's own row, and CSRF-guarded on write.
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const access = await requireAccountAccess();
+  if (!access.allowed) {
+    return access.response;
+  }
+
+  const theme = await getUserTheme(access.auth.userId);
+  return NextResponse.json({ ok: true, theme });
+}
+
+export async function PUT(request: Request) {
+  const csrf = ensureMutationCsrf(request);
+  if (csrf) {
+    return csrf;
+  }
+
+  const access = await requireAccountAccess();
+  if (!access.allowed) {
+    return access.response;
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { theme?: unknown };
+  const theme = normalizeTheme(body.theme);
+  await setUserTheme(access.auth.userId, theme);
+  return NextResponse.json({ ok: true, theme });
+}

--- a/ctf/packages/web/app/globals.css
+++ b/ctf/packages/web/app/globals.css
@@ -2,8 +2,96 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Theme token layer.
+ *
+ * The app historically hardcoded hex colors in CSS modules and inline styles. To
+ * support a user-toggled "comic" dark theme without rewriting every screen, the
+ * shared surface colors are now CSS custom properties. The DEFAULT values below
+ * are exactly the colors the app already shipped, so the default theme renders
+ * pixel-identical to before. The comic theme only overrides these variables under
+ * the `[data-theme="comic"]` selector (set on <html> by the theme toggle).
+ *
+ * Comic values come verbatim from design/artifacts/mockup-sandbox/COMIC_THEME_TOKENS.md.
+ */
 :root {
   color-scheme: dark;
+
+  /* Root document chrome (globals html/body). */
+  --ctf-root-bg: #0b1020;
+  --ctf-root-text: #e5e7eb;
+
+  /* Shared surface palette (community shell, account & data, plugin chrome). */
+  --ctf-bg: #0f1117;
+  --ctf-surface: #161b27;
+  --ctf-panel: #0d0f14;
+  --ctf-icon-rail: #090b0f;
+  --ctf-border: #1e2a3a;
+  --ctf-border-dim: #1e2a3a;
+  --ctf-text: #f9fafb;
+  --ctf-text-shell: #e8eaf0;
+  --ctf-text-secondary: #9ca3af;
+  --ctf-text-subtle: #6b7280;
+  --ctf-text-muted: #4b5563;
+
+  /* Accents and state. */
+  --ctf-brand: #e91e8c;
+  --ctf-gold: #38bdf8;
+  --ctf-danger: #b91c1c;
+  --ctf-success: #22c55e;
+
+  /* Primary call-to-action / logo treatment (the purple→cyan shell gradient). */
+  --ctf-cta-bg: linear-gradient(135deg, #7c3aed 0%, #0ea5e9 100%);
+  --ctf-cta-border: transparent;
+  --ctf-cta-text: #ffffff;
+
+  /* Elevation + geometry. Defaults preserve the existing soft-shadow / rounded look. */
+  --ctf-elevation-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  --ctf-card-radius: 14px;
+  --ctf-control-radius: 10px;
+  --ctf-chip-radius: 6px;
+
+  /* Halftone/newsprint dotted texture — none in the default theme. */
+  --ctf-dot-bg: none;
+  --ctf-dot-size: 0;
+}
+
+:root[data-theme='comic'] {
+  /* Shared surface tokens — COMIC_THEME_TOKENS.md §1. */
+  --ctf-root-bg: #0d0d0d;
+  --ctf-root-text: #ede3cb;
+  --ctf-bg: #0d0d0d;
+  --ctf-surface: #141414;
+  --ctf-panel: #141414;
+  --ctf-icon-rail: #080808;
+  --ctf-border: #d4c49a;
+  --ctf-border-dim: #7a6a50;
+  --ctf-text: #ede3cb;
+  --ctf-text-shell: #ede3cb;
+  --ctf-text-secondary: #7a6a50;
+  --ctf-text-subtle: #7a6a50;
+  --ctf-text-muted: #4a3a2a;
+
+  /* Account/data destructive zone is danger-red; warm gold is the economy accent. */
+  --ctf-brand: #c8a84b;
+  --ctf-gold: #c8a84b;
+  --ctf-danger: #b91c1c;
+  --ctf-success: #22c55e;
+
+  /* No gradients in comic theme — flat ink panel + hard cream border + offset shadow (§12.5). */
+  --ctf-cta-bg: #141414;
+  --ctf-cta-border: #d4c49a;
+  --ctf-cta-text: #d4c49a;
+
+  /* Signature hard offset shadow, sharp corners (§2, §3). */
+  --ctf-elevation-shadow: 3px 3px 0 #d4c49a;
+  --ctf-card-radius: 0px;
+  --ctf-control-radius: 0px;
+  --ctf-chip-radius: 2px;
+
+  /* Newsprint dotted texture (§5). */
+  --ctf-dot-bg: radial-gradient(#d4c49a1a 1px, transparent 1px);
+  --ctf-dot-size: 8px 8px;
 }
 
 * {
@@ -15,8 +103,8 @@ body {
   margin: 0;
   padding: 0;
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
-  background: #0b1020;
-  color: #e5e7eb;
+  background: var(--ctf-root-bg);
+  color: var(--ctf-root-text);
 }
 
 /*

--- a/ctf/packages/web/app/layout.tsx
+++ b/ctf/packages/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
 import { AuthProvider } from '@/hooks/useAuth';
+import { ThemeProvider } from '@/hooks/useTheme';
 import {
   getClerkRuntimeOptions,
   getHostedSignInUrl,
@@ -40,6 +41,17 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        {/*
+          No-flash theme script: runs before paint, reads the saved theme from
+          localStorage, and sets data-theme="comic" on <html> so a returning comic-theme
+          user never sees a flash of the default theme. Default theme = no attribute.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{if(localStorage.getItem('sh-theme')==='comic'){document.documentElement.setAttribute('data-theme','comic');}}catch(e){}})();",
+          }}
+        />
         <ClerkProvider
           {...clerkOptions}
           {...(signInUrl ? { signInUrl } : {})}
@@ -49,7 +61,9 @@ export default function RootLayout({
             : {})}
           {...(afterSignOutUrl ? { afterSignOutUrl } : {})}
         >
-          <AuthProvider>{children}</AuthProvider>
+          <AuthProvider>
+            <ThemeProvider>{children}</ThemeProvider>
+          </AuthProvider>
         </ClerkProvider>
       </body>
     </html>

--- a/ctf/packages/web/components/account-data/account-data-desktop.tsx
+++ b/ctf/packages/web/components/account-data/account-data-desktop.tsx
@@ -7,6 +7,7 @@ import {
   BRAND, BG, SURFACE, BORDER, TEXT, SUBTLE,
   glyphForService, type AccountService,
 } from './account-data-shared';
+import { ThemeToggle } from '../theme/theme-toggle';
 
 type View = 'data' | 'danger';
 
@@ -76,6 +77,10 @@ export function AccountDataDesktop({
           <div style={{ flex: 1 }}>
             <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>Your Data &amp; Privacy</div>
             <div style={{ fontSize: 12, color: SUBTLE }}>See and delete the data Survivor Hub holds across all services</div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+            <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', color: SUBTLE, textTransform: 'uppercase' }}>Theme</span>
+            <ThemeToggle />
           </div>
         </header>
 

--- a/ctf/packages/web/components/account-data/account-data-mobile.tsx
+++ b/ctf/packages/web/components/account-data/account-data-mobile.tsx
@@ -8,6 +8,7 @@ import {
   glyphForService, type AccountService,
 } from './account-data-shared';
 import type { AccountDataView } from './account-data-desktop';
+import { ThemeToggle } from '../theme/theme-toggle';
 
 type MobileProps = {
   view: AccountDataView;
@@ -37,10 +38,11 @@ export function AccountDataMobile({
           <div style={{ width: 34, height: 34, borderRadius: 9, background: `${BRAND}20`, border: `1px solid ${BRAND}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <Shield size={16} color={BRAND} />
           </div>
-          <div>
+          <div style={{ flex: 1 }}>
             <div style={{ fontSize: 16, fontWeight: 700 }}>Account &amp; Data</div>
             <div style={{ fontSize: 11, color: SUBTLE }}>{deletable.length + retained.length} services · your control</div>
           </div>
+          <ThemeToggle />
         </div>
         <div style={{ display: 'flex', gap: 4 }}>
           {(['data', 'danger'] as const).map((t) => (

--- a/ctf/packages/web/components/theme/theme-toggle.tsx
+++ b/ctf/packages/web/components/theme/theme-toggle.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useTheme } from '@/hooks/useTheme';
+import type { ThemeName } from '@/lib/theme/theme-tokens';
+
+const OPTIONS: { value: ThemeName; label: string }[] = [
+  { value: 'default', label: 'Default' },
+  { value: 'comic', label: 'Comic' },
+];
+
+// Minimal two-state segmented control for the app theme. Styled entirely from the
+// shared CSS variables so it reads correctly in both themes. Used in the Account &
+// Data settings surface.
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const activeText = theme === 'comic' ? '#0d0d0d' : '#ffffff';
+
+  return (
+    <div
+      role="group"
+      aria-label="App theme"
+      style={{
+        display: 'inline-flex',
+        border: '1.5px solid var(--ctf-border)',
+        borderRadius: 'var(--ctf-control-radius)',
+        overflow: 'hidden',
+        background: 'var(--ctf-surface)',
+      }}
+    >
+      {OPTIONS.map((option) => {
+        const active = theme === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => setTheme(option.value)}
+            style={{
+              padding: '6px 16px',
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              border: 'none',
+              cursor: 'pointer',
+              background: active ? 'var(--ctf-brand)' : 'transparent',
+              color: active ? activeText : 'var(--ctf-text-subtle)',
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ctf/packages/web/hooks/useTheme.tsx
+++ b/ctf/packages/web/hooks/useTheme.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import {
+  DEFAULT_THEME,
+  normalizeTheme,
+  THEME_ATTRIBUTE,
+  THEME_STORAGE_KEY,
+  type ThemeName,
+} from '@/lib/theme/theme-tokens';
+
+type ThemeContextValue = {
+  theme: ThemeName;
+  setTheme: (theme: ThemeName) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+// Read whatever the no-flash inline script already wrote to <html data-theme>, so the
+// provider's initial state matches the first paint and there is no flicker on hydration.
+function readInitialTheme(): ThemeName {
+  if (typeof document === 'undefined') return DEFAULT_THEME;
+  return normalizeTheme(document.documentElement.getAttribute(THEME_ATTRIBUTE));
+}
+
+function applyThemeAttribute(theme: ThemeName): void {
+  if (typeof document === 'undefined') return;
+  // The default theme is the absence of the attribute, so removing it keeps the
+  // default selectors winning and avoids a stray `data-theme="default"` in the DOM.
+  if (theme === 'comic') {
+    document.documentElement.setAttribute(THEME_ATTRIBUTE, 'comic');
+  } else {
+    document.documentElement.removeAttribute(THEME_ATTRIBUTE);
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  // Start at the default theme so the first client render matches the server-rendered
+  // HTML (no hydration mismatch). The real choice is reconciled in the mount effect
+  // below — the page chrome itself is already correct via the no-flash inline script,
+  // so only theme-dependent React UI (e.g. the toggle indicator) settles after mount.
+  const [theme, setThemeState] = useState<ThemeName>(DEFAULT_THEME);
+  const didInit = useRef(false);
+
+  const applyTheme = useCallback((next: ThemeName, persistToServer: boolean) => {
+    setThemeState(next);
+    applyThemeAttribute(next);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // Private mode / storage disabled — the in-memory + attribute state still applies.
+    }
+    if (persistToServer) {
+      // Best-effort sync to the signed-in user's profile so the choice follows the
+      // account across devices. Unauthenticated callers get a 401 we quietly ignore.
+      void fetch('/api/account/ui-preferences', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ theme: next }),
+      }).catch(() => undefined);
+    }
+  }, []);
+
+  const setTheme = useCallback((next: ThemeName) => applyTheme(next, true), [applyTheme]);
+  const toggleTheme = useCallback(
+    () => applyTheme(theme === 'comic' ? 'default' : 'comic', true),
+    [applyTheme, theme],
+  );
+
+  // On first mount: (1) adopt whatever the no-flash script already applied from
+  // localStorage so React state matches the visible chrome, then (2) pull the signed-in
+  // user's saved theme — the server is the source of truth for a logged-in account, so
+  // it follows them across devices. Runs once; failures / unauthenticated are ignored.
+  useEffect(() => {
+    if (didInit.current) return;
+    didInit.current = true;
+
+    const local = readInitialTheme();
+    if (local !== DEFAULT_THEME) {
+      setThemeState(local);
+    }
+
+    void (async () => {
+      try {
+        const res = await fetch('/api/account/ui-preferences', { credentials: 'same-origin' });
+        if (!res.ok) return;
+        const data: { ok?: boolean; theme?: unknown } = await res.json();
+        if (!data?.ok) return;
+        const serverTheme = normalizeTheme(data.theme);
+        if (serverTheme !== local) {
+          applyTheme(serverTheme, false);
+        }
+      } catch {
+        // Offline or not signed in — keep the local choice.
+      }
+    })();
+  }, [applyTheme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+}

--- a/ctf/packages/web/lib/account/ui-preferences-repository.ts
+++ b/ctf/packages/web/lib/account/ui-preferences-repository.ts
@@ -1,0 +1,25 @@
+import { queryDb } from 'lib/db/postgres';
+import { normalizeTheme, type ThemeName } from 'lib/theme/theme-tokens';
+
+// Per-user UI preferences (currently just the theme choice). Backed by the
+// user_ui_preferences table. Reads return the normalized theme ('default' when no
+// row exists); writes upsert on user_id.
+
+type ThemeRow = { theme: string };
+
+export async function getUserTheme(userId: string): Promise<ThemeName> {
+  const result = await queryDb<ThemeRow>(
+    `SELECT theme FROM user_ui_preferences WHERE user_id = $1 LIMIT 1`,
+    [userId],
+  );
+  return normalizeTheme(result.rows[0]?.theme);
+}
+
+export async function setUserTheme(userId: string, theme: ThemeName): Promise<void> {
+  await queryDb<ThemeRow>(
+    `INSERT INTO user_ui_preferences (user_id, theme, updated_at)
+     VALUES ($1, $2, NOW())
+     ON CONFLICT (user_id) DO UPDATE SET theme = EXCLUDED.theme, updated_at = NOW()`,
+    [userId, theme],
+  );
+}

--- a/ctf/packages/web/lib/theme/theme-tokens.ts
+++ b/ctf/packages/web/lib/theme/theme-tokens.ts
@@ -1,0 +1,70 @@
+// Theme tokens shared across the app.
+//
+// Two themes are supported: the original dark UI ('default') and a comic-book dark
+// theme ('comic'). Surface colors are driven by CSS custom properties defined in
+// app/globals.css; this module owns the parts that live in TypeScript — the theme
+// name type, localStorage key, and the per-plugin accent translation table.
+//
+// The comic-ink accent values are copied verbatim from the design token spec:
+// design/artifacts/mockup-sandbox/COMIC_THEME_TOKENS.md §6. Do not invent values.
+
+export type ThemeName = 'default' | 'comic';
+
+export const THEME_NAMES: readonly ThemeName[] = ['default', 'comic'] as const;
+
+export const DEFAULT_THEME: ThemeName = 'default';
+
+// localStorage key + the attribute the toggle sets on <html>. The spec names the
+// storage key "sh-theme" (§12.2); we keep that exact key.
+export const THEME_STORAGE_KEY = 'sh-theme';
+export const THEME_ATTRIBUTE = 'data-theme';
+
+export function isThemeName(value: unknown): value is ThemeName {
+  return value === 'default' || value === 'comic';
+}
+
+export function normalizeTheme(value: unknown): ThemeName {
+  return isThemeName(value) ? value : DEFAULT_THEME;
+}
+
+// Per-plugin accent translation. Keyed by plugin slug. `standard` is the accent the
+// app already uses; `comic` is the deep, ink-compatible variant (no neon, no glow).
+type AccentPair = { standard: string; comic: string };
+
+export const PLUGIN_ACCENTS: Record<string, AccentPair> = {
+  chyme: { standard: '#22C55E', comic: '#1A5C32' },
+  lighthouse: { standard: '#60A5FA', comic: '#1A4A7A' },
+  trusttransport: { standard: '#38BDF8', comic: '#0C4A6E' },
+  directory: { standard: '#93C5FD', comic: '#1A3A6A' },
+  foundation: { standard: '#F59E0B', comic: '#7A4A05' },
+  'peer-programming': { standard: '#6EE7B7', comic: '#1A5C40' },
+  gdp: { standard: '#06B6D4', comic: '#0E5A68' },
+  'gross-domestic-product': { standard: '#06B6D4', comic: '#0E5A68' },
+  'service-credits': { standard: '#A855F7', comic: '#5C2C8A' },
+  workforce: { standard: '#F97316', comic: '#6A2A05' },
+  gentlepulse: { standard: '#34D399', comic: '#1A5C45' },
+  mood: { standard: '#4ADE80', comic: '#1A5C2A' },
+  socketrelay: { standard: '#FB923C', comic: '#7A3A0C' },
+  'skills-hunt': { standard: '#FBBF24', comic: '#7A5A05' },
+  levelup: { standard: '#22C55E', comic: '#1A5C30' },
+  whatworks: { standard: '#84CC16', comic: '#4A6B10' },
+  'what-works': { standard: '#84CC16', comic: '#4A6B10' },
+  trust: { standard: '#0EA5E9', comic: '#0C5278' },
+  clicklog: { standard: '#EC4899', comic: '#7A1A4A' },
+  'skills-taxonomy': { standard: '#818CF8', comic: '#2A2A7A' },
+  unlock: { standard: '#C084FC', comic: '#5C1A8A' },
+  'weekly-performance': { standard: '#6366F1', comic: '#2A2A6A' },
+  // AI Assistant (the @comic plugin) deliberately uses inkDim in comic theme — no blue.
+  comic: { standard: '#38BDF8', comic: '#7A6A50' },
+  // Account & Data uses comic-danger for its destructive zone.
+  'account-data': { standard: '#E91E8C', comic: '#B91C1C' },
+};
+
+const FALLBACK_ACCENT: AccentPair = { standard: '#6B7280', comic: '#7A6A50' };
+
+// Resolve a plugin's accent for the active theme. Unknown slugs fall back to a
+// neutral grey (standard) / inkDim (comic) so a new plugin never renders unstyled.
+export function getAppAccent(slug: string, theme: ThemeName): string {
+  const pair = PLUGIN_ACCENTS[slug] ?? FALLBACK_ACCENT;
+  return theme === 'comic' ? pair.comic : pair.standard;
+}

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -658,9 +658,23 @@ CREATE TABLE IF NOT EXISTS feed_item_targets (
   item_id UUID NOT NULL REFERENCES feed_items(id) ON DELETE CASCADE,
   target_role TEXT,
   target_plugin TEXT,
-  target_region TEXT,
-  PRIMARY KEY (item_id, target_role, target_plugin, target_region)
+  target_region TEXT
 );
+-- A NULL target_plugin/target_region means "any plugin / any region" — the read path
+-- treats NULL as a wildcard (see listFeedTimeline: "t.target_plugin IS NULL"). NULL
+-- cannot live in a PRIMARY KEY (PK columns are implicitly NOT NULL), so the old
+-- PRIMARY KEY (item_id, target_role, target_plugin, target_region) made every
+-- default-targeted feed item fail to insert — which broke posting community messages
+-- and @comic questions. Replace it with a unique index that treats NULLs as equal
+-- (NULLS NOT DISTINCT, Postgres 15+) so default targeting works and duplicate
+-- (item, role, plugin, region) rows are still de-duplicated. Guarded DDL repairs
+-- legacy databases that still carry the old primary key.
+ALTER TABLE IF EXISTS feed_item_targets DROP CONSTRAINT IF EXISTS feed_item_targets_pkey;
+ALTER TABLE IF EXISTS feed_item_targets ALTER COLUMN target_role DROP NOT NULL;
+ALTER TABLE IF EXISTS feed_item_targets ALTER COLUMN target_plugin DROP NOT NULL;
+ALTER TABLE IF EXISTS feed_item_targets ALTER COLUMN target_region DROP NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_item_targets_unique
+  ON feed_item_targets (item_id, target_role, target_plugin, target_region) NULLS NOT DISTINCT;
 CREATE TABLE IF NOT EXISTS feed_user_read_state (
   user_id TEXT NOT NULL,
   item_id UUID NOT NULL REFERENCES feed_items(id) ON DELETE CASCADE,
@@ -966,6 +980,9 @@ ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS submission_
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS reminder_schedule_hours INTEGER[] NOT NULL DEFAULT ARRAY[0,24,72,168];
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS incentive_amount TEXT NOT NULL DEFAULT '100';
 ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS support_only_after_expiry BOOLEAN NOT NULL DEFAULT TRUE;
+-- Multi-currency (issue #120): the verification incentive is an internal ServiceCredits payout.
+-- incentive_currency names the currency of incentive_amount; it defaults to ServiceCredits (code 'SC').
+ALTER TABLE IF EXISTS unlock_runtime_config ADD COLUMN IF NOT EXISTS incentive_currency TEXT NOT NULL DEFAULT 'SC' REFERENCES currencies(code);
 
 -- === levelup_enrollments table (guarded DDL, schema drift prevention) ===
 CREATE TABLE IF NOT EXISTS levelup_enrollments (
@@ -1148,6 +1165,17 @@ CREATE TABLE IF NOT EXISTS trusttransport_earnings_ledger (
   metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+-- Multi-currency (issue #120): model the settlement currency as an admin-curated, referenced code.
+-- The legacy free-text `currency` column is superseded by `price_currency` (FK -> currencies.code), which
+-- the GDP estimation layer (issue #121) reads. Existing rows are backfilled from `currency` only where it
+-- already matches a known code; unknown legacy values are left for manual reconciliation so no money data
+-- is overwritten. This never asserts a ServiceCredits<->fiat parity.
+ALTER TABLE IF EXISTS trusttransport_payout_requests ADD COLUMN IF NOT EXISTS price_currency TEXT REFERENCES currencies(code);
+ALTER TABLE IF EXISTS trusttransport_earnings_ledger ADD COLUMN IF NOT EXISTS price_currency TEXT REFERENCES currencies(code);
+UPDATE trusttransport_payout_requests SET price_currency = currency
+  WHERE price_currency IS NULL AND currency IN (SELECT code FROM currencies);
+UPDATE trusttransport_earnings_ledger SET price_currency = currency
+  WHERE price_currency IS NULL AND currency IN (SELECT code FROM currencies);
 CREATE TABLE IF NOT EXISTS trusttransport_admin_audit_trail (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   actor_id TEXT NOT NULL,
@@ -1795,7 +1823,8 @@ ALTER TABLE IF EXISTS skills_taxonomy_change_events ADD COLUMN IF NOT EXISTS cre
 CREATE TABLE IF NOT EXISTS directory_profiles (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   claimed_by_user_id TEXT,
-  display_name TEXT NOT NULL,
+  first_name TEXT,
+  last_name TEXT,
   headline TEXT,
   bio TEXT,
   profile_url TEXT,
@@ -1819,7 +1848,8 @@ CREATE TABLE IF NOT EXISTS directory_profiles (
 );
 ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS id UUID;
 ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS claimed_by_user_id TEXT;
-ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS display_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS first_name TEXT;
+ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS last_name TEXT;
 ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS headline TEXT;
 ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS bio TEXT;
 ALTER TABLE IF EXISTS directory_profiles ADD COLUMN IF NOT EXISTS profile_url TEXT;
@@ -2082,6 +2112,11 @@ ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS policy_json JSONB
 ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS created_by_user_id TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency (issue #120): LevelUp stipends and microgrants are internal ServiceCredits payouts.
+-- stipend_currency / microgrant_currency name the currency of stipend_amount_per_payout / microgrant_amount;
+-- both default to ServiceCredits (code 'SC').
+ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS stipend_currency TEXT NOT NULL DEFAULT 'SC' REFERENCES currencies(code);
+ALTER TABLE IF EXISTS levelup_cohorts ADD COLUMN IF NOT EXISTS microgrant_currency TEXT NOT NULL DEFAULT 'SC' REFERENCES currencies(code);
 
 CREATE TABLE IF NOT EXISTS levelup_curriculum_items (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -2393,6 +2428,20 @@ ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS accessi
 ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS trauma_informed_defaults JSONB NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS service_deleted_at TIMESTAMPTZ;
 ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency (issue #120): a Foundation provider can list a service rate on their profile.
+-- rate_amount is the listed amount; rate_currency names its currency (FK -> currencies.code). The quote
+-- process stays free-text/manual this version (no structured quote amount). "Accepts ServiceCredits" is a
+-- separate field in foundation_provider_accepted_currencies, never derived from rate_currency.
+ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS rate_amount NUMERIC;
+ALTER TABLE IF EXISTS foundation_user_extension ADD COLUMN IF NOT EXISTS rate_currency TEXT REFERENCES currencies(code);
+CREATE TABLE IF NOT EXISTS foundation_provider_accepted_currencies (
+  user_id TEXT NOT NULL REFERENCES foundation_user_extension(user_id) ON DELETE CASCADE,
+  currency_code TEXT NOT NULL REFERENCES currencies(code),
+  PRIMARY KEY (user_id, currency_code)
+);
+ALTER TABLE IF EXISTS foundation_provider_accepted_currencies ADD COLUMN IF NOT EXISTS user_id TEXT;
+ALTER TABLE IF EXISTS foundation_provider_accepted_currencies ADD COLUMN IF NOT EXISTS currency_code TEXT;
+CREATE INDEX IF NOT EXISTS idx_foundation_provider_accepted_currencies_user ON foundation_provider_accepted_currencies(user_id);
 
 CREATE TABLE IF NOT EXISTS foundation_call_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -2483,6 +2532,36 @@ ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS claimed_fulf
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS idempotency_key TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency (issue #120): SocketRelay is mutual aid and posts are free. These OPTIONAL columns let a
+-- request name an offered reward when one exists; "Free" must render from the ABSENCE of a price (NULL),
+-- never as $0. Accepted currencies (if any) live in socketrelay_request_accepted_currencies.
+ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS price_amount NUMERIC;
+ALTER TABLE IF EXISTS socketrelay_requests ADD COLUMN IF NOT EXISTS price_currency TEXT REFERENCES currencies(code);
+-- Enforce the "Free = no price, never $0" rule at the DB level (issue #120 follow-up): a request either
+-- has no price (both NULL) or a positive amount in a named currency. Guarded so it is added only once.
+DO $socketrelay_requests_price_consistency$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'socketrelay_requests_price_consistency_check'
+  ) THEN
+    ALTER TABLE socketrelay_requests
+      ADD CONSTRAINT socketrelay_requests_price_consistency_check
+      CHECK (
+        (price_amount IS NULL AND price_currency IS NULL) OR
+        (price_amount IS NOT NULL AND price_amount > 0 AND price_currency IS NOT NULL)
+      );
+  END IF;
+END
+$socketrelay_requests_price_consistency$;
+CREATE TABLE IF NOT EXISTS socketrelay_request_accepted_currencies (
+  request_id UUID NOT NULL REFERENCES socketrelay_requests(id) ON DELETE CASCADE,
+  currency_code TEXT NOT NULL REFERENCES currencies(code),
+  PRIMARY KEY (request_id, currency_code)
+);
+ALTER TABLE IF EXISTS socketrelay_request_accepted_currencies ADD COLUMN IF NOT EXISTS request_id UUID;
+ALTER TABLE IF EXISTS socketrelay_request_accepted_currencies ADD COLUMN IF NOT EXISTS currency_code TEXT;
+CREATE INDEX IF NOT EXISTS idx_socketrelay_request_accepted_currencies_request ON socketrelay_request_accepted_currencies(request_id);
 
 CREATE TABLE IF NOT EXISTS socketrelay_request_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -2585,6 +2664,13 @@ ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS dp_suppresse
 ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS lawful_basis TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS source_plugin TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Multi-currency GDP recognition (issue #121): mark metrics that are USD-normalized ESTIMATES (e.g.
+-- gdp_total_revenue, which rolls multi-currency volume into USD via currency_usd_rates). The in-product
+-- "estimate" label reads this flag; small drift is acceptable and disclosed, since GDP is a morale/
+-- transparency figure, not an accounting ledger.
+ALTER TABLE IF EXISTS gdp_metric_snapshots ADD COLUMN IF NOT EXISTS is_estimate BOOLEAN NOT NULL DEFAULT FALSE;
+-- Mark the USD-normalized aggregate(s) as estimates for any rows that predate the column.
+UPDATE gdp_metric_snapshots SET is_estimate = TRUE WHERE metric_key = 'gdp_total_revenue' AND is_estimate = FALSE;
 
 CREATE TABLE IF NOT EXISTS gdp_admin_audit_trail (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -2606,6 +2692,29 @@ ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS target_type
 ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS target_id TEXT NOT NULL DEFAULT '';
 ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE IF EXISTS gdp_admin_audit_trail ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Multi-currency GDP recognition (issue #121). The notional USD conversion factor per currency, used
+-- ONLY by the GDP estimation layer to roll multi-currency transaction volume into the single,
+-- estimate-labeled GDP figure. LEGAL GUARDRAIL: this rate is NEVER surfaced as a per-wallet or
+-- per-price "ServiceCredits = fiat" equivalence; a user never sees "your N ServiceCredits = $X". The
+-- only place a USD-normalized ServiceCredits value appears is inside the aggregate GDP estimate. The
+-- owner curates rates over time; the most recent as_of per currency_code is the active rate.
+CREATE TABLE IF NOT EXISTS currency_usd_rates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  currency_code TEXT NOT NULL REFERENCES currencies(code),
+  usd_rate NUMERIC NOT NULL CHECK (usd_rate > 0),
+  as_of DATE NOT NULL,
+  source TEXT NOT NULL DEFAULT 'owner',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (currency_code, as_of)
+);
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS currency_code TEXT;
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS usd_rate NUMERIC;
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS as_of DATE;
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'owner';
+ALTER TABLE IF EXISTS currency_usd_rates ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE INDEX IF NOT EXISTS idx_currency_usd_rates_code_asof ON currency_usd_rates(currency_code, as_of DESC);
 
 -- === MOOD MODULE ===
 CREATE TABLE IF NOT EXISTS mood_submissions (
@@ -3452,6 +3561,18 @@ BEGIN
   END IF;
 END
 $comic_answer_ratings_rating_check$;
+
+-- === user_ui_preferences (per-user UI theme choice) ===
+-- Stores the signed-in user's selected app theme so the choice follows their account
+-- across devices. Anonymous visitors rely on localStorage only. `theme` is 'default'
+-- (the original dark UI) or 'comic' (the comic-book dark theme).
+CREATE TABLE IF NOT EXISTS user_ui_preferences (
+  user_id TEXT PRIMARY KEY,
+  theme TEXT NOT NULL DEFAULT 'default',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS user_ui_preferences ADD COLUMN IF NOT EXISTS theme TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE IF EXISTS user_ui_preferences ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 -- skills_taxonomy_dependency_graph view — defined at the END so its source table
 -- (skills_taxonomy_consumer_bindings, created above) already exists. Defining it at the

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -3564,6 +3564,18 @@ BEGIN
 END
 $comic_answer_ratings_rating_check$;
 
+-- === user_ui_preferences (per-user UI theme choice) ===
+-- Stores the signed-in user's selected app theme so the choice follows their account
+-- across devices. Anonymous visitors rely on localStorage only. `theme` is 'default'
+-- (the original dark UI) or 'comic' (the comic-book dark theme).
+CREATE TABLE IF NOT EXISTS user_ui_preferences (
+  user_id TEXT PRIMARY KEY,
+  theme TEXT NOT NULL DEFAULT 'default',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS user_ui_preferences ADD COLUMN IF NOT EXISTS theme TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE IF EXISTS user_ui_preferences ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 -- skills_taxonomy_dependency_graph view — defined at the END so its source table
 -- (skills_taxonomy_consumer_bindings, created above) already exists. Defining it at the
 -- top of the file made a fresh-DB `migrate:schema` fail: the view referenced a table


### PR DESCRIPTION
Adds a user-toggleable "comic book" dark theme alongside the existing dark UI, persisted per signed-in user. Implements the design token spec verbatim (`design/artifacts/mockup-sandbox/COMIC_THEME_TOKENS.md`).

## What's in this PR (the working foundation)
- **CSS variable token layer** (`app/globals.css`). The `:root` defaults equal the colors the app already shipped, so the **default theme is pixel-identical** (no regression); `:root[data-theme="comic"]` overrides them with the spec values — near-black `#0D0D0D`, cream `#EDE3CB` text, hard cream borders, `3px 3px 0` offset shadow, sharp corners, no gradients.
- **ThemeProvider + `useTheme`** — sets `data-theme` on `<html>`, persists to `localStorage` instantly, and syncs to the signed-in user's profile so the choice **follows the account across devices**. Starts at default to avoid a hydration mismatch, then reconciles from localStorage + profile after mount.
- **No-flash inline script** in the root layout applies the saved theme before paint.
- **Persistence**: new `user_ui_preferences` table (`schema.sql` + regenerated `schema.demo.sql`) and `GET`/`PUT /api/account/ui-preferences` (auth + same-origin CSRF, self-service).
- **Accent map** (`lib/theme/theme-tokens.ts`): the per-plugin comic-ink accent translations from spec §6, via `getAppAccent(slug, theme)`.
- **Applied now**: global chrome (body) themes app-wide on toggle; the **toggle control is placed in Account & Data** (desktop + mobile).
- Also advances the `design/` submodule to `e9690ee` (comic token spec + the admin-hub mockup removal from #339).

## Deliberately follow-up (tracked in #341)
Per-screen comic styling of the community shell and the 17 inline-styled plugin screens, plus mobile (React Native) theme parity. Those screens use a `${color}NN` opacity pattern that CSS variables can't retrofit, so each needs a JS token swap — staged separately to avoid a risky mega-diff. The toggle is fully functional today (not a stub): it persists and visibly re-themes the app chrome immediately.

## Checks
`@ctf/web` typecheck, ESLint, schema-drift gate, and EOF check all pass. `schema.demo.sql` regenerated via `generate:demo-schema`.

Parity Ticket: #341 (mobile React Native comic-theme parity + per-screen migration; web + mobile-responsive web done here)