### PR TITLE
fix: slide the Hub suggestion chips in one horizontal row

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -479,7 +479,28 @@
   flex-shrink: 0;
 }
 
+/* The suggestion chips sit in a single row that slides sideways instead of
+   wrapping onto several lines. On a phone, wrapping pushed the chat up and out
+   of view; a horizontal scroll keeps them to one line so more of the chat shows. */
+.chatChipRow {
+  padding: 0 20px 8px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex-shrink: 0;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.chatChipRow::-webkit-scrollbar {
+  display: none;
+}
+
 .chatChip {
+  flex-shrink: 0;
+  white-space: nowrap;
   padding: 6px 14px;
   border-radius: 20px;
   background: rgba(255, 255, 255, 0.04);

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -277,7 +277,7 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
         })}
       </div>
 
-      <div className={styles.chatSuggestions}>
+      <div className={styles.chatChipRow}>
         {SUGGESTIONS.map((suggestion) => (
           <button key={suggestion} type="button" className={styles.chatChip} onClick={() => selectSuggestion(suggestion)}>
             {suggestion}


### PR DESCRIPTION
On phones the Hub suggestion chips ("Show housing options near me", etc.) wrapped onto five stacked lines, pushing the AI chat up and nearly off-screen. This puts them in a single row that slides sideways.

- New `chatChipRow` class: `flex-wrap: nowrap` + `overflow-x: auto`, with the scrollbar hidden, and chips set to `flex-shrink: 0; white-space: nowrap` so they keep their size and overflow horizontally instead of wrapping.
- Kept the shared `chatSuggestions` class untouched so the signed-out sign-in block (which stacks a button and a paragraph) keeps its layout.

More of the chat is visible now, on phone and desktop alike.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_