### PR TITLE
feat: support an external GPU host for Ollama (issue #502)

### DIFF
--- a/ctf/docs/developer/OLLAMA.md
+++ b/ctf/docs/developer/OLLAMA.md
@@ -1,27 +1,75 @@
 # Ollama Model Management
 
-How the self-hosted Ollama service works on Render and how to change its model.
+How the self-hosted Ollama service works and how to change its model. Ollama is the only
+`@comic` AI engine: it writes a draft answer that a person reviews before any survivor sees it
+(see the comic feature inventory). A third-party API is not used for survivor question text, so
+the model stays self-hosted.
 
-## Architecture
+There are two ways to host it. The current setup runs a small model on a CPU box. The upgrade
+moves a stronger model to a GPU host. Both are documented below.
 
-`ctf-ollama` is a **private** Render service (no public domain), reachable only
-by the CTF web service over Render's internal network at
-`http://ctf-ollama:11434`. Defined in `render.yaml`
-(`dockerfilePath: ctf/ops/ollama/Dockerfile`).
+## Why upgrade to a GPU host
 
-Render has no persistent volumes, so the model is **baked into the image at
-build time** — always present on startup, no runtime pull.
+The current model (`llama3.2`, ~3B parameters) runs on a CPU-only Render service. On CPU it is
+both weak and slow. A stronger model (tens of billions of parameters) writes far better drafts but
+needs a GPU — on CPU it would run far past the 30s request timeout in
+`lib/chatbot/ollama.ts`. Render's plans have no GPUs, so a stronger model must run on an external
+GPU host. Tracked in issue #502.
 
-## Changing the active model
+This is the owner's spend decision: an always-on GPU is a real monthly cost. Quantized mid-size
+models keep that cost down while still being much better than `llama3.2`.
+
+### Recommended models (Ollama library names)
+
+| Model | Rough VRAM (quantized) | Notes |
+|---|---|---|
+| `qwen2.5:32b` | ~20–24 GB | Balanced default — strong instruction following, fits a single 24 GB GPU |
+| `gemma2:27b` | ~18–22 GB | Similar tier, slightly smaller |
+| `llama3.3` (70B) | ~40–48 GB | Highest quality of these; needs a larger, more expensive GPU |
+
+Start with `qwen2.5:32b` unless the budget supports a 70B-class GPU. Test the chosen model's drafts
+against real questions before relying on it.
+
+## Moving to an external GPU host (the upgrade)
+
+Two infrastructure steps — these need a GPU provider account and the secrets store, so the owner
+does them:
+
+1. Provision a GPU host running Ollama. Options: RunPod, Lambda, Fly.io GPU machines, or any host
+   with a GPU. Install Ollama, run `ollama serve`, and `ollama pull <model>` (e.g.
+   `ollama pull qwen2.5:32b`).
+2. Secure it. Ollama has no built-in authentication, so the host must not be exposed on the open
+   internet unprotected. Use one of:
+   - the provider's private network so only the web service can reach it, or
+   - a reverse proxy (Caddy/Nginx) in front of Ollama that checks an `Authorization: Bearer`
+     token.
+3. Set these on the web service (`ctf-web`) via Infisical → Render Sync:
+   - `OLLAMA_BASE_URL` → the GPU host's URL (e.g. `https://ollama.example.internal`).
+   - `OLLAMA_MODEL` → the exact model name pulled on the host (e.g. `qwen2.5:32b`).
+   - `OLLAMA_API_KEY` → the bearer token, only if the host is behind a token-checking proxy. Leave
+     unset when the host is private-network only. The web client attaches it as
+     `Authorization: Bearer <token>` on every Ollama request (`lib/chatbot/ollama.ts`).
+
+Once `OLLAMA_BASE_URL` points at the GPU host, the Render `ctf-ollama` service can be removed from
+`render.yaml` and suspended in Render — it is no longer in the path.
+
+## Current setup (Render CPU image — the fallback)
+
+`ctf-ollama` is a **private** Render service (no public domain), reachable only by the web service
+over Render's internal network at `http://ctf-ollama:11434`. Defined in `render.yaml`
+(`dockerfilePath: ctf/ops/ollama/Dockerfile`). Render has no persistent volumes, so the model is
+**baked into the image at build time** — present on startup, no runtime pull.
+
+### Changing the model on the Render CPU image
 
 1. Edit the `ARG` in `ctf/ops/ollama/Dockerfile`:
    ```dockerfile
    ARG OLLAMA_MODEL=llama3.2
    ```
-   Use any model from the [Ollama library](https://ollama.com/library). Commit
-   and push — Render rebuilds the image automatically.
-2. After the deploy completes, set `OLLAMA_MODEL` on the **web service** to match
-   the new name exactly (including any tag, e.g. `llama3.2:1b`).
+   Use any model from the [Ollama library](https://ollama.com/library). Commit and push — Render
+   rebuilds the image automatically.
+2. After the deploy completes, set `OLLAMA_MODEL` on the web service to match the new name exactly
+   (including any tag, e.g. `llama3.2:1b`).
 
 | Model | Approx. image size |
 |---|---|
@@ -31,9 +79,10 @@ build time** — always present on startup, no runtime pull.
 | `phi3` | ~2.2 GB |
 | `mistral` | ~4.1 GB |
 
-Prefer 1B–3B models to keep build times within the platform limit.
+On the CPU image, prefer 1B–3B models to keep build times within the platform limit and responses
+under the timeout. Larger models belong on the GPU host above.
 
-## How the Dockerfile bakes the model
+### How the Dockerfile bakes the model
 
 ```dockerfile
 RUN ollama serve & \
@@ -41,27 +90,31 @@ RUN ollama serve & \
     ollama pull ${OLLAMA_MODEL}
 ```
 
-Ollama must be running to pull. This `RUN` step starts the server in the
-background, polls until ready, then pulls the model. When the layer finishes the
-server process exits, but the model files written to `/root/.ollama/models/`
-persist in the image layer. The container then starts fresh with `ollama serve`
-and finds the model already on disk.
+Ollama must be running to pull. This `RUN` step starts the server in the background, polls until
+ready, then pulls the model. When the layer finishes the server process exits, but the model files
+written to `/root/.ollama/models/` persist in the image layer. The container then starts fresh with
+`ollama serve` and finds the model already on disk.
 
 ## Web service configuration
 
-- `OLLAMA_BASE_URL=http://ctf-ollama:11434`
-- `OLLAMA_MODEL` must exactly match the baked model name.
+- `OLLAMA_BASE_URL` — `http://ctf-ollama:11434` (Render CPU image) or the GPU host URL.
+- `OLLAMA_MODEL` — must exactly match the model name available on the host.
+- `OLLAMA_API_KEY` — optional bearer token for an external host behind a proxy; unset otherwise.
 
 ## Failure checks
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Build times out | Model too large for the build limit | Use a smaller model (`llama3.2:1b`) |
+| Build times out | Model too large for the build limit | Use a smaller model (`llama3.2:1b`) or move to the GPU host |
+| Drafts time out / never arrive | Model too big for the CPU box | Move to the GPU host; check the model fits the GPU's VRAM |
 | `ollama list` never returns during build | Server failed to start | Check build logs for port conflicts |
-| Chat returns `ollama_http_error` | `OLLAMA_MODEL` on web service ≠ baked model | Update the web env var to match exactly |
-| Chat returns `ollama_not_configured` | `OLLAMA_BASE_URL` not set | Set it to the internal URL above |
+| Chat returns `ollama_http_error:401/403` | Host requires a token | Set `OLLAMA_API_KEY` to match the proxy's expected bearer |
+| Chat returns `ollama_http_error` | `OLLAMA_MODEL` ≠ model on the host | Update the web env var to match exactly |
+| Chat returns `ollama_not_configured` | `OLLAMA_BASE_URL` not set | Set it to the host URL above |
 
 ## Notes
 
-- Never assign a public domain to the Ollama service — it has no authentication and must stay private-network only.
-- `ctf/scripts/ollamaModelManager.sh` exists for reference but cannot reach the private service remotely; model changes go through the Dockerfile.
+- Never expose Ollama unauthenticated on a public domain — it has no authentication. Keep it on a
+  private network or behind a token-checking proxy.
+- `ctf/scripts/ollamaModelManager.sh` exists for reference but cannot reach the private service
+  remotely; model changes go through the Dockerfile (CPU image) or the host (GPU).

--- a/ctf/packages/web/lib/chatbot/ollama.ts
+++ b/ctf/packages/web/lib/chatbot/ollama.ts
@@ -2,6 +2,22 @@ const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? '';
 export const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? 'llama3.2';
 const OLLAMA_TIMEOUT_MS = 30_000;
 
+// Optional bearer token for reaching the Ollama host. Empty when the host is the
+// private-network Render service (ctf-ollama), which needs no auth. When Ollama is
+// moved to an external GPU host reachable over the internet, that host must sit
+// behind a gateway/proxy that checks this token — Ollama itself has no auth — and
+// OLLAMA_API_KEY is set on the web service so every request carries it. Backward
+// compatible: unset → no Authorization header → today's behavior, unchanged.
+const OLLAMA_API_KEY = process.env.OLLAMA_API_KEY ?? '';
+
+function ollamaHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (OLLAMA_API_KEY.length > 0) {
+    headers.Authorization = `Bearer ${OLLAMA_API_KEY}`;
+  }
+  return headers;
+}
+
 export type OllamaMessage = {
   role: 'system' | 'user' | 'assistant';
   content: string;
@@ -39,7 +55,7 @@ export async function callOllamaChat(messages: OllamaMessage[]): Promise<OllamaR
   try {
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: ollamaHeaders(),
       body: JSON.stringify({
         model: OLLAMA_MODEL,
         messages,

--- a/render.yaml
+++ b/render.yaml
@@ -114,6 +114,11 @@ services:
   # Private service — reachable by other Render services via internal URL.
   # Model (llama3.2) is baked into the image at build time. Image only rebuilt
   # when ctf/ops/ollama/Dockerfile changes (path-filtered in build-images.yml).
+  # Render has no GPUs, so this runs a small model on CPU. To run a stronger model
+  # (issue #502) move Ollama to an external GPU host and point the web service's
+  # OLLAMA_BASE_URL/OLLAMA_MODEL (and OLLAMA_API_KEY if the host is behind a proxy)
+  # at it — see ctf/docs/developer/OLLAMA.md — then remove this block. Until then
+  # this stays as-is so production keeps a working (if weak) model.
   - type: pserv
     name: ctf-ollama
     runtime: image


### PR DESCRIPTION
Enabling work for #502 — running a stronger `@comic` model on a GPU host. The model upgrade itself is an infrastructure step (provision a GPU host, set secrets) that the owner performs; this PR makes the codebase ready so that step is all that's left.

What this changes:
- `lib/chatbot/ollama.ts`: optional bearer-token auth. Render has no GPUs, so a strong model runs off-platform; Ollama has no built-in auth, so an internet-reachable host sits behind a token-checking proxy. The client now sends `Authorization: Bearer <OLLAMA_API_KEY>` when that var is set. Backward compatible — unset → no header → today's private-network Render service behaves exactly as before.
- `ctf/docs/developer/OLLAMA.md`: rewritten with the GPU-host runbook — recommended models (`qwen2.5:32b` balanced default, `gemma2:27b`, `llama3.3` 70B for max quality), how to secure the host, and the three settings to flip (`OLLAMA_BASE_URL`, `OLLAMA_MODEL`, optional `OLLAMA_API_KEY`). The Render CPU image stays documented as the fallback.
- `render.yaml`: the live `ctf-ollama` model is left unchanged so production keeps a working model until the GPU host exists; added a pointer comment to the migration path.

Owner steps that remain (cannot be done from code — need a GPU provider account + the secrets store):
1. Provision a GPU host running Ollama and `ollama pull <model>`.
2. Secure it (private network, or a proxy that checks the bearer token).
3. Set `OLLAMA_BASE_URL` / `OLLAMA_MODEL` (and `OLLAMA_API_KEY` if proxied) on `ctf-web` via Infisical. Then the Render `ctf-ollama` block can be removed.

Verified: `pnpm -r typecheck` clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_