### PR TITLE
feat: align concierge intents to the reframe (narrow ClickLog, empowerment starters)

### DIFF
--- a/ctf/packages/web/lib/concierge/intents.ts
+++ b/ctf/packages/web/lib/concierge/intents.ts
@@ -69,13 +69,17 @@ export const CONCIERGE_INTENTS: ConciergeIntent[] = [
   {
     slug: 'clicklog',
     name: 'ClickLog',
-    blurb: 'Log what happened and check in when you are safe.',
+    blurb: 'Keep a private record and check in when you are safe.',
+    // Narrow on purpose. ClickLog is for someone who EXPLICITLY wants to record something or set a
+    // safety check-in — it is NOT the route for "I'm being followed" descriptions. Reframe decision
+    // (2026-06-17): logging is not how the app solves a harassment problem, so surveillance phrasing
+    // is intentionally absent here; such messages fall through to the Hub (ask a person) or a
+    // getting-needs-met feature instead.
     keywords: [
-      'log it', 'log what happened', 'keep a record', 'document', 'incident', 'report it',
-      'something happened', 'check in', 'safety check', 'followed me', 'stalking', 'being followed',
-      'harassed', 'they followed', 'write it down', 'evidence',
+      'log it', 'log what happened', 'keep a record', 'want a record', 'write it down',
+      'document it', 'safety check-in', 'check in when i get home',
     ],
-    starter: 'Something happened on my walk home. I want a record, but I don’t want to call police.',
+    starter: 'I want a private record of what happened — and a check-in for when I get home.',
   },
   {
     slug: 'gentlepulse',

--- a/ctf/packages/web/lib/concierge/resolver.ts
+++ b/ctf/packages/web/lib/concierge/resolver.ts
@@ -90,8 +90,17 @@ export function resolveConcierge(text: string): ConciergeMatch[] {
   return scored.filter((m, index) => index === 0 || isCloseRunnerUp(topScore, m.score)).slice(0, CONCIERGE_MAX_MATCHES);
 }
 
-// The example questions from the intent table, for rendering tappable starter prompts on an empty
-// home chat (the one-tap "ask" path). Kept small and ordered by the table.
+// Featured starters for the empty home chat — empowerment-forward (get a place, work, a ride,
+// connection, a repair), per the reframe (2026-06-17): lead with getting-needs-met, not with
+// "log it" or "breathe". ClickLog / Mood / GentlePulse are still resolvable when someone explicitly
+// asks for them, but they are not featured as starters.
+const FEATURED_STARTER_SLUGS = ['lighthouse', 'workforce', 'trusttransport', 'chyme', 'directory'];
+
+// The example questions for tappable starter prompts on an empty home chat (the one-tap "ask" path).
 export function conciergeStarterPrompts(limit = 5): string[] {
-  return CONCIERGE_INTENTS.slice(0, limit).map((intent) => intent.starter);
+  const bySlug = new Map(CONCIERGE_INTENTS.map((intent) => [intent.slug, intent.starter]));
+  const featured = FEATURED_STARTER_SLUGS
+    .map((slug) => bySlug.get(slug))
+    .filter((starter): starter is string => typeof starter === 'string');
+  return featured.slice(0, limit);
 }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Follow-up to the map reframe (#582). Aligns the live concierge with "get what you need, not log it":

- ClickLog intent narrowed to explicit "I want a record / safety check-in" phrasing only. Surveillance descriptions ("being followed", "stalking", "harassed", "something happened") are removed, so they fall through to the Hub (ask a person) or a getting-needs-met feature instead of routing to "log it".
- Featured empty-chat starter prompts are now empowerment-forward (housing, work, a ride, connection, a repair) via a curated slug list, instead of leading with ClickLog/breathe.
- ClickLog and Mood stay resolvable for explicit user-initiated asks; they're just not a problem's answer and not featured.

Web + mobile typecheck clean; EOF clean.

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_