### PR TITLE
fix: make the ServiceCredits send panel full-width on mobile

### DIFF
--- a/ctf/packages/web/components/service-credits/sc-send-panel.tsx
+++ b/ctf/packages/web/components/service-credits/sc-send-panel.tsx
@@ -62,9 +62,9 @@ function SendForm({ wallet, onSent }: { wallet: WalletData | null; onSent: () =>
   );
 }
 
-export function ServiceCreditsSendPanel({ wallet, onSent }: { wallet: WalletData | null; onSent: () => Promise<void> }) {
+export function ServiceCreditsSendPanel({ wallet, onSent, isMobile = false }: { wallet: WalletData | null; onSent: () => Promise<void>; isMobile?: boolean }) {
   return (
-    <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
+    <aside style={{ width: isMobile ? "100%" : 280, borderLeft: isMobile ? "none" : "1px solid rgba(255,255,255,0.06)", borderTop: isMobile ? "1px solid rgba(255,255,255,0.06)" : "none", background: "#0D0F14", padding: "20px 16px", flexShrink: 0, boxSizing: "border-box" }}>
       <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Send Credits</div>
       <SendForm wallet={wallet} onSent={onSent} />
 

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -104,7 +104,7 @@ export function ServiceCreditsShell() {
           </div>
         </div>
         {content}
-        <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} />
+        <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} isMobile />
       </div>
     );
   }


### PR DESCRIPTION
Fixes the "bottom portion not centered" report on the Service Credits plugin shell on mobile.

The send panel (`ServiceCreditsSendPanel` — the Send Credits form + Accepted Everywhere list + Formance card) is a fixed 280px right sidebar on desktop. On mobile the shell renders it below the content but it kept `width: 280px` with a left border, so it sat against the left edge and left empty space on the right — looking off-center. It now takes `isMobile` and renders full-width on phones (`width: 100%`, `box-sizing: border-box`, the left border swapped for a top divider). Desktop is unchanged.

Iterating on a shipped screen's mobile-responsive layout — not design-gated.

Verified: `pnpm -r typecheck` and targeted eslint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_