### PR TITLE
fix: add back-to-apps control to public plugin shells

### DIFF
--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -2,6 +2,7 @@ import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { getHostedSignInUrl } from 'lib/auth/provider-env';
 import { canonicalizePluginSlug, getPluginBySlug } from 'lib/plugins/repository';
 import { getPublicVisitorShell } from '@/components/plugins/public-visitor-registry';
+import { PublicShellFrame } from '@/components/plugins/public-shell-frame';
 import { ChymeShell } from '@/components/chyme/chyme-shell';
 import { DirectoryShell } from '@/components/directory/directory-shell';
 import { FoundationShell } from '@/components/foundation/foundation-shell';
@@ -165,12 +166,14 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
       // normal sign-in / sign-up CTAs.
       const verifyUrl = decision.reason === 'unlock_required' ? '/plugin/unlock' : undefined;
       return (
-        <PublicVisitorShell
-          pluginSlug={selectedPlugin.slug}
-          pluginName={selectedPlugin.name}
-          signInUrl={signInUrl}
-          verifyUrl={verifyUrl}
-        />
+        <PublicShellFrame>
+          <PublicVisitorShell
+            pluginSlug={selectedPlugin.slug}
+            pluginName={selectedPlugin.name}
+            signInUrl={signInUrl}
+            verifyUrl={verifyUrl}
+          />
+        </PublicShellFrame>
       );
     }
 

--- a/ctf/packages/web/components/plugins/public-shell-frame.tsx
+++ b/ctf/packages/web/components/plugins/public-shell-frame.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+/**
+ * Wraps a plugin's public / not-yet-verified visitor shell with a single
+ * back-to-/apps control. These landing shells carry no navigation of their own
+ * (none link back to the launcher), so without this a visitor who opened a
+ * plugin from /apps had no on-screen way back. Verified members never see these
+ * shells — they get the plugin's authenticated shell, which has its own designed
+ * back button — so this control only ever appears where one was missing, and
+ * never doubles an existing one.
+ *
+ * Fixed to the top-left so it overlays the shell without disturbing its layout;
+ * neutral styling reads on every plugin's dark public background.
+ */
+export function PublicShellFrame({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Link
+        href="/apps"
+        aria-label="Back to apps"
+        style={{
+          position: 'fixed',
+          top: 14,
+          left: 14,
+          zIndex: 50,
+          width: 38,
+          height: 38,
+          borderRadius: 10,
+          background: 'rgba(255,255,255,0.06)',
+          border: '1px solid rgba(255,255,255,0.14)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#F9FAFB',
+          textDecoration: 'none',
+          backdropFilter: 'blur(4px)',
+        }}
+      >
+        <ChevronLeft size={20} />
+      </Link>
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Why

You flagged ClickLog as having no back button (only my now-removed generic one). Two findings:

1. **The authenticated ClickLog app already has its own back button** (`clicklog-shell.tsx:174`, in the mobile sticky header — added back in the "phone layouts" commit). Your screenshot is a **stale deploy**: its header text "Personal incident counter — private" today only exists in the empty-state card, and the top `< ClickLog` was the generic bar that #558 removed. Once the latest build deploys, ClickLog shows its own single back button — #558 does not leave it bare.

2. **The genuine gap:** the *public / not-yet-verified* visitor shell for every plugin has **no** back to `/apps`. None of the 22 public shells link back to the launcher, so a visitor who opened a plugin from `/apps` had no way back.

## What this does

Wraps the public-shell render path in `app/apps/[pluginSlug]/page.tsx` with `PublicShellFrame` — a single fixed top-left back-to-`/apps` control. It only appears on the public shells (which have no back of their own), so it never doubles the authenticated shells' existing designed back buttons. One change covers all plugins' public pages.

Verified members never see these shells (they get the authenticated shell with its own back), so this strictly fills a missing affordance.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_