### PR TITLE
fix: compact the Hub hero on phones so the AI chat is visible

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1605,6 +1605,39 @@
  * Stack them full-width instead so each button has even padding and room.
  */
 @media (max-width: 767px) {
+  /* Compact the hero on phones so it doesn't dominate the screen and crowd out
+     the chat / AI Assistant area below it. */
+  .heroBanner {
+    margin: 12px 12px 0;
+    padding: 14px 16px;
+    gap: 12px;
+  }
+
+  .heroBannerTitle {
+    font-size: 18px;
+  }
+
+  .heroBannerSub {
+    font-size: 12px;
+  }
+
+  .heroStats {
+    gap: 8px;
+  }
+
+  .heroStatBlock {
+    flex: 1;
+    padding: 8px 10px;
+  }
+
+  .heroStatValue {
+    font-size: 16px;
+  }
+
+  .heroStatLabel {
+    font-size: 10px;
+  }
+
   .comicConsentActions {
     flex-direction: column;
   }


### PR DESCRIPTION
On phone-width screens the Hub home hero banner took up so much vertical space that the AI chat panel below it was pushed off-screen. This tightens the hero's spacing and type sizes only at the mobile breakpoint (max-width 767px) so the chat is visible without scrolling. Desktop is unchanged.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_