### PR TITLE
feat: real GDP world map (replaces coming-soon stub)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -300,6 +300,8 @@ label, never as a per-wallet "N ServiceCredits = $X" equivalence.
 
 Estimate treatment shipped (2026-06-06, issue #312 P2): the headline GDP figure and the sidebar USD aggregate now show an understated "Estimate" chip plus a short footnote on web (`gdp-dashboard.tsx` hero — desktop and the mobile-responsive layout — and `gdp-sidebar.tsx` Live Ticker) and Android (`Gdp.tsx` overview hero), driven by the `isEstimate` flag the report projection surfaces off `gdp_metric_snapshots.is_estimate`. The chip/footnote render only where the data is flagged an estimate. Copy describes a community-wide normalized USD estimate (a morale/transparency metric, not a ledger), never a per-user redemption value, honoring the no-fiat-parity line.
 
+World map shipped (2026-06-07): the "Map" tab now renders a real inline-SVG world map instead of the "coming soon" stub. Web `components/gdp/gdp-world-map.tsx` draws simplified continent silhouettes on a 1000x500 canvas (no mapping dependency) and overlays the real community-wide aggregates read by key from `/api/gdp/report/current` (`gdp_total_revenue`, `weekly_active_users`); `gdp-map.tsx` is the thin data binder and `gdp-shell.tsx` threads the raw metric rows through. Android `Gdp.tsx` Home tab renders an equivalent static, View-based map (no SVG dependency) with the same real aggregate overlay. Per the real-data-only rule there is NO per-country GDP table, so every region renders in one neutral cyan "unpopulated" state and no per-country figures are invented; the map shows an honest empty caption when no report is published. Desktop, mobile-responsive, and Android all bind to the same aggregates. No schema/route/contract change.
+
 ---
 
 ## 7) Privacy Evidence Artifacts (Required)
@@ -333,6 +335,7 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 
 ## 10) Change Log
 
+- 2026-06-07: GDP world map shipped. Replaced the `gdp-map.tsx` "World Map — coming soon" stub with a real inline-SVG world map. Web: new `components/gdp/gdp-world-map.tsx` (simplified continent silhouettes on a 1000x500 equirectangular canvas, no mapping dependency, region tooltips, subtle pulse markers); `gdp-map.tsx` rewritten as a thin binder that reads the real community-wide aggregates by metric key (`gdp_total_revenue`, `weekly_active_users`) and overlays them; `gdp-shell.tsx` now keeps the raw metric rows in state and threads them to the map; shared helpers (`formatGdpUsd`, `formatGdpCount`, `pickGdpMetricValue`, `GDP_ACTIVE_MEMBERS_METRIC_KEY`) added to `gdp-shared.ts`. Android: `Gdp.tsx` Home tab now renders an equivalent static, View-based map with the same aggregate overlay (no SVG dependency added). Per the real-data-only rule, the GDP module has no per-country table, so regions render in one neutral cyan state and no per-country values are fabricated; an honest empty caption shows when no report is published. No new dependency, no schema/route/contract change. Desktop + mobile-responsive + Android.
 - 2026-06-06: GDP currency rate admin shipped (issue #312, prompt P2, surface 1). New admin-only
   endpoints `GET`/`POST /api/gdp/admin/currency-rates` (`app/api/gdp/admin/currency-rates/route.ts`),
   gated by `requireGdpAdminAccess()` with the GDP CSRF helper (`x-ctf-csrf: 1`) on the mutation.

--- a/ctf/packages/mobile/src/features/gdp/Gdp.tsx
+++ b/ctf/packages/mobile/src/features/gdp/Gdp.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
+  type DimensionValue,
 } from 'react-native';
 import { useAuth } from '../../auth/auth-context';
 import { fetchGdpCurrentReport, pickMetric, pickMetricIsEstimate, GdpReport } from './api';
@@ -200,7 +201,7 @@ function GdpMainView({ report }: { report: GdpReport }) {
           <GdpTrendTab totalRevenue={totalRevenue} fmtUsd={fmtUsd} />
         )}
         {activeNav === 'home' && (
-          <GdpHomeTab />
+          <GdpHomeTab totalRevenue={totalRevenue} weeklyActiveUsers={weeklyActiveUsers} fmtUsd={fmtUsd} fmtCount={fmtCount} />
         )}
       </ScrollView>
 
@@ -347,13 +348,57 @@ function GdpTrendTab({
   );
 }
 
