### PR TITLE
fix: fill dynamic viewport on public visitor shells (no bottom gap on mobile)

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-public-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-public-shell.tsx
@@ -39,7 +39,7 @@ const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
 function DesktopChymePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
       {/* Marketing banner */}
       <div style={{ background: `linear-gradient(90deg, ${ACCENT} 0%, ${ACCENT_CYAN} 100%)`, padding: '10px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
@@ -147,7 +147,7 @@ function DesktopChymePublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileChymePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
       {/* Header */}
       <div style={{ background: `linear-gradient(90deg, ${ACCENT} 0%, ${ACCENT_CYAN} 100%)`, padding: '10px 16px', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
         <Radio size={16} color="#fff" />

--- a/ctf/packages/web/components/clicklog/clicklog-public-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-public-shell.tsx
@@ -16,7 +16,7 @@ const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
 function DesktopClickLogPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <AlertTriangle size={18} color={BRAND} />
@@ -88,7 +88,7 @@ function DesktopClickLogPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileClickLogPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <div style={{ padding: '12px 16px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/ctf/packages/web/components/directory/directory-public-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-public-shell.tsx
@@ -14,7 +14,7 @@ const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
 function DesktopDirectoryPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <BookOpen size={18} color={COLOR} />
@@ -88,7 +88,7 @@ function DesktopDirectoryPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileDirectoryPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '20px 20px 14px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <BookOpen size={20} color={COLOR} />

--- a/ctf/packages/web/components/foundation/foundation-public-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-public-shell.tsx
@@ -13,7 +13,7 @@ const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
 function DesktopFoundationPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Hammer size={18} color={COLOR} />
@@ -63,7 +63,7 @@ function DesktopFoundationPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileFoundationPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Hammer size={20} color={COLOR} />

--- a/ctf/packages/web/components/gdp/gdp-public-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-public-shell.tsx
@@ -20,7 +20,7 @@ const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
 function DesktopGDPPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
       {/* Marketing banner */}
       <div style={{ background: `linear-gradient(90deg, ${ACCENT} 0%, ${ACCENT_CYAN} 100%)`, padding: '10px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
@@ -140,7 +140,7 @@ function DesktopGDPPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileGDPPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <TrendingUp size={20} color={COLOR} />

--- a/ctf/packages/web/components/gentlepulse/gentlepulse-public-shell.tsx
+++ b/ctf/packages/web/components/gentlepulse/gentlepulse-public-shell.tsx
@@ -13,7 +13,7 @@ const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
 function DesktopGentlePulsePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       <div style={{ height: 52, borderBottom: '1px solid rgba(20,184,166,0.1)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Heart size={18} color={COLOR} />
         <span style={{ fontSize: 16, fontWeight: 700 }}>GentlePulse</span>
@@ -52,7 +52,7 @@ function DesktopGentlePulsePublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileGentlePulsePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Heart size={20} color={COLOR} />

--- a/ctf/packages/web/components/levelup/levelup-public-shell.tsx
+++ b/ctf/packages/web/components/levelup/levelup-public-shell.tsx
@@ -36,7 +36,7 @@ function LockedPlaceholderRow({ rounded }: { rounded: number }) {
 
 function DesktopLevelUpPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <BookOpen size={18} color={COLOR} />
         <span style={{ fontSize: 16, fontWeight: 700 }}>LevelUp</span>
@@ -86,7 +86,7 @@ function DesktopLevelUpPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileLevelUpPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <BookOpen size={20} color={COLOR} />

--- a/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
@@ -49,7 +49,7 @@ function LockedListingCard({ orientation }: { orientation: 'row' | 'stacked' }) 
 
 function DesktopLightHousePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Home size={18} color={COLOR} />
         <span style={{ fontSize: 16, fontWeight: 700 }}>LightHouse</span>
@@ -106,7 +106,7 @@ function DesktopLightHousePublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileLightHousePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Home size={20} color={COLOR} />

--- a/ctf/packages/web/components/mood/mood-public-shell.tsx
+++ b/ctf/packages/web/components/mood/mood-public-shell.tsx
@@ -31,7 +31,7 @@ const MOOD_FACES_MOBILE: { emoji: string; label: string }[] = [
 
 function DesktopMoodPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Smile size={18} color={COLOR} />
         <span style={{ fontSize: 16, fontWeight: 700 }}>Mood</span>
@@ -86,7 +86,7 @@ function DesktopMoodPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileMoodPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '24px 24px 40px', gap: 20, textAlign: 'center' }}>
         <div style={{ width: 64, height: 64, borderRadius: 32, background: COLOR + '20', border: `2px solid ${COLOR}40`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <Smile size={28} color={COLOR} />

--- a/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
@@ -30,7 +30,7 @@ function LockedCohortCard() {
 
 function DesktopPeerProgrammingPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Users size={18} color={COLOR} />
         <span style={{ fontSize: 16, fontWeight: 700 }}>Peer Programming</span>
@@ -77,7 +77,7 @@ function DesktopPeerProgrammingPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobilePeerProgrammingPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Users size={20} color={COLOR} />

--- a/ctf/packages/web/components/plugins/generic-public-shell.tsx
+++ b/ctf/packages/web/components/plugins/generic-public-shell.tsx
@@ -24,7 +24,7 @@ export function GenericPublicShell({ pluginName, signInUrl }: PublicVisitorShell
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        minHeight: '100vh',
+        minHeight: '100dvh',
         background: BG,
         fontFamily: "'Inter', system-ui, sans-serif",
         color: TEXT,

--- a/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
@@ -44,7 +44,7 @@ const SPEND_WAYS_MOBILE = [
 
 function DesktopServiceCreditsPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Zap size={18} color={COLOR} />
         <span style={{ fontSize: 16, fontWeight: 700 }}>ServiceCredits</span>
@@ -101,7 +101,7 @@ function DesktopServiceCreditsPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileServiceCreditsPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ flex: 1, padding: '24px 20px 32px', display: 'flex', flexDirection: 'column', gap: 16 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Zap size={20} color={COLOR} />

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-public-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-public-shell.tsx
@@ -42,7 +42,7 @@ const NOMINATE_FIELDS = ['First Name', 'Bio', 'Quora Profile URL', 'Skills', 'Cl
 
 function DesktopSkillsHuntPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Search size={18} color={COLOR} />
@@ -139,7 +139,7 @@ function DesktopSkillsHuntPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileSkillsHuntPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       {/* Header */}
       <div style={{ padding: '16px 20px 12px', display: 'flex', alignItems: 'center', gap: 10, borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
         <Search size={20} color={COLOR} />

--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-public-shell.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-public-shell.tsx
@@ -23,7 +23,7 @@ const WHY_JOIN = [
 
 function DesktopSkillsTaxonomyPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <BookOpen size={18} color={BRAND} />
@@ -114,7 +114,7 @@ function DesktopSkillsTaxonomyPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileSkillsTaxonomyPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <div style={{ padding: '12px 16px 12px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/ctf/packages/web/components/socketrelay/socketrelay-public-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-public-shell.tsx
@@ -23,7 +23,7 @@ const CATEGORIES = ['All', 'Food', 'Transport', 'Legal', 'Employment', 'Childcar
 function DesktopSocketRelayPublic({ signInUrl }: { signInUrl: string }) {
   const COLOR = DESKTOP_COLOR;
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT }}>
       {/* Marketing banner */}
       <div style={{ background: `linear-gradient(90deg, ${ACCENT} 0%, ${ACCENT_CYAN} 100%)`, padding: '10px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
@@ -155,7 +155,7 @@ function DesktopSocketRelayPublic({ signInUrl }: { signInUrl: string }) {
 function MobileSocketRelayPublic({ signInUrl }: { signInUrl: string }) {
   const COLOR = MOBILE_COLOR;
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Share2 size={20} color={COLOR} />

--- a/ctf/packages/web/components/trust/trust-public-shell.tsx
+++ b/ctf/packages/web/components/trust/trust-public-shell.tsx
@@ -29,7 +29,7 @@ const MOBILE_SIGNALS = [
 
 function DesktopTrustPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Shield size={18} color={COLOR} />
@@ -95,7 +95,7 @@ function DesktopTrustPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileTrustPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ flex: 1, padding: '24px 20px 32px', display: 'flex', flexDirection: 'column', gap: 16 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Shield size={20} color={COLOR} />

--- a/ctf/packages/web/components/trusttransport/trusttransport-public-shell.tsx
+++ b/ctf/packages/web/components/trusttransport/trusttransport-public-shell.tsx
@@ -18,7 +18,7 @@ const SERVICE_TYPES = [
 
 function DesktopTrustTransportPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <Car size={18} color={COLOR} />
@@ -96,7 +96,7 @@ function DesktopTrustTransportPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileTrustTransportPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Car size={20} color={COLOR} />

--- a/ctf/packages/web/components/unlock/unlock-public-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-public-shell.tsx
@@ -32,7 +32,7 @@ const REASONS = [
 
 function DesktopUnlockPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <UnlockIcon size={18} color={BRAND} />
@@ -109,7 +109,7 @@ function DesktopUnlockPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileUnlockPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <div style={{ padding: '12px 16px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-public-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-public-shell.tsx
@@ -35,7 +35,7 @@ const ACCESS_ITEMS = [
 
 function DesktopWeeklyPerformancePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <BarChart2 size={18} color={BRAND} />
@@ -118,7 +118,7 @@ function DesktopWeeklyPerformancePublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileWeeklyPerformancePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <div style={{ padding: '12px 16px', background: `${BRAND}10`, borderBottom: `1px solid ${BRAND}25`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/ctf/packages/web/components/whatworks/whatworks-public-shell.tsx
+++ b/ctf/packages/web/components/whatworks/whatworks-public-shell.tsx
@@ -41,7 +41,7 @@ function PreviewEmptyState({ compact }: { compact?: boolean }) {
 
 function DesktopWhatWorksPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', maxHeight: '100%', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', maxHeight: '100%', background: BG, fontFamily: FONT_FAMILY, color: TEXT, overflow: 'hidden' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10, flexShrink: 0, background: '#0D0F14' }}>
         <ListChecks size={18} color={BRAND} />
@@ -117,7 +117,7 @@ function DesktopWhatWorksPublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileWhatWorksPublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', height: '100vh', maxHeight: '100%', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <div style={{ width: '100%', height: '100dvh', maxHeight: '100%', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       {/* Header */}
       <div style={{ padding: '12px 16px', background: '#0D0F14', borderBottom: `1px solid ${BORDER}`, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
         <ListChecks size={17} color={BRAND} />

--- a/ctf/packages/web/components/workforce/workforce-public-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-public-shell.tsx
@@ -26,7 +26,7 @@ const SNAPSHOT = [
 
 function DesktopWorkforcePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, fontFamily: FONT_FAMILY, color: TEXT, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: '1px solid rgba(255,255,255,0.06)', display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <BarChart2 size={18} color={COLOR} />
@@ -103,7 +103,7 @@ function DesktopWorkforcePublic({ signInUrl }: { signInUrl: string }) {
 
 function MobileWorkforcePublic({ signInUrl }: { signInUrl: string }) {
   return (
-    <div style={{ width: '100%', minHeight: '100vh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
+    <div style={{ width: '100%', minHeight: '100dvh', background: BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: TEXT }}>
       <div style={{ padding: '24px 20px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <BarChart2 size={20} color={COLOR} />


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## The problem

Every public visitor shell locked its outer container to a fixed `100vh`. On iPhone (mobile Safari), `100vh` does not equal the part of the page you can actually see — it ignores the browser toolbar. The shells use a top-to-bottom layout with a sign-in action bar docked at the bottom, so the bar landed above the real bottom edge and left a large dead gap of page background between the bar and the browser chrome. Containers that also clipped overflow risked cutting off content taller than the viewport.

## The fix

Switch the outermost layout container of each public shell to the dynamic viewport unit `100dvh`, which equals the visible area. The action bar now docks at the true bottom on mobile and nothing taller than the viewport is clipped. Desktop layouts use `100dvh` too (equal to `vh` on desktop) for consistency. This is a presentational CSS change only — no color, copy, spacing, font, or component-structure changes.

Two patterns, matched per file rather than blind-replaced:

- **Simple top-to-bottom pages** (most files): `minHeight: '100vh'` → `minHeight: '100dvh'` on the root.
- **Bounded app-shell layouts** that keep a fixed-height frame with their own inner `flex: 1; overflowY: auto` scroll region (chyme desktop + mobile, gdp desktop, whatworks desktop + mobile): `height: '100vh'` → `height: '100dvh'` on the root, keeping the existing `overflow: 'hidden'` so the inner region still scrolls and no double scrollbar appears. The gdp mobile layout uses the simple `minHeight` pattern.

## Files changed (21)

- components/chyme/chyme-public-shell.tsx
- components/clicklog/clicklog-public-shell.tsx
- components/directory/directory-public-shell.tsx
- components/foundation/foundation-public-shell.tsx
- components/gdp/gdp-public-shell.tsx
- components/gentlepulse/gentlepulse-public-shell.tsx
- components/levelup/levelup-public-shell.tsx
- components/lighthouse/lighthouse-public-shell.tsx
- components/mood/mood-public-shell.tsx
- components/peer-programming/peer-programming-public-shell.tsx
- components/plugins/generic-public-shell.tsx
- components/service-credits/service-credits-public-shell.tsx
- components/skills-hunt/skills-hunt-public-shell.tsx
- components/skills-taxonomy/skills-taxonomy-public-shell.tsx
- components/socketrelay/socketrelay-public-shell.tsx
- components/trust/trust-public-shell.tsx
- components/trusttransport/trusttransport-public-shell.tsx
- components/unlock/unlock-public-shell.tsx
- components/weekly-performance/weekly-performance-public-shell.tsx
- components/whatworks/whatworks-public-shell.tsx
- components/workforce/workforce-public-shell.tsx

## Validation

- `pnpm install` (no lockfile/manifest change)
- web typecheck `tsc --noEmit` — passed
- `check-eof-format.sh` — passed
- `check-web-android-parity.mjs` — passed
- pre-push full web build — passed

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_