### PR TITLE
chore: remove dead Notifications bell stub from the icon rail

### DIFF
--- a/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { MessageSquare, Zap, Bell, Shield } from 'lucide-react';
+import { MessageSquare, Zap, Shield } from 'lucide-react';
 import type { ShellSection } from './shell-types';
 import styles from './community-shell.module.css';
 
@@ -37,17 +37,6 @@ export function ShellIconRail({ section, onSectionChange, initial = 'S' }: IconR
       </button>
 
       <div className={styles.iconRailSpacer} aria-hidden="true" />
-
-      <button
-        type="button"
-        className={`${styles.iconRailBtn} ${styles.iconRailBtnDisabled}`}
-        aria-label="Notifications coming soon"
-        aria-disabled="true"
-        disabled
-        title="Notifications coming soon"
-      >
-        <Bell size={18} />
-      </button>
 
       <Link
         href="/account/data"


### PR DESCRIPTION
The community-shell icon rail had a permanently **disabled** "Notifications coming soon" bell. There is no notifications design, inventory, schema, or backend — it was a leftover placeholder, and a push-notification system isn't an obvious fit for the platform's trauma-informed, calm-by-default posture. Removed the button and its now-unused `Bell` import; chat, apps, account, and avatar controls are unchanged.

Withdraws the design request in #347. Web typecheck, ESLint, and EOF checks pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_