### PR TITLE
ci: enable schedules for bug report create-issues and triage workflows

### DIFF
--- a/.github/workflows/bug-reports-create-issues.yml
+++ b/.github/workflows/bug-reports-create-issues.yml
@@ -12,8 +12,8 @@ name: Bug Reports — Create Triage Issues
 # Until then the script no-ops safely, so an early run does no harm.
 on:
   workflow_dispatch: {}
-  # schedule:
-  #   - cron: "*/15 * * * *"   # every 15 minutes once enabled
+  schedule:
+    - cron: "*/15 * * * *"   # every 15 minutes
 
 jobs:
   create-triage-issues:

--- a/.github/workflows/bug-reports-triage.yml
+++ b/.github/workflows/bug-reports-triage.yml
@@ -9,8 +9,8 @@ name: Bug Reports — Triage
 # the script no-ops safely.
 on:
   workflow_dispatch: {}
-  # schedule:
-  #   - cron: "*/30 * * * *"   # every 30 minutes once enabled
+  schedule:
+    - cron: "*/30 * * * *"   # every 30 minutes
 
 jobs:
   triage:


### PR DESCRIPTION
Both workflows have been verified by manual dispatch and run successfully, so this turns on their schedules:

- bug-reports-create-issues.yml: every 15 minutes (drains clean reports into the private triage repo).
- bug-reports-triage.yml: every 30 minutes (proposes a fix plan on the oldest needs-triage issue).

bug-reports-build.yml intentionally stays manual-dispatch so the owner kicks each approved build until the pipeline is trusted.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01XdhKo7Eb8fWmb8A67J25zR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdhKo7Eb8fWmb8A67J25zR)_