### PR TITLE
feat: comic theme on plugin shells, batch 3 — service-credits, levelup, trust, clicklog, unlock, whatworks (#341)

### DIFF
--- a/ctf/packages/web/components/clicklog/clicklog-shared.ts
+++ b/ctf/packages/web/components/clicklog/clicklog-shared.ts
@@ -1,6 +1,8 @@
 // Shared constants, types, and derivations for the ClickLog web shell.
 // Palette derives from design/.../survivor-hub/ClickLog.tsx.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 import type { ClicklogIncident } from "../../lib/clicklog/types";
 
 export const BRAND = "#E91E8C";
@@ -10,6 +12,20 @@ export const BORDER = "#1E2A3A";
 export const TEXT = "#F9FAFB";
 export const SUBTLE = "#6B7280";
 export const FAINT = "#4B5563";
+
+// Theme-aware chrome tokens for the ClickLog shell. Default keeps the shipped values (accent stays
+// #E91E8C); comic uses the shared comic surface tokens plus the ClickLog comic-ink accent. The shell
+// paints a solid #1E2A3A chrome border that is distinct from the shared white-alpha border, so it is
+// carried as its own BORDER_SOLID token (default #1E2A3A, comic comic-border-faint).
+export type ClicklogTokens = PluginShellTokens & { BORDER_SOLID: string };
+
+export function getClicklogTokens(theme: ThemeName): ClicklogTokens {
+  if (theme === "comic") {
+    const accent = getAppAccent("clicklog", "comic");
+    return { ...getPluginShellTokens(accent, theme), BORDER_SOLID: "#D4C49A1A" };
+  }
+  return { ...getPluginShellTokens(BRAND, theme), BORDER_SOLID: "#1E2A3A" };
+}
 
 export const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
 

--- a/ctf/packages/web/components/clicklog/clicklog-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-shell.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import type { ClicklogIncident } from "../../lib/clicklog/types";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, BORDER, BRAND, SUBTLE, TEXT, deriveClicklogStats } from "./clicklog-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { deriveClicklogStats, getClicklogTokens } from "./clicklog-shared";
 import { ClicklogIconRail } from "./clicklog-icon-rail";
 import { ClicklogSidebar } from "./clicklog-sidebar";
 import { ClicklogRightRail } from "./clicklog-right-rail";
@@ -26,6 +27,8 @@ export function ClicklogShell() {
   const [geo, setGeo] = useState<Geo>({});
   const [logged, setLogged] = useState(false);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getClicklogTokens(theme);
 
   async function fetchIncidents(initial = false): Promise<void> {
     if (initial) setLoading(true);
@@ -133,16 +136,16 @@ export function ClicklogShell() {
 
   if (isMobile) {
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: `1px solid ${BORDER}` }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}20`, border: `1px solid ${BRAND}40`, display: "flex", alignItems: "center", justifyContent: "center", color: BRAND, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}40`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <AlertTriangle size={18} color={BRAND} style={{ flexShrink: 0 }} />
+            <AlertTriangle size={18} color={t.ACCENT} style={{ flexShrink: 0 }} />
             <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 15, fontWeight: 700, color: TEXT }}>Incident Log</div>
-              <div style={{ fontSize: 11, color: SUBTLE }}>{stats.total} incidents total</div>
+              <div style={{ fontSize: 15, fontWeight: 700, color: t.TITLE }}>Incident Log</div>
+              <div style={{ fontSize: 11, color: t.MUTED }}>{stats.total} incidents total</div>
             </div>
           </div>
         </div>
@@ -152,16 +155,16 @@ export function ClicklogShell() {
   }
 
   return (
-    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
       <ClicklogIconRail />
       <ClicklogSidebar total={stats.total} weekdayCounts={stats.weekdayCounts} />
 
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <AlertTriangle size={18} color={BRAND} />
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+          <AlertTriangle size={18} color={t.ACCENT} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>Incident Log</div>
-            <div style={{ fontSize: 12, color: SUBTLE }}>Personal safety tracking — {stats.total} incidents total</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>Incident Log</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Personal safety tracking — {stats.total} incidents total</div>
           </div>
         </header>
 

--- a/ctf/packages/web/components/levelup/levelup-shell.tsx
+++ b/ctf/packages/web/components/levelup/levelup-shell.tsx
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { ChevronLeft, Plus } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, SUBTLE, TEXT, type Cohort, type Enrollment, type PendingValidation, type NavKey, type Wallet, type Trainer, type Achievement, type WalletView, idempotencyKey } from "./lu-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { getLevelupTokens, type LevelupTokens, type Cohort, type Enrollment, type PendingValidation, type NavKey, type Wallet, type Trainer, type Achievement, type WalletView, idempotencyKey } from "./lu-shared";
 import { LevelUpSidebar } from "./lu-sidebar";
 import { LevelUpBrowse } from "./lu-browse";
 import { LevelUpProgress } from "./lu-progress";
@@ -67,18 +68,18 @@ async function fetchWalletView(signal: AbortSignal): Promise<WalletView | null> 
   return data.wallet ?? null;
 }
 
