### PR TITLE
ci: source Expo workflow app secrets from Infisical

### DIFF
--- a/.github/workflows/expo-android-release.yml
+++ b/.github/workflows/expo-android-release.yml
@@ -25,23 +25,37 @@ jobs:
     env:
       MOBILE_ENV_TARGET: production
       EAS_BUILD_PROFILE: production
-      # Same names the web app and app.config.ts read — reused production secrets.
-      NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY }}
-      NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
-      NEXT_PUBLIC_AUTH_PROVIDER: ${{ secrets.NEXT_PUBLIC_AUTH_PROVIDER }}
-      NEXT_PUBLIC_AUTH_SIGN_IN_URL: ${{ secrets.NEXT_PUBLIC_AUTH_SIGN_IN_URL }}
-      EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID }}
-      EXPO_MOBILE_PROJECT_ID: ${{ secrets.EXPO_MOBILE_PROJECT_ID }}
-      EXPO_MOBILE_UPDATES_URL: ${{ secrets.EXPO_MOBILE_UPDATES_URL }}
+      # The app secrets (Clerk keys, app URL, Expo project id/updates URL) are no
+      # longer GitHub Actions secrets — Infisical is the single source of truth.
+      # The "Inject secrets from Infisical" step below loads them into the job env
+      # for all later steps, so app.config.ts and check:mobile-env read them from
+      # process.env exactly as before.
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Infisical is the single source of truth for app secrets. This step injects
+      # the Clerk keys, the app URL, and the Expo project id/updates URL into the
+      # job env for every later step. env-slug is the environment *slug* (not its
+      # display name): the Production environment's slug is "prod", so
+      # env-slug: production returns a 404. recursive:true also reads secrets
+      # nested in sub-folders, not just the root path.
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
+
       - name: Fail fast when EXPO_TOKEN is missing
         if: ${{ secrets.EXPO_TOKEN == '' }}
         run: |
           echo "EXPO_TOKEN secret is not set. Add it in repository settings before release builds can run."
           exit 1
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -30,23 +30,37 @@ jobs:
     env:
       MOBILE_ENV_TARGET: preview
       EAS_BUILD_PROFILE: preview
-      # Same names the web app and app.config.ts read — reused production secrets.
-      NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY }}
-      NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
-      NEXT_PUBLIC_AUTH_PROVIDER: ${{ secrets.NEXT_PUBLIC_AUTH_PROVIDER }}
-      NEXT_PUBLIC_AUTH_SIGN_IN_URL: ${{ secrets.NEXT_PUBLIC_AUTH_SIGN_IN_URL }}
-      EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID }}
-      EXPO_MOBILE_PROJECT_ID: ${{ secrets.EXPO_MOBILE_PROJECT_ID }}
-      EXPO_MOBILE_UPDATES_URL: ${{ secrets.EXPO_MOBILE_UPDATES_URL }}
+      # The app secrets (Clerk keys, app URL, Expo project id/updates URL) are no
+      # longer GitHub Actions secrets — Infisical is the single source of truth.
+      # The "Inject secrets from Infisical" step below loads them into the job env
+      # for all later steps, so app.config.ts and check:mobile-env read them from
+      # process.env exactly as before.
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Infisical is the single source of truth for app secrets. This step injects
+      # the Clerk keys, the app URL, and the Expo project id/updates URL into the
+      # job env for every later step. env-slug is the environment *slug* (not its
+      # display name): the Production environment's slug is "prod", so
+      # env-slug: production returns a 404. recursive:true also reads secrets
+      # nested in sub-folders, not just the root path.
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
+
       - name: Fail fast when EXPO_TOKEN is missing
         if: ${{ secrets.EXPO_TOKEN == '' }}
         run: |
           echo "EXPO_TOKEN secret is not set. Add it in repository settings before preview builds can run."
           exit 1
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/expo-update.yml
+++ b/.github/workflows/expo-update.yml
@@ -28,23 +28,37 @@ jobs:
       contents: read
     env:
       MOBILE_ENV_TARGET: production
