### PR TITLE
feat: surface an admin link in the Hub and make /admin a real directory

### DIFF
--- a/ctf/packages/web/app/admin/page.tsx
+++ b/ctf/packages/web/app/admin/page.tsx
@@ -3,6 +3,30 @@ import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
 
+// The admin landing page: a single directory of every admin area. Each link points at a
+// route that is itself server-role-gated, so this page only renders for admins. Keep this
+// list in step with the pages under app/admin/* — add a row when a new admin area ships.
+const ADMIN_AREAS: { href: string; name: string; description: string }[] = [
+  { href: '/admin/unlock', name: 'Unlock', description: 'Review and decide who gets full access to the app.' },
+  { href: '/admin/directory', name: 'Directory', description: 'Manage member directory listings and visibility.' },
+  { href: '/admin/socketrelay', name: 'SocketRelay', description: 'Moderate mutual-aid requests and offers.' },
+  { href: '/admin/lighthouse', name: 'LightHouse', description: 'Manage LightHouse listings and review reports.' },
+  { href: '/admin/trusttransport', name: 'TrustTransport', description: 'Oversee transport coordination and disputes.' },
+  { href: '/admin/comic', name: 'AI Assistant', description: 'Review answers from the @comic assistant before they post.' },
+  { href: '/admin/whatworks', name: 'WhatWorks', description: 'Curate problems and the products that solve them.' },
+  { href: '/admin/skills-hunt', name: 'SkillsHunt', description: 'Manage missions, scouts, and the leaderboard.' },
+  { href: '/admin/peer-programming', name: 'Peer Programming', description: 'Set topics and manage pairing assignments.' },
+  { href: '/admin/levelup', name: 'LevelUp', description: 'Run skills-training cohorts and stipend milestones.' },
+  { href: '/admin/weekly-performance', name: 'Weekly Performance', description: 'Manage weekly performance reporting.' },
+  { href: '/admin/workforce', name: 'Workforce', description: 'Manage workforce records and assignments.' },
+  { href: '/admin/foundation', name: 'Foundation', description: 'Manage foundation-level settings and records.' },
+  { href: '/admin/contributions', name: 'Contributions', description: 'Run fundraising drives and review the donation queue.' },
+  { href: '/admin/service-credits', name: 'ServiceCredits', description: 'Treasury, disputes, and governance for the credits ledger.' },
+  { href: '/admin/gdp', name: 'GDP', description: 'Manage GDP figures.' },
+  { href: '/admin/gdp/rates', name: 'GDP Rates', description: 'Manage GDP exchange and conversion rates.' },
+  { href: '/admin/feed-announcements', name: 'Feed Announcements', description: 'Post and manage announcements in the community feed.' },
+];
+
 export default async function AdminPage() {
   const decision = await evaluatePluginAccess({ requiredRoles: ['admin'] });
 
@@ -35,27 +59,33 @@ export default async function AdminPage() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-12 space-y-4">
-      <h1 className="text-2xl font-semibold tracking-tight">Admin baseline access confirmed</h1>
-      <p className="text-sm text-muted-foreground">
-        Route access passed middleware and server-side role verification.
-      </p>
-      <dl className="rounded-lg border bg-card p-4 text-sm">
-        <div className="flex justify-between gap-4">
-          <dt className="font-medium">Authorized user</dt>
-          <dd>{decision.userId}</dd>
-        </div>
-        <div className="mt-2 flex justify-between gap-4">
-          <dt className="font-medium">Role</dt>
-          <dd>{decision.role ?? 'not set'}</dd>
-        </div>
-      </dl>
-      <p className="text-sm">
-        <Link className="underline underline-offset-4" href="/apps/chyme">Open plugin route</Link>
-      </p>
-      <p className="text-sm">
-        <Link className="underline underline-offset-4" href="/admin/unlock">Open Unlock admin queue</Link>
-      </p>
+    <main className="mx-auto max-w-4xl px-6 py-12 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Admin</h1>
+        <p className="text-sm text-muted-foreground">
+          Pick an area to manage. Each area is restricted to admins.
+        </p>
+      </header>
+
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {ADMIN_AREAS.map((area) => (
+          <li key={area.href}>
+            <Link
+              href={area.href}
+              className="block rounded-lg border bg-card p-4 transition hover:border-foreground/30 hover:bg-card/80"
+            >
+              <span className="block text-sm font-medium">{area.name}</span>
+              <span className="mt-1 block text-sm text-muted-foreground">{area.description}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <footer className="border-t pt-4 text-sm text-muted-foreground">
+        Signed in as <span className="font-medium">{decision.userId}</span> · role{' '}
+        <span className="font-medium">{decision.role ?? 'not set'}</span> ·{' '}
+        <Link className="underline underline-offset-4" href="/">Return to home</Link>
+      </footer>
     </main>
   );
 }

--- a/ctf/packages/web/app/page.tsx
+++ b/ctf/packages/web/app/page.tsx
@@ -81,6 +81,7 @@ export default async function HomePage() {
       currentUser={currentUser}
       trust={trust}
       isAuthenticated={isAuthenticated}
+      isAdmin={isAdmin}
       signInUrl={signInUrl}
     />
   );

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -24,6 +24,7 @@ type CommunityShellProps = {
   trust: TrustUserExtension;
   initialSection?: ShellSection;
   isAuthenticated?: boolean;
+  isAdmin?: boolean;
   signInUrl?: string;
 };
 
@@ -114,7 +115,7 @@ function sortPluginsForUi(
   });
 }
 
