### PR TITLE
feat: comic theme on web chrome — community shell, account & data, AI console (#341)

### DIFF
--- a/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
+++ b/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
@@ -3,8 +3,9 @@
 import { useState } from 'react';
 import { Trash2, Lock, CheckCircle, X, Loader2 } from 'lucide-react';
 import {
-  BRAND, BG, BORDER, TEXT, SUBTLE, FULL_ACCOUNT_CONFIRM_PHRASE,
+  getAccountDataTokens, FULL_ACCOUNT_CONFIRM_PHRASE,
 } from './account-data-shared';
+import { useTheme } from '@/hooks/useTheme';
 
 type ConfirmStatus = 'idle' | 'submitting' | 'done' | 'error';
 
@@ -21,6 +22,8 @@ type ConfirmProps = {
 // AccountDataConfirmDelete.tsx / MobileAccountDataConfirmDelete.tsx. On success it shows the
 // "Deletion queued" acknowledgement; the parent decides where to send the user next.
 export function AccountDataConfirmDelete({ serviceCount, isMobile, onCancel, onConfirm }: ConfirmProps) {
+  const { theme } = useTheme();
+  const { BRAND, BG, BORDER, TEXT, SUBTLE } = getAccountDataTokens(theme);
   const [input, setInput] = useState('');
   const [status, setStatus] = useState<ConfirmStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/ctf/packages/web/components/account-data/account-data-desktop.tsx
+++ b/ctf/packages/web/components/account-data/account-data-desktop.tsx
@@ -4,9 +4,10 @@ import {
   Shield, Database, Trash2, Lock, AlertTriangle, Info, Loader2,
 } from 'lucide-react';
 import {
-  BRAND, BG, SURFACE, BORDER, TEXT, SUBTLE,
-  glyphForService, type AccountService,
+  getAccountDataTokens,
+  glyphForService, type AccountService, type AccountDataTokens,
 } from './account-data-shared';
+import { useTheme } from '@/hooks/useTheme';
 import { ThemeToggle } from '../theme/theme-toggle';
 
 type View = 'data' | 'danger';
@@ -28,6 +29,9 @@ export function AccountDataDesktop({
   view, onViewChange, deletable, retained, deletedSlugs, pendingSlug, rowError,
   onDeleteService, onOpenAccountDelete,
 }: DesktopProps) {
+  const { theme } = useTheme();
+  const tokens = getAccountDataTokens(theme);
+  const { BRAND, BG, BORDER, TEXT, SUBTLE } = tokens;
   const remaining = deletable.filter((s) => !deletedSlugs.includes(s.slug));
   const isEmpty = remaining.length === 0;
 
@@ -87,7 +91,7 @@ export function AccountDataDesktop({
         <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '28px 40px' }}>
           {view === 'data' ? (
             isEmpty ? (
-              <EmptyState retained={retained} />
+              <EmptyState retained={retained} tokens={tokens} />
             ) : (
               <DataView
                 remaining={remaining}
@@ -95,10 +99,11 @@ export function AccountDataDesktop({
                 pendingSlug={pendingSlug}
                 rowError={rowError}
                 onDeleteService={onDeleteService}
+                tokens={tokens}
               />
             )
           ) : (
-            <DangerZone serviceCount={deletable.length} onOpenAccountDelete={onOpenAccountDelete} />
+            <DangerZone serviceCount={deletable.length} onOpenAccountDelete={onOpenAccountDelete} tokens={tokens} />
           )}
         </div>
       </div>
@@ -107,14 +112,16 @@ export function AccountDataDesktop({
 }
 
 function DataView({
-  remaining, retained, pendingSlug, rowError, onDeleteService,
+  remaining, retained, pendingSlug, rowError, onDeleteService, tokens,
 }: {
   remaining: AccountService[];
   retained: AccountService[];
   pendingSlug: string | null;
   rowError: { slug: string; message: string } | null;
   onDeleteService: (service: AccountService) => void;
+  tokens: AccountDataTokens;
 }) {
+  const { BRAND, SURFACE, BORDER, TEXT, SUBTLE } = tokens;
   return (
     <>
       <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 16px', borderRadius: 12, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 24 }}>
@@ -155,12 +162,13 @@ function DataView({
         })}
       </div>
 
-      <RetainedList retained={retained} />
+      <RetainedList retained={retained} tokens={tokens} />
     </>
   );
 }
 
-function RetainedList({ retained }: { retained: AccountService[] }) {
+function RetainedList({ retained, tokens }: { retained: AccountService[]; tokens: AccountDataTokens }) {
+  const { BORDER, TEXT, SUBTLE } = tokens;
   if (retained.length === 0) return null;
   return (
     <>
@@ -187,7 +195,8 @@ function RetainedList({ retained }: { retained: AccountService[] }) {
   );
 }
 
-function EmptyState({ retained }: { retained: AccountService[] }) {
+function EmptyState({ retained, tokens }: { retained: AccountService[]; tokens: AccountDataTokens }) {
+  const { BRAND, TEXT, SUBTLE } = tokens;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '40px 24px', textAlign: 'center', minHeight: '60vh' }}>
       <div style={{ width: 64, height: 64, borderRadius: 20, background: `${BRAND}08`, border: `1px dashed ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 20 }}>
@@ -209,7 +218,8 @@ function EmptyState({ retained }: { retained: AccountService[] }) {
   );
 }
 
-function DangerZone({ serviceCount, onOpenAccountDelete }: { serviceCount: number; onOpenAccountDelete: () => void }) {
+function DangerZone({ serviceCount, onOpenAccountDelete, tokens }: { serviceCount: number; onOpenAccountDelete: () => void; tokens: AccountDataTokens }) {
+  const { TEXT } = tokens;
   return (
     <div style={{ maxWidth: 600 }}>
       <div style={{ padding: '22px 24px', borderRadius: 16, background: 'rgba(239,68,68,0.04)', border: '1px solid rgba(239,68,68,0.18)' }}>

--- a/ctf/packages/web/components/account-data/account-data-mobile.tsx
+++ b/ctf/packages/web/components/account-data/account-data-mobile.tsx
@@ -4,10 +4,11 @@ import {
   Shield, Trash2, Lock, AlertTriangle, Info, ChevronRight, Loader2,
 } from 'lucide-react';
 import {
-  BRAND, BG, SURFACE, BORDER, TEXT, SUBTLE,
-  glyphForService, type AccountService,
+  getAccountDataTokens,
+  glyphForService, type AccountService, type AccountDataTokens,
 } from './account-data-shared';
 import type { AccountDataView } from './account-data-desktop';
+import { useTheme } from '@/hooks/useTheme';
 import { ThemeToggle } from '../theme/theme-toggle';
 
 type MobileProps = {
@@ -27,6 +28,9 @@ export function AccountDataMobile({
   view, onViewChange, deletable, retained, deletedSlugs, pendingSlug, rowError,
   onDeleteService, onOpenAccountDelete,
 }: MobileProps) {
+  const { theme } = useTheme();
+  const tokens = getAccountDataTokens(theme);
+  const { BRAND, BG, BORDER, TEXT, SUBTLE } = tokens;
   const remaining = deletable.filter((s) => !deletedSlugs.includes(s.slug));
   const isEmpty = remaining.length === 0;
 
@@ -62,7 +66,7 @@ export function AccountDataMobile({
       <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '14px 16px 24px' }}>
         {view === 'data' ? (
           isEmpty ? (
-            <MobileEmpty retained={retained} />
+            <MobileEmpty retained={retained} tokens={tokens} />
           ) : (
             <MobileDataView
               remaining={remaining}
@@ -70,10 +74,11 @@ export function AccountDataMobile({
               pendingSlug={pendingSlug}
               rowError={rowError}
               onDeleteService={onDeleteService}
+              tokens={tokens}
             />
           )
         ) : (
-          <MobileDanger serviceCount={deletable.length} onOpenAccountDelete={onOpenAccountDelete} />
+          <MobileDanger serviceCount={deletable.length} onOpenAccountDelete={onOpenAccountDelete} tokens={tokens} />
         )}
       </div>
     </div>
@@ -81,14 +86,16 @@ export function AccountDataMobile({
 }
 
 function MobileDataView({
-  remaining, retained, pendingSlug, rowError, onDeleteService,
+  remaining, retained, pendingSlug, rowError, onDeleteService, tokens,
 }: {
   remaining: AccountService[];
   retained: AccountService[];
   pendingSlug: string | null;
   rowError: { slug: string; message: string } | null;
   onDeleteService: (service: AccountService) => void;
+  tokens: AccountDataTokens;
 }) {
+  const { BRAND, SURFACE, BORDER, TEXT, SUBTLE } = tokens;
   return (
     <>
       <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 10, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 16 }}>
@@ -147,7 +154,8 @@ function MobileDataView({
   );
 }
 
-function MobileEmpty({ retained }: { retained: AccountService[] }) {
+function MobileEmpty({ retained, tokens }: { retained: AccountService[]; tokens: AccountDataTokens }) {
+  const { BRAND, TEXT, SUBTLE } = tokens;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '24px 4px', textAlign: 'center' }}>
       <div style={{ width: 56, height: 56, borderRadius: 16, background: `${BRAND}08`, border: `1px dashed ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>
@@ -169,7 +177,8 @@ function MobileEmpty({ retained }: { retained: AccountService[] }) {
   );
 }
 
-function MobileDanger({ serviceCount, onOpenAccountDelete }: { serviceCount: number; onOpenAccountDelete: () => void }) {
+function MobileDanger({ serviceCount, onOpenAccountDelete, tokens }: { serviceCount: number; onOpenAccountDelete: () => void; tokens: AccountDataTokens }) {
+  const { TEXT } = tokens;
   return (
     <div>
       <div style={{ padding: '18px', borderRadius: 14, background: 'rgba(239,68,68,0.04)', border: '1px solid rgba(239,68,68,0.18)' }}>

--- a/ctf/packages/web/components/account-data/account-data-shared.ts
+++ b/ctf/packages/web/components/account-data/account-data-shared.ts
@@ -1,15 +1,49 @@
 // Shared design tokens and types for the Account & Data surface.
 //
-// Tokens mirror the survivor-hub mockups exactly (BRAND `#E91E8C`, bg `#0F1117`, surface `#161B27`,
-// border `#1E2A3A`, text `#F9FAFB`, subtle `#6B7280`). The shell uses inline styles to match the
-// mockup conventions for this surface.
+// The default-theme tokens mirror the survivor-hub mockups exactly (BRAND `#E91E8C`, bg `#0F1117`,
+// surface `#161B27`, border `#1E2A3A`, text `#F9FAFB`, subtle `#6B7280`). The shell uses inline
+// styles with a `${color}NN` opacity pattern (e.g. `background: ${BRAND}15`) that plain CSS
+// variables can't retrofit, so colors are resolved through a theme-aware token object instead.
+//
+// The comic-theme values come verbatim from the Account & Data comic mockup
+// (design/artifacts/mockup-sandbox/src/components/mockups/survivor-hub/ComicAccountData.tsx) and
+// COMIC_THEME_TOKENS.md §1: bg `#0D0D0D`, surface `#141414`, ink border `#D4C49A`, cream text
+// `#EDE3CB`, inkDim secondary `#7A6A50`, and the destructive danger red `#B91C1C` for BRAND.
 
-export const BRAND = '#E91E8C';
-export const BG = '#0F1117';
-export const SURFACE = '#161B27';
-export const BORDER = '#1E2A3A';
-export const TEXT = '#F9FAFB';
-export const SUBTLE = '#6B7280';
+import type { ThemeName } from '../../lib/theme/theme-tokens';
+
+export type AccountDataTokens = {
+  BRAND: string;
+  BG: string;
+  SURFACE: string;
+  BORDER: string;
+  TEXT: string;
+  SUBTLE: string;
+};
+
+const DEFAULT_TOKENS: AccountDataTokens = {
+  BRAND: '#E91E8C',
+  BG: '#0F1117',
+  SURFACE: '#161B27',
+  BORDER: '#1E2A3A',
+  TEXT: '#F9FAFB',
+  SUBTLE: '#6B7280',
+};
+
+const COMIC_TOKENS: AccountDataTokens = {
+  BRAND: '#B91C1C',
+  BG: '#0D0D0D',
+  SURFACE: '#141414',
+  BORDER: '#D4C49A',
+  TEXT: '#EDE3CB',
+  SUBTLE: '#7A6A50',
+};
+
+// Resolve the Account & Data color tokens for the active theme. The default theme returns the
+// exact colors the surface already shipped, so it renders pixel-identical when the toggle is off.
+export function getAccountDataTokens(theme: ThemeName): AccountDataTokens {
+  return theme === 'comic' ? COMIC_TOKENS : DEFAULT_TOKENS;
+}
 
 // One service entry as returned by GET /api/account/services. Names and summaries come straight
 // from the deletion registry — never hardcoded in the components.

--- a/ctf/packages/web/components/account-data/account-data-shell.tsx
+++ b/ctf/packages/web/components/account-data/account-data-shell.tsx
@@ -2,8 +2,12 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
-import { BG, TEXT } from './account-data-shared';
+import { getAccountDataTokens } from './account-data-shared';
 import type { AccountService, AccountServicesResponse } from './account-data-shared';
+
+// Loading and error states are intentionally NOT theme-aware: per COMIC_THEME_TOKENS.md §11 loading
+// screens never adopt the comic theme, and the error state matches that default-dark treatment.
+const { BG, TEXT } = getAccountDataTokens('default');
 import { AccountDataDesktop, type AccountDataView } from './account-data-desktop';
 import { AccountDataMobile } from './account-data-mobile';
 import { AccountDataConfirmDelete } from './account-data-confirm-delete';

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -5,9 +5,18 @@
   background:
     radial-gradient(circle at 15% 10%, rgba(124, 58, 237, 0.22), transparent 35%),
     radial-gradient(circle at 85% 5%, rgba(14, 165, 233, 0.15), transparent 28%),
-    #0F1117;
-  color: #E8EAF0;
+    var(--ctf-bg);
+  color: var(--ctf-text-shell);
   font-family: Inter, system-ui, -apple-system, sans-serif;
+}
+
+/*
+ * Comic theme: no gradients, no glow (COMIC_THEME_TOKENS.md §12.5). Drop the purple/cyan
+ * radial glows and fall back to the flat ink page background. The default theme keeps the
+ * original glow, so it renders exactly as before when the toggle is off.
+ */
+:global([data-theme='comic']) .shell {
+  background: var(--ctf-bg);
 }
 
 .frame {
@@ -20,13 +29,13 @@
 
 /* ─── Shared panel base ───────────────────────────────────────────────────── */
 .panel {
-  background: #0D0F14;
+  background: var(--ctf-panel);
   border-right: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 /* ─── Icon rail (leftmost 72px column) ───────────────────────────────────── */
 .iconRail {
-  background: #090B0F;
+  background: var(--ctf-icon-rail);
   border-right: 1px solid rgba(255, 255, 255, 0.06);
   display: flex;
   flex-direction: column;
@@ -61,14 +70,14 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   font-size: 18px;
   transition: background 0.12s, color 0.12s;
 }
 
 .iconRailBtn:hover {
   background: rgba(255, 255, 255, 0.06);
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
 }
 
 .iconRailBtnDisabled,
@@ -80,7 +89,7 @@
 .iconRailBtnDisabled:hover,
 .iconRailBtn:disabled:hover {
   background: transparent;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .iconRailBtnActive {
@@ -127,7 +136,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
 }
 
 .sidebarSearch {
@@ -137,13 +146,13 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 8px;
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   outline: none;
   box-sizing: border-box;
 }
 
 .sidebarSearch::placeholder {
-  color: #4B5563;
+  color: var(--ctf-text-muted);
 }
 
 .sidebarBody {
@@ -165,7 +174,7 @@
   border-radius: 8px;
   background: transparent;
   cursor: pointer;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   font-size: 14px;
   text-align: left;
   text-decoration: none;
@@ -174,12 +183,12 @@
 
 .sidebarChannel:hover {
   background: rgba(255, 255, 255, 0.04);
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
 }
 
 .sidebarChannelActive {
   background: rgba(124, 58, 237, 0.16);
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
 }
 
 .sidebarChannelActive .sidebarChannelHash {
@@ -187,7 +196,7 @@
 }
 
 .sidebarChannelHash {
-  color: #4B5563;
+  color: var(--ctf-text-muted);
   font-size: 14px;
   flex-shrink: 0;
 }
@@ -217,7 +226,7 @@
   background: transparent;
   cursor: pointer;
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   text-align: left;
   transition: background 0.1s;
   width: calc(100% - 2px);
@@ -254,7 +263,7 @@
 .sidebarFooterMeta {
   margin: 0;
   font-size: 11px;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
 }
 
 /* ─── Main content panel ─────────────────────────────────────────────────── */
@@ -313,14 +322,14 @@
   margin: 0 0 4px;
   font-size: 22px;
   font-weight: 800;
-  color: #F9FAFB;
+  color: var(--ctf-text);
   line-height: 1.3;
 }
 
 .heroBannerSub {
   margin: 0;
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
 }
 
 .heroStats {
@@ -348,7 +357,7 @@
 
 .heroStatLabel {
   font-size: 11px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   display: block;
 }
 
@@ -397,7 +406,7 @@
   padding: 12px 16px;
   font-size: 14px;
   line-height: 1.6;
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
 }
 
 .chatBubbleHub {
@@ -455,14 +464,14 @@
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   cursor: pointer;
   transition: background 0.1s, color 0.1s;
 }
 
 .chatChip:hover {
   background: rgba(255, 255, 255, 0.08);
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
 }
 
 .chatSignInLink {
@@ -486,7 +495,7 @@
   margin-top: 12px;
   text-align: center;
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   line-height: 1.5;
 }
 
@@ -508,11 +517,11 @@
   border: none;
   outline: none;
   font-size: 14px;
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
 }
 
 .chatInput::placeholder {
-  color: #4B5563;
+  color: var(--ctf-text-muted);
 }
 
 .chatSendBtn {
@@ -525,7 +534,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
   font-size: 14px;
   flex-shrink: 0;
   transition: background 0.1s;
@@ -571,7 +580,7 @@
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .appsSortSelect {
@@ -593,13 +602,13 @@
   margin: 0 0 4px;
   font-size: 22px;
   font-weight: 800;
-  color: #F9FAFB;
+  color: var(--ctf-text);
 }
 
 .appsPanelSub {
   margin: 0;
   font-size: 14px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .appsGrid {
@@ -609,7 +618,7 @@
 }
 
 .appsEmpty {
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   font-size: 14px;
   margin: 0 0 12px;
 }
@@ -650,7 +659,7 @@
 
 .appCardPhase {
   font-size: 10px;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
 }
 
 .appCardLive {
@@ -662,13 +671,13 @@
   margin: 0 0 4px;
   font-size: 15px;
   font-weight: 700;
-  color: #F9FAFB;
+  color: var(--ctf-text);
 }
 
 .appCardDesc {
   margin: 0 0 14px;
   font-size: 13px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   line-height: 1.5;
 }
 
@@ -726,13 +735,13 @@
   margin: 0 0 4px;
   font-size: 15px;
   font-weight: 700;
-  color: #F9FAFB;
+  color: var(--ctf-text);
 }
 
 .profileMeta {
   margin: 0 0 10px;
   font-size: 12px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .profileBadge {
@@ -763,7 +772,7 @@
 .quoteAuthor {
   margin: 0;
   font-size: 11px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .memberList {
@@ -784,13 +793,13 @@
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid transparent;
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   text-decoration: none;
 }
 
 .memberItem:hover {
   background: rgba(255, 255, 255, 0.05);
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
 }
 
 .memberItemName {
@@ -822,7 +831,7 @@
   margin: 0 0 8px;
   font-size: 12px;
   font-weight: 700;
-  color: #F9FAFB;
+  color: var(--ctf-text);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -830,7 +839,7 @@
 .sectionDesc {
   margin: 0;
   font-size: 13px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   line-height: 1.5;
 }
 
@@ -852,13 +861,13 @@
   margin: 0 0 2px;
   font-size: 22px;
   font-weight: 800;
-  color: #F9FAFB;
+  color: var(--ctf-text);
 }
 
 .gdpCardSub {
   margin: 0 0 10px;
   font-size: 12px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .gdpProgressTrack {
@@ -880,7 +889,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 11px;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
 }
 
 /* ─── Shared / auth ──────────────────────────────────────────────────────── */
@@ -931,7 +940,7 @@
   gap: 10px;
   height: 52px;
   padding: 0 12px;
-  background: #090B0F;
+  background: var(--ctf-icon-rail);
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   flex-shrink: 0;
 }
@@ -942,7 +951,7 @@
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -975,7 +984,7 @@
 .mobileBarTitle {
   font-size: 14px;
   font-weight: 700;
-  color: #F9FAFB;
+  color: var(--ctf-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -993,7 +1002,7 @@
   border-radius: 8px;
   background: transparent;
   border: 1px solid transparent;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
@@ -1159,7 +1168,7 @@
 .comicCardName {
   font-size: 14px;
   font-weight: 700;
-  color: #F9FAFB;
+  color: var(--ctf-text);
 }
 
 .comicCardBadge {
@@ -1174,7 +1183,7 @@
 
 .comicCardMeta {
   font-size: 12px;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
 }
 
 .comicCardQuestion {
@@ -1193,7 +1202,7 @@
 
 .comicCardQuestionText {
   font-size: 14px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
 }
 
 .comicCardAnswer {
@@ -1217,7 +1226,7 @@
 
 .comicRatingPrompt {
   font-size: 11px;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
   margin-right: 2px;
 }
 
@@ -1229,7 +1238,7 @@
   border-radius: 7px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
@@ -1255,7 +1264,7 @@
   border-radius: 7px;
   background: transparent;
   border: 1px solid transparent;
-  color: #4B5563;
+  color: var(--ctf-text-muted);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
@@ -1357,7 +1366,7 @@
 
 .comicComposerHelperText {
   font-size: 12px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .comicComposerHelperToken {
@@ -1384,7 +1393,7 @@
 
 .comicLockedText {
   font-size: 14px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   flex: 1;
 }
 
@@ -1417,7 +1426,7 @@
   max-height: 90vh;
   overflow-y: auto;
   border-radius: 22px;
-  background: #0D0F14;
+  background: var(--ctf-panel);
   border: 1px solid rgba(124, 58, 237, 0.3);
   box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55);
 }
@@ -1442,7 +1451,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
 }
 
 .comicConsentHeaderRow {
@@ -1466,7 +1475,7 @@
 .comicConsentTitle {
   font-size: 19px;
   font-weight: 800;
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
   margin: 0;
 }
 
@@ -1486,7 +1495,7 @@
 
 .comicConsentLede {
   font-size: 13.5px;
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   line-height: 1.6;
   margin: 0;
 }
@@ -1525,13 +1534,13 @@
 .comicConsentPointTitle {
   font-size: 14px;
   font-weight: 700;
-  color: #E8EAF0;
+  color: var(--ctf-text-shell);
   margin-bottom: 3px;
 }
 
 .comicConsentPointDesc {
   font-size: 12.5px;
-  color: #6B7280;
+  color: var(--ctf-text-subtle);
   line-height: 1.55;
 }
 
@@ -1562,7 +1571,7 @@
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  color: #9CA3AF;
+  color: var(--ctf-text-secondary);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -1587,4 +1596,177 @@
   .comicConsentDismiss {
     width: 100%;
   }
+}
+
+/* ─── Comic theme overrides ──────────────────────────────────────────────────
+ *
+ * Only active under [data-theme='comic']; the default theme above is untouched and
+ * renders pixel-identical when the toggle is off. Values come verbatim from
+ * design/artifacts/mockup-sandbox/COMIC_THEME_TOKENS.md — no gradients, no glow/neon,
+ * sharp corners, and the 3px 3px 0 offset shadow. The standard theme's purple/cyan
+ * accents become the warm ink palette (cream #D4C49A, inkDim #7A6A50). The AI
+ * Assistant surfaces use inkDim specifically (§6, §9 — no blue in comic theme).
+ */
+
+/* Gradient logos, avatars, and primary buttons → flat ink panel + hard cream border
+ * + offset shadow (§12.5). */
+:global([data-theme='comic']) .iconRailLogo,
+:global([data-theme='comic']) .iconRailAvatar,
+:global([data-theme='comic']) .chatAvatar,
+:global([data-theme='comic']) .mobileBarLogo,
+:global([data-theme='comic']) .mobileBarAvatar,
+:global([data-theme='comic']) .profileAvatar {
+  background: var(--ctf-cta-bg);
+  border: 1.5px solid var(--ctf-cta-border);
+  box-shadow: var(--ctf-elevation-shadow);
+  color: var(--ctf-cta-text);
+}
+
+:global([data-theme='comic']) .chatSignInLink,
+:global([data-theme='comic']) .profileLoginBtn,
+:global([data-theme='comic']) .mobileBarSignIn,
+:global([data-theme='comic']) .chatSendBtnActive,
+:global([data-theme='comic']) .comicLockedJoinBtn,
+:global([data-theme='comic']) .comicConsentConfirm,
+:global([data-theme='comic']) .comicConsentHeaderIcon {
+  background: var(--ctf-cta-bg);
+  border: 1.5px solid var(--ctf-cta-border);
+  box-shadow: var(--ctf-elevation-shadow);
+  color: var(--ctf-cta-text);
+}
+
+/* Purple active nav / badge tints → cream ink tint + cream text. */
+:global([data-theme='comic']) .iconRailBtnActive,
+:global([data-theme='comic']) .mobileBarSectionBtnActive {
+  background: #d4c49a14;
+  border-color: #d4c49a;
+  color: var(--ctf-text);
+}
+
+:global([data-theme='comic']) .iconRailBtnActive,
+:global([data-theme='comic']) .sidebarChannelActive {
+  background: #d4c49a14;
+}
+
+:global([data-theme='comic']) .sidebarChannelActive .sidebarChannelHash,
+:global([data-theme='comic']) .sidebarFooterTitle,
+:global([data-theme='comic']) .heroBannerTag,
+:global([data-theme='comic']) .profileBadge,
+:global([data-theme='comic']) .quoteText {
+  color: var(--ctf-border);
+}
+
+:global([data-theme='comic']) .sidebarBadge {
+  background: var(--ctf-border);
+  color: var(--ctf-bg);
+}
+
+:global([data-theme='comic']) .profileBadge,
+:global([data-theme='comic']) .quoteCard {
+  background: #d4c49a08;
+  border-color: #d4c49a45;
+}
+
+/* Hero banner gradient → flat ink surface + cream border. */
+:global([data-theme='comic']) .heroBanner {
+  background: var(--ctf-surface);
+  border: 1.5px solid var(--ctf-border);
+  box-shadow: var(--ctf-elevation-shadow);
+}
+
+/* User chat bubble gradient → flat ink panel + cream border. */
+:global([data-theme='comic']) .chatBubbleUser {
+  background: var(--ctf-surface);
+  border: 1.5px solid var(--ctf-border);
+}
+
+/* AI Assistant cards use inkDim, not cyan (§9). */
+:global([data-theme='comic']) .comicCard {
+  background: var(--ctf-surface);
+  border: 1.5px solid #7a6a5060;
+  box-shadow: 2px 2px 0 #7a6a5030;
+}
+
+:global([data-theme='comic']) .comicCardAvatar,
+:global([data-theme='comic']) .comicPendingAvatar {
+  background: #7a6a5014;
+  border: 1.5px solid #7a6a5050;
+}
+
+:global([data-theme='comic']) .comicCardBadge {
+  background: var(--ctf-surface);
+  border: 1px solid #7a6a5050;
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .comicCardQa,
+:global([data-theme='comic']) .comicCardQuestionText {
+  color: var(--ctf-border);
+}
+
+:global([data-theme='comic']) .comicCardQuestion {
+  background: var(--ctf-bg);
+  border: 1.5px solid #d4c49a28;
+}
+
+:global([data-theme='comic']) .comicRatingRow {
+  border-top: 1.5px solid #d4c49a20;
+}
+
+:global([data-theme='comic']) .comicRatingBtnUp {
+  background: #22c55e14;
+  border-color: #22c55e;
+  color: var(--ctf-success);
+}
+
+:global([data-theme='comic']) .comicRatingBtnDown {
+  background: var(--ctf-surface);
+  border-color: var(--ctf-border-dim);
+  color: var(--ctf-text);
+}
+
+/* AI pending ("reviewing for safety") card → dashed inkDim. */
+:global([data-theme='comic']) .comicPendingCard {
+  background: var(--ctf-surface);
+  border: 1.5px dashed #7a6a5060;
+}
+
+:global([data-theme='comic']) .comicPendingBadge {
+  background: var(--ctf-surface);
+  border: 1px solid #7a6a5040;
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .comicPendingDot {
+  background: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .comicPendingText {
+  color: var(--ctf-border-dim);
+}
+
+/* @comic composer mention chip → inkDim chip on ink background. */
+:global([data-theme='comic']) .comicMentionChip {
+  background: var(--ctf-bg);
+  border: 1px solid var(--ctf-border-dim);
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .comicMentionChipActive {
+  background: #7a6a5022;
+  border-color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .comicComposerHelperToken {
+  color: var(--ctf-border-dim);
+}
+
+/* Consent modal gradient header → flat ink. */
+:global([data-theme='comic']) .comicConsentModal {
+  background: var(--ctf-panel);
+  border: 1.5px solid var(--ctf-border);
+}
+
+:global([data-theme='comic']) .comicConsentHeader {
+  background: var(--ctf-surface);
 }

--- a/ctf/packages/web/components/community-shell/shell-apps-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-apps-panel.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import type { PluginAvailabilityState, PluginRegistryItem } from '../../lib/plugins/repository';
 import type { PluginSortMode } from './shell-types';
 import { getPluginVisuals } from './shell-plugin-config';
+import { useTheme } from '@/hooks/useTheme';
 import styles from './community-shell.module.css';
 
 function getPluginHref(slug: string): string {
@@ -28,6 +29,7 @@ type ShellAppsPanelProps = {
 };
 
 export function ShellAppsPanel({ plugins, activeApp, onAppSelect, sortMode, onSortModeChange }: ShellAppsPanelProps) {
+  const { theme } = useTheme();
 
   return (
     <div className={styles.appsPanel}>
@@ -57,7 +59,7 @@ export function ShellAppsPanel({ plugins, activeApp, onAppSelect, sortMode, onSo
 
       <div className={styles.appsGrid}>
         {plugins.map((plugin) => {
-          const { emoji, color, bg } = getPluginVisuals(plugin.slug);
+          const { emoji, color, bg } = getPluginVisuals(plugin.slug, theme);
           const isActive = activeApp === plugin.slug;
           const pluginHref = getPluginHref(plugin.slug);
           return (

--- a/ctf/packages/web/components/community-shell/shell-plugin-config.ts
+++ b/ctf/packages/web/components/community-shell/shell-plugin-config.ts
@@ -1,3 +1,5 @@
+import { getAppAccent, type ThemeName } from '../../lib/theme/theme-tokens';
+
 type PluginVisuals = {
   emoji: string;
   color: string;
@@ -27,6 +29,18 @@ const PLUGIN_VISUALS: Record<string, PluginVisuals> = {
 
 const FALLBACK: PluginVisuals = { emoji: '🔌', color: '#9CA3AF', bg: '#1a1a2e' };
 
-export function getPluginVisuals(slug: string): PluginVisuals {
-  return PLUGIN_VISUALS[slug] ?? FALLBACK;
+// In comic theme the per-card surface tint is the flat ink surface (COMIC_THEME_TOKENS.md §1,
+// §9 — no neon, no gradients). The accent comes from getAppAccent so the `${color}NN` opacity
+// call sites keep working with the deep, ink-compatible accent.
+const COMIC_CARD_SURFACE = '#141414';
+
+// Resolve a plugin's emoji, accent color, and card-background base for the active theme. The default
+// theme returns the exact colors the shell already shipped (pixel-identical when the toggle is off);
+// comic theme swaps the accent to its deep ink variant and flattens the card base to the ink surface.
+export function getPluginVisuals(slug: string, theme: ThemeName = 'default'): PluginVisuals {
+  const base = PLUGIN_VISUALS[slug] ?? FALLBACK;
+  if (theme === 'comic') {
+    return { emoji: base.emoji, color: getAppAccent(slug, theme), bg: COMIC_CARD_SURFACE };
+  }
+  return base;
 }

--- a/ctf/packages/web/components/community-shell/shell-right-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-right-rail.tsx
@@ -6,6 +6,7 @@ import type { PluginRegistryItem } from '../../lib/plugins/repository';
 import type { ShellCurrentUser } from './shell-types';
 import { getPluginVisuals } from './shell-plugin-config';
 import { TrustRightRailCard } from '../shared/trust/TrustRightRailCard';
+import { useTheme } from '@/hooks/useTheme';
 import styles from './community-shell.module.css';
 
 type ShellRightRailProps = {
@@ -18,6 +19,7 @@ type ShellRightRailProps = {
 };
 
 export function ShellRightRail({ readyApps, implementedCount, currentUser, trust, isAuthenticated = false, signInUrl = '/sign-in' }: ShellRightRailProps) {
+  const { theme } = useTheme();
   const displayName = currentUser.displayName;
   const initial = currentUser.initial;
 
@@ -65,7 +67,7 @@ export function ShellRightRail({ readyApps, implementedCount, currentUser, trust
         <p className={styles.rightRailSectionTitle}>Ready Apps</p>
         <ul className={styles.memberList}>
           {readyApps.map((plugin) => {
-            const { emoji, color } = getPluginVisuals(plugin.slug);
+            const { emoji, color } = getPluginVisuals(plugin.slug, theme);
             const pluginHref = `/apps/${plugin.slug}`;
             return (
               <li key={plugin.slug}>

--- a/ctf/packages/web/components/community-shell/shell-sidebar.tsx
+++ b/ctf/packages/web/components/community-shell/shell-sidebar.tsx
@@ -4,6 +4,7 @@ import type { ShellSection } from './shell-types';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
 import type { HubChannelInfo } from '../../lib/hub/types';
 import { getPluginVisuals } from './shell-plugin-config';
+import { useTheme } from '@/hooks/useTheme';
 import styles from './community-shell.module.css';
 
 type ShellSidebarProps = {
@@ -35,6 +36,7 @@ export function ShellSidebar({
   mobileOpen = false,
   onNavigate,
 }: ShellSidebarProps) {
+  const { theme } = useTheme();
   return (
     <aside className={`${styles.panel} ${styles.leftNav}${mobileOpen ? ` ${styles.leftNavMobileOpen}` : ''}`}>
       <div className={styles.sidebarHeader}>
@@ -78,7 +80,7 @@ export function ShellSidebar({
           </>
         ) : (
           plugins.map((plugin) => {
-            const { emoji, color } = getPluginVisuals(plugin.slug);
+            const { emoji, color } = getPluginVisuals(plugin.slug, theme);
             const isActive = activeApp === plugin.slug;
             return (
               <button


### PR DESCRIPTION
Continues the comic theme work (#341): the first batch of the web per-screen migration, covering the "chrome" surfaces only. Plugin shells follow in a separate batch.

Colors only — no layout, spacing, copy, or behavior changes. The default-dark theme renders exactly as it does today; nothing is visually changed when the toggle is off. Comic values are taken verbatim from `COMIC_THEME_TOKENS.md` (no gradients, no glow/neon, sharp corners, the `3px 3px 0` offset shadow, loading screens left unthemed).

What changed:

Community shell (Hub/Chyme landing chrome)
- The per-app accent tiles in the apps panel, right rail, and sidebar now resolve their accent through `getAppAccent(slug, theme)` via a theme-aware `getPluginVisuals(slug, theme)`. The `${color}NN` / `${bg}NN` opacity call sites keep working; comic uses the deep ink accent and a flat ink card surface.
- `community-shell.module.css` chrome (page background, panel, icon rail, content border, and all text colors) moves to the existing `--ctf-*` CSS variables so it follows the theme.
- A scoped `[data-theme='comic']` block drops the purple/cyan radial glow on the shell, flattens the gradient logos/avatars/buttons to the flat ink treatment, and maps the AI Assistant Q&A and pending cards plus the `@comic` composer chip to inkDim (no blue in comic theme).

Account & Data panels
- `account-data-shared.ts` now exposes `getAccountDataTokens(theme)` in place of the fixed `BRAND/BG/SURFACE/BORDER/TEXT/SUBTLE` constants. The desktop, mobile, and full-account confirm components read tokens from `useTheme()` and thread them down, so the panels become theme-aware while keeping the `${hex}NN` inline-style pattern intact.
- Loading and error states stay default-dark by design (loading screens are never themed).

Out of scope (follow-up): the AI review console under `/admin/comic` is a plugin admin shell, and all other plugin shells / `mood/` files. Those are separate batches.

Validation: `pnpm install`, web `tsc --noEmit`, `check-eof-format.sh`, `check-web-android-parity.mjs`, eslint on the changed dirs, and the full web build (pre-push hook) all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_