-      # Same names the web app and app.config.ts read — reused production secrets.
-      NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY }}
-      NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
-      NEXT_PUBLIC_AUTH_PROVIDER: ${{ secrets.NEXT_PUBLIC_AUTH_PROVIDER }}
-      NEXT_PUBLIC_AUTH_SIGN_IN_URL: ${{ secrets.NEXT_PUBLIC_AUTH_SIGN_IN_URL }}
-      EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID }}
-      EXPO_MOBILE_PROJECT_ID: ${{ secrets.EXPO_MOBILE_PROJECT_ID }}
-      EXPO_MOBILE_UPDATES_URL: ${{ secrets.EXPO_MOBILE_UPDATES_URL }}
+      # The app secrets (Clerk keys, app URL, Expo project id/updates URL) are no
+      # longer GitHub Actions secrets — Infisical is the single source of truth.
+      # The "Inject secrets from Infisical" step below loads them into the job env
+      # for all later steps, so app.config.ts and check:mobile-env read them from
+      # process.env exactly as before.
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Infisical is the single source of truth for app secrets. This step injects
+      # the Clerk keys, the app URL, and the Expo project id/updates URL into the
+      # job env for every later step. env-slug is the environment *slug* (not its
+      # display name): the Production environment's slug is "prod", so
+      # env-slug: production returns a 404. recursive:true also reads secrets
+      # nested in sub-folders, not just the root path.
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
+
       - name: Fail fast when EXPO_TOKEN is missing
         if: ${{ secrets.EXPO_TOKEN == '' }}
         run: |
           echo "EXPO_TOKEN secret is not set. Add it in repository settings before OTA updates can run."
           exit 1
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -72,6 +86,8 @@ jobs:
 
       - name: Publish EAS update
         working-directory: ctf/packages/mobile
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
-          eas update --channel production --message "${GITHUB_SHA}: ${{ github.event.head_commit.message }}" --non-interactive
+          eas update --channel production --message "${GITHUB_SHA}: ${HEAD_COMMIT_MESSAGE}" --non-interactive

--- a/ctf/docs/mobile/EXPO_CLOUD_WORKFLOW.md
+++ b/ctf/docs/mobile/EXPO_CLOUD_WORKFLOW.md
@@ -9,23 +9,42 @@ staging or preview backend.
 
 ## Required Secrets
 
-Configure all of these as GitHub **secrets** (Settings → Secrets and variables → Actions → Secrets).
-The mobile workflows reuse the **same** secrets the web app already uses, so there is one set of
-values to manage.
+Secrets come from **two places**. The app secrets live in Infisical (the single source of truth); the
+GitHub Actions secrets are only the bootstrap credentials the workflow needs before it can reach
+Infisical, plus the EAS token. The mobile workflows reuse the **same** app secret values the web app
+already uses, so there is one set of values to manage.
+
+### GitHub Actions secrets (bootstrap only)
+
+Configure these as GitHub **secrets** (Settings → Secrets and variables → Actions → Secrets):
 
 - `EXPO_TOKEN` — token for EAS CLI auth. The Expo account/owner is taken from this token; there is no
   separate `EXPO_OWNER`.
+- `INFISICAL_CLIENT_ID`, `INFISICAL_CLIENT_SECRET`, `INFISICAL_PROJECT_SLUG`, `INFISICAL_URL` — the
+  credentials the "Inject secrets from Infisical" step uses to read the app secrets at run time. These
+  are the same four values the other Infisical-backed workflows already use, so they are likely
+  already set.
+
+### Infisical app secrets (the `prod` environment)
+
+These live in the Infisical `prod` environment, **not** as GitHub secrets. Each Expo workflow loads
+them into the job environment at run time with an "Inject secrets from Infisical" step. The owner must
+make sure each one exists in Infisical `prod`:
+
 - `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY` — Clerk publishable key. The app derives the Clerk Frontend API
   host (the OAuth sign-in server) from this key, so no separate URL is needed for the endpoints.
 - `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID` — the client id of the Clerk OAuth application the mobile app
-  signs in against (see "Mobile sign-in: Clerk OAuth/OpenID Connect setup" below). Not a secret, but
-  configure it the same way as the other build-time values.
+  signs in against (see "Mobile sign-in: Clerk OAuth/OpenID Connect setup" below).
 - `NEXT_PUBLIC_APP_URL` — base URL of the deployed web/API host (https, no trailing slash).
 - `NEXT_PUBLIC_AUTH_PROVIDER` — auth provider name (defaults to `clerk` when unset).
 - `NEXT_PUBLIC_AUTH_SIGN_IN_URL` — optional hosted Clerk sign-in URL (kept for reference; the native
   app no longer needs it for sign-in).
 - `EXPO_MOBILE_PROJECT_ID` — Expo project id used by `app.config.ts`.
 - `EXPO_MOBILE_UPDATES_URL` — EAS updates URL for the project.
+
+The first four app names are the same ones the web app reads, so they are likely already in Infisical
+`prod`. The three Expo-specific ones — `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID`, `EXPO_MOBILE_PROJECT_ID`,
+and `EXPO_MOBILE_UPDATES_URL` — may need to be added to Infisical `prod` if they are not there yet.
 
 There is **no per-user identity** to configure. The signed-in user is resolved at runtime by an OAuth
 sign-in against Clerk, and every API call carries an `Authorization: Bearer <token>` the backend
@@ -98,7 +117,8 @@ If `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID` or the publishable key is missing, the ap
 
 Before shipping additional features, verify these first:
 
