### PR TITLE
ci: let the CodeRabbit pacing job mark drafts ready for review

### DIFF
--- a/.github/workflows/pace-coderabbit-reviews.yml
+++ b/.github/workflows/pace-coderabbit-reviews.yml
@@ -25,10 +25,14 @@ on:
   workflow_dispatch: {}
 
 # Least privilege: this job only needs to read PR check state and flip one PR's draft
-# flag. It never pushes code and never merges.
+# flag. It never pushes code and never merges. contents must still be WRITE, not read:
+# with an explicit permissions block, the "ready for review" call (GraphQL
+# markPullRequestReadyForReview, what `gh pr ready` uses) is refused as "Resource not
+# accessible by integration" unless the token also has contents: write.
+# See https://github.com/cli/cli/discussions/6924.
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
   checks: read
 
 # If a manual run overlaps the scheduled one, let the latest win rather than double-promote.


### PR DESCRIPTION
The hourly "Pace CodeRabbit reviews" job failed its first real promotion attempt (PR #438) with "Resource not accessible by integration" — until now every run had exited early because no labelled draft was waiting, so the bug never surfaced. With an explicit `permissions:` block, the ready-for-review call (GraphQL `markPullRequestReadyForReview`, which `gh pr ready` uses) also requires `contents: write`, not just `pull-requests: write` (see https://github.com/cli/cli/discussions/6924). One-line permission change; the job still never pushes code or merges.

The next scheduled run (:17 past the hour) will verify it by promoting the waiting draft #438.

Surfaced by the 8-hourly Workflow Health Check (#439); part of the workflow-health pass tracked in #432.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_0181GWVNDorJH5DSUBdK7qwY

---
_Generated by [Claude Code](https://claude.ai/code/session_0181GWVNDorJH5DSUBdK7qwY)_