### PR TITLE
ci: gate Expo Android preview builds behind an opt-in label

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -1,9 +1,16 @@
 name: Expo Preview APK
 
-# Builds an installable Android APK in Expo's cloud (EAS) for any pull request
-# that touches the mobile app, then posts a comment with the install link so a
+# Builds an installable Android APK in Expo's cloud (EAS) for a pull request that
+# touches the mobile app, then posts a comment with the install link so a
 # reviewer can download and run it on a phone — no desktop or Android Studio
 # needed.
+#
+# Quota gate: EAS Android builds on the free plan are a small, fixed monthly
+# allotment, so this does NOT build on every mobile PR. It is opt-in: the build
+# runs only when the PR carries the `build-apk` label (add it when you actually
+# intend to install the app on a phone), or when you start it by hand from the
+# Actions tab ("Run workflow"). While the label is on, pushing new commits
+# rebuilds so you get a fresh APK; remove the label to stop spending builds.
 #
 # There is ONE environment: production. A preview build is just an install
 # channel — it points at the SAME production backend and the SAME Clerk sign-in
@@ -12,9 +19,11 @@ name: Expo Preview APK
 
 on:
   pull_request:
+    types: [labeled, synchronize, reopened]
     paths:
       - "ctf/packages/mobile/**"
       - ".github/workflows/expo-preview.yml"
+  workflow_dispatch:
 
 concurrency:
   group: expo-preview-${{ github.ref }}
@@ -23,6 +32,10 @@ concurrency:
 jobs:
   preview:
     name: Build preview APK
+    # Opt-in only: a manual run, or a PR that carries the `build-apk` label. This
+    # keeps the scarce free-plan Android builds tied to a deliberate request
+    # instead of firing on every mobile-touching PR.
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'build-apk') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The Expo Android preview build was running automatically on every pull request that touched the mobile app. EAS (Expo's build cloud) only gives the free plan a small, fixed number of Android builds per month, so a normal week of mobile work used them all up — the last few preview builds failed with "this account has used its Android builds from the Free plan this month."

This makes the preview build opt-in instead of automatic:

- It now runs only when a pull request carries the `build-apk` label (add it when you actually want to install the app on a phone), or when you start it by hand from the Actions tab ("Run workflow").
- While the label is on, pushing new commits rebuilds so you get a fresh APK; remove the label to stop spending builds.
- The existing filter that limits this to PRs touching `ctf/packages/mobile/**` is kept, so the label only does anything on PRs that actually change the app.

Net effect: zero builds on PRs nobody intends to install, and one build exactly when you ask for it — which keeps the scarce free-plan builds under your control.

Note: the `build-apk` label needs to exist in the repo. Adding it to any PR through the GitHub web UI creates it the first time, or it can be created in the repo's Labels settings.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_