-1. **Secrets** are configured (the list above), all as GitHub secrets.
+1. **Secrets** are configured (the list above): the bootstrap credentials and `EXPO_TOKEN` as GitHub
+   secrets, and the app secrets in the Infisical `prod` environment.
 
 2. **Env contract gate** passes in the Expo workflows:
 

--- a/ctf/docs/mobile/TOMORROW_EXPO_ENV_SETUP_RUNBOOK.md
+++ b/ctf/docs/mobile/TOMORROW_EXPO_ENV_SETUP_RUNBOOK.md
@@ -6,15 +6,24 @@ Scope: `ctf/` mobile workflows only.
 
 ## Goal
 
-Configure the minimum Expo/GitHub secrets required for the mobile CI workflows:
+Configure the secrets required for the mobile CI workflows:
 
 - `.github/workflows/expo-preview.yml`
 - `.github/workflows/expo-update.yml`
 - `.github/workflows/expo-android-release.yml`
 
-There is **one environment: production**. The mobile workflows reuse the **same** secrets the web app
-already uses — there is no separate staging/preview backend, no per-user identity, and no
+There is **one environment: production**. The mobile workflows reuse the **same** app secrets the web
+app already uses — there is no separate staging/preview backend, no per-user identity, and no
 `EXPO_OWNER`.
+
+Secrets come from **two places**:
+
+- **Infisical** (the single source of truth for app secrets) holds the Clerk keys, the app URL, and
+  the Expo project id/updates URL. Each Expo workflow pulls them at run time with an "Inject secrets
+  from Infisical" step that loads them into the job environment for the build steps.
+- **GitHub Actions secrets** hold only the bootstrap credentials the workflow needs *before* it can
+  reach Infisical, plus the EAS token: `EXPO_TOKEN`, `INFISICAL_CLIENT_ID`, `INFISICAL_CLIENT_SECRET`,
+  `INFISICAL_PROJECT_SLUG`, `INFISICAL_URL`.
 
 ---
 
@@ -27,19 +36,36 @@ already uses — there is no separate staging/preview backend, no per-user ident
 
 ## Required Secrets
 
-Set all of these as GitHub **secrets** (Settings → Secrets and variables → Actions → Secrets):
+### GitHub Actions secrets (bootstrap only)
 
-1. `EXPO_TOKEN`
-2. `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`
-3. `NEXT_PUBLIC_APP_URL`
-4. `NEXT_PUBLIC_AUTH_PROVIDER`
-5. `NEXT_PUBLIC_AUTH_SIGN_IN_URL` (optional)
-6. `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID` (for native sign-in)
-7. `EXPO_MOBILE_PROJECT_ID`
-8. `EXPO_MOBILE_UPDATES_URL`
+Set these as GitHub **secrets** (Settings → Secrets and variables → Actions → Secrets). They are the
+credentials the workflow needs before it can reach Infisical, plus the EAS token:
 
-Most are the same names the web app reads, so they are already set. The new one is
-`EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID`.
+1. `EXPO_TOKEN` — EAS CLI login.
+2. `INFISICAL_CLIENT_ID`
+3. `INFISICAL_CLIENT_SECRET`
+4. `INFISICAL_PROJECT_SLUG`
+5. `INFISICAL_URL`
+
+These four `INFISICAL_*` values are the same ones the other Infisical-backed workflows already use, so
+they are likely already set.
+
+### Infisical app secrets (the `prod` environment)
+
+These live in the Infisical `prod` environment, **not** as GitHub secrets. The Expo workflows load
+them at run time. The owner must make sure each one exists in Infisical `prod`:
+
+1. `NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`
+2. `NEXT_PUBLIC_APP_URL`
+3. `NEXT_PUBLIC_AUTH_PROVIDER`
+4. `NEXT_PUBLIC_AUTH_SIGN_IN_URL` (optional)
+5. `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID` (for native sign-in)
+6. `EXPO_MOBILE_PROJECT_ID`
+7. `EXPO_MOBILE_UPDATES_URL`
+
+The first four are the same names the web app reads, so they are likely already in Infisical `prod`.
+The three Expo-specific ones — `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID`, `EXPO_MOBILE_PROJECT_ID`, and
+`EXPO_MOBILE_UPDATES_URL` — may need to be added to Infisical `prod` if they are not there yet.
 
 ---
 

