### PR TITLE
feat: bespoke public visitor screens for levelup, lighthouse, mood, peer-programming, service-credits

### DIFF
--- a/ctf/packages/web/components/levelup/levelup-public-shell.tsx
+++ b/ctf/packages/web/components/levelup/levelup-public-shell.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { BookOpen, CheckCircle, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the LevelUpPublic / MobileLevelUpPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#10B981';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#9CA3AF';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+const HIGHLIGHTS = ['Free for all survivors', 'Earn credits while learning', 'Trainer-led cohorts'];
+
+// Behind the lock overlay the mockup shows blurred sample cohort cards. A public
+// shell has no session and there is no public cohort feed, so the locked region
+// renders neutral blurred placeholder bars instead of fabricated course rows.
+function LockedPlaceholderRow({ rounded }: { rounded: number }) {
+  return (
+    <div style={{ borderRadius: rounded, border: '1px solid rgba(255,255,255,0.07)', padding: '16px 20px', background: 'rgba(255,255,255,0.02)', display: 'flex', gap: 14, alignItems: 'center' }}>
+      <div style={{ flex: 1 }}>
+        <div style={{ height: 12, width: '55%', borderRadius: 6, background: 'rgba(255,255,255,0.08)' }} />
+        <div style={{ display: 'flex', gap: 6, marginTop: 10 }}>
+          <div style={{ height: 16, width: 48, borderRadius: 8, background: 'rgba(255,255,255,0.06)' }} />
+          <div style={{ height: 16, width: 40, borderRadius: 8, background: 'rgba(255,255,255,0.06)' }} />
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
+        <div style={{ height: 12, width: 72, borderRadius: 6, background: 'rgba(255,255,255,0.08)' }} />
+        <div style={{ height: 10, width: 56, borderRadius: 6, background: 'rgba(255,255,255,0.05)' }} />
+      </div>
+    </div>
+  );
+}
+
+function DesktopLevelUpPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <BookOpen size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>LevelUp</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign In</a>
+        </div>
+      </div>
+
+      <div style={{ padding: '48px 64px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+          Cohort-based learning
+        </span>
+        <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+          Earn skills, earn credits —<br /><span style={{ color: COLOR }}>learn alongside other survivors</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 15, color: SUBTLE, maxWidth: 520 }}>
+          Cohort-based courses across tech, finance, trades, and life skills. Complete milestones to earn Service Credits. Trainers are survivor-advocates themselves.
+        </p>
+        <div style={{ display: 'flex', gap: 16, marginTop: 8, flexWrap: 'wrap' }}>
+          {HIGHLIGHTS.map((f) => (
+            <div key={f} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <CheckCircle size={14} color={COLOR} />
+              <span style={{ fontSize: 13, color: SUBTLE }}>{f}</span>
+            </div>
+          ))}
+        </div>
+        <a href={signInUrl} style={{ marginTop: 4, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none', display: 'inline-block' }}>
+          Join the Hub — Free
+        </a>
+      </div>
+
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.55 }} aria-hidden="true">
+          {[0, 1, 2, 3].map((i) => (
+            <LockedPlaceholderRow key={i} rounded={14} />
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={22} color={COLOR} /></div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to enroll in cohorts</div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign in to start learning</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileLevelUpPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <BookOpen size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>LevelUp</span>
+        </div>
+        <p style={{ margin: 0, fontSize: 14, color: SUBTLE, lineHeight: 1.5 }}>Cohort-based courses across tech, finance, trades, and life skills. Complete milestones to earn Service Credits.</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {HIGHLIGHTS.map((f) => (
+            <div key={f} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <CheckCircle size={13} color={COLOR} />
+              <span style={{ fontSize: 13, color: SUBTLE }}>{f}</span>
+            </div>
+          ))}
+        </div>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>Join the Hub — Free</a>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+          {[0, 1, 2, 3].map((i) => (
+            <LockedPlaceholderRow key={i} rounded={12} />
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to enroll</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for LevelUp. Renders the public marketing experience
+ * pixel-faithful to the LevelUpPublic (desktop) and MobileLevelUpPublic (phone)
+ * design mockups, with sign-in affordances pointing at the real hosted sign-in
+ * URL. It shows no private or per-user data: there is no public cohort feed, so
+ * the locked region behind the sign-in overlay renders neutral blurred
+ * placeholders rather than the mockup's fabricated sample cohort rows.
+ */
+export function LevelupPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileLevelUpPublic signInUrl={signInUrl} /> : <DesktopLevelUpPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { Home, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the LightHousePublic / MobileLightHousePublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#EAB308';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#9CA3AF';
+const MUTED = '#6B7280';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// The mockup shows blurred sample listing cards behind a lock overlay. A public
+// shell has no session and there is no public listing feed, so the locked region
+// renders neutral blurred placeholder cards rather than fabricated listings.
+function LockedListingCard({ orientation }: { orientation: 'row' | 'stacked' }) {
+  if (orientation === 'row') {
+    return (
+      <div style={{ borderRadius: 14, border: '1px solid rgba(255,255,255,0.07)', display: 'flex', overflow: 'hidden', background: 'rgba(255,255,255,0.02)' }}>
+        <div style={{ width: 160, height: 100, background: COLOR + '15', flexShrink: 0 }} />
+        <div style={{ flex: 1, padding: '14px 18px', display: 'flex', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <div style={{ height: 12, width: '70%', borderRadius: 6, background: 'rgba(255,255,255,0.08)' }} />
+            <div style={{ height: 10, width: '45%', borderRadius: 6, background: 'rgba(255,255,255,0.05)', marginTop: 8 }} />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'flex-end' }}>
+            <div style={{ height: 14, width: 60, borderRadius: 6, background: 'rgba(255,255,255,0.08)' }} />
+            <div style={{ height: 14, width: 64, borderRadius: 8, background: 'rgba(34,197,94,0.18)' }} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ borderRadius: 12, border: '1px solid rgba(255,255,255,0.07)', overflow: 'hidden' }}>
+      <div style={{ height: 90, background: COLOR + '15' }} />
+      <div style={{ padding: '10px 14px', display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+        <div style={{ height: 12, width: '60%', borderRadius: 6, background: 'rgba(255,255,255,0.08)' }} />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end' }}>
+          <div style={{ height: 12, width: 52, borderRadius: 6, background: 'rgba(255,255,255,0.08)' }} />
+          <div style={{ height: 10, width: 48, borderRadius: 6, background: 'rgba(34,197,94,0.18)' }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DesktopLightHousePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Home size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>LightHouse</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>
+            Sign In
+          </a>
+        </div>
+      </div>
+
+      <div style={{ padding: '48px 64px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+          Privacy-first housing
+        </span>
+        <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+          Safe, verified housing —<br />
+          <span style={{ color: COLOR }}>your location stays private</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 15, color: SUBTLE, maxWidth: 520 }}>
+          All listings are privacy-minimized. Your location is never shared without consent. Trauma-informed hosts. Service Credits accepted. Month-to-month options available.
+        </p>
+        <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
+          <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>
+            Join the Hub — Free
+          </a>
+          <a href={signInUrl} style={{ padding: '14px 24px', borderRadius: 10, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 15, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>
+            How it works
+          </a>
+        </div>
+      </div>
+
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.55 }} aria-hidden="true">
+          {[0, 1, 2, 3].map((i) => (
+            <LockedListingCard key={i} orientation="row" />
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={22} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to view safe housing</div>
+          <div style={{ fontSize: 13, color: MUTED, textAlign: 'center', maxWidth: 300 }}>
+            Filter by price, location, availability, and Service Credit acceptance.
+          </div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>
+            Sign in to browse listings
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileLightHousePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Home size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>LightHouse</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Privacy-first housing</span>
+        <p style={{ margin: 0, fontSize: 14, color: SUBTLE, lineHeight: 1.5 }}>Safe, verified housing. Your location is never shared without consent. Trauma-informed hosts. Service Credits accepted.</p>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>Join the Hub — Free</a>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+          {[0, 1, 2].map((i) => (
+            <LockedListingCard key={i} orientation="stacked" />
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to view listings</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for LightHouse. Renders the public marketing experience
+ * pixel-faithful to the LightHousePublic (desktop) and MobileLightHousePublic
+ * (phone) design mockups, with sign-in affordances pointing at the real hosted
+ * sign-in URL. It shows no private or per-user data: there is no public listing
+ * feed, so the locked region behind the sign-in overlay renders neutral blurred
+ * placeholder cards rather than the mockup's fabricated sample listings.
+ */
+export function LighthousePublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileLightHousePublic signInUrl={signInUrl} /> : <DesktopLightHousePublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/mood/mood-public-shell.tsx
+++ b/ctf/packages/web/components/mood/mood-public-shell.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { Smile, Shield } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the MoodPublic / MobileMoodPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#EC4899';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#9CA3AF';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+const PRIVACY = ['No identity link', 'Zero logs retained', 'Aggregate only'];
+// The mood faces are a static, non-interactive marketing preview of the check-in
+// scale — labels describe the scale, not any per-user data.
+const MOOD_FACES: { emoji: string; label: string }[] = [
+  { emoji: '😢', label: 'Struggling' },
+  { emoji: '😔', label: 'Low' },
+  { emoji: '😐', label: 'Okay' },
+  { emoji: '🙂', label: 'Good' },
+  { emoji: '😄', label: 'Great' },
+];
+const MOOD_FACES_MOBILE: { emoji: string; label: string }[] = [
+  { emoji: '😢', label: 'Low' },
+  { emoji: '😔', label: 'Down' },
+  { emoji: '😐', label: 'Okay' },
+  { emoji: '🙂', label: 'Good' },
+  { emoji: '😄', label: 'Great' },
+];
+
+function DesktopMoodPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Smile size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Mood</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign In</a>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '64px' }}>
+        <div style={{ maxWidth: 600, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 24, textAlign: 'center' }}>
+          <div style={{ width: 80, height: 80, borderRadius: 40, background: COLOR + '20', border: `2px solid ${COLOR}40`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Smile size={36} color={COLOR} />
+          </div>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600 }}>100% anonymous</span>
+          <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+            Check in with yourself.<br /><span style={{ color: COLOR }}>No names, no records.</span>
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, color: SUBTLE, maxWidth: 440 }}>
+            Your mood check-in is completely anonymous — never linked to your identity. Daily check-ins unlock resources, peer support, and gentle nudges.
+          </p>
+
+          <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', justifyContent: 'center' }}>
+            {PRIVACY.map((t) => (
+              <div key={t} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <Shield size={13} color={COLOR} />
+                <span style={{ fontSize: 13, color: SUBTLE }}>{t}</span>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ borderRadius: 16, border: '1px solid rgba(255,255,255,0.08)', padding: '24px 32px', background: 'rgba(255,255,255,0.03)', display: 'flex', flexDirection: 'column', gap: 16, alignItems: 'center', width: '100%' }}>
+            <div style={{ fontSize: 14, color: SUBTLE }}>How are you feeling today?</div>
+            <div style={{ display: 'flex', gap: 20 }}>
+              {MOOD_FACES.map((m) => (
+                <div key={m.label} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
+                  <div style={{ fontSize: 28 }}>{m.emoji}</div>
+                  <div style={{ fontSize: 11, color: '#6B7280' }}>{m.label}</div>
+                </div>
+              ))}
+            </div>
+            <a href={signInUrl} style={{ padding: '12px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>
+              Join to track your journey
+            </a>
+          </div>
+
+          <p style={{ margin: 0, fontSize: 12, color: '#4B5563' }}>Sign in to save your streak, access resources, and see community trends.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileMoodPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '24px 24px 40px', gap: 20, textAlign: 'center' }}>
+        <div style={{ width: 64, height: 64, borderRadius: 32, background: COLOR + '20', border: `2px solid ${COLOR}40`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <Smile size={28} color={COLOR} />
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600 }}>100% anonymous</span>
+        <h1 style={{ margin: 0, fontSize: 26, fontWeight: 800, lineHeight: 1.2 }}>
+          Check in with yourself.<br /><span style={{ color: COLOR }}>No names, no records.</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 14, color: SUBTLE, maxWidth: 300 }}>Your mood is never linked to your identity. Daily check-ins unlock resources and gentle nudges.</p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {PRIVACY.map((t) => (
+            <div key={t} style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'center' }}>
+              <Shield size={12} color={COLOR} />
+              <span style={{ fontSize: 13, color: SUBTLE }}>{t}</span>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ borderRadius: 16, border: '1px solid rgba(255,255,255,0.08)', padding: '20px 24px', background: 'rgba(255,255,255,0.02)', width: '100%' }}>
+          <div style={{ fontSize: 13, color: SUBTLE, marginBottom: 14 }}>How are you feeling today?</div>
+          <div style={{ display: 'flex', justifyContent: 'space-around' }}>
+            {MOOD_FACES_MOBILE.map((m) => (
+              <div key={m.label} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 5 }}>
+                <span style={{ fontSize: 24 }}>{m.emoji}</span>
+                <span style={{ fontSize: 10, color: '#6B7280' }}>{m.label}</span>
+              </div>
+            ))}
+          </div>
+          <a href={signInUrl} style={{ marginTop: 16, width: '100%', padding: '13px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'block', textAlign: 'center', boxSizing: 'border-box' }}>
+            Join to track your journey
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Mood. Renders the public marketing experience
+ * pixel-faithful to the MoodPublic (desktop) and MobileMoodPublic (phone) design
+ * mockups, with sign-in affordances pointing at the real hosted sign-in URL. It
+ * shows no private or per-user data — the mood-face row is a static preview of
+ * the check-in scale, not any recorded mood.
+ */
+export function MoodPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileMoodPublic signInUrl={signInUrl} /> : <DesktopMoodPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Users, Globe, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the PeerProgrammingPublic / MobilePeerProgrammingPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#8B5CF6';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#9CA3AF';
+const MUTED = '#6B7280';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// The mockup shows blurred sample cohort cards behind a lock overlay. A public
+// shell has no session and there is no public cohort feed, so the locked region
+// renders neutral blurred placeholder cards rather than fabricated cohort rows.
+function LockedCohortCard() {
+  return (
+    <div style={{ borderRadius: 14, border: '1px solid rgba(255,255,255,0.07)', padding: '18px 20px', background: 'rgba(255,255,255,0.02)' }}>
+      <div style={{ height: 12, width: '60%', borderRadius: 6, background: 'rgba(255,255,255,0.08)', marginBottom: 10 }} />
+      <div style={{ height: 10, width: '75%', borderRadius: 6, background: 'rgba(255,255,255,0.05)', marginBottom: 12 }} />
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <div style={{ height: 16, width: 64, borderRadius: 8, background: 'rgba(255,255,255,0.06)' }} />
+        <div style={{ height: 10, width: 72, borderRadius: 6, background: 'rgba(255,255,255,0.05)' }} />
+      </div>
+    </div>
+  );
+}
+
+function DesktopPeerProgrammingPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Users size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Peer Programming</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign In</a>
+        </div>
+      </div>
+
+      <div style={{ padding: '48px 64px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+          Deterministic global cohorts
+        </span>
+        <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+          12-person weekly cohorts —<br /><span style={{ color: COLOR }}>you&apos;re always placed, never left out</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 15, color: SUBTLE, maxWidth: 520 }}>
+          Every survivor is matched into a cohort of 12. Global peers, weekly sessions, real skill-building. No competitive selection — you&apos;re guaranteed a spot.
+        </p>
+        <div style={{ display: 'flex', gap: 12, marginTop: 8, alignItems: 'center' }}>
+          <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Join the Hub — Free</a>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <Globe size={14} color={MUTED} />
+            <span style={{ fontSize: 13, color: MUTED }}>Active cohorts across 47 countries</span>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.55 }} aria-hidden="true">
+          {[0, 1, 2, 3].map((i) => (
+            <LockedCohortCard key={i} />
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={22} color={COLOR} /></div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to join your cohort</div>
+          <div style={{ fontSize: 13, color: MUTED, textAlign: 'center', maxWidth: 300 }}>You&apos;ll be matched automatically. First session within 48 hours.</div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign in to get matched</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobilePeerProgrammingPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Users size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>Peer Programming</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Deterministic global cohorts</span>
+        <p style={{ margin: 0, fontSize: 14, color: SUBTLE, lineHeight: 1.5 }}>12-person weekly cohorts across 47 countries. You&apos;re always placed — no competitive selection, guaranteed spot.</p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <Globe size={13} color={MUTED} />
+          <span style={{ fontSize: 12, color: MUTED }}>Active cohorts in 47 countries</span>
+        </div>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>Join the Hub — Free</a>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+          {[0, 1, 2].map((i) => (
+            <LockedCohortCard key={i} />
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to get matched</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Peer Programming. Renders the public marketing
+ * experience pixel-faithful to the PeerProgrammingPublic (desktop) and
+ * MobilePeerProgrammingPublic (phone) design mockups, with sign-in affordances
+ * pointing at the real hosted sign-in URL. It shows no private or per-user data:
+ * there is no public cohort feed, so the locked region behind the sign-in overlay
+ * renders neutral blurred placeholder cards rather than fabricated cohort rows.
+ */
+export function PeerProgrammingPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobilePeerProgrammingPublic signInUrl={signInUrl} /> : <DesktopPeerProgrammingPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/plugins/public-visitor-registry.tsx
+++ b/ctf/packages/web/components/plugins/public-visitor-registry.tsx
@@ -5,6 +5,11 @@ import { DirectoryPublicShell } from '@/components/directory/directory-public-sh
 import { FoundationPublicShell } from '@/components/foundation/foundation-public-shell';
 import { GdpPublicShell } from '@/components/gdp/gdp-public-shell';
 import { GentlePulsePublicShell } from '@/components/gentlepulse/gentlepulse-public-shell';
+import { LevelupPublicShell } from '@/components/levelup/levelup-public-shell';
+import { LighthousePublicShell } from '@/components/lighthouse/lighthouse-public-shell';
+import { MoodPublicShell } from '@/components/mood/mood-public-shell';
+import { PeerProgrammingPublicShell } from '@/components/peer-programming/peer-programming-public-shell';
+import { ServiceCreditsPublicShell } from '@/components/service-credits/service-credits-public-shell';
 import { GenericPublicShell } from '@/components/plugins/generic-public-shell';
 
 /**
@@ -39,6 +44,11 @@ const PUBLIC_VISITOR_SHELLS: Record<string, PublicVisitorShell> = {
   foundation: FoundationPublicShell,
   gdp: GdpPublicShell,
   gentlepulse: GentlePulsePublicShell,
+  levelup: LevelupPublicShell,
+  lighthouse: LighthousePublicShell,
+  mood: MoodPublicShell,
+  'peer-programming': PeerProgrammingPublicShell,
+  'service-credits': ServiceCreditsPublicShell,
 };
 
 /**

--- a/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { Zap, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the ServiceCreditsPublic / MobileServiceCreditsPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#F59E0B';
+const EARN_GREEN = '#22C55E';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#9CA3AF';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// These earn/spend lists are static marketing copy describing how the Hub economy
+// works (program rules), not per-user balances or fabricated transactions, so they
+// are safe to render in a signed-out public shell.
+const EARN_WAYS = [
+  { action: 'Complete a GentlePulse session', credits: '+5' },
+  { action: 'Attend a LevelUp cohort session', credits: '+15' },
+  { action: 'Refer a verified survivor', credits: '+50' },
+  { action: 'Give peer support in Chyme', credits: '+3' },
+  { action: 'Complete Skills Hunt round', credits: '+100' },
+];
+
+const SPEND_WAYS = [
+  { action: 'Pay for housing (LightHouse)', credits: 'Variable' },
+  { action: 'Book a TrustTransport ride', credits: '12–40 ServiceCredits' },
+  { action: 'Hire from Foundation (trades)', credits: 'Variable' },
+  { action: 'Pay a Directory provider', credits: 'Variable' },
+];
+
+const EARN_WAYS_MOBILE = [
+  { action: 'Complete a GentlePulse session', credits: '+5' },
+  { action: 'Attend a LevelUp cohort', credits: '+15' },
+  { action: 'Refer a survivor', credits: '+50' },
+];
+
+const SPEND_WAYS_MOBILE = [
+  { action: 'Housing (LightHouse)', credits: 'Variable' },
+  { action: 'Transport (TrustTransport)', credits: '12–40 cr' },
+  { action: 'Trades (Foundation)', credits: 'Variable' },
+];
+
+function DesktopServiceCreditsPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Zap size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>ServiceCredits</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign In</a>
+        </div>
+      </div>
+
+      <div style={{ padding: '48px 64px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+          The Survivor Hub economy
+        </span>
+        <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+          Earn credits. Spend them<br /><span style={{ color: COLOR }}>on real services, for free.</span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 15, color: SUBTLE, maxWidth: 520 }}>
+          ServiceCredits are earned by participating in the Hub and spent on housing, transport, healthcare, and trades. They are usable across all 18 plugins in the network.
+        </p>
+        <a href={signInUrl} style={{ marginTop: 8, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none', display: 'inline-block' }}>
+          Join the Hub — Free
+        </a>
+      </div>
+
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ display: 'flex', gap: 24, filter: 'blur(3px)', pointerEvents: 'none', opacity: 0.55 }} aria-hidden="true">
+          <div style={{ flex: 1, borderRadius: 16, border: '1px solid rgba(255,255,255,0.07)', padding: '20px 24px', background: 'rgba(255,255,255,0.02)' }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: EARN_GREEN, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 14 }}>Ways to Earn</div>
+            {EARN_WAYS.map((e) => (
+              <div key={e.action} style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                <span style={{ fontSize: 13 }}>{e.action}</span>
+                <span style={{ fontSize: 13, fontWeight: 700, color: EARN_GREEN }}>{e.credits}</span>
+              </div>
+            ))}
+          </div>
+          <div style={{ flex: 1, borderRadius: 16, border: '1px solid rgba(255,255,255,0.07)', padding: '20px 24px', background: 'rgba(255,255,255,0.02)' }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: COLOR, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 14 }}>Ways to Spend</div>
+            {SPEND_WAYS.map((s) => (
+              <div key={s.action} style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                <span style={{ fontSize: 13 }}>{s.action}</span>
+                <span style={{ fontSize: 13, fontWeight: 700, color: COLOR }}>{s.credits}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={22} color={COLOR} /></div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to start earning credits</div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#000', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>Sign in to earn credits</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileServiceCreditsPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ flex: 1, padding: '24px 20px 32px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Zap size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>ServiceCredits</span>
+        </div>
+        <h2 style={{ margin: 0, fontSize: 22, fontWeight: 800, lineHeight: 1.2 }}>
+          Earn credits by participating.<br /><span style={{ color: COLOR }}>Spend them on real services.</span>
+        </h2>
+        <p style={{ margin: 0, fontSize: 14, color: SUBTLE, lineHeight: 1.5 }}>Earn ServiceCredits through learning, mentoring, and community activities. Use them across housing, transport, trades, and more.</p>
+
+        <div style={{ borderRadius: 14, border: '1px solid rgba(255,255,255,0.08)', padding: '16px', background: 'rgba(255,255,255,0.02)' }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: EARN_GREEN, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 10 }}>Ways to Earn</div>
+          {EARN_WAYS_MOBILE.map((e) => (
+            <div key={e.action} style={{ display: 'flex', justifyContent: 'space-between', padding: '7px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+              <span style={{ fontSize: 13 }}>{e.action}</span>
+              <span style={{ fontSize: 13, fontWeight: 700, color: EARN_GREEN }}>{e.credits}</span>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ borderRadius: 14, border: '1px solid rgba(255,255,255,0.08)', padding: '16px', background: 'rgba(255,255,255,0.02)' }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: COLOR, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 10 }}>Ways to Spend</div>
+          {SPEND_WAYS_MOBILE.map((s) => (
+            <div key={s.action} style={{ display: 'flex', justifyContent: 'space-between', padding: '7px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+              <span style={{ fontSize: 13 }}>{s.action}</span>
+              <span style={{ fontSize: 13, fontWeight: 700, color: COLOR }}>{s.credits}</span>
+            </div>
+          ))}
+        </div>
+
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>Join to start earning</a>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for ServiceCredits. Renders the public marketing
+ * experience pixel-faithful to the ServiceCreditsPublic (desktop) and
+ * MobileServiceCreditsPublic (phone) design mockups, with sign-in affordances
+ * pointing at the real hosted sign-in URL. It shows no private or per-user data:
+ * the earn/spend lists are static marketing copy describing the Hub economy's
+ * rules, not any per-user balance or transaction history.
+ */
+export function ServiceCreditsPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileServiceCreditsPublic signInUrl={signInUrl} /> : <DesktopServiceCreditsPublic signInUrl={signInUrl} />;
+}


### PR DESCRIPTION
Adds signed-out public visitor shells for five plugins, each matching its desktop and phone design mockups, and wires them into the public visitor registry. Signed-out people who open these plugin pages now see a bespoke marketing screen with sign-in actions instead of the generic fallback. No route page, framework, auth, or other plugin files were changed.

## What each shell shows

- **levelup** (`components/levelup/levelup-public-shell.tsx`) — Hero with the cohort-based-learning pitch, three highlight bullets, and a "Join the Hub — Free" action. The locked region below the sign-in overlay renders neutral blurred placeholder rows.
- **lighthouse** (`components/lighthouse/lighthouse-public-shell.tsx`) — Privacy-first housing hero with "Join the Hub" and "How it works" actions. The locked listing region renders neutral blurred placeholder cards.
- **mood** (`components/mood/mood-public-shell.tsx`) — Anonymous mood check-in marketing screen with the privacy guarantees and a static, non-interactive mood-scale preview. New file plus one registry line only — no other mood file touched.
- **peer-programming** (`components/peer-programming/peer-programming-public-shell.tsx`) — Deterministic global cohorts hero with the "always placed" pitch and "47 countries" marketing line. The locked cohort region renders neutral blurred placeholder cards.
- **service-credits** (`components/service-credits/service-credits-public-shell.tsx`) — Hub economy hero with the static "Ways to Earn" / "Ways to Spend" lists that describe the program rules.

Every shell uses `useIsMobile()` to switch between the desktop and phone layouts, with inline hex, spacing, and Inter type scale taken from the mockups. Every sign-in / join / call-to-action points at the `signInUrl` prop (the real hosted sign-in URL).

## Real-data-only notes (rule 126 "No Stub Data")

A public shell has no session, so it must never show private or fabricated per-user data. The deviations from the mockups:

- **levelup, lighthouse, peer-programming**: the mockups place blurred sample rows/cards behind the sign-in lock. There is no public cohort or listing feed, so these are replaced with neutral blurred placeholder shapes (no fabricated titles, prices, credits, members, or ratings).
- **service-credits**: the "Ways to Earn" / "Ways to Spend" lists are kept as static marketing copy because they describe the Hub economy's rules, not any per-user balance or transaction history.
- **mood**: no deviation. The mood-face row is a static preview of the check-in scale, not recorded data.

## Validation (run in the worktree before push)

- `pnpm install` — clean, no lockfile or manifest changes committed.
- `pnpm --dir ctf --filter @ctf/web exec tsc --noEmit` — passed.
- `bash ctf/scripts/check-eof-format.sh` — passed.
- `node ctf/scripts/check-web-android-parity.mjs` — passed.
- Pre-push hook full web build — passed.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_