### PR TITLE
feat: real Mood community pulse (replaces coming-soon stub)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
@@ -46,13 +46,15 @@ Scope decisions locked for this rewrite:
 
 1. `mood.check.submit`
 2. `mood.check.eligibility.fetch`
+3. `mood.community.pulse.fetch` (aggregate, anonymous)
 
 ### 3.2 HTTP Projection Routes
 
 User routes (authenticated):
 
-- `POST /api/mood/checks`
-- `GET /api/mood/checks/eligible`
+- `POST /api/mood/submissions` — submit an anonymous mood check (`{ clientId, moodValue, note }`, `x-ctf-csrf: 1`).
+- `GET /api/mood/eligibility?clientId=` — per-device cooldown gate.
+- `GET /api/mood/community` — aggregate, anonymous community pulse. Returns only per-day average mood + counts over the trailing 7 days plus a window total and average; never any per-user rows, notes, or identifiers. Withholds data (returns `hasEnoughData: false` with a zeroed series) until at least `MOOD_PULSE_MIN_SAMPLE` (5) check-ins exist in the window.
 
 Excluded route groups:
 
@@ -63,9 +65,15 @@ Excluded route groups:
 
 ### 4.1 Mood Checks
 
-1. Mood checks store `clientId`, `moodValue`, and check timestamp metadata.
+1. Mood checks store `clientId`, `moodValue`, and check timestamp metadata in `mood_submissions` (`id`, `user_id`, `client_id`, `mood_value`, `note`, `submitted_at`).
 2. Mood values are validated as integer range `1..5`.
 3. Eligibility evaluation is derived from last check timestamp per `clientId`.
+
+### 4.2 Community Pulse (aggregate-only, no new storage)
+
+1. The community pulse is computed on read from the existing `mood_submissions` table — no new table or column is added.
+2. The aggregation query reads only `mood_value` and `submitted_at`, grouped by calendar day over the trailing 7 days. It never selects `user_id`, `client_id`, or `note`, so no result can be tied to a person.
+3. A minimum-sample threshold (`MOOD_PULSE_MIN_SAMPLE` = 5 check-ins in the window) gates display; below it the API returns `hasEnoughData: false` and a zeroed day series.
 
 ## 5) Security, Privacy, and Compliance Controls
 
@@ -84,9 +92,9 @@ Parity points met:
 2. Cooldown and validation semantics match between web and Android (7-day window, 1–5 scale).
 3. No Mood admin parity obligations in web/mobile for this rewrite scope.
 
