### PR TITLE
feat: comic theme on chyme, feed, and AI review console shells (#341)

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-live-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-live-shell.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { Radio } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
-import { DARK_BG, PRIMARY, type CurrentUser, requestJson } from './chyme-shared';
+import { useTheme } from '@/hooks/useTheme';
+import { getChymeTokens, type CurrentUser, requestJson } from './chyme-shared';
 import { ChymeHeader } from './chyme-header';
 import { ChymeSidebar } from './chyme-sidebar';
 import { ChymeRoomView } from './chyme-room-view';
@@ -25,6 +26,8 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
   const [showChat, setShowChat] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getChymeTokens(theme);
 
   useEffect(() => {
     let active = true;
@@ -96,7 +99,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
   }
 
   return (
-    <div style={{ minHeight: '100dvh', width: '100%', background: DARK_BG, fontFamily: "'Inter', system-ui, sans-serif", color: '#E8EAF0', display: 'flex', flexDirection: 'column' }}>
+    <div style={{ minHeight: '100dvh', width: '100%', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: 'flex', flexDirection: 'column' }}>
       <ChymeHeader
         participantCount={room?.participants.length ?? 0}
         isLive={Boolean(room)}
@@ -120,11 +123,11 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
 
           {!room && !loading && (
             <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', flexDirection: 'column', gap: 16 }}>
-              <div style={{ width: 80, height: 80, borderRadius: 24, background: `${PRIMARY}18`, border: `2px solid ${PRIMARY}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <Radio size={36} style={{ color: PRIMARY }} />
+              <div style={{ width: 80, height: 80, borderRadius: 24, background: `${t.ACCENT}18`, border: `2px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Radio size={36} style={{ color: t.ACCENT }} />
               </div>
-              <div style={{ fontSize: 24, fontWeight: 800, color: '#F0FDF4' }}>Join a Room</div>
-              <div style={{ fontSize: 15, color: '#4B5563', textAlign: 'center', maxWidth: 400, lineHeight: 1.6 }}>
+              <div style={{ fontSize: 24, fontWeight: 800, color: t.TITLE }}>Join a Room</div>
+              <div style={{ fontSize: 15, color: t.FAINT, textAlign: 'center', maxWidth: 400, lineHeight: 1.6 }}>
                 Select a live room to listen, speak, and connect with survivors worldwide. All rooms are safe spaces.
               </div>
             </div>

--- a/ctf/packages/web/components/chyme/chyme-shared.ts
+++ b/ctf/packages/web/components/chyme/chyme-shared.ts
@@ -1,10 +1,58 @@
 // Shared constants, types, and helpers for the Chyme web shell.
 // Palette derives from design/.../survivor-hub/ChymeApp.tsx.
 
+import { getAppAccent, type ThemeName } from '@/lib/theme/theme-tokens';
+import { getPluginShellTokens, type PluginShellTokens } from '@/components/shared/plugin-shell-theme';
+
 export const PRIMARY = '#22C55E';
 export const DARK_BG = '#021006';
 export const CARD_BG = '#041a0b';
 export const BORDER = '#052e16';
+// The chrome panel/header/rail surface the shells paint (darker than DARK_BG).
+export const PANEL_BG = '#030d05';
+// Bright title tone the shells use for headings.
+export const TITLE = '#F0FDF4';
+
+// Chyme ships its own deep-green chrome surfaces — a near-black green page background
+// (#021006), a deepest-chrome panel/header/rail (#030d05), a green-ink divider (#052e16),
+// and a mint-white title (#F0FDF4). Those values differ from the shared default surfaces, so
+// the default branch overrides exactly those token slots and leaves the rest of the shared
+// default values (text tones, white-alpha inactive borders, input surface) untouched — so the
+// default theme renders byte-for-byte as today. The shell also paints its accent both as solid
+// #22C55E and as rgba(34,197,94,…) tints; the default theme returns those exact strings so they
+// render identically when the toggle is off, while comic maps each to the Chyme comic-ink accent
+// at the matching alpha. Comic uses the shared comic surfaces plus that comic-ink accent.
+export type ChymeTokens = PluginShellTokens & {
+  ACCENT_TINT_10: string; // back-button background tint (default 0.1)
+  ACCENT_TINT_15: string; // logo/avatar background tint (default 0.15)
+  ACCENT_TINT_30: string; // back-button border tint (default 0.3)
+  ACCENT_TINT_40: string; // logo/avatar border tint (default 0.4)
+};
+
+export function getChymeTokens(theme: ThemeName): ChymeTokens {
+  if (theme === 'comic') {
+    const accent = getAppAccent('chyme', 'comic');
+    return {
+      ...getPluginShellTokens(accent, theme),
+      ACCENT_TINT_10: `${accent}1A`,
+      ACCENT_TINT_15: `${accent}26`,
+      ACCENT_TINT_30: `${accent}4D`,
+      ACCENT_TINT_40: `${accent}66`,
+    };
+  }
+  return {
+    ...getPluginShellTokens(PRIMARY, theme),
+    BG: DARK_BG,
+    HEADER: PANEL_BG,
+    RAIL: PANEL_BG,
+    TITLE,
+    BORDER,
+    ACCENT_TINT_10: 'rgba(34,197,94,0.1)',
+    ACCENT_TINT_15: 'rgba(34,197,94,0.15)',
+    ACCENT_TINT_30: 'rgba(34,197,94,0.3)',
+    ACCENT_TINT_40: 'rgba(34,197,94,0.4)',
+  };
+}
 
 export type CurrentUser = {
   userId: string;

--- a/ctf/packages/web/components/chyme/chyme-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-shell.tsx
@@ -3,7 +3,9 @@
 import Link from 'next/link';
 import { ChevronLeft, Radio } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
+import { useTheme } from '@/hooks/useTheme';
 import { ChymeLiveShell } from '@/components/chyme/chyme-live-shell';
+import { getChymeTokens } from './chyme-shared';
 
 type ChymeShellProps = {
   currentUser: {
@@ -14,24 +16,26 @@ type ChymeShellProps = {
 
 export function ChymeShell({ currentUser }: ChymeShellProps) {
   const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getChymeTokens(theme);
 
   // Phones: drop the 72px side rail for a compact sticky top bar (back + brand)
   // and let the live shell fill the width and stack its panes vertically.
   if (isMobile) {
     return (
-      <div style={{ minHeight: '100dvh', background: '#021006' }}>
-        <div style={{ position: 'sticky', top: 0, zIndex: 20, display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: '#030d05', borderBottom: '1px solid #052e16' }}>
+      <div style={{ minHeight: '100dvh', background: t.BG }}>
+        <div style={{ position: 'sticky', top: 0, zIndex: 20, display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <Link
             href="/apps"
             aria-label="Back to apps"
-            style={{ width: 38, height: 38, borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#22C55E', textDecoration: 'none', flexShrink: 0 }}
+            style={{ width: 38, height: 38, borderRadius: 10, background: t.ACCENT_TINT_10, border: `1px solid ${t.ACCENT_TINT_30}`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.ACCENT, textDecoration: 'none', flexShrink: 0 }}
           >
             <ChevronLeft size={20} />
           </Link>
-          <div style={{ width: 32, height: 32, borderRadius: 9, background: 'rgba(34,197,94,0.15)', border: '1px solid rgba(34,197,94,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#22C55E', flexShrink: 0 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 9, background: t.ACCENT_TINT_15, border: `1px solid ${t.ACCENT_TINT_40}`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.ACCENT, flexShrink: 0 }}>
             <Radio size={18} />
           </div>
-          <span style={{ fontSize: 15, fontWeight: 700, color: '#F0FDF4' }}>Chyme</span>
+          <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE }}>Chyme</span>
         </div>
         <ChymeLiveShell currentUser={currentUser} />
       </div>
@@ -39,18 +43,18 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
   }
 
   return (
-    <div style={{ display: 'flex', minHeight: '100dvh', background: '#021006' }}>
+    <div style={{ display: 'flex', minHeight: '100dvh', background: t.BG }}>
       {/* Left navigation rail */}
       <aside
         style={{
           width: 72,
-          borderRight: '1px solid #052e16',
+          borderRight: `1px solid ${t.BORDER}`,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
           padding: '16px 0',
           gap: 16,
-          background: '#030d05',
+          background: t.RAIL,
           flexShrink: 0,
         }}
       >
@@ -61,21 +65,21 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
             width: 44,
             height: 44,
             borderRadius: 10,
-            background: 'rgba(34,197,94,0.1)',
-            border: '1px solid rgba(34,197,94,0.3)',
+            background: t.ACCENT_TINT_10,
+            border: `1px solid ${t.ACCENT_TINT_30}`,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
             cursor: 'pointer',
-            color: '#22C55E',
+            color: t.ACCENT,
             textDecoration: 'none',
             transition: 'all 0.2s',
           }}
           onMouseEnter={(e) => {
-            (e.currentTarget as HTMLElement).style.background = 'rgba(34,197,94,0.15)';
+            (e.currentTarget as HTMLElement).style.background = t.ACCENT_TINT_15;
           }}
           onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.background = 'rgba(34,197,94,0.1)';
+            (e.currentTarget as HTMLElement).style.background = t.ACCENT_TINT_10;
           }}
         >
           <ChevronLeft size={20} />
@@ -87,12 +91,12 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
             width: 44,
             height: 44,
             borderRadius: 10,
-            background: 'rgba(34,197,94,0.15)',
-            border: '1px solid rgba(34,197,94,0.4)',
+            background: t.ACCENT_TINT_15,
+            border: `1px solid ${t.ACCENT_TINT_40}`,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            color: '#22C55E',
+            color: t.ACCENT,
           }}
           title="Chyme chat"
         >

--- a/ctf/packages/web/components/comic/comic-review-console.module.css
+++ b/ctf/packages/web/components/comic/comic-review-console.module.css
@@ -741,3 +741,175 @@
     width: 100%;
   }
 }
+
+/* ─── Comic theme overrides ──────────────────────────────────────────────────
+ *
+ * Only active under [data-theme='comic']; the default theme above is untouched and
+ * renders pixel-identical when the toggle is off. Values come from the comic surface
+ * variables in app/globals.css, which are set verbatim from
+ * design/artifacts/mockup-sandbox/COMIC_THEME_TOKENS.md — no gradients, no glow/neon,
+ * and the 3px 3px 0 offset shadow for elevation. This is the AI review console, so the
+ * standard cyan accent (#0EA5E9 / #7DD3FC) becomes the warm ink-dim accent (#7A6A50,
+ * the comic AI/Assistant colour from §6 — no blue in comic theme). Status colours the
+ * spec keeps across themes stay as shipped: success green (queue-clear, all-caught-up,
+ * high-confidence) and danger red (errors, rejects, safety flags, low-confidence). The
+ * loading screen is left untouched (§11 — loading screens are never themed).
+ */
+
+/* Chrome surfaces → comic page / panel / icon-rail backgrounds + cream ink dividers. */
+:global([data-theme='comic']) .console {
+  background: var(--ctf-bg);
+  color: var(--ctf-text);
+}
+
+:global([data-theme='comic']) .iconRail {
+  background: var(--ctf-icon-rail);
+  border-right: 1px solid var(--ctf-border);
+}
+
+:global([data-theme='comic']) .queueSidebar,
+:global([data-theme='comic']) .mainHeader,
+:global([data-theme='comic']) .rightRail {
+  background: var(--ctf-panel);
+}
+
+:global([data-theme='comic']) .queueSidebar,
+:global([data-theme='comic']) .rightRail {
+  border-color: var(--ctf-border);
+}
+
+:global([data-theme='comic']) .queueHeader,
+:global([data-theme='comic']) .mainHeader {
+  border-bottom-color: var(--ctf-border);
+}
+
+/* Body / title / secondary text tones → cream and ink-dim. */
+:global([data-theme='comic']) .queueKicker,
+:global([data-theme='comic']) .mainHeaderSub,
+:global([data-theme='comic']) .detailLabel,
+:global([data-theme='comic']) .detailMeta,
+:global([data-theme='comic']) .resetBtn {
+  color: var(--ctf-text-subtle);
+}
+
+:global([data-theme='comic']) .queueSub,
+:global([data-theme='comic']) .queueItemTime,
+:global([data-theme='comic']) .queueEmptyText,
+:global([data-theme='comic']) .charCount {
+  color: var(--ctf-text-muted);
+}
+
+:global([data-theme='comic']) .queueItemQuestion,
+:global([data-theme='comic']) .queueEmptyTitle,
+:global([data-theme='comic']) .draftReadonly,
+:global([data-theme='comic']) .provenanceRow,
+:global([data-theme='comic']) .allCaughtUpText,
+:global([data-theme='comic']) .guidanceItem {
+  color: var(--ctf-text-secondary);
+}
+
+:global([data-theme='comic']) .detailQuestion,
+:global([data-theme='comic']) .draftCard,
+:global([data-theme='comic']) .correctedTextarea {
+  color: var(--ctf-text);
+}
+
+/* Cyan AI accent → ink-dim (§6: AI elements use #7A6A50, no blue). */
+:global([data-theme='comic']) .iconRailLogo,
+:global([data-theme='comic']) .iconRailAvatar {
+  background: #7a6a5014;
+  border: 1px solid #7a6a5050;
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .iconRailBtnActive {
+  background: #7a6a5014;
+  border-color: #7a6a50;
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .queuePendingBadge {
+  background: #7a6a5014;
+  border: 1px solid #7a6a5050;
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .queueItemActive {
+  background: #7a6a5014;
+  border-color: #7a6a50;
+}
+
+:global([data-theme='comic']) .detailLabelCyan,
+:global([data-theme='comic']) .guidanceHead,
+:global([data-theme='comic']) .confNone {
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .notYetSentTag {
+  background: #7a6a5014;
+  color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .draftCard,
+:global([data-theme='comic']) .guidanceCard {
+  background: #7a6a500d;
+  border: 1px solid #7a6a5050;
+}
+
+:global([data-theme='comic']) .correctedTextarea {
+  background: #7a6a500d;
+  border: 1px solid #7a6a5066;
+}
+
+:global([data-theme='comic']) .correctedTextarea:focus-visible {
+  outline-color: #7a6a50;
+  border-color: #7a6a50;
+}
+
+:global([data-theme='comic']) .guidanceBullet {
+  color: var(--ctf-border);
+}
+
+:global([data-theme='comic']) .editBtn {
+  background: #7a6a501a;
+  border: 1px solid #7a6a5066;
+  color: var(--ctf-border-dim);
+  box-shadow: var(--ctf-elevation-shadow);
+}
+
+/* Neutral chrome panels / inputs / chips → ink surfaces + cream borders. */
+:global([data-theme='comic']) .queueItem,
+:global([data-theme='comic']) .backBtn,
+:global([data-theme='comic']) .headerConfPill,
+:global([data-theme='comic']) .detailChannel,
+:global([data-theme='comic']) .provenanceRow,
+:global([data-theme='comic']) .confCard {
+  background: var(--ctf-surface);
+  border-color: var(--ctf-border-dim);
+}
+
+:global([data-theme='comic']) .backBtn {
+  color: var(--ctf-text-secondary);
+}
+
+:global([data-theme='comic']) .confTrack {
+  background: #d4c49a1a;
+}
+
+/* Approve (success) button: drop the gradient for a flat success-green fill (§12.5). */
+:global([data-theme='comic']) .approveBtn {
+  background: var(--ctf-success);
+  box-shadow: var(--ctf-elevation-shadow);
+}
+
+/* Success-state surfaces keep comic-success green (§7). */
+:global([data-theme='comic']) .queueClearBadge {
+  background: #22c55e1f;
+  border: 1px solid #22c55e60;
+}
+
+:global([data-theme='comic']) .queueEmptyIcon,
+:global([data-theme='comic']) .allCaughtUpIcon {
+  background: #22c55e14;
+  border-color: #22c55e40;
+}

--- a/ctf/packages/web/components/feed/feed-announcements-constants.ts
+++ b/ctf/packages/web/components/feed/feed-announcements-constants.ts
@@ -1,5 +1,45 @@
 // Design-sync colour tokens — copied verbatim from design mockup COLOR const
+
+import { getAppAccent, type ThemeName } from '@/lib/theme/theme-tokens';
+import { getPluginShellTokens, type PluginShellTokens } from '@/components/shared/plugin-shell-theme';
+
 export const FEED_COLOR = '#84CC16';
 export const FEED_BG = '#0F1117';
 export const FEED_RAIL_BG = '#090B0F';
 export const FEED_SIDEBAR_BG = '#0D0F14';
+
+// Theme-aware chrome tokens for the live feed shell. The feed paints its lime accent both as the
+// solid #84CC16 and as rgba(132,204,22,…) tints; the default theme returns those exact strings so
+// the shell renders identically when the comic toggle is off. The feed plugin has no comic-spec
+// accent of its own, so comic resolves the shared fallback ink-dim accent via
+// getAppAccent('feed-announcements', 'comic'); the rgba tints map to that accent at matching alpha.
+// Comic uses the shared comic surface tokens plus that accent.
+export type FeedTokens = PluginShellTokens & {
+  ACCENT_TINT_05: string; // faint accent wash (default 0.05)
+  ACCENT_TINT_10: string; // empty-state icon background (default 0.1)
+  ACCENT_TINT_20: string; // empty-state icon border / chat frame (default 0.2)
+  ACCENT_TINT_30: string; // empty-state list dot (default 0.3)
+};
+
+export function getFeedTokens(theme: ThemeName): FeedTokens {
+  if (theme === 'comic') {
+    const accent = getAppAccent('feed-announcements', 'comic');
+    return {
+      ...getPluginShellTokens(accent, theme),
+      ACCENT_TINT_05: `${accent}0D`,
+      ACCENT_TINT_10: `${accent}1A`,
+      ACCENT_TINT_20: `${accent}33`,
+      ACCENT_TINT_30: `${accent}4D`,
+    };
+  }
+  return {
+    ...getPluginShellTokens(FEED_COLOR, theme),
+    BG: FEED_BG,
+    RAIL: FEED_RAIL_BG,
+    HEADER: FEED_SIDEBAR_BG,
+    ACCENT_TINT_05: 'rgba(132,204,22,0.05)',
+    ACCENT_TINT_10: 'rgba(132,204,22,0.1)',
+    ACCENT_TINT_20: 'rgba(132,204,22,0.2)',
+    ACCENT_TINT_30: 'rgba(132,204,22,0.3)',
+  };
+}

--- a/ctf/packages/web/components/feed/live-feed-announcements.tsx
+++ b/ctf/packages/web/components/feed/live-feed-announcements.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ChevronLeft, Megaphone, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
+import { useTheme } from '@/hooks/useTheme';
 import { StreamChatPanel } from '../shared/stream-chat-panel';
 import { FeedAnnouncementsIconRail } from './feed-announcements-icon-rail';
 import { FeedAnnouncementsSidebar } from './feed-announcements-sidebar';
@@ -11,7 +12,7 @@ import { FeedAnnouncementsHeader } from './feed-announcements-header';
 import { FeedAnnouncementsRightPanel } from './feed-announcements-right-panel';
 import { FeedItemCard } from './feed-item-card';
 import { FeedQuestionForm, FeedCommunityForm } from './feed-compose-forms';
-import { FEED_COLOR, FEED_BG } from './feed-announcements-constants';
+import { getFeedTokens, type FeedTokens } from './feed-announcements-constants';
 
 type FeedStreamCredentials = {
   streamApiKey: string;
@@ -98,6 +99,8 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const chatFetchedRef = useRef(false);
+  const { theme } = useTheme();
+  const t = getFeedTokens(theme);
 
   useEffect(() => {
     if (uiTab === 'chat' && !chatFetchedRef.current) {
@@ -290,7 +293,7 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
   ];
 
   return (
-    <div style={{ width: '100%', height: '100%', minHeight: '100dvh', background: FEED_BG, fontFamily: "'Inter', system-ui, sans-serif", color: '#E8EAF0', display: 'flex', flexDirection: isMobile ? 'column' : 'row' }}>
+    <div style={{ width: '100%', height: '100%', minHeight: '100dvh', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: 'flex', flexDirection: isMobile ? 'column' : 'row' }}>
       {!isMobile && <FeedAnnouncementsIconRail uiTab={uiTab} onTabChange={setUiTab} unreadCount={unreadCount} />}
 
       {!isMobile && (
@@ -303,21 +306,21 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
       )}
 
       {isMobile && (
-        <div style={{ position: 'sticky', top: 0, zIndex: 20, background: FEED_BG, borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+        <div style={{ position: 'sticky', top: 0, zIndex: 20, background: t.BG, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
-            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${FEED_COLOR}14`, border: `1px solid ${FEED_COLOR}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: FEED_COLOR, textDecoration: 'none', flexShrink: 0 }}>
+            <Link href="/apps" aria-label="Back to apps" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.ACCENT, textDecoration: 'none', flexShrink: 0 }}>
               <ChevronLeft size={20} />
             </Link>
-            <Megaphone size={18} style={{ color: FEED_COLOR, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: '#F9FAFB', flex: 1 }}>Feed</span>
-            <button onClick={openNewPost} style={{ padding: '8px 14px', borderRadius: 9, background: `${FEED_COLOR}1A`, border: `1px solid ${FEED_COLOR}40`, color: FEED_COLOR, fontSize: 13, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>New post</button>
+            <Megaphone size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Feed</span>
+            <button onClick={openNewPost} style={{ padding: '8px 14px', borderRadius: 9, background: `${t.ACCENT}1A`, border: `1px solid ${t.ACCENT}40`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>New post</button>
           </div>
           <div style={{ display: 'flex', gap: 6, padding: '0 12px 8px' }}>
             {mobileTabs.map(({ key, label }) => (
               <button
                 key={key}
                 onClick={() => setUiTab(key)}
-                style={{ flex: 1, padding: '8px 0', borderRadius: 8, background: uiTab === key ? `${FEED_COLOR}1A` : 'transparent', border: `1px solid ${uiTab === key ? FEED_COLOR + '40' : 'rgba(255,255,255,0.08)'}`, color: uiTab === key ? FEED_COLOR : '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+                style={{ flex: 1, padding: '8px 0', borderRadius: 8, background: uiTab === key ? `${t.ACCENT}1A` : 'transparent', border: `1px solid ${uiTab === key ? t.ACCENT + '40' : t.BORDER_STRONG}`, color: uiTab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
               >
                 {label}
               </button>
@@ -329,7 +332,7 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
                 <button
                   key={key}
                   onClick={() => setFilter(key)}
-                  style={{ whiteSpace: 'nowrap', padding: '5px 12px', borderRadius: 14, background: filter === key ? `${FEED_COLOR}14` : 'transparent', border: `1px solid ${filter === key ? FEED_COLOR + '50' : 'rgba(255,255,255,0.1)'}`, color: filter === key ? FEED_COLOR : '#9CA3AF', fontSize: 12, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}
+                  style={{ whiteSpace: 'nowrap', padding: '5px 12px', borderRadius: 14, background: filter === key ? `${t.ACCENT}14` : 'transparent', border: `1px solid ${filter === key ? t.ACCENT + '50' : t.BORDER_HI}`, color: filter === key ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}
                 >
                   {label}
                 </button>
@@ -344,6 +347,7 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
 
         {uiTab === 'feed' && (
           <FeedTab
+            t={t}
             error={error}
             showPostForm={showPostForm}
             setShowPostForm={setShowPostForm}
@@ -384,14 +388,14 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
 
         {uiTab === 'chat' && (
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: 24 }}>
-            <div style={{ marginBottom: 20, padding: '18px 24px', borderRadius: 16, background: `linear-gradient(135deg,${FEED_COLOR}15 0%,rgba(132,204,22,0.05) 100%)`, border: `1px solid ${FEED_COLOR}25` }}>
-              <div style={{ fontSize: 20, fontWeight: 800, color: '#F9FAFB', marginBottom: 4 }}>Community Chat</div>
-              <div style={{ fontSize: 14, color: '#9CA3AF' }}>Real-time community discussion</div>
+            <div style={{ marginBottom: 20, padding: '18px 24px', borderRadius: 16, background: `linear-gradient(135deg,${t.ACCENT}15 0%,${t.ACCENT_TINT_05} 100%)`, border: `1px solid ${t.ACCENT}25` }}>
+              <div style={{ fontSize: 20, fontWeight: 800, color: t.TITLE, marginBottom: 4 }}>Community Chat</div>
+              <div style={{ fontSize: 14, color: t.SUBTLE }}>Real-time community discussion</div>
             </div>
-            {chatLoading && <div style={{ color: '#9CA3AF', fontSize: 14 }}>Loading chat…</div>}
+            {chatLoading && <div style={{ color: t.SUBTLE, fontSize: 14 }}>Loading chat…</div>}
             {chatError && <div style={{ color: '#EF4444', fontSize: 14 }}>{chatError}</div>}
             {chatCredentials && (
-              <div style={{ flex: 1, borderRadius: 14, overflow: 'hidden', border: `1px solid ${FEED_COLOR}20`, minHeight: isMobile ? '65vh' : undefined }}>
+              <div style={{ flex: 1, borderRadius: 14, overflow: 'hidden', border: `1px solid ${t.ACCENT}20`, minHeight: isMobile ? '65vh' : undefined }}>
                 <StreamChatPanel
                   streamApiKey={chatCredentials.streamApiKey}
                   streamToken={chatCredentials.streamToken}
@@ -405,6 +409,7 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
 
         {uiTab === 'admin' && (
           <AdminTab
+            t={t}
             items={items}
             alertCount={alertCount}
             unreadCount={unreadCount}
@@ -431,6 +436,7 @@ export function LiveFeedAnnouncements({ initialItems, initialConfig, initialErro
 // ---------------------------------------------------------------------------
 
 type FeedTabProps = {
+  t: FeedTokens;
   error: string | null;
   showPostForm: 'question' | 'community' | null;
   setShowPostForm: (v: 'question' | 'community' | null) => void;
@@ -469,7 +475,7 @@ type FeedTabProps = {
 };
 
 function FeedTab({
-  error, showPostForm, setShowPostForm, enabledChannels,
+  t, error, showPostForm, setShowPostForm, enabledChannels,
   questionBody, questionCategory, questionZipCode, questionRadius, llmConsentGranted,
   communityBody, communityCategory,
   busyQuestionId, busyPostId, busyItemId, busyAnswerId,
@@ -522,10 +528,10 @@ function FeedTab({
       )}
 
       <div style={{ display: 'flex', gap: 8, marginBottom: 16, alignItems: 'center' }}>
-        <div style={{ fontSize: 13, color: '#6B7280' }}>{items.length} items</div>
+        <div style={{ fontSize: 13, color: t.MUTED }}>{items.length} items</div>
         <button
           onClick={onRefresh}
-          style={{ padding: '5px 12px', borderRadius: 20, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', color: '#9CA3AF', fontSize: 12, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}
+          style={{ padding: '5px 12px', borderRadius: 20, background: t.INPUT_BG, border: `1px solid ${t.BORDER_STRONG}`, color: t.SUBTLE, fontSize: 12, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}
         >
           <RefreshCw size={12} style={{ opacity: isRefreshing ? 0.5 : 1 }} />
           {isRefreshing ? 'Refreshing…' : 'Refresh'}
@@ -533,7 +539,7 @@ function FeedTab({
       </div>
 
       {visibleItems.length === 0 ? (
-        <FeedEmptyState />
+        <FeedEmptyState t={t} />
       ) : (
         visibleItems.map((item) => (
           <FeedItemCard
@@ -561,23 +567,23 @@ function FeedTab({
 // Empty state — mirrors FeedAnnouncementsEmpty mockup
 // ---------------------------------------------------------------------------
 
-function FeedEmptyState() {
+function FeedEmptyState({ t }: { t: FeedTokens }) {
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '40px 24px', gap: 16 }}>
-      <div style={{ width: 72, height: 72, borderRadius: 20, background: 'rgba(132,204,22,0.1)', border: '1px solid rgba(132,204,22,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <Megaphone size={32} style={{ color: FEED_COLOR, opacity: 0.5 }} />
+      <div style={{ width: 72, height: 72, borderRadius: 20, background: t.ACCENT_TINT_10, border: `1px solid ${t.ACCENT_TINT_20}`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Megaphone size={32} style={{ color: t.ACCENT, opacity: 0.5 }} />
       </div>
       <div style={{ textAlign: 'center', maxWidth: 380 }}>
-        <div style={{ fontSize: 20, fontWeight: 700, color: '#F9FAFB', marginBottom: 8 }}>No posts yet</div>
-        <div style={{ fontSize: 14, color: '#6B7280', lineHeight: 1.7 }}>
+        <div style={{ fontSize: 20, fontWeight: 700, color: t.TITLE, marginBottom: 8 }}>No posts yet</div>
+        <div style={{ fontSize: 14, color: t.MUTED, lineHeight: 1.7 }}>
           The community feed is quiet right now. Posts, announcements, and urgent alerts will stream here in real-time as the community grows.
         </div>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%', maxWidth: 520 }}>
         {['Announcements from the Hub team', 'Community stories from survivors', 'Urgent housing and safety alerts', 'Milestones and celebrations'].map((item) => (
-          <div key={item} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px', borderRadius: 10, background: 'rgba(255,255,255,0.02)', border: '1px dashed rgba(255,255,255,0.08)' }}>
-            <div style={{ width: 8, height: 8, borderRadius: '50%', background: 'rgba(132,204,22,0.3)', flexShrink: 0 }} />
-            <span style={{ fontSize: 13, color: '#6B7280' }}>{item}</span>
+          <div key={item} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px', borderRadius: 10, background: 'rgba(255,255,255,0.02)', border: `1px dashed ${t.BORDER_STRONG}` }}>
+            <div style={{ width: 8, height: 8, borderRadius: '50%', background: t.ACCENT_TINT_30, flexShrink: 0 }} />
+            <span style={{ fontSize: 13, color: t.MUTED }}>{item}</span>
           </div>
         ))}
       </div>
@@ -590,32 +596,33 @@ function FeedEmptyState() {
 // ---------------------------------------------------------------------------
 
 type AdminTabProps = {
+  t: FeedTokens;
   items: FeedTimelineItem[];
   alertCount: number;
   unreadCount: number;
   isAdmin: boolean;
 };
 
-function AdminTab({ items, alertCount, unreadCount, isAdmin }: AdminTabProps) {
+function AdminTab({ t, items, alertCount, unreadCount, isAdmin }: AdminTabProps) {
   return (
     <div style={{ flex: 1, padding: '32px 40px' }}>
-      <div style={{ fontSize: 22, fontWeight: 800, color: '#F9FAFB', marginBottom: 20 }}>Admin: Announcements</div>
+      <div style={{ fontSize: 22, fontWeight: 800, color: t.TITLE, marginBottom: 20 }}>Admin: Announcements</div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginBottom: 24 }}>
         {[
-          { l: 'Total Items', v: String(items.length), c: FEED_COLOR },
+          { l: 'Total Items', v: String(items.length), c: t.ACCENT },
           { l: 'Urgent Alerts', v: String(alertCount), c: '#EF4444' },
           { l: 'Unread', v: String(unreadCount), c: '#F59E0B' },
         ].map(({ l, v, c }) => (
           <div key={l} style={{ padding: 20, borderRadius: 14, background: `${c}08`, border: `1px solid ${c}20` }}>
             <div style={{ fontSize: 28, fontWeight: 800, color: c, marginBottom: 4 }}>{v}</div>
-            <div style={{ fontSize: 13, color: '#6B7280' }}>{l}</div>
+            <div style={{ fontSize: 13, color: t.MUTED }}>{l}</div>
           </div>
         ))}
       </div>
       {isAdmin && (
         <Link
           href="/admin/feed-announcements"
-          style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '10px 20px', borderRadius: 10, background: `${FEED_COLOR}15`, border: `1px solid ${FEED_COLOR}30`, color: FEED_COLOR, fontSize: 14, fontWeight: 600, textDecoration: 'none' }}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '10px 20px', borderRadius: 10, background: `${t.ACCENT}15`, border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 14, fontWeight: 600, textDecoration: 'none' }}
         >
           Open Admin Panel →
         </Link>


### PR DESCRIPTION
Apply the comic theme to the final shell batch, following the exact pattern batches 1, 2, and 3 established and merged. Colors only — no layout, spacing, copy, or behavior changes.

Surfaces themed:
- Chyme: the signed-in chrome and rail (chyme-shell.tsx) and the live chrome wrapper plus the join-a-room empty state (chyme-live-shell.tsx), driven by a new getChymeTokens getter in chyme-shared.ts.
- Feed: feed-announcements-shell.tsx is a thin server wrapper with no inline colors, so the chrome it renders — live-feed-announcements.tsx — is themed instead, driven by a new getFeedTokens getter in feed-announcements-constants.ts.
- AI review console (/admin/comic): comic-review-console.module.css gains a comic override block, mirroring the merged community-shell AI console pattern, driven by the shared comic surface variables in app/globals.css.

Each theme-aware getter keeps every distinct default value on its own token, so the default-dark theme renders byte-for-byte as before when the comic toggle is off. Chyme and the feed keep their own deep-green and lime chrome surfaces and exact rgba accent tints in the default theme; comic swaps in the shared comic surfaces plus the per-app comic-ink accent (Chyme #1A5C32; the feed plugin has no comic-spec accent of its own, so it resolves the shared fallback ink-dim accent). The review console's cyan AI accent becomes ink-dim per the spec (AI elements use no blue in comic), and its approve button drops its gradient for a flat success-green fill.

Status colors the spec keeps across themes stay unchanged: success green and danger red. Loading screens are left untouched per the token spec.

Left as shipped (no comic-spec match): the chyme header, sidebar, and room-view sub-components and the feed icon-rail, sidebar, header, and right-panel sub-components are outside the named shell scope and keep their shipped default surfaces; the feed empty-state list-row 2%-white-alpha wash has no shared token; and the review console's inline lucide icon colors cannot be reached from the CSS module. The chyme audio room, the public shells, and the mood shell were not touched.

This is the final shell batch. The mood shell follows after its open PR merges. The default-dark theme is visually unchanged.

Refs #341.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_