### PR TITLE
ci: run the workflow health check every 8 hours instead of once a day

### DIFF
--- a/.github/workflows/workflow-health-check.yml
+++ b/.github/workflows/workflow-health-check.yml
@@ -1,13 +1,13 @@
 name: Workflow Health Check
 
-# Surfaces failing workflows so they don't go unnoticed. Once a day (and on demand) it asks the
+# Surfaces failing workflows so they don't go unnoticed. Every 8 hours (and on demand) it asks the
 # GitHub API for every active workflow's most recent run on `main`; any whose latest run failed or
 # timed out are collected into ONE always-current triage issue. When everything is green again the
 # issue closes itself. This is visibility only — it never edits code or reruns anything.
 
 on:
   schedule:
-    - cron: '0 13 * * *'
+    - cron: '0 5,13,21 * * *'
   workflow_dispatch:
 
 permissions:
@@ -88,7 +88,7 @@ jobs:
             );
             const body = [
               marker,
-              'These workflows\' most recent run on `' + branch + '` did not pass. Updated automatically by the daily health check (' + new Date().toISOString() + ').',
+              'These workflows\' most recent run on `' + branch + '` did not pass. Updated automatically by the health check that runs every 8 hours (' + new Date().toISOString() + ').',
               '',
               ...lines,
               '',


### PR DESCRIPTION
Moves the Workflow Health Check schedule from one run a day (13:00 UTC) to three runs a day (05:00, 13:00, 21:00 UTC), keeping the original slot. The check itself is unchanged: it surveys every workflow's most recent run on `main` and keeps one triage issue current, closing it when everything is green.

Requested so failing workflows surface within hours instead of up to a day later. Companion triage from today's survey: #432.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_0181GWVNDorJH5DSUBdK7qwY

---
_Generated by [Claude Code](https://claude.ai/code/session_0181GWVNDorJH5DSUBdK7qwY)_