### PR TITLE
fix: only let road-relevant alerts change the driving verdict

### DIFF
--- a/ctf/ops/route-weather/src/hazard.mjs
+++ b/ctf/ops/route-weather/src/hazard.mjs
@@ -24,6 +24,21 @@ function maxNumber(str) {
   return found ? Math.max(...found.map(Number)) : null;
 }
 
+// Classify an NWS alert by how it affects DRIVING. Many real alerts have nothing
+// to do with whether the road is drivable — Red Flag / fire weather, heat, air
+// quality, frost/freeze (agricultural), wind chill, marine/beach — so they must
+// not force a HOLD. Road hazards (snow, ice, high wind, fog, dust, flooding,
+// tornado, etc.) do: a Warning → HOLD, an Advisory/Watch → CAUTION.
+export function classifyAlert(event) {
+  const e = String(event).toLowerCase();
+  if (/(red flag|fire weather|heat|air quality|smoke|frost|freeze|wind chill|small craft|rip current|beach|stagnation|special weather statement|hydrologic|ashfall)/.test(e)) {
+    return 'none';
+  }
+  const road = /(snow|blizzard|ice|sleet|freezing|winter|wind|dust|fog|flood|tornado|thunderstorm|hurricane|tropical|squall|avalanche|storm)/.test(e);
+  if (!road) return 'none';
+  return /warning|emergency/.test(e) ? 'HOLD' : 'CAUTION';
+}
+
 // Assess one sample against active alert names and nearby road events. Returns
 // the level and the short reasons that drove it (already worded for speaking).
 export function assessHazard(sample, alerts = [], roadEvents = []) {
@@ -55,8 +70,8 @@ export function assessHazard(sample, alerts = [], roadEvents = []) {
   if (hasFog) bump('CAUTION', 'fog');
 
   for (const event of alerts) {
-    if (/warning/i.test(event)) bump('HOLD', event);
-    else if (/(advisory|watch)/i.test(event)) bump('CAUTION', event);
+    const level = classifyAlert(event);
+    if (level !== 'none') bump(level, event);
   }
 
   // A reported road closure is a hard HOLD; any other reported road event is at

--- a/ctf/ops/route-weather/src/report.mjs
+++ b/ctf/ops/route-weather/src/report.mjs
@@ -6,7 +6,7 @@
 // (set a response header, or only push an alert when it is not DRIVE).
 
 import { geocode, sampleAt, fetchUSAlerts, inUS } from './providers.mjs';
-import { assessHazard, worst } from './hazard.mjs';
+import { assessHazard, worst, classifyAlert } from './hazard.mjs';
 import { fetchRoadEvents } from './roadconditions.mjs';
 
 // Straight-line miles → rough driving miles. Highway routing is typically
@@ -169,10 +169,15 @@ export async function buildRouteReport({ from, to, via = [], depart, mph }) {
     lines.push(`${when}, ${r.place.name} ${r.place.region}: ${fmtSample(r.sample)}. ${verdictTag(r.hz)}`);
   });
 
-  const allAlerts = [...new Set(
-    rows.flatMap((r) => r.alerts.map((a) => `${a} at ${r.place.name} ${r.place.region}`)),
+  const label = (r, a) => `${a} at ${r.place.name} ${r.place.region}`;
+  const drivingAlerts = [...new Set(
+    rows.flatMap((r) => r.alerts.filter((a) => classifyAlert(a) !== 'none').map((a) => label(r, a))),
   )];
-  if (allAlerts.length) lines.push('', `Alerts: ${allAlerts.join('; ')}.`);
+  if (drivingAlerts.length) lines.push('', `Alerts: ${drivingAlerts.join('; ')}.`);
+  const otherAlerts = [...new Set(
+    rows.flatMap((r) => r.alerts.filter((a) => classifyAlert(a) === 'none').map((a) => label(r, a))),
+  )];
+  if (otherAlerts.length) lines.push('', `Also active (not driving): ${otherAlerts.join('; ')}.`);
 
   const allRoad = [...new Set(
     rows.flatMap((r) => r.roadEvents.map((e) => `${e} (near ${r.place.name} ${r.place.region})`)),
@@ -211,7 +216,7 @@ export async function buildPointReport({ lat, lon, heading, speed }) {
   const overall = worst(assessments.map((a) => a.level));
   const tz = samples[0].timeZone;
 
-  const lines = [`HERE WX. ${point.lat.toFixed(3)}, ${point.lon.toFixed(3)}.`];
+  const lines = ['ROAD WX.'];
   if (overall === 'DRIVE') lines.push('VERDICT: DRIVE. Clear nearby.', '');
   else {
     const idx = assessments.findIndex((a) => a.level === overall);
@@ -222,7 +227,10 @@ export async function buildPointReport({ lat, lon, heading, speed }) {
     const label = s.label || clockInTz(tz, s.at);
     lines.push(`${label}: ${fmtSample(samples[i])}. ${verdictTag(assessments[i])}`);
   });
-  if (alerts.length) lines.push('', `Alerts: ${[...new Set(alerts)].join('; ')}.`);
+  const drivingAlerts = [...new Set(alerts.filter((a) => classifyAlert(a) !== 'none'))];
+  const otherAlerts = [...new Set(alerts.filter((a) => classifyAlert(a) === 'none'))];
+  if (drivingAlerts.length) lines.push('', `Alerts: ${drivingAlerts.join('; ')}.`);
+  if (otherAlerts.length) lines.push('', `Also active (not driving): ${otherAlerts.join('; ')}.`);
   if (roadEvents.length) lines.push('', `Road conditions: ${[...new Set(roadEvents)].join('; ')}.`);
   if (!isUS) lines.push('', 'Note: government hazard alerts are US-only; outside the US the verdict uses wind, temperature, and conditions.');
   lines.push('', `(Times in ${tz}.)`);


### PR DESCRIPTION
## What

Two fixes from real-world use of the route-weather endpoint.

**1. Non-driving alerts no longer force a HOLD.** A Red Flag Warning (fire weather) was making a clear, 84°F, sunny day read **HOLD**, because any alert with "Warning" in it counted. New `classifyAlert` ignores alerts that aren't about the road — fire weather, heat, air quality, frost/freeze, wind chill, marine/beach — for the verdict. Road hazards still drive it (snow, ice, high wind, fog, dust, flooding, tornado…): a Warning → HOLD, an Advisory/Watch → CAUTION. Non-driving alerts are still surfaced under an "Also active (not driving)" line so nothing is hidden.

**2. Drop raw coordinates from the spoken point report.** It read "39.740, -104.990" aloud, which is useless while driving. The header is now just `ROAD WX.` The coordinates are still in the request URL for anyone auditing what was queried, so no data is lost.

## Verified

- `Red Flag Warning`, `Heat Advisory`, `Air Quality Alert`, `Wind Chill Warning` → DRIVE.
- `High Wind Warning`, `Winter Storm Warning`, `Flash Flood Warning` → HOLD; `Wind Advisory`, `Dense Fog Advisory` → CAUTION.
- Full point report on a sunny day with an active Red Flag Warning now reads DRIVE, with the warning listed under "Also active (not driving)". EOF check passes.

Standalone server-only service under `ctf/ops/`; design gate and plugin inventory don't apply.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm)_