### PR TITLE
fix: correct LevelUp description to its real scope (training cohorts)

### DIFF
--- a/ctf/packages/web/lib/plugins/plugin-catalog.ts
+++ b/ctf/packages/web/lib/plugins/plugin-catalog.ts
@@ -132,7 +132,7 @@ export const pluginCatalog: PluginCatalogItem[] = [
     id: 'levelup',
     name: 'LevelUp',
     kind: 'plugin',
-    summary: 'Flexible training cohorts with milestone escrow release, trainer payouts, stipends, and disputes.',
+    summary: 'Paid skills-training cohorts — learn a skill with a trainer and earn stipends as you reach each milestone.',
   },
   {
     id: 'clicklog',

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -158,7 +158,7 @@ const fallbackPluginRegistry: PluginRegistryItem[] = [
   {
     slug: 'levelup',
     name: 'LevelUp',
-    summary: 'Flexible training cohorts with milestone escrow release, trainer payouts, stipends, and disputes.',
+    summary: 'Paid skills-training cohorts — learn a skill with a trainer and earn stipends as you reach each milestone.',
     availabilityState: 'implemented_shell',
     navRank: 170,
     isVisible: true,

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1719,7 +1719,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('weekly-performance', 'Weekly Performance',   'Week selection/guardrails with metrics, comparisons, and export gate checks.',                    'implemented_shell', 140, TRUE),
   ('gdp',                'GDP',                  'Aggregate transparency and admin publish flows with compliance controls.',                        'implemented_shell', 150, TRUE),
   ('service-credits',    'Service Credits',      'Wallet/transfers/escrow/disputes and treasury governance workflows.',                             'implemented_shell', 160, TRUE),
-  ('levelup',            'LevelUp',              'Flexible training cohorts with milestone escrow release, trainer payouts, stipends, and disputes.','implemented_shell', 170, TRUE),
+  ('levelup',            'LevelUp',              'Paid skills-training cohorts — learn a skill with a trainer and earn stipends as you reach each milestone.','implemented_shell', 170, TRUE),
   ('whatworks',          'WhatWorks',            'One shared, survivor-verified list of tools that solved a specific problem, with admin-curated problems and reviewed suggestions.','implemented_shell', 200, TRUE),
   ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'alpha',             210, FALSE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE)


### PR DESCRIPTION
Follow-up to the plugin-descriptions change (#459). The landing page pitches LevelUp as "goal tracking and progress milestones," but the LevelUp plugin is actually **paid skills-training cohorts** (trainers, milestones, stipends). So that landing copy is wrong for this plugin.

Set LevelUp's description to match the real plugin: **"Paid skills-training cohorts — learn a skill with a trainer and earn stipends as you reach each milestone."** Updated the registry seed (`schema.sql`) and the fallback/catalog.

The landing page's LevelUp copy should be corrected on that side separately — tracked in a reminder issue.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_