### PR TITLE
feat: bespoke public visitor screens for skills-hunt, skills-taxonomy, socketrelay, trust, trusttransport

### DIFF
--- a/ctf/packages/web/components/plugins/public-visitor-registry.tsx
+++ b/ctf/packages/web/components/plugins/public-visitor-registry.tsx
@@ -10,6 +10,11 @@ import { LighthousePublicShell } from '@/components/lighthouse/lighthouse-public
 import { MoodPublicShell } from '@/components/mood/mood-public-shell';
 import { PeerProgrammingPublicShell } from '@/components/peer-programming/peer-programming-public-shell';
 import { ServiceCreditsPublicShell } from '@/components/service-credits/service-credits-public-shell';
+import { SkillsHuntPublicShell } from '@/components/skills-hunt/skills-hunt-public-shell';
+import { SkillsTaxonomyPublicShell } from '@/components/skills-taxonomy/skills-taxonomy-public-shell';
+import { SocketRelayPublicShell } from '@/components/socketrelay/socketrelay-public-shell';
+import { TrustPublicShell } from '@/components/trust/trust-public-shell';
+import { TrustTransportPublicShell } from '@/components/trusttransport/trusttransport-public-shell';
 import { UnlockPublicShell } from '@/components/unlock/unlock-public-shell';
 import { WeeklyPerformancePublicShell } from '@/components/weekly-performance/weekly-performance-public-shell';
 import { WhatWorksPublicShell } from '@/components/whatworks/whatworks-public-shell';
