### PR TITLE
feat: add optional 511.org Bay Area road-event fallback to route weather

### DIFF
--- a/ctf/ops/route-weather/README.md
+++ b/ctf/ops/route-weather/README.md
@@ -62,6 +62,13 @@ in a "Road conditions" line. NWS weather *alerts* already cover the go/no-go
 weather hazards with no setup — the feeds add literal closures/incidents on top.
 Tell me which states you drive and I can wire verified feeds for you.
 
+There is also an optional **511.org (San Francisco Bay Area)** source — a
+regional, token-based fallback covering Bay Area roads only. Set
+`SF_BAY_511_TOKEN` to your token from <https://511.org/open-data/token>. Like the
+state feeds it is entirely best-effort: with no token, or if 511.org is down or
+rate-limited, it simply contributes nothing and the rest of the report is
+unaffected. The feature never depends on it.
+
 ## The endpoint
 
 ```

--- a/ctf/ops/route-weather/src/roadconditions.mjs
+++ b/ctf/ops/route-weather/src/roadconditions.mjs
@@ -1,21 +1,27 @@
-// Optional, keyless road-condition events from open state DOT ("511") feeds.
+// Optional road-condition events for the verdict. Two sources, both opt-in and
+// both entirely best-effort — the report NEVER depends on either, and any
+// failure (missing config, downtime, rate limit, unexpected shape) just returns
+// nothing for that source.
 //
-// There is no single nationwide keyless 511 API — feeds are per-state, in
-// different shapes, and many require a key — so nothing is hardcoded here. You
-// opt in by setting one environment variable per state whose value is an OPEN
-// GeoJSON road-event feed URL:
+// 1) Open state DOT ("511") GeoJSON feeds. There is no single nationwide keyless
+//    511 API — feeds are per-state and differ — so nothing is hardcoded. Set one
+//    env var per state whose value is an OPEN GeoJSON road-event feed URL:
+//      ROAD_FEED_CO=https://…        ROAD_FEED_WY=https://…
 //
-//   ROAD_FEED_CO=https://…        ROAD_FEED_WY=https://…
+// 2) 511.org (San Francisco Bay Area) Open Data traffic events — a regional,
+//    token-based fallback covering Bay Area roads only. Set SF_BAY_511_TOKEN to
+//    your 511.org token (https://511.org/open-data/token). Leave it unset to skip.
 //
-// Every configured feed is queried and only events within ROAD_EVENT_RADIUS_MILES
-// of the point are kept, so a point in one state naturally only matches that
-// state's feed. With no ROAD_FEED_* set, this returns nothing and changes nothing.
+// Only events within ROAD_EVENT_RADIUS_MILES of a stop are kept, so a stop in one
+// area only matches the source that covers it.
 
 const RADIUS_MILES = Number(process.env.ROAD_EVENT_RADIUS_MILES) || 25;
 
-// Cached per process; the Render container is short-lived and the feeds change
-// slowly, so a simple memo avoids refetching the same feed for each waypoint.
+// Cached per process; the Render container is short-lived and feeds change
+// slowly, so a simple memo avoids refetching for each waypoint (and keeps the
+// 511.org call well under its hourly rate limit).
 const feedCache = new Map();
+let sfBay511Cache;
 
 function feedUrls() {
   return Object.entries(process.env)
@@ -69,8 +75,12 @@ function headlineOf(props = {}) {
   return 'road event';
 }
 
-// Return short road-event labels within range of the point, across all feeds.
-export async function fetchRoadEvents(lat, lon) {
+function clean(label) {
+  return label.replace(/\s+/g, ' ').trim().slice(0, 120);
+}
+
+// Events from the configured open GeoJSON state feeds.
+async function fetchFeedEvents(lat, lon) {
   const urls = feedUrls();
   if (!urls.length) return [];
   const out = [];
@@ -87,12 +97,51 @@ export async function fetchRoadEvents(lat, lon) {
       for (const f of features) {
         const c = centroid(f.geometry);
         if (c && milesBetween(lat, lon, c.lat, c.lon) <= RADIUS_MILES) {
-          out.push(headlineOf(f.properties).replace(/\s+/g, ' ').trim().slice(0, 120));
+          out.push(clean(headlineOf(f.properties)));
         }
       }
     } catch {
       // A single bad/unreachable feed must not break the whole report.
     }
   }
-  return [...new Set(out)];
+  return out;
+}
+
+// Events from 511.org (SF Bay Area). Optional, token-based, best-effort: returns
+// nothing if the token is unset or anything goes wrong. Each event carries a
+// GeoJSON `geography` geometry and a `headline`.
+async function fetchSfBay511(lat, lon) {
+  const token = process.env.SF_BAY_511_TOKEN;
+  if (!token) return [];
+  try {
+    if (!sfBay511Cache) {
+      const res = await fetch(
+        `https://api.511.org/traffic/events?api_key=${encodeURIComponent(token)}&format=json`,
+        { headers: { Accept: 'application/json' } },
+      );
+      if (!res.ok) return [];
+      const data = await res.json();
+      sfBay511Cache = Array.isArray(data?.events) ? data.events : (Array.isArray(data) ? data : []);
+    }
+    const out = [];
+    for (const e of sfBay511Cache) {
+      const c = centroid(e.geography || e.geometry);
+      if (c && milesBetween(lat, lon, c.lat, c.lon) <= RADIUS_MILES) {
+        out.push(clean(headlineOf(e)));
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+// Return short road-event labels within range of the point, across every
+// configured source. Sources are queried in parallel and merged.
+export async function fetchRoadEvents(lat, lon) {
+  const [feeds, sfBay] = await Promise.all([
+    fetchFeedEvents(lat, lon),
+    fetchSfBay511(lat, lon),
+  ]);
+  return [...new Set([...feeds, ...sfBay])];
 }


### PR DESCRIPTION
## What

Adds an optional, regional road-event source to `ctf/ops/route-weather`: **511.org (San Francisco Bay Area)** traffic events, behind `SF_BAY_511_TOKEN`.

It sits alongside the open GeoJSON state feeds and is **entirely best-effort** — exactly as requested, the feature never depends on it. With no token set, or if 511.org is down, rate-limited, or returns an unexpected shape, it contributes nothing and the rest of the report is unaffected. Events are fetched once per process (under the hourly rate limit), distance-filtered, and folded into the verdict like the state feeds (closure → HOLD, otherwise CAUTION).

Bay Area only — it won't help outside that region, which is why it's a fallback, not a dependency.

## Not a plugin, no UI

Standalone server-only service under `ctf/ops/`; design gate and plugin inventory don't apply. Outside the pnpm workspace and plain `.mjs`, so the app gates don't scan it.

## Tested

Offline with a stubbed 511.org response: a nearby Bay Area incident folds in and a farther one is distance-filtered out; with no token the source returns nothing. EOF check passes.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm)_