-export function CommunityShell({ initialPlugins, shellStats, currentUser, trust, initialSection = 'chat', isAuthenticated = false, signInUrl = '/sign-in' }: CommunityShellProps) {
+export function CommunityShell({ initialPlugins, shellStats, currentUser, trust, initialSection = 'chat', isAuthenticated = false, isAdmin = false, signInUrl = '/sign-in' }: CommunityShellProps) {
   const [section, setSection] = useState<ShellSection>(initialSection);
   const [query, setQuery] = useState('');
   const [plugins, setPlugins] = useState(initialPlugins);
@@ -293,7 +294,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
         </div>
       </header>
       <div className={styles.frame}>
-        <ShellIconRail section={section} onSectionChange={setSection} initial={currentUser.initial} isAuthenticated={isAuthenticated} />
+        <ShellIconRail section={section} onSectionChange={setSection} initial={currentUser.initial} isAuthenticated={isAuthenticated} isAdmin={isAdmin} />
         <ShellSidebar
           section={section}
           channels={channels}

--- a/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { UserButton } from '@clerk/nextjs';
-import { MessageSquare, Zap, Shield } from 'lucide-react';
+import { MessageSquare, Zap, Shield, SlidersHorizontal } from 'lucide-react';
 import type { ShellSection } from './shell-types';
 import { HelpControl } from '../bug-reports/help-control';
 import styles from './community-shell.module.css';
@@ -12,9 +12,10 @@ type IconRailProps = {
   onSectionChange: (s: ShellSection) => void;
   initial?: string;
   isAuthenticated?: boolean;
+  isAdmin?: boolean;
 };
 
-export function ShellIconRail({ section, onSectionChange, initial = 'S', isAuthenticated = false }: IconRailProps) {
+export function ShellIconRail({ section, onSectionChange, initial = 'S', isAuthenticated = false, isAdmin = false }: IconRailProps) {
   return (
     <aside className={styles.iconRail}>
       <div className={styles.iconRailLogo} aria-hidden="true">SH</div>
@@ -40,6 +41,20 @@ export function ShellIconRail({ section, onSectionChange, initial = 'S', isAuthe
       </button>
 
       <div className={styles.iconRailSpacer} aria-hidden="true" />
+
+      {/* Admin entry: only rendered for users whose Clerk role is "admin". This is the one
+          in-app way to reach the admin directory at /admin; the route itself is still
+          server-role-gated, so showing the link to a non-admin would only hit a denial page. */}
+      {isAdmin ? (
+        <Link
+          href="/admin"
+          className={styles.iconRailBtn}
+          aria-label="Admin"
+          title="Admin — manage plugins and review queues"
+        >
+          <SlidersHorizontal size={18} />
+        </Link>
+      ) : null}
 
       <Link
         href="/account/data"


### PR DESCRIPTION
Admins had no in-app way to reach the admin pages. The Hub icon rail showed no admin entry, and `/admin` was a bare diagnostic page that linked to only two routes (chyme and the Unlock queue).

This change:
- Adds an **Admin** link to the Hub icon rail, rendered only when the signed-in user's role is `admin` (the page already computed `isAdmin`; it just wasn't passed into the shell).
- Rebuilds `/admin` from a diagnostic stub into a directory that lists every admin area with a short description.

No auth logic changes: every `/admin/*` route is still server-role-gated, so the link only appears for, and only works for, admins.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_