### PR TITLE
feat: talk to a RunPod serverless endpoint for @comic drafts

### DIFF
--- a/ctf/docs/developer/OLLAMA.md
+++ b/ctf/docs/developer/OLLAMA.md
@@ -53,6 +53,40 @@ does them:
 Once `OLLAMA_BASE_URL` points at the GPU host, the Render `ctf-ollama` service can be removed from
 `render.yaml` and suspended in Render — it is no longer in the path.
 
+## RunPod Serverless (pay-per-use GPU)
+
+RunPod Serverless is the chosen GPU host: it bills per second a worker actively
+runs a request and scales to zero when idle, so a low-traffic, human-reviewed chat
+costs little. Cold starts (a worker loading the model from zero) can take tens of
+seconds to minutes; that is acceptable here because the worst case is one draft
+hitting the 30s timeout and falling back to the template, which a person still
+reviews.
+
+A RunPod Serverless **queue** endpoint speaks RunPod's job API, not Ollama's native
+API. Two pieces make it work:
+
+1. The worker image — `ctf/ops/runpod-ollama/Dockerfile`. It runs Ollama plus a
+   small Python handler (`runpod.serverless.start`) that forwards each job to
+   Ollama's `/api/chat` and returns `{ content, model }`. Point the endpoint's
+   GitHub build at this Dockerfile path. Set the model with the `OLLAMA_MODEL`
+   build argument (default `qwen2.5:32b`).
+   - To avoid rebuilding this large (~20 GB) image on every push to `main`, set the
+     endpoint's build to manual in RunPod, or host the worker Dockerfile in a small
+     dedicated repo and point the endpoint there.
+2. The client adapter — `lib/chatbot/ollama.ts` detects a RunPod endpoint (when
+   `OLLAMA_BASE_URL`'s host is `api.runpod.ai`) and submits a job to `/run`, then
+   polls `/status/<id>` until it finishes, within the same 30s budget as the native
+   path. No native-API change.
+
+Recommended GPU: 24 GB (fits `qwen2.5:32b`). Max workers 1–2 is plenty for a
+low-volume chat; serverless only bills while a worker is actually running.
+
+### Web service settings for RunPod
+
+- `OLLAMA_BASE_URL` → the endpoint URL, `https://api.runpod.ai/v2/<endpoint-id>`.
+- `OLLAMA_API_KEY` → the RunPod API key (sent as the bearer token).
+- `OLLAMA_MODEL` → the model baked into the worker (e.g. `qwen2.5:32b`).
+
 ## Current setup (Render CPU image — the fallback)
 
 `ctf-ollama` is a **private** Render service (no public domain), reachable only by the web service

--- a/ctf/ops/runpod-ollama/Dockerfile
+++ b/ctf/ops/runpod-ollama/Dockerfile
@@ -1,0 +1,73 @@
+# RunPod Serverless worker that serves an Ollama model behind RunPod's job API.
+#
+# Point a RunPod Serverless endpoint's GitHub build at this Dockerfile
+# (Dockerfile path: ctf/ops/runpod-ollama/Dockerfile). The web app talks to the
+# endpoint via lib/chatbot/ollama.ts when OLLAMA_BASE_URL is the endpoint URL
+# (https://api.runpod.ai/v2/<id>) and OLLAMA_API_KEY is the RunPod API key.
+#
+# The handler is written inline (no COPY) so the build does not depend on
+# RunPod's build-context root. See ctf/docs/developer/OLLAMA.md.
+
+FROM ollama/ollama:latest
+
+RUN apt-get update && apt-get install -y python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir runpod requests
+
+# Bake the model into the image so a cold start does not also pay a model
+# download. qwen2.5:32b (~20 GB quantized) fits a 24 GB GPU; override with
+# --build-arg OLLAMA_MODEL=... (e.g. llama3.3 on a 48 GB GPU).
+ARG OLLAMA_MODEL=qwen2.5:32b
+ENV OLLAMA_MODEL=${OLLAMA_MODEL}
+RUN ollama serve & \
+    until ollama list >/dev/null 2>&1; do sleep 2; done && \
+    ollama pull ${OLLAMA_MODEL}
+
+RUN printf '%s\n' \
+    'import os, subprocess, time' \
+    'import requests' \
+    'import runpod' \
+    '' \
+    'OLLAMA_HOST = "http://127.0.0.1:11434"' \
+    'MODEL = os.environ.get("OLLAMA_MODEL", "qwen2.5:32b")' \
+    '' \
+    '# Start Ollama once per worker (on cold start), then wait until it answers.' \
+    'subprocess.Popen(["ollama", "serve"])' \
+    'for _ in range(120):' \
+    '    try:' \
+    '        requests.get(f"{OLLAMA_HOST}/api/tags", timeout=2)' \
+    '        break' \
+    '    except Exception:' \
+    '        time.sleep(1)' \
+    '' \
+    '' \
+    'def handler(job):' \
+    '    data = job.get("input", {}) or {}' \
+    '    messages = data.get("messages")' \
+    '    if not messages:' \
+    '        messages = [{"role": "user", "content": data.get("prompt", "")}]' \
+    '    options = data.get("options", {"temperature": 0.4, "num_predict": 600})' \
+    '    resp = requests.post(' \
+    '        f"{OLLAMA_HOST}/api/chat",' \
+    '        json={' \
+    '            "model": data.get("model", MODEL),' \
+    '            "messages": messages,' \
+    '            "stream": False,' \
+    '            "options": options,' \
+    '        },' \
+    '        timeout=300,' \
+    '    )' \
+    '    resp.raise_for_status()' \
+    '    body = resp.json()' \
+    '    return {' \
+    '        "content": body.get("message", {}).get("content", ""),' \
+    '        "model": body.get("model", MODEL),' \
+    '    }' \
+    '' \
+    '' \
+    'runpod.serverless.start({"handler": handler})' \
+    > /handler.py
+
+# The base image's entrypoint is `ollama`; reset it so the handler runs.
+ENTRYPOINT []
+CMD ["python3", "-u", "/handler.py"]

--- a/ctf/packages/web/lib/chatbot/ollama.ts
+++ b/ctf/packages/web/lib/chatbot/ollama.ts
@@ -18,6 +18,20 @@ function ollamaHeaders(): Record<string, string> {
   return headers;
 }
 
+// When OLLAMA_BASE_URL points at a RunPod serverless endpoint
+// (https://api.runpod.ai/v2/<id>), the host speaks RunPod's job API, not
+// Ollama's native /api/chat. Detect that and route through the job API instead.
+// OLLAMA_API_KEY carries the RunPod API key in that case.
+const RUNPOD_API_HOST = 'api.runpod.ai';
+
+function ollamaProviderIsRunpod(): boolean {
+  try {
+    return new URL(OLLAMA_BASE_URL).hostname.endsWith(RUNPOD_API_HOST);
+  } catch {
+    return false;
+  }
+}
+
 export type OllamaMessage = {
   role: 'system' | 'user' | 'assistant';
   content: string;
@@ -44,6 +58,10 @@ export function isOllamaConfigured(): boolean {
 export async function callOllamaChat(messages: OllamaMessage[]): Promise<OllamaResult> {
   if (!isOllamaConfigured()) {
     throw new Error('ollama_not_configured');
+  }
+
+  if (ollamaProviderIsRunpod()) {
+    return callRunpodChat(messages);
   }
 
   const url = `${OLLAMA_BASE_URL.replace(/\/$/, '')}/api/chat`;
@@ -87,6 +105,97 @@ export async function callOllamaChat(messages: OllamaMessage[]): Promise<OllamaR
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
       console.error('[ollama] Request timed out', { model: OLLAMA_MODEL, timeoutMs: OLLAMA_TIMEOUT_MS });
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// Shape of RunPod's job-status payload (only the fields we read). The worker
+// handler (ctf/ops/runpod-ollama/handler.py or the equivalent in the worker repo)
+// returns { content, model } as the job output.
+type RunpodJobResponse = {
+  id?: string;
+  status?: string;
+  output?: { content?: string; model?: string } | null;
+};
+
+const RUNPOD_TERMINAL_STATUSES = new Set(['COMPLETED', 'FAILED', 'CANCELLED', 'TIMED_OUT']);
+const RUNPOD_POLL_INTERVAL_MS = 1_500;
+
+// Talk to a RunPod serverless endpoint: submit the chat as a job, then poll until
+// it finishes. The whole exchange shares one OLLAMA_TIMEOUT_MS budget, so a slow
+// cold start aborts the same way the native path does — the caller then falls back
+// to the template draft and a human still answers. The endpoint base is
+// OLLAMA_BASE_URL (e.g. https://api.runpod.ai/v2/<id>); OLLAMA_API_KEY is the
+// RunPod API key, sent as the bearer by ollamaHeaders().
+async function callRunpodChat(messages: OllamaMessage[]): Promise<OllamaResult> {
+  const base = OLLAMA_BASE_URL.replace(/\/$/, '');
+  const startedAt = Date.now();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS);
+
+  try {
+    const runResponse = await fetch(`${base}/run`, {
+      method: 'POST',
+      headers: ollamaHeaders(),
+      body: JSON.stringify({
+        input: {
+          model: OLLAMA_MODEL,
+          messages,
+          options: {
+            temperature: 0.4,
+            num_predict: 600,
+          },
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!runResponse.ok) {
+      console.error('[ollama/runpod] submit HTTP error', { status: runResponse.status, latencyMs: Date.now() - startedAt });
+      throw new Error(`ollama_http_error:${runResponse.status}`);
+    }
+
+    let job = (await runResponse.json()) as RunpodJobResponse;
+
+    while (!RUNPOD_TERMINAL_STATUSES.has(job.status ?? '')) {
+      if (!job.id) {
+        throw new Error('ollama_runpod_no_job_id');
+      }
+      await new Promise((resolve) => setTimeout(resolve, RUNPOD_POLL_INTERVAL_MS));
+      const statusResponse = await fetch(`${base}/status/${job.id}`, {
+        method: 'GET',
+        headers: ollamaHeaders(),
+        signal: controller.signal,
+      });
+      if (!statusResponse.ok) {
+        console.error('[ollama/runpod] status HTTP error', { status: statusResponse.status, latencyMs: Date.now() - startedAt });
+        throw new Error(`ollama_http_error:${statusResponse.status}`);
+      }
+      job = (await statusResponse.json()) as RunpodJobResponse;
+    }
+
+    if (job.status !== 'COMPLETED') {
+      console.error('[ollama/runpod] job did not complete', { status: job.status, latencyMs: Date.now() - startedAt });
+      throw new Error(`ollama_runpod_${(job.status ?? 'unknown').toLowerCase()}`);
+    }
+
+    const content = job.output?.content?.trim();
+    if (!content) {
+      console.error('[ollama/runpod] empty job output', { model: OLLAMA_MODEL, latencyMs: Date.now() - startedAt });
+      throw new Error('ollama_empty_response');
+    }
+
+    return {
+      content,
+      latencyMs: Date.now() - startedAt,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      console.error('[ollama/runpod] Request timed out', { model: OLLAMA_MODEL, timeoutMs: OLLAMA_TIMEOUT_MS });
     }
     throw err;
   } finally {


### PR DESCRIPTION
Wires the @comic draft path to a RunPod Serverless GPU endpoint (issue #502). The endpoint `xajbwf8pc1lthk` is already deployed (24 GB, queue-based).

What's here:
- `lib/chatbot/ollama.ts`: a RunPod adapter. When `OLLAMA_BASE_URL`'s host is `api.runpod.ai`, the client submits the chat as a RunPod job (`/run`) and polls `/status/<id>` until it finishes, inside the same 30s budget as the native path. A slow cold start aborts and the caller falls back to the template draft — a human still answers, so impact is contained. Reuses `OLLAMA_API_KEY` (from #505) as the RunPod bearer key.
- `ctf/ops/runpod-ollama/Dockerfile`: a self-hosted RunPod Serverless worker — runs Ollama plus an inline Python handler that forwards each job to `/api/chat` and returns `{ content, model }`. Model baked in at build (default `qwen2.5:32b`). Inlined handler so the build doesn't depend on RunPod's build-context root.
- `OLLAMA.md`: documents the RunPod path and the three web settings.

Inert by default: with `OLLAMA_BASE_URL` unset or pointing at a native Ollama host, behavior is unchanged.

Owner steps to activate:
1. Point the RunPod endpoint's GitHub build at `ctf/ops/runpod-ollama/Dockerfile` (and set the build to manual to avoid rebuilding the ~20 GB image on every `main` push).
2. Set on `ctf-web`: `OLLAMA_BASE_URL=https://api.runpod.ai/v2/xajbwf8pc1lthk`, `OLLAMA_API_KEY=<RunPod API key>`, `OLLAMA_MODEL=qwen2.5:32b`.

Follow-up (separate PR): generate the @comic draft in the background so a cold start never makes a survivor's submit hang.

Verified: `pnpm -r typecheck` clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_