### PR TITLE
chore: consolidate the banned-word list into the voice hook

### DIFF
--- a/.claude/hooks/check-no-pleasantries.mjs
+++ b/.claude/hooks/check-no-pleasantries.mjs
@@ -26,9 +26,16 @@ const BANNED = [
   /\bfeel free\b/i,
   /\b(?:warm|best|kind)(?:est)? regards\b/i,
   /\blooking forward\b/i,
-  // Jargon — plain-language rule. "flywheel" is a buzzword; say the plain thing instead
-  // (e.g. "a loop where each answer improves the next").
-  /\bflywheel\b/i,
+];
+
+// Owner-maintained excluded vocabulary — the single canonical list of jargon / misused words
+// agents must not use in this repo. .github/instructions/098-agent-communication-rules.mdc points
+// here instead of keeping a second copy that drifts. Each entry pairs the banned term with its
+// plain replacement so the block message can name what to use instead.
+const VOCABULARY = [
+  { re: /\bflywheel\b/i, use: 'a plain description of the loop (e.g. "each answer improves the next")' },
+  { re: /\bpunch list\b/i, use: 'list' },
+  { re: /\bstale\b/i, use: 'deprecated' },
 ];
 
 function readStdin() {
@@ -67,15 +74,29 @@ try {
   const input = JSON.parse(readStdin() || '{}');
   if (input.stop_hook_active) process.exit(0); // already retrying; do not loop
   const text = input.transcript_path ? lastAssistantText(input.transcript_path) : '';
-  const match = BANNED.map((re) => text.match(re)).find(Boolean);
-  if (match) {
+  const pleasantry = BANNED.map((re) => text.match(re)).find(Boolean);
+  const vocab = VOCABULARY.map((entry) => {
+    const m = text.match(entry.re);
+    return m ? { term: m[0], use: entry.use } : null;
+  }).find(Boolean);
+
+  if (pleasantry) {
     process.stdout.write(
       JSON.stringify({
         decision: 'block',
         reason:
-          `The reply contains a banned pleasantry/feeling/sign-off ("${match[0]}"). ` +
+          `The reply contains a banned pleasantry/feeling/sign-off ("${pleasantry[0]}"). ` +
           'Restate the result in plain, factual language — no thanks, apologies, well-wishes, ' +
           'sign-offs, jargon, or first-person feeling words — then stop.',
+      }),
+    );
+  } else if (vocab) {
+    process.stdout.write(
+      JSON.stringify({
+        decision: 'block',
+        reason:
+          `The reply uses a banned word ("${vocab.term}"). Use instead: ${vocab.use}. ` +
+          'Restate in plain language, then stop.',
       }),
     );
   }

--- a/.github/instructions/098-agent-communication-rules.mdc
+++ b/.github/instructions/098-agent-communication-rules.mdc
@@ -47,7 +47,4 @@ Fixed 3 errors in schema.sql:
 ## Excluded Vocabulary
 Owner-maintained list of words and phrases agents must not use when communicating in this repo (chat responses, commit messages, PR text, and created/edited files). Use the plain replacement instead. This list is continuously updated; treat every entry as mandatory.
 
-| Do not use | Use instead | Reason |
-|---|---|---|
-| punch list | list | Jargon; unclear meaning. |
-| stale | deprecated | "Stale" is consistently misused; "deprecated" is the intended meaning. |
+The single running list now lives in `.claude/hooks/check-no-pleasantries.mjs` (the `VOCABULARY` array), so it is documented and enforced by the Stop hook in one place — no second copy to drift. Each entry pairs the banned term with its plain replacement. Add or edit banned vocabulary there; do not re-create a table here.


### PR DESCRIPTION
One running list instead of two. The owner-maintained excluded-vocabulary entries move out of `.github/instructions/098-agent-communication-rules.mdc` and into a new `VOCABULARY` array in `.claude/hooks/check-no-pleasantries.mjs`, so the list is both documented and enforced by the Stop hook in one place. The instructions doc now points at the hook instead of holding a second table that drifts.

- `flywheel` added (buzzword).
- Existing entries carried over with their replacements: `punch list` → `list`, the misused word → `deprecated`.
- When the hook blocks a vocabulary term it now names the plain replacement to use.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_