### PR TITLE
fix: TrustTransport Book a Ride never submitted (wrong fields + missing CSRF header)

### DIFF
--- a/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
+++ b/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
@@ -93,10 +93,22 @@ export function TrustTransportShell() {
     setSubmitting(true);
     setBookingError(null);
     try {
+      // The API expects mode + title + details (both required) and optional pickup/dropoff cities — not
+      // fromLocation/toLocation. Build a title/details from the pickup and destination the user typed,
+      // and send the x-ctf-csrf header every mutation requires (without it the request is denied 403).
+      const pickup = from.trim();
+      const dropoff = to.trim();
+      const modeLabel = rideType.charAt(0).toUpperCase() + rideType.slice(1);
       const res = await fetch("/api/trusttransport/requests", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode: rideType, fromLocation: from, toLocation: to }),
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({
+          mode: rideType,
+          title: `${modeLabel}: ${pickup} → ${dropoff}`.slice(0, 160),
+          details: `Pickup: ${pickup}\nDrop-off: ${dropoff}`,
+          pickupCity: pickup,
+          dropoffCity: dropoff,
+        }),
       });
       if (!res.ok) throw new Error("Failed to create request");
       setBooked(true);
@@ -115,7 +127,7 @@ export function TrustTransportShell() {
     setChatError(null);
     setChatLoading(true);
     try {
-      const res = await fetch(`/api/trusttransport/trips/${req.id}/chat`, { method: "POST" });
+      const res = await fetch(`/api/trusttransport/trips/${req.id}/chat`, { method: "POST", headers: { "x-ctf-csrf": "1" } });
       if (!res.ok) throw new Error("Failed to fetch chat credentials");
       const data = (await res.json()) as ChatCreds;
       if (!data.ok) throw new Error(data.message ?? "No chat credentials");


### PR DESCRIPTION
## Bug
On the web TrustTransport "Book a Ride" screen, submitting always failed with **"Failed to create request"** (reported with a screenshot: Ride, Pittston → Walmart).

## Cause
Two mismatches in the web client (`trusttransport-shell.tsx`):
1. **Wrong fields.** It sent `fromLocation`/`toLocation`, but `POST /api/trusttransport/requests` requires non-empty `title` and `details` (plus optional `pickupCity`/`dropoffCity`). Validation rejected the body, and the pickup/destination the user typed were dropped.
2. **Missing CSRF header.** The POST omitted `x-ctf-csrf: 1`, which every mutation requires — so it was denied `403` before validation.

## Fix
- Build `title`/`details` from the pickup and destination, map them to `pickupCity`/`dropoffCity`, and send the `x-ctf-csrf: 1` header.
- Add the same header to the trip-chat POST, which had the identical omission.
- Mobile already sent the correct fields and header (`MUTATION_HEADERS`), so no mobile change is needed.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_