### PR TITLE
feat: bespoke public visitor screens for clicklog, directory, foundation, gdp, gentlepulse

### DIFF
--- a/ctf/packages/web/components/clicklog/clicklog-public-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-public-shell.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { AlertTriangle, Lock, ShieldCheck, Clock, FileText, UserPlus, Eye, EyeOff } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the ClickLogPublic / MobileClickLogPublic design mockups.
+const BRAND = '#E91E8C';
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+function DesktopClickLogPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <AlertTriangle size={18} color={BRAND} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>ClickLog</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: 'rgba(255,255,255,0.06)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign In
+          </a>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: BRAND, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none' }}>
+            <UserPlus size={13} /> Join Free
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '48px 64px' }}>
+        <div style={{ maxWidth: 600, width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 28, textAlign: 'center' }}>
+          {/* Locked button */}
+          <div style={{ position: 'relative' }}>
+            <div style={{ width: 160, height: 160, borderRadius: '50%', background: 'rgba(233,30,140,0.1)', border: '4px solid rgba(233,30,140,0.3)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8, filter: 'blur(2px)', opacity: 0.5 }}>
+              <AlertTriangle size={40} style={{ color: BRAND }} />
+              <span style={{ fontSize: 15, fontWeight: 800, color: BRAND }}>Log Incident</span>
+            </div>
+            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <div style={{ width: 52, height: 52, borderRadius: '50%', background: 'rgba(233,30,140,0.15)', border: `2px solid ${BRAND}50`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Lock size={22} color={BRAND} />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h1 style={{ margin: 0, fontSize: 30, fontWeight: 800, lineHeight: 1.2, marginBottom: 12 }}>
+              Track incidents privately.<br />
+              <span style={{ color: BRAND }}>Sign in to start.</span>
+            </h1>
+            <p style={{ margin: 0, fontSize: 15, color: SUBTLE, lineHeight: 1.7, maxWidth: 440 }}>
+              One tap to log a personal safety incident. Add notes, attach location, and keep a private encrypted history — only visible to you.
+            </p>
+          </div>
+
+          <div style={{ display: 'flex', gap: 12 }}>
+            <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: BRAND, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+              Create free account
+            </a>
+            <a href={signInUrl} style={{ padding: '14px 24px', borderRadius: 10, background: 'rgba(255,255,255,0.05)', border: `1px solid ${BORDER}`, color: '#9CA3AF', fontSize: 15, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+              Sign In
+            </a>
+          </div>
+
+          {/* Features */}
+          <div style={{ display: 'flex', gap: 12, width: '100%' }}>
+            {[
+              { Icon: Eye, label: 'Private by default', desc: 'No one else can see your logs — ever.' },
+              { Icon: ShieldCheck, label: 'Encrypted', desc: 'Your data is protected at rest and in transit.' },
+              { Icon: EyeOff, label: 'Discreet logging', desc: 'One tap — no visible confirmation needed.' },
+            ].map(({ Icon, label, desc }) => (
+              <div key={label} style={{ flex: 1, padding: '14px', borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, textAlign: 'center' }}>
+                <Icon size={20} color={BRAND} style={{ marginBottom: 8, opacity: 0.7 }} />
+                <div style={{ fontSize: 12, fontWeight: 700, color: TEXT, marginBottom: 4 }}>{label}</div>
+                <div style={{ fontSize: 11, color: SUBTLE, lineHeight: 1.5 }}>{desc}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileClickLogPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Header */}
+      <div style={{ padding: '12px 16px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <AlertTriangle size={18} color={BRAND} />
+            <div style={{ fontSize: 16, fontWeight: 700 }}>ClickLog</div>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: 'rgba(255,255,255,0.08)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 11, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: BRAND, border: 'none', color: '#fff', fontSize: 11, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Join Free</a>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '28px 24px', textAlign: 'center', gap: 22 }}>
+        {/* Locked button */}
+        <div style={{ position: 'relative' }}>
+          <div style={{ width: 140, height: 140, borderRadius: '50%', background: 'rgba(233,30,140,0.1)', border: '3px solid rgba(233,30,140,0.25)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 6, filter: 'blur(2px)', opacity: 0.5 }}>
+            <AlertTriangle size={34} color={BRAND} />
+            <span style={{ fontSize: 13, fontWeight: 800, color: BRAND }}>Log Incident</span>
+          </div>
+          <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <div style={{ width: 48, height: 48, borderRadius: '50%', background: 'rgba(233,30,140,0.12)', border: `2px solid ${BRAND}50`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Lock size={18} color={BRAND} />
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div style={{ fontSize: 22, fontWeight: 800, color: TEXT, marginBottom: 8 }}>
+            Track incidents privately
+          </div>
+          <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6, maxWidth: 290 }}>
+            Sign in to start logging personal safety incidents — one tap, encrypted, private.
+          </div>
+        </div>
+
+        <a href={signInUrl} style={{ width: '100%', padding: '14px', borderRadius: 12, background: BRAND, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, boxSizing: 'border-box', textDecoration: 'none' }}>
+          <UserPlus size={15} /> Create free account
+        </a>
+
+        <div style={{ display: 'flex', gap: 8, width: '100%' }}>
+          {[
+            { icon: '👆', label: 'One tap' },
+            { icon: '🔒', label: 'Private' },
+            { icon: '📍', label: 'Location' },
+          ].map(({ icon, label }) => (
+            <div key={label} style={{ flex: 1, padding: '12px 8px', borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, textAlign: 'center' }}>
+              <div style={{ fontSize: 18, marginBottom: 5 }}>{icon}</div>
+              <div style={{ fontSize: 11, fontWeight: 600, color: SUBTLE }}>{label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Bottom nav (locked) */}
+      <div style={{ height: 72, background: '#090B0F', borderTop: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'space-around', flexShrink: 0 }}>
+        {[AlertTriangle, Clock, FileText].map((Icon, i) => (
+          <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4, opacity: 0.3 }}>
+            <Icon size={20} color={SUBTLE} />
+            <span style={{ fontSize: 10, color: SUBTLE }}>{['Log', 'History', 'Export'][i]}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for ClickLog. Pixel-faithful to the ClickLogPublic
+ * (desktop) and MobileClickLogPublic (phone) design mockups, with sign-in
+ * affordances pointing at the real hosted sign-in URL. It shows no private or
+ * per-user data — the whole point of ClickLog is a private, per-user incident
+ * log, so the visitor view is marketing copy and a locked "Log Incident" button
+ * only. The mockup's simulated phone status bar (clock / signal dots) is dropped
+ * because the real app renders inside the browser chrome.
+ */
+export function ClicklogPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileClickLogPublic signInUrl={signInUrl} /> : <DesktopClickLogPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/directory/directory-public-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-public-shell.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { BookOpen, Lock, Search, MapPin } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the DirectoryPublic / MobileDirectoryPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#3B82F6';
+const HUNT_COLOR = '#D946EF';
+const TEXT = '#F9FAFB';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+function DesktopDirectoryPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <BookOpen size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Directory</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign In
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 24px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600 }}>Verified profiles</span>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', fontSize: 12, color: '#9CA3AF', fontWeight: 600 }}>Encrypted chat</span>
+        </div>
+        <h1 style={{ margin: 0, fontSize: 36, fontWeight: 800, lineHeight: 1.1 }}>
+          Connect with verified<br />
+          <span style={{ color: COLOR }}>providers &amp; advocates</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 500 }}>
+          Trauma-informed therapists, housing navigators, legal advocates, employment coaches, and more.
+        </p>
+        <div style={{ display: 'flex', gap: 12, marginTop: 4 }}>
+          <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Join the Hub — Free
+          </a>
+          <a href={signInUrl} style={{ padding: '14px 24px', borderRadius: 10, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 15, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Learn more
+          </a>
+        </div>
+      </div>
+
+      {/* Skills Hunt pinned reward card */}
+      <div style={{ margin: '0 64px 28px', padding: '20px 24px', borderRadius: 16, background: `linear-gradient(135deg, ${HUNT_COLOR}12 0%, rgba(59,130,246,0.06) 100%)`, border: `1px solid ${HUNT_COLOR}30`, display: 'flex', gap: 20, alignItems: 'center' }}>
+        <div style={{ width: 48, height: 48, borderRadius: 14, background: `${HUNT_COLOR}20`, border: `1px solid ${HUNT_COLOR}35`, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          <Search size={22} style={{ color: HUNT_COLOR }} />
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+            <div style={{ fontSize: 15, fontWeight: 800, color: TEXT }}>Skills Hunt — Community Reward</div>
+          </div>
+          <div style={{ fontSize: 13, color: '#9CA3AF', lineHeight: 1.5 }}>
+            Know a survivor with skills the community needs? Sign in to submit their public profile and help grow the Directory. Earn points, badges, and prizes.
+          </div>
+        </div>
+        <a href={signInUrl} style={{ padding: '12px 22px', borderRadius: 12, background: HUNT_COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', flexShrink: 0, whiteSpace: 'nowrap', textDecoration: 'none' }}>
+          Sign in to submit a profile
+        </a>
+      </div>
+
+      {/* Sign-in gate (no fabricated preview profiles) */}
+      <div style={{ padding: '0 64px 64px' }}>
+        <div style={{ borderRadius: 16, border: '1px solid rgba(255,255,255,0.08)', background: 'rgba(255,255,255,0.02)', padding: '56px 24px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 56, height: 56, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={24} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, color: TEXT, textAlign: 'center' }}>Sign in to browse the Directory</div>
+          <div style={{ fontSize: 13, color: '#6B7280', textAlign: 'center', maxWidth: 320, display: 'flex', alignItems: 'center', gap: 6 }}>
+            <MapPin size={13} color="#6B7280" /> Filter by specialty, location, and Service Credit acceptance.
+          </div>
+          <a href={signInUrl} style={{ padding: '12px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign in to connect
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileDirectoryPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '20px 20px 14px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <BookOpen size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>Directory</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Verified profiles</span>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>Therapists, housing navigators, legal advocates, and more — searchable by location and specialty.</p>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      {/* Skills Hunt pinned reward card */}
+      <div style={{ margin: '0 16px 16px', padding: '14px 16px', borderRadius: 14, background: `linear-gradient(135deg, ${HUNT_COLOR}12 0%, rgba(59,130,246,0.05) 100%)`, border: `1px solid ${HUNT_COLOR}30` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+          <div style={{ width: 28, height: 28, borderRadius: 8, background: `${HUNT_COLOR}20`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Search size={14} style={{ color: HUNT_COLOR }} />
+          </div>
+          <div style={{ fontSize: 14, fontWeight: 800, color: TEXT }}>Skills Hunt</div>
+        </div>
+        <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.5, marginBottom: 10 }}>
+          Know a survivor? Sign in to submit their public profile and help grow the Directory. Earn points &amp; badges.
+        </div>
+        <a href={signInUrl} style={{ display: 'block', width: '100%', padding: '11px', borderRadius: 10, background: HUNT_COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textAlign: 'center', boxSizing: 'border-box', textDecoration: 'none' }}>
+          Sign in to submit a profile
+        </a>
+      </div>
+
+      {/* Sign-in gate (no fabricated preview profiles) */}
+      <div style={{ flex: 1, padding: '0 16px 20px' }}>
+        <div style={{ height: '100%', minHeight: 240, borderRadius: 14, border: '1px solid rgba(255,255,255,0.07)', background: 'rgba(255,255,255,0.02)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12, padding: '32px 20px' }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to find providers</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Directory. Pixel-faithful to the DirectoryPublic
+ * (desktop) and MobileDirectoryPublic (phone) design mockups, with sign-in
+ * affordances pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviations from the mockup (no session = no private/fabricated
+ * data): the mockup's blurred preview profile cards (Maria G., James T., …), its
+ * stats bar (47,000+ profiles, 68% accept credits, …), and the reward card's
+ * activity counts (247 submitted this week, 63 active scouts) are all invented
+ * sample data, so they are replaced with an honest sign-in gate and generic
+ * marketing copy. The mockup's "Submit a community profile" modal posts to an
+ * authenticated-only endpoint, so for a visitor its call to action points at the
+ * sign-in URL instead of opening a form that cannot submit. The simulated phone
+ * status bar is dropped because the real app renders inside the browser chrome.
+ */
+export function DirectoryPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileDirectoryPublic signInUrl={signInUrl} /> : <DesktopDirectoryPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/foundation/foundation-public-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-public-shell.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { Hammer, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the FoundationPublic / MobileFoundationPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#EF4444';
+const TEXT = '#F9FAFB';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+function DesktopFoundationPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Hammer size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Foundation</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign In
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+          Trades &amp; skilled services
+        </span>
+        <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+          Find trusted tradespeople<br />
+          <span style={{ color: COLOR }}>who accept Service Credits</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 520 }}>
+          Vetted electricians, plumbers, carpenters, HVAC techs, and more. All background-checked, all trauma-informed. Pay with Service Credits or cash.
+        </p>
+        <a href={signInUrl} style={{ marginTop: 8, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none' }}>
+          Join the Hub — Free
+        </a>
+      </div>
+
+      {/* Sign-in gate (no fabricated provider cards) */}
+      <div style={{ padding: '0 64px 48px' }}>
+        <div style={{ borderRadius: 16, border: '1px solid rgba(255,255,255,0.07)', background: 'rgba(255,255,255,0.02)', padding: '56px 24px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={22} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to book tradespeople</div>
+          <div style={{ fontSize: 13, color: '#6B7280', textAlign: 'center', maxWidth: 300 }}>
+            Filter by trade, location, availability, and Service Credit acceptance.
+          </div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign in to access Foundation
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileFoundationPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Hammer size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>Foundation</span>
+        </div>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>Vetted electricians, plumbers, carpenters, and more. All background-checked and trauma-informed. Pay with Service Credits.</p>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      {/* Sign-in gate (no fabricated provider cards) */}
+      <div style={{ flex: 1, padding: '0 20px 20px' }}>
+        <div style={{ height: '100%', minHeight: 240, borderRadius: 14, border: '1px solid rgba(255,255,255,0.07)', background: 'rgba(255,255,255,0.02)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12, padding: '32px 20px' }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to book tradespeople</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Foundation. Pixel-faithful to the FoundationPublic
+ * (desktop) and MobileFoundationPublic (phone) design mockups, with sign-in
+ * affordances pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviation (no session = no private/fabricated data): the
+ * mockup's blurred provider preview cards (Carlos Rivera, Sarah Johnson, … with
+ * invented rates and ratings) are sample data, so they are replaced with an
+ * honest sign-in gate. The marketing hero copy is kept. The simulated phone
+ * status bar is dropped because the real app renders inside the browser chrome.
+ */
+export function FoundationPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileFoundationPublic signInUrl={signInUrl} /> : <DesktopFoundationPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/gdp/gdp-public-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-public-shell.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import {
+  Globe, BarChart2, MapPin, LogIn, UserPlus, ShieldCheck, Lock, Plus, TrendingUp,
+} from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the GDPPublic / MobileGDPPublic design mockups.
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+const COLOR = '#06B6D4';
+const ACCENT = '#7C3AED';
+const ACCENT_CYAN = '#0EA5E9';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+function DesktopGDPPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
+      {/* Marketing banner */}
+      <div style={{ background: `linear-gradient(90deg, ${ACCENT} 0%, ${ACCENT_CYAN} 100%)`, padding: '10px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <Globe size={15} color="#fff" />
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#fff' }}>Survivor Hub GDP Tracker · The economic output of the survivor community · Public read-only</span>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <a href={signInUrl} style={{ padding: '6px 16px', borderRadius: 7, background: 'rgba(255,255,255,0.15)', border: '1px solid rgba(255,255,255,0.3)', color: '#fff', fontWeight: 600, fontSize: 13, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, textDecoration: 'none' }}>
+            <LogIn size={13} /> Sign In
+          </a>
+          <a href={signInUrl} style={{ padding: '6px 16px', borderRadius: 7, background: 'rgba(255,255,255,0.18)', border: '1px solid rgba(255,255,255,0.45)', color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, textDecoration: 'none' }}>
+            <UserPlus size={13} /> Add Your Skills →
+          </a>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        {/* Left sidebar */}
+        <aside style={{ width: 280, borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ padding: '20px 16px 12px', borderBottom: `1px solid ${BORDER}` }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+              <Globe size={16} color={COLOR} />
+              <span style={{ fontSize: 15, fontWeight: 700 }}>GDP Dashboard</span>
+              <span style={{ marginLeft: 'auto', fontSize: 11, background: `${COLOR}18`, color: COLOR, border: `1px solid ${COLOR}30`, borderRadius: 4, padding: '2px 7px' }}>Public</span>
+            </div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>Read-only · Sign in to contribute your skills</div>
+          </div>
+
+          <div style={{ padding: 16, flex: 1, overflowY: 'auto' }}>
+            {/* Hero stat — locked until sign-in (no fabricated totals) */}
+            <div style={{ borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}25`, padding: '20px 16px', textAlign: 'center', marginBottom: 16 }}>
+              <div style={{ fontSize: 11, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 12 }}>TI Skills Economy</div>
+              <div style={{ width: 44, height: 44, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 12px' }}>
+                <Lock size={18} color={COLOR} />
+              </div>
+              <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 4 }}>Economy totals are coming soon</div>
+              <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>Live totals appear here as verified members add their skills. Sign in to contribute.</div>
+            </div>
+
+            {[
+              { label: 'Active Members', icon: Globe },
+              { label: 'Countries', icon: Globe },
+              { label: 'Monthly Growth', icon: TrendingUp },
+            ].map(({ label, icon: Icon }) => (
+              <div key={label} style={{ borderRadius: 10, border: `1px solid ${BORDER}`, background: SURFACE, padding: '12px', marginBottom: 8, display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ width: 34, height: 34, borderRadius: 8, background: 'rgba(255,255,255,0.05)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <Icon size={16} color={SUBTLE} />
+                </div>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: SUBTLE }}>—</div>
+                  <div style={{ fontSize: 11, color: SUBTLE }}>{label}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        {/* Main area */}
+        <main style={{ flex: 1, overflowY: 'auto', padding: '24px 32px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 24 }}>
+            <div>
+              <div style={{ fontSize: 20, fontWeight: 800 }}>Trafficking-Informed Skills Economy</div>
+              <div style={{ fontSize: 13, color: SUBTLE }}>Economic output of the survivor community · Public dashboard</div>
+            </div>
+            <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 12px', borderRadius: 20, background: SURFACE, border: `1px solid ${BORDER}` }}>
+                <ShieldCheck size={12} color={ACCENT_CYAN} />
+                <span style={{ fontSize: 12, color: ACCENT_CYAN }}>Survivor Verified</span>
+              </div>
+              <div style={{ padding: '8px 18px', borderRadius: 8, background: 'rgba(255,255,255,0.05)', border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 13, cursor: 'not-allowed', display: 'flex', alignItems: 'center', gap: 6 }}>
+                <Lock size={12} /> <Plus size={12} /> Add Skills
+              </div>
+            </div>
+          </div>
+
+          {/* Sector breakdown — locked until sign-in (no fabricated figures) */}
+          <div style={{ borderRadius: 16, border: `1px solid ${BORDER}`, background: SURFACE, padding: '20px 24px', marginBottom: 20 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+              <div style={{ fontSize: 14, fontWeight: 700 }}>Sector Breakdown</div>
+              <BarChart2 size={16} color={SUBTLE} />
+            </div>
+            <div style={{ borderRadius: 10, border: `1px dashed ${BORDER}`, padding: '28px 16px', textAlign: 'center' }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 4 }}>No sector data to show yet</div>
+              <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>Sector totals build up as verified members add their skills.</div>
+            </div>
+          </div>
+
+          {/* Top countries — locked until sign-in (no fabricated figures) */}
+          <div style={{ borderRadius: 16, border: `1px solid ${BORDER}`, background: SURFACE, padding: '20px 24px', marginBottom: 20 }}>
+            <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 14, display: 'flex', alignItems: 'center', gap: 8 }}>
+              <MapPin size={15} color={COLOR} /> Top Countries by Economic Output
+            </div>
+            <div style={{ borderRadius: 10, border: `1px dashed ${BORDER}`, padding: '28px 16px', textAlign: 'center' }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 4 }}>Country rankings are coming soon</div>
+              <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>Rankings appear here once enough members have contributed.</div>
+            </div>
+          </div>
+
+          {/* Auth gate CTA */}
+          <div style={{ borderRadius: 16, border: `2px solid ${COLOR}30`, background: `${COLOR}06`, padding: '28px 32px', textAlign: 'center' }}>
+            <Globe size={32} color={`${COLOR}60`} style={{ marginBottom: 12 }} />
+            <div style={{ fontSize: 18, fontWeight: 800, marginBottom: 8 }}>Add your skills to the economy</div>
+            <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.6, maxWidth: 480, margin: '0 auto 20px' }}>
+              Every verified skill you add increases the collective value of the TI Skills Economy. Create a free account to contribute, earn Service Credits, and appear on the global map.
+            </div>
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'center' }}>
+              <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 10, background: COLOR, border: 'none', color: '#000', fontWeight: 700, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                <UserPlus size={15} style={{ display: 'inline', marginRight: 7 }} /> Add Your Skills Free
+              </a>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function MobileGDPPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <TrendingUp size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>GDP</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Survivor economy dashboard</span>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>The gross domestic product of the survivor economy — economic activity, skill gaps, and contributor rankings.</p>
+
+        {/* Live snapshot — locked until sign-in (no fabricated totals) */}
+        <div style={{ borderRadius: 16, border: `1px solid ${COLOR}30`, background: COLOR + '06', padding: '20px 18px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, textAlign: 'center' }}>
+          <div style={{ width: 44, height: 44, borderRadius: 22, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={18} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: TEXT }}>Economy totals are coming soon</div>
+          <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.5 }}>Live totals build up as verified members add their skills. Sign in to contribute.</div>
+        </div>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 20px 20px' }}>
+        <div style={{ height: '100%', minHeight: 200, borderRadius: 12, border: '1px solid rgba(255,255,255,0.06)', background: 'rgba(255,255,255,0.02)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12, padding: '32px 20px' }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 14, fontWeight: 700, textAlign: 'center' }}>Sign in for contributor rankings</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for GDP. Pixel-faithful to the GDPPublic (desktop) and
+ * MobileGDPPublic (phone) design mockups, with sign-in affordances pointing at
+ * the real hosted sign-in URL.
+ *
+ * Real-data-only deviation (no session = no private/fabricated data): the
+ * mockup hardcodes economic figures (a $247B / $2.4B headline total, 4.9M
+ * members, sector breakdown percentages, a top-countries table with invented
+ * GDP and member counts). Those are sample data, so every figure is replaced
+ * with an honest "coming soon" empty state while the layout, section labels, and
+ * marketing copy are kept. The simulated phone status bar is dropped because the
+ * real app renders inside the browser chrome.
+ */
+export function GdpPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileGDPPublic signInUrl={signInUrl} /> : <DesktopGDPPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/gentlepulse/gentlepulse-public-shell.tsx
+++ b/ctf/packages/web/components/gentlepulse/gentlepulse-public-shell.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Heart, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the GentlePulsePublic / MobileGentlePulsePublic design mockups.
+const BG = '#0A0F0E';
+const COLOR = '#14B8A6';
+const TEXT = '#F9FAFB';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+function DesktopGentlePulsePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      <div style={{ height: 52, borderBottom: '1px solid rgba(20,184,166,0.1)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Heart size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>GentlePulse</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(20,184,166,0.12)', border: '1px solid rgba(20,184,166,0.25)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+        </div>
+      </div>
+
+      <div style={{ padding: '48px 64px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+          Trauma-informed wellness
+        </span>
+        <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+          Guided meditation built<br /><span style={{ color: COLOR }}>for survivors, by therapists</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 500 }}>
+          Every session is written and reviewed by certified trauma therapists. Breathing, grounding, sleep, mindfulness — all free with your Hub membership.
+        </p>
+        <a href={signInUrl} style={{ marginTop: 8, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none' }}>
+          Join the Hub — Free
+        </a>
+      </div>
+
+      {/* Sign-in gate (no fabricated session list) */}
+      <div style={{ padding: '0 64px 48px' }}>
+        <div style={{ borderRadius: 14, border: '1px solid rgba(20,184,166,0.12)', background: 'rgba(20,184,166,0.03)', padding: '56px 24px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={22} color={COLOR} /></div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to access all sessions</div>
+          <div style={{ fontSize: 13, color: '#6B7280', textAlign: 'center', maxWidth: 300 }}>Save progress, track streaks, and get personalized recommendations.</div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in to begin healing</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileGentlePulsePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Heart size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>GentlePulse</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Trauma-informed wellness</span>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>Guided meditation and breathwork written by certified trauma therapists. Breathing, grounding, sleep, mindfulness — all free.</p>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      {/* Sign-in gate (no fabricated session list) */}
+      <div style={{ flex: 1, padding: '0 20px 20px' }}>
+        <div style={{ height: '100%', minHeight: 240, borderRadius: 12, border: '1px solid rgba(20,184,166,0.12)', background: 'rgba(20,184,166,0.03)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12, padding: '32px 20px' }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in for all sessions</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for GentlePulse. Pixel-faithful to the
+ * GentlePulsePublic (desktop) and MobileGentlePulsePublic (phone) design
+ * mockups, with sign-in affordances pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviation (no session = no private/fabricated data): the
+ * mockup's blurred session list (4-7-8 Breathing, Sleep Sanctuary, … with
+ * invented "47.8k plays" counts) is sample data, so it is replaced with an
+ * honest sign-in gate. The marketing hero copy is kept. The simulated phone
+ * status bar is dropped because the real app renders inside the browser chrome.
+ */
+export function GentlePulsePublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileGentlePulsePublic signInUrl={signInUrl} /> : <DesktopGentlePulsePublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/plugins/public-visitor-registry.tsx
+++ b/ctf/packages/web/components/plugins/public-visitor-registry.tsx
@@ -1,5 +1,10 @@
 import type { ComponentType } from 'react';
 import { ChymePublicShell } from '@/components/chyme/chyme-public-shell';
+import { ClicklogPublicShell } from '@/components/clicklog/clicklog-public-shell';
+import { DirectoryPublicShell } from '@/components/directory/directory-public-shell';
+import { FoundationPublicShell } from '@/components/foundation/foundation-public-shell';
+import { GdpPublicShell } from '@/components/gdp/gdp-public-shell';
+import { GentlePulsePublicShell } from '@/components/gentlepulse/gentlepulse-public-shell';
 import { GenericPublicShell } from '@/components/plugins/generic-public-shell';
 
 /**
@@ -29,6 +34,11 @@ export type PublicVisitorShell = ComponentType<PublicVisitorShellProps>;
  */
 const PUBLIC_VISITOR_SHELLS: Record<string, PublicVisitorShell> = {
   chyme: ChymePublicShell,
+  clicklog: ClicklogPublicShell,
+  directory: DirectoryPublicShell,
+  foundation: FoundationPublicShell,
+  gdp: GdpPublicShell,
+  gentlepulse: GentlePulsePublicShell,
 };
 
 /**


### PR DESCRIPTION
Adds signed-out visitor screens for five plugins, built to match their desktop and phone design mockups and wired into the public visitor registry. Each follows the existing Chyme public shell pattern: a named `<Plugin>PublicShell` client component with the shared `PublicVisitorShellProps` signature that picks the desktop or phone layout with `useIsMobile()`, and every sign-in / join / call-to-action points at the hosted sign-in URL.

New files:
- `ctf/packages/web/components/clicklog/clicklog-public-shell.tsx`
- `ctf/packages/web/components/directory/directory-public-shell.tsx`
- `ctf/packages/web/components/foundation/foundation-public-shell.tsx`
- `ctf/packages/web/components/gdp/gdp-public-shell.tsx`
- `ctf/packages/web/components/gentlepulse/gentlepulse-public-shell.tsx`

Registry: added the five imports and map entries to `ctf/packages/web/components/plugins/public-visitor-registry.tsx`, kept in order by slug. No change to the route page or any other plugin.

Each shell and its real-data-only handling (a visitor has no session, so no private or invented data is shown):
- ClickLog — marketing hero with a locked "Log Incident" button and three private-by-default feature cards. No data rows at all, so it matches the mockup as-is. Only deviation: the mockup's simulated phone status bar is dropped because the real app renders inside the browser chrome.
- Directory — hero, a Skills Hunt reward card, and a sign-in gate. The mockup's blurred preview profiles, its stats bar (47,000+ profiles, 68% accept credits, and so on), and the reward card's activity counts (247 this week, 63 scouts) are invented sample data, so they are replaced with an honest sign-in gate and generic copy. The "submit a community profile" modal posts to an endpoint that needs a signed-in account, so for a visitor that call to action points at the sign-in URL instead of opening a form that cannot submit.
- Foundation — hero plus a sign-in gate. The blurred provider preview cards (invented names, rates, ratings) are replaced with an honest sign-in gate; the marketing hero copy is kept.
- GDP — banner, sidebar, and main dashboard layout kept, but every hardcoded economic figure (the headline total, member counts, sector percentages, the top-countries table) is invented sample data and is replaced with honest "coming soon" empty states. Section labels and marketing copy are kept.
- GentlePulse — hero plus a sign-in gate. The blurred session list with invented play counts is replaced with an honest sign-in gate; the marketing hero copy is kept.

Validation in the worktree, all passing: web typecheck (`tsc --noEmit`), EOF format check, web/Android parity check, and the full web build that runs on push.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_