### PR TITLE
fix: clearer TrustTransport copy for an open (unmatched) trip

### DIFF
--- a/ctf/packages/web/components/trusttransport/tt-chat-tab.tsx
+++ b/ctf/packages/web/components/trusttransport/tt-chat-tab.tsx
@@ -20,6 +20,18 @@ function ChatPane({ selected, creds, loading, error }: { selected: TripRequest |
   if (!selected) {
     return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#4B5563", fontSize: 14 }}>Select a trip to chat</div>;
   }
+  // An open/pending trip has no driver yet, so there is no one to chat with — fetching chat
+  // credentials will always fail. Show a calm waiting state instead of a red error.
+  const awaitingDriver = /open|pending|request|search|form|wait/i.test(selected.status ?? "");
+  if (awaitingDriver) {
+    return (
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 10, color: "#9CA3AF", fontSize: 14, padding: 24, textAlign: "center" }}>
+        <MessageSquare size={28} style={{ color: "rgba(249,115,22,0.3)" }} />
+        <div>Chat opens once a driver accepts your trip.</div>
+        <div style={{ fontSize: 13, color: "#6B7280" }}>We&apos;ll bring you here when you&apos;re matched.</div>
+      </div>
+    );
+  }
   if (loading) {
     return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#6B7280", fontSize: 14 }}>Loading chat…</div>;
   }
@@ -67,7 +79,11 @@ export function TrustTransportChatTab({
           const active = selectedRequest?.id === r.id;
           return (
             <button key={r.id} type="button" onClick={() => onSelect(r)} style={{ display: "block", width: "100%", textAlign: "left", padding: "10px 12px", borderRadius: 8, cursor: "pointer", background: active ? `${COLOR}18` : "transparent", border: active ? `1px solid ${COLOR}30` : "1px solid transparent", marginBottom: 4 }}>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0" }}>{r.fromLocation ?? "—"} → {r.toLocation ?? "—"}</div>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0" }}>
+                {(r.pickupCity ?? r.fromLocation) || (r.dropoffCity ?? r.toLocation)
+                  ? `${r.pickupCity ?? r.fromLocation ?? "—"} → ${r.dropoffCity ?? r.toLocation ?? "—"}`
+                  : (r.title?.trim() || "Your trip")}
+              </div>
               <div style={{ fontSize: 11, color: "#6B7280" }}>{r.status ?? "Pending"}</div>
             </button>
           );

--- a/ctf/packages/web/components/trusttransport/tt-shared.ts
+++ b/ctf/packages/web/components/trusttransport/tt-shared.ts
@@ -43,6 +43,11 @@ export interface Mode {
 export interface TripRequest {
   id: string;
   mode?: string;
+  title?: string;
+  // The API returns pickup/dropoff cities and a title — not fromLocation/toLocation. Keep the older
+  // optional names too so nothing breaks, but the UI should read pickupCity/dropoffCity (or title).
+  pickupCity?: string | null;
+  dropoffCity?: string | null;
   fromLocation?: string;
   toLocation?: string;
   status?: string;

--- a/ctf/packages/web/components/trusttransport/tt-tracking-tab.tsx
+++ b/ctf/packages/web/components/trusttransport/tt-tracking-tab.tsx
@@ -28,8 +28,15 @@ function TrackingEmpty({ onBook }: { onBook: () => void }) {
 }
 
 function TrackingCard({ request, onChat }: { request: TripRequest; onChat: (r: TripRequest) => void }) {
-  const route = `${request.fromLocation ?? "—"} → ${request.toLocation ?? "—"}`;
+  const pickup = request.pickupCity ?? request.fromLocation ?? null;
+  const dropoff = request.dropoffCity ?? request.toLocation ?? null;
+  // Show the real pickup → drop-off; fall back to the request title (the API sends pickupCity /
+  // dropoffCity / title, never fromLocation / toLocation), so the route is no longer always "— → —".
+  const route = pickup || dropoff ? `${pickup ?? "—"} → ${dropoff ?? "—"}` : (request.title?.trim() || "Your trip");
   const status = request.status ?? "Pending";
+  // An open/pending request has no driver yet — nothing is being tracked. Only show the live-map
+  // placeholder once a driver is on the way; otherwise say plainly that we're waiting for a driver.
+  const awaitingDriver = /open|pending|request|search|form|wait/i.test(status);
   return (
     <div style={{ padding: "24px", borderRadius: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}30`, marginBottom: 16 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
@@ -39,11 +46,13 @@ function TrackingCard({ request, onChat }: { request: TripRequest; onChat: (r: T
         <div style={{ fontSize: 16, fontWeight: 700, color: "#F9FAFB" }}>{route}</div>
         <Badge style={{ ...statusBadgeStyle(status), fontSize: 12, marginLeft: "auto" }}>{status}</Badge>
       </div>
-      <div style={{ padding: "48px 20px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)", textAlign: "center", color: "#4B5563", fontSize: 13, marginBottom: 16 }}>
-        Live map — tracking in progress
+      <div style={{ padding: "48px 20px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)", textAlign: "center", color: "#9CA3AF", fontSize: 13, marginBottom: 16, lineHeight: 1.5 }}>
+        {awaitingDriver
+          ? "Waiting for a driver to accept. The live map appears once someone's on the way."
+          : "Live map — tracking in progress"}
       </div>
       <button type="button" onClick={() => onChat(request)} style={{ width: "100%", padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
-        <MessageSquare size={14} /> Chat
+        <MessageSquare size={14} /> {awaitingDriver ? "Message (opens when matched)" : "Chat"}
       </button>
     </div>
   );


### PR DESCRIPTION
An open TrustTransport trip with no driver yet showed states that read like something was broken (reported with screenshots). Three fixes on the Tracking and Chat tabs of the web shell:

- **Route was always "— → —".** The cards read `request.fromLocation` / `request.toLocation`, which the API never sends — it sends `title` / `pickupCity` / `dropoffCity`. Now they read the real fields (falling back to the title), so the route reads e.g. "Pittston, Pennsylvania → Walmart".
- **Tracking copy was misleading.** "Live map — tracking in progress" showed even for an open trip with no driver. It's now status-aware: open/pending trips say **"Waiting for a driver to accept. The live map appears once someone's on the way."**
- **Chat showed a red error.** An open trip has no driver to chat with, so fetching chat credentials always failed with "Failed to fetch chat credentials". Replaced with a calm waiting state: **"Chat opens once a driver accepts your trip."**

Copy + a field fix on a shipped screen — iteration, not design-gated.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_