### PR TITLE
ci: add web package to the lint gate

### DIFF
--- a/ctf/package.json
+++ b/ctf/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath ctf/.husky && chmod +x .husky/pre-commit .husky/pre-push || true",
     "build": "echo Build started && pnpm -r --if-present run clean && pnpm -r --if-present run build",
-    "lint": "pnpm -r --if-present --filter=!@ctf/web run lint",
+    "lint": "pnpm -r --if-present run lint",
     "typecheck": "pnpm -r --if-present run typecheck",
     "verify:web": "pnpm --filter @ctf/web run lint && pnpm --filter @ctf/web run typecheck && pnpm run lint && pnpm run typecheck",
     "verify:mobile": "pnpm --filter @ctf/mobile run lint && pnpm --filter @ctf/mobile run typecheck && pnpm --filter @ctf/mobile run build:android:ci && node ./scripts/check-web-android-parity.mjs",

--- a/ctf/packages/web/app/api/clicklog/route.ts
+++ b/ctf/packages/web/app/api/clicklog/route.ts
@@ -5,7 +5,7 @@ import { createIncident, getIncidentsByUser, getIncidentCount } from 'lib/clickl
 import { canCreateIncident } from 'lib/clicklog/policy';
 import { MAX_NOTES_LENGTH } from 'lib/clicklog/constants';
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   const identity = await resolveRequestIdentity();
   if (!identity.userId) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
   let body;
   try {
     body = await req.json();
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
   if (!body.metadata) {

--- a/ctf/packages/web/components/foundation/Foundation.tsx
+++ b/ctf/packages/web/components/foundation/Foundation.tsx
@@ -77,9 +77,10 @@ export function Foundation() {
       } else {
         setConnectionStatus(data.message || 'Failed to create connection');
       }
-    } catch (e: any) {
-      setConnectionStatus(e.message || 'Error connecting');
-      setChatError(e.message || 'Error connecting');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Error connecting';
+      setConnectionStatus(msg);
+      setChatError(msg);
     } finally {
       setConnecting(false);
       setChatLoading(false);

--- a/ctf/packages/web/components/shared/stream-chat-panel.tsx
+++ b/ctf/packages/web/components/shared/stream-chat-panel.tsx
@@ -24,6 +24,9 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
   channelType = 'messaging',
 }) => {
   const [client, setClient] = useState<StreamChat | null>(null);
+  // The Stream Channel type is generically parameterized and impractical to satisfy here; the value is
+  // only passed straight to <Channel channel={channel}>. TODO: type once stream-chat generics are pinned.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [channel, setChannel] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -42,7 +45,7 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
           setLoading(false);
         });
       })
-      .catch((err) => {
+      .catch(() => {
         if (!isMounted) return;
         setError('Failed to connect to chat.');
         setLoading(false);

--- a/ctf/packages/web/components/workforce/workforce-public-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-public-shell.tsx
@@ -7,8 +7,6 @@ import type { PublicVisitorShellProps } from '@/components/plugins/public-visito
 // Palette from the WorkforcePublic / MobileWorkforcePublic design mockups.
 const BG = '#0F1117';
 const COLOR = '#F97316';
-const SURFACE = '#161B27';
-const BORDER = '#1E2A3A';
 const TEXT = '#F9FAFB';
 const SUBTLE = '#6B7280';
 
@@ -66,7 +64,7 @@ function DesktopWorkforcePublic({ signInUrl, verifyUrl }: { signInUrl: string; v
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12, minWidth: 260 }}>
           <div style={{ fontSize: 12, fontWeight: 700, color: '#4B5563', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Live workforce snapshot</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {SNAPSHOT.map(({ label, color }) => (
+            {SNAPSHOT.map(({ label }) => (
               <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                 <div style={{ width: 80, fontSize: 12, color: '#9CA3AF' }}>{label}</div>
                 <div style={{ flex: 1, height: 8, borderRadius: 4, background: 'rgba(255,255,255,0.05)' }} />

--- a/ctf/packages/web/lib/clicklog/repository.ts
+++ b/ctf/packages/web/lib/clicklog/repository.ts
@@ -7,7 +7,7 @@ export async function getIncidentById(id: string): Promise<ClicklogIncident | nu
 }
 
 import { queryDb } from 'lib/db/postgres';
-import { ClicklogIncident, CreateIncidentInput, IncidentMetadata } from './types';
+import { ClicklogIncident, CreateIncidentInput } from './types';
 
 export async function createIncident(input: CreateIncidentInput): Promise<ClicklogIncident> {
   const { userId, metadata } = input;

--- a/ctf/packages/web/src/app/api/peer-programming/cohorts/route.ts
+++ b/ctf/packages/web/src/app/api/peer-programming/cohorts/route.ts
@@ -15,7 +15,7 @@ export async function GET(req: NextRequest) {
   try {
     const cohorts = await getMyCohort(authResult.userId ?? '');
     return NextResponse.json(cohorts, { status: 200 });
-  } catch (e) {
+  } catch {
     return NextResponse.json({ error: 'Failed to load cohorts' }, { status: 500 });
   }
 }


### PR DESCRIPTION
The CI lint gate runs `pnpm --dir ctf run lint`, but that script excluded the web package (`--filter=!@ctf/web`), so web lint problems never blocked a pull request — they had quietly piled up. This includes the web package in the gate and clears the 10 errors that had accumulated so it goes green.

Fixes (all small, no behavior change):
- ClickLog GET route: removed an unused request parameter and an unused catch binding.
- Foundation: replaced a `catch (e: any)` with a typed `instanceof Error` check.
- Stream chat panel: removed an unused catch binding; kept the Stream channel state loosely typed with an explained disable + TODO (the Stream channel type is generically parameterized and impractical to satisfy here).
- Workforce public shell: removed two unused color constants and an unused destructured field.
- ClickLog repository: removed an unused import.
- Peer-programming cohorts route: removed an unused catch binding.

Lint and typecheck pass across all three packages.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_