-Web pixel pass (design `c5d83c0`): the `/apps/mood` shell is rebuilt to `design/.../survivor-hub/Mood.tsx` and its Empty/Loading states. The anonymous check-in flow is wired to the real API — `GET /api/mood/eligibility?clientId=` gates the form (per-device `clientId` persisted in localStorage), and `POST /api/mood/submissions` sends `{ clientId, moodValue, note }` with the `x-ctf-csrf` header. This fixes the prior shell, which called eligibility with no `clientId` and POSTed the wrong field names (both 400'd at runtime). The Community Pulse tab renders the design's honest empty state — there is no aggregate-stats backend yet, so the previous shell's fabricated 7-day averages and distribution percentages were removed rather than re-displayed. Decomposed into modular sub-components within the rule-116 limits; banned "Phase 2" wording removed.
+Web pixel pass (design `c5d83c0`): the `/apps/mood` shell is rebuilt to `design/.../survivor-hub/Mood.tsx` and its Empty/Loading states. The anonymous check-in flow is wired to the real API — `GET /api/mood/eligibility?clientId=` gates the form (per-device `clientId` persisted in localStorage), and `POST /api/mood/submissions` sends `{ clientId, moodValue, note }` with the `x-ctf-csrf` header. This fixes the prior shell, which called eligibility with no `clientId` and POSTed the wrong field names (both 400'd at runtime). The Community Pulse tab now renders a real aggregate (2026-06-07): `GET /api/mood/community` returns an anonymous 7-day average-mood chart plus check-in counts computed from the existing `mood_submissions` table, with loading/empty/error states and a minimum-sample gate so small samples are withheld. Decomposed into modular sub-components within the rule-116 limits; banned "Phase 2" wording removed.
 
-Android pixel pass (design `MobileMood.tsx`, 2026-05-31): built `ctf/packages/mobile/src/features/mood/Mood.tsx` + `api.ts`; retired `MockMood.tsx`. The screen faithfully translates the `MobileMood.tsx` mockup into React Native primitives — dark-mode only (`#0F1117` background), pink `#EC4899` accent, five-mood emoji picker, optional anonymous note, eligibility gate from `GET /api/mood/eligibility?clientId=`, submission via `POST /api/mood/submissions` with `{ clientId, moodValue, note }` + `x-ctf-csrf: 1` header, cooldown display. Omissions from mockup (no aggregate-stats API): Trends tab replaced with honest empty state; community avg card in check-in tab omitted. Home and Private tabs are pure UI and retained. TypeScript, EOF, and parity gates all pass.
+Android pixel pass (design `MobileMood.tsx`, 2026-05-31): built `ctf/packages/mobile/src/features/mood/Mood.tsx` + `api.ts`; retired `MockMood.tsx`. The screen faithfully translates the `MobileMood.tsx` mockup into React Native primitives — dark-mode only (`#0F1117` background), pink `#EC4899` accent, five-mood emoji picker, optional anonymous note, eligibility gate from `GET /api/mood/eligibility?clientId=`, submission via `POST /api/mood/submissions` with `{ clientId, moodValue, note }` + `x-ctf-csrf: 1` header, cooldown display. The Trends tab now renders the real aggregate community pulse (2026-06-07) from `GET /api/mood/community` — a 7-day average-mood chart plus counts, with loading/empty/error states. Home and Private tabs are pure UI and retained. TypeScript, EOF, and parity gates all pass.
 
 ## 7) Seed Coverage Status
 
@@ -99,6 +107,7 @@ Seed script requirement: Provide a deterministic plugin seed script with dummy d
 
 ## 9) Change Log
 
+- 2026-06-07: Community Pulse delivered for real (web + Android). Added `getMoodCommunityPulse` to `lib/mood/repository.ts` and `GET /api/mood/community`, computing an aggregate, anonymous 7-day average-mood chart + counts from the existing `mood_submissions` table (no schema change). Reads only `mood_value` + `submitted_at`; withholds data until 5 check-ins exist in the window. Web `mood-community.tsx` and mobile `Mood.tsx` Trends tab now render the real chart with loading/empty/error states; the previous "coming soon" stub and the omitted mobile chart are replaced. No schema change.
 - 2026-05-31: Android pixel pass. Built `Mood.tsx` + `api.ts` in `ctf/packages/mobile/src/features/mood/`; retired `MockMood.tsx`. Real bindings to `GET /api/mood/eligibility` and `POST /api/mood/submissions`. Omitted Trends tab chart and community-avg card (no aggregate-stats API). TypeScript, EOF, and parity gates pass. Android delivery status: ✅.
 - 2026-05-29: Web UI circle-back (design `c5d83c0`). Rebuilt the mood shell to the `Mood.tsx` mockup + Empty/Loading; fixed the eligibility (`?clientId=`) and submission (`{ clientId, moodValue, note }` + CSRF header) API contracts that previously 400'd; replaced fabricated trend/distribution data with the design's honest Community Pulse empty state; decomposed into modular sub-components within the rule-116 limits; removed banned "Phase 2" wording. No schema/API change.
 - 2026-05-18: Renamed "Gaps, Ambiguities, and Known Debt (Planning)" to canonical "Gaps and Known Technical Debt" per Rule 120.

--- a/ctf/packages/mobile/src/features/mood/Mood.tsx
+++ b/ctf/packages/mobile/src/features/mood/Mood.tsx
@@ -1,8 +1,9 @@
 // Real Mood screen — pixel-pass to design/artifacts/mockup-sandbox/src/components/mockups/survivor-hub/MobileMood.tsx
-// API bindings: GET /api/mood/eligibility, POST /api/mood/submissions
-// Omissions vs mockup (no aggregate stats API):
-//   - Trends tab: replaced with honest empty state (no 7-day chart, no community counts — no backing API)
-//   - Community avg card in check-in tab: omitted (fabricated in mockup; no aggregate endpoint)
+// API bindings: GET /api/mood/eligibility, POST /api/mood/submissions, GET /api/mood/community
+// The Trends tab renders the real aggregate community pulse (7-day average-mood
+// chart + counts) from /api/mood/community. The backend returns only counts and
+// per-day averages — never per-user rows — and withholds data until a minimum
+// number of check-ins exist, so a clean empty state shows below that threshold.
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -15,7 +16,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { fetchMoodEligibility, submitMood } from './api';
+import { fetchMoodCommunity, fetchMoodEligibility, submitMood, type CommunityPulse } from './api';
 
 const COLOR = '#EC4899';
 const BG = '#0F1117';
@@ -151,12 +152,96 @@ function SubmittedView({ onReset }: { onReset: () => void }) {
   );
 }
 
-// Trends tab: no aggregate-stats API exists; honest empty state per real-data-only rule.
+function weekdayLabel(dateIso: string): string {
+  const d = new Date(`${dateIso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return '';
+  return ['S', 'M', 'T', 'W', 'T', 'F', 'S'][d.getUTCDay()];
+}
+
+function faceForAverage(avg: number | null): { emoji: string; color: string } {
+  if (avg === null || Number.isNaN(avg)) return { emoji: '·', color: '#6B7280' };
+  const rounded = Math.max(1, Math.min(5, Math.round(avg)));
+  const match = MOODS.find((m) => m.value === rounded);
+  return match ? { emoji: match.emoji, color: match.color } : { emoji: '·', color: '#6B7280' };
+}
+
+// Trends tab: real aggregate community pulse from GET /api/mood/community.
+// Shows an empty state until the backend reports enough check-ins.
 function TrendsView() {
+  const [pulse, setPulse] = useState<CommunityPulse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [errored, setErrored] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setErrored(false);
+    fetchMoodCommunity()
+      .then((data) => { if (active) setPulse(data.pulse); })
+      .catch(() => { if (active) setErrored(true); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  if (loading) return <ActivityIndicator color={COLOR} style={s.loader} />;
+
+  if (errored || pulse === null || !pulse.hasEnoughData) {
+    return (
+      <View style={s.emptyWrap}>
+        <Text style={s.emptyTitle}>Community Wellness</Text>
+        <Text style={s.emptySub}>
+          Aggregated trends appear here once enough members have checked in. All data is fully anonymous — no names, no IDs, only mood scores by day.
+        </Text>
+      </View>
+    );
+  }
+
+  const headline = faceForAverage(pulse.averageMood);
+
   return (
-    <View style={s.emptyWrap}>
-      <Text style={s.emptyTitle}>Community Wellness</Text>
-      <Text style={s.emptySub}>Aggregated trends will appear here once community data is available.</Text>
+    <View>
+      <Text style={s.trendsTitle}>Community Wellness</Text>
+      <Text style={s.trendsSub}>Aggregated · Individual data never exposed</Text>
+
+      <View style={s.trendsCardsRow}>
+        <View style={[s.trendsCard, { backgroundColor: `${headline.color}10`, borderColor: `${headline.color}25` }]}>
+          <Text style={s.trendsCardEmoji}>{headline.emoji}</Text>
+          <Text style={[s.trendsCardValue, { color: headline.color }]}>
+            {pulse.averageMood !== null ? pulse.averageMood.toFixed(1) : '—'}/5
+          </Text>
+          <Text style={s.trendsCardLabel}>Avg mood ({pulse.windowDays}-day)</Text>
+        </View>
+        <View style={[s.trendsCard, { backgroundColor: `${COLOR}08`, borderColor: `${COLOR}20` }]}>
+          <Text style={[s.trendsCardValue, { color: COLOR }]}>{pulse.totalCount.toLocaleString()}</Text>
+          <Text style={s.trendsCardLabel}>Check-ins this week</Text>
+        </View>
+      </View>
+
+      <View style={s.chartCard}>
+        <Text style={s.chartTitle}>{pulse.windowDays}-Day Community Mood</Text>
+        <View style={s.chartRow}>
+          {pulse.days.map((day) => {
+            const heightPx = day.averageMood ? Math.max(6, (day.averageMood / 5) * 60) : 6;
+            return (
+              <React.Fragment key={day.dateIso}>
+                <View style={s.chartCol}>
+                  <View style={s.chartBarTrack}>
+                    <View
+                      style={[
+                        s.chartBar,
+                        { height: heightPx },
+                        day.averageMood ? { backgroundColor: COLOR } : s.chartBarEmpty,
+                      ]}
+                    />
+                  </View>
+                  <Text style={s.chartDayLabel}>{weekdayLabel(day.dateIso)}</Text>
+                  <Text style={s.chartDayValue}>{day.averageMood ? day.averageMood.toFixed(1) : '·'}</Text>
+                </View>
+              </React.Fragment>
+            );
+          })}
+        </View>
+      </View>
     </View>
   );
 }
@@ -345,6 +430,29 @@ const s = StyleSheet.create({
   emptyEmoji: { fontSize: 56, marginBottom: 16 },
   emptyTitle: { fontSize: 18, fontWeight: '800', color: '#F9FAFB', marginBottom: 6, textAlign: 'center' },
   emptySub: { fontSize: 13, color: '#6B7280', textAlign: 'center', lineHeight: 20 },
+  trendsTitle: { fontSize: 18, fontWeight: '800', color: '#F9FAFB', marginBottom: 4 },
+  trendsSub: { fontSize: 12, color: '#6B7280', marginBottom: 16 },
+  trendsCardsRow: { flexDirection: 'row', gap: 10, marginBottom: 12 },
+  trendsCard: { flex: 1, padding: 14, borderRadius: 12, borderWidth: 1, alignItems: 'center' },
+  trendsCardEmoji: { fontSize: 26, marginBottom: 2 },
+  trendsCardValue: { fontSize: 20, fontWeight: '800', marginBottom: 2 },
+  trendsCardLabel: { fontSize: 11, color: '#6B7280', textAlign: 'center' },
+  chartCard: {
+    padding: 16, borderRadius: 14,
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    borderWidth: 1, borderColor: 'rgba(255,255,255,0.06)',
+  },
+  chartTitle: { fontSize: 13, fontWeight: '700', color: '#9CA3AF', marginBottom: 12 },
+  chartRow: { flexDirection: 'row', gap: 6, alignItems: 'flex-end', height: 96 },
+  chartCol: { flex: 1, alignItems: 'center', justifyContent: 'flex-end' },
+  chartBarTrack: { width: '100%', height: 60, justifyContent: 'flex-end', alignItems: 'stretch' },
+  chartBar: { width: '100%', borderTopLeftRadius: 3, borderTopRightRadius: 3 },
+  chartBarEmpty: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1, borderColor: 'rgba(255,255,255,0.1)', borderStyle: 'dashed',
+  },
+  chartDayLabel: { fontSize: 10, color: '#4B5563', marginTop: 4 },
+  chartDayValue: { fontSize: 10, color: COLOR, fontWeight: '700' },
   navBar: {
     height: 72, flexDirection: 'row', alignItems: 'center',
     justifyContent: 'space-around', paddingHorizontal: 8,

--- a/ctf/packages/mobile/src/features/mood/api.ts
+++ b/ctf/packages/mobile/src/features/mood/api.ts
@@ -1,6 +1,7 @@
 // Mood plugin API client — binds to real backend routes.
 // GET  /api/mood/eligibility?clientId=   → EligibilityResponse
 // POST /api/mood/submissions             → SubmitResponse
+// GET  /api/mood/community               → CommunityResponse (aggregate only)
 
 const API_BASE = process.env.EXPO_PUBLIC_API_BASE || 'https://api.chargingthefuture.com';
 
@@ -9,6 +10,26 @@ export type EligibilityResponse = {
   eligible: boolean;
   cooldownUntilIso: string | null;
   lastSubmissionAtIso: string | null;
+};
+
+export type CommunityPulseDay = {
+  dateIso: string;
+  averageMood: number | null;
+  count: number;
+};
+
+export type CommunityPulse = {
+  windowDays: number;
+  minSample: number;
+  totalCount: number;
+  averageMood: number | null;
+  hasEnoughData: boolean;
+  days: CommunityPulseDay[];
+};
+
+export type CommunityResponse = {
+  ok: boolean;
+  pulse: CommunityPulse;
 };
 
 export type SubmitResponse = {
@@ -26,6 +47,15 @@ export async function fetchMoodEligibility(clientId: string): Promise<Eligibilit
     throw new Error(`eligibility_fetch_failed:${res.status}`);
   }
   return res.json() as Promise<EligibilityResponse>;
+}
+
+export async function fetchMoodCommunity(): Promise<CommunityResponse> {
+  const url = `${API_BASE}/api/mood/community`;
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) {
+    throw new Error(`community_fetch_failed:${res.status}`);
+  }
+  return res.json() as Promise<CommunityResponse>;
 }
 
 export async function submitMood(

--- a/ctf/packages/web/app/api/mood/community/route.ts
+++ b/ctf/packages/web/app/api/mood/community/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { requireMoodAccess, moodErrorResponse } from 'lib/mood/_lib';
+import { getMoodCommunityPulse } from 'lib/mood/repository';
+import { reportError } from 'lib/observability/report';
+
+// GET /api/mood/community — aggregate, anonymous community pulse for the Mood
+// plugin. Returns only counts and averages over the trailing window; never any
+// per-user rows, notes, or identifiers.
+export async function GET() {
+  const gate = await requireMoodAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const pulse = await getMoodCommunityPulse();
+    return NextResponse.json({ ok: true, pulse }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'mood', op: 'community' });
+    return moodErrorResponse(error, 'Community pulse unavailable.');
+  }
+}

--- a/ctf/packages/web/components/mood/mood-community.tsx
+++ b/ctf/packages/web/components/mood/mood-community.tsx
@@ -1,57 +1,155 @@
 "use client";
 
-// Community Pulse tab. There is no aggregate-stats backend yet (only
-// eligibility + submissions exist), so per the design's empty state this shows
-// the honest "data appears once members check in" placeholder rather than the
-// mockup's fabricated 7-day averages and distribution percentages.
+// Community Pulse tab. Renders the real aggregate from GET /api/mood/community:
+// a 7-day average-mood chart plus headline counts. The backend returns only
+// counts and per-day averages — never per-user rows — and suppresses the data
+// until a minimum number of check-ins exist, so a clean empty state shows first.
+import { useEffect, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { BarChart2, Lock, Shield, Smile } from "lucide-react";
-import { BORDER, COLOR, DAYS, SUBTLE, SURFACE, TEXT } from "./mood-shared";
+import {
+  BORDER,
+  COLOR,
+  SUBTLE,
+  SURFACE,
+  TEXT,
+  moodFaceForAverage,
+  weekdayLabel,
+  type MoodCommunityPulse,
+  type MoodCommunityResponse,
+} from "./mood-shared";
 
-export function MoodCommunity() {
+function PrivacyFooter() {
   return (
-    <ScrollArea style={{ flex: 1 }}>
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: 48 }}>
-        <div style={{ maxWidth: 460, textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
-          <div style={{ width: 80, height: 80, borderRadius: 24, background: `${COLOR}10`, border: `2px dashed ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
-            <Smile size={34} color={`${COLOR}60`} />
+    <>
+      <div style={{ display: "flex", gap: 24, flexWrap: "wrap", justifyContent: "center" }}>
+        {[
+          { icon: Shield, label: "Anonymous by design" },
+          { icon: Lock, label: "Zero personal data stored" },
+        ].map(({ icon: Icon, label }) => (
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 13, color: SUBTLE }}>
+            <Icon size={14} color={COLOR} /> {label}
           </div>
-          <div style={{ fontSize: 20, fontWeight: 800, color: TEXT }}>Community pulse coming soon</div>
-          <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
-            Aggregated community mood trends appear here once enough members have checked in. All data is fully anonymous — no names, no IDs, only aggregated mood scores by day.
-          </div>
+        ))}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11, color: `${SUBTLE}90` }}>
+        <BarChart2 size={12} color={SUBTLE} /> Aggregated across the whole community — individual check-ins are never shown.
+      </div>
+    </>
+  );
+}
 
