### PR TITLE
feat: bespoke public visitor screens for unlock, weekly-performance, whatworks, workforce

### DIFF
--- a/ctf/packages/web/components/plugins/public-visitor-registry.tsx
+++ b/ctf/packages/web/components/plugins/public-visitor-registry.tsx
@@ -10,6 +10,10 @@ import { LighthousePublicShell } from '@/components/lighthouse/lighthouse-public
 import { MoodPublicShell } from '@/components/mood/mood-public-shell';
 import { PeerProgrammingPublicShell } from '@/components/peer-programming/peer-programming-public-shell';
 import { ServiceCreditsPublicShell } from '@/components/service-credits/service-credits-public-shell';
+import { UnlockPublicShell } from '@/components/unlock/unlock-public-shell';
+import { WeeklyPerformancePublicShell } from '@/components/weekly-performance/weekly-performance-public-shell';
+import { WhatWorksPublicShell } from '@/components/whatworks/whatworks-public-shell';
+import { WorkforcePublicShell } from '@/components/workforce/workforce-public-shell';
 import { GenericPublicShell } from '@/components/plugins/generic-public-shell';
 
 /**
@@ -49,6 +53,10 @@ const PUBLIC_VISITOR_SHELLS: Record<string, PublicVisitorShell> = {
   mood: MoodPublicShell,
   'peer-programming': PeerProgrammingPublicShell,
   'service-credits': ServiceCreditsPublicShell,
+  unlock: UnlockPublicShell,
+  'weekly-performance': WeeklyPerformancePublicShell,
+  whatworks: WhatWorksPublicShell,
+  workforce: WorkforcePublicShell,
 };
 
 /**

--- a/ctf/packages/web/components/unlock/unlock-public-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-public-shell.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { Unlock as UnlockIcon, UserPlus, ChevronRight } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the UnlockPublic / MobileUnlockPublic design mockups.
+const BRAND = '#10B981';
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// How verification works — static marketing copy describing the onboarding flow.
+const STEPS = [
+  { n: '1', icon: '📝', title: 'Create a free account', desc: 'Sign up in 60 seconds. No credit card needed.' },
+  { n: '2', icon: '🔗', title: 'Submit your Quora URL', desc: 'Share your public Quora profile for identity verification.' },
+  { n: '3', icon: '🔍', title: 'Admin reviews within 48h', desc: 'A human checks your profile — not an algorithm.' },
+  { n: '4', icon: '🔓', title: 'Full access unlocked', desc: 'Access all apps, the marketplace, and the economy.' },
+];
+
+// Reasons survivors are asked for a public Quora profile — static marketing copy.
+const REASONS = [
+  { icon: '🛡', t: 'Safe community', d: 'Prevents bad actors from creating fake survivor accounts.' },
+  { icon: '🔗', t: 'Proof of identity', d: "Quora history proves you're a real person online." },
+  { icon: '🤝', t: 'Admin-reviewed', d: 'Every submission is reviewed by a real human, not a bot.' },
+  { icon: '🌐', t: 'Public profile only', d: 'We only need your public Quora URL — no login access.' },
+];
+
+function DesktopUnlockPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <UnlockIcon size={18} color={BRAND} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Unlock Access</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: 'rgba(255,255,255,0.06)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign In
+          </a>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: BRAND, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none' }}>
+            <UserPlus size={13} /> Create Account
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 40px', display: 'flex', gap: 48, alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, fontSize: 12, color: BRAND, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+            Verified access only
+          </span>
+          <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.15 }}>
+            Create your account to begin<br />
+            <span style={{ color: BRAND }}>the verification process</span>
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 520, lineHeight: 1.7 }}>
+            Survivor Hub uses Quora profile verification to confirm that members are real people. This protects the community from trafficker infiltration and protects the integrity of this economy.
+          </p>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: BRAND, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8, textDecoration: 'none' }}>
+              <UserPlus size={16} /> Get started — it&apos;s free
+            </a>
+          </div>
+        </div>
+        <div style={{ width: 280, flexShrink: 0 }}>
+          <div style={{ padding: '20px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}` }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>Why Quora verification?</div>
+            {REASONS.map(({ icon, t, d }) => (
+              <div key={t} style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+                <span style={{ fontSize: 18, flexShrink: 0 }}>{icon}</span>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{t}</div>
+                  <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>{d}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Verification flow steps */}
+      <div style={{ padding: '0 64px 48px' }}>
+        <div style={{ fontSize: 14, fontWeight: 700, color: TEXT, marginBottom: 16 }}>How verification works</div>
+        <div style={{ display: 'flex', gap: 12 }}>
+          {STEPS.map(({ n, icon, title, desc }) => (
+            <div key={n} style={{ flex: 1, padding: '20px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}` }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+                <div style={{ width: 26, height: 26, borderRadius: '50%', background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, color: BRAND }}>{n}</div>
+                <span style={{ fontSize: 18 }}>{icon}</span>
+              </div>
+              <div style={{ fontSize: 14, fontWeight: 600, color: TEXT, marginBottom: 6 }}>{title}</div>
+              <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>{desc}</div>
+            </div>
+          ))}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <a href={signInUrl} style={{ padding: '14px 24px', borderRadius: 12, background: BRAND, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8, textDecoration: 'none' }}>
+              Start now <ChevronRight size={15} />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileUnlockPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Header */}
+      <div style={{ padding: '12px 16px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <UnlockIcon size={16} color={BRAND} />
+            <span style={{ fontSize: 16, fontWeight: 700 }}>Unlock Access</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: 'rgba(255,255,255,0.08)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 11, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: BRAND, border: 'none', color: '#fff', fontSize: 11, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Join Free</a>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '24px 16px' }}>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, fontSize: 11, color: BRAND, fontWeight: 600, display: 'inline-block', marginBottom: 14 }}>
+          Verified access only
+        </span>
+
+        <h1 style={{ margin: '0 0 12px', fontSize: 26, fontWeight: 800, lineHeight: 1.2 }}>
+          Create your account to begin{' '}
+          <span style={{ color: BRAND }}>the verification process</span>
+        </h1>
+        <p style={{ margin: '0 0 22px', fontSize: 13, color: '#9CA3AF', lineHeight: 1.7 }}>
+          Survivor Hub uses Quora profile verification to confirm members are real people. This protects the community and protects the integrity of this economy.
+        </p>
+
+        <a href={signInUrl} style={{ width: '100%', padding: '14px', borderRadius: 12, background: BRAND, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, boxSizing: 'border-box', marginBottom: 20, textDecoration: 'none' }}>
+          <UserPlus size={15} /> Get started — it&apos;s free
+        </a>
+
+        {/* How it works */}
+        <div style={{ marginBottom: 20 }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: TEXT, marginBottom: 12 }}>How verification works</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {STEPS.map(({ n, icon, title, desc }) => (
+              <div key={n} style={{ display: 'flex', gap: 12, padding: '14px', borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, alignItems: 'center' }}>
+                <div style={{ width: 28, height: 28, borderRadius: '50%', background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, color: BRAND, flexShrink: 0 }}>{n}</div>
+                <span style={{ fontSize: 18, flexShrink: 0 }}>{icon}</span>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: TEXT }}>{title}</div>
+                  <div style={{ fontSize: 11, color: SUBTLE }}>{desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Why Quora mini panel */}
+        <div style={{ padding: '14px', borderRadius: 14, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 20 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: BRAND, marginBottom: 12 }}>Why Quora verification?</div>
+          {REASONS.slice(0, 3).map(({ icon, t, d }) => (
+            <div key={t} style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
+              <span style={{ fontSize: 16, flexShrink: 0 }}>{icon}</span>
+              <div>
+                <div style={{ fontSize: 12, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{t}</div>
+                <div style={{ fontSize: 11, color: SUBTLE, lineHeight: 1.5 }}>{d}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <a href={signInUrl} style={{ width: '100%', padding: '14px', borderRadius: 12, background: BRAND, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, boxSizing: 'border-box', textDecoration: 'none' }}>
+          Start verification <ChevronRight size={14} />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Unlock. Pixel-faithful to the UnlockPublic
+ * (desktop) and MobileUnlockPublic (phone) design mockups, with every sign-in,
+ * join, and call-to-action pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only: the mockup is pure marketing — it describes how Quora
+ * verification works and carries no per-user data, so it is reproduced as-is.
+ * The simulated phone status bar and the decorative locked bottom nav are
+ * dropped because the real app renders inside the browser chrome.
+ */
+export function UnlockPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileUnlockPublic signInUrl={signInUrl} /> : <DesktopUnlockPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-public-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-public-shell.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { BarChart2, Lock, UserPlus, LogIn } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the WeeklyPerformancePublic / MobileWeeklyPerformancePublic design mockups.
+const BRAND = '#F59E0B';
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// Neutral placeholder cards shown blurred behind the sign-in lock. The mockup
+// hardcoded sample figures here; a public visitor has no session, so the values
+// are neutral dashes rather than fabricated numbers — the cards only hint at the
+// layout that appears once signed in.
+const PLACEHOLDER_METRICS = [
+  { label: 'Total Members', color: '#A78BFA' },
+  { label: 'New Sign-ups', color: '#22C55E' },
+  { label: 'Plugin Engagements', color: BRAND },
+  { label: 'GDP Delta', color: '#06B6D4' },
+];
+
+// What you get access to — static marketing copy.
+const ACCESS_ITEMS = [
+  { icon: '📊', t: 'Weekly metric cards', d: 'Member count, sign-ups, engagement, GDP delta' },
+  { icon: '📈', t: 'Day-by-day chart', d: 'Plugin engagement compared to prior week' },
+  { icon: '🗓️', t: 'Full week history', d: 'Browse closed weeks going back in time' },
+  { icon: '📤', t: 'Admin export (gated)', d: 'Admins can export data as CSV' },
+];
+
+function DesktopWeeklyPerformancePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <BarChart2 size={18} color={BRAND} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Weekly Performance</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: 'rgba(255,255,255,0.06)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none' }}>
+            <LogIn size={13} /> Sign In
+          </a>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: BRAND, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none' }}>
+            <UserPlus size={13} /> Join Free
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 32px', display: 'flex', gap: 48, alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, fontSize: 12, color: BRAND, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+            Updated weekly
+          </span>
+          <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.15 }}>
+            See how the platform grows<br />
+            <span style={{ color: BRAND }}>week over week</span>
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 500, lineHeight: 1.7 }}>
+            Member growth, plugin engagement, and GDP delta — all tracked weekly. Sign in to view current and historical data.
+          </p>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: BRAND, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+              Sign in to view metrics
+            </a>
+          </div>
+        </div>
+        <div style={{ width: 260, flexShrink: 0 }}>
+          <div style={{ padding: '20px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}` }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>What you get access to</div>
+            {ACCESS_ITEMS.map((item) => (
+              <div key={item.t} style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+                <span style={{ fontSize: 18, flexShrink: 0 }}>{item.icon}</span>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{item.t}</div>
+                  <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>{item.d}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Placeholder metric cards + lock overlay (no fabricated figures) */}
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ filter: 'blur(6px)', pointerEvents: 'none', opacity: 0.4 }} aria-hidden>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 12, marginBottom: 20 }}>
+            {PLACEHOLDER_METRICS.map(({ label, color }) => (
+              <div key={label} style={{ padding: '18px 16px', borderRadius: 14, background: SURFACE, border: `1px solid ${color}20` }}>
+                <div style={{ fontSize: 11, color: SUBTLE, marginBottom: 10 }}>{label}</div>
+                <div style={{ fontSize: 28, fontWeight: 800, color }}>—</div>
+                <div style={{ fontSize: 11, color: SUBTLE, marginTop: 6 }}>—</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ padding: '20px 24px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, height: 120 }} />
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${BRAND}50`, background: `${BRAND}10`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={22} color={BRAND} />
+          </div>
+          <div style={{ fontSize: 18, fontWeight: 700, textAlign: 'center' }}>Sign in to view platform performance</div>
+          <div style={{ fontSize: 13, color: SUBTLE, textAlign: 'center', maxWidth: 340, lineHeight: 1.6 }}>
+            Survivors can view weekly metrics. Admin accounts can additionally lock weeks and export data.
+          </div>
+          <a href={signInUrl} style={{ padding: '12px 28px', borderRadius: 9, background: BRAND, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Create free account
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileWeeklyPerformancePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Header */}
+      <div style={{ padding: '12px 16px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <BarChart2 size={18} color={BRAND} />
+            <div style={{ fontSize: 16, fontWeight: 700 }}>Weekly Performance</div>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: 'rgba(255,255,255,0.08)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 11, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: BRAND, border: 'none', color: '#fff', fontSize: 11, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Join Free</a>
+          </div>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '20px 16px 0' }}>
+        <div style={{ fontSize: 20, fontWeight: 800, color: TEXT, marginBottom: 8 }}>See how the platform grows</div>
+        <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6, marginBottom: 16 }}>
+          Member growth, plugin engagement, and GDP delta — tracked week over week.
+        </div>
+        <a href={signInUrl} style={{ width: '100%', padding: '13px', borderRadius: 12, background: BRAND, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, boxSizing: 'border-box', marginBottom: 20, textDecoration: 'none' }}>
+          <UserPlus size={15} /> Create free account
+        </a>
+      </div>
+
+      {/* Placeholder cards + lock overlay (no fabricated figures) */}
+      <div style={{ padding: '0 16px 32px', position: 'relative' }}>
+        <div style={{ filter: 'blur(5px)', pointerEvents: 'none', opacity: 0.4 }} aria-hidden>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginBottom: 12 }}>
+            {PLACEHOLDER_METRICS.map(({ label, color }) => (
+              <div key={label} style={{ padding: '14px 12px', borderRadius: 12, background: SURFACE, border: `1px solid ${color}20` }}>
+                <div style={{ fontSize: 9, color: SUBTLE, marginBottom: 6 }}>{label}</div>
+                <div style={{ fontSize: 22, fontWeight: 800, color }}>—</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ height: 90, borderRadius: 14, background: SURFACE, border: `1px solid ${BORDER}` }} />
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10 }}>
+          <div style={{ width: 44, height: 44, borderRadius: '50%', border: `2px solid ${BRAND}50`, background: `${BRAND}10`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={18} color={BRAND} />
+          </div>
+          <div style={{ fontSize: 14, fontWeight: 700, textAlign: 'center' }}>Sign in to view metrics</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Weekly Performance. Pixel-faithful to the
+ * WeeklyPerformancePublic (desktop) and MobileWeeklyPerformancePublic (phone)
+ * design mockups, with every sign-in, join, and call-to-action pointing at the
+ * real hosted sign-in URL.
+ *
+ * Real-data-only deviation (no session = no private/fabricated data): the
+ * mockup hardcodes sample weekly metrics (4,912 members, 213 sign-ups, 1,847
+ * engagements, +$1.2M GDP delta, "+XX vs last week"). Those numbers are
+ * replaced with neutral dashes behind the same blurred lock overlay, so the
+ * layout and the sign-in gate read true without showing invented figures. The
+ * simulated phone status bar and the decorative locked bottom nav are dropped
+ * because the real app renders inside the browser chrome.
+ */
+export function WeeklyPerformancePublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileWeeklyPerformancePublic signInUrl={signInUrl} /> : <DesktopWeeklyPerformancePublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/whatworks/whatworks-public-shell.tsx
+++ b/ctf/packages/web/components/whatworks/whatworks-public-shell.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { ListChecks, UserPlus, BadgeCheck, Ban, Lock, ChevronRight } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the WhatWorksPublic / MobileWhatWorksPublic design mockups.
+const BRAND = '#84CC16';
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// Why trust this list — static marketing copy.
+const TRUST = [
+  { icon: <BadgeCheck size={15} color={BRAND} />, t: 'Survivor-verified', d: 'Used by a real member who said it helped.' },
+  { icon: <Ban size={15} color={BRAND} />, t: 'No ads or affiliates', d: 'Nothing here is sponsored.' },
+  { icon: <Lock size={15} color={BRAND} />, t: 'Anonymous', d: 'Suggesting never reveals who you are.' },
+];
+
+// The mockup's "A look at the list" preview hardcoded sample survivor reviews
+// (specific products, quoted notes, verified counts). A public visitor has no
+// session and the live list is not wired in, so the preview renders an honest
+// empty state that keeps the section framing without inventing reviews.
+function PreviewEmptyState({ compact }: { compact?: boolean }) {
+  return (
+    <div style={{ borderRadius: 14, border: `1px dashed ${BORDER}`, background: `${BRAND}06`, padding: compact ? '20px 16px' : '28px 24px', textAlign: 'center' }}>
+      <div style={{ width: compact ? 38 : 44, height: compact ? 38 : 44, borderRadius: '50%', background: `${BRAND}12`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 10px' }}>
+        <ListChecks size={compact ? 17 : 20} color={BRAND} />
+      </div>
+      <div style={{ fontSize: compact ? 13 : 14, fontWeight: 700, color: TEXT, marginBottom: 4 }}>The verified list opens once you join</div>
+      <div style={{ fontSize: compact ? 12 : 12.5, color: SUBTLE, lineHeight: 1.55, maxWidth: 420, margin: '0 auto' }}>
+        Each problem holds the specific tools a survivor here bought, used, and said helped. Create a free, verified account to browse them and add what worked for you.
+      </div>
+    </div>
+  );
+}
+
+function DesktopWhatWorksPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', maxHeight: '100%', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10, flexShrink: 0, background: '#0D0F14' }}>
+        <ListChecks size={18} color={BRAND} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>What Works</span>
+        <span style={{ fontSize: 12, color: SUBTLE, marginLeft: 4 }}>· survivor-verified tools</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: 'rgba(255,255,255,0.06)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 13, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none' }}>
+            <UserPlus size={13} /> Create Account
+          </a>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+        {/* Hero */}
+        <div style={{ padding: '44px 64px 28px', display: 'flex', gap: 48, alignItems: 'flex-start', maxWidth: 1100, margin: '0 auto' }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <span style={{ padding: '4px 14px', borderRadius: 20, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, fontSize: 12, color: BRAND, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 6, width: 'fit-content' }}>
+              <BadgeCheck size={13} /> One shared, survivor-verified list
+            </span>
+            <h1 style={{ margin: 0, fontSize: 36, fontWeight: 800, lineHeight: 1.12, letterSpacing: '-0.02em' }}>
+              The tools that<br /><span style={{ color: BRAND }}>actually work</span>.
+            </h1>
+            <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 520, lineHeight: 1.7 }}>
+              Pick a problem you&apos;re facing. Underneath it is a list of specific products a survivor here bought, used, and said helped — each with a direct link to get it. No ads. No affiliates. Nothing sold.
+            </p>
+            <div style={{ display: 'flex', gap: 12, marginTop: 4 }}>
+              <a href={signInUrl} style={{ padding: '13px 28px', borderRadius: 10, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 15, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8, textDecoration: 'none' }}>
+                <UserPlus size={16} /> Join to suggest items
+              </a>
+            </div>
+          </div>
+          <div style={{ width: 260, flexShrink: 0 }}>
+            <div style={{ padding: '18px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}` }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>Why trust this list?</div>
+              {TRUST.map(({ icon, t, d }) => (
+                <div key={t} style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+                  <span style={{ flexShrink: 0, marginTop: 1 }}>{icon}</span>
+                  <div>
+                    <div style={{ fontSize: 12.5, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{t}</div>
+                    <div style={{ fontSize: 11.5, color: SUBTLE, lineHeight: 1.5 }}>{d}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* List preview — honest empty state (no fabricated reviews) */}
+        <div style={{ padding: '0 64px 56px', maxWidth: 1100, margin: '0 auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+            <span style={{ fontSize: 13, fontWeight: 700, color: TEXT }}>A look at the list</span>
+            <span style={{ fontSize: 12, color: SUBTLE }}>· survivor-verified, opens after you join</span>
+          </div>
+
+          <PreviewEmptyState />
+
+          {/* Join gate */}
+          <div style={{ marginTop: 28, padding: '24px', borderRadius: 16, background: `${BRAND}08`, border: `1px solid ${BRAND}25`, display: 'flex', alignItems: 'center', gap: 16 }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 16, fontWeight: 700, color: TEXT, marginBottom: 4 }}>See every problem — and add what worked for you</div>
+              <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6 }}>Create a free, verified account to view the full list and suggest the tools that helped you.</div>
+            </div>
+            <a href={signInUrl} style={{ padding: '13px 26px', borderRadius: 10, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, textDecoration: 'none' }}>
+              Get started <ChevronRight size={15} />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileWhatWorksPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', height: '100vh', maxHeight: '100%', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Header */}
+      <div style={{ padding: '12px 16px', background: '#0D0F14', borderBottom: `1px solid ${BORDER}`, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <ListChecks size={17} color={BRAND} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>What Works</span>
+        <a href={signInUrl} style={{ marginLeft: 'auto', padding: '6px 13px', borderRadius: 8, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 12.5, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+      </div>
+
+      {/* Scroll */}
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '18px 16px' }}>
+        <span style={{ padding: '4px 11px', borderRadius: 20, background: `${BRAND}12`, border: `1px solid ${BRAND}25`, fontSize: 11, color: BRAND, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+          <BadgeCheck size={12} /> One shared, survivor-verified list
+        </span>
+        <h1 style={{ margin: '12px 0 8px', fontSize: 24, fontWeight: 800, lineHeight: 1.15, letterSpacing: '-0.01em' }}>
+          The tools that<br /><span style={{ color: BRAND }}>actually work</span>.
+        </h1>
+        <p style={{ margin: 0, fontSize: 13, color: '#9CA3AF', lineHeight: 1.65 }}>
+          Pick a problem you&apos;re facing. Underneath is a list of specific products a survivor here used and said helped — each with a direct link. No ads. Nothing sold.
+        </p>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, margin: '20px 0 12px' }}>
+          <span style={{ fontSize: 12.5, fontWeight: 700 }}>A look at the list</span>
+          <span style={{ fontSize: 11, color: SUBTLE }}>· opens after you join</span>
+        </div>
+
+        <PreviewEmptyState compact />
+
+        {/* Gate */}
+        <div style={{ marginTop: 20, padding: '18px', borderRadius: 14, background: `${BRAND}08`, border: `1px solid ${BRAND}25`, textAlign: 'center' }}>
+          <div style={{ width: 40, height: 40, borderRadius: '50%', background: `${BRAND}15`, border: `1px solid ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 10px' }}>
+            <Lock size={18} color={BRAND} />
+          </div>
+          <div style={{ fontSize: 15, fontWeight: 700, marginBottom: 4 }}>See every problem &amp; add yours</div>
+          <div style={{ fontSize: 12.5, color: SUBTLE, lineHeight: 1.55, marginBottom: 14 }}>Create a free, verified account to view the full list and suggest what worked for you.</div>
+          <a href={signInUrl} style={{ width: '100%', padding: '12px', borderRadius: 10, background: BRAND, border: 'none', color: '#0A0E06', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, boxSizing: 'border-box', textDecoration: 'none' }}>
+            <UserPlus size={15} /> Create free account
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for What Works. Pixel-faithful to the WhatWorksPublic
+ * (desktop) and MobileWhatWorksPublic (phone) design mockups, with every
+ * sign-in, join, and call-to-action pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviation (no session = no private/fabricated data): the
+ * mockup's "A look at the list" preview hardcoded sample survivor reviews
+ * (specific products, quoted notes, "N verified" counts). The live list is not
+ * wired into the public view, so the preview is replaced with an honest empty
+ * state that keeps the section framing and marketing copy without inventing
+ * reviews or verified counts. The simulated phone status bar is dropped because
+ * the real app renders inside the browser chrome.
+ */
+export function WhatWorksPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileWhatWorksPublic signInUrl={signInUrl} /> : <DesktopWhatWorksPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/workforce/workforce-public-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-public-shell.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { BarChart2, TrendingUp, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the WorkforcePublic / MobileWorkforcePublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#B45309';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// Snapshot categories from the mockup. The mockup filled these bars with sample
+// percentages; a public visitor has no session, so the bars render empty as a
+// neutral placeholder rather than showing fabricated distribution figures.
+const SNAPSHOT = [
+  { label: 'Employed', color: '#22C55E' },
+  { label: 'In Training', color: COLOR },
+  { label: 'Seeking Work', color: '#F59E0B' },
+  { label: 'Exploring', color: '#6B7280' },
+];
+
+function DesktopWorkforcePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <BarChart2 size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Workforce</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign In
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 32px', display: 'flex', gap: 80 }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+            5M survivor goal
+          </span>
+          <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+            Real-time workforce data<br />
+            <span style={{ color: COLOR }}>for every survivor</span>
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 460 }}>
+            Live skills distribution, employment gaps, and personalized pathways across our growing network. Your workforce coach lives here.
+          </p>
+          <a href={signInUrl} style={{ marginTop: 8, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none' }}>
+            Join the Hub — Free
+          </a>
+        </div>
+
+        {/* Snapshot — empty bars (no fabricated distribution) */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, minWidth: 260 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: '#4B5563', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Live workforce snapshot</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {SNAPSHOT.map(({ label, color }) => (
+              <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ width: 80, fontSize: 12, color: '#9CA3AF' }}>{label}</div>
+                <div style={{ flex: 1, height: 8, borderRadius: 4, background: 'rgba(255,255,255,0.05)' }} />
+                <div style={{ fontSize: 13, fontWeight: 700, color: SUBTLE, width: 32, textAlign: 'right' }}>—</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ fontSize: 11, color: SUBTLE, lineHeight: 1.5 }}>The snapshot fills in once you sign in.</div>
+        </div>
+      </div>
+
+      {/* Skill gap table — locked behind sign-in (no fabricated figures) */}
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ borderRadius: 16, border: '1px solid rgba(255,255,255,0.07)', overflow: 'hidden', filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden>
+          <div style={{ padding: '14px 20px', borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', gap: 8, alignItems: 'center' }}>
+            <TrendingUp size={14} color={COLOR} />
+            <span style={{ fontSize: 13, fontWeight: 700 }}>Top skill gaps right now</span>
+          </div>
+          {SNAPSHOT.map((_, i) => (
+            <div key={i} style={{ padding: '12px 20px', borderBottom: '1px solid rgba(255,255,255,0.04)', display: 'flex', alignItems: 'center', gap: 12 }}>
+              <div style={{ fontSize: 13, flex: 1, height: 10, borderRadius: 4, background: 'rgba(255,255,255,0.06)' }} />
+              <div style={{ width: 80, height: 10, borderRadius: 4, background: 'rgba(255,255,255,0.06)' }} />
+              <div style={{ width: 40, height: 10, borderRadius: 4, background: 'rgba(255,255,255,0.06)' }} />
+            </div>
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={22} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to see your personalized pathway</div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign in to access Workforce
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileWorkforcePublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <BarChart2 size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>Workforce</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>5M survivor goal</span>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>Real-time skills distribution, employment gaps, and personalized pathways across our growing network.</p>
+
+        {/* Snapshot — empty bars (no fabricated distribution) */}
+        <div style={{ borderRadius: 12, border: '1px solid rgba(255,255,255,0.07)', padding: '14px 16px', background: 'rgba(255,255,255,0.02)' }}>
+          <div style={{ fontSize: 11, color: SUBTLE, marginBottom: 10 }}>Live snapshot</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {SNAPSHOT.map(({ label }) => (
+              <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ width: 65, fontSize: 11, color: '#9CA3AF' }}>{label}</span>
+                <div style={{ flex: 1, height: 6, borderRadius: 3, background: 'rgba(255,255,255,0.05)' }} />
+                <span style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, width: 28, textAlign: 'right' }}>—</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative', minHeight: 300 }}>
+        <div style={{ height: 200, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.4, borderRadius: 12, border: '1px solid rgba(255,255,255,0.06)', background: 'rgba(255,255,255,0.02)' }} aria-hidden />
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 14, fontWeight: 700, textAlign: 'center' }}>Sign in for your personalized pathway</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Workforce. Pixel-faithful to the WorkforcePublic
+ * (desktop) and MobileWorkforcePublic (phone) design mockups, with every
+ * sign-in, join, and call-to-action pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviation (no session = no private/fabricated data): the
+ * mockup hardcoded a live snapshot (37/25/20/18% bars), a "4.9M survivors
+ * tracked" count, and a blurred skill-gap table with invented unmet-demand
+ * numbers and trends. The snapshot bars render empty with neutral dashes, the
+ * fabricated survivor count is dropped (the badge keeps only the stated "5M
+ * survivor goal"), and the gap table keeps the same blurred lock layout with
+ * neutral placeholder rows instead of invented figures. The simulated phone
+ * status bar is dropped because the real app renders inside the browser chrome.
+ */
+export function WorkforcePublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileWorkforcePublic signInUrl={signInUrl} /> : <DesktopWorkforcePublic signInUrl={signInUrl} />;
+}


### PR DESCRIPTION
Adds signed-out public visitor shells for four plugins — Unlock, Weekly Performance, What Works, and Workforce — built pixel-faithful to their desktop and phone design mockups, and wires each into the public visitor registry. Every sign-in, join, and call-to-action points at the real hosted sign-in URL. Each shell switches between the desktop and phone layout with `useIsMobile()`. No route page, framework, auth, or other plugin files were touched.

Files created:
- `ctf/packages/web/components/unlock/unlock-public-shell.tsx`
- `ctf/packages/web/components/weekly-performance/weekly-performance-public-shell.tsx`
- `ctf/packages/web/components/whatworks/whatworks-public-shell.tsx`
- `ctf/packages/web/components/workforce/workforce-public-shell.tsx`

Files changed:
- `ctf/packages/web/components/plugins/public-visitor-registry.tsx` — added the four imports and map entries in alphabetical order by slug.

Per-shell summary and real-data-only handling (a public shell has no session, so it never shows private or fabricated per-user data):

- Unlock — marketing onboarding that explains how Quora profile verification works. The mockup carries no per-user data, so it is reproduced as-is. The simulated phone status bar and the decorative locked bottom nav are dropped.
- Weekly Performance — hero plus an access-summary panel, with blurred metric cards behind a sign-in lock. The mockup's sample figures (4,912 members, 213 sign-ups, 1,847 engagements, +$1.2M GDP delta, "+XX vs last week") are replaced with neutral dashes behind the same blurred lock overlay. The simulated phone status bar and decorative locked bottom nav are dropped.
- What Works — hero plus a "why trust this list" panel. The mockup's "A look at the list" preview hardcoded sample survivor reviews (specific products, quoted notes, "N verified" counts); since the live list is not wired into the public view, that preview is replaced with an honest empty state that keeps the section framing and the join gate. The simulated phone status bar is dropped.
- Workforce — hero plus a live-snapshot panel and a locked skill-gap table. The snapshot bars render empty with neutral dashes, the fabricated "4.9M survivors tracked" count is dropped (the badge keeps only the stated "5M survivor goal"), and the gap table keeps the same blurred lock layout with neutral placeholder rows instead of invented unmet-demand figures. The simulated phone status bar is dropped.

Validation in the worktree: web typecheck (`tsc --noEmit`) passed; `check-eof-format.sh` passed; `check-web-android-parity.mjs` passed; the pre-push full web build passed. `pnpm install` left the lockfile and manifest unchanged.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_