### PR TITLE
ci: rebuild ledger image when the entrypoint changes, not just the Dockerfile

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -74,7 +74,9 @@ jobs:
               - 'ctf/tsconfig.base.json'
               - 'ctf/pnpm-workspace.yaml'
             formance:
-              - 'ctf/ops/formance/Dockerfile.ledger'
+              # Whole dir, not just the Dockerfile: formance-entrypoint.sh is COPYd
+              # into the image, so a change to it must rebuild ctf-formance-ledger too.
+              - 'ctf/ops/formance/**'
             routeweather:
               - 'ctf/ops/route-weather/**'
 

--- a/ctf/ops/formance/Dockerfile.ledger
+++ b/ctf/ops/formance/Dockerfile.ledger
@@ -1,17 +1,17 @@
-# Formance Ledger — Render private service.
-# Wraps the official GHCR image with Render-compatible configuration.
+# Formance Ledger — Railway service.
+# Wraps the official GHCR image with a self-bootstrapping entrypoint.
 #
-# State lives entirely in external Neon Postgres (Render has no persistent
-# volumes). FORMANCE_POSTGRES_URI must be set in the Render dashboard. AUTO_UPGRADE
-# runs schema migrations on container start.
+# State lives entirely in an external Postgres (the Railway Postgres). The host
+# has no persistent volume — FORMANCE_POSTGRES_URI must be set on the service.
+# AUTO_UPGRADE runs schema migrations on container start.
 #
 # The base image's ENTRYPOINT is `ledger`, so it is reset to [] here and the
-# `serve` subcommand is invoked through a shell that expands Render's $PORT.
+# `serve` subcommand is invoked through a shell that expands the platform's $PORT.
 FROM ghcr.io/formancehq/ledger:v2.3.15-dev.1.g1077fe2@sha256:5c280c2b1b397c6d910e88d7f1719666fadf3b2be18ab6dad31a905dee876db7
 
-# Render has no persistent volumes — Formance state lives in the external
-# Neon Postgres database. AUTO_UPGRADE runs schema migrations on start.
-# FORMANCE_POSTGRES_URI must be set in the Render dashboard (Neon connection string).
+# The host has no persistent volume — Formance state lives in the external
+# Railway Postgres. AUTO_UPGRADE runs schema migrations on start.
+# FORMANCE_POSTGRES_URI must be set on the service (the Railway Postgres URL).
 ENV POSTGRES_MAX_OPEN_CONNS=40 \
     POSTGRES_MAX_IDLE_CONNS=40 \
     POSTGRES_CONN_MAX_IDLE_TIME=5m \


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

CI/infra fix. The `build-images` workflow's path filter for the ledger image only watched `ctf/ops/formance/Dockerfile.ledger`, so PR #585's fix to `formance-entrypoint.sh` did **not** rebuild `ctf-formance-ledger:latest` — even though the entrypoint is `COPY`d into the image (the "Build ctf-formance-ledger" job showed `skipped`). Result: the published image still has the old, buggy entrypoint.

- Widen the formance filter to `ctf/ops/formance/**` so entrypoint (and any ops-file) changes rebuild the image.
- Refresh `Dockerfile.ledger` header comments (Render/Neon → Railway) to match where the ledger runs. Touching `Dockerfile.ledger` also forces a ledger-only rebuild on this merge, publishing #585's entrypoint fix into `:latest` (web image is not rebuilt).

After this merges and the "Build ctf-formance-ledger" job is green, redeploy the Railway ledger service to pull the new `:latest`; it then self-bootstraps the ledger books on boot.

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_