-function ShellHeader({ nav, isAdmin }: { nav: NavKey; isAdmin: boolean }) {
+function ShellHeader({ nav, isAdmin, t }: { nav: NavKey; isAdmin: boolean; t: LevelupTokens }) {
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 24 }}>
       <div>
-        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: TEXT }}>{HEADINGS[nav]}</h1>
-        <div style={{ fontSize: 13, color: SUBTLE, marginTop: 4 }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: t.TEXT_BODY }}>{HEADINGS[nav]}</h1>
+        <div style={{ fontSize: 13, color: t.TEXT_SUBTLE, marginTop: 4 }}>
           {SUBHEADINGS[nav]}
         </div>
       </div>
       {nav === "browse" && (
         <button type="button" disabled={!isAdmin}
-          style={{ display: "flex", alignItems: "center", gap: 6, background: "rgba(255,255,255,0.05)", color: SUBTLE, border: "1px solid #1E2A3A", borderRadius: 8, padding: "9px 18px", fontSize: 13, fontWeight: 600, cursor: isAdmin ? "pointer" : "not-allowed", opacity: isAdmin ? 1 : 0.5 }}>
+          style={{ display: "flex", alignItems: "center", gap: 6, background: "rgba(255,255,255,0.05)", color: t.TEXT_SUBTLE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 8, padding: "9px 18px", fontSize: 13, fontWeight: 600, cursor: isAdmin ? "pointer" : "not-allowed", opacity: isAdmin ? 1 : 0.5 }}>
           <Plus size={14} /> Create Cohort
         </button>
       )}
