### PR TITLE
feat: comic theme on plugin shells, batch 2 — skills-taxonomy, skills-hunt, workforce, gentlepulse, weekly-performance, gdp (#341)

### DIFF
--- a/ctf/packages/web/components/gdp/gdp-shared.ts
+++ b/ctf/packages/web/components/gdp/gdp-shared.ts
@@ -1,8 +1,20 @@
 // Shared constants and types for the GDP web shell.
 // Palette/layout derive from design/.../survivor-hub/GDP.tsx.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const COLOR = "#06B6D4";
 export const BG = "#0F1117";
+
+// Theme-aware chrome tokens for the GDP shell. Default keeps the shipped values (accent
+// stays #06B6D4); comic uses the shared comic surface tokens plus the GDP comic-ink accent.
+export type GdpTokens = PluginShellTokens;
+
+export function getGdpTokens(theme: ThemeName): GdpTokens {
+  const accent = theme === "comic" ? getAppAccent("gdp", "comic") : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 export interface GdpSector {
   name: string;

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -5,20 +5,21 @@ import Link from "next/link";
 import { ChevronLeft, Globe } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, COLOR, GDP_HEADLINE_METRIC_KEY, type GdpMetricRow, type GdpMetrics, type GdpReport, type GdpTab } from "./gdp-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { getGdpTokens, GDP_HEADLINE_METRIC_KEY, type GdpMetricRow, type GdpMetrics, type GdpReport, type GdpTab, type GdpTokens } from "./gdp-shared";
 import { GdpLoading } from "./gdp-loading";
 import { GdpIconRail } from "./gdp-icon-rail";
 import { GdpSidebar } from "./gdp-sidebar";
 import { GdpDashboard } from "./gdp-dashboard";
 import { GdpMap } from "./gdp-map";
 
-function ShellHeader({ metrics }: { metrics: GdpMetrics }) {
+function ShellHeader({ t, metrics }: { t: GdpTokens; metrics: GdpMetrics }) {
   return (
-    <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-      <Globe size={18} style={{ color: COLOR }} />
+    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+      <Globe size={18} style={{ color: t.ACCENT }} />
       <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Gross Domestic Product — TI Skills Economy</div>
-        <div style={{ fontSize: 12, color: "#6B7280" }}>
+        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>Gross Domestic Product — TI Skills Economy</div>
+        <div style={{ fontSize: 12, color: t.MUTED }}>
           {metrics.countries ? `${metrics.countries} countries · ` : ""}{metrics.members ? `${metrics.members} survivors` : "Loading…"}
         </div>
       </div>
@@ -27,10 +28,10 @@ function ShellHeader({ metrics }: { metrics: GdpMetrics }) {
   );
 }
 
-function EmptyReport() {
+function EmptyReport({ t }: { t: GdpTokens }) {
   return (
-    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 12, color: "#6B7280" }}>
-      <Globe size={48} style={{ color: COLOR, opacity: 0.3 }} />
+    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 12, color: t.MUTED }}>
+      <Globe size={48} style={{ color: t.ACCENT, opacity: 0.3 }} />
       <div style={{ fontSize: 16, fontWeight: 600 }}>No GDP report published yet</div>
       <div style={{ fontSize: 13 }}>Check back soon.</div>
     </div>
@@ -38,6 +39,7 @@ function EmptyReport() {
 }
 
 function GdpContent({
+  t,
   error,
   report,
   tab,
@@ -46,6 +48,7 @@ function GdpContent({
   metrics,
   metricRows,
 }: {
+  t: GdpTokens;
   error: string | null;
   report: GdpReport | null;
   tab: GdpTab;
@@ -57,7 +60,7 @@ function GdpContent({
   if (error) {
     return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF4444", fontSize: 14, padding: 24 }}>{error}</div>;
   }
-  if (!report) return <EmptyReport />;
+  if (!report) return <EmptyReport t={t} />;
   if (tab === "dashboard") return <GdpDashboard sectors={sectors} countries={countries} metrics={metrics} />;
   return <GdpMap metricRows={metricRows} />;
 }
@@ -84,6 +87,8 @@ export default function GdpShell() {
   // (gdp_total_revenue, weekly_active_users) by key. No per-country data exists.
   const [metricRows, setMetricRows] = useState<GdpMetricRow[]>([]);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getGdpTokens(theme);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -122,34 +127,34 @@ export default function GdpShell() {
       { key: "map", label: "Map" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "Inter, system-ui, sans-serif", color: "#E8EAF0", display: "flex", flexDirection: "column" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT, display: "flex", flexDirection: "column" }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Globe size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>GDP</span>
+            <Globe size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>GDP</span>
             <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>↑ Live</Badge>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
         </div>
-        <GdpContent error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
+        <GdpContent t={t} error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
       </div>
     );
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "Inter, system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <GdpIconRail tab={tab} onTab={setTab} />
       <GdpSidebar metrics={metrics} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <ShellHeader metrics={metrics} />
-        <GdpContent error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
+        <ShellHeader t={t} metrics={metrics} />
+        <GdpContent t={t} error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
       </div>
     </div>
   );

--- a/ctf/packages/web/components/gentlepulse/gentlepulse-shell.tsx
+++ b/ctf/packages/web/components/gentlepulse/gentlepulse-shell.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { ChevronLeft, Heart } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, COLOR, FAINT, type Session, type Tab } from "./gp-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { getGentlePulseTokens, type Session, type Tab } from "./gp-shared";
 import { GentlePulseLoading } from "./gp-loading";
 import { GentlePulseIconRail } from "./gp-icon-rail";
 import { GentlePulseSidebar } from "./gp-sidebar";
@@ -28,6 +29,8 @@ export function GentlePulseShell() {
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [submitting, setSubmitting] = useState(false);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getGentlePulseTokens(theme);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -87,7 +90,7 @@ export function GentlePulseShell() {
   if (loading) return <GentlePulseLoading />;
   if (error) {
     return (
-      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
+      <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
         {error}
       </div>
     );
@@ -130,25 +133,25 @@ export function GentlePulseShell() {
       { key: "chat", label: "Chat" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#080D0C", borderBottom: "1px solid rgba(20,184,166,0.1)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Heart size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>GentlePulse</span>
-            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>✓ Safe</Badge>
+            <Heart size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>GentlePulse</span>
+            <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>✓ Safe</Badge>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
           {tab === "sessions" && (
             <div style={{ display: "flex", gap: 6, padding: "0 12px 10px", overflowX: "auto" }}>
               {categories.map((c) => (
-                <button key={c} onClick={() => setCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${COLOR}14` : "transparent", border: `1px solid ${category === c ? COLOR + "50" : "rgba(255,255,255,0.1)"}`, color: category === c ? COLOR : "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
+                <button key={c} onClick={() => setCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${t.ACCENT}14` : "transparent", border: `1px solid ${category === c ? t.ACCENT + "50" : t.BORDER_HI}`, color: category === c ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
               ))}
             </div>
           )}
@@ -159,7 +162,7 @@ export function GentlePulseShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <GentlePulseIconRail tab={tab} onTab={setTab} />
       <GentlePulseSidebar
         categories={categories}
@@ -170,13 +173,13 @@ export function GentlePulseShell() {
       />
 
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: "1px solid rgba(20,184,166,0.1)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#080D0C", flexShrink: 0 }}>
-          <Heart size={18} style={{ color: COLOR }} />
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+          <Heart size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>💚 GentlePulse — Guided Meditation</div>
-            <div style={{ fontSize: 12, color: FAINT }}>Trauma-informed · Expert-designed · Safe sanctuary</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>💚 GentlePulse — Guided Meditation</div>
+            <div style={{ fontSize: 12, color: t.FAINT }}>Trauma-informed · Expert-designed · Safe sanctuary</div>
           </div>
-          <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
+          <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
             ✓ Trauma-Informed
           </Badge>
         </header>

--- a/ctf/packages/web/components/gentlepulse/gp-shared.ts
+++ b/ctf/packages/web/components/gentlepulse/gp-shared.ts
@@ -1,6 +1,9 @@
 // Shared constants, types, and helpers for the GentlePulse web shell.
 // Palette derives from design/.../survivor-hub/GentlePulse.tsx.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const COLOR = "#14B8A6";
 export const BG = "#0A0F0E";
 export const RAIL_BG = "#060A09";
@@ -8,6 +11,28 @@ export const PANEL_BG = "#080D0C";
 export const TEXT = "#E8EAF0";
 export const SUBTLE = "#6B7280";
 export const FAINT = "#4B5563";
+
+// GentlePulse ships its own green-tinted chrome surfaces — a darker page background (#0A0F0E),
+// a deepest-chrome panel/header (#080D0C), a darker icon rail (#060A09), and a teal-tinted
+// divider (rgba(20,184,166,0.1), i.e. the accent at 0.1). Those four values differ from the
+// shared default surfaces, so the default branch overrides exactly those four token slots and
+// leaves the rest of the shared default values (text tones, white-alpha inactive borders, input
+// surface) untouched — so the default theme renders byte-for-byte as today. Comic uses the shared
+// comic surfaces plus the GentlePulse comic-ink accent.
+export type GentlePulseTokens = PluginShellTokens;
+
+export function getGentlePulseTokens(theme: ThemeName): GentlePulseTokens {
+  if (theme === "comic") {
+    return getPluginShellTokens(getAppAccent("gentlepulse", "comic"), theme);
+  }
+  return {
+    ...getPluginShellTokens(COLOR, theme),
+    BG,
+    HEADER: PANEL_BG,
+    RAIL: RAIL_BG,
+    BORDER: "rgba(20,184,166,0.1)",
+  };
+}
 
 export type Tab = "sessions" | "playing" | "chat";
 

--- a/ctf/packages/web/components/skills-hunt/sh-shared.ts
+++ b/ctf/packages/web/components/skills-hunt/sh-shared.ts
@@ -1,6 +1,8 @@
 // Shared constants, types, and helpers for the Skills Hunt web shell.
 // Palette/layout derive from design/.../survivor-hub/SkillsHunt.tsx.
 import { Search, Trophy, Target, Users } from "lucide-react";
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 import type {
   SkillsHuntRound,
   SkillsHuntLeaderboardItem,
@@ -23,6 +25,15 @@ export const COLOR = "#D946EF";
 export const BG = "#0F1117";
 export const BIO_MAX = 280;
 export const MAX_SKILLS = 10;
+
+// Theme-aware chrome tokens for the Skills Hunt shell. Default keeps the shipped values (accent
+// stays #D946EF); comic uses the shared comic surface tokens plus the Skills Hunt comic-ink accent.
+export type SkillsHuntTokens = PluginShellTokens;
+
+export function getSkillsHuntTokens(theme: ThemeName): SkillsHuntTokens {
+  const accent = theme === "comic" ? getAppAccent("skills-hunt", "comic") : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 export const SKILL_TAXONOMY: Record<string, string[]> = {
   "Technology":         ["Software Engineering", "UI/UX Design", "Data Analysis", "Cybersecurity", "Web Development", "IT Support"],

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -4,9 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Bell, ChevronLeft, Search } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTheme } from "@/hooks/useTheme";
 import { AppLoading } from "@/components/shared/app-loading";
 import {
-  BG, COLOR, TABS, type Tab,
+  getSkillsHuntTokens, TABS, type SkillsHuntTokens, type Tab,
   type SkillsHuntRound, type SkillsHuntLeaderboardItem, type SkillsHuntAchievement,
   type SkillsHuntNotification, type SkillsHuntSubmission, type SkillsHuntMissionWithProgress,
 } from "./sh-shared";
@@ -20,21 +21,21 @@ import { SkillsHuntMyFindsTab } from "./sh-my-finds-tab";
 import { SkillsHuntRightPanel } from "./sh-right-panel";
 import { useNominationForm } from "./sh-use-nomination-form";
 
-function CenteredNote({ color, children }: { color: string; children: React.ReactNode }) {
+function CenteredNote({ t, color, children }: { t: SkillsHuntTokens; color: string; children: React.ReactNode }) {
   return (
-    <div style={{ width: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center" }}>
+    <div style={{ width: "100%", minHeight: "100vh", background: t.BG, display: "flex", alignItems: "center", justifyContent: "center" }}>
       <div style={{ fontSize: 14, color }}>{children}</div>
     </div>
   );
 }
 
-function ShellHeader({ activeRound }: { activeRound: SkillsHuntRound | null }) {
+function ShellHeader({ t, activeRound }: { t: SkillsHuntTokens; activeRound: SkillsHuntRound | null }) {
   return (
-    <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-      <Search size={18} style={{ color: COLOR }} />
+    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+      <Search size={18} style={{ color: t.ACCENT }} />
       <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>Skills Hunt</div>
-        <div style={{ fontSize: 12, color: "#6B7280" }}>
+        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>Skills Hunt</div>
+        <div style={{ fontSize: 12, color: t.MUTED }}>
           {activeRound ? activeRound.name : "Nominate survivors · build the Directory · grow the economy"}
         </div>
       </div>
@@ -113,6 +114,8 @@ export function SkillsHuntShell({
   const [loadingFinds, setLoadingFinds] = useState(false);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getSkillsHuntTokens(theme);
 
   const { form, submitted, resetForm } = useNominationForm(activeRound);
 
@@ -235,7 +238,7 @@ export function SkillsHuntShell({
   }
 
   if (loadingRounds) return <AppLoading />;
-  if (globalError) return <CenteredNote color="#EF4444">{globalError}</CenteredNote>;
+  if (globalError) return <CenteredNote t={t} color="#EF4444">{globalError}</CenteredNote>;
 
   const { currentUserEntry, noActiveRound, unreadCount } = deriveShellState({ leaderboard, serverCurrentUserEntry, userId, rounds, notifications });
   const showModeratorTools = isAdmin || isModerator;
@@ -251,22 +254,22 @@ export function SkillsHuntShell({
 
   if (isMobile) {
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}1A`, border: `1px solid ${COLOR}40`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}1A`, border: `1px solid ${t.ACCENT}40`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Search size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Skills Hunt</span>
-            <button type="button" onClick={() => setNotifOpen((o) => !o)} aria-label="Notifications" style={{ position: "relative", width: 38, height: 38, borderRadius: 10, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", color: "#9CA3AF", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0 }}>
+            <Search size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Skills Hunt</span>
+            <button type="button" onClick={() => setNotifOpen((o) => !o)} aria-label="Notifications" style={{ position: "relative", width: 38, height: 38, borderRadius: 10, background: t.INPUT_BG, border: `1px solid ${t.BORDER_STRONG}`, color: t.SUBTLE, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0 }}>
               <Bell size={18} />
               {unreadCount > 0 && <span style={{ position: "absolute", top: 5, right: 5, width: 8, height: 8, borderRadius: "50%", background: "#EF4444" }} />}
             </button>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px", overflowX: "auto" }}>
-            {TABS.map((t) => (
-              <button key={t.key} onClick={() => setTab(t.key)} style={{ whiteSpace: "nowrap", padding: "6px 12px", borderRadius: 8, background: tab === t.key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === t.key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === t.key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{t.label}</button>
+            {TABS.map((tabItem) => (
+              <button key={tabItem.key} onClick={() => setTab(tabItem.key)} style={{ whiteSpace: "nowrap", padding: "6px 12px", borderRadius: 8, background: tab === tabItem.key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === tabItem.key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === tabItem.key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{tabItem.label}</button>
             ))}
           </div>
         </div>
@@ -279,14 +282,14 @@ export function SkillsHuntShell({
   }
 
   return (
-    <div style={{ position: "relative", width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ position: "relative", width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <SkillsHuntIconRail tab={tab} onTab={setTab} notifOpen={notifOpen} onToggleNotif={() => setNotifOpen((o) => !o)} unreadCount={unreadCount} />
       {notifOpen && (
         <SkillsHuntNotifications notifications={notifications} onClose={() => setNotifOpen(false)} onMarkRead={(id) => void markRead(id)} />
       )}
       <SkillsHuntSidebar tab={tab} onTab={setTab} achievements={achievements} currentUserEntry={currentUserEntry} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <ShellHeader activeRound={activeRound} />
+        <ShellHeader t={t} activeRound={activeRound} />
         <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
           {content}
         </div>

--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, BORDER, BRAND, TEXT, type StSector } from "./st-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { getSkillsTaxonomyTokens, type StSector } from "./st-shared";
 import { SkillsTaxonomyIconRail } from "./st-icon-rail";
 import { SkillsTaxonomySectorsColumn } from "./st-sectors-column";
 import { SkillsTaxonomyTitlesColumn } from "./st-titles-column";
@@ -20,6 +21,8 @@ export function SkillsTaxonomyBrowser({ isAdmin }: { isAdmin: boolean }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getSkillsTaxonomyTokens(theme);
   const [mobileView, setMobileView] = useState<"sectors" | "titles" | "skills">("sectors");
 
   useEffect(() => {
@@ -55,17 +58,17 @@ export function SkillsTaxonomyBrowser({ isAdmin }: { isAdmin: boolean }) {
     const backTarget = mobileView === "skills" ? "titles" : "sectors";
     const backLabel = mobileView === "skills" ? "Job titles" : "Sectors";
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: `1px solid ${BORDER}` }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, display: "flex", alignItems: "center", justifyContent: "center", color: BRAND, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>Skills Taxonomy</span>
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Skills Taxonomy</span>
           </div>
           {mobileView !== "sectors" && (
             <div style={{ padding: "0 12px 10px" }}>
-              <button type="button" onClick={() => setMobileView(backTarget)} style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", padding: "8px 12px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, color: "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
+              <button type="button" onClick={() => setMobileView(backTarget)} style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", padding: "8px 12px", borderRadius: 8, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, color: t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
                 <ChevronLeft size={14} /> {backLabel}
               </button>
             </div>
@@ -102,7 +105,7 @@ export function SkillsTaxonomyBrowser({ isAdmin }: { isAdmin: boolean }) {
   }
 
   return (
-    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
       <SkillsTaxonomyIconRail />
       <SkillsTaxonomySectorsColumn
         sectors={sectors}

--- a/ctf/packages/web/components/skills-taxonomy/st-shared.ts
+++ b/ctf/packages/web/components/skills-taxonomy/st-shared.ts
@@ -9,6 +9,8 @@ import type {
   TaxonomyHierarchySector,
   TaxonomyHierarchySkill,
 } from "../../lib/skills-taxonomy/types";
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 
 export type StSector = TaxonomyHierarchySector;
 export type StJobTitle = TaxonomyHierarchyJobTitle;
@@ -21,6 +23,26 @@ export const BORDER = "#1E2A3A";
 export const TEXT = "#F9FAFB";
 export const SUBTLE = "#6B7280";
 export const FAINT = "#4B5563";
+
+// Theme-aware chrome tokens for the Skills Taxonomy browser. This shell uses a solid blue-grey
+// divider (#1E2A3A) rather than a white-alpha border, so BORDER_SOLID carries that one extra
+// default value. The default theme returns the shipped values so it renders identically when the
+// comic toggle is off; comic uses the shared comic surfaces plus the Skills Taxonomy comic-ink accent.
+export type SkillsTaxonomyTokens = PluginShellTokens & {
+  BORDER_SOLID: string; // solid divider (default #1E2A3A)
+};
+
+export function getSkillsTaxonomyTokens(theme: ThemeName): SkillsTaxonomyTokens {
+  if (theme === "comic") {
+    const accent = getAppAccent("skills-taxonomy", "comic");
+    const base = getPluginShellTokens(accent, theme);
+    return { ...base, BORDER_SOLID: base.BORDER };
+  }
+  return {
+    ...getPluginShellTokens(BRAND, theme),
+    BORDER_SOLID: BORDER,
+  };
+}
 
 // Stable per-sector accent colors (the data model has no color column; the
 // mockup assigns a fixed palette across the sector list).

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
@@ -4,9 +4,9 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTheme } from "@/hooks/useTheme";
 import {
-  BG,
-  TEXT,
+  getWeeklyPerformanceTokens,
   type ComparisonResponse,
   type CurrentWeekResponse,
   type MetricsResponse,
@@ -63,6 +63,8 @@ export function WeeklyPerformanceShell({ isAdmin }: WeeklyPerformanceShellProps)
   const [comparison, setComparison] = useState<WpComparison | null>(null);
   const [error, setError] = useState<string | null>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getWeeklyPerformanceTokens(theme);
 
   useEffect(() => {
     let active = true;
@@ -126,22 +128,22 @@ export function WeeklyPerformanceShell({ isAdmin }: WeeklyPerformanceShellProps)
 
   if (isMobile) {
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", display: "flex", alignItems: "center", justifyContent: "center", color: TEXT, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: t.BTN_BG, border: `1px solid ${t.BORDER_HI}`, display: "flex", alignItems: "center", justifyContent: "center", color: t.TITLE, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>Weekly Performance</span>
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Weekly Performance</span>
           </div>
           <div style={{ display: "flex", gap: 8, padding: "0 12px 10px" }}>
-            <select value={selectedWeekStart ?? ""} onChange={(e) => setSelectedWeekStart(e.target.value)} style={{ flex: 1, padding: "8px 10px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 8, color: "#E8EAF0", fontSize: 13 }}>
+            <select value={selectedWeekStart ?? ""} onChange={(e) => setSelectedWeekStart(e.target.value)} style={{ flex: 1, padding: "8px 10px", background: t.INPUT_BG, border: `1px solid ${t.BORDER_HI}`, borderRadius: 8, color: t.TEXT, fontSize: 13 }}>
               {weeks.map((w) => (
                 <option key={w.weekStartDate} value={w.weekStartDate}>Week of {w.weekStartDate}</option>
               ))}
             </select>
             {isAdmin && (
-              <button onClick={exportSelected} style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>Export</button>
+              <button onClick={exportSelected} style={{ padding: "8px 14px", borderRadius: 8, background: t.BTN_BG, border: `1px solid ${t.BORDER_HI}`, color: t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>Export</button>
             )}
           </div>
         </div>
@@ -151,7 +153,7 @@ export function WeeklyPerformanceShell({ isAdmin }: WeeklyPerformanceShellProps)
   }
 
   return (
-    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
       <WeeklyPerformanceIconRail />
       <WeeklyPerformanceSidebar
         weeks={weeks}

--- a/ctf/packages/web/components/weekly-performance/wp-shared.ts
+++ b/ctf/packages/web/components/weekly-performance/wp-shared.ts
@@ -3,6 +3,9 @@
 // Types mirror the shapes returned by lib/weekly-performance/repository.ts
 // (which exports inferred return types rather than named types).
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const BRAND = "#F59E0B";
 export const BG = "#0F1117";
 export const SURFACE = "#161B27";
@@ -10,6 +13,29 @@ export const BORDER = "#1E2A3A";
 export const TEXT = "#F9FAFB";
 export const SUBTLE = "#6B7280";
 export const FAINT = "#4B5563";
+
+// Theme-aware chrome tokens for the Weekly Performance shell. The shell paints a few neutral
+// white-alpha button surfaces (the back button and the export button use rgba(255,255,255,0.05),
+// which is not in the shared token set), so BTN_BG carries that one extra default value. The
+// default theme returns the shipped values so it renders identically when the comic toggle is off;
+// comic uses the shared comic surfaces plus the Weekly Performance comic-ink accent.
+export type WeeklyPerformanceTokens = PluginShellTokens & {
+  BTN_BG: string; // neutral control surface (default rgba(255,255,255,0.05))
+};
+
+export function getWeeklyPerformanceTokens(theme: ThemeName): WeeklyPerformanceTokens {
+  if (theme === "comic") {
+    const accent = getAppAccent("weekly-performance", "comic");
+    return {
+      ...getPluginShellTokens(accent, theme),
+      BTN_BG: "#141414", // comic-surface
+    };
+  }
+  return {
+    ...getPluginShellTokens(BRAND, theme),
+    BTN_BG: "rgba(255,255,255,0.05)",
+  };
+}
 
 export type WeekStatus = "open" | "locked" | "published";
 

--- a/ctf/packages/web/components/workforce/workforce-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-shell.tsx
@@ -5,7 +5,10 @@ import Link from 'next/link';
 import { BarChart2, ChevronLeft, Target, Plus } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useIsMobile } from '@/hooks/use-is-mobile';
+import { useTheme } from '@/hooks/useTheme';
 import { AppLoading } from '@/components/shared/app-loading';
+import { getAppAccent, type ThemeName } from '@/lib/theme/theme-tokens';
+import { getPluginShellTokens, type PluginShellTokens } from '@/components/shared/plugin-shell-theme';
 import type { WorkforceDashboard, WorkforceGroupedReportItem, WorkforceProfile } from '../../lib/workforce/types';
 import { WorkforceIconRail } from './workforce-icon-rail';
 import { WorkforceSidebar } from './workforce-sidebar';
@@ -15,6 +18,15 @@ import { WorkforceSectorGaps } from './workforce-sector-gaps';
 import { WorkforceProfilePanel } from './workforce-profile-panel';
 
 const COLOR = '#B45309';
+
+// Theme-aware chrome tokens for the Workforce shell. Default keeps the shipped values (accent
+// stays #B45309); comic uses the shared comic surface tokens plus the Workforce comic-ink accent.
+type WorkforceTokens = PluginShellTokens;
+
+function getWorkforceTokens(theme: ThemeName): WorkforceTokens {
+  const accent = theme === 'comic' ? getAppAccent('workforce', 'comic') : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 type Tab = 'dashboard';
 type SidebarView = 'overview' | 'sector' | 'skill-level';
@@ -30,7 +42,7 @@ function WorkforceLoadingState() {
   return <AppLoading />;
 }
 
-function WorkforceEmptyState() {
+function WorkforceEmptyState({ t }: { t: WorkforceTokens }) {
   return (
     <div
       style={{
@@ -55,13 +67,13 @@ function WorkforceEmptyState() {
           justifyContent: 'center',
         }}
       >
-        <BarChart2 size={32} style={{ color: COLOR, opacity: 0.5 }} />
+        <BarChart2 size={32} style={{ color: t.ACCENT, opacity: 0.5 }} />
       </div>
       <div style={{ textAlign: 'center', maxWidth: 360 }}>
-        <div style={{ fontSize: 20, fontWeight: 700, color: '#F9FAFB', marginBottom: 8 }}>
+        <div style={{ fontSize: 20, fontWeight: 700, color: t.TITLE, marginBottom: 8 }}>
           No workforce data yet
         </div>
-        <div style={{ fontSize: 14, color: '#6B7280', lineHeight: 1.7, marginBottom: 24 }}>
+        <div style={{ fontSize: 14, color: t.MUTED, lineHeight: 1.7, marginBottom: 24 }}>
           Once profiles are submitted and sectors assigned, workforce distribution and gap analysis will appear here.
         </div>
       </div>
@@ -75,7 +87,7 @@ function WorkforceEmptyState() {
         }}
       >
         {[
-          { label: 'Total Members', color: COLOR },
+          { label: 'Total Members', color: t.ACCENT },
           { label: 'Recruited', color: '#22C55E' },
           { label: 'Not Recruited', color: '#F59E0B' },
           { label: 'Sector Gaps', color: '#EF4444' },
@@ -94,7 +106,7 @@ function WorkforceEmptyState() {
             }}
           >
             <div style={{ width: 32, height: 8, borderRadius: 4, background: `${color}20` }} />
-            <div style={{ fontSize: 12, color: '#4B5563', textAlign: 'center' }}>{label}</div>
+            <div style={{ fontSize: 12, color: t.FAINT, textAlign: 'center' }}>{label}</div>
           </div>
         ))}
       </div>
@@ -112,7 +124,7 @@ function WorkforceEmptyState() {
           style={{
             fontSize: 13,
             fontWeight: 600,
-            color: COLOR,
+            color: t.ACCENT,
             marginBottom: 6,
             display: 'flex',
             alignItems: 'center',
@@ -121,7 +133,7 @@ function WorkforceEmptyState() {
         >
           <Target size={14} /> Sector Gaps
         </div>
-        <div style={{ fontSize: 13, color: '#4B5563' }}>
+        <div style={{ fontSize: 13, color: t.FAINT }}>
           No sector data — gaps populate as workforce profiles are submitted and sectors assigned.
         </div>
       </div>
@@ -130,7 +142,7 @@ function WorkforceEmptyState() {
         style={{
           padding: '12px 28px',
           borderRadius: 12,
-          background: COLOR,
+          background: t.ACCENT,
           border: 'none',
           color: '#fff',
           fontSize: 14,
@@ -148,11 +160,13 @@ function WorkforceEmptyState() {
 }
 
 function WorkforceDashboardContent({
+  t,
   dashboard,
   sectorItems,
   skillItems,
   activeView,
 }: {
+  t: WorkforceTokens;
   dashboard: WorkforceDashboard | null;
   sectorItems: WorkforceGroupedReportItem[];
   skillItems: WorkforceGroupedReportItem[];
@@ -161,7 +175,7 @@ function WorkforceDashboardContent({
   const isEmpty = !dashboard || dashboard.workforceTotal === 0;
 
   if (isEmpty) {
-    return <WorkforceEmptyState />;
+    return <WorkforceEmptyState t={t} />;
   }
 
   return (
@@ -195,6 +209,8 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     profile: null,
   });
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getWorkforceTokens(theme);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -259,7 +275,7 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
         style={{
           display: 'flex',
           height: '100dvh',
-          background: '#0F1117',
+          background: t.BG,
           alignItems: 'center',
           justifyContent: 'center',
           fontFamily: "'Inter', system-ui, sans-serif",
@@ -275,6 +291,7 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
 
   const content = (
     <WorkforceDashboardContent
+      t={t}
       dashboard={dashboard}
       sectorItems={sectorItems}
       skillItems={skillItems}
@@ -291,18 +308,18 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     // ctf-self-responsive opts out of the global mobile de-flex so this flex
     // column keeps a real height — the dashboard's ScrollArea needs it to scroll.
     return (
-      <div className="ctf-self-responsive" style={{ height: '100dvh', display: 'flex', flexDirection: 'column', background: '#0F1117', fontFamily: "'Inter', system-ui, sans-serif", color: '#E8EAF0' }}>
-        <div style={{ background: '#0D0F14', borderBottom: '1px solid rgba(255,255,255,0.06)', flexShrink: 0 }}>
+      <div className="ctf-self-responsive" style={{ height: '100dvh', display: 'flex', flexDirection: 'column', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ background: t.HEADER, borderBottom: `1px solid ${t.BORDER}`, flexShrink: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}20`, border: `1px solid ${COLOR}40`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: COLOR, textDecoration: 'none', flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}40`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.ACCENT, textDecoration: 'none', flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <BarChart2 size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: '#F9FAFB', flex: 1 }}>Workforce</span>
+            <BarChart2 size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Workforce</span>
           </div>
           <div style={{ display: 'flex', gap: 6, padding: '0 12px 8px', overflowX: 'auto' }}>
             {views.map(({ key, label }) => (
-              <button key={key} onClick={() => setView(key)} style={{ whiteSpace: 'nowrap', padding: '6px 12px', borderRadius: 8, background: view === key ? `${COLOR}20` : 'transparent', border: `1px solid ${view === key ? COLOR + '40' : 'rgba(255,255,255,0.08)'}`, color: view === key ? COLOR : '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>{label}</button>
+              <button key={key} onClick={() => setView(key)} style={{ whiteSpace: 'nowrap', padding: '6px 12px', borderRadius: 8, background: view === key ? `${t.ACCENT}20` : 'transparent', border: `1px solid ${view === key ? t.ACCENT + '40' : t.BORDER_STRONG}`, color: view === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>{label}</button>
             ))}
           </div>
         </div>
@@ -319,9 +336,9 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
         width: '100%',
         height: '100%',
         minHeight: '100dvh',
-        background: '#0F1117',
+        background: t.BG,
         fontFamily: "'Inter', system-ui, sans-serif",
-        color: '#E8EAF0',
+        color: t.TEXT,
         display: 'flex',
       }}
     >
@@ -338,21 +355,21 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
         <header
           style={{
             height: 56,
-            borderBottom: '1px solid rgba(255,255,255,0.06)',
+            borderBottom: `1px solid ${t.BORDER}`,
             display: 'flex',
             alignItems: 'center',
             padding: '0 24px',
             gap: 16,
-            background: '#0D0F14',
+            background: t.HEADER,
             flexShrink: 0,
           }}
         >
-          <BarChart2 size={18} style={{ color: COLOR }} />
+          <BarChart2 size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: '#E8EAF0' }}>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>
               Workforce Dashboard
             </div>
-            <div style={{ fontSize: 12, color: '#6B7280' }}>
+            <div style={{ fontSize: 12, color: t.MUTED }}>
               {dashboard
                 ? `${dashboard.workforceTotal.toLocaleString()} members · ${dashboard.recruitedTotal.toLocaleString()} recruited`
                 : 'Live workforce tracker'}


### PR DESCRIPTION
Plugin-shell batch 2 for the comic theme (#341), continuing the web per-screen migration.

Applies the comic theme to six more plugin shells, reusing the shared `getPluginShellTokens` helper that batch 1 added. Each shell now reads the active theme and resolves a per-plugin token bundle: the shipped accent and surfaces in the default theme, the comic surfaces plus the plugin's comic-ink accent when the comic toggle is on.

Shells themed:
- skills-taxonomy (the browser, which holds the shell chrome the thin `skills-taxonomy-shell.tsx` wrapper renders)
- skills-hunt
- workforce
- gentlepulse
- weekly-performance
- gdp

Colors only — no layout, spacing, copy, or behavior changes. Every distinct default value keeps its own token, so the default-dark theme renders byte-for-byte as before; nothing changes when the toggle is off. Status colors the spec keeps across themes (green success badges, red error text and unread dots) are left unchanged. GentlePulse keeps its own green-tinted default surfaces, and the workforce empty-state indigo decorations have no comic-spec match, so those stay as shipped in the default theme.

Public shells (`*-public-shell.tsx`) and admin shells (`*-admin-shell.tsx`) are not touched here — public shells are already done and admin shells are a later batch. Sub-panels and rails are also left for a later batch.

Validation: web `tsc --noEmit`, the EOF format check, the web/android parity check, and eslint on the changed files all pass. The pre-commit typecheck gate and the pre-push full web build both passed.

Refs #341.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_