### PR TITLE
fix: make the AI answer review screen usable on a phone

### DIFF
--- a/ctf/packages/web/app/admin/comic/page.tsx
+++ b/ctf/packages/web/app/admin/comic/page.tsx
@@ -3,8 +3,8 @@ import { ComicReviewConsole } from '../../../components/comic/comic-review-conso
 
 export const dynamic = 'force-dynamic';
 
-// Owner Review & Correction Console for the AI Assistant (@comic). Admin-gated server-side; the
-// client console fetches the pending queue and resolves items via the admin /api/comic/review*
+// Owner Review & Correction Dashboard for the AI Assistant (@comic). Admin-gated server-side; the
+// client screen fetches the pending queue and resolves items via the admin /api/comic/review*
 // routes. This is the supervision surface that keeps unreviewed drafts away from survivors.
 export default async function ComicReviewConsolePage() {
   const decision = await evaluatePluginAccess({ requiredRoles: ['admin'] });
@@ -14,7 +14,7 @@ export default async function ComicReviewConsolePage() {
       <main className="mx-auto max-w-3xl px-6 py-12 space-y-4">
         <h1 className="text-2xl font-semibold tracking-tight">Admin access denied</h1>
         <p className="text-sm text-muted-foreground">
-          The AI Assistant review console is restricted to admins. Request blocked by server-side role policy.
+          The AI Assistant review dashboard is for admins only. Your account does not have admin access.
         </p>
         <dl className="rounded-lg border bg-card p-4 text-sm">
           <div className="flex justify-between gap-4">

--- a/ctf/packages/web/components/comic/comic-review-console.module.css
+++ b/ctf/packages/web/components/comic/comic-review-console.module.css
@@ -704,6 +704,23 @@
   font-weight: 700;
 }
 
+/* Mobile-only "Back to queue" control inside the detail pane (hidden on desktop, where the
+   queue sidebar is always visible). Shown via the max-width: 900px media query below. */
+.mobileQueueBack {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid #1E2A3A;
+  color: #9CA3AF;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .visuallyHidden {
   position: absolute;
   width: 1px;
@@ -728,13 +745,42 @@
 }
 
 @media (max-width: 900px) {
+  /* Single-column master/detail. The four-column desktop layout collapses to one
+     column on a phone; the queue list and the detail pane each take the full screen and
+     we swap between them based on whether an item is selected. Previously the queue
+     sidebar was hidden outright at this width, so the owner saw only the detail pane's
+     "Select an answer to review" prompt with no list to select from — pending items were
+     unreachable on mobile. */
   .console {
     grid-template-columns: 1fr;
   }
 
-  .iconRail,
-  .queueSidebar {
+  .iconRail {
     display: none;
+  }
+
+  /* No item selected → show the queue list full-screen, hide the detail pane. */
+  .consoleList .queueSidebar {
+    display: flex;
+    height: 100vh;
+  }
+
+  .consoleList .main {
+    display: none;
+  }
+
+  /* Item selected → hide the queue list, show the detail pane full-screen. */
+  .consoleDetail .queueSidebar {
+    display: none;
+  }
+
+  .consoleDetail .main {
+    display: flex;
+    height: 100vh;
+  }
+
+  .mobileQueueBack {
+    display: inline-flex;
   }
 
   .confCol {

--- a/ctf/packages/web/components/comic/comic-review-console.tsx
+++ b/ctf/packages/web/components/comic/comic-review-console.tsx
@@ -315,7 +315,7 @@ export function ComicReviewConsole() {
                   <Pencil size={15} color="#0EA5E9" /> Edit &amp; approve answer
                 </>
               ) : (
-                'Review & Correction Console'
+                'Review & Correction Dashboard'
               )}
             </div>
             <div className={styles.mainHeaderSub}>Approve, correct, or reject AI Assistant answers before they reach survivors</div>
@@ -429,14 +429,14 @@ export function ComicReviewConsole() {
                 </div>
               )}
 
-              {/* Provenance + confidence (real fields only — no fabricated sources). */}
+              {/* Source + confidence (real fields only — no fabricated sources). */}
               <div className={styles.detailTwoCol}>
                 <div className={styles.detailCol}>
-                  <div className={styles.detailLabel}>Provenance</div>
+                  <div className={styles.detailLabel}>Source</div>
                   <div className={styles.provenanceList}>
                     {selected.safetyCategory ? null : (
                       <div className={styles.provenanceRow}>
-                        <FileText size={13} color="#0EA5E9" /> Drafted by engine: {selected.engine}
+                        <FileText size={13} color="#0EA5E9" /> Drafted by: {selected.engine}
                       </div>
                     )}
                     <div className={styles.provenanceRow}>
@@ -471,7 +471,7 @@ export function ComicReviewConsole() {
                       </div>
                     ) : (
                       <div className={styles.confHint}>
-                        <AlertTriangle size={13} /> No calibrated confidence yet — every draft is held for human review.
+                        <AlertTriangle size={13} /> No confidence score yet — every draft is held for human review.
                       </div>
                     )}
                   </div>

--- a/ctf/packages/web/components/comic/comic-review-console.tsx
+++ b/ctf/packages/web/components/comic/comic-review-console.tsx
@@ -229,7 +229,7 @@ export function ComicReviewConsole() {
   }
 
   return (
-    <div className={styles.console}>
+    <div className={`${styles.console} ${selected ? styles.consoleDetail : styles.consoleList}`}>
       {/* Icon rail */}
       <aside className={styles.iconRail}>
         <div className={styles.iconRailLogo} aria-hidden="true">
@@ -359,6 +359,18 @@ export function ComicReviewConsole() {
             </div>
           ) : (
             <div className={styles.detail}>
+              {/* Mobile-only: return to the queue list (the sidebar is hidden at phone width). */}
+              <button
+                type="button"
+                className={styles.mobileQueueBack}
+                onClick={() => {
+                  setEditing(false);
+                  setSelectedId(null);
+                }}
+              >
+                <ArrowLeft size={14} /> Back to queue
+              </button>
+
               {/* Asker meta */}
               <div className={styles.detailMeta}>
                 <span className={styles.detailChannel}>@comic</span>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## Problem
A member asks the AI Assistant a question (types `@comic` in the home chat). Every question is captured and queued for the owner to approve, correct, or reject before any answer reaches the member. On a phone, the owner's review screen showed only "Select an answer to review" with no list to pick from — so questions sat in the queue with no way to open and answer them. (Reported live: 7 test questions sent, nothing appeared to accept or answer.)

## Cause
The review screen used a four-column desktop layout (icon rail · queue list · detail · guidance). At phone width the layout hid the icon rail **and the entire queue list**, leaving only the detail pane. The detail pane's "Select an answer to review" message only shows when items exist but none is selected — so the questions were there, just unreachable on a phone. On a desktop browser the queue showed fine.

## Fix
On phones the screen now works as a list/detail pair:
- **Queue list fills the screen when nothing is selected** — the owner sees the pending questions and taps one.
- Tapping opens the **detail view** with a new **"Back to queue"** button to return to the list.

All changes are inside the existing `max-width: 900px` rule plus two selection-driven helper classes, so the desktop layout is unchanged.

## Also in this PR
The app calls an operator screen a **dashboard**, not a "console". Renamed the visible title and plain-languaged nearby labels on this screen:
- "Review & Correction Console" → "Review & Correction Dashboard"
- "Provenance" → "Source"
- "Drafted by engine: X" → "Drafted by: X"
- "No calibrated confidence yet" → "No confidence score yet"
- access-denied copy: dropped "Request blocked by server-side role policy" for "Your account does not have admin access"

Code identifiers (component, file, CSS class names) are unchanged. Other admin screens still labelled "console" are a separate copy sweep, not done here.

## How to verify
- On a phone, open the admin review URL: the pending questions list now fills the screen; tap one to approve/correct/reject; "Back to queue" returns to the list.
- On desktop: layout is unchanged.

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1