### PR TITLE
fix: remove all per-plugin loading skeletons; use the single AppLoading

### DIFF
--- a/ctf/packages/web/components/clicklog/clicklog-loading.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/ClickLogLoading.tsx.
-import { BG } from "./clicklog-shared";
-
-export function ClicklogLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as ClicklogLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/gdp/gdp-loading.tsx
+++ b/ctf/packages/web/components/gdp/gdp-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/GDPLoading.tsx.
-import { BG } from "./gdp-shared";
-
-export function GdpLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as GdpLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/gentlepulse/gp-loading.tsx
+++ b/ctf/packages/web/components/gentlepulse/gp-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/GentlePulseLoading.tsx.
-import { BG } from "./gp-shared";
-
-export function GentlePulseLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as GentlePulseLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/levelup/lu-loading.tsx
+++ b/ctf/packages/web/components/levelup/lu-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/LevelUpLoading.tsx.
-import { BG } from "./lu-shared";
-
-export function LevelUpLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as LevelUpLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/mood/mood-loading.tsx
+++ b/ctf/packages/web/components/mood/mood-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/MoodLoading.tsx.
-import { BG } from "./mood-shared";
-
-export function MoodLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as MoodLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/peer-programming/pp-loading.tsx
+++ b/ctf/packages/web/components/peer-programming/pp-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/PeerProgrammingLoading.tsx.
-import { BG } from "./pp-shared";
-
-export function PeerProgrammingLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as PeerProgrammingLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/skills-taxonomy/st-loading.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/st-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/SkillsTaxonomyLoading.tsx.
-import { BG } from "./st-shared";
-
-export function SkillsTaxonomyLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as SkillsTaxonomyLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/socketrelay/sr-loading.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/SocketRelayLoading.tsx.
-import { BG } from "./sr-shared";
-
-export function SocketRelayLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as SocketRelayLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/unlock/unlock-loading.tsx
+++ b/ctf/packages/web/components/unlock/unlock-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/UnlockLoading.tsx.
-import { BG } from "./unlock-shared";
-
-export function UnlockLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as UnlockLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/weekly-performance/wp-loading.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-loading.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-// STATE: Loading — data fetch in progress. Ported from
-// design/.../survivor-hub/WeeklyPerformanceLoading.tsx.
-import { BG } from "./wp-shared";
-
-export function WeeklyPerformanceLoading() {
-  return (
-    <div style={{ display: "flex", height: "100vh", width: "100%", background: BG, alignItems: "center", justifyContent: "center", fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: "center", padding: "0 32px" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: "0.18em", color: "rgba(255,255,255,0.22)", textTransform: "uppercase", fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as WeeklyPerformanceLoading } from "@/components/shared/app-loading";

--- a/ctf/packages/web/components/whatworks/ww-loading.tsx
+++ b/ctf/packages/web/components/whatworks/ww-loading.tsx
@@ -1,19 +1,4 @@
-'use client';
-
-// STATE: Loading — ported from design/.../survivor-hub/WhatWorksLoading.tsx.
-import { BG } from './ww-shared';
-
-export function WhatWorksLoading() {
-  return (
-    <div style={{ display: 'flex', height: '100dvh', width: '100%', background: BG, alignItems: 'center', justifyContent: 'center', fontFamily: "'Inter',system-ui" }}>
-      <div style={{ textAlign: 'center', padding: '0 32px' }}>
-        <div style={{ fontSize: 11, letterSpacing: '0.18em', color: 'rgba(255,255,255,0.22)', textTransform: 'uppercase', fontWeight: 500, marginBottom: 16, lineHeight: 2 }}>
-          EXIT THEIR ECONOMY
-        </div>
-        <div style={{ fontSize: 11, letterSpacing: '0.18em', color: 'rgba(255,255,255,0.22)', textTransform: 'uppercase', fontWeight: 500, lineHeight: 2 }}>
-          EXIT THE PSYOP
-        </div>
-      </div>
-    </div>
-  );
-}
+// The app has a single loading screen (AppLoading) and no per-plugin loading
+// skeletons. This previously rendered a custom skeleton; it now re-exports the
+// shared loading screen under the existing name so call sites are unchanged.
+export { AppLoading as WhatWorksLoading } from "@/components/shared/app-loading";


### PR DESCRIPTION
There should be no loading skeletons — the app is meant to have one loading screen (`AppLoading`), and with its built-in delay (PR #460) it rarely appears at all. But eleven plugins shipped their own custom loading-skeleton components: ClickLog, SocketRelay, Skills Taxonomy, Peer Programming, Mood, Unlock, GentlePulse, GDP, LevelUp, Weekly Performance, and WhatWorks.

Each of those now re-exports `AppLoading` under its existing name, so the skeleton markup is deleted and every call site is unchanged. (Lighthouse and Directory already rendered `AppLoading`.) Result: one loading screen everywhere, no skeletons.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_