@@ -115,6 +116,7 @@ function ShellContent({
   trainers,
   achievements,
   wallet,
+  t,
 }: {
   nav: NavKey;
   loading: boolean;
@@ -124,15 +126,16 @@ function ShellContent({
   trainers: React.ReactNode;
   achievements: React.ReactNode;
   wallet: React.ReactNode;
+  t: LevelupTokens;
 }) {
-  if (loading) return <CenteredNote color={SUBTLE}>Loading…</CenteredNote>;
+  if (loading) return <CenteredNote color={t.TEXT_SUBTLE}>Loading…</CenteredNote>;
   if (error) return <CenteredNote color="#EF4444">{error}</CenteredNote>;
   if (nav === "browse") return <>{browse}</>;
   if (nav === "progress") return <>{progress}</>;
   if (nav === "trainers") return <>{trainers}</>;
   if (nav === "achievements") return <>{achievements}</>;
   if (nav === "wallet") return <>{wallet}</>;
-  return <CenteredNote color={SUBTLE}>{HEADINGS[nav]} — coming soon</CenteredNote>;
+  return <CenteredNote color={t.TEXT_SUBTLE}>{HEADINGS[nav]} — coming soon</CenteredNote>;
 }
 
 export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: boolean; query?: { track?: string; status?: string; startDate?: string; cohortId?: string } }) {
@@ -153,6 +156,8 @@ export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: b
   const [walletView, setWalletView] = useState<WalletView | null>(null);
   const [sectionLoaded, setSectionLoaded] = useState<Record<string, boolean>>({});
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getLevelupTokens(theme);
 
   const load = useCallback(async (signal: AbortSignal) => {
     setLoading(true);
@@ -240,11 +245,12 @@ export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: b
 
   const content = (
     <>
-      <ShellHeader nav={nav} isAdmin={isAdmin} />
+      <ShellHeader nav={nav} isAdmin={isAdmin} t={t} />
       <ShellContent
         nav={nav}
         loading={loading}
         error={error}
+        t={t}
         browse={(
           <LevelUpBrowse
             cohorts={filtered}
@@ -263,9 +269,9 @@ export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: b
           />
         )}
         progress={<LevelUpProgress enrollments={enrollments} onBrowse={() => setNav("browse")} />}
-        trainers={sectionLoaded.trainers ? <LevelUpTrainers trainers={trainers} /> : <CenteredNote color={SUBTLE}>Loading…</CenteredNote>}
-        achievements={sectionLoaded.achievements ? <LevelUpAchievements achievements={achievements} /> : <CenteredNote color={SUBTLE}>Loading…</CenteredNote>}
-        wallet={sectionLoaded.wallet ? <LevelUpWallet wallet={walletView} /> : <CenteredNote color={SUBTLE}>Loading…</CenteredNote>}
+        trainers={sectionLoaded.trainers ? <LevelUpTrainers trainers={trainers} /> : <CenteredNote color={t.TEXT_SUBTLE}>Loading…</CenteredNote>}
+        achievements={sectionLoaded.achievements ? <LevelUpAchievements achievements={achievements} /> : <CenteredNote color={t.TEXT_SUBTLE}>Loading…</CenteredNote>}
+        wallet={sectionLoaded.wallet ? <LevelUpWallet wallet={walletView} /> : <CenteredNote color={t.TEXT_SUBTLE}>Loading…</CenteredNote>}
       />
     </>
   );
@@ -279,17 +285,17 @@ export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: b
       { key: "wallet", label: "Wallet" },
     ];
     return (
-      <div style={{ minHeight: "100dvh", background: BG, fontFamily: "Inter, system-ui, sans-serif", color: TEXT }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100dvh", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT_BODY }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: "rgba(34,197,94,0.12)", border: "1px solid rgba(34,197,94,0.3)", display: "flex", alignItems: "center", justifyContent: "center", color: "#22C55E", textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: t.ACCENT_TINT_BG, border: `1px solid ${t.ACCENT_TINT_BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>LevelUp</span>
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>LevelUp</span>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px", overflowX: "auto" }}>
             {navItems.map(({ key, label }) => (
-              <button key={key} onClick={() => setNav(key)} style={{ whiteSpace: "nowrap", padding: "6px 12px", borderRadius: 8, background: nav === key ? "rgba(34,197,94,0.12)" : "transparent", border: `1px solid ${nav === key ? "rgba(34,197,94,0.4)" : "rgba(255,255,255,0.08)"}`, color: nav === key ? "#22C55E" : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{label}</button>
+              <button key={key} onClick={() => setNav(key)} style={{ whiteSpace: "nowrap", padding: "6px 12px", borderRadius: 8, background: nav === key ? t.ACCENT_TINT_BG : "transparent", border: `1px solid ${nav === key ? t.ACCENT_NAV_BORDER : t.BORDER_STRONG}`, color: nav === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{label}</button>
             ))}
           </div>
         </div>
@@ -299,7 +305,7 @@ export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: b
   }
 
   return (
-    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "Inter, system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT_BODY, overflow: "hidden" }}>
       <LevelUpSidebar nav={nav} onNav={setNav} isAdmin={isAdmin} balance={balance} escrow={escrow} />
       <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
         <div style={{ flex: 1, overflowY: "auto", padding: "24px 28px" }}>

--- a/ctf/packages/web/components/levelup/lu-shared.ts
+++ b/ctf/packages/web/components/levelup/lu-shared.ts
@@ -2,6 +2,9 @@
 // Palette derives from design/.../survivor-hub/LevelUp.tsx.
 // LevelUp is grant-only ("earn or earn nothing") — no UI ever spends/deducts a user's ServiceCredits.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const GREEN = "#22C55E";
 export const BG = "#0F1117";
 export const SURFACE = "#161B27";
@@ -9,6 +12,44 @@ export const BORDER = "#1E2A3A";
 export const MUTED = "#4B5563";
 export const TEXT = "#E2E8F0";
 export const SUBTLE = "#94A3B8";
+
+// Theme-aware chrome tokens for the LevelUp shell. Default keeps the shipped values (accent stays the
+// green #22C55E, painted as solid and as rgba(34,197,94,…) tints); comic uses the shared comic surface
+// tokens plus the LevelUp comic-ink accent. LevelUp uses its own body/secondary text tones (#E2E8F0,
+// #94A3B8) and a solid #1E2A3A chrome border, distinct from the shared defaults, so each is carried as
+// its own token to keep the default theme byte-for-byte identical.
+export type LevelupTokens = PluginShellTokens & {
+  BORDER_SOLID: string; // solid chrome border (default #1E2A3A)
+  TEXT_BODY: string; // primary body text (default #E2E8F0)
+  TEXT_SUBTLE: string; // secondary text (default #94A3B8)
+  ACCENT_TINT_BG: string; // back-button / active-nav background tint (default 0.12)
+  ACCENT_TINT_BORDER: string; // back-button icon border tint (default 0.3)
+  ACCENT_NAV_BORDER: string; // active-nav border tint (default 0.4)
+};
+
+export function getLevelupTokens(theme: ThemeName): LevelupTokens {
+  if (theme === "comic") {
+    const accent = getAppAccent("levelup", "comic");
+    return {
+      ...getPluginShellTokens(accent, theme),
+      BORDER_SOLID: "#D4C49A1A",
+      TEXT_BODY: "#EDE3CB",
+      TEXT_SUBTLE: "#7A6A50",
+      ACCENT_TINT_BG: `${accent}1F`,
+      ACCENT_TINT_BORDER: `${accent}4D`,
+      ACCENT_NAV_BORDER: `${accent}66`,
+    };
+  }
+  return {
+    ...getPluginShellTokens(GREEN, theme),
+    BORDER_SOLID: "#1E2A3A",
+    TEXT_BODY: "#E2E8F0",
+    TEXT_SUBTLE: "#94A3B8",
+    ACCENT_TINT_BG: "rgba(34,197,94,0.12)",
+    ACCENT_TINT_BORDER: "rgba(34,197,94,0.3)",
+    ACCENT_NAV_BORDER: "rgba(34,197,94,0.4)",
+  };
+}
 
 export const TRACK_COLORS: Record<string, string> = {
   Tech: "#3B82F6",

--- a/ctf/packages/web/components/service-credits/sc-shared.ts
+++ b/ctf/packages/web/components/service-credits/sc-shared.ts
@@ -5,8 +5,20 @@
 // it must NEVER be shown at a fiat / dollar equivalent. Balances render as
 // "credits" only.
 
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
+
 export const COLOR = "#F59E0B";
 export const BG = "#0F1117";
+
+// Theme-aware chrome tokens for the ServiceCredits shell. Default keeps the shipped values (accent
+// stays #F59E0B); comic uses the shared comic surface tokens plus the ServiceCredits comic-ink accent.
+export type ServiceCreditsTokens = PluginShellTokens;
+
+export function getServiceCreditsTokens(theme: ThemeName): ServiceCreditsTokens {
+  const accent = theme === "comic" ? getAppAccent("service-credits", "comic") : COLOR;
+  return getPluginShellTokens(accent, theme);
+}
 
 export type WalletData = { availableBalance: number; escrowBalance: number };
 export type Tab = "wallet" | "earn" | "info";

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -5,8 +5,9 @@ import Link from "next/link";
 import { ChevronLeft, Coins } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTheme } from "@/hooks/useTheme";
 import { AppLoading } from "@/components/shared/app-loading";
-import { BG, COLOR, fmtCredits, type Tab, type WalletData } from "./sc-shared";
+import { BG, fmtCredits, getServiceCreditsTokens, type ServiceCreditsTokens, type Tab, type WalletData } from "./sc-shared";
 import { ServiceCreditsIconRail } from "./sc-icon-rail";
 import { ServiceCreditsSidebar } from "./sc-sidebar";
 import { ServiceCreditsWalletTab } from "./sc-wallet-tab";
@@ -22,15 +23,15 @@ function CenteredNote({ color, children }: { color: string; children: React.Reac
   );
 }
 
-function ShellHeader({ balance }: { balance: number }) {
+function ShellHeader({ balance, t }: { balance: number; t: ServiceCreditsTokens }) {
   return (
-    <header style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-      <Coins size={18} style={{ color: COLOR }} />
+    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
+      <Coins size={18} style={{ color: t.ACCENT }} />
       <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: "#E8EAF0" }}>ServiceCredits — Utility Tokens</div>
-        <div style={{ fontSize: 12, color: "#6B7280" }}>Earn · Spend · Trade · Across all mini-apps</div>
+        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>ServiceCredits — Utility Tokens</div>
+        <div style={{ fontSize: 12, color: t.MUTED }}>Earn · Spend · Trade · Across all mini-apps</div>
       </div>
-      <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
+      <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
         {fmtCredits(balance)} credits
       </Badge>
     </header>
@@ -43,6 +44,8 @@ export function ServiceCreditsShell() {
   const [wallet, setWallet] = useState<WalletData | null>(null);
   const [tab, setTab] = useState<Tab>("wallet");
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getServiceCreditsTokens(theme);
 
   async function refreshWallet() {
     const res = await fetch("/api/service-credits/wallet");
@@ -84,19 +87,19 @@ export function ServiceCreditsShell() {
       { key: "info", label: "Info" },
     ];
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0" }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${COLOR}14`, border: `1px solid ${COLOR}30`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR, textDecoration: "none", flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Coins size={18} style={{ color: COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", flex: 1 }}>ServiceCredits</span>
-            <Badge style={{ background: `${COLOR}20`, color: COLOR, border: `1px solid ${COLOR}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{fmtCredits(balance)}</Badge>
+            <Coins size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>ServiceCredits</span>
+            <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{fmtCredits(balance)}</Badge>
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${COLOR}1A` : "transparent", border: `1px solid ${tab === key ? COLOR + "40" : "rgba(255,255,255,0.08)"}`, color: tab === key ? COLOR : "#9CA3AF", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
             ))}
           </div>
         </div>
@@ -107,11 +110,11 @@ export function ServiceCreditsShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: "#E8EAF0", display: "flex" }}>
+    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <ServiceCreditsIconRail tab={tab} onTab={setTab} />
       <ServiceCreditsSidebar />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <ShellHeader balance={balance} />
+        <ShellHeader balance={balance} t={t} />
         {content}
       </div>
       <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} />

--- a/ctf/packages/web/components/unlock/unlock-shared.ts
+++ b/ctf/packages/web/components/unlock/unlock-shared.ts
@@ -2,6 +2,8 @@
 // Palette derives from design/.../survivor-hub/Unlock.tsx.
 
 import { CheckCircle, Clock, XCircle } from "lucide-react";
+import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
+import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 import type { UnlockReviewStatus } from "../../lib/unlock/types";
 
 export const BRAND = "#10B981";
@@ -11,6 +13,25 @@ export const BORDER = "#1E2A3A";
 export const TEXT = "#F9FAFB";
 export const SUBTLE = "#6B7280";
 export const FAINT = "#4B5563";
+
+// Theme-aware chrome tokens for the Unlock shell chrome (the submission and status views — the
+// UnlockShell itself is a thin controller with no inline colors). Default keeps the shipped values
+// (accent stays the green #10B981); comic uses the shared comic surface tokens plus the Unlock
+// comic-ink accent. The shell paints a solid #1E2A3A chrome border and a #161B27 card surface that are
+// distinct from the shared defaults, so each is carried as its own token to keep the default theme
+// byte-for-byte identical.
+export type UnlockTokens = PluginShellTokens & {
+  BORDER_SOLID: string; // solid chrome border (default #1E2A3A)
+  SURFACE_CARD: string; // raised card surface (default #161B27)
+};
+
+export function getUnlockTokens(theme: ThemeName): UnlockTokens {
+  if (theme === "comic") {
+    const accent = getAppAccent("unlock", "comic");
+    return { ...getPluginShellTokens(accent, theme), BORDER_SOLID: "#D4C49A1A", SURFACE_CARD: "#141414" };
+  }
+  return { ...getPluginShellTokens(BRAND, theme), BORDER_SOLID: "#1E2A3A", SURFACE_CARD: "#161B27" };
+}
 
 export type DisplayStatus = "pending" | "approved" | "rejected";
 

--- a/ctf/packages/web/components/unlock/unlock-status-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-status-view.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { ChevronLeft, Unlock as UnlockIcon } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, BORDER, STATUS_CONFIG, SUBTLE, TEXT, type DisplayStatus } from "./unlock-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { STATUS_CONFIG, getUnlockTokens, type DisplayStatus } from "./unlock-shared";
 import { UnlockIconRail } from "./unlock-icon-rail";
 import { UnlockSidebar } from "./unlock-sidebar";
 import { UnlockStatusCard } from "./unlock-status-card";
@@ -27,6 +28,8 @@ export function UnlockStatusView({
   const cfg = STATUS_CONFIG[status];
   const Icon = cfg.icon;
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getUnlockTokens(theme);
 
   const content = (
     <UnlockStatusCard
@@ -41,14 +44,14 @@ export function UnlockStatusView({
 
   if (isMobile) {
     return (
-      <div style={{ minHeight: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: "#0D0F14", borderBottom: `1px solid ${BORDER}` }}>
+      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
+        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
             <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${cfg.color}1A`, border: `1px solid ${cfg.color}40`, display: "flex", alignItems: "center", justifyContent: "center", color: cfg.color, textDecoration: "none", flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
             <UnlockIcon size={18} color={cfg.color} style={{ flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>Verification Status</span>
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Verification Status</span>
             <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "4px 10px", borderRadius: 20, background: cfg.bg, border: `1px solid ${cfg.color}30`, fontSize: 11, fontWeight: 600, color: cfg.color, flexShrink: 0 }}>
               <Icon size={11} /> {cfg.label}
             </div>
@@ -60,16 +63,16 @@ export function UnlockStatusView({
   }
 
   return (
-    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
       <UnlockIconRail />
       <UnlockSidebar status={status} />
 
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <UnlockIcon size={18} color={cfg.color} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>Verification Status</div>
-            <div style={{ fontSize: 12, color: SUBTLE }}>Quora profile · account unlock</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>Verification Status</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Quora profile · account unlock</div>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "4px 12px", borderRadius: 20, background: cfg.bg, border: `1px solid ${cfg.color}30`, fontSize: 11, fontWeight: 600, color: cfg.color }}>
             <Icon size={11} /> {cfg.label}

--- a/ctf/packages/web/components/unlock/unlock-submission-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-submission-view.tsx
@@ -2,7 +2,8 @@
 
 import { CheckCircle, ExternalLink, Send, Shield, Unlock as UnlockIcon } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { BG, BORDER, BRAND, SUBTLE, SURFACE, TEXT } from "./unlock-shared";
+import { useTheme } from "@/hooks/useTheme";
+import { getUnlockTokens } from "./unlock-shared";
 
 const WHY = [
   { icon: "🔗", t: "Real-person proof", d: "Quora activity proves you're a real person with history online." },
@@ -27,41 +28,43 @@ export function UnlockSubmissionView({
 }) {
   const canSubmit = url.trim().length > 0 && !submitting;
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const tok = getUnlockTokens(theme);
   return (
-    <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter',system-ui", color: TEXT, display: "flex", flexDirection: "column" }}>
-      <div style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 28px", gap: 12, background: "#0D0F14", flexShrink: 0 }}>
-        <UnlockIcon size={18} color={BRAND} />
+    <div style={{ width: "100%", minHeight: "100vh", background: tok.BG, fontFamily: "'Inter',system-ui", color: tok.TITLE, display: "flex", flexDirection: "column" }}>
+      <div style={{ height: 56, borderBottom: `1px solid ${tok.BORDER}`, display: "flex", alignItems: "center", padding: "0 28px", gap: 12, background: tok.HEADER, flexShrink: 0 }}>
+        <UnlockIcon size={18} color={tok.ACCENT} />
         <div>
           <div style={{ fontSize: 15, fontWeight: 600 }}>Unlock Full Access</div>
-          <div style={{ fontSize: 12, color: SUBTLE }}>Verify your Quora profile to get started</div>
+          <div style={{ fontSize: 12, color: tok.MUTED }}>Verify your Quora profile to get started</div>
         </div>
       </div>
 
       <div style={{ flex: 1, display: "flex", alignItems: "flex-start", justifyContent: "center", padding: isMobile ? "24px 16px" : "48px 64px", gap: isMobile ? 24 : 40, flexWrap: "wrap" }}>
         <div style={{ flex: 1, maxWidth: 520, minWidth: isMobile ? 0 : 320 }}>
           <div style={{ marginBottom: 28 }}>
-            <div style={{ fontSize: 26, fontWeight: 800, color: TEXT, marginBottom: 10 }}>Submit your Quora profile URL</div>
-            <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
+            <div style={{ fontSize: 26, fontWeight: 800, color: tok.TITLE, marginBottom: 10 }}>Submit your Quora profile URL</div>
+            <div style={{ fontSize: 14, color: tok.MUTED, lineHeight: 1.7 }}>
               To unlock full access to Survivor Hub, submit your Quora profile URL for manual verification. This helps us confirm you are a real person and reduces infiltration risk from bad actors.
             </div>
           </div>
 
           <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
             <div>
-              <label style={{ fontSize: 13, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 8 }}>
-                Your Quora Profile URL <span style={{ color: BRAND }}>*</span>
+              <label style={{ fontSize: 13, fontWeight: 600, color: tok.SUBTLE, display: "block", marginBottom: 8 }}>
+                Your Quora Profile URL <span style={{ color: tok.ACCENT }}>*</span>
               </label>
-              <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "11px 14px", background: "rgba(255,255,255,0.04)", border: `1px solid ${url ? BRAND + "50" : BORDER}`, borderRadius: 12 }}>
-                <ExternalLink size={14} color={SUBTLE} style={{ flexShrink: 0 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "11px 14px", background: tok.INPUT_BG, border: `1px solid ${url ? tok.ACCENT + "50" : tok.BORDER_SOLID}`, borderRadius: 12 }}>
+                <ExternalLink size={14} color={tok.MUTED} style={{ flexShrink: 0 }} />
                 <input
                   value={url}
                   onChange={(e) => onUrlChange(e.target.value)}
                   onKeyDown={(e) => { if (e.key === "Enter" && canSubmit) onSubmit(); }}
                   placeholder="https://quora.com/profile/your-name"
-                  style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: TEXT, fontFamily: "inherit" }}
+                  style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: tok.TITLE, fontFamily: "inherit" }}
                 />
               </div>
-              <div style={{ fontSize: 11, color: "#4B5563", marginTop: 6 }}>
+              <div style={{ fontSize: 11, color: tok.FAINT, marginTop: 6 }}>
                 Make sure your Quora profile is set to public before submitting.
               </div>
               {error && <div style={{ fontSize: 12, color: "#F87171", marginTop: 8 }}>{error}</div>}
@@ -70,7 +73,7 @@ export function UnlockSubmissionView({
             <button
               onClick={onSubmit}
               disabled={!canSubmit}
-              style={{ padding: "14px", borderRadius: 12, background: canSubmit ? BRAND : "rgba(255,255,255,0.06)", border: "none", color: canSubmit ? "#fff" : SUBTLE, fontSize: 15, fontWeight: 700, cursor: canSubmit ? "pointer" : "default", display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}
+              style={{ padding: "14px", borderRadius: 12, background: canSubmit ? tok.ACCENT : tok.BORDER, border: "none", color: canSubmit ? "#fff" : tok.MUTED, fontSize: 15, fontWeight: 700, cursor: canSubmit ? "pointer" : "default", display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}
             >
               <Send size={16} /> {submitting ? "Submitting…" : "Submit for Verification"}
             </button>
@@ -78,26 +81,26 @@ export function UnlockSubmissionView({
         </div>
 
         <div style={{ width: isMobile ? "100%" : 300, flexShrink: 0 }}>
-          <div style={{ padding: "20px", borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 16 }}>
-            <div style={{ fontSize: 13, fontWeight: 700, color: BRAND, marginBottom: 14 }}>Why we verify via Quora</div>
+          <div style={{ padding: "20px", borderRadius: 16, background: tok.SURFACE_CARD, border: `1px solid ${tok.BORDER_SOLID}`, marginBottom: 16 }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: tok.ACCENT, marginBottom: 14 }}>Why we verify via Quora</div>
             {WHY.map(({ icon, t, d }) => (
               <div key={t} style={{ display: "flex", gap: 10, marginBottom: 12 }}>
                 <span style={{ fontSize: 16, flexShrink: 0 }}>{icon}</span>
                 <div>
-                  <div style={{ fontSize: 13, fontWeight: 600, color: TEXT, marginBottom: 2 }}>{t}</div>
-                  <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5 }}>{d}</div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: tok.TITLE, marginBottom: 2 }}>{t}</div>
+                  <div style={{ fontSize: 12, color: tok.MUTED, lineHeight: 1.5 }}>{d}</div>
                 </div>
               </div>
             ))}
           </div>
-          <div style={{ padding: "14px 16px", borderRadius: 12, background: `${BRAND}06`, border: `1px solid ${BRAND}20` }}>
+          <div style={{ padding: "14px 16px", borderRadius: 12, background: `${tok.ACCENT}06`, border: `1px solid ${tok.ACCENT}20` }}>
             <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 8 }}>
-              <Shield size={13} color={BRAND} />
-              <span style={{ fontSize: 12, fontWeight: 600, color: BRAND }}>What gets unlocked</span>
+              <Shield size={13} color={tok.ACCENT} />
+              <span style={{ fontSize: 12, fontWeight: 600, color: tok.ACCENT }}>What gets unlocked</span>
             </div>
             {UNLOCKS.map((f) => (
-              <div key={f} style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 12, color: SUBTLE, marginBottom: 5 }}>
-                <CheckCircle size={11} color={BORDER} /> {f}
+              <div key={f} style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 12, color: tok.MUTED, marginBottom: 5 }}>
+                <CheckCircle size={11} color={tok.BORDER_SOLID} /> {f}
               </div>
             ))}
           </div>

--- a/ctf/packages/web/components/whatworks/whatworks-shell.tsx
+++ b/ctf/packages/web/components/whatworks/whatworks-shell.tsx
@@ -7,8 +7,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { ChevronLeft, ListChecks, Search, ShieldCheck } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
+import { useTheme } from '@/hooks/useTheme';
 import {
-  BG, BRAND, BORDER, SUBTLE, TEXT,
+  BG, BRAND, TEXT, getWhatWorksTokens,
   type SuggestDraft, type WhatWorksListResponse, type WhatWorksProblem,
   type WhatWorksProblemOption, type WhatWorksProduct, type WhatWorksStats,
 } from './ww-shared';
@@ -57,6 +58,8 @@ export function WhatWorksShell() {
   const [busyProductId, setBusyProductId] = useState<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getWhatWorksTokens(theme);
 
   async function loadList(): Promise<void> {
     setError(null);
@@ -183,7 +186,7 @@ export function WhatWorksShell() {
         <div style={{ marginBottom: 20, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#fecaca', fontSize: 13 }}>{error}</div>
       ) : null}
       {visibleProblems.length === 0 ? (
-        <div style={{ fontSize: 14, color: SUBTLE, padding: '24px 0' }}>No tools or problems match “{query}”.</div>
+        <div style={{ fontSize: 14, color: t.MUTED, padding: '24px 0' }}>No tools or problems match “{query}”.</div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
           {visibleProblems.map((problem) => (
@@ -202,29 +205,29 @@ export function WhatWorksShell() {
 
   if (isMobile) {
     return (
-      <div style={{ minHeight: '100dvh', background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT }}>
-        <div style={{ position: 'sticky', top: 0, zIndex: 20, background: '#0D0F14', borderBottom: `1px solid ${BORDER}` }}>
+      <div style={{ minHeight: '100dvh', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
+        <div style={{ position: 'sticky', top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: BRAND, textDecoration: 'none', flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.ACCENT, textDecoration: 'none', flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <ListChecks size={18} color={BRAND} style={{ flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: TEXT, flex: 1 }}>What Works</span>
+            <ListChecks size={18} color={t.ACCENT} style={{ flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>What Works</span>
             {isAdmin ? (
-              <Link href="/admin/whatworks" aria-label="Admin" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '7px 10px', borderRadius: 9, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 12, fontWeight: 700, textDecoration: 'none', flexShrink: 0 }}>
+              <Link href="/admin/whatworks" aria-label="Admin" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '7px 10px', borderRadius: 9, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 12, fontWeight: 700, textDecoration: 'none', flexShrink: 0 }}>
                 <ShieldCheck size={13} /> Admin
               </Link>
             ) : null}
           </div>
           <div style={{ padding: '0 12px 10px' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', borderRadius: 9, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}` }}>
-              <Search size={14} color={SUBTLE} />
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', borderRadius: 9, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}` }}>
+              <Search size={14} color={t.MUTED} />
               <input
                 aria-label="Search tools or problems"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="Search tools or problems…"
-                style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 13, color: TEXT, fontFamily: 'inherit' }}
+                style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 13, color: t.TITLE, fontFamily: 'inherit' }}
               />
             </div>
           </div>
@@ -237,7 +240,7 @@ export function WhatWorksShell() {
   }
 
   return (
-    <div style={{ display: 'flex', height: '100dvh', maxHeight: '100%', background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: 'hidden' }}>
+    <div style={{ display: 'flex', height: '100dvh', maxHeight: '100%', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: 'hidden' }}>
       <WhatWorksIconRail />
       <WhatWorksSidebar
         problems={visibleProblems}
@@ -247,25 +250,25 @@ export function WhatWorksShell() {
       />
 
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: '#0D0F14', flexShrink: 0 }}>
-          <ListChecks size={18} color={BRAND} />
+        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: t.HEADER, flexShrink: 0 }}>
+          <ListChecks size={18} color={t.ACCENT} />
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>What Works</div>
-            <div style={{ fontSize: 12, color: SUBTLE }}>Survivor-verified tools · by problem</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>What Works</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Survivor-verified tools · by problem</div>
           </div>
           {isAdmin ? (
-            <Link href="/admin/whatworks" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 9, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 12, fontWeight: 700, textDecoration: 'none' }}>
+            <Link href="/admin/whatworks" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 9, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 12, fontWeight: 700, textDecoration: 'none' }}>
               <ShieldCheck size={13} /> Admin
             </Link>
           ) : null}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', borderRadius: 9, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, width: 220 }}>
