### PR TITLE
feat: shared currency selector (component + /api/currencies) toward unified multi-currency picker

### DIFF
--- a/ctf/packages/mobile/src/features/currency/CurrencySelect.tsx
+++ b/ctf/packages/mobile/src/features/currency/CurrencySelect.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import type { Currency } from './types';
+import { SERVICE_CREDITS_LABEL } from './types';
+import { sortPreferred } from './format';
+import { fetchCurrencies } from './api';
+
+// Shared payment-currency selector for the mobile app (issue #420) — the React Native counterpart of
+// the web CurrencySelect. One control reused by every value-bearing feature so the options and ordering
+// stay identical: ServiceCredits first, then fiat, crypto, and barter, read live from the currencies
+// catalog. ServiceCredits always renders by its label, never the bare "SC" code, and a ServiceCredits
+// amount is never shown at a fiat equivalent. Rendered as a horizontal row of selectable chips (no extra
+// dependency). Barter (requiresAmount=false) appears too; callers use the returned Currency to decide
+// whether to show an amount input.
+
+function optionLabel(currency: Currency): string {
+  if (currency.isServiceCredits) return SERVICE_CREDITS_LABEL;
+  return currency.symbol ? `${currency.label} (${currency.symbol})` : currency.label;
+}
+
+export function CurrencySelect({
+  value,
+  onChange,
+  currencies: provided,
+}: {
+  value: string;
+  onChange: (_code: string, _currency: Currency | null) => void;
+  currencies?: Currency[];
+}) {
+  const [currencies, setCurrencies] = useState<Currency[]>(provided ?? []);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (provided) {
+      setCurrencies(provided);
+      return;
+    }
+    let active = true;
+    fetchCurrencies()
+      .then((list) => {
+        if (active) setCurrencies(list);
+      })
+      .catch((e: unknown) => {
+        if (active) setError(e instanceof Error ? e.message : 'Failed to load currencies');
+      });
+    return () => {
+      active = false;
+    };
+  }, [provided]);
+
+  const sorted = sortPreferred(currencies);
+
+  if (sorted.length === 0) {
+    return <Text style={styles.placeholder}>{error ? 'Currencies unavailable' : 'Loading…'}</Text>;
+  }
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.row}>
+      {sorted.map((currency) => {
+        const selected = currency.code === value;
+        return (
+          <TouchableOpacity
+            key={currency.code}
+            onPress={() => onChange(currency.code, currency)}
+            style={[styles.chip, selected && styles.chipSelected]}
+            accessibilityRole="button"
+            accessibilityState={{ selected }}
+          >
+            <Text style={[styles.chipText, selected && styles.chipTextSelected]}>{optionLabel(currency)}</Text>
+          </TouchableOpacity>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    gap: 8,
+    paddingVertical: 4,
+  },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.12)',
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  chipSelected: {
+    borderColor: '#22C55E',
+    backgroundColor: 'rgba(34,197,94,0.15)',
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#E8EAF0',
+  },
+  chipTextSelected: {
+    color: '#FFFFFF',
+  },
+  placeholder: {
+    fontSize: 13,
+    color: '#9CA3AF',
+    paddingVertical: 8,
+  },
+});

--- a/ctf/packages/mobile/src/features/currency/api.ts
+++ b/ctf/packages/mobile/src/features/currency/api.ts
@@ -1,0 +1,10 @@
+// Fetches the active currency catalog for the shared payment selector (issue #420). Mirrors
+// GET /api/currencies (web app/api/currencies/route.ts). ServiceCredits sorts first; barter is
+// included when present in the catalog.
+import { authedFetchJson } from '../../auth/authedFetch';
+import type { Currency } from './types';
+
+export async function fetchCurrencies(): Promise<Currency[]> {
+  const data = await authedFetchJson<{ ok: boolean; currencies?: Currency[] }>('/api/currencies');
+  return Array.isArray(data.currencies) ? data.currencies : [];
+}

--- a/ctf/packages/mobile/src/features/currency/index.ts
+++ b/ctf/packages/mobile/src/features/currency/index.ts
@@ -3,3 +3,5 @@
 export * from './types';
 export * from './format';
 export * from './assert';
+export * from './api';
+export * from './CurrencySelect';

