### PR TITLE
feat: add admin bug report review page

### DIFF
--- a/.github/instructions/129-bug-reporting-and-triage-rules.mdc
+++ b/.github/instructions/129-bug-reporting-and-triage-rules.mdc
@@ -131,6 +131,12 @@ title (`fix:`, `feat:`, …). This is an explicit owner instruction (2026-06-10)
   and relabels it `built`. Uses the external Claude Code GitHub Action — pin its version and confirm
   its inputs on first run. Manual-dispatch only on purpose (the owner kicks each build until the
   pipeline is trusted).
+- **Admin review surface**: `/admin/bug-reports` (page `app/admin/bug-reports/`, shell
+  `components/bug-reports/bug-reports-admin-shell.tsx`, admin API `app/api/bug-reports/admin/`). Lists
+  all reports with held ones first, showing **redacted** text + the risk flags that explain the hold
+  (never raw text). An admin can **release** a held report (sets it back to `new`, so the create-issues
+  job publishes the redacted copy to triage on its next run) or **reject** it. Reachable from the
+  `/admin` landing. This is the surface the owner uses to clear the `held_for_review` queue.
 
 **Label flow in the triage repo** (create these in `chargingthefuture/bug-reports`):
 `user-report` → `needs-triage` → (triage) `triaged` + `awaiting-owner-approval` → (owner adds)
@@ -141,6 +147,7 @@ title (`fix:`, `feat:`, …). This is an explicit owner instruction (2026-06-10)
 - The in-app "Report a problem" form is a net-new surface and is **design-gated** (rule 127). Build it
   only once a design lands in the `design/` submodule. `DESIGN PASS REQUIRED` was announced on
   2026-06-10 and a design-prompt issue was filed for the Replit design agent.
-- The private in-app admin view for `held_for_review` reports is not built yet.
+- ~~The private in-app admin view for `held_for_review` reports is not built yet.~~ Built: see the
+  "Admin review surface" entry above (`/admin/bug-reports`).
 - All three workflows are manual-dispatch until the triage repo's labels exist, `GH_PAT` can read+write
   it, and `ANTHROPIC_API_KEY` / `DATABASE_URL` are available; then uncomment the schedules.

--- a/ctf/packages/web/app/admin/bug-reports/page.tsx
+++ b/ctf/packages/web/app/admin/bug-reports/page.tsx
@@ -1,0 +1,43 @@
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import Link from 'next/link';
+import { BugReportsAdminShell } from '../../../components/bug-reports/bug-reports-admin-shell';
+
+export const dynamic = 'force-dynamic';
+
+// Admin review of in-app bug reports. Admin-gated server-side; the client shell lists reports
+// (held ones first) and releases or rejects them via the admin /api/bug-reports/admin routes.
+// Held reports are the ones the sanitizer flagged — they wait here for a human, and are never
+// auto-published to the triage repo. Only redacted text is ever shown (rule 129).
+export default async function BugReportsAdminPage() {
+  const decision = await evaluatePluginAccess({ requiredRoles: ['admin'] });
+
+  if (!decision.allowed) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-12 space-y-4">
+        <h1 className="text-2xl font-semibold tracking-tight">Admin access denied</h1>
+        <p className="text-sm text-muted-foreground">
+          The bug report review area is restricted to admins. Request blocked by server-side role policy.
+        </p>
+        <dl className="rounded-lg border bg-card p-4 text-sm">
+          <div className="flex justify-between gap-4">
+            <dt className="font-medium">HTTP status</dt>
+            <dd>{decision.status}</dd>
+          </div>
+          <div className="mt-2 flex justify-between gap-4">
+            <dt className="font-medium">Deny code</dt>
+            <dd>{decision.code}</dd>
+          </div>
+          <div className="mt-2 flex justify-between gap-4">
+            <dt className="font-medium">Reason</dt>
+            <dd>{decision.reason}</dd>
+          </div>
+        </dl>
+        <p className="text-sm">
+          <Link className="underline underline-offset-4" href="/admin">Back to admin</Link>
+        </p>
+      </main>
+    );
+  }
+
+  return <BugReportsAdminShell />;
+}

