### PR TITLE
fix: concierge chips scroll horizontally and use a distinct color from @comic

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -485,6 +485,43 @@
   background: rgba(14, 165, 233, 0.18);
 }
 
+/* Concierge "ask what you need" chips. Emerald — deliberately NOT the sky-blue
+   (#38BDF8) the @comic AI Assistant uses, so a member can tell "route me to a
+   feature" apart from "ask the AI". The rail scrolls horizontally instead of
+   wrapping, so the long prompt sentences stay on one line on a phone. */
+.conciergeChipRail {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+  margin-bottom: 8px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+}
+
+.conciergeChip {
+  flex: 0 0 auto;
+  max-width: 260px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 14px;
+  border-radius: 8px;
+  background: rgba(52, 211, 153, 0.1);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  color: #34D399;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.conciergeChip:hover {
+  background: rgba(52, 211, 153, 0.18);
+}
+
 .chatTime {
   font-size: 11px;
   color: #374151;

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -266,16 +266,13 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
           it posts the question and an instant reply pointing at the best-matching feature, so there is
           always an immediate response. */}
       {starterPrompts.length > 0 ? (
-        <div
-          style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}
-          role="group"
-          aria-label="Ask what you need"
-        >
+        <div className={styles.conciergeChipRail} role="group" aria-label="Ask what you need">
           {starterPrompts.map((prompt) => (
             <button
               key={prompt}
               type="button"
-              className={styles.chatActionBtn}
+              className={styles.conciergeChip}
+              title={prompt}
               onClick={() => sendConciergeAsk(prompt)}
             >
               {prompt}


### PR DESCRIPTION
Two problems with the persistent "ask what you need" concierge chips:

- They wrapped (`flex-wrap: wrap`), so the long prompt sentences stacked as full-width blocks and looked broken on a phone. They now live in a single **horizontally-scrolling rail**, each chip one line (ellipsis, full text on tap / in `title`).
- They used `chatActionBtn`, whose color `#38BDF8` is the exact sky-blue the **@comic** AI Assistant uses (`comic-cards.tsx` Sparkles), so a member couldn't tell "route me to a feature" from "ask the AI". The chips are now **emerald `#34D399`**, deliberately distinct from the @comic blue.

CSS + class swap only; no change to the concierge resolver behavior.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_