--- a/ctf/packages/web/app/api/currencies/route.ts
+++ b/ctf/packages/web/app/api/currencies/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { listActiveCurrencies } from 'lib/currency/repository';
+import { reportError } from 'lib/observability/report';
+
+// Active currency catalog for the shared payment selector (issue #420). Any signed-in user can read it
+// — the list is reference data, not sensitive, and is needed in every value-bearing plugin's create
+// form. `any_authenticated` so a still-gated user can also see the options. ServiceCredits sorts first;
+// barter is included when present in the catalog (kind=barter, requiresAmount=false).
+export async function GET() {
+  const decision = await evaluatePluginAccess({ minUnlockTier: 'any_authenticated' });
+  if (!decision.allowed) {
+    return NextResponse.json(decision, { status: decision.status });
+  }
+
+  try {
+    const currencies = await listActiveCurrencies();
+    return NextResponse.json({ ok: true, currencies }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'currency', op: 'list' });
+    return NextResponse.json(
+      { ok: false, code: 'currency_catalog_unavailable', message: 'Unable to load the currency list.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/components/shared/currency-select.tsx
+++ b/ctf/packages/web/components/shared/currency-select.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Currency } from "lib/currency/types";
+import { SERVICE_CREDITS_LABEL } from "lib/currency/types";
+import { sortPreferred } from "lib/currency/format";
+
+// Shared payment-currency selector (issue #420). One control reused by every value-bearing plugin so
+// the options and ordering stay identical: ServiceCredits first, then fiat, crypto, and barter — read
+// live from the currencies catalog (`GET /api/currencies`). ServiceCredits always renders by its label,
+// never the bare "SC" code, and a ServiceCredits amount is never shown at a fiat equivalent. Barter
+// (kind=barter, requiresAmount=false) appears here too; callers can use the returned Currency to decide
+// whether to show an amount input.
+
+function optionLabel(currency: Currency): string {
+  if (currency.isServiceCredits) return SERVICE_CREDITS_LABEL;
+  return currency.symbol ? `${currency.label} (${currency.symbol})` : currency.label;
+}
+
+export interface CurrencySelectProps {
+  value: string;
+  onChange: (code: string, currency: Currency | null) => void;
+  id?: string;
+  disabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+  /** Optional pre-fetched list; if omitted the component fetches the catalog itself. */
+  currencies?: Currency[];
+}
+
+export function CurrencySelect({
+  value,
+  onChange,
+  id,
+  disabled,
+  className,
+  ariaLabel,
+  currencies: provided,
+}: CurrencySelectProps) {
+  const [currencies, setCurrencies] = useState<Currency[]>(provided ?? []);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (provided) {
+      setCurrencies(provided);
+      return;
+    }
+    let active = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/currencies", { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to load currencies");
+        const data = (await res.json()) as { currencies?: Currency[] };
+        if (active) setCurrencies(Array.isArray(data.currencies) ? data.currencies : []);
+      } catch (e: unknown) {
+        if (active) setError(e instanceof Error ? e.message : "Failed to load currencies");
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [provided]);
+
+  const sorted = sortPreferred(currencies);
+
+  return (
+    <select
+      id={id}
+      className={className}
+      disabled={disabled || sorted.length === 0}
+      value={value}
+      aria-label={ariaLabel ?? "Currency"}
+      onChange={(event) => {
+        const code = event.target.value;
+        onChange(code, sorted.find((c) => c.code === code) ?? null);
+      }}
+    >
+      {sorted.length === 0 ? (
+        <option value="">{error ? "Currencies unavailable" : "Loading…"}</option>
+      ) : (
+        sorted.map((currency) => (
+          <option key={currency.code} value={currency.code}>
+            {optionLabel(currency)}
+          </option>
+        ))
+      )}
+    </select>
+  );
+}


### PR DESCRIPTION
First step toward #420: one reusable payment-currency selector so every value-bearing plugin can offer the same options in the same order, instead of each rolling its own picker.

## What's here
- **`GET /api/currencies`** — returns the active currency catalog (`listActiveCurrencies`) for any signed-in user. Reference data, not sensitive; `any_authenticated` so even a still-gated user sees the options in a form.
- **Web `components/shared/currency-select.tsx`** — a native `<select>` reused across plugins. ServiceCredits is rendered by its label (never the bare `SC` code), fiat/crypto show their symbol, and **barter** is included automatically (it's in the catalog now). Returns the chosen `Currency` so callers can hide the amount field for barter (`requiresAmount = false`).
- **Mobile `features/currency/{api,CurrencySelect}`** — the React Native mirror: a horizontal row of selectable chips, same ordering and labels, no new dependency.

Reads the catalog **live**, so ServiceCredits stays first and any catalog change (new fiat/crypto, barter) appears with no code change.

## Not in this PR
No plugin has adopted it yet — that follows one plugin at a time (TrustTransport, SocketRelay, LightHouse, Foundation), skipping LevelUp (ServiceCredits-only). Each adoption changes a payment surface, so those go through the review lane.

Toward: #420

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_