### PR TITLE
feat: wire the concierge into the home chat (tappable starter prompts)

### DIFF
--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -116,6 +116,8 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
     input,
     setInput,
     sendMessage,
+    sendConciergeAsk,
+    starterPrompts,
     rateComicAnswer,
     composerMentionsComic,
     consentModalOpen,
@@ -208,6 +210,20 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
             <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
               Survivor Hub is live. Share with the community, or type <strong>@comic</strong> to ask the AI Assistant.
             </div>
+            {starterPrompts.length > 0 ? (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 8 }}>
+                {starterPrompts.map((prompt) => (
+                  <button
+                    key={prompt}
+                    type="button"
+                    className={styles.chatActionBtn}
+                    onClick={() => sendConciergeAsk(prompt)}
+                  >
+                    {prompt}
+                  </button>
+                ))}
+              </div>
+            ) : null}
           </div>
         ) : null}
 

--- a/ctf/packages/web/components/community-shell/use-home-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-home-chat.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { HubJoinResponse, HubMessage, HubMessagesResponse } from '../../lib/hub/types';
+import { resolveConcierge, conciergeStarterPrompts } from '../../lib/concierge/resolver';
 import type { ChatMessage, ComicAnswerRating, ComicStreamItem, ShellCurrentUser } from './shell-types';
 
 type ChatConnectionState = 'loading' | 'live' | 'fallback';
@@ -436,12 +437,53 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
     [],
   );
 
+  // Concierge starter prompts (real questions from the landing page) for the empty home chat — a
+  // one-tap way to "ask what you need" and get pointed at the right feature.
+  const starterPrompts = useMemo(() => conciergeStarterPrompts(5), []);
+
+  // Run a concierge ask: show the question as the member's own message, then an instant local reply
+  // that points at the best-matching feature (with an "Open X" button), or a gentle fall-back to the
+  // AI Assistant / community when nothing matches. Purely local — it does not post to the community
+  // and does not touch the @comic or peer-post paths.
+  const sendConciergeAsk = useCallback((promptText: string) => {
+    const text = promptText.trim();
+    if (!text) {
+      return;
+    }
+    const time = formatTimeLabel(new Date());
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const matches = resolveConcierge(text);
+    const userMsg: ChatMessage = { id: `concierge-q-${stamp}`, from: 'user', text, time };
+
+    const top = matches[0];
+    const second = matches[1];
+    const reply: ChatMessage = top
+      ? {
+        id: `concierge-a-${stamp}`,
+        from: 'hub',
+        text: second ? `${top.blurb} (Or try ${second.name}.)` : top.blurb,
+        time,
+        actionLabel: `Open ${top.name} →`,
+        actionSlug: top.slug,
+      }
+      : {
+        id: `concierge-a-${stamp}`,
+        from: 'hub',
+        text: 'I’m not sure which feature fits that yet — type @comic to ask the AI Assistant, or share it with the community below.',
+        time,
+      };
+
+    setMessages((previous) => mergeMessages(previous, [userMsg, reply]));
+  }, []);
+
   return {
     messages,
     comicItems,
     input,
     setInput,
     sendMessage,
+    sendConciergeAsk,
+    starterPrompts,
     rateComicAnswer,
     composerMentionsComic,
     consentModalOpen,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Task 3 (additive slice): wires the concierge resolver into the home chat. On the empty home chat, tappable starter prompts (real questions from the landing page) appear; tapping one runs the client-side `resolveConcierge` and posts an instant local reply pointing at the best feature with an "Open X" button (reusing the existing `chatActionBtn`). No confident match → a nudge to `@comic` or the community.

## Guardrail-safe
- Existing empty-state copy is unchanged; the `@comic` and peer-post send paths are untouched. Purely additive.
- Resolver is pure client-safe TS, so no API route is needed.

## Deferred (next slice)
- Typed-message routing (route vs. post) — it alters the shipped typed→community-post behavior, so it's a deliberate separate step.

Stacked on #578 (the resolver lib); once that merges this diff is just the two home-chat files. Web typecheck + EOF clean.

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_