--- a/ctf/packages/mobile/scripts/check-mobile-env.mjs
+++ b/ctf/packages/mobile/scripts/check-mobile-env.mjs
@@ -11,10 +11,11 @@ try {
 // The mobile app reads the SAME environment names as the web app and ships to a
 // SINGLE production environment (demo/staging data is a runtime Unleash flag, not
 // a deploy environment). It requires:
-//   - NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY  Clerk publishable key (real sign-in)
-//   - NEXT_PUBLIC_APP_URL               https API base URL (the deployed host)
-//   - EXPO_MOBILE_PROJECT_ID            EAS project id
-//   - EXPO_MOBILE_UPDATES_URL           EAS updates URL
+//   - NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY   Clerk publishable key (real sign-in)
+//   - NEXT_PUBLIC_APP_URL                https API base URL (the deployed host)
+//   - EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID  Clerk OAuth client id (native sign-in)
+//   - EXPO_MOBILE_PROJECT_ID             EAS project id
+//   - EXPO_MOBILE_UPDATES_URL            EAS updates URL
 //
 // There is NO per-user identity to configure: the user signs in with Clerk at
 // runtime and API calls carry a verified bearer token. Profile is informational
@@ -40,6 +41,7 @@ function parseUrl(value) {
 
 requireVar('NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY');
 requireVar('NEXT_PUBLIC_APP_URL');
+requireVar('EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID');
 requireVar('EXPO_MOBILE_PROJECT_ID');
 requireVar('EXPO_MOBILE_UPDATES_URL');
 

--- a/ctf/packages/mobile/src/auth/authedFetch.ts
+++ b/ctf/packages/mobile/src/auth/authedFetch.ts
@@ -92,5 +92,8 @@ export async function authedFetchJson<T>(path: string, options?: RequestInit): P
         : `Network request failed: ${response.status}`;
     throw new Error(message);
   }
+  if (payload === null) {
+    throw new Error(`Expected JSON response from ${path}`);
+  }
   return payload as T;
 }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## What changed

PR #353 added three Expo workflows that read the mobile app secrets straight from GitHub Actions secrets. Repo policy makes the self-hosted Infisical instance the single source of truth for app secrets, so this reworks them. CodeRabbit flagged this on the three workflow files; the owner approved moving to Infisical.

### Infisical rework (the three Expo workflows)
- `expo-preview.yml`, `expo-android-release.yml`, `expo-update.yml`: removed the app-secret mappings from the job-level `env:` block (`NEXT_PUBLIC_AUTH_PUBLISHABLE_KEY`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_AUTH_PROVIDER`, `NEXT_PUBLIC_AUTH_SIGN_IN_URL`, `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID`, `EXPO_MOBILE_PROJECT_ID`, `EXPO_MOBILE_UPDATES_URL`). Kept the non-secret static vars (`MOBILE_ENV_TARGET`, `EAS_BUILD_PROFILE`).
- Added an "Inject secrets from Infisical" step right after `Checkout` and before any step that needs the secrets. It copies the same pattern the `generate-product-update.yml` workflow already uses, with `env-slug: prod` (the Production environment's slug; `production` returns a 404). The step loads the app secrets into the job environment, so `app.config.ts`, `check:mobile-env`, and `eas build`/`eas update` read them from the environment exactly as before.
- `EXPO_TOKEN` and the four Infisical bootstrap credentials (`INFISICAL_CLIENT_ID`, `INFISICAL_CLIENT_SECRET`, `INFISICAL_PROJECT_SLUG`, `INFISICAL_URL`) stay as GitHub Actions secrets, since they are needed before the workflow can reach Infisical.

### Shell-injection fix (`expo-update.yml`)
- The `eas update` step embedded the commit message directly in the shell command. Moved it to a step-level `HEAD_COMMIT_MESSAGE` environment variable and referenced the shell variable instead, so the message can no longer be treated as a workflow expression.

### `authedFetchJson` null guard (`ctf/packages/mobile/src/auth/authedFetch.ts`)
- Throws a clear error when the JSON body is `null` instead of returning `null` cast to the expected type.

### Mobile env gate (`ctf/packages/mobile/scripts/check-mobile-env.mjs`)
- Requires `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID` so the gate fails fast when it is missing.

### Docs
- `ctf/docs/mobile/TOMORROW_EXPO_ENV_SETUP_RUNBOOK.md` and `ctf/docs/mobile/EXPO_CLOUD_WORKFLOW.md`: split the secrets list into GitHub Actions bootstrap secrets vs Infisical `prod` app secrets, and described how the workflows load them at run time.

## Owner action needed

The owner must make sure the app secrets exist in the Infisical `prod` environment. The first four (`NEXT_PUBLIC_*`) are likely already there for the web app; the three Expo-specific ones — `EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID`, `EXPO_MOBILE_PROJECT_ID`, `EXPO_MOBILE_UPDATES_URL` — may need to be added if they are not present yet. This cannot be checked from here.

## Validation
- `pnpm install --frozen-lockfile`: up to date
- mobile typecheck (`tsc --noEmit`): passed
- eslint on `authedFetch.ts` and `check-mobile-env.mjs`: passed
- `check-eof-format.sh`: passed
- YAML parse of the three workflows: valid (actionlint not installed in this environment)
- pre-push hook (lint, typecheck, web build): passed

Opened as a draft because it is security-sensitive secrets infrastructure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_