### PR TITLE
feat: comic theme on mobile — context, toggle, and Account/Hub/Chyme tokens (#341)

### DIFF
--- a/ctf/packages/mobile/App.tsx
+++ b/ctf/packages/mobile/App.tsx
@@ -24,6 +24,7 @@ import { Unlock, AdminUnlock } from './src/features/unlock';
 import { SkillsTaxonomy } from './src/features/skills-taxonomy';
 import { AccountData } from './src/features/account-data';
 import { AuthProvider, useAuth } from './src/features/trusttransport/auth-context';
+import { ThemeProvider, useTheme } from './src/theme';
 import { LoadingScreen } from './src/components/shared/LoadingScreen';
 
 type FeatureKey =
@@ -100,13 +101,16 @@ const featureOrder: Array<{ key: FeatureKey; label: string }> = [
 export default function App() {
   return (
     <AuthProvider>
-      <AppShell />
+      <ThemeProvider>
+        <AppShell />
+      </ThemeProvider>
     </AuthProvider>
   );
 }
 
 function AppShell() {
   const { isLoading } = useAuth();
+  const { tokens } = useTheme();
   const [selected, setSelected] = useState<FeatureKey>('home');
 
   const featureView = useMemo(() => {
@@ -195,28 +199,43 @@ function AppShell() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>ChargingTheFuture Mobile</Text>
-      <Text style={styles.subtitle}>Web/Android plugin parity hub</Text>
+    <SafeAreaView style={[styles.container, { backgroundColor: tokens.bg }]}>
+      <Text style={[styles.title, { color: tokens.textPrimary }]}>ChargingTheFuture Mobile</Text>
+      <Text style={[styles.subtitle, { color: tokens.textSecondary }]}>
+        Web/Android plugin parity hub
+      </Text>
 
       <ScrollView horizontal style={styles.pillRow} contentContainerStyle={styles.pillContent}>
-        {featureOrder.map((feature) => (
-          <TouchableOpacity
-            key={feature.key}
-            style={[styles.pill, selected === feature.key ? styles.pillActive : null]}
-            onPress={() => setSelected(feature.key)}
-          >
-            <Text
-              style={[styles.pillText, selected === feature.key ? styles.pillTextActive : null]}
+        {featureOrder.map((feature) => {
+          const active = selected === feature.key;
+          return (
+            <TouchableOpacity
+              key={feature.key}
+              style={[
+                styles.pill,
+                {
+                  backgroundColor: active ? tokens.textPrimary : tokens.surface,
+                  borderColor: active ? tokens.textPrimary : tokens.border,
+                  borderRadius: tokens.isComic ? 0 : 999,
+                },
+              ]}
+              onPress={() => setSelected(feature.key)}
             >
-              {feature.label}
-            </Text>
-          </TouchableOpacity>
-        ))}
+              <Text
+                style={[
+                  styles.pillText,
+                  { color: active ? tokens.bg : tokens.textSecondary },
+                ]}
+              >
+                {feature.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
       </ScrollView>
 
       <View style={styles.content}>{featureView}</View>
-      <StatusBar style="auto" />
+      <StatusBar style={tokens.isComic ? 'light' : 'auto'} />
     </SafeAreaView>
   );
 }

--- a/ctf/packages/mobile/src/features/account-data/AccountData.tsx
+++ b/ctf/packages/mobile/src/features/account-data/AccountData.tsx
@@ -1,10 +1,14 @@
 // Real Account & Data screen — pixel-pass to
 // design/artifacts/mockup-sandbox/src/components/mockups/survivor-hub/MobileAccountData.tsx
-// (plus MobileAccountDataEmpty / MobileAccountDataConfirmDelete states).
+// (default theme) and ComicMobileAccountData.tsx / ComicMobileAccountDanger.tsx (comic theme).
 //
 // API bindings: GET /api/account/services, DELETE /api/account/services/:slug,
 // DELETE /api/account/full-account. Service names and summaries come from the live registry
 // projection — never hardcoded here.
+//
+// Theme: colours come from the active theme tokens (useTheme). In comic theme the panels use
+// the ink/cream/danger palette with sharp corners and the 3px offset shadow; in default theme
+// the screen is visually unchanged from before. The theme toggle lives in this screen's header.
 //
 // Omissions vs mockup (no backing API): "Export your data" and "Deactivate instead" controls are
 // not rendered — there is no export or deactivate endpoint, and the real-data-only rule forbids
@@ -21,20 +25,13 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { useTheme, type ThemeTokens } from '../../theme';
 import {
   fetchAccountServices,
   deleteServiceData,
   deleteFullAccount,
   type AccountService,
 } from './api';
-
-const BRAND = '#E91E8C';
-const BG = '#0F1117';
-const SURFACE = '#161B27';
-const BORDER = '#1E2A3A';
-const TEXT = '#F9FAFB';
-const SUBTLE = '#6B7280';
-const DANGER = '#EF4444';
 
 const CONFIRM_PHRASE = 'delete my account';
 
@@ -50,9 +47,21 @@ function glyph(slug: string): string {
   return SERVICE_GLYPH[slug] ?? '📁';
 }
 
+// The Account & Data accent is the destructive-zone colour: comic-danger in comic theme,
+// the existing pink brand in default theme. Everything else is driven from the theme tokens.
+function accentFor(t: ThemeTokens): string {
+  return t.isComic ? '#B91C1C' : '#E91E8C';
+}
+
 type Tab = 'data' | 'danger';
 
+type Styles = ReturnType<typeof makeStyles>;
+
 export function AccountData() {
+  const { tokens, theme, setTheme } = useTheme();
+  const brand = accentFor(tokens);
+  const s = useMemo(() => makeStyles(tokens, brand), [tokens, brand]);
+
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [deletable, setDeletable] = useState<AccountService[]>([]);
@@ -80,7 +89,7 @@ export function AccountData() {
   }, [load]);
 
   const remaining = useMemo(
-    () => deletable.filter((s) => !deletedSlugs.includes(s.slug)),
+    () => deletable.filter((svc) => !deletedSlugs.includes(svc.slug)),
     [deletable, deletedSlugs],
   );
   const totalServices = deletable.length + retained.length;
@@ -114,7 +123,7 @@ export function AccountData() {
   if (loading) {
     return (
       <View style={[s.root, s.center]}>
-        <ActivityIndicator color={BRAND} />
+        <ActivityIndicator color={brand} />
       </View>
     );
   }
@@ -134,6 +143,9 @@ export function AccountData() {
   if (confirmOpen) {
     return (
       <ConfirmDelete
+        s={s}
+        tokens={tokens}
+        brand={brand}
         serviceCount={totalServices}
         onCancel={() => setConfirmOpen(false)}
       />
@@ -155,6 +167,13 @@ export function AccountData() {
             <Text style={s.headerSub}>{totalServices} services · your control</Text>
           </View>
         </View>
+
+        {/* App theme toggle — keeps web and mobile in sync for the signed-in user */}
+        <View style={s.themeRow}>
+          <Text style={s.themeLabel}>App theme</Text>
+          <ThemeToggleControl />
+        </View>
+
         <View style={s.tabRow}>
           {(['data', 'danger'] as Tab[]).map((t) => {
             const active = tab === t;
@@ -182,7 +201,7 @@ export function AccountData() {
       <ScrollView style={s.scroll} contentContainerStyle={s.scrollContent}>
         {tab === 'data' ? (
           isEmpty ? (
-            <EmptyState hasRetained={retained.length > 0} />
+            <EmptyState s={s} hasRetained={retained.length > 0} />
           ) : (
             <>
               <View style={s.notice}>
@@ -197,7 +216,7 @@ export function AccountData() {
                   const isPending = pendingSlug === service.slug;
                   const error = rowError?.slug === service.slug ? rowError.message : null;
                   return (
-                    // key goes on the Fragment, not the View: @types/react 19.2 rejects `key`
+                    // key goes on the Fragment, not the View: @types/react rejects `key`
                     // on class-based host components like View ("does not exist on ViewProps").
                     <React.Fragment key={service.slug}>
                       <View style={[s.row, error ? s.rowError : null, isPending && s.rowPending]}>
@@ -215,7 +234,7 @@ export function AccountData() {
                           accessibilityRole="button"
                           accessibilityLabel={`Delete your ${service.name} data`}
                         >
-                          {isPending ? <ActivityIndicator color={DANGER} size="small" /> : <Text style={s.deleteBtnText}>🗑</Text>}
+                          {isPending ? <ActivityIndicator color={brand} size="small" /> : <Text style={s.deleteBtnText}>🗑</Text>}
                         </TouchableOpacity>
                       </View>
                     </React.Fragment>
@@ -249,14 +268,41 @@ export function AccountData() {
             </>
           )
         ) : (
-          <DangerZone serviceCount={totalServices} onContinue={() => setConfirmOpen(true)} />
+          <DangerZone s={s} tokens={tokens} serviceCount={totalServices} onContinue={() => setConfirmOpen(true)} />
         )}
       </ScrollView>
     </View>
   );
+
+  // Inline so the toggle reads the same theme context (theme + setTheme) without prop
+  // drilling. Mirrors the shared ThemeToggle but uses this screen's themed styles.
+  function ThemeToggleControl() {
+    const options: Array<{ value: 'default' | 'comic'; label: string }> = [
+      { value: 'default', label: 'Default' },
+      { value: 'comic', label: 'Comic' },
+    ];
+    return (
+      <View accessibilityRole="radiogroup" accessibilityLabel="App theme" style={s.themeGroup}>
+        {options.map((opt) => {
+          const active = theme === opt.value;
+          return (
+            <TouchableOpacity
+              key={opt.value}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: active }}
+              onPress={() => setTheme(opt.value)}
+              style={[s.themeOption, active && s.themeOptionActive]}
+            >
+              <Text style={[s.themeOptionText, active && s.themeOptionTextActive]}>{opt.label}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    );
+  }
 }
 
-function EmptyState({ hasRetained }: { hasRetained: boolean }) {
+function EmptyState({ s, hasRetained }: { s: Styles; hasRetained: boolean }) {
   return (
     <View style={s.emptyWrap}>
       <View style={s.emptyAnchor}>
@@ -277,7 +323,8 @@ function EmptyState({ hasRetained }: { hasRetained: boolean }) {
   );
 }
 
-function DangerZone({ serviceCount, onContinue }: { serviceCount: number; onContinue: () => void }) {
+function DangerZone({ s, tokens, serviceCount, onContinue }: { s: Styles; tokens: ThemeTokens; serviceCount: number; onContinue: () => void }) {
+  const danger = tokens.danger;
   const points: Array<{ t: string; warn: boolean }> = [
     { t: 'All personal data permanently deleted', warn: true },
     { t: 'ServiceCredits settled via standard process', warn: false },
@@ -293,7 +340,7 @@ function DangerZone({ serviceCount, onContinue }: { serviceCount: number; onCont
       {points.map((p, i) => (
         <React.Fragment key={i}>
           <View style={s.bulletRow}>
-            <View style={[s.bulletDot, { backgroundColor: p.warn ? DANGER : '#4B5563' }]} />
+            <View style={[s.bulletDot, { backgroundColor: p.warn ? danger : tokens.textSecondary }]} />
             <Text style={[s.bulletText, p.warn ? s.bulletTextWarn : null]}>{p.t}</Text>
           </View>
         </React.Fragment>
@@ -305,7 +352,7 @@ function DangerZone({ serviceCount, onContinue }: { serviceCount: number; onCont
   );
 }
 
-function ConfirmDelete({ serviceCount, onCancel }: { serviceCount: number; onCancel: () => void }) {
+function ConfirmDelete({ s, tokens, brand, serviceCount, onCancel }: { s: Styles; tokens: ThemeTokens; brand: string; serviceCount: number; onCancel: () => void }) {
   const [input, setInput] = useState('');
   const [status, setStatus] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -365,7 +412,7 @@ function ConfirmDelete({ serviceCount, onCancel }: { serviceCount: number; onCan
           {points.map((p, i) => (
             <React.Fragment key={i}>
               <View style={s.bulletRow}>
-                <Text style={[s.confirmBulletGlyph, { color: p.warn ? DANGER : SUBTLE }]}>{p.warn ? '🗑' : '🔒'}</Text>
+                <Text style={[s.confirmBulletGlyph, { color: p.warn ? tokens.danger : tokens.textSecondary }]}>{p.warn ? '🗑' : '🔒'}</Text>
                 <Text style={s.confirmBulletText}>{p.t}</Text>
               </View>
             </React.Fragment>
@@ -380,7 +427,7 @@ function ConfirmDelete({ serviceCount, onCancel }: { serviceCount: number; onCan
             value={input}
             onChangeText={setInput}
             placeholder={CONFIRM_PHRASE}
-            placeholderTextColor="#4B5563"
+            placeholderTextColor={tokens.textMuted}
             autoCapitalize="none"
             autoCorrect={false}
             style={[s.confirmInput, ready && s.confirmInputReady]}
@@ -400,7 +447,7 @@ function ConfirmDelete({ serviceCount, onCancel }: { serviceCount: number; onCan
           accessibilityRole="button"
         >
           {status === 'submitting' ? (
-            <ActivityIndicator color={DANGER} size="small" />
+            <ActivityIndicator color={brand} size="small" />
           ) : (
             <Text style={[s.confirmDeleteText, ready ? s.confirmDeleteTextReady : null]}>🗑 Delete permanently</Text>
           )}
@@ -418,86 +465,98 @@ function ConfirmDelete({ serviceCount, onCancel }: { serviceCount: number; onCan
   );
 }
 
-const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: BG },
-  center: { alignItems: 'center', justifyContent: 'center', padding: 32 },
-  header: { paddingHorizontal: 16, paddingTop: 14, paddingBottom: 10, borderBottomWidth: 1, borderBottomColor: BORDER },
-  headerRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
-  headerIcon: { width: 34, height: 34, borderRadius: 9, backgroundColor: `${BRAND}20`, borderWidth: 1, borderColor: `${BRAND}35`, alignItems: 'center', justifyContent: 'center' },
-  headerIconText: { fontSize: 16, color: BRAND },
-  headerTitle: { fontSize: 16, fontWeight: '700', color: TEXT },
-  headerSub: { fontSize: 11, color: SUBTLE },
-  tabRow: { flexDirection: 'row', gap: 4 },
-  tab: { flex: 1, paddingVertical: 7, borderRadius: 8, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center' },
-  tabActive: { backgroundColor: `${BRAND}18`, borderColor: `${BRAND}40` },
-  tabDangerActive: { backgroundColor: 'rgba(239,68,68,0.12)', borderColor: 'rgba(239,68,68,0.4)' },
-  tabText: { fontSize: 12, color: SUBTLE },
-  tabTextActive: { color: BRAND, fontWeight: '700' },
-  tabTextDangerActive: { color: DANGER, fontWeight: '700' },
-  scroll: { flex: 1 },
-  scrollContent: { padding: 16, paddingBottom: 28 },
-  notice: { padding: 12, borderRadius: 10, backgroundColor: `${BRAND}0D`, borderWidth: 1, borderColor: `${BRAND}25`, marginBottom: 16 },
-  noticeText: { fontSize: 12, color: '#9CA3AF', lineHeight: 18 },
-  sectionLabel: { fontSize: 12, fontWeight: '700', color: SUBTLE, textTransform: 'uppercase', letterSpacing: 0.7, marginBottom: 10 },
-  list: { gap: 7, marginBottom: 22 },
-  row: { flexDirection: 'row', alignItems: 'center', gap: 10, padding: 11, borderRadius: 12, backgroundColor: SURFACE, borderWidth: 1, borderColor: BORDER },
-  rowError: { borderColor: 'rgba(239,68,68,0.35)' },
-  rowPending: { opacity: 0.7 },
-  rowGlyph: { width: 30, height: 30, borderRadius: 8, backgroundColor: `${BRAND}10`, borderWidth: 1, borderColor: `${BRAND}20`, alignItems: 'center', justifyContent: 'center' },
-  rowGlyphText: { fontSize: 14 },
-  rowBody: { flex: 1 },
-  rowName: { fontSize: 13, fontWeight: '600', color: TEXT },
-  rowSummary: { fontSize: 11, color: '#4B5563', lineHeight: 15, marginTop: 1 },
-  rowSummaryError: { color: '#F87171' },
-  deleteBtn: { paddingVertical: 6, paddingHorizontal: 10, borderRadius: 7, backgroundColor: 'rgba(239,68,68,0.06)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.2)', minWidth: 36, alignItems: 'center' },
-  deleteBtnText: { color: DANGER, fontSize: 13 },
-  retainedRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, padding: 11, borderRadius: 12, backgroundColor: 'rgba(255,255,255,0.01)', borderWidth: 1, borderColor: BORDER },
-  retainedGlyph: { width: 30, height: 30, borderRadius: 8, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center', justifyContent: 'center' },
-  retainedNameRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 3 },
-  retainedName: { fontSize: 13, fontWeight: '600', color: SUBTLE },
-  lockGlyph: { fontSize: 10 },
-  retainedReason: { fontSize: 11, color: '#4B5563', lineHeight: 15 },
-  emptyWrap: { alignItems: 'center', paddingVertical: 24 },
-  emptyAnchor: { width: 56, height: 56, borderRadius: 16, backgroundColor: `${BRAND}14`, borderWidth: 1, borderColor: `${BRAND}30`, borderStyle: 'dashed', alignItems: 'center', justifyContent: 'center', marginBottom: 16 },
-  emptyAnchorText: { fontSize: 24 },
-  emptyTitle: { fontSize: 19, fontWeight: '800', color: TEXT, marginBottom: 8, textAlign: 'center' },
-  emptySub: { fontSize: 13, color: SUBTLE, lineHeight: 20, textAlign: 'center', marginBottom: 20 },
-  dangerCard: { padding: 18, borderRadius: 14, backgroundColor: 'rgba(239,68,68,0.04)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.18)' },
-  dangerTitle: { fontSize: 15, fontWeight: '700', color: TEXT, marginBottom: 10 },
-  dangerBody: { fontSize: 13, color: '#9CA3AF', lineHeight: 20, marginBottom: 14 },
-  bulletRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 8, marginBottom: 7 },
-  bulletDot: { width: 4, height: 4, borderRadius: 2, marginTop: 6 },
-  bulletText: { flex: 1, fontSize: 12, color: '#9CA3AF', lineHeight: 17 },
-  bulletTextWarn: { color: '#F87171' },
-  dangerBtn: { marginTop: 8, paddingVertical: 11, borderRadius: 10, backgroundColor: 'rgba(239,68,68,0.1)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.35)', alignItems: 'center' },
-  dangerBtnText: { color: DANGER, fontSize: 14, fontWeight: '700' },
-  confirmHeader: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 16, paddingTop: 14, paddingBottom: 14, borderBottomWidth: 1, borderBottomColor: BORDER },
-  confirmHeaderIcon: { width: 34, height: 34, borderRadius: 9, backgroundColor: 'rgba(239,68,68,0.12)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.25)', alignItems: 'center', justifyContent: 'center' },
-  confirmHeaderIconText: { fontSize: 16 },
-  confirmClose: { width: 30, height: 30, borderRadius: 8, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center', justifyContent: 'center' },
-  confirmCloseText: { color: SUBTLE, fontSize: 14 },
-  confirmInfo: { padding: 16, borderRadius: 14, backgroundColor: 'rgba(239,68,68,0.05)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.18)', marginBottom: 18 },
-  confirmInfoTitle: { fontSize: 14, fontWeight: '700', color: TEXT, marginBottom: 12 },
-  confirmBulletGlyph: { fontSize: 13, marginTop: 1 },
-  confirmBulletText: { flex: 1, fontSize: 12, color: '#9CA3AF', lineHeight: 18 },
-  confirmFieldWrap: { padding: 14, borderRadius: 12, backgroundColor: SURFACE, borderWidth: 1, borderColor: BORDER, marginBottom: 18 },
-  confirmFieldLabel: { fontSize: 13, color: '#9CA3AF', marginBottom: 10, lineHeight: 19 },
-  confirmPhrase: { color: DANGER, fontWeight: '700' },
-  confirmInput: { paddingVertical: 11, paddingHorizontal: 12, backgroundColor: BG, borderWidth: 1, borderColor: BORDER, borderRadius: 9, fontSize: 14, color: TEXT },
-  confirmInputReady: { borderColor: 'rgba(239,68,68,0.5)', color: DANGER },
-  confirmErrorBox: { padding: 12, borderRadius: 8, backgroundColor: 'rgba(239,68,68,0.08)', borderWidth: 1, borderColor: 'rgba(239,68,68,0.3)', marginBottom: 16 },
-  confirmErrorText: { color: '#F87171', fontSize: 13, lineHeight: 18 },
-  confirmDeleteBtn: { paddingVertical: 14, borderRadius: 12, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: BORDER, alignItems: 'center', marginBottom: 10 },
-  confirmDeleteBtnReady: { backgroundColor: 'rgba(239,68,68,0.14)', borderColor: 'rgba(239,68,68,0.45)' },
-  confirmDeleteText: { color: '#374151', fontSize: 15, fontWeight: '700' },
-  confirmDeleteTextReady: { color: DANGER },
-  keepBtn: { paddingVertical: 14, borderRadius: 12, backgroundColor: `${BRAND}12`, borderWidth: 1, borderColor: `${BRAND}30`, alignItems: 'center' },
-  keepText: { color: BRAND, fontSize: 15, fontWeight: '600' },
-  doneGlyph: { fontSize: 48, marginBottom: 18 },
-  doneTitle: { fontSize: 20, fontWeight: '800', color: TEXT, marginBottom: 10, textAlign: 'center' },
-  doneSub: { fontSize: 13, color: SUBTLE, lineHeight: 21, textAlign: 'center' },
-  errTitle: { fontSize: 16, fontWeight: '700', color: TEXT, marginBottom: 8, textAlign: 'center' },
-  errSub: { fontSize: 13, color: '#9CA3AF', textAlign: 'center', marginBottom: 16 },
-  retryBtn: { paddingVertical: 10, paddingHorizontal: 24, borderRadius: 10, backgroundColor: `${BRAND}15`, borderWidth: 1, borderColor: `${BRAND}30` },
-  retryText: { color: BRAND, fontSize: 14, fontWeight: '600' },
-});
+function makeStyles(t: ThemeTokens, brand: string) {
+  const danger = t.danger;
+  const r = t.radius;
+  const rChip = t.radiusChip;
+  return StyleSheet.create({
+    root: { flex: 1, backgroundColor: t.bg },
+    center: { alignItems: 'center', justifyContent: 'center', padding: 32 },
+    header: { paddingHorizontal: 16, paddingTop: 14, paddingBottom: 10, borderBottomWidth: t.isComic ? 2 : 1, borderBottomColor: t.border },
+    headerRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
+    headerIcon: { width: 34, height: 34, borderRadius: rChip, backgroundColor: t.isComic ? t.bg : `${brand}20`, borderWidth: t.isComic ? 2 : 1, borderColor: t.isComic ? t.border : `${brand}35`, alignItems: 'center', justifyContent: 'center' },
+    headerIconText: { fontSize: 16, color: brand },
+    headerTitle: { fontSize: 16, fontWeight: '700', color: t.textPrimary, letterSpacing: t.isComic ? 0.6 : 0, textTransform: t.isComic ? 'uppercase' : 'none' },
+    headerSub: { fontSize: 11, color: t.textSecondary },
+    themeRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 },
+    themeLabel: { fontSize: 11, fontWeight: '700', color: t.textSecondary, textTransform: 'uppercase', letterSpacing: 0.7 },
+    themeGroup: { flexDirection: 'row', borderWidth: 1.5, borderColor: t.border, borderRadius: rChip, overflow: 'hidden', backgroundColor: t.surface },
+    themeOption: { paddingHorizontal: 14, paddingVertical: 5 },
+    themeOptionActive: { backgroundColor: t.isComic ? t.border : t.textPrimary },
+    themeOptionText: { fontSize: 11, fontWeight: '700', color: t.textSecondary, textTransform: 'uppercase', letterSpacing: 0.6 },
+    themeOptionTextActive: { color: t.bg },
+    tabRow: { flexDirection: 'row', gap: t.isComic ? 5 : 4 },
+    tab: { flex: 1, paddingVertical: 7, borderRadius: t.isComic ? 0 : 8, backgroundColor: t.isComic ? 'transparent' : 'rgba(255,255,255,0.04)', borderWidth: t.isComic ? 2 : 1, borderColor: t.isComic ? `${t.borderDim}40` : t.border, alignItems: 'center' },
+    tabActive: { backgroundColor: t.isComic ? `${t.border}14` : `${brand}18`, borderColor: t.isComic ? t.border : `${brand}40` },
+    tabDangerActive: { backgroundColor: t.isComic ? `${danger}18` : 'rgba(239,68,68,0.12)', borderColor: t.isComic ? danger : 'rgba(239,68,68,0.4)' },
+    tabText: { fontSize: t.isComic ? 11 : 12, color: t.textSecondary, textTransform: t.isComic ? 'uppercase' : 'none', letterSpacing: t.isComic ? 0.6 : 0 },
+    tabTextActive: { color: t.isComic ? t.textPrimary : brand, fontWeight: '700' },
+    tabTextDangerActive: { color: danger, fontWeight: '700' },
+    scroll: { flex: 1 },
+    scrollContent: { padding: 16, paddingBottom: 28 },
+    notice: { padding: 12, borderRadius: r, backgroundColor: t.isComic ? `${t.border}08` : `${brand}0D`, borderWidth: t.isComic ? 2 : 1, borderColor: t.isComic ? t.border : `${brand}25`, marginBottom: 16 },
+    noticeText: { fontSize: 12, color: t.textSecondary, lineHeight: 18 },
+    sectionLabel: { fontSize: t.isComic ? 9 : 12, fontWeight: t.isComic ? '800' : '700', color: t.isComic ? t.border : t.textSecondary, textTransform: 'uppercase', letterSpacing: t.isComic ? 1.4 : 0.7, marginBottom: 10, ...(t.isComic ? { borderLeftWidth: 3, borderLeftColor: t.border, paddingLeft: 7 } : {}) },
+    list: { gap: t.isComic ? 5 : 7, marginBottom: 22 },
+    row: { flexDirection: 'row', alignItems: 'center', gap: 10, padding: 11, borderRadius: r, backgroundColor: t.surface, borderWidth: t.isComic ? 1.5 : 1, borderColor: t.isComic ? `${t.border}35` : t.border },
+    rowError: { borderColor: t.isComic ? danger : 'rgba(239,68,68,0.35)' },
+    rowPending: { opacity: 0.7 },
+    rowGlyph: { width: 30, height: 30, borderRadius: rChip, backgroundColor: t.isComic ? `${t.border}0C` : `${brand}10`, borderWidth: 1, borderColor: t.isComic ? `${t.border}30` : `${brand}20`, alignItems: 'center', justifyContent: 'center' },
+    rowGlyphText: { fontSize: 14 },
+    rowBody: { flex: 1 },
+    rowName: { fontSize: 13, fontWeight: t.isComic ? '700' : '600', color: t.textPrimary },
+    rowSummary: { fontSize: t.isComic ? 10 : 11, color: t.textMuted, lineHeight: 15, marginTop: 1 },
+    rowSummaryError: { color: t.isComic ? danger : '#F87171' },
+    deleteBtn: { paddingVertical: 6, paddingHorizontal: 10, borderRadius: t.isComic ? 0 : 7, backgroundColor: t.isComic ? t.surface : 'rgba(239,68,68,0.06)', borderWidth: 1.5, borderColor: t.isComic ? `${danger}60` : 'rgba(239,68,68,0.2)', minWidth: 36, alignItems: 'center' },
+    deleteBtnText: { color: danger, fontSize: 13, fontWeight: t.isComic ? '800' : '400' },
+    retainedRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, padding: 11, borderRadius: r, backgroundColor: t.isComic ? `${t.border}05` : 'rgba(255,255,255,0.01)', borderWidth: 1, borderColor: t.isComic ? `${t.borderDim}35` : t.border },
+    retainedGlyph: { width: 30, height: 30, borderRadius: rChip, backgroundColor: t.isComic ? `${t.border}08` : 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: t.isComic ? `${t.borderDim}30` : t.border, alignItems: 'center', justifyContent: 'center' },
+    retainedNameRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 3 },
+    retainedName: { fontSize: 13, fontWeight: t.isComic ? '700' : '600', color: t.textSecondary },
+    lockGlyph: { fontSize: 10 },
+    retainedReason: { fontSize: t.isComic ? 10 : 11, color: t.textMuted, lineHeight: 15 },
+    emptyWrap: { alignItems: 'center', paddingVertical: 24 },
+    emptyAnchor: { width: 56, height: 56, borderRadius: t.isComic ? 0 : 16, backgroundColor: t.isComic ? `${t.border}14` : `${brand}14`, borderWidth: t.isComic ? 2 : 1, borderColor: t.isComic ? t.border : `${brand}30`, borderStyle: t.isComic ? 'solid' : 'dashed', alignItems: 'center', justifyContent: 'center', marginBottom: 16 },
+    emptyAnchorText: { fontSize: 24 },
+    emptyTitle: { fontSize: 19, fontWeight: '800', color: t.textPrimary, marginBottom: 8, textAlign: 'center' },
+    emptySub: { fontSize: 13, color: t.textSecondary, lineHeight: 20, textAlign: 'center', marginBottom: 20 },
+    dangerCard: { padding: 18, borderRadius: r, backgroundColor: t.isComic ? `${danger}08` : 'rgba(239,68,68,0.04)', borderWidth: 2, borderColor: t.isComic ? danger : 'rgba(239,68,68,0.18)' },
+    dangerTitle: { fontSize: 15, fontWeight: t.isComic ? '800' : '700', color: t.textPrimary, marginBottom: 10, textTransform: t.isComic ? 'uppercase' : 'none', letterSpacing: t.isComic ? 0.6 : 0 },
+    dangerBody: { fontSize: 13, color: t.textSecondary, lineHeight: 20, marginBottom: 14 },
+    bulletRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 8, marginBottom: 7 },
+    bulletDot: { width: 4, height: 4, borderRadius: t.isComic ? 0 : 2, marginTop: 6 },
+    bulletText: { flex: 1, fontSize: 12, color: t.textSecondary, lineHeight: 17 },
+    bulletTextWarn: { color: t.isComic ? `${danger}CC` : '#F87171' },
+    dangerBtn: { marginTop: 8, paddingVertical: 11, borderRadius: r, backgroundColor: t.isComic ? `${danger}12` : 'rgba(239,68,68,0.1)', borderWidth: 2, borderColor: t.isComic ? danger : 'rgba(239,68,68,0.35)', alignItems: 'center' },
+    dangerBtnText: { color: danger, fontSize: 14, fontWeight: t.isComic ? '800' : '700', textTransform: t.isComic ? 'uppercase' : 'none', letterSpacing: t.isComic ? 0.6 : 0 },
+    confirmHeader: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 16, paddingTop: 14, paddingBottom: 14, borderBottomWidth: t.isComic ? 2 : 1, borderBottomColor: t.isComic ? t.border : t.border },
+    confirmHeaderIcon: { width: 34, height: 34, borderRadius: rChip, backgroundColor: t.isComic ? `${danger}12` : 'rgba(239,68,68,0.12)', borderWidth: t.isComic ? 2 : 1, borderColor: t.isComic ? danger : 'rgba(239,68,68,0.25)', alignItems: 'center', justifyContent: 'center' },
+    confirmHeaderIconText: { fontSize: 16 },
+    confirmClose: { width: 30, height: 30, borderRadius: rChip, backgroundColor: t.isComic ? t.surface : 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: t.border, alignItems: 'center', justifyContent: 'center' },
+    confirmCloseText: { color: t.textSecondary, fontSize: 14 },
+    confirmInfo: { padding: 16, borderRadius: r, backgroundColor: t.isComic ? `${danger}08` : 'rgba(239,68,68,0.05)', borderWidth: 2, borderColor: t.isComic ? danger : 'rgba(239,68,68,0.18)', marginBottom: 18 },
+    confirmInfoTitle: { fontSize: 14, fontWeight: '700', color: t.textPrimary, marginBottom: 12 },
+    confirmBulletGlyph: { fontSize: 13, marginTop: 1 },
+    confirmBulletText: { flex: 1, fontSize: 12, color: t.textSecondary, lineHeight: 18 },
+    confirmFieldWrap: { padding: 14, borderRadius: r, backgroundColor: t.surface, borderWidth: t.isComic ? 1.5 : 1, borderColor: t.border, marginBottom: 18 },
+    confirmFieldLabel: { fontSize: 13, color: t.textSecondary, marginBottom: 10, lineHeight: 19 },
+    confirmPhrase: { color: danger, fontWeight: '700' },
+    confirmInput: { paddingVertical: 11, paddingHorizontal: 12, backgroundColor: t.bg, borderWidth: t.isComic ? 1.5 : 1, borderColor: t.border, borderRadius: r, fontSize: 14, color: t.textPrimary },
+    confirmInputReady: { borderColor: t.isComic ? danger : 'rgba(239,68,68,0.5)', color: danger },
+    confirmErrorBox: { padding: 12, borderRadius: r, backgroundColor: t.isComic ? `${danger}10` : 'rgba(239,68,68,0.08)', borderWidth: 1.5, borderColor: t.isComic ? danger : 'rgba(239,68,68,0.3)', marginBottom: 16 },
+    confirmErrorText: { color: t.isComic ? danger : '#F87171', fontSize: 13, lineHeight: 18 },
+    confirmDeleteBtn: { paddingVertical: 14, borderRadius: r, backgroundColor: t.isComic ? t.surface : 'rgba(255,255,255,0.04)', borderWidth: t.isComic ? 1.5 : 1, borderColor: t.border, alignItems: 'center', marginBottom: 10 },
+    confirmDeleteBtnReady: { backgroundColor: t.isComic ? `${danger}14` : 'rgba(239,68,68,0.14)', borderColor: t.isComic ? danger : 'rgba(239,68,68,0.45)' },
+    confirmDeleteText: { color: t.textMuted, fontSize: 15, fontWeight: '700' },
+    confirmDeleteTextReady: { color: danger },
+    keepBtn: { paddingVertical: 14, borderRadius: r, backgroundColor: t.isComic ? `${t.border}12` : `${brand}12`, borderWidth: 1, borderColor: t.isComic ? t.border : `${brand}30`, alignItems: 'center' },
+    keepText: { color: t.isComic ? t.textPrimary : brand, fontSize: 15, fontWeight: '600' },
+    doneGlyph: { fontSize: 48, marginBottom: 18 },
+    doneTitle: { fontSize: 20, fontWeight: '800', color: t.textPrimary, marginBottom: 10, textAlign: 'center' },
+    doneSub: { fontSize: 13, color: t.textSecondary, lineHeight: 21, textAlign: 'center' },
+    errTitle: { fontSize: 16, fontWeight: '700', color: t.textPrimary, marginBottom: 8, textAlign: 'center' },
+    errSub: { fontSize: 13, color: t.textSecondary, textAlign: 'center', marginBottom: 16 },
+    retryBtn: { paddingVertical: 10, paddingHorizontal: 24, borderRadius: r, backgroundColor: t.isComic ? `${t.border}15` : `${brand}15`, borderWidth: 1, borderColor: t.isComic ? t.border : `${brand}30` },
+    retryText: { color: t.isComic ? t.textPrimary : brand, fontSize: 14, fontWeight: '600' },
+  });
+}

--- a/ctf/packages/mobile/src/features/chyme/ChymeRoom.tsx
+++ b/ctf/packages/mobile/src/features/chyme/ChymeRoom.tsx
@@ -36,15 +36,17 @@ import { ChymeRoomList } from './chyme-room-list';
 import { ChymeAudioRoom } from './ChymeAudioRoom';
 import { ChymeChatView } from './chyme-chat-view';
 import type { ChatMessage } from './chyme-chat-view';
+import { useTheme, getAppAccent, type ThemeTokens } from '../../theme';
 
 type ViewState = 'loading' | 'error' | 'empty' | 'roomList' | 'inRoom' | 'chat';
 
 type RoomPayload = Awaited<ReturnType<typeof getChymeRoom>>;
 type MessagePayload = Awaited<ReturnType<typeof getChymeMessages>>['messages'][number];
 
-const PRIMARY = '#22C55E';
-
 export const ChymeRoom: React.FC = () => {
+  const { tokens, theme } = useTheme();
+  const styles = React.useMemo(() => makeStyles(tokens), [tokens]);
+  const accent = getAppAccent('chyme', theme);
   const [viewState, setViewState] = useState<ViewState>('loading');
   const [room, setRoom] = useState<RoomPayload | null>(null);
   const [joinInfo, setJoinInfo] = useState<ChymeJoinResponse | null>(null);
@@ -132,7 +134,7 @@ export const ChymeRoom: React.FC = () => {
   }
 
   if (viewState === 'empty' || !room) {
-    return <ChymeEmpty onStartRoom={handleJoinRoom} />;
+    return <ChymeEmpty onStartRoom={handleJoinRoom} tokens={tokens} accent={accent} />;
   }
 
   if (viewState === 'chat') {
@@ -184,38 +186,46 @@ export const ChymeRoom: React.FC = () => {
         onTabChange={setTab}
         onJoinRoom={handleJoinRoom}
         onStartRoom={handleJoinRoom}
+        tokens={tokens}
+        accent={accent}
       />
     </View>
   );
 };
 
-const styles = StyleSheet.create({
-  errorContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#021006',
-    paddingHorizontal: 24,
-  },
-  errorTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: '#F0FDF4',
-    marginBottom: 8,
-  },
-  errorMsg: {
-    fontSize: 14,
-    color: '#6B7280',
-    textAlign: 'center',
-    marginBottom: 20,
-    lineHeight: 22,
-  },
-  retryBtn: {
-    paddingVertical: 12,
-    paddingHorizontal: 32,
-    borderRadius: 12,
-    backgroundColor: PRIMARY,
-  },
-  retryBtnText: { color: '#fff', fontWeight: '700', fontSize: 15 },
-  roomListContainer: { flex: 1, backgroundColor: '#021006' },
-});
+function makeStyles(t: ThemeTokens) {
+  // Default theme keeps the deep-green Chyme chrome; comic theme uses the ink palette.
+  const bg = t.isComic ? t.bg : '#021006';
+  return StyleSheet.create({
+    errorContainer: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: bg,
+      paddingHorizontal: 24,
+    },
+    errorTitle: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: t.isComic ? t.textPrimary : '#F0FDF4',
+      marginBottom: 8,
+    },
+    errorMsg: {
+      fontSize: 14,
+      color: t.textSecondary,
+      textAlign: 'center',
+      marginBottom: 20,
+      lineHeight: 22,
+    },
+    retryBtn: {
+      paddingVertical: 12,
+      paddingHorizontal: 32,
+      borderRadius: t.radius,
+      backgroundColor: t.isComic ? t.surface : t.success,
+      borderWidth: t.isComic ? 1.5 : 0,
+      borderColor: t.border,
+    },
+    retryBtnText: { color: t.isComic ? t.border : '#fff', fontWeight: '700', fontSize: 15 },
+    roomListContainer: { flex: 1, backgroundColor: bg },
+  });
+}

--- a/ctf/packages/mobile/src/features/chyme/chyme-empty.tsx
+++ b/ctf/packages/mobile/src/features/chyme/chyme-empty.tsx
@@ -1,131 +1,125 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-
-const PRIMARY = '#22C55E';
+import { type ThemeTokens } from '../../theme';
 
 type Props = {
   onStartRoom: () => void;
+  tokens: ThemeTokens;
+  accent: string;
 };
 
-export const ChymeEmpty: React.FC<Props> = ({ onStartRoom }) => (
-  <View style={styles.container}>
-    <View style={styles.statusBar}>
-      <Text style={styles.clock}>9:41</Text>
-      <Text style={styles.signal}>●●●</Text>
-    </View>
-
-    <View style={styles.header}>
-      <Text style={styles.headerTitle}>Chyme</Text>
-    </View>
-
-    <View style={styles.body}>
-      <View style={styles.iconRing}>
-        {/* Radio icon placeholder — no backing field for icon asset */}
-        <Text style={styles.iconGlyph}>📻</Text>
+export const ChymeEmpty: React.FC<Props> = ({ onStartRoom, tokens, accent }) => {
+  const styles = useMemo(() => makeStyles(tokens, accent), [tokens, accent]);
+  return (
+    <View style={styles.container}>
+      <View style={styles.statusBar}>
+        <Text style={styles.clock}>9:41</Text>
+        <Text style={styles.signal}>●●●</Text>
       </View>
-      <Text style={styles.title}>No rooms live yet</Text>
-      <Text style={styles.subtitle}>
-        Be the first to start a room. Topics can be healing, skills, or anything your community needs.
-      </Text>
-      {/* Start Room: backed by POST /api/chyme/join */}
-      <TouchableOpacity style={styles.primaryBtn} onPress={onStartRoom}>
-        <Text style={styles.primaryBtnText}>+ Start a Room</Text>
-      </TouchableOpacity>
-      {/* Schedule: no backend endpoint for scheduling yet — omitted as interactive action */}
-      <View style={styles.scheduleBtn}>
-        <Text style={styles.scheduleBtnText}>Schedule for Later</Text>
+
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Chyme</Text>
+      </View>
+
+      <View style={styles.body}>
+        <View style={styles.iconRing}>
+          {/* Radio icon placeholder — no backing field for icon asset */}
+          <Text style={styles.iconGlyph}>📻</Text>
+        </View>
+        <Text style={styles.title}>No rooms live yet</Text>
+        <Text style={styles.subtitle}>
+          Be the first to start a room. Topics can be healing, skills, or anything your community needs.
+        </Text>
+        {/* Start Room: backed by POST /api/chyme/join */}
+        <TouchableOpacity style={styles.primaryBtn} onPress={onStartRoom}>
+          <Text style={styles.primaryBtnText}>+ Start a Room</Text>
+        </TouchableOpacity>
+        {/* Schedule: no backend endpoint for scheduling yet — omitted as interactive action */}
+        <View style={styles.scheduleBtn}>
+          <Text style={styles.scheduleBtnText}>Schedule for Later</Text>
+        </View>
+      </View>
+
+      <View style={styles.footer}>
+        <Text style={styles.footerText}>
+          🎤  Rooms are end-to-end encrypted and Safe Space verified
+        </Text>
       </View>
     </View>
+  );
+};
 
-    <View style={styles.footer}>
-      <Text style={styles.footerText}>
-        🎤  Rooms are end-to-end encrypted and Safe Space verified
-      </Text>
-    </View>
-  </View>
-);
-
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#0F1117' },
-  statusBar: {
-    backgroundColor: '#090B0F',
-    paddingTop: 12,
-    paddingBottom: 6,
-    paddingHorizontal: 16,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  clock: { fontSize: 13, fontWeight: '600', color: '#F9FAFB' },
-  signal: { fontSize: 11, color: '#6B7280' },
-  header: {
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#1E2A3A',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  headerTitle: { fontSize: 15, fontWeight: '700', color: '#F9FAFB' },
-  body: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-  },
-  iconRing: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: `${PRIMARY}15`,
-    borderWidth: 1,
-    borderColor: `${PRIMARY}40`,
-    borderStyle: 'dashed',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 20,
-  },
-  iconGlyph: { fontSize: 28 },
-  title: {
-    fontSize: 18,
-    fontWeight: '800',
-    color: '#F9FAFB',
-    marginBottom: 10,
-    textAlign: 'center',
-  },
-  subtitle: {
-    fontSize: 14,
-    color: '#6B7280',
-    lineHeight: 22,
-    marginBottom: 28,
-    textAlign: 'center',
-  },
-  primaryBtn: {
-    width: '100%',
-    paddingVertical: 14,
-    borderRadius: 12,
-    backgroundColor: PRIMARY,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 12,
-  },
-  primaryBtnText: { color: '#000', fontWeight: '700', fontSize: 15 },
-  scheduleBtn: {
-    width: '100%',
-    paddingVertical: 14,
-    borderRadius: 12,
-    backgroundColor: '#161B27',
-    borderWidth: 1,
-    borderColor: '#1E2A3A',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  scheduleBtnText: { color: '#F9FAFB', fontWeight: '600', fontSize: 15 },
-  footer: {
-    padding: 16,
-    borderTopWidth: 1,
-    borderTopColor: '#1E2A3A',
-    backgroundColor: '#161B27',
-  },
-  footerText: { fontSize: 12, color: '#6B7280' },
-});
+function makeStyles(t: ThemeTokens, accent: string) {
+  const chrome = t.isComic ? t.surfaceAlt : '#090B0F';
+  const divider = t.isComic ? t.border : '#1E2A3A';
+  const r = t.radius;
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: t.bg },
+    statusBar: {
+      backgroundColor: chrome,
+      paddingTop: 12,
+      paddingBottom: 6,
+      paddingHorizontal: 16,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    clock: { fontSize: 13, fontWeight: '600', color: t.textPrimary },
+    signal: { fontSize: 11, color: t.textSecondary },
+    header: {
+      paddingVertical: 14,
+      paddingHorizontal: 16,
+      borderBottomWidth: t.isComic ? 2 : 1,
+      borderBottomColor: divider,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    headerTitle: { fontSize: 15, fontWeight: '700', color: t.textPrimary, letterSpacing: t.isComic ? 0.6 : 0, textTransform: t.isComic ? 'uppercase' : 'none' },
+    body: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 24 },
+    iconRing: {
+      width: 72,
+      height: 72,
+      borderRadius: t.isComic ? 0 : 36,
+      backgroundColor: t.isComic ? `${t.border}12` : `${accent}15`,
+      borderWidth: t.isComic ? 2 : 1,
+      borderColor: t.isComic ? t.border : `${accent}40`,
+      borderStyle: t.isComic ? 'solid' : 'dashed',
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 20,
+    },
+    iconGlyph: { fontSize: 28 },
+    title: { fontSize: 18, fontWeight: '800', color: t.textPrimary, marginBottom: 10, textAlign: 'center' },
+    subtitle: { fontSize: 14, color: t.textSecondary, lineHeight: 22, marginBottom: 28, textAlign: 'center' },
+    primaryBtn: {
+      width: '100%',
+      paddingVertical: 14,
+      borderRadius: r,
+      backgroundColor: t.isComic ? t.surface : accent,
+      borderWidth: t.isComic ? 1.5 : 0,
+      borderColor: t.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 12,
+    },
+    primaryBtnText: { color: t.isComic ? t.border : '#000', fontWeight: t.isComic ? '800' : '700', fontSize: 15, textTransform: t.isComic ? 'uppercase' : 'none', letterSpacing: t.isComic ? 0.6 : 0 },
+    scheduleBtn: {
+      width: '100%',
+      paddingVertical: 14,
+      borderRadius: r,
+      backgroundColor: t.surface,
+      borderWidth: t.isComic ? 1.5 : 1,
+      borderColor: t.isComic ? `${t.borderDim}50` : '#1E2A3A',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    scheduleBtnText: { color: t.isComic ? t.textSecondary : t.textPrimary, fontWeight: '600', fontSize: 15 },
+    footer: {
+      padding: 16,
+      borderTopWidth: t.isComic ? 2 : 1,
+      borderTopColor: divider,
+      backgroundColor: t.surface,
+    },
+    footerText: { fontSize: 12, color: t.textSecondary },
+  });
+}

--- a/ctf/packages/mobile/src/features/chyme/chyme-room-list.tsx
+++ b/ctf/packages/mobile/src/features/chyme/chyme-room-list.tsx
@@ -2,6 +2,9 @@
  * ChymeRoomList — renders the Chyme room-directory screen.
  * Bound to real data from GET /api/chyme/room:
  *   - roomName, participants, callActive.
+ * Theme: colours come from the active theme tokens (passed in from ChymeRoom). Default
+ * theme keeps the deep-green Chyme chrome; comic theme uses the ink/cream palette with
+ * sharp corners per ComicChyme.tsx.
  * Omissions from mockup (no backing API field):
  *   - Multiple room cards (API returns one canonical room only).
  *   - Live listener count (not in room response; participants.length used instead).
@@ -9,7 +12,7 @@
  *   - Upcoming/scheduled rooms (no backend endpoint).
  *   - Nations stat (no backend field).
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ScrollView,
   StyleSheet,
@@ -17,8 +20,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-
-const PRIMARY = '#22C55E';
+import { type ThemeTokens } from '../../theme';
 
 export type RoomSummary = {
   roomId: string;
@@ -34,6 +36,8 @@ type Props = {
   onTabChange: (_tab: 'live' | 'upcoming') => void;
   onJoinRoom: () => void;
   onStartRoom: () => void;
+  tokens: ThemeTokens;
+  accent: string;
 };
 
 export const ChymeRoomList: React.FC<Props> = ({
@@ -42,224 +46,202 @@ export const ChymeRoomList: React.FC<Props> = ({
   onTabChange,
   onJoinRoom,
   onStartRoom,
-}) => (
-  <View style={styles.container}>
-    <View style={styles.statusBar}>
-      <Text style={styles.clock}>9:41</Text>
-      <Text style={styles.signal}>•••</Text>
-    </View>
-
-    <View style={styles.header}>
-      <View style={styles.headerLeft}>
-        <View style={styles.iconBox}>
-          {/* Radio icon — no direct RN lucide; using text glyph */}
-          <Text style={styles.iconGlyph}>📻</Text>
-        </View>
-        <View>
-          <Text style={styles.headerTitle}>Chyme 🎙️</Text>
-          <Text style={styles.headerSubtitle}>Social Audio · Encrypted</Text>
-        </View>
+  tokens,
+  accent,
+}) => {
+  const styles = useMemo(() => makeStyles(tokens, accent), [tokens, accent]);
+  return (
+    <View style={styles.container}>
+      <View style={styles.statusBar}>
+        <Text style={styles.clock}>9:41</Text>
+        <Text style={styles.signal}>•••</Text>
       </View>
-    </View>
 
-    {/* Stats — listeners omitted (no direct API field); participants used */}
-    <View style={styles.statsRow}>
-      <View style={[styles.statBox, styles.statBoxPrimary]}>
-        <Text style={styles.statValuePrimary}>1</Text>
-        <Text style={styles.statLabel}>Live Rooms</Text>
-      </View>
-      <View style={styles.statBox}>
-        <Text style={styles.statValue}>{room.participantCount}</Text>
-        <Text style={styles.statLabel}>Participants</Text>
-      </View>
-      {/* Nations omitted — no backing API field */}
-    </View>
-
-    {/* Tabs */}
-    <View style={styles.tabRow}>
-      <TouchableOpacity
-        style={[styles.tab, tab === 'live' && styles.tabActive]}
-        onPress={() => onTabChange('live')}
-      >
-        <Text style={[styles.tabText, tab === 'live' && styles.tabTextActive]}>
-          🔴 Live
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        style={[styles.tab, tab === 'upcoming' && styles.tabActive]}
-        onPress={() => onTabChange('upcoming')}
-      >
-        <Text style={[styles.tabText, tab === 'upcoming' && styles.tabTextActive]}>
-          📅 Upcoming
-        </Text>
-      </TouchableOpacity>
-    </View>
-
-    {/* Start Room CTA */}
-    <View style={styles.ctaWrapper}>
-      <TouchableOpacity style={styles.startBtn} onPress={onStartRoom}>
-        <Text style={styles.startBtnText}>+ Start a Room</Text>
-      </TouchableOpacity>
-    </View>
-
-    <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
-      {tab === 'live' ? (
-        <TouchableOpacity style={styles.roomCard} onPress={onJoinRoom}>
-          <View style={styles.roomCardHeader}>
-            <View style={styles.liveDot} />
-            <Text style={styles.roomName}>{room.roomName}</Text>
+      <View style={styles.header}>
+        <View style={styles.headerLeft}>
+          <View style={styles.iconBox}>
+            {/* Radio icon — no direct RN lucide; using text glyph */}
+            <Text style={styles.iconGlyph}>📻</Text>
           </View>
-          {/* Host display name not in room response — omitted */}
-          <View style={styles.roomMeta}>
-            <Text style={styles.roomMetaText}>
-              {room.participantCount} participant{room.participantCount !== 1 ? 's' : ''}
+          <View>
+            <Text style={styles.headerTitle}>Chyme 🎙️</Text>
+            <Text style={styles.headerSubtitle}>Social Audio · Encrypted</Text>
+          </View>
+        </View>
+      </View>
+
+      {/* Stats — listeners omitted (no direct API field); participants used */}
+      <View style={styles.statsRow}>
+        <View style={[styles.statBox, styles.statBoxPrimary]}>
+          <Text style={styles.statValuePrimary}>1</Text>
+          <Text style={styles.statLabel}>Live Rooms</Text>
+        </View>
+        <View style={styles.statBox}>
+          <Text style={styles.statValue}>{room.participantCount}</Text>
+          <Text style={styles.statLabel}>Participants</Text>
+        </View>
+        {/* Nations omitted — no backing API field */}
+      </View>
+
+      {/* Tabs */}
+      <View style={styles.tabRow}>
+        <TouchableOpacity
+          style={[styles.tab, tab === 'live' && styles.tabActive]}
+          onPress={() => onTabChange('live')}
+        >
+          <Text style={[styles.tabText, tab === 'live' && styles.tabTextActive]}>🔴 Live</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tab, tab === 'upcoming' && styles.tabActive]}
+          onPress={() => onTabChange('upcoming')}
+        >
+          <Text style={[styles.tabText, tab === 'upcoming' && styles.tabTextActive]}>📅 Upcoming</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Start Room CTA */}
+      <View style={styles.ctaWrapper}>
+        <TouchableOpacity style={styles.startBtn} onPress={onStartRoom}>
+          <Text style={styles.startBtnText}>+ Start a Room</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
+        {tab === 'live' ? (
+          <TouchableOpacity style={styles.roomCard} onPress={onJoinRoom}>
+            <View style={styles.roomCardHeader}>
+              <View style={styles.liveDot} />
+              <Text style={styles.roomName}>{room.roomName}</Text>
+            </View>
+            {/* Host display name not in room response — omitted */}
+            <View style={styles.roomMeta}>
+              <Text style={styles.roomMetaText}>
+                {room.participantCount} participant{room.participantCount !== 1 ? 's' : ''}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        ) : (
+          // Upcoming rooms: no backend endpoint — show informational message only
+          <View style={styles.upcomingPlaceholder}>
+            <Text style={styles.upcomingText}>
+              No upcoming rooms scheduled. Use Start a Room to schedule one.
             </Text>
           </View>
-        </TouchableOpacity>
-      ) : (
-        // Upcoming rooms: no backend endpoint — show informational message only
-        <View style={styles.upcomingPlaceholder}>
-          <Text style={styles.upcomingText}>
-            No upcoming rooms scheduled. Use Start a Room to schedule one.
-          </Text>
-        </View>
-      )}
-    </ScrollView>
-  </View>
-);
+        )}
+      </ScrollView>
+    </View>
+  );
+};
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#021006' },
-  statusBar: {
-    height: 44,
-    backgroundColor: '#030d05',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 16,
-  },
-  clock: { fontSize: 13, fontWeight: '700', color: '#E8EAF0' },
-  signal: { fontSize: 12, color: '#9CA3AF' },
-  header: {
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    borderBottomWidth: 1,
-    borderBottomColor: '#052e16',
-    backgroundColor: '#030d05',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  headerLeft: { flexDirection: 'row', alignItems: 'center', gap: 10 },
-  iconBox: {
-    width: 38,
-    height: 38,
-    borderRadius: 12,
-    backgroundColor: `${PRIMARY}20`,
-    borderWidth: 1,
-    borderColor: `${PRIMARY}40`,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  iconGlyph: { fontSize: 18 },
-  headerTitle: { fontSize: 18, fontWeight: '800', color: '#F0FDF4' },
-  headerSubtitle: { fontSize: 11, color: PRIMARY },
-  statsRow: {
-    flexDirection: 'row',
-    gap: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    backgroundColor: '#030d05',
-    borderBottomWidth: 1,
-    borderBottomColor: '#052e16',
-  },
-  statBox: {
-    flex: 1,
-    paddingVertical: 10,
-    borderRadius: 10,
-    backgroundColor: 'rgba(255,255,255,0.03)',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.07)',
-    alignItems: 'center',
-  },
-  statBoxPrimary: {
-    backgroundColor: `${PRIMARY}10`,
-    borderColor: `${PRIMARY}20`,
-  },
-  statValue: { fontSize: 16, fontWeight: '800', color: '#E8EAF0' },
-  statValuePrimary: { fontSize: 16, fontWeight: '800', color: PRIMARY },
-  statLabel: { fontSize: 11, color: '#4B5563', marginTop: 2 },
-  tabRow: {
-    flexDirection: 'row',
-    gap: 6,
-    paddingHorizontal: 16,
-    paddingTop: 12,
-    paddingBottom: 8,
-  },
-  tab: {
-    flex: 1,
-    paddingVertical: 8,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: '#052e16',
-    alignItems: 'center',
-  },
-  tabActive: {
-    backgroundColor: `${PRIMARY}18`,
-    borderColor: `${PRIMARY}40`,
-  },
-  tabText: { fontSize: 13, color: '#6B7280', fontWeight: '400' },
-  tabTextActive: { color: PRIMARY, fontWeight: '700' },
-  ctaWrapper: { paddingHorizontal: 16, paddingBottom: 10 },
-  startBtn: {
-    width: '100%',
-    paddingVertical: 12,
-    borderRadius: 12,
-    backgroundColor: PRIMARY,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  startBtnText: { color: '#fff', fontSize: 14, fontWeight: '700' },
-  list: { flex: 1 },
-  listContent: { paddingHorizontal: 16, paddingBottom: 16 },
-  roomCard: {
-    padding: 16,
-    borderRadius: 14,
-    backgroundColor: 'rgba(34,197,94,0.05)',
-    borderWidth: 1,
-    borderColor: '#052e16',
-    marginBottom: 10,
-  },
-  roomCardHeader: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 8,
-    marginBottom: 8,
-  },
-  liveDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: PRIMARY,
-    marginTop: 5,
-  },
-  roomName: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#F0FDF4',
-    flex: 1,
-    lineHeight: 20,
-  },
-  roomMeta: { flexDirection: 'row', alignItems: 'center' },
-  roomMetaText: { fontSize: 12, color: '#16A34A' },
-  upcomingPlaceholder: {
-    paddingVertical: 24,
-    alignItems: 'center',
-  },
-  upcomingText: {
-    fontSize: 14,
-    color: '#4B5563',
-    textAlign: 'center',
-    lineHeight: 22,
-  },
-});
+function makeStyles(t: ThemeTokens, accent: string) {
+  const bg = t.isComic ? t.bg : '#021006';
+  const chrome = t.isComic ? t.surfaceAlt : '#030d05';
+  const divider = t.isComic ? t.border : '#052e16';
+  const r = t.radius;
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: bg },
+    statusBar: {
+      height: 44,
+      backgroundColor: chrome,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+    },
+    clock: { fontSize: 13, fontWeight: '700', color: t.isComic ? t.border : '#E8EAF0' },
+    signal: { fontSize: 12, color: t.textSecondary },
+    header: {
+      paddingHorizontal: 16,
+      paddingVertical: 14,
+      borderBottomWidth: t.isComic ? 2 : 1,
+      borderBottomColor: divider,
+      backgroundColor: chrome,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    headerLeft: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+    iconBox: {
+      width: 38,
+      height: 38,
+      borderRadius: t.isComic ? 0 : 12,
+      backgroundColor: t.isComic ? t.surface : `${accent}20`,
+      borderWidth: t.isComic ? 2 : 1,
+      borderColor: t.isComic ? t.border : `${accent}40`,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    iconGlyph: { fontSize: 18 },
+    headerTitle: { fontSize: 18, fontWeight: '800', color: t.isComic ? t.textPrimary : '#F0FDF4', letterSpacing: t.isComic ? 0.6 : 0, textTransform: t.isComic ? 'uppercase' : 'none' },
+    headerSubtitle: { fontSize: 11, color: t.isComic ? t.textSecondary : accent },
+    statsRow: {
+      flexDirection: 'row',
+      gap: 8,
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      backgroundColor: chrome,
+      borderBottomWidth: t.isComic ? 2 : 1,
+      borderBottomColor: divider,
+    },
+    statBox: {
+      flex: 1,
+      paddingVertical: 10,
+      borderRadius: r,
+      backgroundColor: t.isComic ? t.surface : 'rgba(255,255,255,0.03)',
+      borderWidth: t.isComic ? 1.5 : 1,
+      borderColor: t.isComic ? `${t.border}35` : 'rgba(255,255,255,0.07)',
+      alignItems: 'center',
+    },
+    statBoxPrimary: {
+      backgroundColor: t.isComic ? `${t.border}10` : `${accent}10`,
+      borderColor: t.isComic ? t.border : `${accent}20`,
+    },
+    statValue: { fontSize: 16, fontWeight: '800', color: t.isComic ? t.textPrimary : '#E8EAF0' },
+    statValuePrimary: { fontSize: 16, fontWeight: '800', color: t.isComic ? t.border : accent },
+    statLabel: { fontSize: 11, color: t.textSecondary, marginTop: 2 },
+    tabRow: { flexDirection: 'row', gap: 6, paddingHorizontal: 16, paddingTop: 12, paddingBottom: 8 },
+    tab: {
+      flex: 1,
+      paddingVertical: 8,
+      borderRadius: r,
+      borderWidth: t.isComic ? 2 : 1,
+      borderColor: t.isComic ? `${t.borderDim}40` : '#052e16',
+      alignItems: 'center',
+    },
+    tabActive: {
+      backgroundColor: t.isComic ? `${t.border}14` : `${accent}18`,
+      borderColor: t.isComic ? t.border : `${accent}40`,
+    },
+    tabText: { fontSize: 13, color: t.textSecondary, fontWeight: '400', textTransform: t.isComic ? 'uppercase' : 'none', letterSpacing: t.isComic ? 0.6 : 0 },
+    tabTextActive: { color: t.isComic ? t.textPrimary : accent, fontWeight: '700' },
+    ctaWrapper: { paddingHorizontal: 16, paddingBottom: 10 },
+    startBtn: {
+      width: '100%',
+      paddingVertical: 12,
+      borderRadius: r,
+      backgroundColor: t.isComic ? t.surface : accent,
+      borderWidth: t.isComic ? 1.5 : 0,
+      borderColor: t.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    startBtnText: { color: t.isComic ? t.border : '#fff', fontSize: 14, fontWeight: t.isComic ? '800' : '700', textTransform: t.isComic ? 'uppercase' : 'none', letterSpacing: t.isComic ? 0.6 : 0 },
+    list: { flex: 1 },
+    listContent: { paddingHorizontal: 16, paddingBottom: 16 },
+    roomCard: {
+      padding: 16,
+      borderRadius: r,
+      backgroundColor: t.isComic ? t.surface : 'rgba(34,197,94,0.05)',
+      borderWidth: t.isComic ? 1.5 : 1,
+      borderColor: t.isComic ? `${t.border}35` : '#052e16',
+      marginBottom: 10,
+    },
+    roomCardHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: 8, marginBottom: 8 },
+    liveDot: { width: 8, height: 8, borderRadius: t.isComic ? 0 : 4, backgroundColor: t.success, marginTop: 5 },
+    roomName: { fontSize: 14, fontWeight: '600', color: t.isComic ? t.textPrimary : '#F0FDF4', flex: 1, lineHeight: 20 },
+    roomMeta: { flexDirection: 'row', alignItems: 'center' },
+    roomMetaText: { fontSize: 12, color: t.isComic ? t.textSecondary : '#16A34A' },
+    upcomingPlaceholder: { paddingVertical: 24, alignItems: 'center' },
+    upcomingText: { fontSize: 14, color: t.textSecondary, textAlign: 'center', lineHeight: 22 },
+  });
+}

--- a/ctf/packages/mobile/src/features/hub/HubHome.tsx
+++ b/ctf/packages/mobile/src/features/hub/HubHome.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -10,19 +10,9 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useTheme, getAppAccent, type ThemeName, type ThemeTokens } from '../../theme';
 import { fetchHubMessages, sendHubMessage } from './api';
 import type { HubMessage } from './api';
-
-// Palette pulled from the locked mobile mockups (MobileHome.tsx / MobileHubPublic.tsx).
-const BG = '#0F1117';
-const HEADER_BG = '#090B0F';
-const TEXT = '#F9FAFB';
-const SUBTLE = '#6B7280';
-const DIMMER = '#4B5563';
-const BRAND = '#7C3AED';
-const BRAND_LIGHT = '#A78BFA';
-const CYAN = '#0EA5E9';
-const BORDER = 'rgba(255,255,255,0.06)';
 
 // The Hub stream is feed-backed and flattened on the server to one author shape per message:
 // "Survivor Hub" for admin announcements + AI Q&A, "Community member" for peer-to-peer posts.
@@ -53,43 +43,47 @@ function dedupKey(message: HubMessage): string {
   return `${message.userId}|${message.displayName}|${message.text}|${message.sentAtIso}`;
 }
 
-function MessageCard({ message }: { message: HubMessage }) {
+type Styles = ReturnType<typeof makeStyles>;
+
+function MessageCard({ message, s, tokens, theme }: { message: HubMessage; s: Styles; tokens: ThemeTokens; theme: ThemeName }) {
   const official = isOfficial(message);
-  const accent = official ? BRAND_LIGHT : '#22C55E';
+  // Official posts use the Hub brand (chyme accent in comic). Community posts use the
+  // success/green accent. Both come from the active theme so they switch with the toggle.
+  const accent = official ? getAppAccent('chyme', theme) : tokens.success;
 
   return (
-    <View style={[styles.card, official ? styles.cardOfficial : styles.cardCommunity]}>
-      <View style={styles.cardHeader}>
-        <View style={[styles.avatar, official ? styles.avatarOfficial : { backgroundColor: `${accent}22` }]}>
-          <Text style={[styles.avatarText, official ? styles.avatarTextOfficial : { color: accent }]}>
+    <View style={[s.card, official ? s.cardOfficial : s.cardCommunity]}>
+      <View style={s.cardHeader}>
+        <View style={[s.avatar, { backgroundColor: tokens.isComic ? `${accent}18` : `${accent}22`, borderWidth: tokens.isComic ? 1 : 0, borderColor: `${accent}40` }]}>
+          <Text style={[s.avatarText, { color: tokens.isComic ? tokens.textPrimary : accent }]}>
             {avatarInitials(message)}
           </Text>
         </View>
-        <View style={styles.cardMeta}>
-          <View style={styles.cardNameRow}>
-            <Text style={styles.cardName}>{message.displayName}</Text>
+        <View style={s.cardMeta}>
+          <View style={s.cardNameRow}>
+            <Text style={s.cardName}>{message.displayName}</Text>
             {official && (
-              <View style={styles.officialBadge}>
-                <Text style={styles.officialBadgeText}>Official</Text>
+              <View style={s.officialBadge}>
+                <Text style={s.officialBadgeText}>Official</Text>
               </View>
             )}
           </View>
-          <Text style={styles.cardTime}>{formatTime(message.sentAtIso)}</Text>
+          <Text style={s.cardTime}>{formatTime(message.sentAtIso)}</Text>
         </View>
       </View>
-      <Text style={styles.cardBody}>{message.text}</Text>
+      <Text style={s.cardBody}>{message.text}</Text>
     </View>
   );
 }
 
-function EmptyState() {
+function EmptyState({ s }: { s: Styles }) {
   return (
-    <View style={styles.emptyWrap}>
-      <View style={styles.emptyIcon}>
+    <View style={s.emptyWrap}>
+      <View style={s.emptyIcon}>
         <Text style={{ fontSize: 28 }}>💬</Text>
       </View>
-      <Text style={styles.emptyTitle}>Nothing posted yet</Text>
-      <Text style={styles.emptyBody}>
+      <Text style={s.emptyTitle}>Nothing posted yet</Text>
+      <Text style={s.emptyBody}>
         Announcements, answers, and community posts will appear here. Be the first to share an update.
       </Text>
     </View>
@@ -97,6 +91,9 @@ function EmptyState() {
 }
 
 export const HubHome = () => {
+  const { tokens, theme } = useTheme();
+  const s = useMemo(() => makeStyles(tokens, theme), [tokens, theme]);
+
   const [messages, setMessages] = useState<HubMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -158,62 +155,64 @@ export const HubHome = () => {
     }
   }, [input, sending]);
 
+  const hubAccent = getAppAccent('chyme', theme);
+
   return (
-    <View style={styles.screen}>
-      <View style={styles.header}>
-        <View style={styles.headerAvatar}>
-          <Text style={styles.headerAvatarText}>SH</Text>
+    <View style={s.screen}>
+      <View style={s.header}>
+        <View style={s.headerAvatar}>
+          <Text style={s.headerAvatarText}>SH</Text>
         </View>
         <View>
-          <Text style={styles.headerTitle}>Survivor Hub</Text>
-          <Text style={styles.headerSub}>Community · Live</Text>
+          <Text style={s.headerTitle}>Survivor Hub</Text>
+          <Text style={s.headerSub}>Community · Live</Text>
         </View>
       </View>
 
       {loading ? (
-        <View style={styles.center}>
-          <ActivityIndicator size="large" color={BRAND_LIGHT} />
+        <View style={s.center}>
+          <ActivityIndicator size="large" color={hubAccent} />
         </View>
       ) : error ? (
-        <View style={styles.center}>
-          <Text style={styles.errorText}>{error}</Text>
-          <Pressable style={styles.retryBtn} onPress={load}>
-            <Text style={styles.retryText}>Retry</Text>
+        <View style={s.center}>
+          <Text style={s.errorText}>{error}</Text>
+          <Pressable style={s.retryBtn} onPress={load}>
+            <Text style={s.retryText}>Retry</Text>
           </Pressable>
         </View>
       ) : messages.length === 0 ? (
-        <EmptyState />
+        <EmptyState s={s} />
       ) : (
         <FlatList
           data={messages}
           keyExtractor={(item) => item.id}
-          renderItem={({ item }) => <MessageCard message={item} />}
-          contentContainerStyle={styles.list}
+          renderItem={({ item }) => <MessageCard message={item} s={s} tokens={tokens} theme={theme} />}
+          contentContainerStyle={s.list}
           showsVerticalScrollIndicator={false}
         />
       )}
 
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-        {sendError && <Text style={styles.sendError}>{sendError}</Text>}
-        <View style={styles.composer}>
+        {sendError && <Text style={s.sendError}>{sendError}</Text>}
+        <View style={s.composer}>
           <TextInput
-            style={styles.input}
+            style={s.input}
             value={input}
             onChangeText={setInput}
             placeholder="Share an update with the community…"
-            placeholderTextColor={DIMMER}
+            placeholderTextColor={tokens.textMuted}
             multiline
             editable={!sending}
           />
           <Pressable
-            style={[styles.sendBtn, input.trim() ? styles.sendBtnActive : null]}
+            style={[s.sendBtn, input.trim() ? s.sendBtnActive : null]}
             onPress={handleSend}
             disabled={!input.trim() || sending}
           >
             {sending ? (
-              <ActivityIndicator size="small" color="#fff" />
+              <ActivityIndicator size="small" color={tokens.isComic ? tokens.bg : '#fff'} />
             ) : (
-              <Text style={[styles.sendBtnText, input.trim() ? styles.sendBtnTextActive : null]}>Send</Text>
+              <Text style={[s.sendBtnText, input.trim() ? s.sendBtnTextActive : null]}>Send</Text>
             )}
           </Pressable>
         </View>
@@ -222,220 +221,94 @@ export const HubHome = () => {
   );
 };
 
-const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: BG,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingHorizontal: 20,
-    paddingVertical: 14,
-    backgroundColor: HEADER_BG,
-    borderBottomWidth: 1,
-    borderBottomColor: BORDER,
-  },
-  headerAvatar: {
-    width: 36,
-    height: 36,
-    borderRadius: 10,
-    backgroundColor: BRAND,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  headerAvatarText: {
-    fontSize: 13,
-    fontWeight: '800',
-    color: '#fff',
-  },
-  headerTitle: {
-    fontSize: 16,
-    fontWeight: '800',
-    color: TEXT,
-  },
-  headerSub: {
-    fontSize: 11,
-    color: '#22C55E',
-  },
-  list: {
-    padding: 16,
-    gap: 10,
-  },
-  card: {
-    borderRadius: 14,
-    borderWidth: 1,
-    padding: 14,
-    marginBottom: 10,
-  },
-  cardOfficial: {
-    backgroundColor: 'rgba(124,58,237,0.07)',
-    borderColor: 'rgba(124,58,237,0.22)',
-  },
-  cardCommunity: {
-    backgroundColor: 'rgba(255,255,255,0.02)',
-    borderColor: 'rgba(255,255,255,0.06)',
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 8,
-  },
-  avatar: {
-    width: 28,
-    height: 28,
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarOfficial: {
-    backgroundColor: BRAND,
-  },
-  avatarText: {
-    fontSize: 11,
-    fontWeight: '800',
-  },
-  avatarTextOfficial: {
-    color: '#fff',
-  },
-  cardMeta: {
-    flex: 1,
-  },
-  cardNameRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  cardName: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: TEXT,
-  },
-  officialBadge: {
-    paddingHorizontal: 5,
-    paddingVertical: 1,
-    borderRadius: 3,
-    backgroundColor: 'rgba(124,58,237,0.2)',
-  },
-  officialBadgeText: {
-    fontSize: 10,
-    fontWeight: '600',
-    color: BRAND_LIGHT,
-  },
-  cardTime: {
-    fontSize: 11,
-    color: DIMMER,
-    marginTop: 1,
-  },
-  cardBody: {
-    fontSize: 13,
-    color: '#D1D5DB',
-    lineHeight: 21,
-  },
-  center: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 24,
-  },
-  errorText: {
-    fontSize: 14,
-    color: '#EF4444',
-    textAlign: 'center',
-    marginBottom: 16,
-  },
-  retryBtn: {
-    paddingHorizontal: 20,
-    paddingVertical: 10,
-    borderRadius: 10,
-    backgroundColor: 'rgba(124,58,237,0.2)',
-    borderWidth: 1,
-    borderColor: 'rgba(124,58,237,0.4)',
-  },
-  retryText: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: BRAND_LIGHT,
-  },
-  emptyWrap: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 32,
-  },
-  emptyIcon: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: 'rgba(124,58,237,0.12)',
-    borderWidth: 1,
-    borderColor: 'rgba(124,58,237,0.3)',
-    borderStyle: 'dashed',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 20,
-  },
-  emptyTitle: {
-    fontSize: 18,
-    fontWeight: '800',
-    color: TEXT,
-    marginBottom: 10,
-    textAlign: 'center',
-  },
-  emptyBody: {
-    fontSize: 14,
-    color: SUBTLE,
-    lineHeight: 22,
-    textAlign: 'center',
-  },
-  sendError: {
-    fontSize: 12,
-    color: '#F87171',
-    paddingHorizontal: 16,
-    paddingTop: 8,
-  },
-  composer: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    gap: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    backgroundColor: HEADER_BG,
-    borderTopWidth: 1,
-    borderTopColor: BORDER,
-  },
-  input: {
-    flex: 1,
-    maxHeight: 120,
-    minHeight: 44,
-    borderRadius: 14,
-    backgroundColor: 'rgba(255,255,255,0.04)',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.1)',
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    fontSize: 14,
-    color: '#E8EAF0',
-  },
-  sendBtn: {
-    width: 44,
-    height: 44,
-    borderRadius: 12,
-    backgroundColor: 'rgba(255,255,255,0.06)',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  sendBtnActive: {
-    backgroundColor: CYAN,
-  },
-  sendBtnText: {
-    fontSize: 12,
-    fontWeight: '700',
-    color: DIMMER,
-  },
-  sendBtnTextActive: {
-    color: '#fff',
-  },
-});
+function makeStyles(t: ThemeTokens, theme: ThemeName) {
+  const r = t.radius;
+  const official = getAppAccent('chyme', theme);
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: t.bg },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      paddingHorizontal: 20,
+      paddingVertical: 14,
+      backgroundColor: t.surfaceAlt,
+      borderBottomWidth: t.isComic ? 2 : 1,
+      borderBottomColor: t.isComic ? t.border : t.borderFaint,
+    },
+    headerAvatar: {
+      width: 36,
+      height: 36,
+      borderRadius: t.isComic ? 0 : 10,
+      backgroundColor: t.isComic ? t.surface : official,
+      borderWidth: t.isComic ? 2 : 0,
+      borderColor: t.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    headerAvatarText: { fontSize: 13, fontWeight: '800', color: t.isComic ? t.border : '#fff' },
+    headerTitle: { fontSize: 16, fontWeight: '800', color: t.textPrimary, letterSpacing: t.isComic ? 0.6 : 0, textTransform: t.isComic ? 'uppercase' : 'none' },
+    headerSub: { fontSize: 11, color: t.success },
+    list: { padding: 16, gap: 10 },
+    card: { borderRadius: r, borderWidth: t.isComic ? 1.5 : 1, padding: 14, marginBottom: 10 },
+    cardOfficial: { backgroundColor: t.isComic ? `${official}10` : 'rgba(124,58,237,0.07)', borderColor: t.isComic ? `${official}50` : 'rgba(124,58,237,0.22)' },
+    cardCommunity: { backgroundColor: t.surface, borderColor: t.isComic ? `${t.border}40` : t.borderFaint },
+    cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 8 },
+    avatar: { width: 28, height: 28, borderRadius: t.isComic ? 0 : 8, alignItems: 'center', justifyContent: 'center' },
+    avatarText: { fontSize: 11, fontWeight: '800' },
+    cardMeta: { flex: 1 },
+    cardNameRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+    cardName: { fontSize: 13, fontWeight: '700', color: t.textPrimary, letterSpacing: t.isComic ? 0.4 : 0 },
+    officialBadge: { paddingHorizontal: 5, paddingVertical: 1, borderRadius: t.radiusChip, backgroundColor: t.isComic ? 'transparent' : 'rgba(124,58,237,0.2)', borderWidth: t.isComic ? 1 : 0, borderColor: `${t.border}40` },
+    officialBadgeText: { fontSize: 10, fontWeight: t.isComic ? '700' : '600', color: t.isComic ? t.border : '#A78BFA', letterSpacing: t.isComic ? 0.6 : 0, textTransform: t.isComic ? 'uppercase' : 'none' },
+    cardTime: { fontSize: 11, color: t.textSecondary, marginTop: 1 },
+    cardBody: { fontSize: 13, color: t.isComic ? t.textPrimary : '#D1D5DB', lineHeight: 21 },
+    center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+    errorText: { fontSize: 14, color: t.danger, textAlign: 'center', marginBottom: 16 },
+    retryBtn: { paddingHorizontal: 20, paddingVertical: 10, borderRadius: r, backgroundColor: t.isComic ? `${t.border}14` : 'rgba(124,58,237,0.2)', borderWidth: t.isComic ? 1.5 : 1, borderColor: t.isComic ? t.border : 'rgba(124,58,237,0.4)' },
+    retryText: { fontSize: 13, fontWeight: '700', color: t.isComic ? t.textPrimary : '#A78BFA' },
+    emptyWrap: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+    emptyIcon: {
+      width: 72,
+      height: 72,
+      borderRadius: t.isComic ? 0 : 36,
+      backgroundColor: t.isComic ? `${t.border}12` : 'rgba(124,58,237,0.12)',
+      borderWidth: t.isComic ? 2 : 1,
+      borderColor: t.isComic ? t.border : 'rgba(124,58,237,0.3)',
+      borderStyle: t.isComic ? 'solid' : 'dashed',
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 20,
+    },
+    emptyTitle: { fontSize: 18, fontWeight: '800', color: t.textPrimary, marginBottom: 10, textAlign: 'center' },
+    emptyBody: { fontSize: 14, color: t.textSecondary, lineHeight: 22, textAlign: 'center' },
+    sendError: { fontSize: 12, color: t.danger, paddingHorizontal: 16, paddingTop: 8 },
+    composer: {
+      flexDirection: 'row',
+      alignItems: 'flex-end',
+      gap: 8,
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      backgroundColor: t.surfaceAlt,
+      borderTopWidth: t.isComic ? 2 : 1,
+      borderTopColor: t.isComic ? t.border : t.borderFaint,
+    },
+    input: {
+      flex: 1,
+      maxHeight: 120,
+      minHeight: 44,
+      borderRadius: r,
+      backgroundColor: t.isComic ? t.surface : 'rgba(255,255,255,0.04)',
+      borderWidth: t.isComic ? 2 : 1,
+      borderColor: t.isComic ? `${t.border}60` : 'rgba(255,255,255,0.1)',
+      paddingHorizontal: 14,
+      paddingVertical: 10,
+      fontSize: 14,
+      color: t.textPrimary,
+    },
+    sendBtn: { width: 44, height: 44, borderRadius: r, backgroundColor: t.isComic ? t.surface : 'rgba(255,255,255,0.06)', borderWidth: t.isComic ? 1.5 : 0, borderColor: `${t.borderDim}60`, alignItems: 'center', justifyContent: 'center' },
+    sendBtnActive: { backgroundColor: t.isComic ? t.border : '#0EA5E9', borderColor: t.border },
+    sendBtnText: { fontSize: 12, fontWeight: '700', color: t.textSecondary },
+    sendBtnTextActive: { color: t.isComic ? t.bg : '#fff' },
+  });
+}

--- a/ctf/packages/mobile/src/theme/ThemeToggle.tsx
+++ b/ctf/packages/mobile/src/theme/ThemeToggle.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTheme } from './theme-context';
+import { type ThemeName } from './theme-tokens';
+
+// Two-state segmented control for the app theme, mirroring the web's ThemeToggle
+// (components/theme/theme-toggle.tsx). Styled from the active theme tokens so it reads
+// correctly in both themes. Lives in the Account & Data screen.
+
+const OPTIONS: { value: ThemeName; label: string }[] = [
+  { value: 'default', label: 'Default' },
+  { value: 'comic', label: 'Comic' },
+];
+
+export const ThemeToggle: React.FC = () => {
+  const { theme, setTheme, tokens } = useTheme();
+
+  return (
+    <View
+      accessibilityRole="radiogroup"
+      accessibilityLabel="App theme"
+      style={[
+        styles.group,
+        {
+          borderColor: tokens.border,
+          borderRadius: tokens.radiusChip,
+          backgroundColor: tokens.surface,
+        },
+      ]}
+    >
+      {OPTIONS.map((option) => {
+        const active = theme === option.value;
+        return (
+          <TouchableOpacity
+            key={option.value}
+            accessibilityRole="radio"
+            accessibilityState={{ selected: active }}
+            onPress={() => setTheme(option.value)}
+            style={[
+              styles.option,
+              active && { backgroundColor: tokens.isComic ? tokens.border : tokens.textPrimary },
+            ]}
+          >
+            <Text
+              style={[
+                styles.optionText,
+                { color: active ? tokens.bg : tokens.textSecondary },
+              ]}
+            >
+              {option.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  group: {
+    flexDirection: 'row',
+    borderWidth: 1.5,
+    overflow: 'hidden',
+    alignSelf: 'flex-start',
+  },
+  option: {
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+  },
+  optionText: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.7,
+    textTransform: 'uppercase',
+  },
+});

--- a/ctf/packages/mobile/src/theme/index.ts
+++ b/ctf/packages/mobile/src/theme/index.ts
@@ -1,0 +1,14 @@
+export { ThemeProvider, useTheme } from './theme-context';
+export { ThemeToggle } from './ThemeToggle';
+export {
+  DEFAULT_THEME,
+  THEME_NAMES,
+  THEME_STORAGE_KEY,
+  getAppAccent,
+  getThemeTokens,
+  isThemeName,
+  normalizeTheme,
+  PLUGIN_ACCENTS,
+  type ThemeName,
+  type ThemeTokens,
+} from './theme-tokens';

--- a/ctf/packages/mobile/src/theme/theme-context.tsx
+++ b/ctf/packages/mobile/src/theme/theme-context.tsx
@@ -1,0 +1,135 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import * as SecureStore from 'expo-secure-store';
+import { authedFetch } from '../auth/authedFetch';
+import {
+  DEFAULT_THEME,
+  THEME_STORAGE_KEY,
+  getThemeTokens,
+  normalizeTheme,
+  type ThemeName,
+  type ThemeTokens,
+} from './theme-tokens';
+
+// Mobile theme provider — mirrors the web's hooks/useTheme.tsx shape.
+//
+// The choice persists two ways, matching the web:
+//   1. On-device, so a returning user keeps their theme offline. The web uses
+//      localStorage under the "sh-theme" key; the device equivalent here is
+//      expo-secure-store under the same key.
+//   2. Server-side, via PUT /api/account/ui-preferences, so the choice follows the
+//      signed-in account across devices and stays in sync with the web. On load we
+//      read GET /api/account/ui-preferences (the server is the source of truth for a
+//      signed-in account); failures / signed-out simply keep the local choice.
+//
+// SecureStore keys must be alphanumeric / '.' / '-' / '_', so the literal "sh-theme"
+// from the spec is a valid key as-is.
+
+type ThemeContextValue = {
+  theme: ThemeName;
+  tokens: ThemeTokens;
+  setTheme: (_theme: ThemeName) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const PREFERENCES_PATH = '/api/account/ui-preferences';
+
+async function readStoredTheme(): Promise<ThemeName> {
+  try {
+    const raw = await SecureStore.getItemAsync(THEME_STORAGE_KEY);
+    return normalizeTheme(raw);
+  } catch {
+    return DEFAULT_THEME;
+  }
+}
+
+async function writeStoredTheme(theme: ThemeName): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Storage unavailable — the in-memory choice still applies this session.
+  }
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<ThemeName>(DEFAULT_THEME);
+  const didInit = useRef(false);
+
+  const applyTheme = useCallback((next: ThemeName, persistToServer: boolean) => {
+    setThemeState(next);
+    void writeStoredTheme(next);
+    if (persistToServer) {
+      // Best-effort sync to the signed-in user's profile so the choice follows the
+      // account across devices and matches the web. The account routes require the
+      // same-origin CSRF confirmation header. Signed-out callers get a 401 we ignore.
+      void authedFetch(PREFERENCES_PATH, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+        body: JSON.stringify({ theme: next }),
+      }).catch(() => undefined);
+    }
+  }, []);
+
+  const setTheme = useCallback((next: ThemeName) => applyTheme(next, true), [applyTheme]);
+  const toggleTheme = useCallback(
+    () => applyTheme(theme === 'comic' ? 'default' : 'comic', true),
+    [applyTheme, theme],
+  );
+
+  // On first mount: adopt the on-device choice immediately, then reconcile with the
+  // server (the source of truth for a signed-in account) so the theme follows the
+  // user across devices. Runs once; offline / signed-out keeps the local choice.
+  useEffect(() => {
+    if (didInit.current) return;
+    didInit.current = true;
+    let cancelled = false;
+
+    void (async () => {
+      const local = await readStoredTheme();
+      if (cancelled) return;
+      if (local !== DEFAULT_THEME) {
+        setThemeState(local);
+      }
+      try {
+        const res = await authedFetch(PREFERENCES_PATH);
+        if (!res.ok) return;
+        const data = (await res.json()) as { ok?: boolean; theme?: unknown };
+        if (!data?.ok || cancelled) return;
+        const serverTheme = normalizeTheme(data.theme);
+        if (serverTheme !== local) {
+          applyTheme(serverTheme, false);
+        }
+      } catch {
+        // Offline or not signed in — keep the local choice.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applyTheme]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, tokens: getThemeTokens(theme), setTheme, toggleTheme }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+}

--- a/ctf/packages/mobile/src/theme/theme-tokens.ts
+++ b/ctf/packages/mobile/src/theme/theme-tokens.ts
@@ -1,0 +1,147 @@
+// Theme tokens for the mobile app — mirrors the web's lib/theme/theme-tokens.ts.
+//
+// Two themes are supported: the original dark UI ('default') and a comic-book dark
+// theme ('comic'). The web drives surface colors through CSS custom properties; React
+// Native has no CSS variables, so this module also exposes a flat palette object
+// (getThemeTokens) that each screen reads to colour its StyleSheet. The theme name
+// type, storage key, and per-plugin accent table match the web verbatim so a user's
+// choice stays in sync across web and mobile through /api/account/ui-preferences.
+//
+// Comic-ink values are copied verbatim from the design token spec:
+// design/artifacts/mockup-sandbox/COMIC_THEME_TOKENS.md. Do not invent values.
+
+export type ThemeName = 'default' | 'comic';
+
+export const THEME_NAMES: readonly ThemeName[] = ['default', 'comic'] as const;
+
+export const DEFAULT_THEME: ThemeName = 'default';
+
+// Storage key — the web uses "sh-theme" (spec §12.2). We keep the exact same key so
+// the on-device value and the server value line up with the web client.
+export const THEME_STORAGE_KEY = 'sh-theme';
+
+export function isThemeName(value: unknown): value is ThemeName {
+  return value === 'default' || value === 'comic';
+}
+
+export function normalizeTheme(value: unknown): ThemeName {
+  return isThemeName(value) ? value : DEFAULT_THEME;
+}
+
+// Per-plugin accent translation. Keyed by plugin slug. `standard` is the accent the
+// app already uses; `comic` is the deep, ink-compatible variant (no neon, no glow).
+type AccentPair = { standard: string; comic: string };
+
+export const PLUGIN_ACCENTS: Record<string, AccentPair> = {
+  chyme: { standard: '#22C55E', comic: '#1A5C32' },
+  lighthouse: { standard: '#60A5FA', comic: '#1A4A7A' },
+  trusttransport: { standard: '#38BDF8', comic: '#0C4A6E' },
+  directory: { standard: '#93C5FD', comic: '#1A3A6A' },
+  foundation: { standard: '#F59E0B', comic: '#7A4A05' },
+  'peer-programming': { standard: '#6EE7B7', comic: '#1A5C40' },
+  gdp: { standard: '#06B6D4', comic: '#0E5A68' },
+  'gross-domestic-product': { standard: '#06B6D4', comic: '#0E5A68' },
+  'service-credits': { standard: '#A855F7', comic: '#5C2C8A' },
+  workforce: { standard: '#F97316', comic: '#6A2A05' },
+  gentlepulse: { standard: '#34D399', comic: '#1A5C45' },
+  mood: { standard: '#4ADE80', comic: '#1A5C2A' },
+  socketrelay: { standard: '#FB923C', comic: '#7A3A0C' },
+  'skills-hunt': { standard: '#FBBF24', comic: '#7A5A05' },
+  levelup: { standard: '#22C55E', comic: '#1A5C30' },
+  whatworks: { standard: '#84CC16', comic: '#4A6B10' },
+  'what-works': { standard: '#84CC16', comic: '#4A6B10' },
+  trust: { standard: '#0EA5E9', comic: '#0C5278' },
+  clicklog: { standard: '#EC4899', comic: '#7A1A4A' },
+  'skills-taxonomy': { standard: '#818CF8', comic: '#2A2A7A' },
+  unlock: { standard: '#C084FC', comic: '#5C1A8A' },
+  'weekly-performance': { standard: '#6366F1', comic: '#2A2A6A' },
+  // AI Assistant (the @comic plugin) deliberately uses inkDim in comic theme — no blue.
+  comic: { standard: '#38BDF8', comic: '#7A6A50' },
+  // Account & Data uses comic-danger for its destructive zone.
+  'account-data': { standard: '#E91E8C', comic: '#B91C1C' },
+};
+
+const FALLBACK_ACCENT: AccentPair = { standard: '#6B7280', comic: '#7A6A50' };
+
+// Resolve a plugin's accent for the active theme. Unknown slugs fall back to a
+// neutral grey (standard) / inkDim (comic) so a new plugin never renders unstyled.
+export function getAppAccent(slug: string, theme: ThemeName): string {
+  const pair = PLUGIN_ACCENTS[slug] ?? FALLBACK_ACCENT;
+  return theme === 'comic' ? pair.comic : pair.standard;
+}
+
+// Flat palette a screen reads to colour its StyleSheet. The comic side is copied
+// verbatim from COMIC_THEME_TOKENS.md sections 1-2; the default side keeps the existing
+// dark palette the shipped screens already use so 'default' is visually unchanged.
+export type ThemeTokens = {
+  /** Root page background — outermost container. */
+  bg: string;
+  /** Panels, cards, header bars. */
+  surface: string;
+  /** Deepest chrome — icon rail / status bar (darker than surface). */
+  surfaceAlt: string;
+  /** Primary hard border colour. */
+  border: string;
+  /** Dimmed / secondary border colour. */
+  borderDim: string;
+  /** Very faint row-divider tint. */
+  borderFaint: string;
+  /** Primary body text. */
+  textPrimary: string;
+  /** Secondary text, descriptions, timestamps. */
+  textSecondary: string;
+  /** Deeply muted text — disabled / fine print. */
+  textMuted: string;
+  /** Destructive / danger colour. */
+  danger: string;
+  /** Success / live indicator. */
+  success: string;
+  /** Warm gold accent — hero stats, progress, economy callouts. */
+  gold: string;
+  /** Border radius applied to cards / buttons (0 in comic theme). */
+  radius: number;
+  /** Border radius for chips / badges (2 in comic theme). */
+  radiusChip: number;
+  /** True when the comic theme is active — lets a screen branch on flat styling. */
+  isComic: boolean;
+};
+
+const DEFAULT_TOKENS: ThemeTokens = {
+  bg: '#0F1117',
+  surface: '#161B27',
+  surfaceAlt: '#090B0F',
+  border: '#1E2A3A',
+  borderDim: '#283548',
+  borderFaint: 'rgba(255,255,255,0.06)',
+  textPrimary: '#F9FAFB',
+  textSecondary: '#6B7280',
+  textMuted: '#4B5563',
+  danger: '#EF4444',
+  success: '#22C55E',
+  gold: '#C8A84B',
+  radius: 12,
+  radiusChip: 6,
+  isComic: false,
+};
+
+const COMIC_TOKENS: ThemeTokens = {
+  bg: '#0D0D0D',
+  surface: '#141414',
+  surfaceAlt: '#080808',
+  border: '#D4C49A',
+  borderDim: '#7A6A50',
+  borderFaint: 'rgba(212,196,154,0.1)',
+  textPrimary: '#EDE3CB',
+  textSecondary: '#7A6A50',
+  textMuted: '#4A3A2A',
+  danger: '#B91C1C',
+  success: '#22C55E',
+  gold: '#C8A84B',
+  radius: 0,
+  radiusChip: 2,
+  isComic: true,
+};
+
+export function getThemeTokens(theme: ThemeName): ThemeTokens {
+  return theme === 'comic' ? COMIC_TOKENS : DEFAULT_TOKENS;
+}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Mobile half of the comic-theme work for issue #341 (the web foundation already shipped). The web per-screen migration is a separate follow-up.

## What changed
- New `ctf/packages/mobile/src/theme/` — `ThemeContext`/`useTheme` mirroring the web theme shape (`default` | `comic` plus a token getter), a `ThemeToggle`, and comic `theme-tokens` (values copied verbatim from `COMIC_THEME_TOKENS.md`). The selection persists on-device with `expo-secure-store` (the app's existing storage; AsyncStorage is not a dependency) under the same `sh-theme` key the web uses, and syncs to the same `GET/PUT /api/account/ui-preferences` endpoint, so a member's theme stays consistent across web and mobile.
- `App.tsx` wraps the app in `ThemeProvider` (inside `AuthProvider`, so the synced preference call carries the signed-in bearer token), and the dev hub chrome follows the theme.
- A theme toggle in the **Account & Data** screen, and comic tokens applied to the **Account & Data**, **Hub/Home**, and **Chyme** surfaces per the `ComicMobile*` / `ComicChyme` mockups, driving colors from the token getter so they switch with the toggle.
- Loading screens are left untouched (per the comic-theme spec). No gradients/glow; sharp corners and the `3px 3px 0` offset shadow in comic theme.

No API contract change — it consumes the existing `ui-preferences` route. Other plugins' mobile screens are out of scope here (the web per-screen migration follows).

## Validation
mobile + web `tsc --noEmit`, EOF formatting, and the web/Android parity check all pass. No direct `key`-on-host-element patterns (the CI strict-types gotcha).

Closes part of #341 (mobile parity).

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1