### PR TITLE
ci: drop the dead Render deploy step from the ledger image build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -168,13 +168,11 @@ jobs:
           cache-from: type=gha,scope=ctf-formance-ledger
           cache-to: type=gha,scope=ctf-formance-ledger,mode=max
 
-      - name: Trigger Render deploy
-        env:
-          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_SERVICE_NAME: ctf-formance-ledger
-          # Optional explicit id; when unset the script finds it by name.
-          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID_CTF_FORMANCE }}
-        run: bash .github/scripts/render-deploy.sh
+      # No Render deploy step: the ledger runs on Railway now (PR #570), not Render.
+      # The image is pushed to GHCR above; redeploy the Railway ledger service to
+      # pull :latest (or enable Railway's image-update watch to auto-pull). This
+      # workflow does not deploy to Railway. The old "Trigger Render deploy" step
+      # was removed — it only 404'd against the deleted Render service.
 
   # ── ctf-route-weather ───────────────────────────────────────────
   # No-UI plain-text route weather service. Tiny dependency-free Node image,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

CI cleanup. The ledger moved to Railway (#570), so the `build-ctf-formance-ledger` job's "Trigger Render deploy" step now 404s against the deleted Render service (`not found: service`). Non-fatal, but dead — removed it. The job still builds and pushes `ctf-formance-ledger:latest` to GHCR; the operator redeploys the Railway ledger to pull it (or enables Railway's image-update watch). This workflow does not deploy to Railway.

Follow-up (manual, no code): the `RENDER_SERVICE_ID_CTF_FORMANCE` GitHub secret and `RENDER_SERVICE_ID_FORMANCE` Infisical secret are now unused and can be removed.

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_