### PR TITLE
feat: add no-UI plain-text route weather service

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,6 +62,7 @@ jobs:
       ollama: ${{ steps.filter.outputs.ollama }}
       rasa: ${{ steps.filter.outputs.rasa }}
       formance: ${{ steps.filter.outputs.formance }}
+      routeweather: ${{ steps.filter.outputs.routeweather }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -81,6 +82,8 @@ jobs:
               - 'ctf/ops/rasa/**'
             formance:
               - 'ctf/ops/formance/Dockerfile.ledger'
+            routeweather:
+              - 'ctf/ops/route-weather/**'
 
   # ── ctf-web ─────────────────────────────────────────────────────
   build-web:
@@ -267,4 +270,49 @@ jobs:
           RENDER_SERVICE_NAME: ctf-formance-ledger
           # Optional explicit id; when unset the script finds it by name.
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CTF_FORMANCE }}
+        run: bash .github/scripts/render-deploy.sh
+
+  # ── ctf-route-weather ───────────────────────────────────────────
+  # No-UI plain-text route weather service. Tiny dependency-free Node image,
+  # rebuilds only when ctf/ops/route-weather/** changes.
+  build-route-weather:
+    name: Build ctf-route-weather
+    needs: changes
+    if: needs.changes.outputs.routeweather == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ctf-route-weather
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ctf/ops/route-weather
+          file: ctf/ops/route-weather/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ctf-route-weather
+          cache-to: type=gha,scope=ctf-route-weather,mode=max
+
+      - name: Trigger Render deploy
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_NAME: ctf-route-weather
+          # Optional explicit id; when unset the script finds it by name.
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CTF_ROUTE_WEATHER }}
         run: bash .github/scripts/render-deploy.sh

--- a/.github/workflows/route-weather-briefing.yml
+++ b/.github/workflows/route-weather-briefing.yml
@@ -11,8 +11,13 @@ name: Route weather briefing
 
 on:
   schedule:
-    # 11:00 UTC daily. Adjust to your departure time / time zone as you like.
-    - cron: '0 11 * * *'
+    # 10:00 UTC daily — early morning before a day's driving. GitHub cron is
+    # ALWAYS in UTC and does not shift for daylight saving, so set it for your
+    # home time zone. Rough guide (standard time):
+    #   5 AM Eastern  = 10:00 UTC   |  5 AM Central = 11:00 UTC
+    #   5 AM Mountain = 12:00 UTC   |  5 AM Pacific = 13:00 UTC
+    # (subtract 1 hour during daylight saving). Change the number below to suit.
+    - cron: '0 10 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/route-weather-briefing.yml
+++ b/.github/workflows/route-weather-briefing.yml
@@ -1,0 +1,44 @@
+name: Route weather briefing
+
+# Builds the plain-text route weather report for a fixed route and pushes it to
+# your phone via ntfy.sh. Free: runs on a GitHub Actions cron, no always-on
+# server. Configure the route under Settings → Secrets and variables → Actions:
+#   Variables: ROUTE_FROM (required), ROUTE_TO (required), ROUTE_VIA (optional,
+#              ';'-separated), ROUTE_DEPART (optional), ROUTE_MPH (optional)
+#   Secret:    NTFY_TOPIC (the ntfy.sh topic to publish to; keep it private)
+# If NTFY_TOPIC is unset the report is printed in the run log instead.
+# See ctf/ops/route-weather/README.md.
+
+on:
+  schedule:
+    # 11:00 UTC daily. Adjust to your departure time / time zone as you like.
+    - cron: '0 11 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  briefing:
+    name: Build and push briefing
+    runs-on: ubuntu-latest
+    # Skip the scheduled run if the route is not configured yet; manual runs
+    # still execute so you can test.
+    if: github.event_name == 'workflow_dispatch' || vars.ROUTE_FROM != ''
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build and push the briefing
+        working-directory: ctf/ops/route-weather
+        env:
+          ROUTE_FROM: ${{ vars.ROUTE_FROM }}
+          ROUTE_TO: ${{ vars.ROUTE_TO }}
+          ROUTE_VIA: ${{ vars.ROUTE_VIA }}
+          ROUTE_DEPART: ${{ vars.ROUTE_DEPART }}
+          ROUTE_MPH: ${{ vars.ROUTE_MPH }}
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+        run: node src/briefing.mjs

--- a/ctf/ops/README.md
+++ b/ctf/ops/README.md
@@ -35,3 +35,7 @@ docker-compose -f ops/docker-compose.yml down
 ## Rasa (AI Assistant NLU)
 
 `rasa/` — Rasa 3.x **NLU-only** project + `Dockerfile` for the `ctf-rasa` Render service. The NLU model is **trained at build time** (`rasa train nlu`) and baked into the image, so the container serves the stateless `POST /model/parse` endpoint with no runtime training. The comic backend (`lib/comic/rasa.ts`) calls it server-side at `http://ctf-rasa:5005` to attach a real intent + confidence to each `@comic` turn. Image rebuilds only when `ctf/ops/rasa/**` changes (path-filtered in `build-images.yml`). The action server and SQL tracker store are deferred. See `docs/developer/RASA.md` for the deploy runbook.
+
+## route-weather (personal / experimental)
+
+`route-weather/` — a no-UI, plain-text weather service for driving (`ctf-route-weather` Render web service). Give it a start and end place (and optional stops), or just a lat/lon, and it returns plain text — temperature, wind/gusts, conditions, and active hazard alerts, timed to your estimated arrival at each stop. Dependency-free ESM on Node's built-in `fetch`/`http`; keyless data sources (US → National Weather Service, elsewhere → Open-Meteo). **Not a plugin** — no DB, schema, or UI surface, and not in the plugin registry, so it skips the design-pass gate and plugin inventory. Image rebuilds only when `ctf/ops/route-weather/**` changes. A companion GitHub Actions cron (`route-weather-briefing.yml`) pushes a fixed-route briefing to your phone via ntfy.sh. See `route-weather/README.md`.