--- a/ctf/packages/web/app/admin/page.tsx
+++ b/ctf/packages/web/app/admin/page.tsx
@@ -25,6 +25,7 @@ const ADMIN_AREAS: { href: string; name: string; description: string }[] = [
   { href: '/admin/gdp', name: 'GDP', description: 'Manage GDP figures.' },
   { href: '/admin/gdp/rates', name: 'GDP Rates', description: 'Manage GDP exchange and conversion rates.' },
   { href: '/admin/feed-announcements', name: 'Feed Announcements', description: 'Post and manage announcements in the community feed.' },
+  { href: '/admin/bug-reports', name: 'Bug Reports', description: 'Review reports flagged for a human and track ones sent to triage.' },
 ];
 
 export default async function AdminPage() {

--- a/ctf/packages/web/app/api/bug-reports/_lib.ts
+++ b/ctf/packages/web/app/api/bug-reports/_lib.ts
@@ -22,6 +22,20 @@ export async function requireReporterAccess(): Promise<BugReportApiGate> {
   return { allowed: true, auth: decision };
 }
 
+// The admin review surface (/admin/bug-reports and its API) is restricted to admins. Every
+// admin route gates on this regardless of what the nav shows (see rule 131).
+export async function requireBugReportAdminAccess(): Promise<BugReportApiGate> {
+  const decision = await evaluatePluginAccess({ requiredRoles: ['admin'] });
+  if (!decision.allowed) {
+    return {
+      allowed: false,
+      response: NextResponse.json(decision, { status: decision.status }),
+    };
+  }
+
+  return { allowed: true, auth: decision };
+}
+
 export function ensureMutationCsrf(request: Request): NextResponse | null {
   if (request.method === 'GET' || request.method === 'HEAD') {
     return null;

--- a/ctf/packages/web/app/api/bug-reports/admin/[id]/resolve/route.ts
+++ b/ctf/packages/web/app/api/bug-reports/admin/[id]/resolve/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { requireBugReportAdminAccess, ensureMutationCsrf } from '../../../_lib';
+import { BUG_REPORT_ERROR_CODE } from 'lib/bug-reports/constants';
+import { releaseHeldReport, rejectReport } from 'lib/bug-reports/repository';
+import { reportError } from 'lib/observability/report';
+
+type ResolveBody = { action?: unknown };
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Resolve a held (or new) bug report. `release` sends it back to `new` so the create-issues
+// job publishes the redacted copy to the triage repo; `reject` drops it so it never does.
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const gate = await requireBugReportAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const { id } = await params;
+  if (!UUID_REGEX.test(id)) {
+    return NextResponse.json(
+      { ok: false, code: BUG_REPORT_ERROR_CODE.invalidPayload, message: 'Invalid report id.' },
+      { status: 400 },
+    );
+  }
+
+  let body: ResolveBody;
+  try {
+    body = (await request.json()) as ResolveBody;
+  } catch {
+    return NextResponse.json(
+      { ok: false, code: BUG_REPORT_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
+      { status: 400 },
+    );
+  }
+
+  if (body.action !== 'release' && body.action !== 'reject') {
+    return NextResponse.json(
+      { ok: false, code: BUG_REPORT_ERROR_CODE.invalidPayload, message: 'action must be "release" or "reject".' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const changed =
+      body.action === 'release' ? await releaseHeldReport(id) : await rejectReport(id);
+
+    if (!changed) {
+      // No row moved: the report was already resolved (published/rejected) or does not exist.
+      return NextResponse.json(
+        { ok: false, code: BUG_REPORT_ERROR_CODE.forbidden, message: 'Report is not in a state that can be resolved.' },
+        { status: 409 },
+      );
+    }
+
+    const newStatus = body.action === 'release' ? 'new' : 'rejected';
+    return NextResponse.json({ ok: true, id, status: newStatus }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'bug-reports', op: 'admin-resolve' });
+    return NextResponse.json(
+      {
+        ok: false,
+        code: BUG_REPORT_ERROR_CODE.persistenceUnavailable,
+        message: 'Unable to resolve this report.',
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/bug-reports/admin/route.ts
+++ b/ctf/packages/web/app/api/bug-reports/admin/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { requireBugReportAdminAccess } from '../_lib';
+import { BUG_REPORT_ERROR_CODE } from 'lib/bug-reports/constants';
+import { listReportsForAdmin } from 'lib/bug-reports/repository';
+import { reportError } from 'lib/observability/report';
+
+// Admin list of bug reports for the /admin/bug-reports review page. Held reports first.
+// Redacted text only — the raw user text never leaves the database (rule 129).
+export async function GET() {
+  const gate = await requireBugReportAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const rows = await listReportsForAdmin();
+    const items = rows.map((row) => ({
+      id: row.id,
+      status: row.status,
+      redactedMessage: row.redacted_message,
+      redactedContext: row.redacted_context,
+      riskFlags: row.risk_flags ?? [],
+      riskLevel: row.risk_level,
+      pageUrl: row.page_url,
+      pluginSlug: row.plugin_slug,
+      appVersion: row.app_version,
+      triageRepo: row.triage_repo,
+      issueNumber: row.issue_number,
+      issueUrl: row.issue_url,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+
+    return NextResponse.json({ ok: true, items }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'bug-reports', op: 'admin-list' });
+    return NextResponse.json(
+      {
+        ok: false,
+        code: BUG_REPORT_ERROR_CODE.persistenceUnavailable,
+        message: 'Unable to load bug reports.',
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
+++ b/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+
+type BugReportStatus = 'new' | 'held_for_review' | 'issue_created' | 'rejected' | 'resolved';
+
+type AdminBugReport = {
+  id: string;
+  status: BugReportStatus;
+  redactedMessage: string | null;
+  redactedContext: string | null;
+  riskFlags: string[];
+  riskLevel: 'clean' | 'flagged' | 'unknown';
+  pageUrl: string | null;
+  pluginSlug: string | null;
+  appVersion: string | null;
+  triageRepo: string | null;
+  issueNumber: number | null;
+  issueUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+// Plain labels for why the sanitizer held a report, so an admin understands the flag at a glance.
+const RISK_FLAG_LABEL: Record<string, string> = {
+  pii_email: 'email removed',
+  pii_phone: 'phone removed',
+  pii_card: 'long number removed',
+  secret_token: 'token-like string removed',
+  abusive_language: 'abusive language',
+};
+
+const STATUS_LABEL: Record<BugReportStatus, string> = {
+  held_for_review: 'Held for review',
+  new: 'Queued for triage',
+  issue_created: 'Sent to triage',
+  rejected: 'Rejected',
+  resolved: 'Resolved',
+};
+
+const STATUS_PILL_CLASS: Record<BugReportStatus, string> = {
+  held_for_review: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  new: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
+  issue_created: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  rejected: 'bg-muted text-muted-foreground border-border',
+  resolved: 'bg-muted text-muted-foreground border-border',
+};
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, { cache: 'no-store', ...init });
+  const payload = (await response.json().catch(() => null)) as T | { message?: string } | null;
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === 'object' && 'message' in payload ? payload.message : 'Request failed.';
+    throw new Error(typeof message === 'string' ? message : 'Request failed.');
+  }
+  return payload as T;
+}
+
+function formatWhen(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return 'unknown time';
+  return new Date(then).toLocaleString();
+}
+
+export function BugReportsAdminShell() {
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [items, setItems] = useState<AdminBugReport[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const payload = await requestJson<{ items: AdminBugReport[] }>('/api/bug-reports/admin');
+      setItems(payload.items);
+      setLoadState('ready');
+      setError(null);
+    } catch (loadError) {
+      setLoadState('error');
+      setError(loadError instanceof Error ? loadError.message : 'Unable to load bug reports.');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const heldCount = useMemo(() => items.filter((i) => i.status === 'held_for_review').length, [items]);
+
+  const resolve = useCallback(
+    async (id: string, action: 'release' | 'reject') => {
+      const confirmText =
+        action === 'release'
+          ? 'Send this report to the triage repo? The redacted text becomes a triage issue on the next run (within 15 minutes).'
+          : 'Reject this report? It will never be sent to triage.';
+      if (typeof window !== 'undefined' && !window.confirm(confirmText)) {
+        return;
+      }
+
+      setBusyId(id);
+      setError(null);
+      try {
+        await requestJson(`/api/bug-reports/admin/${id}/resolve`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'x-ctf-csrf': '1' },
+          body: JSON.stringify({ action }),
+        });
+        await refresh();
+      } catch (resolveError) {
+        setError(resolveError instanceof Error ? resolveError.message : 'Unable to resolve this report.');
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [refresh],
+  );
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-12 space-y-8">
+      <header className="space-y-2">
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Bug Reports</h1>
+          <span className="rounded border border-indigo-500/40 bg-indigo-500/15 px-2 py-0.5 text-xs font-medium text-indigo-300">
+            ADMIN
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Reports filed from inside the app. A report the safety check flagged is{' '}
+          <span className="font-medium">held for review</span> and never sent to the triage repo on its own —
+          release it to send the redacted copy to triage, or reject it. Only redacted text is shown here; the
+          raw text stays in the database.
+        </p>
+        {loadState === 'ready' ? (
+          <p className="text-sm text-muted-foreground">
+            {heldCount > 0
+              ? `${heldCount} report${heldCount === 1 ? '' : 's'} waiting for your review.`
+              : 'No reports are waiting for review.'}
+          </p>
+        ) : null}
+      </header>
+
+      {error ? (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300" role="status">
+          {error}
+        </div>
+      ) : null}
+
+      {loadState === 'loading' ? (
+        <p className="text-sm text-muted-foreground">Loading reports…</p>
+      ) : null}
+
+      {loadState === 'ready' && items.length === 0 ? (
+        <div className="rounded-lg border bg-card p-8 text-center text-sm text-muted-foreground">
+          No bug reports yet. When someone files one from inside the app, it shows up here.
+        </div>
+      ) : null}
+
+      <ul className="space-y-3">
+        {items.map((report) => {
+          const canResolve = report.status === 'held_for_review' || report.status === 'new';
+          return (
+            <li key={report.id} className="rounded-lg border bg-card p-4 space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className={`rounded border px-2 py-0.5 text-xs font-medium ${STATUS_PILL_CLASS[report.status]}`}
+                >
+                  {STATUS_LABEL[report.status]}
+                </span>
+                <span className="text-xs text-muted-foreground">{formatWhen(report.createdAt)}</span>
+                {report.pluginSlug ? (
+                  <span className="text-xs text-muted-foreground">· {report.pluginSlug}</span>
+                ) : null}
+              </div>
+
+              <p className="whitespace-pre-wrap text-sm">{report.redactedMessage || '(no message)'}</p>
+
+              {report.redactedContext ? (
+                <p className="whitespace-pre-wrap text-sm text-muted-foreground">
+                  <span className="font-medium">What they were trying to do: </span>
+                  {report.redactedContext}
+                </p>
+              ) : null}
+
+              {report.riskFlags.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {report.riskFlags.map((flag) => (
+                    <span
+                      key={flag}
+                      className="rounded border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-300"
+                    >
+                      {RISK_FLAG_LABEL[flag] ?? flag}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                {report.pageUrl ? <span>Page: {report.pageUrl}</span> : null}
+                {report.appVersion ? <span>App: {report.appVersion}</span> : null}
+                {report.issueUrl ? (
+                  <Link className="underline underline-offset-4" href={report.issueUrl} target="_blank" rel="noreferrer">
+                    Triage issue #{report.issueNumber ?? '?'}
+                  </Link>
+                ) : null}
+              </div>
+
+              {canResolve ? (
+                <div className="flex gap-2 pt-1">
+                  <button
+                    type="button"
+                    onClick={() => void resolve(report.id, 'release')}
+                    disabled={busyId === report.id}
+                    className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-sm font-medium text-emerald-300 transition hover:bg-emerald-500/20 disabled:opacity-50"
+                  >
+                    {report.status === 'held_for_review' ? 'Release to triage' : 'Send to triage now'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void resolve(report.id, 'reject')}
+                    disabled={busyId === report.id}
+                    className="rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:opacity-50"
+                  >
+                    Reject
+                  </button>
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+
+      <footer className="border-t pt-4 text-sm text-muted-foreground">
+        <Link className="underline underline-offset-4" href="/admin">Back to admin</Link>
+      </footer>
+    </main>
+  );
+}

--- a/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
+++ b/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
@@ -2,16 +2,16 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-
-type BugReportStatus = 'new' | 'held_for_review' | 'issue_created' | 'rejected' | 'resolved';
+import type { BugReportStatus, BugReportRiskLevel } from 'lib/bug-reports/constants';
+import type { BugReportRiskFlag } from 'lib/bug-reports/sanitize';
 
 type AdminBugReport = {
   id: string;
   status: BugReportStatus;
   redactedMessage: string | null;
   redactedContext: string | null;
-  riskFlags: string[];
-  riskLevel: 'clean' | 'flagged' | 'unknown';
+  riskFlags: BugReportRiskFlag[];
+  riskLevel: BugReportRiskLevel;
   pageUrl: string | null;
   pluginSlug: string | null;
   appVersion: string | null;
@@ -160,7 +160,11 @@ export function BugReportsAdminShell() {
 
       <ul className="space-y-3">
         {items.map((report) => {
-          const canResolve = report.status === 'held_for_review' || report.status === 'new';
+          // A held report can be released to triage; a new one is already queued for the drain,
+          // so it only offers reject. Release on a new report would 409 (the update only matches
+          // held_for_review), so the button is hidden there.
+          const canRelease = report.status === 'held_for_review';
+          const canReject = report.status === 'held_for_review' || report.status === 'new';
           return (
             <li key={report.id} className="rounded-lg border bg-card p-4 space-y-3">
               <div className="flex flex-wrap items-center gap-2">
@@ -207,24 +211,28 @@ export function BugReportsAdminShell() {
                 ) : null}
               </div>
 
-              {canResolve ? (
+              {canRelease || canReject ? (
                 <div className="flex gap-2 pt-1">
-                  <button
-                    type="button"
-                    onClick={() => void resolve(report.id, 'release')}
-                    disabled={busyId === report.id}
-                    className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-sm font-medium text-emerald-300 transition hover:bg-emerald-500/20 disabled:opacity-50"
-                  >
-                    {report.status === 'held_for_review' ? 'Release to triage' : 'Send to triage now'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void resolve(report.id, 'reject')}
-                    disabled={busyId === report.id}
-                    className="rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:opacity-50"
-                  >
-                    Reject
-                  </button>
+                  {canRelease ? (
+                    <button
+                      type="button"
+                      onClick={() => void resolve(report.id, 'release')}
+                      disabled={busyId === report.id}
+                      className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-sm font-medium text-emerald-300 transition hover:bg-emerald-500/20 disabled:opacity-50"
+                    >
+                      Release to triage
+                    </button>
+                  ) : null}
+                  {canReject ? (
+                    <button
+                      type="button"
+                      onClick={() => void resolve(report.id, 'reject')}
+                      disabled={busyId === report.id}
+                      className="rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:opacity-50"
+                    >
+                      Reject
+                    </button>
+                  ) : null}
                 </div>
               ) : null}
             </li>

--- a/ctf/packages/web/lib/bug-reports/repository.ts
+++ b/ctf/packages/web/lib/bug-reports/repository.ts
@@ -112,6 +112,71 @@ export async function listReportsReadyForIssue(limit: number): Promise<BugReport
   return result.rows;
 }
 
+// What an admin sees for one report. Deliberately omits raw_message / raw_context: the
+// raw user text never leaves the database (rule 129), so even the admin review surface
+// shows only the redacted copy plus the risk flags that explain why a report was held.
+export type BugReportAdminRow = {
+  id: string;
+  status: BugReportStatus;
+  redacted_message: string | null;
+  redacted_context: string | null;
+  risk_flags: BugReportRiskFlag[];
+  risk_level: BugReportRiskLevel;
+  page_url: string | null;
+  plugin_slug: string | null;
+  app_version: string | null;
+  triage_repo: string | null;
+  issue_number: number | null;
+  issue_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+// Admin list of reports for the /admin/bug-reports review page. Held reports surface
+// first (they are the ones waiting on a human), then the rest, newest within each group.
+// Redacted fields only — never the raw text.
+export async function listReportsForAdmin(limit = 200): Promise<BugReportAdminRow[]> {
+  const result = await queryDb<BugReportAdminRow>(
+    `SELECT id, status, redacted_message, redacted_context, risk_flags, risk_level,
+            page_url, plugin_slug, app_version, triage_repo, issue_number, issue_url,
+            created_at, updated_at
+       FROM bug_reports
+      ORDER BY (status = 'held_for_review') DESC, created_at DESC
+      LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows;
+}
+
+// Release a held report back into the `new` state so the create-issues job picks it up on
+// its next run and publishes the redacted copy to the triage repo. Only a held report can
+// be released; the guard keeps a double-click from disturbing an already-published row.
+// Returns true when a row actually changed.
+export async function releaseHeldReport(id: string): Promise<boolean> {
+  const result = await queryDb(
+    `UPDATE bug_reports
+        SET status = 'new', updated_at = NOW()
+      WHERE id = $1 AND status = 'held_for_review'`,
+    [id],
+  );
+
+  return (result.rowCount ?? 0) > 0;
+}
+
+// Reject a report so it never reaches the triage repo. Allowed from `held_for_review` or
+// `new` (a clean report an admin decides not to forward). Returns true when a row changed.
+export async function rejectReport(id: string): Promise<boolean> {
+  const result = await queryDb(
+    `UPDATE bug_reports
+        SET status = 'rejected', updated_at = NOW()
+      WHERE id = $1 AND status IN ('held_for_review', 'new')`,
+    [id],
+  );
+
+  return (result.rowCount ?? 0) > 0;
+}
+
 // Mark a report as published into the triage repo.
 export async function markReportIssueCreated(
   id: string,


### PR DESCRIPTION
## Why

You reported `bug-reports-create-issues.yml` "not working" — you submitted a report and nothing appeared in the triage repo. The pipeline was actually behaving correctly: the latest scheduled run logged `created 0 issue(s)` because the drain only picks `status = 'new'`, and a report the safety check flags is born `held_for_review`. There was **no in-app surface to see or release held reports** (rule 129 listed it as "not built yet"), so a flagged report had nowhere to go and the `/admin` landing had no Bug Reports entry.

## What this adds

- **`/admin/bug-reports`** — an admin-role-gated review page listing all reports, **held ones first**, each with a status pill, the **redacted** text, the risk flags that explain why it was held (e.g. "email removed", "token-like string removed"), and metadata. Raw user text is never shown — only the redacted copy, per rule 129.
- **Release / Reject actions.** *Release* sets a held report back to `new`, so the existing 15‑minute create-issues job publishes the redacted copy to the triage repo on its next run. *Reject* drops it so it's never sent.
- **Admin API.** `GET /api/bug-reports/admin` (list) and `POST /api/bug-reports/admin/[id]/resolve` (`release`/`reject`), both admin-gated with the CSRF header; repository helpers `listReportsForAdmin` / `releaseHeldReport` / `rejectReport`.
- **A Bug Reports card** on the `/admin` landing.
- Rule 129 updated to mark the admin view built.

The page also doubles as a diagnostic: if your test report is `held_for_review`, it'll be at the top to release; if it isn't there at all, the report never persisted (and we look upstream at the submit path).

## Note on the design gate

Per rule 131 (admin-surface build rules), the owner pre-authorized building admin pages now as internal operator tooling, in the admin visual language, bound to real data — not design-pass-gated. Built consistent with the existing `/admin` pages' style.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin interface for reviewing and moderating flagged bug reports
  * Admins can release held reports back to new status or reject them
  * Reports display status, risk indicators, context summaries, and timestamps for informed triage decisions

* **Documentation**
  * Updated bug reporting triage rules to reflect completed admin review functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->