### PR TITLE
ci: run bug report create-issues job every 8 hours instead of every 15 minutes

### DIFF
--- a/.github/workflows/bug-reports-create-issues.yml
+++ b/.github/workflows/bug-reports-create-issues.yml
@@ -13,7 +13,7 @@ name: Bug Reports — Create Triage Issues
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "*/15 * * * *"   # every 15 minutes
+    - cron: "0 */8 * * *"   # every 8 hours (00:00, 08:00, 16:00 UTC)
 
 jobs:
   create-triage-issues:


### PR DESCRIPTION
Changes the bug report create-issues job from every 15 minutes to every 8 hours (00:00, 08:00, 16:00 UTC). Manual dispatch from the Actions tab still works any time for an immediate run.

The triage workflow is unchanged (separate schedule). Backend/CI-only.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01XdhKo7Eb8fWmb8A67J25zR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdhKo7Eb8fWmb8A67J25zR)_