### PR TITLE
fix: install RunPod worker deps in a venv (PEP 668 build failure)

### DIFF
--- a/ctf/ops/runpod-ollama/Dockerfile
+++ b/ctf/ops/runpod-ollama/Dockerfile
@@ -10,9 +10,15 @@
 
 FROM ollama/ollama:latest
 
-RUN apt-get update && apt-get install -y python3 python3-pip \
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv \
     && rm -rf /var/lib/apt/lists/*
-RUN pip3 install --no-cache-dir runpod requests
+# The base image's system Python is "externally managed" (PEP 668), so a
+# system-wide `pip install` is refused and the build fails. Install the handler's
+# dependencies into a virtual environment instead, and put it first on PATH so the
+# CMD's python3 resolves to it.
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir runpod requests
 
 # Bake the model into the image so a cold start does not also pay a model
 # download. qwen2.5:32b (~20 GB quantized) fits a 24 GB GPU; override with


### PR DESCRIPTION
The RunPod worker build failed on `pip3 install --no-cache-dir runpod requests` (exit code 1). The `ollama/ollama` base image's system Python is externally managed (PEP 668), so a system-wide `pip install` is refused.

Fix: install the handler's dependencies into a virtual environment and put it first on `PATH` so the `CMD`'s `python3` resolves to it. Adds `python3-venv` to the apt step.

This is the worker image at `ctf/ops/runpod-ollama/Dockerfile`; copy the corrected file into the dedicated worker repo being created for the RunPod endpoint.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_