### PR TITLE
fix: surface [reportError] lines in the Render debug agent

### DIFF
--- a/ctf/scripts/render-debug-agent.sh
+++ b/ctf/scripts/render-debug-agent.sh
@@ -81,6 +81,14 @@ fi
 
 echo "==> $(echo "$LOGS" | wc -l) log lines fetched. Scanning for errors..."
 
+# Surface our own structured error lines so caught errors (which return a friendly
+# 5xx and would otherwise be invisible) are diagnosable here. These come from
+# lib/observability/report.ts reportError, whose contract forbids secrets/PII — so
+# they are safe to print in the (public) Actions log, unlike raw app log lines.
+echo "==> Structured [reportError] lines (safe — no secrets/PII by contract):"
+echo "$LOGS" | grep -F '[reportError]' | tail -50 || true
+echo "==> (end reportError lines)"
+
 # ── 2. Detect known error patterns ───────────────────────────────────────────
 
 FIXES=()


### PR DESCRIPTION
Follow-up to #525. The debug agent now fetches logs correctly, but it only reports its hardcoded patterns ("No known error patterns found") and doesn't surface the directory error.

This makes it print the structured `[reportError] …` lines after fetching. Those come from `lib/observability/report.ts` `reportError`, whose contract forbids secrets/PII, so they're safe to show in the public Actions log — unlike raw app log lines, which this deliberately does NOT dump.

After merge: reload the Directory (to generate a fresh error in the log window), then re-run "Render Debug Agent" — the run output will include `[reportError] area=directory op=list_members …` with the stack, and I'll fix the 503 from it.

Script-only change; `pnpm -r typecheck` clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_