### PR TITLE
fix: ClickLog location — specific error reason + faster network fix

### DIFF
--- a/ctf/packages/web/components/clicklog/clicklog-log-panel.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-log-panel.tsx
@@ -11,6 +11,7 @@ export function ClicklogLogPanel({
   submitting,
   locationAdded,
   geoStatus,
+  geoError,
   onToggleForm,
   onNoteChange,
   onAddLocation,
@@ -23,6 +24,7 @@ export function ClicklogLogPanel({
   submitting: boolean;
   locationAdded: boolean;
   geoStatus: "idle" | "locating" | "error";
+  geoError: string | null;
   onToggleForm: () => void;
   onNoteChange: (value: string) => void;
   onAddLocation: () => void;
@@ -68,7 +70,7 @@ export function ClicklogLogPanel({
           </div>
           {geoStatus === "error" && (
             <div style={{ marginTop: 8, fontSize: 11, color: SUBTLE, lineHeight: 1.5 }}>
-              Couldn&apos;t get your location — check location permissions and try again.
+              {geoError ?? "Couldn't get your location — check location permissions and try again."}
             </div>
           )}
         </div>

--- a/ctf/packages/web/components/clicklog/clicklog-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-shell.tsx
@@ -26,6 +26,7 @@ export function ClicklogShell() {
   const [note, setNote] = useState("");
   const [geo, setGeo] = useState<Geo>({});
   const [geoStatus, setGeoStatus] = useState<"idle" | "locating" | "error">("idle");
+  const [geoError, setGeoError] = useState<string | null>(null);
   const [logged, setLogged] = useState(false);
   const isMobile = useIsMobile();
   const { theme } = useTheme();
@@ -57,20 +58,35 @@ export function ClicklogShell() {
 
   function addLocation(): void {
     if (!navigator.geolocation) {
+      setGeoError("This browser can't access location.");
       setGeoStatus("error");
       return;
     }
     setGeoStatus("locating");
+    setGeoError(null);
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         setGeo({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
         setGeoStatus("idle");
+        setGeoError(null);
       },
-      () => {
+      (err) => {
         setGeo({});
+        // Surface the specific reason. On iPhone, location commonly fails even when
+        // Safari's per-site toggle says Allow — the OS-level Location Services for
+        // Safari must also be on — so name that path for a denied permission.
+        const message =
+          err.code === err.PERMISSION_DENIED
+            ? "Location is blocked. On iPhone: Settings → Privacy & Security → Location Services → turn it on and set Safari Websites to “While Using the App”, then reload and try again."
+            : err.code === err.TIMEOUT
+              ? "Location timed out — try again."
+              : "Your location is unavailable right now — try again, ideally with Wi-Fi on.";
+        setGeoError(message);
         setGeoStatus("error");
       },
-      { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 },
+      // High accuracy (GPS) is slow and flaky on mobile and an incident log does not
+      // need pinpoint precision, so prefer the faster network fix; keep a 10s timeout.
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
     );
   }
 
@@ -88,6 +104,7 @@ export function ClicklogShell() {
       setNote("");
       setGeo({});
       setGeoStatus("idle");
+      setGeoError(null);
       flashLogged();
       await fetchIncidents();
     } catch (e) {
@@ -135,11 +152,12 @@ export function ClicklogShell() {
         submitting={busy}
         locationAdded={typeof geo.latitude === "number"}
         geoStatus={geoStatus}
+        geoError={geoError}
         onToggleForm={() => setShowForm((s) => !s)}
         onNoteChange={setNote}
         onAddLocation={addLocation}
         onSubmit={() => void postIncident({ ...geo, notes: note })}
-        onCancel={() => { setShowForm(false); setNote(""); setGeo({}); setGeoStatus("idle"); }}
+        onCancel={() => { setShowForm(false); setNote(""); setGeo({}); setGeoStatus("idle"); setGeoError(null); }}
       />
 
       {incidents.length > 0 && (


### PR DESCRIPTION
ClickLog "Add location" reported only a generic failure even with Safari's per-site Location set to Allow, so the real cause was hidden.

- The geolocation error callback now maps the error code to a specific message: permission blocked vs timeout vs unavailable. The blocked-permission case names the iOS path — on iPhone the per-site Allow toggle is moot unless OS-level Location Services for Safari is also on, so it points there.
- Switched `enableHighAccuracy` to `false`: GPS is slow/flaky on mobile and an incident log doesn't need pinpoint precision; the network fix is faster and more reliable (this alone likely resolves a high-accuracy timeout).
- `geoError` resets on success/cancel/submit.

This makes the failure self-explanatory and likely fixes the common timeout case; if it's genuinely an OS-level permission, the message now tells you exactly where to enable it.

Verified: `pnpm -r typecheck` + eslint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_