@@ -53,6 +58,11 @@ const PUBLIC_VISITOR_SHELLS: Record<string, PublicVisitorShell> = {
   mood: MoodPublicShell,
   'peer-programming': PeerProgrammingPublicShell,
   'service-credits': ServiceCreditsPublicShell,
+  'skills-hunt': SkillsHuntPublicShell,
+  'skills-taxonomy': SkillsTaxonomyPublicShell,
+  socketrelay: SocketRelayPublicShell,
+  trust: TrustPublicShell,
+  trusttransport: TrustTransportPublicShell,
   unlock: UnlockPublicShell,
   'weekly-performance': WeeklyPerformancePublicShell,
   whatworks: WhatWorksPublicShell,

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-public-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-public-shell.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { Search, Lock } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the SkillsHuntPublic / MobileSkillsHuntPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#D946EF';
+const TEXT = '#F9FAFB';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// Static description of how Skills Hunt works (marketing copy, not user data).
+const HOW_IT_WORKS = [
+  {
+    step: '1',
+    icon: '👤',
+    title: 'Someone you believe may be a survivor',
+    desc: "You don't need to be 100% certain — your best judgment is enough.",
+  },
+  {
+    step: '2',
+    icon: '🔗',
+    title: 'Enter their info',
+    desc: 'First name, bio, Quora profile for social proof, skills, and claimed professions.',
+  },
+  {
+    step: '3',
+    icon: '⚡',
+    title: 'They join our economy',
+    desc: 'Their skills become tradeable in the network. We build self-sufficient pathways.',
+  },
+  {
+    step: '4',
+    icon: '🏆',
+    title: 'You earn points',
+    desc: 'Climb the leaderboard. Earn badges. Find hidden gems.',
+  },
+];
+
+const NOMINATE_FIELDS = ['First Name', 'Bio', 'Quora Profile URL', 'Skills', 'Claimed Professions'];
+
+function DesktopSkillsHuntPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Search size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Skills Hunt</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign In
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 32px', display: 'flex', gap: 48, alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+            Gamified talent scouting
+          </span>
+          <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.15 }}>
+            Help find 5 million survivors<br />
+            <span style={{ color: COLOR }}>and map their hidden talents</span>
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 520, lineHeight: 1.7 }}>
+            This is not a referral button. You nominate someone you believe may be a survivor — entering their first name, bio, Quora profile, skills, and claimed professions. Their profile seeds the Directory so we can trade and stop depending on traffickers for basic needs.
+          </p>
+          <div style={{ display: 'flex', gap: 12, marginTop: 4 }}>
+            <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+              Join the Hub — Free
+            </a>
+          </div>
+        </div>
+
+        {/* How it works */}
+        <div style={{ width: 300, flexShrink: 0 }}>
+          <div style={{ padding: '20px', borderRadius: 16, background: 'rgba(255,255,255,0.02)', border: `1px solid ${COLOR}20` }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: COLOR, marginBottom: 14 }}>How Skills Hunt works</div>
+            {HOW_IT_WORKS.map((item) => (
+              <div key={item.step} style={{ display: 'flex', gap: 12, marginBottom: 14, alignItems: 'flex-start' }}>
+                <span style={{ fontSize: 20, flexShrink: 0 }}>{item.icon}</span>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: '#E8EAF0', marginBottom: 2 }}>{item.title}</div>
+                  <div style={{ fontSize: 12, color: '#6B7280', lineHeight: 1.5 }}>{item.desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Blurred form + leaderboard preview behind a sign-in lock (neutral placeholders, no fabricated scouts) */}
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ display: 'flex', gap: 16, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+          {/* Blurred form */}
+          <div style={{ flex: 1, maxWidth: 420, padding: '20px', borderRadius: 16, border: '1px solid rgba(255,255,255,0.07)', background: 'rgba(255,255,255,0.02)' }}>
+            <div style={{ fontSize: 15, fontWeight: 700, marginBottom: 16 }}>Nominate a Survivor</div>
+            {NOMINATE_FIELDS.map((f) => (
+              <div key={f} style={{ marginBottom: 12 }}>
+                <div style={{ fontSize: 12, color: '#6B7280', marginBottom: 4 }}>{f}</div>
+                <div style={{ height: 40, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }} />
+              </div>
+            ))}
+            <div style={{ height: 46, borderRadius: 10, background: COLOR + '50' }} />
+          </div>
+          {/* Blurred leaderboard (neutral placeholder rows) */}
+          <div style={{ flex: 1, padding: '20px', borderRadius: 16, border: '1px solid rgba(255,255,255,0.07)', background: 'rgba(255,255,255,0.02)' }}>
+            <div style={{ fontSize: 15, fontWeight: 700, marginBottom: 16 }}>Scout Leaderboard</div>
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                <div style={{ width: 24, fontSize: 16 }}>{['🥇', '🥈', '🥉', '#4'][i]}</div>
+                <div style={{ width: 36, height: 36, borderRadius: '50%', background: COLOR + '30' }} />
+                <div style={{ flex: 1 }}>
+                  <div style={{ height: 12, width: '55%', borderRadius: 6, background: 'rgba(255,255,255,0.10)', marginBottom: 6 }} />
+                  <div style={{ height: 9, width: '40%', borderRadius: 5, background: 'rgba(255,255,255,0.05)' }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={22} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Join to start scouting</div>
+          <div style={{ fontSize: 13, color: '#6B7280', textAlign: 'center', maxWidth: 320 }}>
+            Survivors only. Sign in to nominate people you believe may be survivors and help grow our self-sustaining economy.
+          </div>
+          <a href={signInUrl} style={{ padding: '12px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign in to scout
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileSkillsHuntPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      {/* Header */}
+      <div style={{ padding: '16px 20px 12px', display: 'flex', alignItems: 'center', gap: 10, borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+        <Search size={20} color={COLOR} />
+        <span style={{ fontSize: 20, fontWeight: 800 }}>Skills Hunt</span>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Community-powered talent scouting</span>
+        <h2 style={{ margin: 0, fontSize: 22, fontWeight: 800, lineHeight: 1.2 }}>
+          Help find 5M survivors<br />
+          <span style={{ color: COLOR }}>&amp; map their skills</span>
+        </h2>
+        <p style={{ margin: 0, fontSize: 13, color: '#9CA3AF', lineHeight: 1.6 }}>
+          This is not a referral button. You nominate someone you believe may be a survivor — first name, bio, Quora profile, skills, and professions. Their profile seeds the Directory so we can trade and stop depending on traffickers.
+        </p>
+
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      {/* Blurred form preview + lock (neutral placeholders) */}
+      <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.4 }} aria-hidden="true">
+          <div style={{ fontSize: 14, fontWeight: 700 }}>Nominate a Survivor</div>
+          {NOMINATE_FIELDS.map((f) => (
+            <div key={f}>
+              <div style={{ fontSize: 11, color: '#6B7280', marginBottom: 4 }}>{f}</div>
+              <div style={{ height: 40, borderRadius: 10, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }} />
+            </div>
+          ))}
+          <div style={{ height: 46, borderRadius: 12, background: COLOR + '60' }} />
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={20} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Join to start scouting</div>
+          <div style={{ fontSize: 12, color: '#6B7280', textAlign: 'center', maxWidth: 260, lineHeight: 1.5 }}>Survivors only. Nominate people you believe may be survivors and help build our self-sustaining economy.</div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in to scout</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Skills Hunt. Pixel-faithful to the SkillsHuntPublic
+ * (desktop) and MobileSkillsHuntPublic (phone) design mockups, with every sign-in
+ * affordance pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviations from the mockup (no session = no private/fabricated
+ * data): the mockup's hero activity counters (247 found this week, 1,482 skills
+ * mapped, 63 scouts active) and the named scout leaderboard rows (Amara O.,
+ * Maria G., Priya S., DeShawn W. with survivor counts) are invented sample data,
+ * so the counters are dropped and the leaderboard renders neutral blurred
+ * placeholder rows behind the sign-in lock. The "Nominate a Survivor" form posts
+ * to an authenticated-only endpoint, so its blurred preview stays decorative and
+ * its calls to action point at the sign-in URL. The simulated phone status bar is
+ * dropped because the real app renders inside the browser chrome.
+ */
+export function SkillsHuntPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileSkillsHuntPublic signInUrl={signInUrl} /> : <DesktopSkillsHuntPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-public-shell.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-public-shell.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { BookOpen, Lock, ChevronRight, UserPlus, LogIn } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the SkillsTaxonomyPublic / MobileSkillsTaxonomyPublic mockups.
+const BRAND = '#8B5CF6';
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// Static marketing copy describing why the taxonomy matters (not user data).
+const WHY_JOIN = [
+  { icon: '⚡', t: 'Trade with anyone', d: 'Skills map to real services you can buy or sell.' },
+  { icon: '🎓', t: 'Find learning cohorts', d: 'LevelUp matches you with peers based on shared skills.' },
+  { icon: '🔍', t: 'Skills Hunt discovery', d: 'Scouts use this database to nominate and verify survivors.' },
+  { icon: '🗺️', t: 'GDP contribution', d: 'Each skill added grows the survivor-economy estimate.' },
+];
+
+function DesktopSkillsTaxonomyPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <BookOpen size={18} color={BRAND} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Skills Taxonomy</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: 'rgba(255,255,255,0.06)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none' }}>
+            <LogIn size={13} /> Sign In
+          </a>
+          <a href={signInUrl} style={{ padding: '7px 16px', borderRadius: 8, background: BRAND, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, textDecoration: 'none' }}>
+            <UserPlus size={13} /> Join Free
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 32px', display: 'flex', gap: 48, alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: `${BRAND}15`, border: `1px solid ${BRAND}30`, fontSize: 12, color: BRAND, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+            Skills · sectors · job titles
+          </span>
+          <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.15 }}>
+            The survivor skills database<br />
+            <span style={{ color: BRAND }}>is yours to explore</span>
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 500, lineHeight: 1.7 }}>
+            Browse every skill, job title, and sector represented by survivors worldwide. Sign in to search, filter, and match skills to real opportunities.
+          </p>
+          <a href={signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: BRAND, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', display: 'flex', alignItems: 'center', gap: 8, textDecoration: 'none' }}>
+            Sign in to explore <ChevronRight size={16} />
+          </a>
+        </div>
+
+        {/* Why join */}
+        <div style={{ width: 280, flexShrink: 0 }}>
+          <div style={{ padding: '20px', borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}` }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>Why the taxonomy matters</div>
+            {WHY_JOIN.map((item) => (
+              <div key={item.t} style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+                <span style={{ fontSize: 18, flexShrink: 0 }}>{item.icon}</span>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{item.t}</div>
+                  <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>{item.d}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Blurred taxonomy preview + lock overlay (neutral placeholders, no fabricated sector data) */}
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ display: 'flex', gap: 16, filter: 'blur(5px)', pointerEvents: 'none', opacity: 0.45 }} aria-hidden="true">
+          {[0, 1, 2].map((col) => (
+            <div key={col} style={{ flex: 1, padding: '16px', borderRadius: 14, border: `1px solid ${BRAND}25`, background: SURFACE }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 14 }}>
+                <div style={{ width: 8, height: 8, borderRadius: '50%', background: BRAND }} />
+                <div style={{ height: 12, width: 90, borderRadius: 6, background: 'rgba(255,255,255,0.10)' }} />
+              </div>
+              {[0, 1, 2].map((row) => (
+                <div key={row} style={{ padding: '9px 12px', borderRadius: 8, background: 'rgba(255,255,255,0.03)', border: `1px solid ${BORDER}`, marginBottom: 6 }}>
+                  <div style={{ height: 11, width: '70%', borderRadius: 5, background: 'rgba(255,255,255,0.08)' }} />
+                  <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+                    {[0, 1, 2].map((s) => (
+                      <span key={s} style={{ height: 16, width: 42, borderRadius: 10, background: `${BRAND}15`, display: 'inline-block' }} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${BRAND}50`, background: `${BRAND}10`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={22} color={BRAND} />
+          </div>
+          <div style={{ fontSize: 18, fontWeight: 700, textAlign: 'center' }}>Sign in to explore the full skills database</div>
+          <div style={{ fontSize: 13, color: SUBTLE, textAlign: 'center', maxWidth: 340 }}>
+            Browse every skill and sector, search by job title, and see which survivors you can trade with.
+          </div>
+          <a href={signInUrl} style={{ padding: '12px 28px', borderRadius: 9, background: BRAND, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Create free account
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileSkillsTaxonomyPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Header */}
+      <div style={{ padding: '12px 16px 12px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <BookOpen size={18} color={BRAND} />
+            <div style={{ fontSize: 16, fontWeight: 700 }}>Skills Taxonomy</div>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: 'rgba(255,255,255,0.08)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 11, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+            <a href={signInUrl} style={{ padding: '5px 10px', borderRadius: 6, background: BRAND, border: 'none', color: '#fff', fontSize: 11, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Join Free</a>
+          </div>
+        </div>
+      </div>
+
+      {/* Hero copy */}
+      <div style={{ padding: '20px 16px 0' }}>
+        <div style={{ fontSize: 20, fontWeight: 800, color: TEXT, marginBottom: 8 }}>
+          Explore the survivor skills database
+        </div>
+        <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6, marginBottom: 16 }}>
+          Every skill, job title, and sector represented by survivors. Sign in to search, filter, and trade with survivors who have the skills you need.
+        </div>
+        <a href={signInUrl} style={{ width: '100%', padding: '13px', borderRadius: 12, background: BRAND, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, boxSizing: 'border-box', marginBottom: 16, textDecoration: 'none' }}>
+          <UserPlus size={15} /> Create free account
+        </a>
+      </div>
+
+      {/* Blurred sector list + lock overlay (neutral placeholders) */}
+      <div style={{ padding: '0 16px 32px', position: 'relative' }}>
+        <div style={{ filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.4 }} aria-hidden="true">
+          <div style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>All Sectors</div>
+          {['#3B82F6', '#10B981', '#F59E0B', '#EC4899', '#8B5CF6', '#06B6D4'].map((dot, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', borderRadius: 10, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 6 }}>
+              <div style={{ width: 8, height: 8, borderRadius: '50%', background: dot }} />
+              <div style={{ height: 12, width: 130, borderRadius: 6, background: 'rgba(255,255,255,0.08)', flex: 1 }} />
+              <ChevronRight size={14} color={SUBTLE} />
+            </div>
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: '50%', border: `2px solid ${BRAND}50`, background: `${BRAND}12`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={20} color={BRAND} />
+          </div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to explore</div>
+          <div style={{ fontSize: 12, color: SUBTLE, textAlign: 'center', maxWidth: 240 }}>
+            Full access to all sectors, job titles, and skills requires an account.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Skills Taxonomy. Pixel-faithful to the
+ * SkillsTaxonomyPublic (desktop) and MobileSkillsTaxonomyPublic (phone) design
+ * mockups, with every sign-in affordance pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviations from the mockup (no session = no live data): the
+ * mockup's exact aggregate counts (128 skills, 47 job titles, 9 sectors), shown
+ * in the hero pill, the stat triplet, and the stats strip, are hardcoded sample
+ * figures, so they are replaced with neutral phrasing ("Skills · sectors · job
+ * titles") rather than fabricated totals. The blurred sector/job-title preview
+ * (Technology / Healthcare / Trades with named jobs and "Skill A/B/C" tags, and
+ * the six named sector rows) renders as neutral blurred placeholder cards behind
+ * the sign-in lock instead of invented taxonomy rows. The simulated phone status
+ * bar is dropped because the real app renders inside the browser chrome.
+ */
+export function SkillsTaxonomyPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileSkillsTaxonomyPublic signInUrl={signInUrl} /> : <DesktopSkillsTaxonomyPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/socketrelay/socketrelay-public-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-public-shell.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import {
+  Share2, Search, Shield, ShieldCheck, Lock, LogIn, UserPlus, Heart, Plus,
+} from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the SocketRelayPublic / MobileSocketRelayPublic mockups.
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+const DESKTOP_COLOR = '#FB923C';
+const MOBILE_COLOR = '#F43F5E';
+const ACCENT = '#7C3AED';
+const ACCENT_CYAN = '#0EA5E9';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+const CATEGORIES = ['All', 'Food', 'Transport', 'Legal', 'Employment', 'Childcare', 'Housing', 'Mental Health'];
+
+function DesktopSocketRelayPublic({ signInUrl }: { signInUrl: string }) {
+  const COLOR = DESKTOP_COLOR;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT }}>
+      {/* Marketing banner */}
+      <div style={{ background: `linear-gradient(90deg, ${ACCENT} 0%, ${ACCENT_CYAN} 100%)`, padding: '10px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <Share2 size={15} color="#fff" />
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#fff' }}>SocketRelay · Mutual aid, free forever</span>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <a href={signInUrl} style={{ padding: '6px 16px', borderRadius: 7, background: 'rgba(255,255,255,0.15)', border: '1px solid rgba(255,255,255,0.3)', color: '#fff', fontWeight: 600, fontSize: 13, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, textDecoration: 'none' }}>
+            <LogIn size={13} /> Sign In
+          </a>
+          <a href={signInUrl} style={{ padding: '6px 16px', borderRadius: 7, background: 'rgba(255,255,255,0.18)', border: '1px solid rgba(255,255,255,0.45)', color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, textDecoration: 'none' }}>
+            <UserPlus size={13} /> Post a Need Free →
+          </a>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flex: 1 }}>
+        {/* Left sidebar */}
+        <aside style={{ width: 300, borderRight: `1px solid ${BORDER}`, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ padding: '16px 16px 10px', borderBottom: `1px solid ${BORDER}` }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+              <Share2 size={16} color={COLOR} />
+              <span style={{ fontSize: 15, fontWeight: 700 }}>SocketRelay</span>
+              <span style={{ marginLeft: 'auto', fontSize: 11, background: `${COLOR}18`, color: COLOR, border: `1px solid ${COLOR}30`, borderRadius: 4, padding: '2px 7px' }}>Public Feed</span>
+            </div>
+            <div style={{ position: 'relative', marginBottom: 10 }}>
+              <Search size={13} style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: SUBTLE }} />
+              <input placeholder="Search needs & offers…" style={{ width: '100%', padding: '8px 10px 8px 30px', background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, borderRadius: 8, fontSize: 13, color: SUBTLE, outline: 'none', boxSizing: 'border-box' }} readOnly />
+            </div>
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+              {CATEGORIES.map((c) => (
+                <span key={c} style={{ fontSize: 11, padding: '3px 8px', borderRadius: 12, border: `1px solid ${c === 'All' ? COLOR + '50' : BORDER}`, color: c === 'All' ? COLOR : SUBTLE, background: c === 'All' ? `${COLOR}10` : 'transparent', cursor: 'default' }}>{c}</span>
+              ))}
+            </div>
+          </div>
+
+          {/* How it works (static marketing copy, no fabricated counts) */}
+          <div style={{ padding: '12px 12px 8px' }}>
+            {[
+              'Post a need or an offer — always free',
+              'Anonymous posts are supported',
+              'Survivors respond and connect directly',
+            ].map((l) => (
+              <div key={l} style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '7px 0', borderBottom: `1px solid ${BORDER}` }}>
+                <Heart size={13} color={COLOR} style={{ marginTop: 2, flexShrink: 0 }} />
+                <span style={{ fontSize: 12, color: SUBTLE }}>{l}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Auth gate to post */}
+          <div style={{ margin: '12px', borderRadius: 12, border: `2px dashed ${COLOR}30`, background: `${COLOR}06`, padding: '16px', textAlign: 'center' }}>
+            <Lock size={16} color={SUBTLE} style={{ marginBottom: 6 }} />
+            <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 4 }}>Sign in to post or respond</div>
+            <div style={{ fontSize: 11, color: SUBTLE, marginBottom: 10 }}>Posting is always free. Anonymous posts supported.</div>
+            <a href={signInUrl} style={{ display: 'block', width: '100%', padding: '9px', borderRadius: 8, background: `linear-gradient(90deg,${ACCENT},${ACCENT_CYAN})`, border: 'none', color: '#fff', fontWeight: 700, fontSize: 12, cursor: 'pointer', boxSizing: 'border-box', textDecoration: 'none' }}>
+              Create Free Account →
+            </a>
+          </div>
+        </aside>
+
+        {/* Main feed */}
+        <main style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ padding: '16px 24px', borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{ fontSize: 15, fontWeight: 700 }}>Live Relay Feed</div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>Public · Updates in real time</div>
+            <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 20, background: SURFACE, border: `1px solid ${BORDER}` }}>
+                <ShieldCheck size={12} color={ACCENT_CYAN} />
+                <span style={{ fontSize: 11, color: ACCENT_CYAN }}>Survivor Verified</span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 20, background: SURFACE, border: `1px solid ${BORDER}` }}>
+                <Shield size={12} color={SUBTLE} />
+                <span style={{ fontSize: 11, color: SUBTLE }}>Anonymous posts protected</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Blurred feed preview + lock (neutral placeholders, no fabricated needs/offers) */}
+          <div style={{ flex: 1, position: 'relative', minHeight: 360 }}>
+            <div style={{ padding: '16px 24px', display: 'flex', flexDirection: 'column', gap: 10, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+              {[0, 1, 2, 3, 4].map((i) => {
+                const need = i % 2 === 0;
+                return (
+                  <div key={i} style={{ borderRadius: 12, border: `1px solid ${need ? '#FB923C30' : '#22C55E30'}`, background: need ? '#FB923C06' : '#22C55E06', padding: '14px 16px' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                      <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 8px', borderRadius: 4, background: need ? '#FB923C20' : '#22C55E20', color: need ? '#FB923C' : '#22C55E' }}>{need ? 'NEED' : 'OFFER'}</span>
+                      <span style={{ height: 14, width: 60, borderRadius: 4, background: 'rgba(255,255,255,0.06)' }} />
+                    </div>
+                    <div style={{ height: 13, width: '70%', borderRadius: 6, background: 'rgba(255,255,255,0.10)', marginBottom: 10 }} />
+                    <div style={{ height: 10, width: '45%', borderRadius: 5, background: 'rgba(255,255,255,0.05)' }} />
+                  </div>
+                );
+              })}
+            </div>
+            <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+              <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Lock size={22} color={COLOR} />
+              </div>
+              <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to see the live relay feed</div>
+              <div style={{ fontSize: 13, color: SUBTLE, textAlign: 'center', maxWidth: 320 }}>
+                Browse open needs and offers, then respond directly. Posting is always free and anonymous posts are supported.
+              </div>
+              <a href={signInUrl} style={{ padding: '12px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontWeight: 700, fontSize: 14, cursor: 'pointer', textDecoration: 'none' }}>
+                Sign in to respond
+              </a>
+            </div>
+          </div>
+
+          {/* Bottom CTA */}
+          <div style={{ padding: '16px 24px', borderTop: `1px solid ${BORDER}`, display: 'flex', gap: 10, alignItems: 'center' }}>
+            <div style={{ fontSize: 13, color: SUBTLE }}>Want to help or need something?</div>
+            <a href={signInUrl} style={{ padding: '9px 22px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, textDecoration: 'none' }}>
+              <Plus size={14} /> Post a Need
+            </a>
+            <a href={signInUrl} style={{ padding: '9px 22px', borderRadius: 9, background: 'transparent', border: `1px solid ${COLOR}50`, color: COLOR, fontWeight: 700, fontSize: 13, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, textDecoration: 'none' }}>
+              <Heart size={14} /> Post an Offer
+            </a>
+            <div style={{ marginLeft: 'auto', fontSize: 12, color: SUBTLE, display: 'flex', alignItems: 'center', gap: 5 }}>
+              <Shield size={12} color={SUBTLE} /> Anonymous posts always available
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function MobileSocketRelayPublic({ signInUrl }: { signInUrl: string }) {
+  const COLOR = MOBILE_COLOR;
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Share2 size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>Socket Relay</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Peer-to-peer needs board</span>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>Post what you need, offer what you have. Clothing, furniture, skills, time — the survivor community connects directly.</p>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      {/* Blurred feed preview + lock (neutral placeholders) */}
+      <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+          {[0, 1, 2, 3].map((i) => {
+            const need = i % 2 === 0;
+            return (
+              <div key={i} style={{ borderRadius: 12, border: '1px solid rgba(255,255,255,0.07)', padding: '12px 14px' }}>
+                <div style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
+                  <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 8px', borderRadius: 4, background: need ? COLOR + '20' : '#22C55E20', color: need ? COLOR : '#22C55E' }}>{need ? 'NEED' : 'OFFER'}</span>
+                </div>
+                <div style={{ height: 13, width: '75%', borderRadius: 6, background: 'rgba(255,255,255,0.10)' }} />
+                <div style={{ height: 10, width: '35%', borderRadius: 5, background: 'rgba(255,255,255,0.05)', marginTop: 8 }} />
+              </div>
+            );
+          })}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to post and respond</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for SocketRelay. Pixel-faithful to the SocketRelayPublic
+ * (desktop) and MobileSocketRelayPublic (phone) design mockups, with every sign-in
+ * affordance pointing at the real hosted sign-in URL. Each breakpoint keeps its own
+ * mockup accent (desktop #FB923C, phone #F43F5E).
+ *
+ * Real-data-only deviations from the mockup (no session = no live data): the
+ * desktop mockup's banner counters (847 open requests, 12,400 fulfilled this
+ * month), the sidebar stat rows (847 active requests, 12.4K fulfilled, $0 to
+ * post), and every relay request/offer card (named posters like Marcus B.,
+ * Amara O., James T., locations, credit amounts, timestamps) are invented sample
+ * data, so the counters are dropped, the sidebar shows static "how it works" copy,
+ * and the feed renders neutral blurred placeholder cards behind a sign-in lock.
+ * The phone mockup's four blurred sample posts are likewise replaced with neutral
+ * placeholders. The search input and category chips are read-only marketing
+ * decoration; the simulated phone status bar is dropped because the real app
+ * renders inside the browser chrome.
+ */
+export function SocketRelayPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileSocketRelayPublic signInUrl={signInUrl} /> : <DesktopSocketRelayPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/trust/trust-public-shell.tsx
+++ b/ctf/packages/web/components/trust/trust-public-shell.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { Shield, CheckCircle } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the TrustPublic / MobileTrustPublic design mockups.
+const BG = '#0F1117';
+const COLOR = '#0284C7';
+const TEXT = '#F9FAFB';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+// Static description of the voluntary signals Trust aggregates (marketing copy).
+const DESKTOP_SIGNALS = [
+  'Identity verification',
+  'Survivor-status attestation (non-coercive)',
+  'Service Credit transaction history',
+  'Community peer vouches',
+  'Cohort completion record',
+];
+
+const MOBILE_SIGNALS = [
+  'Identity verification',
+  'Survivor-status attestation',
+  'Service Credit history',
+  'Community peer vouches',
+  'Cohort completion record',
+];
+
+function DesktopTrustPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Shield size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Trust</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>Sign In</a>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '64px' }}>
+        <div style={{ maxWidth: 640, display: 'flex', gap: 56, alignItems: 'flex-start' }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+              Privacy-respecting identity
+            </span>
+            <h1 style={{ margin: 0, fontSize: 32, fontWeight: 800, lineHeight: 1.1 }}>
+              Your Trust score proves<br />
+              <span style={{ color: COLOR }}>you&apos;re real — without exposing who you are</span>
+            </h1>
+            <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF' }}>
+              Trust aggregates voluntary signals to establish credibility on the platform. Providers and peers can trust you. You reveal nothing beyond what you choose.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {DESKTOP_SIGNALS.map((s) => (
+                <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <CheckCircle size={14} color={COLOR} />
+                  <span style={{ fontSize: 14, color: '#D1D5DB' }}>{s}</span>
+                </div>
+              ))}
+            </div>
+            <a href={signInUrl} style={{ marginTop: 8, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none' }}>
+              Join the Hub — Free
+            </a>
+          </div>
+
+          {/* Trust score preview (empty state — no fabricated score) */}
+          <div style={{ width: 240, borderRadius: 16, border: `1px solid ${COLOR}30`, padding: '24px 20px', background: COLOR + '06', display: 'flex', flexDirection: 'column', gap: 16, alignItems: 'center', flexShrink: 0 }}>
+            <div style={{ width: 72, height: 72, borderRadius: 36, border: `3px solid ${COLOR}`, background: COLOR + '15', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Shield size={32} color={COLOR} />
+            </div>
+            <div style={{ textAlign: 'center' }}>
+              <div style={{ fontSize: 11, color: '#6B7280' }}>Your Trust Score</div>
+              <div style={{ fontSize: 32, fontWeight: 900, color: COLOR, marginTop: 2 }}>—</div>
+              <div style={{ fontSize: 12, color: '#6B7280', marginTop: 2 }}>Sign in to build yours</div>
+            </div>
+            <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {DESKTOP_SIGNALS.slice(0, 3).map((s) => (
+                <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 8, border: '1px solid rgba(255,255,255,0.06)', opacity: 0.4 }}>
+                  <div style={{ width: 14, height: 14, borderRadius: 7, border: `1px solid ${COLOR}50` }} />
+                  <span style={{ fontSize: 11, color: '#9CA3AF' }}>{s}</span>
+                </div>
+              ))}
+            </div>
+            <a href={signInUrl} style={{ width: '100%', padding: '11px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', textAlign: 'center', boxSizing: 'border-box', textDecoration: 'none' }}>
+              Sign in to verify
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileTrustPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ flex: 1, padding: '24px 20px 32px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Shield size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>Trust</span>
+        </div>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Privacy-respecting identity</span>
+        <h2 style={{ margin: 0, fontSize: 22, fontWeight: 800, lineHeight: 1.2 }}>
+          Prove you&apos;re real.<br />
+          <span style={{ color: COLOR }}>Without exposing who you are.</span>
+        </h2>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>Trust aggregates voluntary signals to establish credibility. Providers and peers can trust you — you reveal nothing beyond what you choose.</p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {MOBILE_SIGNALS.map((s) => (
+            <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <CheckCircle size={13} color={COLOR} />
+              <span style={{ fontSize: 13, color: '#D1D5DB' }}>{s}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Trust score preview card (empty state) */}
+        <div style={{ borderRadius: 16, border: `1px solid ${COLOR}30`, padding: '20px', background: COLOR + '06', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+          <div style={{ width: 60, height: 60, borderRadius: 30, border: `3px solid ${COLOR}`, background: COLOR + '15', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Shield size={26} color={COLOR} />
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: 11, color: '#6B7280' }}>Your Trust Score</div>
+            <div style={{ fontSize: 28, fontWeight: 900, color: COLOR, marginTop: 2 }}>—</div>
+            <div style={{ fontSize: 11, color: '#6B7280', marginTop: 2 }}>Sign in to build yours</div>
+          </div>
+          <a href={signInUrl} style={{ width: '100%', padding: '13px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textAlign: 'center', boxSizing: 'border-box', textDecoration: 'none' }}>
+            Join the Hub — Free
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for Trust. Pixel-faithful to the TrustPublic (desktop)
+ * and MobileTrustPublic (phone) design mockups, with every sign-in affordance
+ * pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only note: the mockup already renders the score as an em-dash ("—")
+ * empty state and the signal list is static marketing copy describing what Trust
+ * aggregates, so there is no fabricated per-user data to remove. The simulated
+ * phone status bar is dropped because the real app renders inside the browser
+ * chrome.
+ */
+export function TrustPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileTrustPublic signInUrl={signInUrl} /> : <DesktopTrustPublic signInUrl={signInUrl} />;
+}

--- a/ctf/packages/web/components/trusttransport/trusttransport-public-shell.tsx
+++ b/ctf/packages/web/components/trusttransport/trusttransport-public-shell.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { Car, Lock, Package, Utensils } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+
+// Palette from the TrustTransportPublic / MobileTrustTransportPublic mockups.
+const BG = '#0F1117';
+const COLOR = '#F97316';
+const TEXT = '#F9FAFB';
+const FONT_FAMILY = "'Inter', system-ui, sans-serif";
+
+const SERVICE_TYPES = [
+  { icon: Car, label: 'Rides', desc: 'Safe passenger transport', color: COLOR },
+  { icon: Package, label: 'Packages', desc: 'Item delivery', color: '#3B82F6' },
+  { icon: Utensils, label: 'Food', desc: 'Meal delivery', color: '#22C55E' },
+];
+
+function DesktopTrustTransportPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+      {/* Top bar */}
+      <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
+        <Car size={18} color={COLOR} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>TrustTransport</span>
+        <div style={{ marginLeft: 'auto' }}>
+          <a href={signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign In
+          </a>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div style={{ padding: '48px 64px 32px', display: 'flex', gap: 80 }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <span style={{ padding: '4px 14px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 12, color: COLOR, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
+            Safety-first transport
+          </span>
+          <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
+            Rides, deliveries, and food —<br />
+            <span style={{ color: COLOR }}>trauma-informed drivers only</span>
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, color: '#9CA3AF', maxWidth: 480 }}>
+            Every driver is background-checked and trauma-informed. Your pickup location is never stored permanently. Pay with Service Credits.
+          </p>
+          <a href={signInUrl} style={{ marginTop: 8, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none' }}>
+            Join the Hub — Free
+          </a>
+        </div>
+
+        {/* Service type preview */}
+        <div style={{ display: 'flex', gap: 14, alignItems: 'flex-start' }}>
+          {SERVICE_TYPES.map(({ icon: Icon, label, desc, color }, i) => (
+            <div key={label} style={{ borderRadius: 14, border: `1px solid ${i === 0 ? color + '40' : 'rgba(255,255,255,0.07)'}`, padding: '20px 20px', background: i === 0 ? color + '08' : 'rgba(255,255,255,0.02)', display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'center', minWidth: 110 }}>
+              <div style={{ width: 40, height: 40, borderRadius: 20, background: color + '20', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Icon size={18} color={color} />
+              </div>
+              <span style={{ fontSize: 14, fontWeight: 700 }}>{label}</span>
+              <span style={{ fontSize: 11, color: '#9CA3AF', textAlign: 'center' }}>{desc}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Blurred driver preview + lock (neutral placeholders, no fabricated drivers) */}
+      <div style={{ padding: '0 64px 48px', position: 'relative' }}>
+        <div style={{ borderRadius: 16, border: '1px solid rgba(255,255,255,0.07)', padding: '20px 24px', background: 'rgba(255,255,255,0.02)', filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 14, color: '#9CA3AF' }}>Available drivers near you</div>
+          {[0, 1, 2].map((i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+              <div style={{ width: 40, height: 40, borderRadius: 20, background: COLOR + '25' }} />
+              <div style={{ flex: 1 }}>
+                <div style={{ height: 13, width: 130, borderRadius: 6, background: 'rgba(255,255,255,0.10)', marginBottom: 6 }} />
+                <div style={{ height: 10, width: 90, borderRadius: 5, background: 'rgba(255,255,255,0.05)' }} />
+              </div>
+              <div style={{ height: 13, width: 44, borderRadius: 6, background: 'rgba(34,197,94,0.25)' }} />
+            </div>
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+          <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Lock size={22} color={COLOR} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to book a safe ride</div>
+          <div style={{ fontSize: 13, color: '#6B7280', textAlign: 'center', maxWidth: 300 }}>
+            Schedule rides, track packages, and order food — all with trauma-informed drivers.
+          </div>
+          <a href={signInUrl} style={{ padding: '11px 28px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>
+            Sign in to book transport
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileTrustTransportPublic({ signInUrl }: { signInUrl: string }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+      <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Car size={20} color={COLOR} />
+          <span style={{ fontSize: 20, fontWeight: 800 }}>TrustTransport</span>
+        </div>
+        <p style={{ margin: 0, fontSize: 14, color: '#9CA3AF', lineHeight: 1.5 }}>Rides, package delivery, and food — all with trauma-informed, background-checked providers. Pay with Service Credits.</p>
+
+        {/* Service type cards */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          {SERVICE_TYPES.map(({ icon: Icon, label, color }, i) => (
+            <div key={label} style={{ flex: 1, borderRadius: 12, border: `1px solid ${i === 0 ? color + '40' : 'rgba(255,255,255,0.07)'}`, padding: '14px 8px', display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'center', background: i === 0 ? color + '08' : 'rgba(255,255,255,0.02)' }}>
+              <Icon size={20} color={color} />
+              <span style={{ fontSize: 12, fontWeight: 600 }}>{label}</span>
+            </div>
+          ))}
+        </div>
+        <a href={signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>Join the Hub — Free</a>
+      </div>
+
+      {/* Blurred driver preview + lock (neutral placeholders) */}
+      <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative', minHeight: 280 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, filter: 'blur(4px)', pointerEvents: 'none', opacity: 0.5 }} aria-hidden="true">
+          <div style={{ fontSize: 12, color: '#6B7280' }}>Available drivers</div>
+          {[0, 1, 2].map((i) => (
+            <div key={i} style={{ borderRadius: 12, border: '1px solid rgba(255,255,255,0.07)', padding: '12px 14px', display: 'flex', gap: 12, alignItems: 'center' }}>
+              <div style={{ width: 36, height: 36, borderRadius: 18, background: COLOR + '25' }} />
+              <div style={{ flex: 1 }}>
+                <div style={{ height: 13, width: 120, borderRadius: 6, background: 'rgba(255,255,255,0.10)', marginBottom: 6 }} />
+                <div style={{ height: 10, width: 60, borderRadius: 5, background: 'rgba(255,255,255,0.05)' }} />
+              </div>
+              <div style={{ height: 13, width: 44, borderRadius: 6, background: 'rgba(34,197,94,0.25)' }} />
+            </div>
+          ))}
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 24, border: `2px solid ${COLOR}50`, background: COLOR + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Lock size={20} color={COLOR} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, textAlign: 'center' }}>Sign in to book transport</div>
+          <a href={signInUrl} style={{ padding: '10px 24px', borderRadius: 9, background: COLOR, border: 'none', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', textDecoration: 'none' }}>Sign in</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signed-out visitor view for TrustTransport. Pixel-faithful to the
+ * TrustTransportPublic (desktop) and MobileTrustTransportPublic (phone) design
+ * mockups, with every sign-in affordance pointing at the real hosted sign-in URL.
+ *
+ * Real-data-only deviations from the mockup (no session = no live data): the
+ * blurred "Available drivers near you" list (Jose Martinez, Aisha Thompson,
+ * David Kim with ratings, trip counts, and ETAs) is invented sample data, so it
+ * renders as neutral blurred placeholder rows behind the sign-in lock. The
+ * service-type cards (Rides / Packages / Food) are static marketing descriptions
+ * and are kept. The simulated phone status bar is dropped because the real app
+ * renders inside the browser chrome.
+ */
+export function TrustTransportPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  return isMobile ? <MobileTrustTransportPublic signInUrl={signInUrl} /> : <DesktopTrustTransportPublic signInUrl={signInUrl} />;
+}


### PR DESCRIPTION
Builds signed-out visitor screens for five Survivor Hub plugins, matching their desktop and phone design mockups, and wires each into the existing public visitor registry. No route, framework, auth, or other plugin files changed.

Parity Status: web + mobile-responsive + android complete

## What each screen shows

- **skills-hunt** — talent-scouting hero, a "How Skills Hunt works" panel, and a sign-in gate. Both the desktop and phone layouts adapt through the shared phone-width check.
- **skills-taxonomy** — "explore the survivor skills database" hero, a "why the taxonomy matters" panel, and a locked sector/job-title preview behind a sign-in gate.
- **socketrelay** — public relay marketing banner, sidebar with categories and a "how it works" list, and a locked live-feed preview. Keeps each mockup's own accent (desktop orange, phone pink-red).
- **trust** — privacy-respecting identity hero with the voluntary-signal list and an empty Trust score card (em-dash, "Sign in to build yours").
- **trusttransport** — safety-first transport hero, Rides / Packages / Food service cards, and a locked "available drivers" preview.

Every sign-in, join, and call-to-action points at the real hosted sign-in URL.

## Real-data-only handling (no session = no private or invented data)

A signed-out visitor has no session, so any sample rows or counts the mockups hardcoded are replaced with neutral blurred placeholders or honest empty states:

- **skills-hunt** — dropped the hero activity counters (247 found this week, 1,482 skills mapped, 63 scouts active) and replaced the named scout leaderboard (Amara O., Maria G., Priya S., DeShawn W.) with neutral blurred placeholder rows. The nomination form preview stays decorative behind the lock.
- **skills-taxonomy** — replaced the exact aggregate totals (128 skills, 47 job titles, 9 sectors) with neutral phrasing, and the named sector/job-title preview (Technology, Healthcare, Trades, "Skill A/B/C") with neutral blurred placeholder cards.
- **socketrelay** — dropped the banner and sidebar counters (847 open requests, 12,400 fulfilled, 12.4K, $0) and replaced every named relay need/offer card (Marcus B., Amara O., James T., locations, credit amounts, timestamps) with neutral blurred placeholder cards. The sidebar shows static "how it works" copy instead of stat rows.
- **trust** — no deviation needed: the mockup already renders the score as an em-dash empty state and the signal list is static marketing copy.
- **trusttransport** — replaced the named driver list (Jose Martinez, Aisha Thompson, David Kim with ratings, trips, ETAs) with neutral blurred placeholder rows. The Rides / Packages / Food service cards are static descriptions and are kept.

The simulated phone status bar from each mobile mockup is dropped because the real app renders inside the browser chrome.

## Validation

- `pnpm install` — clean, no lockfile or manifest change.
- Web typecheck (`tsc --noEmit`) — passed.
- `check-eof-format.sh` — passed.
- `check-web-android-parity.mjs` — passed.
- Pre-push full web build — passed.

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_