### PR TITLE
fix: make Formance ledger entrypoint reliably self-bootstrap on Railway

### DIFF
--- a/ctf/docs/developer/FORMANCE.md
+++ b/ctf/docs/developer/FORMANCE.md
@@ -57,10 +57,14 @@ it as a Docker-image service; no Dockerfile build happens on Railway.
      auto-bootstrap uses). Generate with `openssl rand -hex 16`.
    - `FORMANCE_LEDGER` — production book name (e.g. `ctf-service-credits`).
    - `FORMANCE_LEDGER_STAGING` — optional demo book name.
-   - `PORT` is injected by Railway and read by the entrypoint (defaults to 3068); do
-     not hardcode it.
-4. **Expose the service** and copy its public `https://…up.railway.app` domain (or a
-   custom domain).
+   - `PORT` — the entrypoint binds whatever `PORT` is set to (default 3068). Railway
+     may inject its own `PORT`; the public domain's target port (next step) MUST match
+     whatever the ledger actually listens on. Deterministic setup: set `PORT=3068`
+     here and use target port 3068 below. A mismatch returns curl `(52) Empty reply
+     from server` even though the container logs `HTTP server started`.
+4. **Expose the service** (Settings → Networking → public domain) and set its
+   **target port** to the ledger's listen port (3068 with the pin above). Copy the
+   public `https://…up.railway.app` domain (or a custom domain).
 5. **Point the web app at it.** In Infisical (which syncs to the Render web service),
    set:
    - `FORMANCE_API_URL` — the ledger's **public https** Railway URL.

--- a/ctf/ops/formance/formance-entrypoint.sh
+++ b/ctf/ops/formance/formance-entrypoint.sh
@@ -23,23 +23,33 @@ ledger serve --bind="0.0.0.0:${PORT}" --worker=true --worker-grpc-address=127.0.
 LEDGER_PID=$!
 
 # Idempotently create a ledger book once the API is up. Retries through the
-# server's warm-up (connection refused / 5xx); treats 201 as created and 400/409
-# as already-exists. Always returns 0 so a hiccup never crashes the container.
+# server's warm-up (connection refused / 5xx / any not-yet-ready code); treats 201
+# as created and 400/409 as already-exists. Always returns 0 so a hiccup never
+# crashes the container.
 ensure_ledger() {
   name="$1"
   [ -n "$name" ] || return 0
   attempt=0
-  while [ "$attempt" -lt 40 ]; do
+  # ~3 minutes of retries so a slow first-boot schema migration (AUTO_UPGRADE)
+  # finishes and the HTTP API is serving before we give up.
+  while [ "$attempt" -lt 60 ]; do
+    # curl writes the 3-digit status to stdout; on a connection failure it writes
+    # 000. Do NOT append `|| echo 000` — that emitted "000\n000", which matched
+    # neither branch below and made the loop quit on the very first attempt
+    # (the bug that left the ledgers uncreated on a fresh deploy).
     code="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
-      -H "Authorization: Bearer ${FORMANCE_API_TOKEN:-}" "${API}/v2/${name}" 2>/dev/null || echo 000)"
+      -H "Authorization: Bearer ${FORMANCE_API_TOKEN:-}" "${API}/v2/${name}" 2>/dev/null)"
+    # Normalize to a clean 3-digit code (digits only, last 3, default 000) so odd
+    # output ("", "000000", etc.) is treated as "not ready" and retried, not fatal.
+    code="$(printf '%s' "$code" | tr -cd '0-9')"
+    code="$(printf '%s' "${code:-000}" | tail -c 3)"
     case "$code" in
       201) echo "[entrypoint] created ledger '${name}'"; return 0 ;;
       400|409) echo "[entrypoint] ledger '${name}' already exists (HTTP ${code})"; return 0 ;;
-      000|5??) attempt=$((attempt + 1)); sleep 3 ;;
-      *) echo "[entrypoint] WARN: create '${name}' returned HTTP ${code} (non-fatal)"; return 0 ;;
+      *) attempt=$((attempt + 1)); sleep 3 ;;
     esac
   done
-  echo "[entrypoint] WARN: gave up ensuring ledger '${name}'; run 'pnpm formance:bootstrap' manually."
+  echo "[entrypoint] WARN: gave up ensuring ledger '${name}' after retries; create it once with 'pnpm formance:bootstrap' or POST /v2/${name}."
   return 0
 }
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Fixes the Formance ledger container's auto-bootstrap, which gave up on the first attempt on a fresh Railway deploy and left the ledger books uncreated.

Root cause: in `formance-entrypoint.sh`, `curl -w '%{http_code}' … || echo 000` produced `000\n000` when the API wasn't ready yet (connection refused). That matched neither the retry nor the success branch, so the loop hit the give-up case immediately instead of retrying through the server's warm-up.

Changes (`ctf/ops/formance/formance-entrypoint.sh`):
- Drop `|| echo 000` (curl already prints `000` on failure).
- Normalize the code to a clean 3-digit value (digits only, last 3, default `000`) so empty/odd output is treated as "not ready" and retried.
- Retry on any non-terminal code (only `201`/`400`/`409` are terminal); extend to ~3 minutes to cover a slow first-boot `AUTO_UPGRADE` migration.

`FORMANCE.md`: document the Railway public-domain target-port requirement (must match the ledger's listen port; `PORT=3068` + target `3068`) — a mismatch returns curl `(52) Empty reply from server` even though the container logs `HTTP server started`.

Takes effect after `build-images.yml` rebuilds `ctf-formance-ledger:latest` and the Railway service is redeployed. Not application/ledger logic — container startup + docs only.

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_