### PR TITLE
fix: add accessible labels to icon-only buttons across the app

### DIFF
--- a/ctf/packages/mobile/src/features/chyme/ChymeAudioRoom.tsx
+++ b/ctf/packages/mobile/src/features/chyme/ChymeAudioRoom.tsx
@@ -177,7 +177,7 @@ const ChymeAudioRoomLive: React.FC<{ onOpenChat: () => void; onLeave: () => void
             <Text style={styles.liveText}>Live</Text>
           </View>
           <Text style={styles.roomLabel}>Members Only 🔒</Text>
-          <TouchableOpacity style={styles.chatBtn} onPress={onOpenChat}>
+          <TouchableOpacity style={styles.chatBtn} onPress={onOpenChat} accessibilityRole="button" accessibilityLabel="Open chat">
             <Text style={styles.chatBtnIcon}>💬</Text>
           </TouchableOpacity>
         </View>

--- a/ctf/packages/mobile/src/features/chyme/chyme-chat-view.tsx
+++ b/ctf/packages/mobile/src/features/chyme/chyme-chat-view.tsx
@@ -104,6 +104,8 @@ export const ChymeChatView: React.FC<Props> = ({
           style={[styles.sendBtn, input.trim() && styles.sendBtnActive]}
           onPress={onSend}
           disabled={!input.trim() || sending}
+          accessibilityRole="button"
+          accessibilityLabel="Send message"
         >
           <Text style={styles.sendBtnIcon}>›</Text>
         </TouchableOpacity>

--- a/ctf/packages/mobile/src/features/comic/ComicComposer.tsx
+++ b/ctf/packages/mobile/src/features/comic/ComicComposer.tsx
@@ -135,6 +135,8 @@ export function ComicComposer({ onAsked }: ComicComposerProps) {
             style={[styles.sendBtn, isAsk && input.trim() ? styles.sendBtnActive : null]}
             onPress={handleSend}
             disabled={!input.trim() || sending}
+            accessibilityRole="button"
+            accessibilityLabel="Send"
           >
             {sending ? (
               <ActivityIndicator size="small" color="#fff" />

--- a/ctf/packages/mobile/src/features/comic/comic-cards.tsx
+++ b/ctf/packages/mobile/src/features/comic/comic-cards.tsx
@@ -94,6 +94,8 @@ export function ComicAnswerCard({ item, askedByLabel, onRate }: ComicAnswerCardP
           <Pressable
             style={[styles.flagBtn, rating === 'flagged' ? styles.flagBtnActive : null]}
             onPress={() => onRate(item.answerTurnId as string, 'flagged')}
+            accessibilityRole="button"
+            accessibilityLabel="Flag answer"
           >
             <Ionicons
               name={rating === 'flagged' ? 'flag' : 'flag-outline'}

--- a/ctf/packages/mobile/src/features/directory/AdminDirectory.tsx
+++ b/ctf/packages/mobile/src/features/directory/AdminDirectory.tsx
@@ -230,7 +230,7 @@ export const AdminDirectory = () => {
               {isUnclaimed ? 'Unclaimed' : 'Claimed'} · {sourceLabel(p).label}
             </Text>
           </View>
-          <TouchableOpacity onPress={closeDrawer} style={styles.editHeaderClose}>
+          <TouchableOpacity onPress={closeDrawer} style={styles.editHeaderClose} accessibilityRole="button" accessibilityLabel="Close">
             <Text style={styles.editHeaderCloseText}>✕</Text>
           </TouchableOpacity>
         </View>

--- a/ctf/packages/mobile/src/features/gentlepulse/GentlePulse.tsx
+++ b/ctf/packages/mobile/src/features/gentlepulse/GentlePulse.tsx
@@ -137,13 +137,13 @@ function PlayerView({
       <Text style={styles.playerTitle}>{session.title}</Text>
       <Text style={styles.playerDesc} numberOfLines={4}>{session.description}</Text>
       <View style={styles.playerControls}>
-        <TouchableOpacity onPress={onBack} style={styles.playerCtrlBtn}>
+        <TouchableOpacity onPress={onBack} style={styles.playerCtrlBtn} accessibilityRole="button" accessibilityLabel="Back">
           <Text style={styles.playerCtrlText}>←</Text>
         </TouchableOpacity>
-        <TouchableOpacity onPress={() => setIsPaused(!isPaused)} style={styles.playerPlayBtn}>
+        <TouchableOpacity onPress={() => setIsPaused(!isPaused)} style={styles.playerPlayBtn} accessibilityRole="button" accessibilityLabel={isPaused ? 'Play' : 'Pause'}>
           <Ionicons name={isPaused ? 'play' : 'pause'} size={28} color={BG} />
         </TouchableOpacity>
-        <TouchableOpacity onPress={onStop} style={styles.playerCtrlBtn}>
+        <TouchableOpacity onPress={onStop} style={styles.playerCtrlBtn} accessibilityRole="button" accessibilityLabel="Stop">
           <Text style={styles.playerCtrlText}>✕</Text>
         </TouchableOpacity>
       </View>

--- a/ctf/packages/mobile/src/features/socketrelay/SocketRelay.tsx
+++ b/ctf/packages/mobile/src/features/socketrelay/SocketRelay.tsx
@@ -436,6 +436,8 @@ export function SocketRelay() {
         <TouchableOpacity
           style={styles.headerAddBtn}
           onPress={() => setActiveNav('post')}
+          accessibilityRole="button"
+          accessibilityLabel="Add request"
         >
           <Text style={styles.headerAddBtnText}>+</Text>
         </TouchableOpacity>

--- a/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
+++ b/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
@@ -57,6 +57,7 @@ export function ChymeChatPanel({
           />
           <button
             onClick={onSend}
+            aria-label="Send"
             disabled={sending || !draft.trim()}
             style={{ width: 28, height: 28, borderRadius: 6, background: draft.trim() ? PRIMARY : 'transparent', border: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: draft.trim() ? 'pointer' : 'not-allowed' }}
           >

--- a/ctf/packages/web/components/chyme/chyme-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-shell.tsx
@@ -61,6 +61,7 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
         {/* Back button */}
         <Link
           href="/apps"
+          aria-label="Back to apps"
           style={{
             width: 44,
             height: 44,

--- a/ctf/packages/web/components/contributions/admin/contributions-admin-settings.tsx
+++ b/ctf/packages/web/components/contributions/admin/contributions-admin-settings.tsx
@@ -97,6 +97,7 @@ export function ContributionsAdminSettings({ t, config, saving, error, onSave, i
           </div>
           <button
             type="button"
+            aria-label="Toggle fundraiser banner"
             aria-pressed={bannerEnabled}
             onClick={() => setBannerEnabled((b) => !b)}
             style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: bannerEnabled ? t.ACCENT : t.MUTED, display: 'flex' }}

--- a/ctf/packages/web/components/directory/directory-admin-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-admin-shell.tsx
@@ -370,7 +370,7 @@ export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }
               <div style={{ fontSize: 15, fontWeight: 700 }}>Edit Profile</div>
               <div style={{ fontSize: 11, color: SUBTLE }}>{p.claimedByUserId == null ? "Unclaimed" : "Claimed"} · {sourceBadge(p).label}</div>
             </div>
-            <button onClick={closeDrawer} style={{ width: 30, height: 30, borderRadius: 8, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
+            <button onClick={closeDrawer} aria-label="Close" style={{ width: 30, height: 30, borderRadius: 8, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
               <X size={14} color={SUBTLE} />
             </button>
           </div>
@@ -448,7 +448,7 @@ export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }
                         <Edit2 size={12} /> Edit profile
                       </button>
                       {p.claimedByUserId == null && (
-                        <button onClick={() => void handleDelete(p)} disabled={saving} style={{ width: 34, height: 34, borderRadius: 9, background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.2)", color: "#EF4444", cursor: saving ? "not-allowed" : "pointer", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                        <button onClick={() => void handleDelete(p)} disabled={saving} aria-label="Delete profile" style={{ width: 34, height: 34, borderRadius: 9, background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.2)", color: "#EF4444", cursor: saving ? "not-allowed" : "pointer", display: "flex", alignItems: "center", justifyContent: "center" }}>
                           <Trash2 size={13} />
                         </button>
                       )}
@@ -556,7 +556,7 @@ export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }
                       {isEditing ? <><X size={11} /> Close</> : <><Edit2 size={11} /> Edit</>}
                     </button>
                     {p.claimedByUserId == null && (
-                      <button onClick={() => void handleDelete(p)} disabled={saving} style={{ width: 28, height: 28, borderRadius: 7, background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.2)", color: "#EF4444", cursor: saving ? "not-allowed" : "pointer", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                      <button onClick={() => void handleDelete(p)} disabled={saving} aria-label="Delete profile" style={{ width: 28, height: 28, borderRadius: 7, background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.2)", color: "#EF4444", cursor: saving ? "not-allowed" : "pointer", display: "flex", alignItems: "center", justifyContent: "center" }}>
                         <Trash2 size={12} />
                       </button>
                     )}
@@ -577,7 +577,7 @@ export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }
               <div style={{ fontSize: 13, fontWeight: 700 }}>Edit Profile</div>
               <div style={{ fontSize: 11, color: SUBTLE }}>{editing.claimedByUserId == null ? "Unclaimed" : "Claimed"} · {sourceBadge(editing).label}</div>
             </div>
-            <button onClick={closeDrawer} style={{ width: 26, height: 26, borderRadius: 6, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}>
+            <button onClick={closeDrawer} aria-label="Close" style={{ width: 26, height: 26, borderRadius: 6, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}>
               <X size={12} />
             </button>
           </div>

--- a/ctf/packages/web/components/directory/directory-browse.tsx
+++ b/ctf/packages/web/components/directory/directory-browse.tsx
@@ -82,7 +82,7 @@ export function DirectoryBrowse({
                   <button style={{ flex: 1, padding: "8px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 4 }}>
                     View Profile <ChevronRight size={12} />
                   </button>
-                  <button style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", color: "#9CA3AF", fontSize: 12, cursor: "pointer", display: "flex", alignItems: "center", gap: 4 }}>
+                  <button aria-label="Message" style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", color: "#9CA3AF", fontSize: 12, cursor: "pointer", display: "flex", alignItems: "center", gap: 4 }}>
                     <MessageSquare size={12} />
                   </button>
                 </div>

--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -231,10 +231,10 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
           <BookOpen size={20} style={{ color: t.ACCENT }} />
         </div>
         <div style={{ flex: 1 }} />
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: t.MUTED }}>
+        <button aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: t.MUTED }}>
           <Bell size={18} />
         </button>
-        <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: t.MUTED }}>
+        <button aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: t.MUTED }}>
           <Settings size={18} />
         </button>
         <Avatar style={{ width: 36, height: 36, marginTop: 4 }}>

--- a/ctf/packages/web/components/gentlepulse/gp-icon-rail.tsx
+++ b/ctf/packages/web/components/gentlepulse/gp-icon-rail.tsx
@@ -16,13 +16,13 @@ export function GentlePulseIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab
         <Heart size={20} style={{ color: COLOR }} />
       </div>
       {NAV.map(({ icon: Icon, key }) => (
-        <button key={key} onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : FAINT }}>
+        <button key={key} onClick={() => onTab(key)} aria-label={key === "sessions" ? "Sessions" : "Now playing"} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : FAINT }}>
           <Icon size={20} />
         </button>
       ))}
       <div style={{ flex: 1 }} />
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: FAINT }}><Bell size={18} /></button>
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: FAINT }}><Settings size={18} /></button>
+      <button aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: FAINT }}><Bell size={18} /></button>
+      <button aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: FAINT }}><Settings size={18} /></button>
       <Avatar style={{ width: 36, height: 36 }}>
         <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
       </Avatar>

--- a/ctf/packages/web/components/gentlepulse/gp-player.tsx
+++ b/ctf/packages/web/components/gentlepulse/gp-player.tsx
@@ -35,10 +35,10 @@ export function GentlePulsePlayer({
             </div>
           </div>
           <div style={{ display: "flex", justifyContent: "center", gap: 20, marginBottom: 24 }}>
-            <button style={{ width: 56, height: 56, borderRadius: "50%", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}>
+            <button aria-label="Volume" style={{ width: 56, height: 56, borderRadius: "50%", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}>
               <Volume2 size={20} />
             </button>
-            <button onClick={onTogglePause} style={{ width: 72, height: 72, borderRadius: "50%", background: COLOR, border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
+            <button onClick={onTogglePause} aria-label={isPaused ? "Play" : "Pause"} style={{ width: 72, height: 72, borderRadius: "50%", background: COLOR, border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
               {isPaused ? <Play size={28} style={{ color: "#0A0F0E" }} /> : <Pause size={28} style={{ color: "#0A0F0E" }} />}
             </button>
             <button onClick={onClose} style={{ width: 56, height: 56, borderRadius: "50%", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE, fontSize: 14 }}>

--- a/ctf/packages/web/components/lighthouse/lighthouse-icon-rail.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-icon-rail.tsx
@@ -3,10 +3,10 @@
 import { Bell, Heart, Home, MessageSquare, Search, Settings } from "lucide-react";
 import { COLOR, type Tab } from "./shared";
 
-const NAV: { icon: React.ElementType; key: Tab }[] = [
-  { icon: Search, key: "browse" },
-  { icon: Heart, key: "matches" },
-  { icon: MessageSquare, key: "chat" },
+const NAV: { icon: React.ElementType; key: Tab; label: string }[] = [
+  { icon: Search, key: "browse", label: "Browse" },
+  { icon: Heart, key: "matches", label: "Matches" },
+  { icon: MessageSquare, key: "chat", label: "Chat" },
 ];
 
 export function LighthouseIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => void }) {
@@ -15,14 +15,14 @@ export function LighthouseIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab)
       <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
         <Home size={20} style={{ color: COLOR }} />
       </div>
-      {NAV.map(({ icon: Icon, key }) => (
-        <button key={key} onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
+      {NAV.map(({ icon: Icon, key, label }) => (
+        <button key={key} aria-label={label} onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
           <Icon size={20} />
         </button>
       ))}
       <div style={{ flex: 1 }} />
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Bell size={18} /></button>
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Settings size={18} /></button>
+      <button aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Bell size={18} /></button>
+      <button aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Settings size={18} /></button>
       <div style={{ width: 36, height: 36, borderRadius: 12, background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700, display: "flex", alignItems: "center", justifyContent: "center" }}>S</div>
     </aside>
   );

--- a/ctf/packages/web/components/mood/mood-icon-rail.tsx
+++ b/ctf/packages/web/components/mood/mood-icon-rail.tsx
@@ -19,7 +19,7 @@ export function MoodIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => vo
         <Smile size={20} style={{ color: t.ACCENT }} />
       </div>
       {NAV.map(({ icon: Icon, key }) => (
-        <button key={key} type="button" onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${t.ACCENT}20` : "transparent", border: tab === key ? `1px solid ${t.ACCENT}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? t.ACCENT : t.SUBTLE }}>
+        <button key={key} type="button" onClick={() => onTab(key)} aria-label={key === "checkin" ? "Check-in" : "Community Pulse"} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${t.ACCENT}20` : "transparent", border: tab === key ? `1px solid ${t.ACCENT}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? t.ACCENT : t.SUBTLE }}>
           <Icon size={20} />
         </button>
       ))}

--- a/ctf/packages/web/components/peer-programming/pp-chat-tab.tsx
+++ b/ctf/packages/web/components/peer-programming/pp-chat-tab.tsx
@@ -69,7 +69,7 @@ export function PeerProgrammingChatTab({
               disabled={submitting}
               style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 14, color: "#E8EAF0" }}
             />
-            <button type="button" onClick={onSend} disabled={!canSend} style={{ width: 32, height: 32, borderRadius: 8, background: canSend ? COLOR : "rgba(255,255,255,0.06)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: canSend ? "pointer" : "not-allowed" }}>
+            <button type="button" aria-label="Send" onClick={onSend} disabled={!canSend} style={{ width: 32, height: 32, borderRadius: 8, background: canSend ? COLOR : "rgba(255,255,255,0.06)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: canSend ? "pointer" : "not-allowed" }}>
               <Send size={14} style={{ color: canSend ? "#fff" : "#4B5563" }} />
             </button>
           </div>

--- a/ctf/packages/web/components/peer-programming/pp-icon-rail.tsx
+++ b/ctf/packages/web/components/peer-programming/pp-icon-rail.tsx
@@ -4,10 +4,10 @@ import { Users, Video, MessageSquare, Bell, Settings } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { COLOR, type Tab } from "./pp-shared";
 
-const TABS: { icon: React.ElementType; key: Tab }[] = [
-  { icon: Users, key: "cohorts" },
-  { icon: Video, key: "session" },
-  { icon: MessageSquare, key: "chat" },
+const TABS: { icon: React.ElementType; key: Tab; label: string }[] = [
+  { icon: Users, key: "cohorts", label: "Cohorts" },
+  { icon: Video, key: "session", label: "Session" },
+  { icon: MessageSquare, key: "chat", label: "Chat" },
 ];
 
 export function PeerProgrammingIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => void }) {
@@ -16,14 +16,14 @@ export function PeerProgrammingIconRail({ tab, onTab }: { tab: Tab; onTab: (tab:
       <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
         <Users size={20} style={{ color: COLOR }} />
       </div>
-      {TABS.map(({ icon: Icon, key }) => (
-        <button key={key} type="button" onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
+      {TABS.map(({ icon: Icon, key, label }) => (
+        <button key={key} type="button" aria-label={label} onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : "#6B7280" }}>
           <Icon size={20} />
         </button>
       ))}
       <div style={{ flex: 1 }} />
-      <button type="button" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Bell size={18} /></button>
-      <button type="button" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Settings size={18} /></button>
+      <button type="button" aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Bell size={18} /></button>
+      <button type="button" aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}><Settings size={18} /></button>
       <Avatar style={{ width: 36, height: 36 }}>
         <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
       </Avatar>

--- a/ctf/packages/web/components/socketrelay/sr-icon-rail.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-icon-rail.tsx
@@ -4,10 +4,10 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Bell, MessageSquare, Plus, Settings, Share2 } from "lucide-react";
 import { COLOR, SUBTLE, type Tab } from "./sr-shared";
 
-const NAV: { icon: React.ElementType; key: Tab }[] = [
-  { icon: Share2, key: "feed" },
-  { icon: Plus, key: "post" },
-  { icon: MessageSquare, key: "chat" },
+const NAV: { icon: React.ElementType; key: Tab; label: string }[] = [
+  { icon: Share2, key: "feed", label: "Feed" },
+  { icon: Plus, key: "post", label: "Post" },
+  { icon: MessageSquare, key: "chat", label: "Chat" },
 ];
 
 export function SocketRelayIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab) => void }) {
@@ -16,14 +16,14 @@ export function SocketRelayIconRail({ tab, onTab }: { tab: Tab; onTab: (tab: Tab
       <div style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}30`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
         <Share2 size={20} style={{ color: COLOR }} />
       </div>
-      {NAV.map(({ icon: Icon, key }) => (
-        <button key={key} onClick={() => onTab(key)} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : SUBTLE }}>
+      {NAV.map(({ icon: Icon, key, label }) => (
+        <button key={key} onClick={() => onTab(key)} aria-label={label} style={{ width: 44, height: 44, borderRadius: 12, background: tab === key ? `${COLOR}20` : "transparent", border: tab === key ? `1px solid ${COLOR}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: tab === key ? COLOR : SUBTLE }}>
           <Icon size={20} />
         </button>
       ))}
       <div style={{ flex: 1 }} />
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Bell size={18} /></button>
-      <button style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Settings size={18} /></button>
+      <button aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Bell size={18} /></button>
+      <button aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}><Settings size={18} /></button>
       <Avatar style={{ width: 36, height: 36 }}>
         <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
       </Avatar>

--- a/ctf/packages/web/components/socketrelay/sr-post.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-post.tsx
@@ -50,7 +50,7 @@ function TagEditor({
         {tags.map((tag) => (
           <span key={tag} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "5px 10px", borderRadius: 14, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600 }}>
             {tag}
-            <X size={12} style={{ cursor: "pointer" }} onClick={() => onChange(tags.filter((t) => t !== tag))} />
+            <X size={12} aria-label="Remove tag" style={{ cursor: "pointer" }} onClick={() => onChange(tags.filter((t) => t !== tag))} />
           </span>
         ))}
       </div>


### PR DESCRIPTION
First step of the accessibility rollout: an app-wide sweep so every icon-only interactive control has an accessible label, for screen-reader and keyboard users.

The codebase was already largely labeled — this fills the gaps found across web and mobile:
- **Web**: GentlePulse player Volume and Play/Pause buttons; the Directory provider-card Message button; and the per-plugin icon-rail nav buttons (Browse/Matches/Chat, Cohorts/Session/Chat, Feed/Post/Chat, etc.) given per-item labels.
- **Mobile**: the @comic composer Send button.

Only `aria-label` / `accessibilityLabel` (+ `accessibilityRole`) attributes and the supporting nav-label fields were added — no layout, styling, or logic change. Typecheck and lint pass for web and mobile.

Next in the rollout (separate PRs): converting the remaining plugin forms to the shared `FormField`, and the focus/contrast baseline.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_