### PR TITLE
fix: use plain "Road weather"/"Route weather" report headers

### DIFF
--- a/ctf/ops/route-weather/README.md
+++ b/ctf/ops/route-weather/README.md
@@ -96,7 +96,7 @@ The phrasing is written to be spoken cleanly by Siri (directions as words,
 "degrees", 12-hour times) while still reading fine by eye. Example reply:
 
 ```
-ROUTE WX. Denver Colorado to Salt Lake City Utah.
+Route weather. Denver Colorado to Salt Lake City Utah.
 VERDICT: HOLD at Vail Colorado — gusting 41, snow, Winter Weather Advisory.
 
 Now, Denver Colorado: 34 degrees, wind west 12, clear. DRIVE.

--- a/ctf/ops/route-weather/src/report.mjs
+++ b/ctf/ops/route-weather/src/report.mjs
@@ -153,7 +153,7 @@ export async function buildRouteReport({ from, to, via = [], depart, mph }) {
   const overall = worst(rows.map((r) => r.hz.level));
   const first = places[0];
   const last = places[places.length - 1];
-  const lines = [`ROUTE WX. ${first.name} ${first.region} to ${last.name} ${last.region}.`];
+  const lines = [`Route weather. ${first.name} ${first.region} to ${last.name} ${last.region}.`];
 
   if (overall === 'DRIVE') {
     lines.push('VERDICT: DRIVE. Clear along the route.', '');
@@ -216,7 +216,7 @@ export async function buildPointReport({ lat, lon, heading, speed }) {
   const overall = worst(assessments.map((a) => a.level));
   const tz = samples[0].timeZone;
 
-  const lines = ['ROAD WX.'];
+  const lines = ['Road weather.'];
   if (overall === 'DRIVE') lines.push('VERDICT: DRIVE. Clear nearby.', '');
   else {
     const idx = assessments.findIndex((a) => a.level === overall);


### PR DESCRIPTION
## What

The point and route reports opened with `ROAD WX.` / `ROUTE WX.`. "WX" is old shorthand for "weather" — jargon, and Siri reads it aloud as "W X," which means nothing. Replaced with plain words: `Road weather.` and `Route weather.` Updated the README example to match.

No logic change. Standalone server-only service under `ctf/ops/`; design gate and plugin inventory don't apply.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm)_