### PR TITLE
feat: shared ShareLink control (show URL, open, copy) and mandatory link-sharing rule

### DIFF
--- a/.github/instructions/130-link-sharing-and-copy-url-rules.mdc
+++ b/.github/instructions/130-link-sharing-and-copy-url-rules.mdc
@@ -1,0 +1,55 @@
+# Link Sharing and Copy-URL Rules
+
+## Status
+
+**Decided by the owner. This is settled — do not relitigate.** The owner has repeatedly asked for one
+shared way to share/copy any link, app-wide. Build against it. There is no excuse for a hand-rolled
+copy button or a bare "copy" icon anywhere.
+
+## Why this exists
+
+Members are non-technical. When they share something, they need to (1) see exactly what link they're
+about to share, (2) open it to check it, and (3) copy it — with clear confirmation that the copy
+worked. A naked copy icon that silently writes something to the clipboard, or a "Share" that links to
+the app homepage instead of the thing being shared, fails them. This was shipped wrong more than once,
+so it is now a hard rule.
+
+## The one shared control (mandatory)
+
+Every share / copy-link affordance MUST use the shared control — never a custom button, a raw
+`navigator.clipboard.writeText`, or a raw `window.open` / `Linking.openURL` for sharing:
+
+- **Web:** `ShareLink` — `ctf/packages/web/components/shared/share-link.tsx`.
+- **Mobile (React Native):** `ShareLink` — `ctf/packages/mobile/src/components/shared/ShareLink.tsx`.
+
+### What the control must always do
+
+1. **Open a popup**, not copy-on-click-with-no-context. The popup shows:
+   - the **full, absolute URL** as selectable text (so the member sees exactly what they'll share);
+   - **Open in new tab** (web) / **Open link** (mobile) — opens the URL;
+   - **Copy link** — on web, copies the absolute URL and shows clear "Copied!" feedback; on mobile,
+     hands off to the OS share sheet (React Native `Share`), which includes Copy plus share-to-app, so
+     no extra clipboard dependency is needed.
+2. **Share an absolute URL.** A relative path (e.g. `/apps/socketrelay`) is resolved against the
+   current origin before sharing — never share or copy a bare relative path.
+3. **Point at the specific resource**, never the app homepage. A "share this post" link must carry the
+   post's id (e.g. `/apps/socketrelay?request=<id>`), not `/apps/socketrelay`. If the resource has no
+   deep-linkable destination yet, build the destination (or the deep-link param) — do not fall back to
+   the homepage.
+4. **Be accessible** (see `ctf/docs/developer/ACCESSIBLE_FORMS_STANDARD.md`): the trigger announces it
+   opens a popup (`aria-haspopup`/`aria-expanded`); the popup is a labelled dialog; focus moves into
+   the URL field on open and returns to the trigger on Escape/outside-click; copy feedback is
+   announced (`aria-live`). On mobile the equivalent accessibility roles/labels apply.
+5. **Never silently no-op.** On web, if the async clipboard API is unavailable, fall back to a hidden
+   `textarea` + `execCommand` so the copy still works. On mobile, the OS share sheet is the copy/share
+   path, so there is nothing to silently fail.
+
+## For agents
+
+- Adding any "Share", "Copy link", or link-out affordance? Use `ShareLink`. If a needed capability is
+  missing, extend `ShareLink` — do not fork a one-off.
+- Reviewing a diff that adds a copy/share button, a `clipboard.writeText`, or a `window.open`/
+  `Linking.openURL` for a user-facing share? That's a defect unless it goes through `ShareLink`.
+- A share link that resolves to the app homepage is always wrong — it must target the specific resource.
+- Deprecated: the old copy-only `CopyLink` (`ctf/packages/web/components/shared/copy-link.tsx`). Do not
+  add new usages; convert any remaining ones to `ShareLink`.

--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -112,6 +112,7 @@ and hides meaning.
 - [127-design-pass-gating-rules.mdc](127-design-pass-gating-rules.mdc)
 - [128-design-sync-workflow-rules.mdc](128-design-sync-workflow-rules.mdc)
 - [129-bug-reporting-and-triage-rules.mdc](129-bug-reporting-and-triage-rules.mdc)
+- [130-link-sharing-and-copy-url-rules.mdc](130-link-sharing-and-copy-url-rules.mdc)
 - [200-plugin-command-contract-templates.mdc](200-plugin-command-contract-templates.mdc)
 - [201-plugin-command-schema-template.mdc](201-plugin-command-schema-template.mdc)
 - [202-plugin-access-policy-schema-template.mdc](202-plugin-access-policy-schema-template.mdc)

--- a/ctf/packages/mobile/src/components/shared/ShareLink.tsx
+++ b/ctf/packages/mobile/src/components/shared/ShareLink.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { Text, Modal, TouchableOpacity, Pressable, StyleSheet, Linking, Share } from 'react-native';
+
+// THE shared way to share any URL across the mobile app — the React Native counterpart of the web
+// `ShareLink` (the v2 "useLink" pattern). A trigger opens a popup that (1) shows the full link, (2)
+// opens it, and (3) copies/shares it through the OS share sheet (which includes Copy on iOS and
+// Android — no extra dependency). Every share/copy-link affordance must use this. See
+// .github/instructions/130-link-sharing-and-copy-url-rules.mdc.
+//
+// Callers pass an ABSOLUTE url (the mobile app has no page origin to resolve a relative path against).
+
+type ShareLinkProps = {
+  /** Absolute URL to share. */
+  url: string;
+  /** Visible text on the trigger. */
+  label?: string;
+  /** Heading shown in the popup. */
+  title?: string;
+  /** Accent color for the trigger text. */
+  color?: string;
+};
+
+export function ShareLink({ url, label = 'Share', title = 'Share this link', color = '#FB923C' }: ShareLinkProps) {
+  const [open, setOpen] = useState(false);
+
+  async function openLink() {
+    try {
+      if (await Linking.canOpenURL(url)) {
+        await Linking.openURL(url);
+      }
+    } catch {
+      // ignore — nothing to do if the OS can't open it
+    }
+    setOpen(false);
+  }
+
+  async function shareLink() {
+    try {
+      await Share.share({ message: url, url });
+    } catch {
+      // ignore — the member dismissed the share sheet
+    }
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <TouchableOpacity
+        onPress={() => setOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel={`${label} link`}
+        accessibilityHint="Opens a menu to view, open, or copy the link"
+      >
+        <Text style={[styles.trigger, { color }]}>{label}</Text>
+      </TouchableOpacity>
+
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+        <Pressable style={styles.backdrop} onPress={() => setOpen(false)} accessibilityLabel="Close">
+          <Pressable style={styles.sheet} onPress={() => undefined}>
+            <Text style={styles.title} accessibilityRole="header">
+              {title}
+            </Text>
+            <Text style={styles.url} selectable accessibilityLabel={`Link, ${url}`}>
+              {url}
+            </Text>
+            <TouchableOpacity style={styles.item} onPress={() => void openLink()} accessibilityRole="button">
+              <Text style={styles.itemText}>Open link</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.item} onPress={() => void shareLink()} accessibilityRole="button">
+              <Text style={styles.itemText}>Copy or share link</Text>
+            </TouchableOpacity>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  trigger: { fontSize: 12, fontWeight: '600' },
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  sheet: { backgroundColor: '#161B27', borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 20, gap: 12 },
+  title: { fontSize: 13, fontWeight: '700', color: '#9CA3AF' },
+  url: { fontSize: 13, color: '#E8EAF0', padding: 10, backgroundColor: 'rgba(255,255,255,0.04)', borderRadius: 8 },
+  item: { paddingVertical: 12 },
+  itemText: { fontSize: 15, fontWeight: '600', color: '#E8EAF0' },
+});

--- a/ctf/packages/web/components/shared/share-link.tsx
+++ b/ctf/packages/web/components/shared/share-link.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { Share2, Copy, Check, ExternalLink } from "lucide-react";
+
+// THE shared way to share any URL across the web app (the v2 "useLink" pattern). A trigger button opens
+// a small popup that (1) shows the full, absolute link, (2) lets you open it in a new tab, and (3)
+// copies it with clear feedback. Every "share"/"copy link" affordance in the app must use this — never a
+// bare copy button or a raw window.open. See .github/instructions/130-link-sharing-and-copy-url-rules.mdc.
+//
+// Accessibility: the trigger has aria-haspopup/aria-expanded; the popup is a labelled dialog; opening it
+// moves focus to the (selectable) URL field; Escape and an outside click close it and return focus to the
+// trigger; copy feedback is announced via aria-live.
+
+function toAbsolute(url: string): string {
+  if (typeof window === "undefined") return url;
+  try {
+    return new URL(url, window.location.origin).href;
+  } catch {
+    return url;
+  }
+}
+
+async function writeToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy path (older mobile browsers / insecure contexts)
+  }
+  try {
+    const el = document.createElement("textarea");
+    el.value = text;
+    el.setAttribute("readonly", "");
+    el.style.position = "absolute";
+    el.style.left = "-9999px";
+    document.body.appendChild(el);
+    el.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(el);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+export function ShareLink({
+  url,
+  label = "Share",
+  title = "Share this link",
+  className,
+  iconSize = 14,
+}: {
+  /** Absolute or app-relative URL. Relative is resolved against the current origin before sharing. */
+  url: string;
+  /** Visible text on the trigger button. */
+  label?: string;
+  /** Heading shown inside the popup. */
+  title?: string;
+  className?: string;
+  iconSize?: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const urlRef = useRef<HTMLInputElement>(null);
+  const dialogId = useId();
+
+  const absolute = toAbsolute(url);
+
+  useEffect(() => {
+    if (!open) return;
+    // Focus the URL field so a keyboard/AT user lands on the link itself.
+    urlRef.current?.focus();
+    urlRef.current?.select();
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+    function onPointerDown(e: PointerEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [open]);
+
+  async function onCopy() {
+    const ok = await writeToClipboard(absolute);
+    setCopied(ok);
+    window.setTimeout(() => setCopied(false), 2000);
+  }
+
+  function onOpenNewTab() {
+    window.open(absolute, "_blank", "noopener,noreferrer");
+    setOpen(false);
+  }
+
+  const itemStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    width: "100%",
+    padding: "8px 10px",
+    background: "transparent",
+    border: "none",
+    borderRadius: 8,
+    color: "#E8EAF0",
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+    textAlign: "left",
+  };
+
+  return (
+    <div ref={rootRef} style={{ position: "relative", display: "inline-flex" }}>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setOpen((o) => !o);
+        }}
+        className={className}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? dialogId : undefined}
+        style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "transparent", border: "none", padding: 0, margin: 0, cursor: "pointer", color: "inherit", font: "inherit" }}
+      >
+        <Share2 size={iconSize} />
+        <span>{label}</span>
+      </button>
+
+      {open ? (
+        <div
+          id={dialogId}
+          role="dialog"
+          aria-label={title}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: "absolute",
+            bottom: "calc(100% + 8px)",
+            left: 0,
+            zIndex: 50,
+            width: 280,
+            maxWidth: "80vw",
+            padding: 12,
+            background: "#161B27",
+            border: "1px solid #1E2A3A",
+            borderRadius: 12,
+            boxShadow: "0 12px 28px rgba(0,0,0,0.45)",
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 700, color: "#9CA3AF" }}>{title}</div>
+          <input
+            ref={urlRef}
+            readOnly
+            value={absolute}
+            aria-label="Link URL"
+            onFocus={(e) => e.currentTarget.select()}
+            style={{ width: "100%", padding: "8px 10px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 12, color: "#E8EAF0", outline: "none", boxSizing: "border-box" }}
+          />
+          <button type="button" onClick={() => void onCopy()} style={itemStyle}>
+            {copied ? <Check size={15} /> : <Copy size={15} />}
+            <span aria-live="polite">{copied ? "Copied!" : "Copy link"}</span>
+          </button>
+          <button type="button" onClick={onOpenNewTab} style={itemStyle}>
+            <ExternalLink size={15} />
+            <span>Open in new tab</span>
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/socketrelay/sr-feed.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-feed.tsx
@@ -4,7 +4,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
 import { MapPin, Share2 } from "lucide-react";
 import { COLOR, FAINT, SUBTLE, requestTags, settlementLabel, srHandle, timeAgo, type SrRequest } from "./sr-shared";
-import { CopyLink } from "@/components/shared/copy-link";
+import { ShareLink } from "@/components/shared/share-link";
 
 function CardAction({ open, isOwn, submitting, onClaim, onEdit }: { open: boolean; isOwn: boolean; submitting: boolean; onClaim: () => void; onEdit: () => void }) {
   if (!open) return <div style={{ fontSize: 12, color: "#22C55E", fontWeight: 600 }}>✓ closed</div>;
@@ -60,7 +60,7 @@ function RequestCard({
             <span style={{ color: COLOR, fontWeight: 600 }}>{srHandle(r.ownerUsername, r.id)}</span>
             {r.city && <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><MapPin size={11} /> {r.city}</span>}
             <span>· {timeAgo(r.createdAtIso)}</span>
-            <CopyLink url="/apps/socketrelay" label="Share" className="sr-share" />
+            <ShareLink url={`/apps/socketrelay?request=${r.id}`} label="Share" title="Share this request" className="sr-share" />
           </div>
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-end", flexShrink: 0 }}>


### PR DESCRIPTION
One shared way to share/copy any link — the v2 "useLink" pattern you've asked for repeatedly — plus an agent rule so it's actually followed. Also fixes the SocketRelay "Share" linking to the app homepage instead of the post.

- **Web `ShareLink`** (`components/shared/share-link.tsx`): a trigger that opens an accessible popup showing the **full absolute URL** (selectable), with **Open in new tab** and **Copy link** (with "Copied!" feedback). Focus moves into the URL field on open; Escape/outside-click close it and restore focus; the trigger announces it opens a popup.
- **Mobile `ShareLink`** (`src/components/shared/ShareLink.tsx`): the same popup for React Native — shows the URL with **Open link** and **Copy or share link**, the latter using the OS share sheet (which includes Copy on iOS/Android, so no new dependency).
- **SocketRelay** feed now uses `ShareLink` with a **per-post URL** (`/apps/socketrelay?request=<id>`) instead of `/apps/socketrelay`.
- **New agent rule** `.github/instructions/130-link-sharing-and-copy-url-rules.mdc` (registered in the index): makes `ShareLink` mandatory for every share/copy-url affordance, requires an absolute URL pointing at the **specific resource** (never the homepage), and deprecates the copy-only `CopyLink`. This is the "sufficient agent instructions" that was missing.

Follow-ups (tracked): converting any remaining share/copy affordances across other plugins to `ShareLink`, and making the SocketRelay shell actually open the post for `?request=<id>`.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_