### PR TITLE
fix: drop redundant per-line DRIVE so the readout is clear aloud

### DIFF
--- a/ctf/ops/route-weather/src/report.mjs
+++ b/ctf/ops/route-weather/src/report.mjs
@@ -166,7 +166,10 @@ export async function buildRouteReport({ from, to, via = [], depart, mph }) {
     const when = i === 0 && Math.abs(r.eta - Date.now()) < 30 * 60 * 1000
       ? 'Now'
       : clockInTz(originTz, r.eta);
-    lines.push(`${when}, ${r.place.name} ${r.place.region}: ${fmtSample(r.sample)}. ${verdictTag(r.hz)}`);
+    // Only call out a stop's verdict when it is not DRIVE — the overall verdict
+    // is already stated up top, so repeating "DRIVE" on every line reads badly.
+    const tag = r.hz.level === 'DRIVE' ? '' : ` ${verdictTag(r.hz)}`;
+    lines.push(`${when}, ${r.place.name} ${r.place.region}: ${fmtSample(r.sample)}.${tag}`);
   });
 
   const label = (r, a) => `${a} at ${r.place.name} ${r.place.region}`;
@@ -231,7 +234,8 @@ export async function buildPointReport({ lat, lon, heading, speed }) {
 
   stops.forEach((s, i) => {
     const label = s.label || clockInTz(tz, s.at);
-    lines.push(`${label}: ${fmtSample(samples[i])}. ${verdictTag(assessments[i])}`);
+    const tag = assessments[i].level === 'DRIVE' ? '' : ` ${verdictTag(assessments[i])}`;
+    lines.push(`${label}: ${fmtSample(samples[i])}.${tag}`);
   });
   const drivingAlerts = [...new Set(alerts.filter((a) => classifyAlert(a) !== 'none'))];
   const otherAlerts = [...new Set(alerts.filter((a) => classifyAlert(a) === 'none'))];


### PR DESCRIPTION
## What

Every reading line ended with `. DRIVE.`, which Siri read as the verdict stuck onto the end of each line ("…sunny. Drive." four times) even though the overall verdict is already stated up top. Now a line only shows its verdict when it's **CAUTION or HOLD**, so a clear day reads as plain weather and a bad hour/stop stands out. Applies to both the point and route reports.

Clear day now reads: *"Road weather near Chicago, Illinois. Verdict: drive. Clear nearby. Now: 91 degrees, wind south-southwest 5, mostly clear. …"* — verdict once, up front.

Standalone server-only service under `ctf/ops/`; design gate and plugin inventory don't apply.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqufbDHDWVRq18wuP2nyGm)_