-          <div style={{ width: "100%", borderRadius: 14, border: `1px solid ${BORDER}`, background: SURFACE, padding: "20px 24px" }}>
-            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 16 }}>
-              <span style={{ fontSize: 13, fontWeight: 600, color: SUBTLE }}>7-day community average</span>
-              <span style={{ fontSize: 12, color: `${SUBTLE}80` }}>Waiting for check-ins…</span>
-            </div>
-            <div style={{ display: "flex", gap: 8, height: 80, alignItems: "flex-end" }}>
-              {DAYS.map((day) => (
-                <div key={day} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
-                  <div style={{ flex: 1, width: "100%", borderRadius: "4px 4px 0 0", background: "rgba(255,255,255,0.04)", border: `1px dashed ${BORDER}`, minHeight: 40 }} />
-                  <span style={{ fontSize: 10, color: `${SUBTLE}60` }}>{day}</span>
-                </div>
-              ))}
-            </div>
-          </div>
+function EmptyPulse({ message }: { message: string }) {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: 48 }}>
+      <div style={{ maxWidth: 460, textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
+        <div style={{ width: 80, height: 80, borderRadius: 24, background: `${COLOR}10`, border: `2px dashed ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <Smile size={34} color={`${COLOR}60`} />
+        </div>
+        <div style={{ fontSize: 20, fontWeight: 800, color: TEXT }}>Not enough check-ins yet</div>
+        <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>{message}</div>
+        <PrivacyFooter />
+      </div>
+    </div>
+  );
+}
 
-          <div style={{ display: "flex", gap: 24 }}>
-            {[
-              { icon: Shield, label: "Anonymous by design" },
-              { icon: Lock, label: "Zero personal data stored" },
-            ].map(({ icon: Icon, label }) => (
-              <div key={label} style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 13, color: SUBTLE }}>
-                <Icon size={14} color={COLOR} /> {label}
-              </div>
-            ))}
-          </div>
+function PulseChart({ pulse }: { pulse: MoodCommunityPulse }) {
+  const maxScale = 5;
+  const headline = moodFaceForAverage(pulse.averageMood);
+  return (
+    <div style={{ width: "100%", maxWidth: 640, margin: "0 auto", display: "flex", flexDirection: "column", gap: 20 }}>
+      <div>
+        <div style={{ fontSize: 22, fontWeight: 800, color: TEXT, marginBottom: 4 }}>Community Wellness Trends</div>
+        <div style={{ fontSize: 14, color: SUBTLE }}>Aggregated anonymous data · Individual data never exposed</div>
+      </div>
 
-          <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11, color: `${SUBTLE}90` }}>
-            <BarChart2 size={12} color={SUBTLE} /> Trends populate as the community grows.
-          </div>
+      {/* Headline cards */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 12 }}>
+        <div style={{ padding: 20, borderRadius: 14, background: `${headline.color}10`, border: `1px solid ${headline.color}25`, textAlign: "center" }}>
+          <div style={{ fontSize: 40, lineHeight: 1 }}>{headline.emoji}</div>
+          <div style={{ fontSize: 24, fontWeight: 800, color: headline.color, marginTop: 6 }}>{pulse.averageMood?.toFixed(1) ?? "—"}<span style={{ fontSize: 14, color: SUBTLE, fontWeight: 600 }}> / 5</span></div>
+          <div style={{ fontSize: 12, color: SUBTLE, marginTop: 2 }}>Average mood ({pulse.windowDays}-day)</div>
+        </div>
+        <div style={{ padding: 20, borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}20`, textAlign: "center" }}>
+          <div style={{ fontSize: 28, fontWeight: 800, color: COLOR }}>{pulse.totalCount.toLocaleString()}</div>
+          <div style={{ fontSize: 12, color: SUBTLE, marginTop: 6 }}>Check-ins this week</div>
         </div>
       </div>
-    </ScrollArea>
+
+      {/* 7-day chart */}
+      <div style={{ padding: "24px", borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}` }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: SUBTLE, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 16 }}>{pulse.windowDays}-Day Community Mood</div>
+        <div style={{ display: "flex", gap: 10, alignItems: "flex-end", height: 140 }}>
+          {pulse.days.map((day) => {
+            const face = moodFaceForAverage(day.averageMood);
+            const heightPx = day.averageMood ? Math.max(8, (day.averageMood / maxScale) * 90) : 0;
+            return (
+              <div key={day.dateIso} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6, justifyContent: "flex-end", height: "100%" }}>
+                <div style={{ fontSize: 15 }}>{day.averageMood ? face.emoji : ""}</div>
+                {day.averageMood ? (
+                  <div style={{ width: "100%", borderRadius: "6px 6px 0 0", background: `linear-gradient(to top, ${COLOR}, ${COLOR}60)`, height: `${heightPx}px` }} />
+                ) : (
+                  <div style={{ width: "100%", borderRadius: "6px 6px 0 0", background: "rgba(255,255,255,0.04)", border: `1px dashed ${BORDER}`, height: 24 }} />
+                )}
+                <span style={{ fontSize: 10, color: SUBTLE }}>{weekdayLabel(day.dateIso)}</span>
+                <span style={{ fontSize: 10, color: COLOR, fontWeight: 700 }}>{day.averageMood ? day.averageMood.toFixed(1) : "·"}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 14 }}>
+        <PrivacyFooter />
+      </div>
+    </div>
   );
+}
+
+export function MoodCommunity() {
+  const [pulse, setPulse] = useState<MoodCommunityPulse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/mood/community", { signal: controller.signal, cache: "no-store" });
+        if (!res.ok) throw new Error("Community pulse unavailable.");
+        const data = (await res.json()) as MoodCommunityResponse;
+        if (!controller.signal.aborted) setPulse(data.pulse);
+      } catch (e) {
+        if (!controller.signal.aborted) setError(e instanceof Error ? e.message : "Community pulse unavailable.");
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }
+    void load();
+    return () => { controller.abort(); };
+  }, []);
+
+  let body;
+  if (loading) {
+    body = (
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 48, color: SUBTLE, fontSize: 14 }}>
+        Loading community pulse…
+      </div>
+    );
+  } else if (error) {
+    body = <EmptyPulse message="The community pulse could not be loaded right now. Please try again shortly." />;
+  } else if (!pulse || !pulse.hasEnoughData) {
+    body = <EmptyPulse message="Aggregated community mood trends appear here once enough members have checked in. All data is fully anonymous — no names, no IDs, only mood scores by day." />;
+  } else {
+    body = (
+      <div style={{ flex: 1, padding: 24 }}>
+        <PulseChart pulse={pulse} />
+      </div>
+    );
+  }
+
+  return <ScrollArea style={{ flex: 1 }}>{body}</ScrollArea>;
 }

--- a/ctf/packages/web/components/mood/mood-shared.ts
+++ b/ctf/packages/web/components/mood/mood-shared.ts
@@ -59,6 +59,44 @@ export function getMoodClientId(): string {
   }
 }
 
+// Community Pulse response from GET /api/mood/community. Aggregate only — no
+// per-user data is ever returned by the backend.
+export type MoodCommunityPulseDay = {
+  dateIso: string;
+  averageMood: number | null;
+  count: number;
+};
+
+export type MoodCommunityPulse = {
+  windowDays: number;
+  minSample: number;
+  totalCount: number;
+  averageMood: number | null;
+  hasEnoughData: boolean;
+  days: MoodCommunityPulseDay[];
+};
+
+export type MoodCommunityResponse = {
+  ok: boolean;
+  pulse: MoodCommunityPulse;
+};
+
+// Map a 1..5 average mood to the matching emoji + label + color for display.
+export function moodFaceForAverage(avg: number | null): { emoji: string; label: string; color: string } {
+  if (avg === null || Number.isNaN(avg)) return { emoji: "·", label: "No data", color: SUBTLE };
+  const rounded = Math.max(1, Math.min(5, Math.round(avg)));
+  const match = MOODS.find((m) => m.value === rounded);
+  return match ? { emoji: match.emoji, label: match.label, color: match.color } : { emoji: "·", label: "No data", color: SUBTLE };
+}
+
+// Short weekday label (Mon, Tue, …) for a yyyy-mm-dd date string, in UTC so it
+// lines up with the server's day buckets.
+export function weekdayLabel(dateIso: string): string {
+  const d = new Date(`${dateIso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return "";
+  return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][d.getUTCDay()];
+}
+
 export function daysUntil(iso: string | null): number | null {
   if (!iso) return null;
   const target = new Date(iso).getTime();

--- a/ctf/packages/web/lib/mood/constants.ts
+++ b/ctf/packages/web/lib/mood/constants.ts
@@ -8,3 +8,12 @@ export const MOOD_ERROR_CODE = {
 } as const;
 
 export const MOOD_COOLDOWN_DAYS = 7;
+
+// Community Pulse aggregation window in days. We summarize check-ins over the
+// trailing week so the chart matches the design's "7-day community mood".
+export const MOOD_PULSE_WINDOW_DAYS = 7;
+
+// Minimum total check-ins in the window before the aggregate is shown. Below
+// this threshold we return an empty state so a handful of submissions can never
+// be reverse-engineered into anything resembling an individual mood.
+export const MOOD_PULSE_MIN_SAMPLE = 5;

--- a/ctf/packages/web/lib/mood/repository.ts
+++ b/ctf/packages/web/lib/mood/repository.ts
@@ -1,6 +1,90 @@
 import { randomUUID } from 'crypto';
 import { queryDb } from 'lib/db/postgres';
-import { MOOD_COOLDOWN_DAYS } from './constants';
+import { MOOD_COOLDOWN_DAYS, MOOD_PULSE_MIN_SAMPLE, MOOD_PULSE_WINDOW_DAYS } from './constants';
+
+// One bucket of the community pulse: a single day in the trailing window with
+// the average mood (1..5) and how many check-ins it is made of. Never any
+// per-user data — only counts and averages.
+export type MoodCommunityPulseDay = {
+  dateIso: string;
+  averageMood: number | null;
+  count: number;
+};
+
+export type MoodCommunityPulse = {
+  windowDays: number;
+  minSample: number;
+  totalCount: number;
+  averageMood: number | null;
+  // hasEnoughData is false until at least MOOD_PULSE_MIN_SAMPLE check-ins exist
+  // in the window; the UI shows an empty state in that case.
+  hasEnoughData: boolean;
+  days: MoodCommunityPulseDay[];
+};
+
+// Aggregate, anonymous community mood over the trailing window. This reads only
+// mood_value + submitted_at and groups by calendar day; it never selects
+// user_id, client_id, the note, or any row-level identifier, so nothing here can
+// be tied back to a person. When the window holds fewer than the minimum sample
+// of check-ins we report hasEnoughData=false and suppress the per-day averages.
+export async function getMoodCommunityPulse(): Promise<MoodCommunityPulse> {
+  const windowDays = MOOD_PULSE_WINDOW_DAYS;
+
+  const result = await queryDb<{ day: Date; avg_mood: string; count: string }>(
+    `SELECT date_trunc('day', submitted_at) AS day,
+            AVG(mood_value)::numeric(10,4) AS avg_mood,
+            COUNT(*) AS count
+     FROM mood_submissions
+     WHERE submitted_at >= NOW() - ($1::int * INTERVAL '1 day')
+     GROUP BY day
+     ORDER BY day ASC`,
+    [windowDays],
+  );
+
+  const byIso = new Map<string, { sum: number; count: number }>();
+  let totalCount = 0;
+  let totalSum = 0;
+
+  for (const row of result.rows) {
+    const count = Number.parseInt(row.count, 10);
+    const avg = Number.parseFloat(row.avg_mood);
+    if (!Number.isFinite(count) || count <= 0 || !Number.isFinite(avg)) continue;
+    const iso = new Date(row.day).toISOString().slice(0, 10);
+    byIso.set(iso, { sum: avg * count, count });
+    totalCount += count;
+    totalSum += avg * count;
+  }
+
+  // Build a contiguous day series for the whole window so the chart always has
+  // one bar per day, even on days with no check-ins.
+  const days: MoodCommunityPulseDay[] = [];
+  const today = new Date();
+  for (let offset = windowDays - 1; offset >= 0; offset -= 1) {
+    const d = new Date(today);
+    d.setUTCDate(d.getUTCDate() - offset);
+    const iso = d.toISOString().slice(0, 10);
+    const bucket = byIso.get(iso);
+    days.push({
+      dateIso: iso,
+      averageMood: bucket ? Math.round((bucket.sum / bucket.count) * 100) / 100 : null,
+      count: bucket ? bucket.count : 0,
+    });
+  }
+
+  const hasEnoughData = totalCount >= MOOD_PULSE_MIN_SAMPLE;
+  const averageMood = hasEnoughData && totalCount > 0 ? Math.round((totalSum / totalCount) * 100) / 100 : null;
+
+  return {
+    windowDays,
+    minSample: MOOD_PULSE_MIN_SAMPLE,
+    totalCount: hasEnoughData ? totalCount : 0,
+    averageMood,
+    hasEnoughData,
+    // Below threshold we still return a flat, empty day series (counts zeroed)
+    // so the client renders the empty chart without leaking the small counts.
+    days: hasEnoughData ? days : days.map((d) => ({ ...d, averageMood: null, count: 0 })),
+  };
+}
 
 export async function getMoodEligibility(input: { clientId: string }): Promise<{ eligible: boolean; cooldownUntilIso: string | null; lastSubmissionAtIso: string | null }> {
   const result = await queryDb<{ submitted_at: Date }>(


### PR DESCRIPTION
Replaces the Mood plugin's "Community pulse coming soon" stub with a real aggregate.

A new `GET /api/mood/community` route and `getMoodCommunityPulse` repository function compute an **anonymous** 7-day average-mood chart plus check-in counts from the existing `mood_submissions` table. The query reads only the mood value and timestamp grouped by day — it never returns per-user rows, notes, or identifiers — and withholds data until at least 5 check-ins exist in the window, showing a clean empty state otherwise. The web Community Pulse tab and the mobile Trends tab both render the real chart with loading, empty, and error states.

No schema change: the pulse is derived from existing data only.

Built by a background agent; web + mobile typecheck, ESLint, and EOF checks all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_