-            <Search size={14} color={SUBTLE} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', borderRadius: 9, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, width: 220 }}>
+            <Search size={14} color={t.MUTED} />
             <input
               aria-label="Search tools or problems"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search tools or problems…"
-              style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 12.5, color: TEXT, fontFamily: 'inherit' }}
+              style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 12.5, color: t.TITLE, fontFamily: 'inherit' }}
             />
           </div>
         </header>

--- a/ctf/packages/web/components/whatworks/ww-shared.ts
+++ b/ctf/packages/web/components/whatworks/ww-shared.ts
@@ -1,5 +1,8 @@
 // Design tokens taken verbatim from design/.../survivor-hub/WhatWorks.tsx (no token system in
 // the mockups — hex values are matched directly per the design-mockup implementation rules).
+import { getAppAccent, type ThemeName } from '@/lib/theme/theme-tokens';
+import { getPluginShellTokens, type PluginShellTokens } from '@/components/shared/plugin-shell-theme';
+
 export const BRAND = '#84CC16';
 export const BG = '#0F1117';
 export const SURFACE = '#161B27';
@@ -7,6 +10,20 @@ export const BORDER = '#1E2A3A';
 export const TEXT = '#F9FAFB';
 export const SUBTLE = '#6B7280';
 export const FAINT = '#4B5563';