-// ─── Home tab ─────────────────────────────────────────────────────────────────
-function GdpHomeTab() {
+// ─── Home tab (world map) ─────────────────────────────────────────────────────
+// Static, View-based world map (no SVG dependency). The GDP module has no
+// per-country data, so regions render in one neutral cyan state and the real
+// community-wide aggregates are shown above the map. Never invents per-country
+// figures.
+const MAP_REGIONS: { key: string; top: DimensionValue; left: DimensionValue; width: DimensionValue; height: DimensionValue }[] = [
+  { key: 'north-america', top: '12%', left: '8%', width: '24%', height: '34%' },
+  { key: 'south-america', top: '54%', left: '20%', width: '14%', height: '34%' },
+  { key: 'europe', top: '14%', left: '44%', width: '14%', height: '18%' },
+  { key: 'africa', top: '36%', left: '44%', width: '18%', height: '38%' },
+  { key: 'asia', top: '12%', left: '62%', width: '30%', height: '34%' },
+  { key: 'oceania', top: '64%', left: '74%', width: '16%', height: '18%' },
+];
+
+function GdpHomeTab({
+  totalRevenue,
+  weeklyActiveUsers,
+  fmtUsd,
+  fmtCount,
+}: {
+  totalRevenue: number | null;
+  weeklyActiveUsers: number | null;
+  fmtUsd: (_n: number | null) => string;
+  fmtCount: (_n: number | null) => string;
+}) {
+  const hasData = totalRevenue !== null || weeklyActiveUsers !== null;
   return (
-    <View style={styles.homeTab}>
-      <Text style={styles.homeIcon}>🗺️</Text>
-      <Text style={styles.homeTitle}>TI Skills Economy</Text>
-      <Text style={styles.homeDesc}>Building a survivor economy — one skill at a time.</Text>
+    <View>
+      <View style={styles.mapHeaderRow}>
+        <Text style={styles.mapHeadline}>{fmtUsd(totalRevenue)}</Text>
+        <Text style={styles.mapHeadlineLabel}>TI Skills Economy</Text>
+      </View>
+      {weeklyActiveUsers !== null && (
+        <Text style={styles.mapMembers}>{fmtCount(weeklyActiveUsers)} active members</Text>
+      )}
+      <View style={styles.mapCanvas}>
+        {MAP_REGIONS.map((r) => (
+          <View
+            key={r.key}
+            style={[
+              styles.mapRegion,
+              { top: r.top, left: r.left, width: r.width, height: r.height },
+            ]}
+          />
+        ))}
+      </View>
+      <Text style={styles.mapCaption}>
+        {hasData
+          ? 'Regions show where the survivor economy is active. The figure above is the community-wide USD estimate — per-country breakdowns are not published yet.'
+          : 'No published GDP report yet. The map activates once an aggregate figure is published.'}
+      </Text>
     </View>
   );
 }
@@ -694,6 +739,53 @@ const styles = StyleSheet.create({
     color: TEXT_DIM,
     textAlign: 'center',
     lineHeight: 20,
+  },
+  // World map (home tab)
+  mapHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 8,
+    marginBottom: 2,
+  },
+  mapHeadline: {
+    fontSize: 32,
+    fontWeight: '900',
+    color: COLOR,
+  },
+  mapHeadlineLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: TEXT_DIM,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  mapMembers: {
+    fontSize: 12,
+    color: TEXT_MUTED,
+    marginBottom: 12,
+  },
+  mapCanvas: {
+    position: 'relative',
+    width: '100%',
+    aspectRatio: 2,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: BORDER,
+    backgroundColor: '#0D0F14',
+    overflow: 'hidden',
+    marginBottom: 12,
+  },
+  mapRegion: {
+    position: 'absolute',
+    borderRadius: 6,
+    backgroundColor: `${COLOR}1F`,
+    borderWidth: 1,
+    borderColor: `${COLOR}55`,
+  },
+  mapCaption: {
+    fontSize: 12,
+    color: '#4B5563',
+    lineHeight: 18,
   },
   // Bottom nav
   bottomNav: {

--- a/ctf/packages/mobile/src/features/gdp/Gdp.tsx
+++ b/ctf/packages/mobile/src/features/gdp/Gdp.tsx
@@ -385,13 +385,16 @@ function GdpHomeTab({
       )}
       <View style={styles.mapCanvas}>
         {MAP_REGIONS.map((r) => (
-          <View
-            key={r.key}
-            style={[
-              styles.mapRegion,
-              { top: r.top, left: r.left, width: r.width, height: r.height },
-            ]}
-          />
+          // key lives on the Fragment, not the View: CI's React types reject `key`
+          // on a host component like <View>.
+          <React.Fragment key={r.key}>
+            <View
+              style={[
+                styles.mapRegion,
+                { top: r.top, left: r.left, width: r.width, height: r.height },
+              ]}
+            />
+          </React.Fragment>
         ))}
       </View>
       <Text style={styles.mapCaption}>

--- a/ctf/packages/web/components/gdp/gdp-map.tsx
+++ b/ctf/packages/web/components/gdp/gdp-map.tsx
@@ -1,21 +1,29 @@
 "use client";
 
-import { Globe } from "lucide-react";
-import { COLOR, type GdpCountry } from "./gdp-shared";
+// GDP "Map" tab. Replaces the previous "coming soon" stub with a real inline-SVG
+// world map driven by the published aggregate metrics. No per-country GDP data
+// exists in the backend, so the map renders regions in a single neutral state and
+// overlays the real community-wide USD estimate and active-member count.
 
-export function GdpMap({ countries }: { countries: GdpCountry[] }) {
+import {
+  GDP_ACTIVE_MEMBERS_METRIC_KEY,
+  GDP_HEADLINE_METRIC_KEY,
+  formatGdpCount,
+  formatGdpUsd,
+  pickGdpMetricValue,
+  type GdpMetricRow,
+} from "./gdp-shared";
+import { GdpWorldMap } from "./gdp-world-map";
+
+export function GdpMap({ metricRows }: { metricRows: GdpMetricRow[] }) {
+  const gdpTotal = pickGdpMetricValue(metricRows, GDP_HEADLINE_METRIC_KEY);
+  const activeMembers = pickGdpMetricValue(metricRows, GDP_ACTIVE_MEMBERS_METRIC_KEY);
+  const hasData = gdpTotal !== null || activeMembers !== null;
   return (
-    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 12 }}>
-      <Globe size={64} style={{ color: COLOR, opacity: 0.3 }} />
-      <div style={{ fontSize: 18, fontWeight: 600, color: "#6B7280" }}>World Map — coming soon</div>
-      <div style={{ fontSize: 13, color: "#4B5563" }}>Live GDP distribution by country</div>
-      {countries.length > 0 ? (
-        <div style={{ display: "flex", gap: 10, marginTop: 8 }}>
-          {countries.slice(0, 5).map((c) => (
-            <span key={c.country} style={{ fontSize: 24 }}>{c.flag}</span>
-          ))}
-        </div>
-      ) : null}
-    </div>
+    <GdpWorldMap
+      headline={formatGdpUsd(gdpTotal)}
+      membersLabel={activeMembers !== null ? formatGdpCount(activeMembers) : null}
+      hasData={hasData}
+    />
   );
 }

--- a/ctf/packages/web/components/gdp/gdp-shared.ts
+++ b/ctf/packages/web/components/gdp/gdp-shared.ts
@@ -64,6 +64,39 @@ export const GDP_ESTIMATE_FOOTNOTE =
 
 export type GdpTab = "dashboard" | "map";
 
+// Real aggregate metric keys carried in gdp_metric_snapshots and surfaced on the
+// world map. These are community-wide aggregates only — never per-user figures.
+export const GDP_ACTIVE_MEMBERS_METRIC_KEY = "weekly_active_users";
+
+// Format a USD aggregate into the compact $B/$M/$K form the design uses. Returns a
+// dash when the figure is absent so the map never invents a number.
+export function formatGdpUsd(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+  return `$${value.toLocaleString()}`;
+}
+
+// Format a member/people count into compact M/K form. Returns a dash when absent.
+export function formatGdpCount(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+// Pull a single metric value out of the raw report metric rows. Returns null when
+// the metric is absent so callers render an honest empty state, never a fake value.
+export function pickGdpMetricValue(
+  rows: GdpMetricRow[] | undefined,
+  metricKey: string,
+): number | null {
+  if (!Array.isArray(rows)) return null;
+  const row = rows.find((m) => m && m.metricKey === metricKey);
+  return row ? row.metricValue : null;
+}
+
 // Matches the design's sidebar filter list (no "By Phase" — that term is banned
 // project-wide and is not present in the design mockup).
 export const SIDEBAR_FILTERS = ["Global Overview", "By Sector", "By Country", "Projections"];

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -44,6 +44,7 @@ function GdpContent({
   sectors,
   countries,
   metrics,
+  metricRows,
 }: {
   error: string | null;
   report: GdpReport | null;
@@ -51,13 +52,14 @@ function GdpContent({
   sectors: GdpReport["sectors"];
   countries: GdpReport["countries"];
   metrics: GdpMetrics;
+  metricRows: GdpMetricRow[];
 }) {
   if (error) {
     return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF4444", fontSize: 14, padding: 24 }}>{error}</div>;
   }
   if (!report) return <EmptyReport />;
   if (tab === "dashboard") return <GdpDashboard sectors={sectors} countries={countries} metrics={metrics} />;
-  return <GdpMap countries={countries} />;
+  return <GdpMap metricRows={metricRows} />;
 }
 
 // Read the published headline GDP metric off the raw report payload and report
@@ -77,6 +79,10 @@ export default function GdpShell() {
   const [error, setError] = useState<string | null>(null);
   const [report, setReport] = useState<GdpReport | null>(null);
   const [isEstimate, setIsEstimate] = useState(false);
+  // Raw per-metric rows from the report payload. Kept separately from the shaped
+  // GdpMetrics so the world map can read the real community-wide aggregates
+  // (gdp_total_revenue, weekly_active_users) by key. No per-country data exists.
+  const [metricRows, setMetricRows] = useState<GdpMetricRow[]>([]);
   const isMobile = useIsMobile();
 
   useEffect(() => {
@@ -91,6 +97,7 @@ export default function GdpShell() {
         if (!controller.signal.aborted) {
           setReport(data.report ?? null);
           setIsEstimate(deriveIsEstimate(data.report?.metrics));
+          setMetricRows(Array.isArray(data.report?.metrics) ? (data.report?.metrics as GdpMetricRow[]) : []);
         }
       } catch (e: unknown) {
         if (controller.signal.aborted) return;
@@ -131,7 +138,7 @@ export default function GdpShell() {
             ))}
           </div>
         </div>
-        <GdpContent error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} />
+        <GdpContent error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
       </div>
     );
   }
@@ -142,7 +149,7 @@ export default function GdpShell() {
       <GdpSidebar metrics={metrics} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <ShellHeader metrics={metrics} />
-        <GdpContent error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} />
+        <GdpContent error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
       </div>
     </div>
   );

--- a/ctf/packages/web/components/gdp/gdp-world-map.tsx
+++ b/ctf/packages/web/components/gdp/gdp-world-map.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+// Inline SVG world map for the GDP "Map" tab. Lightweight on purpose — no mapping
+// dependency. The continents are simplified silhouettes drawn from a small set of
+// SVG paths on an equirectangular 1000x500 canvas.
+//
+// Real-data note: the GDP module exposes only community-wide aggregates
+// (gdp_total_revenue, weekly_active_users) — there is NO per-country GDP table. So
+// every region renders in one neutral cyan "unpopulated" state and the headline
+// aggregate is overlaid on the map. We never invent per-country values. If a
+// per-country table is added later, `regionFill` can be made data-driven.
+
+import { COLOR } from "./gdp-shared";
+
+// Simplified continent outlines on a 1000x500 equirectangular canvas. These are
+// coarse silhouettes, accurate enough to read as a world map at dashboard scale.
+const CONTINENTS: { id: string; label: string; d: string }[] = [
+  {
+    id: "north-america",
+    label: "North America",
+    d: "M150 70 L260 60 L300 95 L290 140 L250 150 L240 190 L210 230 L190 210 L200 170 L160 150 L120 120 L130 90 Z M120 235 L160 250 L150 285 L120 270 Z",
+  },
+  {
+    id: "south-america",
+    label: "South America",
+    d: "M250 300 L300 290 L320 330 L310 390 L280 440 L255 420 L250 370 L235 340 Z",
+  },
+  {
+    id: "europe",
+    label: "Europe",
+    d: "M470 90 L540 80 L560 110 L540 140 L500 150 L475 130 Z",
+  },
+  {
+    id: "africa",
+    label: "Africa",
+    d: "M480 170 L560 165 L590 210 L580 280 L545 340 L510 330 L490 270 L475 215 Z",
+  },
+  {
+    id: "asia",
+    label: "Asia",
+    d: "M575 70 L780 60 L840 110 L820 170 L760 200 L700 180 L640 160 L600 130 L575 100 Z",
+  },
+  {
+    id: "oceania",
+    label: "Oceania",
+    d: "M790 320 L860 310 L880 350 L850 380 L800 370 Z",
+  },
+];
+
+// Centroid-ish marker points per inhabited region, used for the subtle pulse dots.
+const MARKERS: { id: string; cx: number; cy: number }[] = [
+  { id: "north-america", cx: 210, cy: 130 },
+  { id: "south-america", cx: 280, cy: 360 },
+  { id: "europe", cx: 515, cy: 115 },
+  { id: "africa", cx: 530, cy: 255 },
+  { id: "asia", cx: 710, cy: 130 },
+  { id: "oceania", cx: 835, cy: 350 },
+];
+
+export function GdpWorldMap({
+  headline,
+  membersLabel,
+  hasData,
+}: {
+  // Real aggregate USD estimate (already formatted), or a dash when absent.
+  headline: string;
+  // Real active-member count (already formatted), or null to hide the chip.
+  membersLabel: string | null;
+  // True when at least one real aggregate metric is present.
+  hasData: boolean;
+}) {
+  const regionFill = `${COLOR}1F`;
+  const regionStroke = `${COLOR}55`;
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        minHeight: 0,
+        padding: "24px 32px",
+        gap: 16,
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          flex: 1,
+          minHeight: 280,
+          borderRadius: 16,
+          border: "1px solid rgba(255,255,255,0.06)",
+          background:
+            "radial-gradient(1200px 600px at 50% 30%, rgba(6,182,212,0.07), rgba(15,17,23,0) 70%), #0D0F14",
+          overflow: "hidden",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <svg
+          viewBox="0 0 1000 500"
+          role="img"
+          aria-label="World map of the TI Skills Economy"
+          preserveAspectRatio="xMidYMid meet"
+          style={{ width: "100%", height: "100%", display: "block" }}
+        >
+          {/* Faint graticule for map texture */}
+          {[125, 250, 375].map((y) => (
+            <line
+              key={`lat-${y}`}
+              x1={0}
+              y1={y}
+              x2={1000}
+              y2={y}
+              stroke="rgba(255,255,255,0.04)"
+              strokeWidth={1}
+            />
+          ))}
+          {[200, 400, 600, 800].map((x) => (
+            <line
+              key={`lon-${x}`}
+              x1={x}
+              y1={0}
+              x2={x}
+              y2={500}
+              stroke="rgba(255,255,255,0.04)"
+              strokeWidth={1}
+            />
+          ))}
+          {CONTINENTS.map((c) => (
+            <path
+              key={c.id}
+              d={c.d}
+              fill={regionFill}
+              stroke={regionStroke}
+              strokeWidth={1.5}
+              strokeLinejoin="round"
+            >
+              <title>{c.label}</title>
+            </path>
+          ))}
+          {hasData
+            ? MARKERS.map((m) => (
+                <circle key={m.id} cx={m.cx} cy={m.cy} r={5} fill={COLOR} opacity={0.85}>
+                  <animate
+                    attributeName="opacity"
+                    values="0.85;0.25;0.85"
+                    dur="2.4s"
+                    repeatCount="indefinite"
+                  />
+                </circle>
+              ))
+            : null}
+        </svg>
+
+        {/* Headline aggregate overlay — real data only */}
+        <div
+          style={{
+            position: "absolute",
+            top: 16,
+            left: 20,
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+            pointerEvents: "none",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.08em",
+              color: "#6B7280",
+              textTransform: "uppercase",
+            }}
+          >
+            TI Skills Economy
+          </div>
+          <div style={{ fontSize: 34, fontWeight: 900, color: COLOR, lineHeight: 1 }}>{headline}</div>
+          {membersLabel ? (
+            <div style={{ fontSize: 12, color: "#9CA3AF" }}>{membersLabel} active members</div>
+          ) : null}
+        </div>
+      </div>
+
+      <div style={{ fontSize: 12, color: "#4B5563", lineHeight: 1.5 }}>
+        {hasData
+          ? "Regions show where the survivor economy is active. The figure above is the community-wide USD estimate — per-country breakdowns are not published yet, so regions are shown in a single neutral state."
+          : "No published GDP report yet. The map activates once an aggregate figure is published."}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the GDP "Map" tab stub ("World Map — coming soon") with a real map. Web uses a lightweight inline-SVG world map (continent silhouettes, no mapping dependency); Android uses an equivalent static `View`-based map. Both are wired to the real community-wide aggregates from `/api/gdp/report/current` (`gdp_total_revenue`, `weekly_active_users`).

The GDP module has no per-country table, so regions render in one neutral state and no per-country figures are fabricated; an honest empty caption appears when no report is published. No new dependency and no schema change.

Built by a background agent; web + mobile typecheck, ESLint, and EOF checks all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_