### PR TITLE
ci: add manual Run DB Migration workflow (applies schema.sql to prod)

### DIFF
--- a/.github/workflows/run-db-migration.yml
+++ b/.github/workflows/run-db-migration.yml
@@ -1,0 +1,67 @@
+name: Run DB Migration
+
+# Manual, button-press migration of the production database. Applies ctf/schema.sql
+# (idempotent — every table/column uses CREATE TABLE / ADD COLUMN IF NOT EXISTS) to
+# the production Neon Postgres. There is no automatic migration on deploy: the web
+# container only starts the server, so a schema change merged to main is NOT live in
+# the database until this workflow is run.
+#
+# Why this exists: code that selects a newly added column (e.g. comic_review_queue.
+# draft_turn_id) errors until the column exists, which can make an admin page render
+# empty. Run this after merging a schema.sql change.
+#
+# Secrets: reuses the same Infisical machine-identity secrets the other workflows use
+# (INFISICAL_CLIENT_ID / INFISICAL_CLIENT_SECRET / INFISICAL_PROJECT_SLUG /
+# INFISICAL_URL). DATABASE_URL is fetched from Infisical at runtime — never stored here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'migrate production' to confirm applying ctf/schema.sql to the PRODUCTION database"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Apply ctf/schema.sql to production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check confirmation phrase
+        if: ${{ inputs.confirm != 'migrate production' }}
+        run: |
+          echo "::error::Confirmation did not match. Re-run and type exactly: migrate production"
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Install dependencies
+        working-directory: ctf
+        run: pnpm install --frozen-lockfile
+
+      # Fetches production secrets (including DATABASE_URL) from Infisical into the
+      # job env. env-slug is the environment *slug* — Production's slug is "prod".
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
+
+      - name: Apply schema.sql
+        working-directory: ctf
+        run: pnpm migrate:schema


### PR DESCRIPTION
Adds a manual "Run DB Migration" workflow so production schema changes can be applied with a button press.

Why: there is no automatic migration on deploy — the web container only starts the server (`node packages/web/server.js`), and no workflow applies `schema.sql` to production. So a schema change merged to `main` is not live in the database until applied by hand. That's why the @comic admin console rendered empty after #507 — its query selects the new `comic_review_queue.draft_turn_id` column, which doesn't exist in prod yet.

What it does:
- `workflow_dispatch` (manual button) with a `confirm` input that must equal `migrate production`.
- Fetches `DATABASE_URL` from Infisical at runtime using the same machine-identity secrets the other workflows already use (`INFISICAL_CLIENT_ID` / `INFISICAL_CLIENT_SECRET` / `INFISICAL_PROJECT_SLUG` / `INFISICAL_URL`). No new secrets, nothing stored in the workflow.
- Runs `pnpm migrate:schema` (applies `ctf/schema.sql`). Idempotent — every table/column uses `CREATE TABLE` / `ADD COLUMN IF NOT EXISTS`, so re-running is safe.

After this merges: run it once (Actions → Run DB Migration → type `migrate production`) to add `draft_turn_id` to prod, which should make the review console populate.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_