### PR TITLE
fix: remove ClickLog emergency line; make Add location give feedback

### DIFF
--- a/ctf/packages/mobile/src/features/clicklog/ClicklogScreen.tsx
+++ b/ctf/packages/mobile/src/features/clicklog/ClicklogScreen.tsx
@@ -216,13 +216,6 @@ function ClicklogEmpty({ onLog }: { onLog: () => void }) {
             </React.Fragment>
           ))}
         </View>
-
-        <View style={styles.safetyNote}>
-          <Ionicons name="shield-checkmark-outline" size={14} color={BRAND} style={styles.safetyIcon} />
-          <Text style={styles.safetyText}>
-            In an emergency, contact local emergency services first.
-          </Text>
-        </View>
       </View>
 
       <View style={styles.bottomNav}>

--- a/ctf/packages/web/components/clicklog/clicklog-empty-state.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-empty-state.tsx
@@ -2,7 +2,7 @@
 
 // STATE: Authenticated, no incidents logged yet. Ported from
 // design/.../survivor-hub/ClickLogEmpty.tsx.
-import { AlertTriangle, ShieldCheck } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { BG, BORDER, BRAND, SUBTLE, SURFACE, TEXT } from "./clicklog-shared";
 
 const STEPS = [
@@ -47,11 +47,6 @@ export function ClicklogEmptyState({ onLog }: { onLog: () => void }) {
                 <div style={{ fontSize: 11, color: SUBTLE, lineHeight: 1.5 }}>{item.desc}</div>
               </div>
             ))}
-          </div>
-
-          <div style={{ padding: "12px 16px", borderRadius: 12, background: "rgba(233,30,140,0.05)", border: "1px solid rgba(233,30,140,0.15)", display: "flex", alignItems: "center", gap: 10 }}>
-            <ShieldCheck size={16} color={BRAND} />
-            <span style={{ fontSize: 12, color: SUBTLE }}>In an emergency, always contact local emergency services first.</span>
           </div>
         </div>
       </div>

