### PR TITLE
fix: auto-refresh the comic review console so new questions appear

### DIFF
--- a/ctf/packages/web/components/comic/comic-review-console.tsx
+++ b/ctf/packages/web/components/comic/comic-review-console.tsx
@@ -127,6 +127,20 @@ export function ComicReviewConsole() {
     void refresh();
   }, [refresh]);
 
+  // Keep the queue fresh so a question a survivor just sent to @comic shows up
+  // without a manual page reload. Poll only while the reviewer is idle — no item
+  // open, not editing, no action in flight — so a background refresh can never
+  // wipe an in-progress correction or steal the current selection.
+  useEffect(() => {
+    if (selectedId !== null || editing || resolving) {
+      return;
+    }
+    const intervalId = window.setInterval(() => {
+      void refresh();
+    }, 15000);
+    return () => window.clearInterval(intervalId);
+  }, [refresh, selectedId, editing, resolving]);
+
   // Live status of the Ollama drafting backend (a RunPod endpoint or a native Ollama host).
   // Best-effort: a failure just leaves the badge hidden, never blocks the review queue.
   useEffect(() => {


### PR DESCRIPTION
## Problem

A survivor sends a question to `@comic` in the Hub chat; the admin opens the Review & Correction Console and sees nothing. It looks like the feature is broken.

The backend is actually correct — `routeComicMessage()` enqueues a `pending` row in `comic_review_queue` the instant a message mentions `@comic`, and `listPendingComicReviews()` returns those rows whether or not an AI draft has been attached yet. The bug is in the console: `ComicReviewConsole` fetched the queue **once on mount** (`useEffect(() => void refresh(), [refresh])`) and never again. So a question queued *after* the admin opened the page only appears on a manual reload.

## Fix

Add a 15-second poll that re-fetches the queue **only while the reviewer is idle** — no item open (`selectedId === null`), not editing, and no approve/reject in flight. Pausing on those conditions means a background refresh can never wipe an in-progress correction (the seed effect re-runs when the selected item's reference changes) or move the current selection. When the reviewer finishes and the selection clears, polling resumes.

## Scope note

This is the confirmed, code-level gap that matches the report. If a question still never appears after a reload, the cause is upstream of the console (the send was rejected — e.g. content moderation, rate limit — and showed an error banner in the Hub chat, or the message did not contain a literal `@comic` mention), not the queue display.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_