### PR TITLE
fix: directory list 503 — cast id comparisons to text (v2 varchar id)

### DIFF
--- a/ctf/packages/web/lib/directory/repository.ts
+++ b/ctf/packages/web/lib/directory/repository.ts
@@ -116,7 +116,10 @@ async function loadProfileSkills(client: PoolClient, profileId: string): Promise
       SELECT sk.id, sk.name, dps.display_order
       FROM directory_profile_skills dps
       JOIN skills_taxonomy_skills sk ON sk.id = dps.skill_id
-      WHERE dps.profile_id = $1
+      -- Compare ids as text: directory_profiles.id carried over from v2 as varchar,
+      -- so a direct uuid (dps.profile_id) = varchar comparison fails to plan. Cast
+      -- both to text. Proper id-type reconciliation is tracked in the #520 cleanup.
+      WHERE dps.profile_id::text = $1
       ORDER BY dps.display_order ASC, sk.name ASC
     `,
     [profileId],
@@ -479,7 +482,7 @@ export async function listDirectoryForMember(
             $3::uuid IS NULL
             OR EXISTS (
               SELECT 1 FROM directory_profile_skills dps
-              WHERE dps.profile_id = p.id AND dps.skill_id = $3::uuid
+              WHERE dps.profile_id::text = p.id::text AND dps.skill_id = $3::uuid
             )
           )
           AND (
@@ -524,7 +527,7 @@ export async function listDirectoryForMember(
             $3::uuid IS NULL
             OR EXISTS (
               SELECT 1 FROM directory_profile_skills dps
-              WHERE dps.profile_id = p.id AND dps.skill_id = $3::uuid
+              WHERE dps.profile_id::text = p.id::text AND dps.skill_id = $3::uuid
             )
           )
           AND (


### PR DESCRIPTION
Fixes the Directory "No providers found" 503. The Render Debug Agent (now working) surfaced the exact error:
```
[reportError] area=directory op=list_members error: operator does not exist: uuid = character varying
```

Root cause: `directory_profiles.id` carried over from v2 as `character varying`, while `directory_profile_skills.profile_id` is `uuid`. The list/count query's skill-filter `EXISTS (… WHERE dps.profile_id = p.id …)` compares uuid to varchar. Postgres resolves operators at plan time, so the query failed to plan on **every** load (even with no skill filter selected) → 503 → the client showed the empty state. The data is fine (66 active profiles).

Change: cast both sides to text in the two skill-filter `EXISTS` clauses and in `loadProfileSkills` (`dps.profile_id::text = p.id::text` / `= $1`). The uuid=uuid `sector_id`/`job_title_id` joins are untouched.

This is the fast read-path tolerance fix; the proper reconciliation of `directory_profiles` to the v3 shape (uuid `id`, drop v2-only columns) is tracked in the #520 cleanup.

Verified: `pnpm -r typecheck` + eslint on the file clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_