### PR TITLE
feat: announce city and state in the point weather report

### DIFF
--- a/ctf/ops/route-weather/README.md
+++ b/ctf/ops/route-weather/README.md
@@ -78,9 +78,11 @@ GET /weather?lat=39.74&lon=-104.99&heading=270&speed=58
 GET /weather?from=Denver,CO&to=Salt Lake City,UT&via=Vail,CO&via=Grand Junction,CO&depart=06:00&mph=55
 ```
 
-- `lat`+`lon` → current conditions plus the next three hours at that point. Add
-  `heading` (compass degrees) and optional `speed` (mph) to also get a look
-  about one hour down that bearing — useful for "what's coming" while moving.
+- `lat`+`lon` → current conditions plus the next three hours at that point. It
+  names the place it's reporting for (city + state, via a keyless reverse-geocode
+  lookup; silently omitted if that lookup fails). Add `heading` (compass degrees)
+  and optional `speed` (mph) to also get a look about one hour down that bearing —
+  useful for "what's coming" while moving.
 - `from`+`to` (plus any number of `via`) → one line per stop, each showing the
   forecast for the estimated time you'll arrive. `depart` is `HH:MM` (read in the
   origin's time zone) or a full timestamp; `mph` defaults to 58 (a loaded truck's

--- a/ctf/ops/route-weather/src/providers.mjs
+++ b/ctf/ops/route-weather/src/providers.mjs
@@ -79,6 +79,23 @@ export async function geocode(query) {
   };
 }
 
+// Turn coordinates into a place name (city + state/region). Keyless and
+// best-effort: returns null on any failure so the report still works.
+export async function reverseGeocode(lat, lon) {
+  try {
+    const data = await getJson(
+      `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${lat}&longitude=${lon}&localityLanguage=en`,
+    );
+    const city = data.city || data.locality || '';
+    const region = data.principalSubdivision || '';
+    const country = (data.countryCode || '').toUpperCase();
+    if (!city && !region) return null;
+    return { city, region, country };
+  } catch {
+    return null;
+  }
+}
+
 // Pick the forecast entry closest to a target time.
 function nearestIndex(epochs, targetEpoch) {
   let best = 0;

--- a/ctf/ops/route-weather/src/report.mjs
+++ b/ctf/ops/route-weather/src/report.mjs
@@ -5,7 +5,7 @@
 // Each builder returns { text, verdict } so callers can act on the verdict
 // (set a response header, or only push an alert when it is not DRIVE).
 
-import { geocode, sampleAt, fetchUSAlerts, inUS } from './providers.mjs';
+import { geocode, sampleAt, fetchUSAlerts, inUS, reverseGeocode } from './providers.mjs';
 import { assessHazard, worst, classifyAlert } from './hazard.mjs';
 import { fetchRoadEvents } from './roadconditions.mjs';
 
@@ -207,16 +207,22 @@ export async function buildPointReport({ lat, lon, heading, speed }) {
   }
 
   const isUS = inUS(point.lat, point.lon);
-  const [samples, alerts, roadEvents] = await Promise.all([
+  const [samples, alerts, roadEvents, place] = await Promise.all([
     Promise.all(stops.map((s) => sampleAt(s.point, s.at))),
     isUS ? fetchUSAlerts(point.lat, point.lon) : Promise.resolve([]),
     isUS ? fetchRoadEvents(point.lat, point.lon) : Promise.resolve([]),
+    reverseGeocode(point.lat, point.lon),
   ]);
   const assessments = samples.map((s) => assessHazard(s, alerts, roadEvents));
   const overall = worst(assessments.map((a) => a.level));
   const tz = samples[0].timeZone;
 
-  const lines = ['Road weather.'];
+  // Name where this is, so it's clear aloud (e.g. "near Aurora, Colorado").
+  let where = '';
+  if (place?.city && place?.region) where = ` near ${place.city}, ${place.region}`;
+  else if (place?.region) where = ` in ${place.region}`;
+  else if (place?.city) where = ` near ${place.city}`;
+  const lines = [`Road weather${where}.`];
   if (overall === 'DRIVE') lines.push('VERDICT: DRIVE. Clear nearby.', '');
   else {
     const idx = assessments.findIndex((a) => a.level === overall);


### PR DESCRIPTION
## What

The single-point report opened with a bare `Road weather.` This adds the location name right after it, so it's clear aloud where the report is for — e.g. *"Road weather near Aurora, Colorado. Drive — clear nearby…"*

New keyless `reverseGeocode` (BigDataCloud reverse-geocode-client) turns the coordinates into city + state. It's **best-effort**: any failure returns null and the header silently falls back to `Road weather.`, so the report never breaks. It runs in parallel with the existing weather/alert lookups, so no added latency.

Confirms the point report's purpose: weather at your current location for now + the next 3 hours, with the drive/hold verdict.

Standalone server-only service under `ctf/ops/`; design gate and plugin inventory don't apply.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm)_