--- a/ctf/ops/route-weather/Dockerfile
+++ b/ctf/ops/route-weather/Dockerfile
@@ -1,0 +1,11 @@
+# Image for the ctf-route-weather Render service.
+# No build step and no dependencies — plain ESM on Node's built-in fetch/http.
+FROM node:20-alpine
+
+WORKDIR /app
+COPY package.json ./
+COPY src ./src
+
+# Render injects PORT at runtime; the server reads it (defaults to 3000 locally).
+EXPOSE 3000
+CMD ["node", "src/server.mjs"]

--- a/ctf/ops/route-weather/README.md
+++ b/ctf/ops/route-weather/README.md
@@ -1,0 +1,119 @@
+# route-weather (personal / experimental — not a community plugin)
+
+A no-UI, plain-text weather service for driving. You give it a start and end
+place (and optional stops along the way), or just your current location, and it
+replies with **plain text** — temperature, wind (with gusts), conditions, and any
+active hazard alerts — timed to roughly when you'll reach each stop. No HTML, no
+ads, no styling. Built to be read by eye at a stop, or spoken aloud by Siri while
+driving.
+
+This lives under `ctf/ops/` on purpose: it is a **standalone service, not a
+plugin**. It has no database, no schema, no UI surface, and is not in the plugin
+registry — so it does not go through the design-pass gate or the plugin feature
+inventory process. It reuses the repo's existing build-and-deploy pipeline
+(GitHub Actions builds a Docker image → GHCR → Render pulls it) and nothing else.
+
+## Two halves
+
+| Half | What it is | Where it runs | Cost |
+|---|---|---|---|
+| **On-demand** | An HTTP endpoint you call (e.g. from an Apple Shortcut) and get plain text back | `ctf-route-weather` web service on Render | one small instance |
+| **Scheduled briefing** | A daily/whenever push of a fixed route to your phone | a GitHub Actions cron → ntfy.sh notification | free |
+
+## Data sources (both keyless)
+
+- **US points → National Weather Service** (`api.weather.gov`): temperature, wind,
+  and active hazard alerts (high wind, winter storm, ice, blowing dust, etc.).
+- **Everywhere else → Open-Meteo** (`api.open-meteo.com`): temperature, wind, and
+  explicit wind **gusts**, worldwide. No hazard alerts outside the US.
+- Place names → Open-Meteo geocoding.
+
+**Honest limit on "road conditions":** weather APIs do not report road surface
+state (ice on the deck, closures, chain controls). What you get here is the
+*weather hazard* half — the part that tells you whether to roll — via NWS alerts
+plus wind/temp. True surface and closure data comes from each state's DOT 511
+feed; wiring those in is a later add, not in this first version.
+
+## The endpoint
+
+```
+GET /health
+GET /weather?lat=39.74&lon=-104.99
+GET /weather?from=Denver,CO&to=Salt Lake City,UT&via=Vail,CO&via=Grand Junction,CO&depart=06:00&mph=55
+```
+
+- `lat`+`lon` → current conditions plus the next three hours at that point.
+- `from`+`to` (plus any number of `via`) → one line per stop, each showing the
+  forecast for the estimated time you'll arrive. `depart` is `HH:MM` (read in the
+  origin's time zone) or a full timestamp; `mph` defaults to 55. Arrival times are
+  estimated from straight-line distance × 1.2, so treat them as approximate.
+
+Example reply:
+
+```
+ROUTE WX  Denver CO -> Salt Lake City UT
+
+NOW   Denver CO  34F  wind 12 W  clear
+10:30 Vail CO  21F  wind 28 NW  gust 41  light snow  [ALERT: Winter Weather Advisory]
+17:30 Salt Lake City UT  44F  wind 9 S  rain
+
+ALERTS:
+- Vail CO: Winter Weather Advisory
+
+(times in America/Denver; ETAs assume 55 mph)
+```
+
+### Access token
+
+If the environment variable `ROUTE_WEATHER_TOKEN` is set, every `/weather` call
+must send it, either as `Authorization: Bearer <token>` or `?token=<token>`.
+This stops strangers from running up the weather APIs through your endpoint. The
+token is never committed — set it as a Render service environment variable (via
+Infisical → Render Sync, same as every other secret in this repo). Generate one
+locally with `openssl rand -hex 16`.
+
+## Run it locally
+
+```sh
+cd ctf/ops/route-weather
+node src/server.mjs
+# then, in another terminal:
+curl "localhost:3000/weather?from=Denver,CO&to=Vail,CO&depart=06:00"
+```
+
+No `npm install` — there are no dependencies.
+
+## Deploy (uses the existing pipeline)
+
+1. Merge to `main`. `build-images.yml` builds `ghcr.io/chargingthefuture/ctf-route-weather:latest` and pushes it to GHCR (path-filtered: only rebuilds when `ctf/ops/route-weather/**` changes).
+2. **First time only:** make the new GHCR package public (org → Packages → `ctf-route-weather` → Package settings → visibility → Public), so Render can pull it without credentials.
+3. The `ctf-route-weather` service in `render.yaml` pulls the image. Set `ROUTE_WEATHER_TOKEN` on it in Infisical/Render.
+4. The endpoint is then at `https://ctf-route-weather.onrender.com/weather?...` (or whatever domain Render assigns).
+
+> A free/idle Render instance can cold-start (~30–60s) on the first request after
+> a quiet spell. If that lag bothers you while driving, run it on a small
+> always-on plan or add a keep-warm ping.
+
+## The scheduled briefing
+
+`.github/workflows/route-weather-briefing.yml` runs `src/briefing.mjs` on a cron.
+It builds the report for a fixed route (from repository **variables**) and pushes
+it to your phone via [ntfy.sh](https://ntfy.sh) (install the ntfy app, subscribe
+to your topic). Configure under the repo's Settings → Secrets and variables →
+Actions:
+
+- Variables: `ROUTE_FROM`, `ROUTE_TO`, `ROUTE_VIA` (optional, `;`-separated), `ROUTE_DEPART` (optional), `ROUTE_MPH` (optional).
+- Secret: `NTFY_TOPIC` (the topic name; treat it as private since anyone who knows it can read your pushes).
+
+If `NTFY_TOPIC` is absent the report is just printed in the Action log.
+
+## Apple Shortcut (voice, no app to install)
+
+1. **Get Current Location** (for the point report) — or skip for a fixed route.
+2. **Get Contents of URL** → your endpoint, e.g.
+   `https://ctf-route-weather.onrender.com/weather?lat=[Latitude]&lon=[Longitude]`,
+   method GET, with header `Authorization: Bearer <your token>`.
+3. **Get text from** the response.
+4. **Speak Text**.
+
+Name it "Road weather" and trigger it with "Hey Siri, road weather."