--- a/ctf/packages/web/components/clicklog/clicklog-log-panel.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-log-panel.tsx
@@ -10,6 +10,7 @@ export function ClicklogLogPanel({
   note,
   submitting,
   locationAdded,
+  geoStatus,
   onToggleForm,
   onNoteChange,
   onAddLocation,
@@ -21,6 +22,7 @@ export function ClicklogLogPanel({
   note: string;
   submitting: boolean;
   locationAdded: boolean;
+  geoStatus: "idle" | "locating" | "error";
   onToggleForm: () => void;
   onNoteChange: (value: string) => void;
   onAddLocation: () => void;
@@ -55,14 +57,20 @@ export function ClicklogLogPanel({
           <div style={{ display: "flex", gap: 8, marginTop: 10, alignItems: "center" }}>
             <button
               onClick={onAddLocation}
-              style={{ display: "flex", alignItems: "center", gap: 5, padding: "7px 12px", borderRadius: 8, background: locationAdded ? `${BRAND}18` : "rgba(255,255,255,0.04)", border: `1px solid ${locationAdded ? BRAND + "40" : BORDER}`, color: locationAdded ? BRAND : SUBTLE, fontSize: 12, cursor: "pointer" }}
+              disabled={geoStatus === "locating"}
+              style={{ display: "flex", alignItems: "center", gap: 5, padding: "7px 12px", borderRadius: 8, background: locationAdded ? `${BRAND}18` : "rgba(255,255,255,0.04)", border: `1px solid ${locationAdded ? BRAND + "40" : BORDER}`, color: locationAdded ? BRAND : SUBTLE, fontSize: 12, cursor: geoStatus === "locating" ? "not-allowed" : "pointer", opacity: geoStatus === "locating" ? 0.7 : 1 }}
             >
-              <MapPin size={12} /> {locationAdded ? "Location added" : "Add location"}
+              <MapPin size={12} /> {locationAdded ? "Location added" : geoStatus === "locating" ? "Locating…" : "Add location"}
             </button>
             <div style={{ flex: 1 }} />
             <button onClick={onCancel} style={{ padding: "7px 14px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 12, cursor: "pointer" }}>Cancel</button>
             <button onClick={onSubmit} disabled={submitting} style={{ padding: "7px 18px", borderRadius: 8, background: BRAND, border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: submitting ? "not-allowed" : "pointer", opacity: submitting ? 0.7 : 1 }}>Submit</button>
           </div>
+          {geoStatus === "error" && (
+            <div style={{ marginTop: 8, fontSize: 11, color: SUBTLE, lineHeight: 1.5 }}>
+              Couldn&apos;t get your location — check location permissions and try again.
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/ctf/packages/web/components/clicklog/clicklog-right-rail.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-right-rail.tsx
@@ -33,7 +33,7 @@ export function ClicklogRightRail({
       <div style={{ padding: "14px", borderRadius: 12, background: "rgba(233,30,140,0.05)", border: "1px solid rgba(233,30,140,0.15)", marginBottom: 14 }}>
         <div style={{ fontSize: 12, fontWeight: 600, color: BRAND, marginBottom: 6 }}>Safety reminder</div>
         <div style={{ fontSize: 11, color: SUBTLE, lineHeight: 1.6 }}>
-          ClickLog is for personal tracking only. In an emergency, always contact local emergency services first.
+          ClickLog is for personal tracking only.
         </div>
       </div>
       <button

--- a/ctf/packages/web/components/clicklog/clicklog-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-shell.tsx
@@ -25,6 +25,7 @@ export function ClicklogShell() {
   const [showForm, setShowForm] = useState(false);
   const [note, setNote] = useState("");
   const [geo, setGeo] = useState<Geo>({});
+  const [geoStatus, setGeoStatus] = useState<"idle" | "locating" | "error">("idle");
   const [logged, setLogged] = useState(false);
   const isMobile = useIsMobile();
   const { theme } = useTheme();
@@ -55,10 +56,21 @@ export function ClicklogShell() {
   }
 
   function addLocation(): void {
-    if (!navigator.geolocation) return;
+    if (!navigator.geolocation) {
+      setGeoStatus("error");
+      return;
+    }
+    setGeoStatus("locating");
     navigator.geolocation.getCurrentPosition(
-      (pos) => setGeo({ latitude: pos.coords.latitude, longitude: pos.coords.longitude }),
-      () => setGeo({}),
+      (pos) => {
+        setGeo({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+        setGeoStatus("idle");
+      },
+      () => {
+        setGeo({});
+        setGeoStatus("error");
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 },
     );
   }
 
@@ -75,6 +87,7 @@ export function ClicklogShell() {
       setShowForm(false);
       setNote("");
       setGeo({});
+      setGeoStatus("idle");
       flashLogged();
       await fetchIncidents();
     } catch (e) {
@@ -121,11 +134,12 @@ export function ClicklogShell() {
         note={note}
         submitting={busy}
         locationAdded={typeof geo.latitude === "number"}
+        geoStatus={geoStatus}
         onToggleForm={() => setShowForm((s) => !s)}
         onNoteChange={setNote}
         onAddLocation={addLocation}
         onSubmit={() => void postIncident({ ...geo, notes: note })}
-        onCancel={() => { setShowForm(false); setNote(""); setGeo({}); }}
+        onCancel={() => { setShowForm(false); setNote(""); setGeo({}); setGeoStatus("idle"); }}
       />
 
       {incidents.length > 0 && (


### PR DESCRIPTION
Two ClickLog fixes from your requests.

1. Removed the emergency-services line ("In an emergency, always contact local emergency services first.")
   - Web empty state: removed the whole safety-reminder box (and dropped the now-unused `ShieldCheck` import).
   - Web right rail: kept "ClickLog is for personal tracking only.", removed the second sentence.
   - Mobile: removed the `safetyNote` block.

2. "Add location" button now gives feedback instead of silently failing.
   - `clicklog-shell.tsx`: `addLocation()` sets a `geoStatus` (`idle`/`locating`/`error`), calls `getCurrentPosition` with `{ enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 }`, and resets on submit/cancel.
   - `clicklog-log-panel.tsx`: button reads "Locating…" while in flight (disabled), "Location added" on success, and shows "Couldn't get your location — check location permissions and try again." on failure/denial/timeout.

Note: mobile ClickLog uses a location toggle fetched at submit time (the big Log button already shows a spinner), so the web immediate-fetch feedback model doesn't map onto it; left as-is. One residual mobile gap flagged by the agent: if mobile location permission is denied, the incident still logs silently without location and the user isn't told — a possible follow-up.

Verified: `pnpm -r typecheck`, eslint on all changed files, and EOF all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_