### PR TITLE
ci: add a daily Workflow Health Check that surfaces failing workflows

### DIFF
--- a/.github/workflows/workflow-health-check.yml
+++ b/.github/workflows/workflow-health-check.yml
@@ -1,0 +1,105 @@
+name: Workflow Health Check
+
+# Surfaces failing workflows so they don't go unnoticed. Once a day (and on demand) it asks the
+# GitHub API for every active workflow's most recent run on `main`; any whose latest run failed or
+# timed out are collected into ONE always-current triage issue. When everything is green again the
+# issue closes itself. This is visibility only — it never edits code or reruns anything.
+
+on:
+  schedule:
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  issues: write
+  contents: read
+
+concurrency:
+  group: workflow-health-check
+  cancel-in-progress: false
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Survey workflows and update the triage issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- workflow-health-check -->';
+            const label = 'ci-health';
+            const { owner, repo } = context.repo;
+            const branch = context.payload.repository?.default_branch || 'main';
+
+            const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, {
+              owner, repo, per_page: 100,
+            });
+
+            const failing = [];
+            for (const wf of workflows) {
+              if (wf.state !== 'active') continue;
+              // Skip this workflow itself — its current run is in progress and would never be flagged,
+              // but excluding it keeps the survey unambiguous.
+              if (wf.path === '.github/workflows/workflow-health-check.yml') continue;
+              let latest;
+              try {
+                const res = await github.rest.actions.listWorkflowRuns({
+                  owner, repo, workflow_id: wf.id, branch, per_page: 1,
+                });
+                latest = res.data.workflow_runs[0];
+              } catch (e) {
+                // Dynamic / default-setup workflows (CodeQL default, Copilot) may not be queryable.
+                continue;
+              }
+              if (!latest || latest.status !== 'completed') continue;
+              if (latest.conclusion === 'failure' || latest.conclusion === 'timed_out') {
+                failing.push({
+                  name: wf.name,
+                  conclusion: latest.conclusion,
+                  url: latest.html_url,
+                  when: latest.run_started_at || latest.created_at,
+                });
+              }
+            }
+
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: label, per_page: 100,
+            });
+            const existing = open.find((i) => (i.body || '').includes(marker));
+
+            if (failing.length === 0) {
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: existing.number,
+                  body: 'All workflows are green again on `' + branch + '`. Closing automatically.',
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: existing.number, state: 'closed',
+                });
+              }
+              core.info('No failing workflows on ' + branch + '.');
+              return;
+            }
+
+            failing.sort((a, b) => a.name.localeCompare(b.name));
+            const lines = failing.map(
+              (f) => '- **' + f.name + '** — last run ' + f.conclusion + ' ([logs](' + f.url + ')), ' + f.when,
+            );
+            const body = [
+              marker,
+              'These workflows\' most recent run on `' + branch + '` did not pass. Updated automatically by the daily health check (' + new Date().toISOString() + ').',
+              '',
+              ...lines,
+              '',
+              'A workflow drops off this list once its next run on `' + branch + '` passes; this issue closes when all are green.',
+            ].join('\n');
+            const title = 'Workflow health: ' + failing.length + ' not passing on ' + branch;
+
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, title, body });
+              core.info('Updated issue #' + existing.number + ' with ' + failing.length + ' failing.');
+            } else {
+              const created = await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
+              core.info('Opened issue #' + created.data.number + ' with ' + failing.length + ' failing.');
+            }

--- a/docs/ops/workflow-autofix-trigger-prompt.md
+++ b/docs/ops/workflow-autofix-trigger-prompt.md
@@ -1,0 +1,44 @@
+# Scheduled "fix failing workflows" agent prompt
+
+This is the prompt to paste into a **Claude Code on the web scheduled trigger** (your account
+feature: set a cadence, e.g. every few hours, scoped to `chargingthefuture/chargingthefuture`).
+It pairs with the always-on visibility job in `.github/workflows/workflow-health-check.yml`: that
+job *surfaces* failures in a triage issue; this agent *fixes* the tractable ones.
+
+The agent can't schedule itself — each session is ephemeral — so the cadence comes from the web
+trigger. Keep the prompt scoped and conservative so it never guesses on risky changes.
+
+---
+
+## Prompt
+
+```
+Survey this repository's GitHub Actions workflows and fix what is safely fixable.
+
+1. List the active workflows. For each, check its most recent run on `main` and note any whose
+   latest run failed or timed out. (The "Workflow Health Check" job's triage issue is a good
+   starting list, but verify against the API — it may be stale.)
+2. For each failing workflow, read the failing job's logs and find the root cause.
+3. Fix only changes that are small and unambiguous — for example: a stale `pnpm-lock.yaml`
+   (`pnpm install` then commit the lockfile), a renamed/missing script, a missing env-var guard,
+   an EOF/formatting check, or a `--frozen-lockfile` drift. For each fix: work on a descriptive
+   branch, open a PR with a Conventional-Commit title and a `Parity Status:` line, and — only for
+   low-risk infra/CI changes — enable auto-merge.
+4. Do NOT guess on anything that is ambiguous, touches secrets/credentials, changes money/ledger
+   or auth/CSRF/schema, or needs a product decision. For those, open or update a single triage
+   issue describing the failure and what you suspect, then stop.
+5. Never print, commit, or rotate secrets. Don't re-run a flaky workflow more than twice.
+6. Finish by replying with a short list: what you fixed (with PR links) and what you left for a
+   human and why.
+
+Scope: only the chargingthefuture/chargingthefuture repository.
+```
+
+---
+
+## Notes
+
+- The health-check workflow opens/updates one issue labelled `ci-health` and closes it when all
+  workflows are green again — so the agent and a human share the same live list.
+- Most "silent" failures are the same root cause hitting many scheduled jobs at once (e.g. a stale
+  lockfile breaks every `pnpm install --frozen-lockfile` job). Fix the shared cause first.


### PR DESCRIPTION
Option 1 of the two you approved: make failing workflows visible so they stop slipping by.

## What it does
`.github/workflows/workflow-health-check.yml` runs daily (and on demand). It asks the GitHub API for every active workflow's most recent run on `main`; any that **failed or timed out** are collected into **one** always-current triage issue (label `ci-health`). When everything is green again, the issue closes itself.

- Visibility only — it never edits code or re-runs anything.
- Permissions are minimal: `actions: read`, `issues: write`, `contents: read`.
- Skips itself and gracefully skips dynamic/default-setup workflows (CodeQL default, Copilot) that aren't queryable.

## Plus the option-2 prompt
`docs/ops/workflow-autofix-trigger-prompt.md` is the ready-to-paste prompt for a **Claude Code on the web scheduled trigger** that auto-fixes the *tractable* failures this job surfaces (stale lockfiles, renamed scripts, EOF/format, frozen-lockfile drift), opens PRs for them, and leaves anything risky/ambiguous as a triage issue. You set the cadence in the web UI; I can't schedule myself.

Together: the workflow gives always-on visibility; the trigger does the fixing.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_