--- a/ctf/ops/route-weather/README.md
+++ b/ctf/ops/route-weather/README.md
@@ -45,22 +45,24 @@ GET /weather?from=Denver,CO&to=Salt Lake City,UT&via=Vail,CO&via=Grand Junction,
 - `lat`+`lon` → current conditions plus the next three hours at that point.
 - `from`+`to` (plus any number of `via`) → one line per stop, each showing the
   forecast for the estimated time you'll arrive. `depart` is `HH:MM` (read in the
-  origin's time zone) or a full timestamp; `mph` defaults to 55. Arrival times are
-  estimated from straight-line distance × 1.2, so treat them as approximate.
+  origin's time zone) or a full timestamp; `mph` defaults to 58 (a loaded truck's
+  effective rolling average). Arrival times are estimated from straight-line
+  distance × 1.25, so treat them as approximate — they only bucket each stop to
+  the nearest forecast hour.
 
-Example reply:
+The phrasing is written to be spoken cleanly by Siri (directions as words,
+"degrees", 12-hour times) while still reading fine by eye. Example reply:
 
 ```
-ROUTE WX  Denver CO -> Salt Lake City UT
+ROUTE WX. Denver Colorado to Salt Lake City Utah.
 
-NOW   Denver CO  34F  wind 12 W  clear
-10:30 Vail CO  21F  wind 28 NW  gust 41  light snow  [ALERT: Winter Weather Advisory]
-17:30 Salt Lake City UT  44F  wind 9 S  rain
+Now, Denver Colorado: 34 degrees, wind west 12, clear.
+10:36 AM, Vail Colorado: 21 degrees, wind northwest 28 gusting 41, light snow. ALERT: Winter Weather Advisory.
+5:10 PM, Salt Lake City Utah: 44 degrees, wind south 9, rain.
 
-ALERTS:
-- Vail CO: Winter Weather Advisory
+Alerts: Winter Weather Advisory at Vail Colorado.
 
-(times in America/Denver; ETAs assume 55 mph)
+(Times in America/Denver. ETAs assume 58 mph and are approximate.)
 ```
 
 ### Access token

--- a/ctf/ops/route-weather/package.json
+++ b/ctf/ops/route-weather/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ctf-route-weather",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "No-UI plain-text route weather service (personal/experimental).",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node src/server.mjs",
+    "briefing": "node src/briefing.mjs"
+  }
+}

--- a/ctf/ops/route-weather/src/briefing.mjs
+++ b/ctf/ops/route-weather/src/briefing.mjs
@@ -1,0 +1,59 @@
+// Scheduled briefing: builds the route report once and pushes it to your phone
+// as a plain-text notification, then exits. Meant to run from a GitHub Actions
+// cron (see .github/workflows/route-weather-briefing.yml), so there is no
+// always-on server cost for the scheduled half.
+//
+// Configuration (all via environment variables / GitHub secrets — never hardcode):
+//   ROUTE_FROM    required, e.g. "Denver, CO"
+//   ROUTE_TO      required, e.g. "Salt Lake City, UT"
+//   ROUTE_VIA     optional, semicolon-separated, e.g. "Vail, CO; Grand Junction, CO"
+//   ROUTE_DEPART  optional, "HH:MM" or ISO; defaults to now
+//   ROUTE_MPH     optional, defaults to 55
+//   NTFY_TOPIC    optional, an ntfy.sh topic name to publish to (ntfy.sh app)
+//   NTFY_URL      optional, full base URL of a self-hosted ntfy (default https://ntfy.sh)
+// If no NTFY_TOPIC is set the report is printed to stdout (visible in the Action log).
+
+import { buildRouteReport } from './report.mjs';
+
+async function main() {
+  const from = process.env.ROUTE_FROM;
+  const to = process.env.ROUTE_TO;
+  if (!from || !to) {
+    console.error('[briefing] ROUTE_FROM and ROUTE_TO are required.');
+    process.exit(1);
+  }
+  const via = (process.env.ROUTE_VIA || '')
+    .split(';')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const text = await buildRouteReport({
+    from,
+    to,
+    via,
+    depart: process.env.ROUTE_DEPART || undefined,
+    mph: process.env.ROUTE_MPH || undefined,
+  });
+
+  const topic = process.env.NTFY_TOPIC;
+  if (!topic) {
+    console.log(text);
+    return;
+  }
+  const base = (process.env.NTFY_URL || 'https://ntfy.sh').replace(/\/$/, '');
+  const res = await fetch(`${base}/${topic}`, {
+    method: 'POST',
+    headers: { Title: 'Route weather', 'Content-Type': 'text/plain; charset=utf-8' },
+    body: text,
+  });
+  if (!res.ok) {
+    console.error(`[briefing] push failed: HTTP ${res.status}`);
+    process.exit(1);
+  }
+  console.log('[briefing] pushed.');
+}
+
+main().catch((err) => {
+  console.error(`[briefing] ${err.message}`);
+  process.exit(1);
+});

