### PR TITLE
chore: ban the word "console" in agent replies, use "dashboard"

### DIFF
--- a/.claude/hooks/check-no-pleasantries.mjs
+++ b/.claude/hooks/check-no-pleasantries.mjs
@@ -36,6 +36,9 @@ const VOCABULARY = [
   { re: /\bflywheel\b/i, use: 'a plain description of the loop (e.g. "each answer improves the next")' },
   { re: /\bpunch list\b/i, use: 'list' },
   { re: /\bstale\b/i, use: 'drop it — it usually adds no value; if you mean something specific, name it (out-of-date, superseded, no longer current)' },
+  // "console" reads as developer jargon for a screen; say "dashboard". The negative lookahead skips
+  // the code identifiers console.log / console.error / console.info so quoting real code never trips.
+  { re: /\bconsole\b(?!\.\w)/i, use: 'dashboard' },
 ];
 
 function readStdin() {


### PR DESCRIPTION
## What

Adds the word "console" to the owner-maintained excluded vocabulary in the plain-voice Stop hook (`.claude/hooks/check-no-pleasantries.mjs`), so agents say **dashboard** instead. Requested by the owner.

## How

One entry in the `VOCABULARY` list:

```js
{ re: /\bconsole\b(?!\.\w)/i, use: 'dashboard' },
```

The negative lookahead `(?!\.\w)` skips the code identifiers `console.log` / `console.error` / `console.info`, so quoting real code in a reply never trips the check, while prose like "the review console" is flagged with the suggestion to use "dashboard". Verified against both cases.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_