### PR TITLE
fix: hub support copy, @comic consent Enter, and total-member count

### DIFF
--- a/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
+++ b/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
@@ -40,6 +40,15 @@ export function ComicConsentModal({ open, onConfirm, onDismiss }: ComicConsentMo
         return;
       }
 
+      // Enter confirms the dialog. On mobile the soft keyboard keeps focus in the chat input, so a
+      // press of Return would otherwise fall through to the composer and silently re-open this same
+      // modal instead of turning the assistant on. Treat Enter as "turn it on" regardless of focus.
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onConfirm();
+        return;
+      }
+
       if (event.key !== 'Tab') return;
 
       // Focus trap: keep Tab / Shift+Tab cycling within the dialog.
@@ -72,7 +81,7 @@ export function ComicConsentModal({ open, onConfirm, onDismiss }: ComicConsentMo
       // Restore focus to the opener on close/unmount.
       opener?.focus?.();
     };
-  }, [open, onDismiss]);
+  }, [open, onDismiss, onConfirm]);
 
   if (!open) {
     return null;

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -306,6 +306,9 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
           onChange={(event) => setInput(event.target.value)}
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
+              // While the first-use consent modal is open, Enter belongs to the modal ("turn it
+              // on"), not the composer. Sending here would only re-open the already-open modal.
+              if (consentModalOpen) return;
               void sendMessage();
             }
           }}

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -324,7 +324,7 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
       </div>
 
       <p className={styles.chatFootnote}>
-        {isLive ? 'Live support connected through Chyme and GetStream.' : 'Live support keeps syncing as new messages arrive.'}
+        {isLive ? 'Human-in-the-loop AI support and community support channel.' : 'Support channel keeps syncing as new messages arrive.'}
       </p>
 
       <ComicConsentModal open={consentModalOpen} onConfirm={() => void confirmConsent()} onDismiss={dismissConsent} />

--- a/ctf/packages/web/lib/engagement/login-activity.ts
+++ b/ctf/packages/web/lib/engagement/login-activity.ts
@@ -24,3 +24,23 @@ export async function countActiveUsersLastDays(days: number): Promise<number> {
 
   return Number.parseInt(result.rows[0]?.total ?? '0', 10);
 }
+
+// Total people signed up — the headline "Members" figure. Prefer the Clerk-mirrored `users`
+// identity table (one row per account), which is the true signup count. Environments built only
+// from the canonical schema.sql have no `users` table, so fall back to the count of distinct
+// authenticated users seen in login_events. Returns null only if neither source can be read.
+export async function countTotalMembers(): Promise<number | null> {
+  const usersTable = await queryDb<{ reg: string | null }>(
+    `SELECT to_regclass('public.users')::text AS reg`,
+  );
+
+  if (usersTable.rows[0]?.reg) {
+    const result = await queryDb<{ total: string }>(`SELECT COUNT(*)::text AS total FROM users`);
+    return Number.parseInt(result.rows[0]?.total ?? '0', 10);
+  }
+
+  const fallback = await queryDb<{ total: string }>(
+    `SELECT COUNT(DISTINCT user_id)::text AS total FROM login_events`,
+  );
+  return Number.parseInt(fallback.rows[0]?.total ?? '0', 10);
+}

--- a/ctf/packages/web/lib/gdp/repository.ts
+++ b/ctf/packages/web/lib/gdp/repository.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { queryDb } from 'lib/db/postgres';
+import { countTotalMembers } from 'lib/engagement/login-activity';
 
 type PublicationRow = {
   id: string;
@@ -106,12 +107,17 @@ export async function upsertPublication(input: {
 }
 
 export async function getGdpShellStats(): Promise<{ memberCount: number | null; gdpValueUsd: number | null }> {
-  const report = await getLatestPublication();
-  if (!report) return { memberCount: null, gdpValueUsd: null };
-  const memberMetric = report.metrics.find((m) => m.metricKey === 'weekly_active_users');
-  const gdpMetric = report.metrics.find((m) => m.metricKey === 'gdp_total_revenue');
+  // Member count is the total number of people signed up (every account), read directly from the
+  // identity table — independent of whether a weekly GDP report has been published. The GDP value
+  // still comes from the latest published report. The two are fetched together but kept separate so
+  // a missing report never blanks the member count, and a member-count read error never blanks GDP.
+  const [memberCount, report] = await Promise.all([
+    countTotalMembers().catch(() => null),
+    getLatestPublication().catch(() => null),
+  ]);
+  const gdpMetric = report?.metrics.find((m) => m.metricKey === 'gdp_total_revenue') ?? null;
   return {
-    memberCount: memberMetric ? memberMetric.metricValue : null,
+    memberCount,
     gdpValueUsd: gdpMetric ? gdpMetric.metricValue : null,
   };
 }


### PR DESCRIPTION
Three hub fixes on one branch.

**1. Support footnote copy.** Replaced `Live support connected through Chyme and GetStream.` (leaked internal service names, inaccurate) with `Human-in-the-loop AI support and community support channel.` The offline variant now reads `Support channel keeps syncing as new messages arrive.`

**2. @comic first-use consent — Enter did nothing.** On the first `@comic` mention the consent dialog opens, but on mobile the soft keyboard keeps focus in the chat input. Pressing Return then fell through to the composer's send handler, which (consent not yet granted) silently re-opened the same dialog — the message was never sent and the text stayed in the box. Now the dialog treats Enter as "turn it on" regardless of focus, and the composer ignores Enter while the dialog is open so it can't re-open it.

**3. Hub "Members" stat showed weekly logins, not signups.** It read the `weekly_active_users` metric off the latest published GDP report, so it counted weekly logins and went blank when no report was published. It now counts total members directly from the identity table (`users`, one row per account), falling back to distinct authenticated users from `login_events` where the canonical schema has no `users` table. Member count is now independent of the GDP publication; the GDP value still comes from the latest report.

Parity Status: web + mobile-responsive + android complete

(All three changes are on the web hub shell, which also serves the phone-width layout. The React Native app has no @comic consent dialog or hub hero stat, so there is no Android surface to update.)

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_