--- a/ctf/ops/route-weather/src/providers.mjs
+++ b/ctf/ops/route-weather/src/providers.mjs
@@ -106,7 +106,10 @@ async function sampleNWS(lat, lon, etaEpoch) {
     provider: 'NWS',
     timeZone,
     tempF: round(p.temperatureUnit === 'F' ? p.temperature : p.temperature * 1.8 + 32),
-    wind: (p.windSpeed || '').replace(/ mph$/i, '') + (p.windDirection ? ` ${p.windDirection}` : ''),
+    // NWS gives windSpeed as text ("12 mph" or "10 to 15 mph") and a compass
+    // abbreviation; NWS hourly does not include a separate gust value.
+    windText: (p.windSpeed || '').replace(/ mph$/i, '').trim(),
+    windDir: p.windDirection || '',
     gust: '',
     condition: (p.shortForecast || '').toLowerCase(),
   };
@@ -134,12 +137,12 @@ async function sampleOpenMeteo(lat, lon, etaEpoch) {
   // hourly.time are local wall-clock strings; convert to true UTC epoch.
   const epochs = (h.time || []).map((t) => Date.parse(`${t}:00Z`) - offset);
   const i = nearestIndex(epochs, etaEpoch);
-  const dir = degToCompass(h.wind_direction_10m?.[i]);
   return {
     provider: 'Open-Meteo',
     timeZone: data.timezone || 'UTC',
     tempF: round(h.temperature_2m?.[i]),
-    wind: `${round(h.wind_speed_10m?.[i])}${dir ? ` ${dir}` : ''}`,
+    windText: h.wind_speed_10m?.[i] != null ? String(round(h.wind_speed_10m[i])) : '',
+    windDir: degToCompass(h.wind_direction_10m?.[i]),
     gust: h.wind_gusts_10m?.[i] != null ? String(round(h.wind_gusts_10m[i])) : '',
     condition: WMO[h.weather_code?.[i]] || '',
   };

--- a/ctf/ops/route-weather/src/providers.mjs
+++ b/ctf/ops/route-weather/src/providers.mjs
@@ -1,0 +1,160 @@
+// Weather + geocoding data sources for the route-weather service.
+//
+// Both sources are KEYLESS on purpose — this is a public open-source repo and a
+// keyless source is nothing to leak. US points use the National Weather Service
+// (api.weather.gov: temperature, wind, and active hazard alerts). Everywhere
+// else falls back to Open-Meteo (global, includes wind gusts). Place names are
+// turned into coordinates with Open-Meteo's free geocoding endpoint.
+
+const NWS_HEADERS = {
+  // NWS requires a User-Agent that identifies the caller.
+  'User-Agent': 'ctf-route-weather (https://github.com/chargingthefuture/chargingthefuture)',
+  Accept: 'application/geo+json',
+};
+
+const COMPASS = [
+  'N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE',
+  'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW',
+];
+
+// World Meteorological Organization weather codes → plain words (Open-Meteo).
+const WMO = {
+  0: 'clear', 1: 'mostly clear', 2: 'partly cloudy', 3: 'overcast',
+  45: 'fog', 48: 'freezing fog',
+  51: 'light drizzle', 53: 'drizzle', 55: 'heavy drizzle',
+  56: 'freezing drizzle', 57: 'freezing drizzle',
+  61: 'light rain', 63: 'rain', 65: 'heavy rain',
+  66: 'freezing rain', 67: 'freezing rain',
+  71: 'light snow', 73: 'snow', 75: 'heavy snow', 77: 'snow grains',
+  80: 'rain showers', 81: 'rain showers', 82: 'heavy rain showers',
+  85: 'snow showers', 86: 'heavy snow showers',
+  95: 'thunderstorm', 96: 'thunderstorm with hail', 99: 'thunderstorm with hail',
+};
+
+function degToCompass(deg) {
+  if (deg == null || Number.isNaN(deg)) return '';
+  return COMPASS[Math.round(deg / 22.5) % 16];
+}
+
+const round = (n) => (n == null || Number.isNaN(n) ? null : Math.round(n));
+
+// Rough continental-US bounding box. Good enough to pick NWS vs Open-Meteo when
+// we only have raw coordinates (point mode) and no country code.
+export function inUS(lat, lon) {
+  return lat >= 24 && lat <= 50 && lon >= -125 && lon <= -66;
+}
+
+async function getJson(url, headers) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`${url} → HTTP ${res.status}`);
+  return res.json();
+}
+
+// "Denver, CO" → { name, lat, lon, region, countryCode, timeZone }
+export async function geocode(query) {
+  const [namePart, regionPart] = query.split(',').map((s) => s.trim());
+  const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(namePart)}&count=10&language=en&format=json`;
+  const data = await getJson(url);
+  const results = data.results || [];
+  if (results.length === 0) throw new Error(`could not find a place named "${query}"`);
+  // If the caller gave a region hint after the comma, prefer a matching result.
+  let pick = results[0];
+  if (regionPart) {
+    const hint = regionPart.toUpperCase();
+    const match = results.find(
+      (r) =>
+        (r.admin1 && r.admin1.toUpperCase().includes(hint)) ||
+        (r.admin1_id && String(r.admin1_id) === hint) ||
+        (r.country_code && r.country_code.toUpperCase() === hint),
+    );
+    if (match) pick = match;
+  }
+  return {
+    name: pick.name,
+    lat: pick.latitude,
+    lon: pick.longitude,
+    region: pick.admin1 || pick.country_code || '',
+    countryCode: (pick.country_code || '').toUpperCase(),
+    timeZone: pick.timezone || 'UTC',
+  };
+}
+
+// Pick the forecast entry closest to a target time.
+function nearestIndex(epochs, targetEpoch) {
+  let best = 0;
+  let bestDiff = Infinity;
+  for (let i = 0; i < epochs.length; i += 1) {
+    const diff = Math.abs(epochs[i] - targetEpoch);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = i;
+    }
+  }
+  return best;
+}
+
+async function sampleNWS(lat, lon, etaEpoch) {
+  const point = await getJson(`https://api.weather.gov/points/${lat},${lon}`, NWS_HEADERS);
+  const hourlyUrl = point.properties?.forecastHourly;
+  const timeZone = point.properties?.timeZone || 'UTC';
+  if (!hourlyUrl) throw new Error('NWS returned no hourly forecast for this point');
+  const hourly = await getJson(hourlyUrl, NWS_HEADERS);
+  const periods = hourly.properties?.periods || [];
+  const epochs = periods.map((p) => Date.parse(p.startTime));
+  const p = periods[nearestIndex(epochs, etaEpoch)];
+  return {
+    provider: 'NWS',
+    timeZone,
+    tempF: round(p.temperatureUnit === 'F' ? p.temperature : p.temperature * 1.8 + 32),
+    wind: (p.windSpeed || '').replace(/ mph$/i, '') + (p.windDirection ? ` ${p.windDirection}` : ''),
+    gust: '',
+    condition: (p.shortForecast || '').toLowerCase(),
+  };
+}
+
+export async function fetchUSAlerts(lat, lon) {
+  try {
+    const data = await getJson(`https://api.weather.gov/alerts/active?point=${lat},${lon}`, NWS_HEADERS);
+    return (data.features || [])
+      .map((f) => f.properties?.event)
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function sampleOpenMeteo(lat, lon, etaEpoch) {
+  const url =
+    `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +
+    '&hourly=temperature_2m,wind_speed_10m,wind_gusts_10m,wind_direction_10m,weather_code' +
+    '&temperature_unit=fahrenheit&wind_speed_unit=mph&timezone=auto&forecast_days=3';
+  const data = await getJson(url);
+  const h = data.hourly || {};
+  const offset = (data.utc_offset_seconds || 0) * 1000;
+  // hourly.time are local wall-clock strings; convert to true UTC epoch.
+  const epochs = (h.time || []).map((t) => Date.parse(`${t}:00Z`) - offset);
+  const i = nearestIndex(epochs, etaEpoch);
+  const dir = degToCompass(h.wind_direction_10m?.[i]);
+  return {
+    provider: 'Open-Meteo',
+    timeZone: data.timezone || 'UTC',
+    tempF: round(h.temperature_2m?.[i]),
+    wind: `${round(h.wind_speed_10m?.[i])}${dir ? ` ${dir}` : ''}`,
+    gust: h.wind_gusts_10m?.[i] != null ? String(round(h.wind_gusts_10m[i])) : '',
+    condition: WMO[h.weather_code?.[i]] || '',
+  };
+}
+
+// Choose the right source for a point and return a normalized sample.
+export async function sampleAt({ lat, lon, countryCode }, etaEpoch) {
+  const useNWS = countryCode ? countryCode === 'US' : inUS(lat, lon);
+  if (useNWS) {
+    try {
+      return await sampleNWS(lat, lon, etaEpoch);
+    } catch {
+      // Fall back to the global source if NWS is unavailable for this point.
+      return sampleOpenMeteo(lat, lon, etaEpoch);
+    }
+  }
+  return sampleOpenMeteo(lat, lon, etaEpoch);
+}

--- a/ctf/ops/route-weather/src/report.mjs
+++ b/ctf/ops/route-weather/src/report.mjs
@@ -1,0 +1,135 @@
+// Turns a route (named waypoints) or a single point into plain text a person
+// can read at a glance or have Siri read aloud. No HTML, no styling — just text.
+
+import { geocode, sampleAt, fetchUSAlerts, inUS } from './providers.mjs';
+
+const ROAD_FACTOR = 1.2; // straight-line miles → rough driving miles
+const DEFAULT_MPH = 55;
+
+// Great-circle distance in miles.
+function haversineMiles(a, b) {
+  const toRad = (d) => (d * Math.PI) / 180;
+  const R = 3958.8;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+// Timezone offset like "-06:00" for a given IANA zone at a given moment.
+function tzOffset(timeZone, date) {
+  const parts = new Intl.DateTimeFormat('en-US', { timeZone, timeZoneName: 'longOffset' }).formatToParts(date);
+  const name = parts.find((p) => p.type === 'timeZoneName')?.value || 'GMT+00:00';
+  const m = name.match(/GMT([+-]\d{2}:\d{2})/);
+  return m ? m[1] : '+00:00';
+}
+
+// "YYYY-MM-DD" for a given zone.
+function ymdInTz(timeZone, date) {
+  const p = new Intl.DateTimeFormat('en-CA', {
+    timeZone, year: 'numeric', month: '2-digit', day: '2-digit',
+  }).formatToParts(date);
+  const get = (t) => p.find((x) => x.type === t)?.value;
+  return `${get('year')}-${get('month')}-${get('day')}`;
+}
+
+function clockInTz(timeZone, epoch) {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone, hour: '2-digit', minute: '2-digit', hour12: false,
+  }).format(new Date(epoch));
+}
+
+// Resolve the departure moment (epoch ms). Accepts "HH:MM" (read in the origin's
+// zone, rolled to tomorrow if already well past), a full ISO timestamp, or none.
+function resolveDepart(depart, originTz) {
+  const now = Date.now();
+  if (!depart) return now;
+  if (/^\d{1,2}:\d{2}$/.test(depart)) {
+    const ymd = ymdInTz(originTz, new Date(now));
+    const off = tzOffset(originTz, new Date(now));
+    let epoch = Date.parse(`${ymd}T${depart.padStart(5, '0')}:00${off}`);
+    if (epoch < now - 60 * 60 * 1000) epoch += 24 * 60 * 60 * 1000;
+    return epoch;
+  }
+  const parsed = Date.parse(depart);
+  return Number.isNaN(parsed) ? now : parsed;
+}
+
+function fmtSample(s) {
+  const bits = [`${s.tempF == null ? '?' : s.tempF}F`];
+  if (s.wind) bits.push(`wind ${s.wind}`);
+  if (s.gust) bits.push(`gust ${s.gust}`);
+  if (s.condition) bits.push(s.condition);
+  return bits.join('  ');
+}
+
+// Build the multi-stop route report from origin, optional waypoints, destination.
+export async function buildRouteReport({ from, to, via = [], depart, mph }) {
+  if (!from || !to) throw new Error('need both a "from" and a "to" place');
+  const speed = Number(mph) > 0 ? Number(mph) : DEFAULT_MPH;
+  const names = [from, ...via.filter(Boolean), to];
+  const places = [];
+  for (const n of names) {
+    // Sequential: a few geocodes, keeps it simple and within rate limits.
+    // eslint-disable-next-line no-await-in-loop
+    places.push(await geocode(n));
+  }
+
+  const originTz = places[0].timeZone;
+  const departEpoch = resolveDepart(depart, originTz);
+
+  // Cumulative driving time → an estimated arrival epoch per stop.
+  let miles = 0;
+  const etas = [departEpoch];
+  for (let i = 1; i < places.length; i += 1) {
+    miles += haversineMiles(places[i - 1], places[i]) * ROAD_FACTOR;
+    etas.push(departEpoch + (miles / speed) * 3600 * 1000);
+  }
+
+  const rows = await Promise.all(
+    places.map(async (p, i) => {
+      const sample = await sampleAt(p, etas[i]);
+      const alerts = p.countryCode === 'US' || inUS(p.lat, p.lon) ? await fetchUSAlerts(p.lat, p.lon) : [];
+      return { place: p, eta: etas[i], sample, alerts };
+    }),
+  );
+
+  const head = `ROUTE WX  ${places[0].name} ${places[0].region} -> ${places[places.length - 1].name} ${places[places.length - 1].region}`;
+  const lines = [head, ''];
+  rows.forEach((r, i) => {
+    const when = i === 0 && Math.abs(r.eta - Date.now()) < 30 * 60 * 1000
+      ? 'NOW  '
+      : clockInTz(originTz, r.eta);
+    const tag = r.alerts.length ? `  [ALERT: ${r.alerts[0]}]` : '';
+    lines.push(`${when} ${r.place.name} ${r.place.region}  ${fmtSample(r.sample)}${tag}`);
+  });
+
+  const allAlerts = rows.flatMap((r) => r.alerts.map((a) => `- ${r.place.name} ${r.place.region}: ${a}`));
+  if (allAlerts.length) {
+    lines.push('', 'ALERTS:', ...[...new Set(allAlerts)]);
+  }
+  lines.push('', `(times in ${originTz}; ETAs assume ${speed} mph)`);
+  return lines.join('\n');
+}
+
+// Build the single-point report (current conditions + the next few hours).
+export async function buildPointReport({ lat, lon }) {
+  const point = { lat: Number(lat), lon: Number(lon) };
+  if (Number.isNaN(point.lat) || Number.isNaN(point.lon)) throw new Error('need numeric lat and lon');
+  const now = Date.now();
+  const hours = [0, 1, 2, 3];
+  const samples = await Promise.all(hours.map((h) => sampleAt(point, now + h * 3600 * 1000)));
+  const alerts = inUS(point.lat, point.lon) ? await fetchUSAlerts(point.lat, point.lon) : [];
+  const tz = samples[0].timeZone;
+  const lines = [`HERE WX  ${point.lat.toFixed(3)}, ${point.lon.toFixed(3)}`, ''];
+  samples.forEach((s, i) => {
+    const label = i === 0 ? 'NOW  ' : clockInTz(tz, now + hours[i] * 3600 * 1000);
+    lines.push(`${label} ${fmtSample(s)}`);
+  });
+  if (alerts.length) lines.push('', 'ALERTS:', ...[...new Set(alerts)].map((a) => `- ${a}`));
+  lines.push('', `(times in ${tz})`);
+  return lines.join('\n');
+}

--- a/ctf/ops/route-weather/src/report.mjs
+++ b/ctf/ops/route-weather/src/report.mjs
@@ -1,10 +1,24 @@
 // Turns a route (named waypoints) or a single point into plain text a person
 // can read at a glance or have Siri read aloud. No HTML, no styling — just text.
+// Phrasing is written to be spoken cleanly: directions are words ("northwest"),
+// temperatures say "degrees", and times are 12-hour, so Siri reads it naturally.
 
 import { geocode, sampleAt, fetchUSAlerts, inUS } from './providers.mjs';
 
-const ROAD_FACTOR = 1.2; // straight-line miles → rough driving miles
-const DEFAULT_MPH = 55;
+// Straight-line miles → rough driving miles. Highway routing is typically
+// 1.2–1.3× the great-circle distance once roads bend around terrain.
+const ROAD_FACTOR = 1.25;
+// Effective rolling average for a loaded truck over a long haul (governed cruise
+// minus grades and slower state limits). Only used to bucket each stop to the
+// nearest forecast hour, so approximate is fine. Override per request with `mph`.
+const DEFAULT_MPH = 58;
+
+const COMPASS_WORDS = {
+  N: 'north', NNE: 'north-northeast', NE: 'northeast', ENE: 'east-northeast',
+  E: 'east', ESE: 'east-southeast', SE: 'southeast', SSE: 'south-southeast',
+  S: 'south', SSW: 'south-southwest', SW: 'southwest', WSW: 'west-southwest',
+  W: 'west', WNW: 'west-northwest', NW: 'northwest', NNW: 'north-northwest',
+};
 
 // Great-circle distance in miles.
 function haversineMiles(a, b) {
@@ -36,9 +50,10 @@ function ymdInTz(timeZone, date) {
   return `${get('year')}-${get('month')}-${get('day')}`;
 }
 
+// 12-hour clock, e.g. "6:00 AM" — reads better aloud than "06:00".
 function clockInTz(timeZone, epoch) {
   return new Intl.DateTimeFormat('en-US', {
-    timeZone, hour: '2-digit', minute: '2-digit', hour12: false,
+    timeZone, hour: 'numeric', minute: '2-digit', hour12: true,
   }).format(new Date(epoch));
 }
 
@@ -58,12 +73,22 @@ function resolveDepart(depart, originTz) {
   return Number.isNaN(parsed) ? now : parsed;
 }
 
+function windPhrase(s) {
+  if (!s.windText && !s.windDir) return '';
+  const dir = s.windDir ? (COMPASS_WORDS[s.windDir] || s.windDir.toLowerCase()) : '';
+  let phrase = 'wind';
+  if (dir) phrase += ` ${dir}`;
+  if (s.windText) phrase += ` ${s.windText}`;
+  if (s.gust) phrase += ` gusting ${s.gust}`;
+  return phrase;
+}
+
 function fmtSample(s) {
-  const bits = [`${s.tempF == null ? '?' : s.tempF}F`];
-  if (s.wind) bits.push(`wind ${s.wind}`);
-  if (s.gust) bits.push(`gust ${s.gust}`);
-  if (s.condition) bits.push(s.condition);
-  return bits.join('  ');
+  const parts = [`${s.tempF == null ? 'temperature unavailable' : `${s.tempF} degrees`}`];
+  const wind = windPhrase(s);
+  if (wind) parts.push(wind);
+  if (s.condition) parts.push(s.condition);
+  return parts.join(', ');
 }
 
 // Build the multi-stop route report from origin, optional waypoints, destination.
@@ -74,7 +99,6 @@ export async function buildRouteReport({ from, to, via = [], depart, mph }) {
   const places = [];
   for (const n of names) {
     // Sequential: a few geocodes, keeps it simple and within rate limits.
-    // eslint-disable-next-line no-await-in-loop
     places.push(await geocode(n));
   }
 
@@ -97,21 +121,22 @@ export async function buildRouteReport({ from, to, via = [], depart, mph }) {
     }),
   );
 
-  const head = `ROUTE WX  ${places[0].name} ${places[0].region} -> ${places[places.length - 1].name} ${places[places.length - 1].region}`;
-  const lines = [head, ''];
+  const first = places[0];
+  const last = places[places.length - 1];
+  const lines = [`ROUTE WX. ${first.name} ${first.region} to ${last.name} ${last.region}.`, ''];
   rows.forEach((r, i) => {
     const when = i === 0 && Math.abs(r.eta - Date.now()) < 30 * 60 * 1000
-      ? 'NOW  '
+      ? 'Now'
       : clockInTz(originTz, r.eta);
-    const tag = r.alerts.length ? `  [ALERT: ${r.alerts[0]}]` : '';
-    lines.push(`${when} ${r.place.name} ${r.place.region}  ${fmtSample(r.sample)}${tag}`);
+    const tag = r.alerts.length ? ` ALERT: ${r.alerts[0]}.` : '';
+    lines.push(`${when}, ${r.place.name} ${r.place.region}: ${fmtSample(r.sample)}.${tag}`);
   });
 
-  const allAlerts = rows.flatMap((r) => r.alerts.map((a) => `- ${r.place.name} ${r.place.region}: ${a}`));
-  if (allAlerts.length) {
-    lines.push('', 'ALERTS:', ...[...new Set(allAlerts)]);
-  }
-  lines.push('', `(times in ${originTz}; ETAs assume ${speed} mph)`);
+  const allAlerts = [...new Set(
+    rows.flatMap((r) => r.alerts.map((a) => `${a} at ${r.place.name} ${r.place.region}`)),
+  )];
+  if (allAlerts.length) lines.push('', `Alerts: ${allAlerts.join('; ')}.`);
+  lines.push('', `(Times in ${originTz}. ETAs assume ${speed} mph and are approximate.)`);
   return lines.join('\n');
 }
 
@@ -124,12 +149,12 @@ export async function buildPointReport({ lat, lon }) {
   const samples = await Promise.all(hours.map((h) => sampleAt(point, now + h * 3600 * 1000)));
   const alerts = inUS(point.lat, point.lon) ? await fetchUSAlerts(point.lat, point.lon) : [];
   const tz = samples[0].timeZone;
-  const lines = [`HERE WX  ${point.lat.toFixed(3)}, ${point.lon.toFixed(3)}`, ''];
+  const lines = [`HERE WX. ${point.lat.toFixed(3)}, ${point.lon.toFixed(3)}.`, ''];
   samples.forEach((s, i) => {
-    const label = i === 0 ? 'NOW  ' : clockInTz(tz, now + hours[i] * 3600 * 1000);
-    lines.push(`${label} ${fmtSample(s)}`);
+    const label = i === 0 ? 'Now' : clockInTz(tz, now + hours[i] * 3600 * 1000);
+    lines.push(`${label}: ${fmtSample(s)}.`);
   });
-  if (alerts.length) lines.push('', 'ALERTS:', ...[...new Set(alerts)].map((a) => `- ${a}`));
-  lines.push('', `(times in ${tz})`);
+  if (alerts.length) lines.push('', `Alerts: ${[...new Set(alerts)].join('; ')}.`);
+  lines.push('', `(Times in ${tz}.)`);
   return lines.join('\n');
 }

--- a/ctf/ops/route-weather/src/server.mjs
+++ b/ctf/ops/route-weather/src/server.mjs
@@ -1,0 +1,67 @@
+// Tiny no-UI HTTP server. Returns text/plain weather for a route or a point so an
+// Apple Shortcut (or curl, or anything) can read it and Siri can speak it.
+//
+//   GET /health                                  → "ok"
+//   GET /weather?lat=39.7&lon=-104.9             → current + next 3h at a point
+//   GET /weather?from=Denver,CO&to=Vail,CO       → multi-stop route, ETA-aligned
+//        &via=Frisco,CO&depart=06:00&mph=55
+//
+// If ROUTE_WEATHER_TOKEN is set, every /weather request must send it as either
+// `Authorization: Bearer <token>` or `?token=<token>`. This keeps strangers from
+// running up the (free) weather APIs on your behalf. The token never appears in
+// any committed file — set it as a Render/Infisical environment variable.
+
+import http from 'node:http';
+import { buildRouteReport, buildPointReport } from './report.mjs';
+
+const PORT = Number(process.env.PORT) || 3000;
+const TOKEN = process.env.ROUTE_WEATHER_TOKEN || '';
+
+if (!TOKEN) {
+  console.warn('[route-weather] ROUTE_WEATHER_TOKEN is not set — /weather is OPEN to anyone.');
+}
+
+function authorized(req, url) {
+  if (!TOKEN) return true;
+  const header = req.headers.authorization || '';
+  const bearer = header.replace(/^Bearer\s+/i, '');
+  return bearer === TOKEN || url.searchParams.get('token') === TOKEN;
+}
+
+function sendText(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end(body.endsWith('\n') ? body : `${body}\n`);
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname === '/health') return sendText(res, 200, 'ok');
+  if (url.pathname !== '/weather') return sendText(res, 404, 'not found');
+  if (!authorized(req, url)) return sendText(res, 401, 'unauthorized');
+
+  try {
+    const q = url.searchParams;
+    let text;
+    if (q.has('lat') && q.has('lon')) {
+      text = await buildPointReport({ lat: q.get('lat'), lon: q.get('lon') });
+    } else if (q.has('from') && q.has('to')) {
+      text = await buildRouteReport({
+        from: q.get('from'),
+        to: q.get('to'),
+        via: q.getAll('via'),
+        depart: q.get('depart') || undefined,
+        mph: q.get('mph') || undefined,
+      });
+    } else {
+      return sendText(res, 400, 'give either lat+lon, or from+to (with optional via, depart, mph)');
+    }
+    return sendText(res, 200, text);
+  } catch (err) {
+    return sendText(res, 502, `could not build the report: ${err.message}`);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`[route-weather] listening on :${PORT}`);
+});

--- a/render.yaml
+++ b/render.yaml
@@ -84,6 +84,31 @@ services:
       # value is re-baked. Syncing a `NEXT_PUBLIC_*` value into Render at runtime
       # is a no-op for the client; do not rely on it.
 
+  # ── route-weather (personal, no-UI plain-text weather) ───────────
+  # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-route-weather:latest
+  # Standalone service (NOT a plugin): no DB, no schema, no UI surface, not in the
+  # plugin registry. Returns text/plain weather for a route or a point so an Apple
+  # Shortcut / Siri can read it. See ctf/ops/route-weather/README.md.
+  # First deploy: make the new GHCR package public so Render can pull it.
+  - type: web
+    name: ctf-route-weather
+    runtime: image
+    image:
+      url: ghcr.io/chargingthefuture/ctf-route-weather:latest
+    region: ohio
+    # Cheapest tier is plenty — dependency-free Node, no DB. Starter avoids the
+    # free-tier spin-down so the endpoint answers quickly when asked while driving.
+    plan: starter
+    healthCheckPath: /health
+    envVars:
+      # PORT is injected by Render and read by the server. Do NOT hardcode it.
+      - key: NODE_ENV
+        value: production
+      # Shared access token — set in Render/Infisical, never committed. When set,
+      # every /weather call must present it. Generate with: openssl rand -hex 16
+      - key: ROUTE_WEATHER_TOKEN
+        sync: false
+
   # ── Ollama ────────────────────────────────────────────────────────
   # Image built by build-images.yml → ghcr.io/chargingthefuture/ctf-ollama:latest
   # Private service — reachable by other Render services via internal URL.


### PR DESCRIPTION
## What

A standalone, no-UI service under `ctf/ops/route-weather/` that returns **plain-text** weather for a driving route or a single point — temperature, wind (with gusts), conditions, and active hazard alerts, timed to your estimated arrival at each stop. Built to be read by eye at a stop, or spoken aloud by Siri (via an Apple Shortcut) while driving. No HTML, no styling, no ads.

This is **not a plugin**: no database, no schema, no UI surface, and it is not in the plugin registry. It reuses only the existing build-and-deploy pipeline (GitHub Actions builds a Docker image → GHCR → Render pulls it). Server-only with no rendered surface, so the design-pass gate (rule 127) and the plugin feature inventory process do not apply.

## Pieces

- `src/providers.mjs` — keyless data sources: US points → National Weather Service (temp, wind, hazard alerts); elsewhere → Open-Meteo (temp, wind + gusts). Place names → Open-Meteo geocoding.
- `src/report.mjs` — named-waypoint routing with estimated arrival times, timezone-aware 12-hour clock, and Siri-friendly phrasing (compass directions as words, "degrees", "gusting").
- `src/server.mjs` — tiny `text/plain` HTTP endpoint (`/weather`, `/health`) with an optional bearer-token gate (`ROUTE_WEATHER_TOKEN`, never committed).
- `src/briefing.mjs` — scheduled briefing that pushes a fixed route to a phone via ntfy.sh.
- `Dockerfile` + `package.json` — dependency-free Node 20 image, no build step.
- `build-images.yml` — path-filtered build/push of `ctf-route-weather` to GHCR.
- `render.yaml` — `ctf-route-weather` web service pulling the image (Starter tier to avoid free-tier cold starts).
- `route-weather-briefing.yml` — GitHub Actions cron for the briefing.

## CI note

This service lives outside the pnpm workspace and is plain `.mjs`, so the app's lint / typecheck / build / modularity gates do not scan it. CI runs and tests the app, not this service.

## Known limit

Weather APIs cover the weather-hazard half of "road conditions" (wind, temp, NWS alerts). True road surface/closure data (state DOT 511 feeds) is a documented later add.

## Deploy steps (manual, around merge)

1. Merge → `build-images.yml` builds & pushes the image.
2. One-time: make the new GHCR package public so Render can pull it.
3. Set `ROUTE_WEATHER_TOKEN` on the Render service.
4. For the briefing: set repo variables `ROUTE_FROM`/`ROUTE_TO` (+ optional) and secret `NTFY_TOPIC`.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm