### PR TITLE
feat: comic theme on plugin shells, batch 1 — directory, foundation, lighthouse, socketrelay, trusttransport, peer-programming (#341)

### DIFF
--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -7,7 +7,8 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { BookOpen, ChevronLeft, Search, MessageSquare, Users, Bell, Settings } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, COLOR, type Member, type Sector, type SkillsHuntRewardCard } from "./shared";
+import { useTheme } from "@/hooks/useTheme";
+import { BG, getDirectoryTokens, type Member, type Sector, type SkillsHuntRewardCard } from "./shared";
 import { DirectoryProfileDetail } from "./directory-profile-detail";
 import { DirectoryLoadingSkeleton } from "./directory-loading-skeleton";
 import { DirectoryBrowse } from "./directory-browse";
@@ -52,6 +53,8 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
   const [rewardCard, setRewardCard] = useState<SkillsHuntRewardCard | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getDirectoryTokens(theme);
 
   useEffect(() => {
     async function fetchMeta() {
@@ -210,29 +213,29 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
 
   if (isMobile) {
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <BookOpen size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Directory</span>
+            <BookOpen size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Directory</span>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {TABS.map(({ key }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer", textTransform: "capitalize" }}>{key}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer", textTransform: "capitalize" }}>{key}</button>
             ))}
           </div>
           {tab === "browse" && (
             <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
               <div style={{ position: "relative" }}>
-                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
-                <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search providers…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: t.FAINT }} />
+                <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search providers…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }} />
               </div>
               <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
                 {sectorFilters.map((f) => (
-                  <button key={f} onClick={() => setActiveFilter(f)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: activeFilter === f ? `${COLOR}14` : "transparent", border: `1px solid ${activeFilter === f ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: activeFilter === f ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{f}</button>
+                  <button key={f} onClick={() => setActiveFilter(f)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: activeFilter === f ? `${t.ACCENT}14` : "transparent", border: `1px solid ${activeFilter === f ? t.ACCENT + "50" : t.BORDER_HI}`, color: activeFilter === f ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{f}</button>
                 ))}
               </div>
             </div>
@@ -244,75 +247,75 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       {/* Icon rail */}
-      <aside style={{ width: 72, background: "#090B0F", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
-          <BookOpen size={20} style={{ color: COLOR }} />
+      <aside style={{ width: 72, background: t.RAIL, borderRight: `1px solid ${t.BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
+        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${t.ACCENT}30`, border: `1px solid ${t.ACCENT}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+          <BookOpen size={20} style={{ color: t.ACCENT }} />
         </div>
         {TABS.map(({ icon: Icon, key }) => (
-          <button key={key} onClick={() => setTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
+          <button key={key} onClick={() => setTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${t.ACCENT}20` : "transparent", border: tab === key ? `1px solid ${t.ACCENT}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? t.ACCENT : t.MUTED }}>
             <Icon size={20} />
           </button>
         ))}
         <div style={{ flex: 1 }} />
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
+        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: t.MUTED }}>
           <Bell size={18} />
         </button>
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
+        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: t.MUTED }}>
           <Settings size={18} />
         </button>
         <Avatar style={{ width: 36, height: 36, marginTop: 4 }}>
-          <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
+          <AvatarFallback style={{ background: `${t.ACCENT}30`, color: t.ACCENT, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
         </Avatar>
       </aside>
 
       {/* Sidebar */}
-      <aside style={{ width: 240, background: "#0D0F14", borderRight: "1px solid rgba(255,255,255,0.06)", display: "flex", flexDirection: "column", flexShrink: 0 }}>
+      <aside style={{ width: 240, background: t.HEADER, borderRight: `1px solid ${t.BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
         <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#6B7280", textTransform: "uppercase", marginBottom: 12 }}>📇 Directory</div>
+          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: t.MUTED, textTransform: "uppercase", marginBottom: 12 }}>📇 Directory</div>
           <div style={{ position: "relative", marginBottom: 12 }}>
-            <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
+            <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: t.FAINT }} />
             <input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search providers…"
-              style={{ width: "100%", padding: "7px 10px 7px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }}
+              style={{ width: "100%", padding: "7px 10px 7px 30px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }}
             />
           </div>
         </div>
         <ScrollArea style={{ flex: 1 }}>
           <div style={{ padding: "0 8px 16px" }}>
             {sectorFilters.map((f) => (
-              <div key={f} onClick={() => setActiveFilter(f)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: activeFilter === f ? `${COLOR}18` : "transparent", borderLeft: activeFilter === f ? `2px solid ${COLOR}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
-                <span style={{ fontSize: 13, color: activeFilter === f ? "#E8EAF0" : "#9CA3AF", flex: 1 }}>{f}</span>
+              <div key={f} onClick={() => setActiveFilter(f)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: activeFilter === f ? `${t.ACCENT}18` : "transparent", borderLeft: activeFilter === f ? `2px solid ${t.ACCENT}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
+                <span style={{ fontSize: 13, color: activeFilter === f ? t.TEXT : t.SUBTLE, flex: 1 }}>{f}</span>
               </div>
             ))}
-            <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", padding: "0 10px" }}>Community Stats</div>
+            <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: t.FAINT, textTransform: "uppercase", padding: "0 10px" }}>Community Stats</div>
             {[{ l: "Sectors", v: String(sectors.length) }, { l: "Active Listings", v: String(members.length) }].map(({ l, v }) => (
-              <div key={l} style={{ padding: "6px 10px", fontSize: 12, color: "#6B7280" }}>
-                {l}: <span style={{ color: COLOR, fontWeight: 600 }}>{v}</span>
+              <div key={l} style={{ padding: "6px 10px", fontSize: 12, color: t.MUTED }}>
+                {l}: <span style={{ color: t.ACCENT, fontWeight: 600 }}>{v}</span>
               </div>
             ))}
           </div>
         </ScrollArea>
-        <div style={{ padding: 12, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
-          <div style={{ padding: "10px 12px", borderRadius: 10, background: `${COLOR}10`, border: `1px solid ${COLOR}25` }}>
-            <div style={{ fontSize: 12, fontWeight: 600, color: COLOR, marginBottom: 2 }}>Become a Provider</div>
-            <div style={{ fontSize: 11, color: "#6B7280" }}>Claim your profile today</div>
+        <div style={{ padding: 12, borderTop: `1px solid ${t.BORDER}` }}>
+          <div style={{ padding: "10px 12px", borderRadius: 10, background: `${t.ACCENT}10`, border: `1px solid ${t.ACCENT}25` }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: t.ACCENT, marginBottom: 2 }}>Become a Provider</div>
+            <div style={{ fontSize: 11, color: t.MUTED }}>Claim your profile today</div>
           </div>
         </div>
       </aside>
 
       {/* Main */}
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <BookOpen size={18} style={{ color: COLOR }} />
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+          <BookOpen size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>📇 Directory</div>
-            <div style={{ fontSize: 12, color: "#6B7280" }}>Verified providers · Trauma-informed · Safe</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>📇 Directory</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Verified providers · Trauma-informed · Safe</div>
           </div>
-          <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
+          <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
             ✓ Verified Network
           </Badge>
         </header>

--- a/ctf/packages/web/components/directory/shared.ts
+++ b/ctf/packages/web/components/directory/shared.ts
@@ -1,11 +1,23 @@
 // Shared constants, types, and helpers for the Directory web shell.
 // Palette and layout derive from design/.../survivor-hub/Directory.tsx.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const COLOR = "#3B82F6";
 export const SKILLS_HUNT_COLOR = "#A855F7";
 // App surface background as rendered by the mockup (the mockup's `BG`
 // constant is dead code; every rendered surface uses #0F1117).
 export const BG = "#0F1117";
+
+// Theme-aware chrome tokens for the Directory shell. Default keeps the shipped values (accent
+// stays #3B82F6); comic uses the shared comic surface tokens plus the Directory comic-ink accent.
+export type DirectoryTokens = PluginShellTokens;
+
+export function getDirectoryTokens(theme: ThemeName): DirectoryTokens {
+  const accent = theme === "comic" ? getAppAccent("directory", "comic") : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 export interface Member {
   id: string;

--- a/ctf/packages/web/components/foundation/foundation-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-shell.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { ChevronLeft, Hammer, Search } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { AppLoading } from "@/components/shared/app-loading";
-import { COLOR, FONT, type FoundationTab, type ProviderView, type QuoteView } from "./foundation-ui";
+import { useTheme } from "@/hooks/useTheme";
+import { FONT, getFoundationTokens, type FoundationTab, type ProviderView, type QuoteView } from "./foundation-ui";
 import { IconRail, FilterSidebar, RightRail } from "./foundation-rails";
 import { BrowsePanel, QuotesPanel, ChatPanel } from "./foundation-panels";
 import { ProviderProfile } from "./foundation-profile";
@@ -34,6 +35,8 @@ export function FoundationShell() {
   const [quoteError, setQuoteError] = useState<string | null>(null);
   const [quoteSuccess, setQuoteSuccess] = useState(false);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getFoundationTokens(theme);
 
   // Trade filter has no client-side field to match on; it scopes the server search query.
   const searchTerm = [trade === "All Trades" ? "" : trade, query].filter(Boolean).join(" ").trim();
@@ -152,25 +155,25 @@ export function FoundationShell() {
       { key: "chat", label: "Chat" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: "#0F1117", fontFamily: FONT, color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: FONT, color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Hammer size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Foundation</span>
+            <Hammer size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Foundation</span>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
           {tab === "browse" && (
             <div style={{ padding: "0 12px 10px" }}>
               <div style={{ position: "relative" }}>
-                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
-                <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search trade providers…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: t.FAINT }} />
+                <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search trade providers…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }} />
               </div>
             </div>
           )}
@@ -181,15 +184,15 @@ export function FoundationShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: "#0F1117", fontFamily: FONT, color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: FONT, color: t.TEXT, display: "flex" }}>
       <IconRail tab={tab} onTab={setTab} />
       <FilterSidebar query={query} onQuery={setQuery} trade={trade} onTrade={setTrade} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <Hammer size={18} style={{ color: COLOR }} />
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+          <Hammer size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Foundation — Trade Services</div>
-            <div style={{ fontSize: 12, color: "#6B7280" }}>Vetted providers · Background-checked · Safe</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>Foundation — Trade Services</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Vetted providers · Background-checked · Safe</div>
           </div>
         </header>
         {content}

--- a/ctf/packages/web/components/foundation/foundation-ui.ts
+++ b/ctf/packages/web/components/foundation/foundation-ui.ts
@@ -1,7 +1,19 @@
 import type { FoundationQuoteState } from "@/lib/foundation/types";
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 
 export const COLOR = "#EF4444";
 export const FONT = "'Inter', system-ui, sans-serif";
+
+// Theme-aware color tokens for the Foundation shell chrome. The default theme keeps the exact
+// values the shell already shipped (accent stays Foundation's shipped #EF4444); comic uses the
+// shared comic surface tokens plus the Foundation comic-ink accent from getAppAccent.
+export type FoundationTokens = PluginShellTokens;
+
+export function getFoundationTokens(theme: ThemeName): FoundationTokens {
+  const accent = theme === "comic" ? getAppAccent("foundation", "comic") : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 /** Provider view model — only fields the real search API returns. */
 export interface ProviderView {

--- a/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ChevronLeft, Search } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, COLOR, type ChatCredentials, type Match, type Profile, type Property, type Tab } from "./shared";
+import { useTheme } from "@/hooks/useTheme";
+import { BG, getLighthouseTokens, type ChatCredentials, type Match, type Profile, type Property, type Tab } from "./shared";
 import { LighthouseIconRail } from "./lighthouse-icon-rail";
 import { LighthouseFilterSidebar, type ListingFilter, filterProperties } from "./lighthouse-filter-sidebar";
 import { LighthouseRightPanel } from "./lighthouse-right-panel";
@@ -30,6 +31,8 @@ export function LighthouseShell() {
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getLighthouseTokens(theme);
 
   useEffect(() => {
     async function fetchAll() {
@@ -89,9 +92,9 @@ export function LighthouseShell() {
 
   if (!profile) {
     return (
-      <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: 40, textAlign: "center" }}>
-        <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB" }}>Welcome to LightHouse</div>
-        <div style={{ fontSize: 14, color: "#9CA3AF", maxWidth: 420, lineHeight: 1.6 }}>No profile found yet. Create your LightHouse profile to browse safe, verified housing and connect with hosts.</div>
+      <div style={{ width: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: 40, textAlign: "center" }}>
+        <div style={{ fontSize: 22, fontWeight: 800, color: t.TITLE }}>Welcome to LightHouse</div>
+        <div style={{ fontSize: 14, color: t.SUBTLE, maxWidth: 420, lineHeight: 1.6 }}>No profile found yet. Create your LightHouse profile to browse safe, verified housing and connect with hosts.</div>
       </div>
     );
   }
@@ -151,29 +154,29 @@ export function LighthouseShell() {
       { key: "credits", label: "Credits" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>🏠 LightHouse</span>
-            <span style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>✓ Private</span>
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>🏠 LightHouse</span>
+            <span style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>✓ Private</span>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
           {tab === "browse" && (
             <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
               <div style={{ position: "relative" }}>
-                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: "#4B5563" }} />
-                <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="City or neighborhood…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+                <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: t.FAINT }} />
+                <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="City or neighborhood…" style={{ width: "100%", padding: "8px 10px 8px 30px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }} />
               </div>
               <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
                 {filters.map(({ key, label }) => (
-                  <button key={key} onClick={() => setFilter(key)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: filter === key ? `${COLOR}14` : "transparent", border: `1px solid ${filter === key ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: filter === key ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{label}</button>
+                  <button key={key} onClick={() => setFilter(key)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: filter === key ? `${t.ACCENT}14` : "transparent", border: `1px solid ${filter === key ? t.ACCENT + "50" : t.BORDER_HI}`, color: filter === key ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{label}</button>
                 ))}
               </div>
             </div>
@@ -185,17 +188,17 @@ export function LighthouseShell() {
   }
 
   return (
-    <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <LighthouseIconRail tab={tab} onTab={setTab} />
       <LighthouseFilterSidebar properties={properties} search={search} onSearch={setSearch} filter={filter} onFilter={setFilter} />
 
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>🏠 LightHouse — Safe Housing</div>
-            <div style={{ fontSize: 12, color: "#6B7280" }}>Verified listings · Privacy-first</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>🏠 LightHouse — Safe Housing</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Verified listings · Privacy-first</div>
           </div>
-          <span style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>✓ Privacy Protected</span>
+          <span style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>✓ Privacy Protected</span>
         </header>
 
         <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflowY: "auto" }}>

--- a/ctf/packages/web/components/lighthouse/shared.ts
+++ b/ctf/packages/web/components/lighthouse/shared.ts
@@ -1,10 +1,22 @@
 // Shared constants and types for the LightHouse web shell.
 // Palette and layout derive from design/.../survivor-hub/LightHouse.tsx.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const COLOR = "#EAB308";
 // App surface background as rendered by the mockup (the mockup's `BG`
 // constant is dead code; every rendered surface uses #0F1117).
 export const BG = "#0F1117";
+
+// Theme-aware chrome tokens for the LightHouse shell. Default keeps the shipped values (accent
+// stays #EAB308); comic uses the shared comic surface tokens plus the LightHouse comic-ink accent.
+export type LighthouseTokens = PluginShellTokens;
+
+export function getLighthouseTokens(theme: ThemeName): LighthouseTokens {
+  const accent = theme === "comic" ? getAppAccent("lighthouse", "comic") : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 export type Tab = "browse" | "matches" | "chat";
 

--- a/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ChevronLeft, Users } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, type Message, type Room, type Tab } from "./pp-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { BG, getPeerProgrammingTokens, type Message, type PeerProgrammingTokens, type Room, type Tab } from "./pp-shared";
 import { PeerProgrammingLoading } from "./pp-loading";
 import { PeerProgrammingIconRail } from "./pp-icon-rail";
 import { PeerProgrammingSidebar } from "./pp-sidebar";
@@ -26,16 +27,16 @@ async function fetchRoomData(signal: AbortSignal): Promise<{ room: Room; message
   return { room, messages };
 }
 
-function ShellHeader({ active }: { active: boolean }) {
+function ShellHeader({ active, t }: { active: boolean; t: PeerProgrammingTokens }) {
   return (
-    <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-      <Users size={18} style={{ color: "#8B5CF6" }} />
+    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+      <Users size={18} style={{ color: t.ACCENT }} />
       <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Peer Programming</div>
-        <div style={{ fontSize: 12, color: "#6B7280" }}>Weekly global masterminds · 12 per cohort · Always-open</div>
+        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>Peer Programming</div>
+        <div style={{ fontSize: 12, color: t.MUTED }}>Weekly global masterminds · 12 per cohort · Always-open</div>
       </div>
       {active && (
-        <span style={{ background: "#8B5CF620", color: "#8B5CF6", border: "1px solid #8B5CF635", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
+        <span style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
           Cohort Active
         </span>
       )}
@@ -55,6 +56,8 @@ export function PeerProgrammingShell() {
   const [feedbackSuccess, setFeedbackSuccess] = useState(false);
   const [feedbackError, setFeedbackError] = useState<string | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getPeerProgrammingTokens(theme);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -169,18 +172,18 @@ export function PeerProgrammingShell() {
       { key: "chat", label: "Chat" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: "rgba(139,92,246,0.12)", border: "1px solid rgba(139,92,246,0.3)", display: "flex", alignItems: "center", justifyContent: "center", color: "#8B5CF6", textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: t.ACCENT_TINT_BG, border: `1px solid ${t.ACCENT_TINT_BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Users size={18} style={{ color: "#8B5CF6", flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Peer Programming</span>
+            <Users size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Peer Programming</span>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? "rgba(139,92,246,0.12)" : "transparent", border: `1px solid ${tab === key ? "rgba(139,92,246,0.4)" : "rgba(255,255,255,0.08)"}`, color: tab === key ? "#8B5CF6" : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? t.ACCENT_TINT_BG : "transparent", border: `1px solid ${tab === key ? t.ACCENT_TAB_BORDER : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
         </div>
@@ -190,11 +193,11 @@ export function PeerProgrammingShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <PeerProgrammingIconRail tab={tab} onTab={setTab} />
       <PeerProgrammingSidebar />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <ShellHeader active={Boolean(room?.cohortId)} />
+        <ShellHeader active={Boolean(room?.cohortId)} t={t} />
         {content}
       </div>
       <PeerProgrammingRightPanel room={room} participants={participants} onJoinSession={() => setTab("session")} />

--- a/ctf/packages/web/components/peer-programming/pp-shared.ts
+++ b/ctf/packages/web/components/peer-programming/pp-shared.ts
@@ -1,8 +1,39 @@
 // Shared constants, types, and helpers for the Peer Programming web shell.
 // Palette/layout derive from design/.../survivor-hub/PeerProgramming.tsx.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const COLOR = "#8B5CF6";
 export const BG = "#0F1117";
+
+// Theme-aware chrome tokens for the Peer Programming shell. The shell paints its accent as the
+// solid #8B5CF6 and as rgba(139,92,246,…) tints; the default theme returns those exact strings
+// so it renders identically when the comic toggle is off. Comic uses the shared comic surface
+// tokens plus the Peer Programming comic-ink accent (as solid + matching alpha tints).
+export type PeerProgrammingTokens = PluginShellTokens & {
+  ACCENT_TINT_BG: string; // link/tab background tint (default 0.12)
+  ACCENT_TINT_BORDER: string; // link icon border tint (default 0.3)
+  ACCENT_TAB_BORDER: string; // active tab border tint (default 0.4)
+};
+
+export function getPeerProgrammingTokens(theme: ThemeName): PeerProgrammingTokens {
+  if (theme === "comic") {
+    const accent = getAppAccent("peer-programming", "comic");
+    return {
+      ...getPluginShellTokens(accent, theme),
+      ACCENT_TINT_BG: `${accent}1F`,
+      ACCENT_TINT_BORDER: `${accent}4D`,
+      ACCENT_TAB_BORDER: `${accent}66`,
+    };
+  }
+  return {
+    ...getPluginShellTokens(COLOR, theme),
+    ACCENT_TINT_BG: "rgba(139,92,246,0.12)",
+    ACCENT_TINT_BORDER: "rgba(139,92,246,0.3)",
+    ACCENT_TAB_BORDER: "rgba(139,92,246,0.4)",
+  };
+}
 
 export interface Participant {
   id: string;

--- a/ctf/packages/web/components/shared/plugin-shell-theme.ts
+++ b/ctf/packages/web/components/shared/plugin-shell-theme.ts
@@ -1,0 +1,66 @@
+// Shared chrome color tokens for plugin web shells.
+//
+// Every plugin shell paints the same chrome surfaces with the same default-dark hex values
+// (page background #0F1117, header #0D0F14, body text #E8EAF0, bright title #F9FAFB, two grey
+// text tones #9CA3AF and #6B7280, faint #4B5563, and white-alpha borders). This helper returns
+// those exact values for the default theme — so a shell renders pixel-identical when the comic
+// toggle is off — and the comic surface tokens from COMIC_THEME_TOKENS.md when it is on.
+//
+// The per-plugin accent is passed in (resolved by the caller via getAppAccent(slug, theme)),
+// because each shell owns its own accent token. The `${color}NN` opacity call sites in the
+// shells keep working against ACCENT and the white-alpha BORDER tokens unchanged.
+
+import { type ThemeName } from '../../lib/theme/theme-tokens';
+
+export type PluginShellTokens = {
+  ACCENT: string;
+  BG: string;
+  HEADER: string;
+  RAIL: string;
+  TEXT: string;
+  TITLE: string;
+  SUBTLE: string;
+  MUTED: string;
+  FAINT: string;
+  BORDER: string;
+  BORDER_STRONG: string;
+  BORDER_HI: string;
+  INPUT_BG: string;
+};
+
+// Build the chrome token set for a shell. `accent` is the already-resolved accent for the
+// active theme (default keeps the shell's shipped accent; comic uses the comic-ink accent).
+export function getPluginShellTokens(accent: string, theme: ThemeName): PluginShellTokens {
+  if (theme === 'comic') {
+    return {
+      ACCENT: accent,
+      BG: '#0D0D0D', // comic-bg
+      HEADER: '#080808', // comic-surface-alt (deepest chrome)
+      RAIL: '#080808', // comic-surface-alt (icon rail)
+      TEXT: '#EDE3CB', // comic-text-primary
+      TITLE: '#EDE3CB', // comic-text-primary
+      SUBTLE: '#7A6A50', // comic-text-secondary
+      MUTED: '#7A6A50', // comic-text-secondary
+      FAINT: '#4A3A2A', // comic-text-muted
+      BORDER: '#D4C49A1A', // comic-border-faint
+      BORDER_STRONG: '#D4C49A2E',
+      BORDER_HI: '#D4C49A3A',
+      INPUT_BG: '#141414', // comic-surface
+    };
+  }
+  return {
+    ACCENT: accent,
+    BG: '#0F1117',
+    HEADER: '#0D0F14',
+    RAIL: '#090B0F',
+    TEXT: '#E8EAF0',
+    TITLE: '#F9FAFB',
+    SUBTLE: '#9CA3AF',
+    MUTED: '#6B7280',
+    FAINT: '#4B5563',
+    BORDER: 'rgba(255,255,255,0.06)',
+    BORDER_STRONG: 'rgba(255,255,255,0.08)',
+    BORDER_HI: 'rgba(255,255,255,0.1)',
+    INPUT_BG: 'rgba(255,255,255,0.04)',
+  };
+}

--- a/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
@@ -5,12 +5,11 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { ChevronLeft, Share2 } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTheme } from "@/hooks/useTheme";
 import {
   BG,
   CATEGORIES,
-  COLOR,
-  SUBTLE,
-  TEXT,
+  getSocketRelayTokens,
   type SrChatCredentials,
   type SrFulfillment,
   type SrFulfillmentsResponse,
@@ -73,6 +72,8 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getSocketRelayTokens(theme);
 
   const fetchData = useCallback(async (showLoading = true) => {
     if (showLoading) setLoading(true);
@@ -221,27 +222,27 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
       { key: "chat", label: "Chat" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Share2 size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>SocketRelay</span>
-            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{openCount} open</Badge>
+            <Share2 size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TEXT, flex: 1 }}>SocketRelay</span>
+            <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{openCount} open</Badge>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
           {tab === "feed" && (
             <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
-              <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search requests…" style={{ width: "100%", padding: "8px 10px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)", borderRadius: 8, fontSize: 13, color: "#9CA3AF", outline: "none", boxSizing: "border-box" }} />
+              <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search requests…" style={{ width: "100%", padding: "8px 10px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }} />
               <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
                 {CATEGORIES.map((c) => (
-                  <button key={c} onClick={() => setCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${COLOR}14` : "transparent", border: `1px solid ${category === c ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: category === c ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
+                  <button key={c} onClick={() => setCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${t.ACCENT}14` : "transparent", border: `1px solid ${category === c ? t.ACCENT + "50" : t.BORDER_HI}`, color: category === c ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
                 ))}
               </div>
             </div>
@@ -253,7 +254,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
   }
 
   return (
-    <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: "flex" }}>
+    <div style={{ width: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <SocketRelayIconRail tab={tab} onTab={setTab} />
       <SocketRelaySidebar
         category={category}
@@ -266,13 +267,13 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
       />
 
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <Share2 size={18} style={{ color: COLOR }} />
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+          <Share2 size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>🔂 SocketRelay — Mutual Aid</div>
-            <div style={{ fontSize: 12, color: SUBTLE }}>Real-time requests · Privacy-minimized</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>🔂 SocketRelay — Mutual Aid</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Real-time requests · Privacy-minimized</div>
           </div>
-          <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
+          <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
             {openCount} open
           </Badge>
         </header>

--- a/ctf/packages/web/components/socketrelay/sr-shared.ts
+++ b/ctf/packages/web/components/socketrelay/sr-shared.ts
@@ -4,11 +4,23 @@
 // need/offer/credits/urgency framing is not backed by the data model, so the
 // shell renders the real request/claim/fulfillment model instead.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const COLOR = "#FB923C";
 export const BG = "#0F1117";
 export const TEXT = "#E8EAF0";
 export const SUBTLE = "#6B7280";
 export const FAINT = "#4B5563";
+
+// Theme-aware chrome tokens for the SocketRelay shell. Default keeps the shipped values (accent
+// stays #FB923C); comic uses the shared comic surface tokens plus the SocketRelay comic-ink accent.
+export type SocketRelayTokens = PluginShellTokens;
+
+export function getSocketRelayTokens(theme: ThemeName): SocketRelayTokens {
+  const accent = theme === "comic" ? getAppAccent("socketrelay", "comic") : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 export type Tab = "feed" | "post" | "chat";
 

--- a/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
+++ b/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
@@ -6,7 +6,8 @@ import { Car, ChevronLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { AppLoading } from "@/components/shared/app-loading";
-import { BG, deriveRideTypes, type ChatCreds, type Mode, type Tab, type TripRequest } from "./tt-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { BG, deriveRideTypes, getTrustTransportTokens, type ChatCreds, type Mode, type Tab, type TripRequest, type TrustTransportTokens } from "./tt-shared";
 import { TrustTransportIconRail } from "./tt-icon-rail";
 import { TrustTransportSidebar } from "./tt-sidebar";
 import { TrustTransportBookTab } from "./tt-book-tab";
@@ -14,13 +15,13 @@ import { TrustTransportTrackingTab } from "./tt-tracking-tab";
 import { TrustTransportChatTab } from "./tt-chat-tab";
 import { TrustTransportRightPanel } from "./tt-right-panel";
 
-function ShellHeader() {
+function ShellHeader({ t }: { t: TrustTransportTokens }) {
   return (
-    <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-      <Car size={18} style={{ color: "#F97316" }} />
+    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+      <Car size={18} style={{ color: t.ACCENT }} />
       <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>TrustTransport</div>
-        <div style={{ fontSize: 12, color: "#6B7280" }}>Rides · Packages · Food · Safety-first</div>
+        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>TrustTransport</div>
+        <div style={{ fontSize: 12, color: t.MUTED }}>Rides · Packages · Food · Safety-first</div>
       </div>
       <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
         Safety-First
@@ -49,6 +50,8 @@ export function TrustTransportShell() {
   // can't overwrite the credentials for a trip the user has since switched to.
   const activeChatReqRef = useRef<string | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getTrustTransportTokens(theme);
 
   async function fetchRequests() {
     const res = await fetch("/api/trusttransport/requests");
@@ -184,18 +187,18 @@ export function TrustTransportShell() {
       { key: "chat", label: "Chat" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: "rgba(249,115,22,0.12)", border: "1px solid rgba(249,115,22,0.3)", display: "flex", alignItems: "center", justifyContent: "center", color: "#F97316", textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: t.ACCENT_TINT_BG, border: `1px solid ${t.ACCENT_TINT_BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Car size={18} style={{ color: "#F97316", flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>TrustTransport</span>
+            <Car size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>TrustTransport</span>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? "rgba(249,115,22,0.12)" : "transparent", border: `1px solid ${tab === key ? "rgba(249,115,22,0.4)" : "rgba(255,255,255,0.08)"}`, color: tab === key ? "#F97316" : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? t.ACCENT_TINT_BG : "transparent", border: `1px solid ${tab === key ? t.ACCENT_TAB_BORDER : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
         </div>
@@ -205,11 +208,11 @@ export function TrustTransportShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <TrustTransportIconRail tab={tab} onTab={setTab} />
       <TrustTransportSidebar rideTypes={rideTypes} rideType={rideType} onRideType={setRideType} requests={requests} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <ShellHeader />
+        <ShellHeader t={t} />
         {content}
       </div>
       <TrustTransportRightPanel requestCount={requests.length} modeCount={modes.length || rideTypes.length} onBook={() => setTab("book")} />

--- a/ctf/packages/web/components/trusttransport/tt-shared.ts
+++ b/ctf/packages/web/components/trusttransport/tt-shared.ts
@@ -1,9 +1,39 @@
 // Shared constants, types, and helpers for the TrustTransport web shell.
 // Palette/layout derive from design/.../survivor-hub/TrustTransport.tsx.
 import { Car, Package, Utensils } from "lucide-react";
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 
 export const COLOR = "#F97316";
 export const BG = "#0F1117";
+
+// Theme-aware chrome tokens for the TrustTransport shell. The shell paints its accent both as
+// the solid #F97316 and as rgba(249,115,22,…) tints; the default theme returns those exact
+// strings so it renders identically when the comic toggle is off. Comic uses the shared comic
+// surface tokens plus the TrustTransport comic-ink accent (as solid + matching alpha tints).
+export type TrustTransportTokens = PluginShellTokens & {
+  ACCENT_TINT_BG: string; // link/tab background tint (default 0.12)
+  ACCENT_TINT_BORDER: string; // link icon border tint (default 0.3)
+  ACCENT_TAB_BORDER: string; // active tab border tint (default 0.4)
+};
+
+export function getTrustTransportTokens(theme: ThemeName): TrustTransportTokens {
+  if (theme === "comic") {
+    const accent = getAppAccent("trusttransport", "comic");
+    return {
+      ...getPluginShellTokens(accent, theme),
+      ACCENT_TINT_BG: `${accent}1F`,
+      ACCENT_TINT_BORDER: `${accent}4D`,
+      ACCENT_TAB_BORDER: `${accent}66`,
+    };
+  }
+  return {
+    ...getPluginShellTokens(COLOR, theme),
+    ACCENT_TINT_BG: "rgba(249,115,22,0.12)",
+    ACCENT_TINT_BORDER: "rgba(249,115,22,0.3)",
+    ACCENT_TAB_BORDER: "rgba(249,115,22,0.4)",
+  };
+}
 
 export interface Mode {
   id: string;


### PR DESCRIPTION
Continues #341 (comic theme), the web per-screen migration. This is plugin-shell batch 1.

Makes six plugin web shells theme-aware so they switch with the per-user comic-theme toggle: directory, foundation, lighthouse, socketrelay, trusttransport, and peer-programming. This is colors only — no layout, spacing, copy, or behavior changes.

What changed:
- Each shell read its surface and accent colors from hardcoded hex constants in inline styles using the `${color}NN` opacity pattern. Those are now driven by a small theme-aware token object: `useTheme()` picks the active theme and a per-plugin getter resolves the chrome colors. The accent comes from `getAppAccent(slug, "comic")` in comic theme and the plugin's already-shipped accent in the default theme.
- New shared helper `components/shared/plugin-shell-theme.ts` holds the common chrome token set (page background, header, icon rail, body and title text, two grey text tones, faint, white-alpha borders, input background) so the six shells map the same default values the same way. The comic values are taken verbatim from `COMIC_THEME_TOKENS.md`.
- trusttransport and peer-programming paint their accent as solid plus `rgba(...)` tints; their getters return the exact default rgba strings so the default theme is unchanged, and the comic-ink accent with matching alpha in comic theme.

Default theme is visually unchanged: every token returns the exact value the shell already shipped when the toggle is off, so the default-dark theme renders the same as today. Loading and error states stay default-dark by design (loading screens are not themed per the token spec; the brief error message is left as is). No comic mockup exists yet for any of these six, so they follow the shared comic surface and accent treatment, consistent with the web chrome batch (#372).

Validation: web `tsc --noEmit` clean, EOF format check passed, web/android parity check passed, eslint clean on the changed files, and the full web build passed (also via the pre-push hook).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_