### PR TITLE
ci: harden schema drift DB-token match (case-insensitive, whitespace-tolerant)

### DIFF
--- a/ctf/scripts/check-schema-drift.sh
+++ b/ctf/scripts/check-schema-drift.sh
@@ -55,7 +55,9 @@ contract_schema_failed=false
 
 # Tokens that mark a file as actually touching the database layer. Used to decide whether a changed
 # shared/server file is DB-impacting (content-aware) instead of treating the whole package as such.
-DB_CONTENT_RE='queryDb|withDbTransaction|CREATE TABLE|ALTER TABLE|INSERT INTO|DELETE FROM|CREATE INDEX|drizzle|lib/db/postgres'
+# SQL keywords are matched case-insensitively (grep -Ei below) and tolerate any run of whitespace
+# between words, so variants like "create table" and "CREATE   TABLE" are still caught.
+DB_CONTENT_RE='queryDb|withDbTransaction|CREATE[[:space:]]+TABLE|ALTER[[:space:]]+TABLE|INSERT[[:space:]]+INTO|DELETE[[:space:]]+FROM|CREATE[[:space:]]+INDEX|drizzle|lib/db/postgres'
 
 validate_contract_file() {
   local file="$1"
@@ -136,7 +138,7 @@ for file in "${files[@]}"; do
       && [[ ! "$file" =~ ^ctf/packages/shared/dist/.*/auth/ ]] \
       && [[ ! "$file" =~ ^ctf/packages/shared/dist/auth/ ]] \
       && [[ -f "$file" ]] \
-      && grep -Eq "$DB_CONTENT_RE" -- "$file"; then
+      && grep -Eiq "$DB_CONTENT_RE" -- "$file"; then
       db_impacting_changed=true
     fi
   fi


### PR DESCRIPTION
## What this changes

Follow-up to #546 (the content-aware schema drift gate). CodeRabbit flagged — correctly — that the DB-token patterns matched only exact case and a single literal space. So SQL written as `create table` (lowercase) or `CREATE   TABLE` (multiple spaces or tabs) would slip past the gate and avoid the schema check.

This makes the match robust:
- `DB_CONTENT_RE` now uses `[[:space:]]+` between SQL keywords (`CREATE[[:space:]]+TABLE`, etc.) so any run of whitespace matches.
- The `grep -Eq` becomes `grep -Eiq` so matching is case-insensitive.

This only ever makes the gate **stricter** (more likely to flag a file as DB-impacting), so it cannot let a real schema change through — it closes a gap where one could.

## Verification

- `bash -n` syntax check passes.
- Spot-checks: `create table foo`, `CREATE   TABLE bar`, and `ALTER  TABLE x` now match; a plain `export const FOO = 1;` still does not; `queryDb(...)` still matches.
- Gate run against this branch: `db_impacting_changed=false` — passes.

Schema Drift: none (changes the gate script only; no schema/contract/seed change).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiataxoKFz3Ldx5mePiJ3m)_