+
+// Theme-aware chrome tokens for the WhatWorks shell. Default keeps the shipped values (accent stays
+// #84CC16); comic uses the shared comic surface tokens plus the WhatWorks comic-ink accent. The shell
+// paints a solid #1E2A3A chrome border that is distinct from the shared white-alpha border, so it is
+// carried as its own BORDER_SOLID token (default #1E2A3A, comic comic-border-faint).
+export type WhatWorksTokens = PluginShellTokens & { BORDER_SOLID: string };
+
+export function getWhatWorksTokens(theme: ThemeName): WhatWorksTokens {
+  if (theme === 'comic') {
+    const accent = getAppAccent('whatworks', 'comic');
+    return { ...getPluginShellTokens(accent, theme), BORDER_SOLID: '#D4C49A1A' };
+  }
+  return { ...getPluginShellTokens(BRAND, theme), BORDER_SOLID: '#1E2A3A' };
+}
 
 // The external long-form explainer the right-rail footnote points at (owner-confirmed).
 export const LOOK_MA_URL = 'https://www.chargingthefuture.com/look-ma';


### PR DESCRIPTION
Part of #341 (comic theme), web per-screen migration, plugin-shell batch 3.

Makes more plugin web shells theme-aware so they switch with the per-user comic-theme toggle, following the exact pattern batches 1 and 2 established. Colors only — no layout, spacing, copy, or behavior changes. Each shell calls useTheme() and a per-plugin getter that resolves the accent (getAppAccent(slug, "comic") in comic, the shell's shipped accent in default) and merges it with getPluginShellTokens(accent, theme).

Shells themed in this batch:
- service-credits — follows the shared chrome token set.
- levelup — carries its own body and secondary text tones (#E2E8F0, #94A3B8), its solid #1E2A3A chrome border, and its green accent tints as named default tokens.
- clicklog — shared chrome set plus its solid #1E2A3A chrome border as its own token.
- whatworks — shared chrome set plus its solid #1E2A3A chrome border as its own token.
- unlock — the UnlockShell is a thin controller with no inline colors, so its chrome is themed in the two views it renders (the submission view and the status view). The icon rail, sidebar, and right rail are left untouched.

Not changed this batch:
- trust — has no signed-in main user shell to theme. Its only top-level shell is the public signed-out shell (excluded by the batch scope — public is done), and its other surfaces are widget cards embedded in Directory and community right rails (sub-panels, excluded). Reported, left untouched.

Default-dark is visually unchanged: a distinct token is added for every distinct default value, so nothing changes when the toggle is off. service-credits, levelup, and unlock render credit balances and status — this is presentational theming only; no amount, calculation, or behavior changes. Loading screens and brief error states stay default-dark by design, and status colors the spec keeps across themes (success green, error red) are unchanged. One neutral overlay in levelup (rgba(255,255,255,0.05) on the disabled Create Cohort button) has no token match and no comic-spec value, so it is left as is.

Validation: web tsc --noEmit clean (after removing .next), EOF format check passed, web/android parity check passed, eslint clean on the changed files, and the pre-push full web build passed.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_