### PR TITLE
fix: base CSRF same-origin check on the request host, not NEXT_PUBLIC_APP_URL

### DIFF
--- a/ctf/packages/web/app/api/account/_lib.ts
+++ b/ctf/packages/web/app/api/account/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
 
 // Shared helpers for the account-level deletion routes under `/api/account/**`.
@@ -37,22 +37,16 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json(
-        { ok: false, code: ACCOUNT_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: ACCOUNT_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/app/api/bug-reports/_lib.ts
+++ b/ctf/packages/web/app/api/bug-reports/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { BUG_REPORT_ERROR_CODE } from 'lib/bug-reports/constants';
 
 export type BugReportApiGate =
@@ -34,25 +34,14 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: BUG_REPORT_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
       { status: 403 },
     );
   }
-
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       { ok: false, code: BUG_REPORT_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },

--- a/ctf/packages/web/app/api/comic/_lib.ts
+++ b/ctf/packages/web/app/api/comic/_lib.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
 import { ensureComicAdmin } from 'lib/comic/policy';
 import { COMIC_ERROR_CODE } from 'lib/comic/constants';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export type ComicApiGate =
   | {
@@ -69,19 +69,8 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       {
         ok: false,
@@ -92,7 +81,7 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/contributions/_lib.ts
+++ b/ctf/packages/web/app/api/contributions/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ensureContributionsAdmin } from 'lib/contributions/policy';
 import { insertContributionsAudit } from 'lib/contributions/repository';
 import { reportError } from 'lib/observability/report';
@@ -42,25 +42,16 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  // Fail open when the app URL or the Origin header is absent — this matches the established
-  // repo convention (see app/api/foundation/_lib.ts). Non-browser clients (the mobile app) do
-  // not always send Origin; the required x-ctf-csrf header above is what blocks browser CSRF.
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json(
-        { ok: false, code: 'contributions_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: 'contributions_csrf_denied', message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: 'contributions_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/app/api/directory/_lib.ts
+++ b/ctf/packages/web/app/api/directory/_lib.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
 import { ensureDirectoryAdmin } from 'lib/directory/policy';
 import { DIRECTORY_ERROR_CODE } from 'lib/directory/constants';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export type DirectoryApiGate =
   | {
@@ -69,19 +69,8 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       {
         ok: false,
@@ -92,7 +81,7 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/feed/_lib.ts
+++ b/ctf/packages/web/app/api/feed/_lib.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
 import { ensureFeedAdmin } from 'lib/feed/policy';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export type FeedApiGate =
   | {
@@ -69,19 +69,8 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       {
         ok: false,
@@ -92,7 +81,7 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/foundation/_lib.ts
+++ b/ctf/packages/web/app/api/foundation/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ensureFoundationAdmin } from 'lib/foundation/policy';
 import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 
@@ -58,26 +58,15 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
       { status: 403 },
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },

--- a/ctf/packages/web/app/api/gdp/_lib.ts
+++ b/ctf/packages/web/app/api/gdp/_lib.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { ensureGdpAdmin } from 'lib/gdp/policy';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export async function requireGdpReadAccess() {
   const decision = await evaluatePluginAccess({ requireUsername: false });
@@ -35,18 +35,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/app/api/gentlepulse/_lib.ts
+++ b/ctf/packages/web/app/api/gentlepulse/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export type GentlePulseApiGate =
   | { allowed: true; auth: AllowDecision }
@@ -33,18 +33,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/app/api/levelup/_lib.ts
+++ b/ctf/packages/web/app/api/levelup/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ensureLevelupAdmin } from 'lib/levelup/policy';
 import { reportError } from 'lib/observability/report';
 
@@ -36,18 +36,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/app/api/lighthouse/_lib.ts
+++ b/ctf/packages/web/app/api/lighthouse/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ensureLighthouseAdmin } from 'lib/lighthouse/policy';
 import { LIGHTHOUSE_ERROR_CODE } from 'lib/lighthouse/constants';
 
@@ -58,25 +58,15 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
       { status: 403 },
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },

--- a/ctf/packages/web/app/api/mood/_lib.ts
+++ b/ctf/packages/web/app/api/mood/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { MOOD_ERROR_CODE } from 'lib/mood/constants';
 import { reportError } from 'lib/observability/report';
 
@@ -25,22 +25,16 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json(
-        { ok: false, code: MOOD_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: MOOD_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: MOOD_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/app/api/peer-programming/_lib.ts
+++ b/ctf/packages/web/app/api/peer-programming/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { PEER_PROGRAMMING_ERROR_CODE } from 'lib/peer-programming/constants';
 import { ensurePeerProgrammingAdmin } from 'lib/peer-programming/policy';
 import { reportError } from 'lib/observability/report';
@@ -44,22 +44,16 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json(
-        { ok: false, code: PEER_PROGRAMMING_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: PEER_PROGRAMMING_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: PEER_PROGRAMMING_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/app/api/service-credits/_lib.ts
+++ b/ctf/packages/web/app/api/service-credits/_lib.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ensureServiceCreditsAdmin } from 'lib/service-credits/policy';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { reportError } from 'lib/observability/report';
 
 export async function requireServiceCreditsReadAccess() {
@@ -36,18 +36,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/app/api/skills-hunt/_lib.ts
+++ b/ctf/packages/web/app/api/skills-hunt/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ensureSkillsHuntAdmin, ensureSkillsHuntModeratorOrAdmin } from 'lib/skills-hunt/policy';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
 
@@ -102,25 +102,15 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
       { status: 403 },
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       { ok: false, code: SKILLS_HUNT_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },

--- a/ctf/packages/web/app/api/skills-taxonomy/_lib.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/_lib.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { ensureTaxonomyAdmin } from 'lib/skills-taxonomy/policy';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export type SkillsTaxonomyApiGate =
   | {
@@ -69,19 +69,8 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       {
         ok: false,
@@ -92,7 +81,7 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/app/api/socketrelay/_lib.ts
+++ b/ctf/packages/web/app/api/socketrelay/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ensureSocketRelayAdmin } from 'lib/socketrelay/policy';
 import { SOCKETRELAY_ERROR_CODE } from 'lib/socketrelay/constants';
 import { reportError } from 'lib/observability/report';
@@ -44,25 +44,15 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: SOCKETRELAY_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
       { status: 403 },
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       { ok: false, code: SOCKETRELAY_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },

--- a/ctf/packages/web/app/api/trusttransport/_lib.ts
+++ b/ctf/packages/web/app/api/trusttransport/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { TRUSTTRANSPORT_ERROR_CODE } from 'lib/trusttransport/constants';
 import { ensureTrustTransportAdmin, ensureTrustTransportProviderRole } from 'lib/trusttransport/policy';
 import { reportError } from 'lib/observability/report';
@@ -58,24 +58,17 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    const appHost = new URL(appUrl).host;
-    const originHost = new URL(origin).host;
-    if (appHost !== originHost) {
-      return NextResponse.json(
-        { ok: false, code: TRUSTTRANSPORT_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: TRUSTTRANSPORT_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: TRUSTTRANSPORT_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/app/api/weekly-performance/_lib.ts
+++ b/ctf/packages/web/app/api/weekly-performance/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { ensureWeeklyPerformanceAdmin } from 'lib/weekly-performance/policy';
 
 export async function requireWeeklyPerformanceReadAccess() {
@@ -35,18 +35,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'weekly_performance_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'weekly_performance_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'weekly_performance_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'weekly_performance_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/app/api/whatworks/_lib.ts
+++ b/ctf/packages/web/app/api/whatworks/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export type WhatWorksApiGate =
   | { allowed: true; auth: AllowDecision }
@@ -44,18 +44,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return whatworksError('Missing CSRF confirmation header.', 'whatworks_csrf_denied', 403);
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return whatworksError('Cross-origin mutation denied by CSRF policy.', 'whatworks_csrf_denied', 403);
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return whatworksError('Invalid request origin metadata.', 'whatworks_csrf_denied', 403);
+  }
+  if (originCheck === 'cross_origin') {
+    return whatworksError('Cross-origin mutation denied by CSRF policy.', 'whatworks_csrf_denied', 403);
   }
 
   return null;

--- a/ctf/packages/web/app/api/workforce/_lib.ts
+++ b/ctf/packages/web/app/api/workforce/_lib.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { ensureWorkforceAdmin } from 'lib/workforce/policy';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import { getAppUrl } from 'lib/auth/runtime-env';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 
 export type WorkforceApiGate =
   | {
@@ -69,19 +69,8 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  let appHost = '';
-  let originHost = '';
-  try {
-    appHost = new URL(appUrl).host;
-    originHost = new URL(origin).host;
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       {
         ok: false,
@@ -92,7 +81,7 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  if (appHost !== originHost) {
+  if (originCheck === 'cross_origin') {
     return NextResponse.json(
       {
         ok: false,

--- a/ctf/packages/web/lib/auth/csrf.ts
+++ b/ctf/packages/web/lib/auth/csrf.ts
@@ -1,0 +1,29 @@
+// Same-origin CSRF check based on the host the request was actually delivered to
+// (the proxied public host), NOT a build-time-configured URL. A browser sets the
+// Origin header to the page's origin and cannot forge it cross-site, so requiring
+// Origin's host to equal our own delivered host blocks cross-site writes while
+// working on any domain the app is served on.
+export type MutationOriginCheck = 'allow' | 'invalid_origin' | 'cross_origin';
+
+export function checkMutationOrigin(request: Request): MutationOriginCheck {
+  const origin = request.headers.get('origin');
+  // No Origin header (e.g. the native app / non-browser clients) is not a cross-site
+  // browser write; allow it, preserving the existing fail-open-on-missing-Origin behavior.
+  if (!origin) return 'allow';
+
+  // x-forwarded-host is set by the proxy (Render) to the public domain; fall back to Host.
+  // It can be a comma-separated list when multiple proxies are involved — take the first.
+  const forwarded = request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? '';
+  const requestHost = forwarded.split(',')[0]?.trim() ?? '';
+  // If we genuinely cannot determine our own host, preserve the prior fail-open behavior.
+  if (requestHost === '') return 'allow';
+
+  let originHost = '';
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return 'invalid_origin';
+  }
+
+  return originHost === requestHost ? 'allow' : 'cross_origin';
+}

--- a/ctf/packages/web/lib/foundation/_lib.ts
+++ b/ctf/packages/web/lib/foundation/_lib.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from '../auth/server-authz';
 import { ensureFoundationAdmin } from './policy';
+import { checkMutationOrigin } from '../auth/csrf';
 import { FOUNDATION_ERROR_CODE } from './constants';
 
 export type FoundationApiGate =
@@ -53,6 +54,20 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
   if (request.headers.get('x-ctf-csrf') !== '1') {
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.csrfDenied, message: 'Missing CSRF confirmation header.' },
+      { status: 403 },
+    );
+  }
+
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/lib/gdp/_lib.ts
+++ b/ctf/packages/web/lib/gdp/_lib.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from '../auth/server-authz';
 import { ensureGdpAdmin } from './policy';
-import { getAppUrl } from '../auth/runtime-env';
+import { checkMutationOrigin } from '../auth/csrf';
 
 export async function requireGdpReadAccess() {
   const decision = await evaluatePluginAccess({ requireUsername: false });
@@ -35,18 +35,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'gdp_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/lib/gentlepulse/_lib.ts
+++ b/ctf/packages/web/lib/gentlepulse/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from '../auth/server-authz';
-import { getAppUrl } from '../auth/runtime-env';
+import { checkMutationOrigin } from '../auth/csrf';
 
 export type GentlePulseApiGate =
   | { allowed: true; auth: AllowDecision }
@@ -33,18 +33,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'gentlepulse_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/lib/levelup/_lib.ts
+++ b/ctf/packages/web/lib/levelup/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from '../auth/server-authz';
-import { getAppUrl } from '../auth/runtime-env';
+import { checkMutationOrigin } from '../auth/csrf';
 import { ensureLevelupAdmin } from './policy';
 
 export async function requireLevelupReadAccess() {
@@ -35,18 +35,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'levelup_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/lib/lighthouse/_lib.ts
+++ b/ctf/packages/web/lib/lighthouse/_lib.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from '../auth/server-authz';
 import { ensureLighthouseAdmin } from './policy';
+import { checkMutationOrigin } from '../auth/csrf';
 import { LIGHTHOUSE_ERROR_CODE } from './constants';
 
 export type LighthouseApiGate =
@@ -53,6 +54,20 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
   if (request.headers.get('x-ctf-csrf') !== '1') {
     return NextResponse.json(
       { ok: false, code: LIGHTHOUSE_ERROR_CODE.csrfDenied, message: 'Missing CSRF confirmation header.' },
+      { status: 403 },
+    );
+  }
+
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
+    return NextResponse.json(
+      { ok: false, code: LIGHTHOUSE_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: LIGHTHOUSE_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/lib/mood/_lib.ts
+++ b/ctf/packages/web/lib/mood/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from '../auth/server-authz';
-import { getAppUrl } from '../auth/runtime-env';
+import { checkMutationOrigin } from '../auth/csrf';
 import { MOOD_ERROR_CODE } from './constants';
 
 export async function requireMoodAccess() {
@@ -24,22 +24,16 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     );
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json(
-        { ok: false, code: MOOD_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: MOOD_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: MOOD_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/lib/peer-programming/_lib.ts
+++ b/ctf/packages/web/lib/peer-programming/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from '../auth/server-authz';
-import { getAppUrl } from '../auth/runtime-env';
+import { checkMutationOrigin } from '../auth/csrf';
 import { PEER_PROGRAMMING_ERROR_CODE } from './constants';
 import { ensurePeerProgrammingAdmin } from './policy';
 
@@ -38,21 +38,16 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
       { status: 403 },
     );
   }
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json(
-        { ok: false, code: PEER_PROGRAMMING_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json(
       { ok: false, code: PEER_PROGRAMMING_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: PEER_PROGRAMMING_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
       { status: 403 },
     );
   }

--- a/ctf/packages/web/lib/service-credits/_lib.ts
+++ b/ctf/packages/web/lib/service-credits/_lib.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from '../auth/server-authz';
 import { ensureServiceCreditsAdmin } from './policy';
-import { getAppUrl } from '../auth/runtime-env';
+import { checkMutationOrigin } from '../auth/csrf';
 
 export async function requireServiceCreditsReadAccess() {
   const decision = await evaluatePluginAccess({ requireUsername: false });
@@ -35,18 +35,12 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
     return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Missing CSRF confirmation header.' }, { status: 403 });
   }
 
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
-  }
-
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
-    }
-  } catch {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
     return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Invalid request origin metadata.' }, { status: 403 });
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json({ ok: false, code: 'service_credits_csrf_denied', message: 'Cross-origin mutation denied by CSRF policy.' }, { status: 403 });
   }
 
   return null;

--- a/ctf/packages/web/lib/trust/_lib.ts
+++ b/ctf/packages/web/lib/trust/_lib.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from '../auth/server-authz';
-import { getAppUrl } from '../auth/runtime-env';
+import { checkMutationOrigin } from '../auth/csrf';
 import { TRUST_ERROR_CODE } from './constants';
 
 export type TrustApiGate =
@@ -37,19 +37,19 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
       { status: 403 },
     );
   }
-  const appUrl = getAppUrl();
-  const origin = request.headers.get('origin');
-  if (!appUrl || !origin) {
-    return null;
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
+    return NextResponse.json(
+      { ok: false, code: TRUST_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
   }
-  try {
-    if (new URL(appUrl).host !== new URL(origin).host) {
-      return NextResponse.json(
-        { ok: false, code: TRUST_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
-        { status: 403 },
-      );
-    }
-  } catch {}
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: TRUST_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
+      { status: 403 },
+    );
+  }
   return null;
 }
 


### PR DESCRIPTION
## What and why

A real user on the live site (`app.chargingthefuture.com`) hit **"Cross-origin mutation denied by CSRF policy"** on every write. Root cause: every mutating endpoint's `ensureMutationCsrf` compared the request's `Origin` host to `new URL(NEXT_PUBLIC_APP_URL).host`, and `NEXT_PUBLIC_APP_URL` is **baked into the web image at build time**. Whenever the live serving host differs from that baked value (apex vs `app.` vs `www.`, a domain change, a Render URL, etc.), the hosts don't match and all writes 403.

## Fix (owner-approved approach)

Compare the `Origin` to the host the request was **actually delivered to** — the standard same-origin CSRF defense — instead of a build-time-configured URL.

- New shared helper `ctf/packages/web/lib/auth/csrf.ts` → `checkMutationOrigin(request)`:
  - No `Origin` header (the native app / non-browser clients) → `allow` (preserves prior fail-open-on-missing-Origin).
  - Otherwise compare `Origin` host to `x-forwarded-host` (set by the Render proxy to the public domain), falling back to `Host`. Match → allow; mismatch → `cross_origin`; malformed Origin → `invalid_origin`.
- All ~30 plugin CSRF helpers now call it, **keeping each one's `x-ctf-csrf` header check, error codes, and response shapes unchanged**. The `getAppUrl()` dependency is removed from the CSRF path only.

Net effect: writes work on whatever domain serves the app, with no rebuild, and survive future domain changes. A browser still can't forge `Origin` cross-site, so the protection is intact. `NEXT_PUBLIC_APP_URL` stays for the auth/canonical-URL uses that genuinely need a single configured value (`provider-env.ts`, `app/layout.tsx`).

## Files
- New: `lib/auth/csrf.ts`.
- Changed: the `_lib.ts` CSRF helper in ~30 endpoints (feed, directory, comic, workforce, skills-hunt, skills-taxonomy, socketrelay, trusttransport, lighthouse, foundation, trust, mood, peer-programming, gdp, gentlepulse, levelup, service-credits, weekly-performance, whatworks, account, contributions, bug-reports, …).

## Validation
- web `tsc --noEmit`: clean (all 31 files) · recursive workspace typecheck (pre-push gate): pass
- eslint on changed files: 0 warnings
- EOF check on changed files: pass
- web `build:ci`: pass

## Review lane
Security control (CSRF) across many endpoints → draft + `coderabbit` label; owner merges after CodeRabbit review. Not auto-merged. After merge + web redeploy, the live "Cross-origin mutation denied" error is resolved.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated CSRF origin validation logic across API and library modules. A new centralized origin-checking mechanism now validates that state-changing requests originate from the same origin, replacing duplicated validation code. Security behavior remains unchanged—same-origin requests continue to be allowed, while cross-origin mutations are denied with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->