### PR TITLE
fix: change Contributions icon from heart to gift

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -284,6 +284,7 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-06-18: Changed the Contributions plugin icon from `Heart` to `Gift` across the shell, public shell, banner, and admin shell (`components/contributions/**`). The heart duplicated the app brand logo (also a heart); `Gift` is distinct and fits the fundraiser/gift-drive purpose. Icon swap only — no copy, route, schema, or contract change.
 - 2026-06-12: Android API client (`ContributionsApi.ts`) now calls the backend through the shared authenticated fetch wrapper (`authedFetch`): the signed-in member's Clerk bearer token is attached and the base URL comes from runtime config, replacing the plain dev-only fetch against hardcoded emulator/localhost URLs. No backend, schema, or contract change.
 - 2026-06-10: UI build + two owner-requested backend rules. Shipped the full Contributions UI on
   web and Android from the approved design mockups (issue #393): the member surfaces (signed-out

--- a/ctf/packages/web/components/contributions/admin/contributions-admin-shell.tsx
+++ b/ctf/packages/web/components/contributions/admin/contributions-admin-shell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Heart } from 'lucide-react';
+import { Gift } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import type {
@@ -200,7 +200,7 @@ export function ContributionsAdminShell() {
         <div style={{ padding: '12px 16px 10px', background: t.SURFACE, borderBottom: `1px solid ${t.BORDER_SOLID}`, flexShrink: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <div style={{ width: 26, height: 26, borderRadius: 7, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Heart size={13} color="#fff" />
+              <Gift size={13} color="#fff" />
             </div>
             <span style={{ fontSize: 16, fontWeight: 700, color: t.TITLE }}>Contributions Admin</span>
           </div>
@@ -230,7 +230,7 @@ export function ContributionsAdminShell() {
         <div style={{ padding: '18px 14px 14px', borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
             <div style={{ width: 28, height: 28, borderRadius: 8, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Heart size={14} color="#fff" />
+              <Gift size={14} color="#fff" />
             </div>
             <span style={{ fontWeight: 700, fontSize: 14, color: t.TITLE }}>Contributions</span>
           </div>

--- a/ctf/packages/web/components/contributions/contributions-banner.tsx
+++ b/ctf/packages/web/components/contributions/contributions-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Heart, DollarSign, MessageSquare, Star } from 'lucide-react';
+import { Gift, DollarSign, MessageSquare, Star } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import {
@@ -113,7 +113,7 @@ export function ContributionsBanner() {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '10px 18px', background: t.SURFACE, borderBottom: `1px solid ${t.BORDER_SOLID}`, fontFamily: FONT_FAMILY, flexWrap: 'wrap' }}>
       <div style={{ width: 28, height: 28, borderRadius: 7, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-        <Heart size={13} color="#fff" />
+        <Gift size={13} color="#fff" />
       </div>
       <div style={{ fontSize: 13, color: t.MUTED, flexShrink: 0, maxWidth: 260 }}>If everyone who&apos;s able gave a little, this drive would be covered.</div>
       <div style={{ display: 'flex', gap: 14, flex: 1, alignItems: 'center', minWidth: 240 }}>

--- a/ctf/packages/web/components/contributions/contributions-public-shell.tsx
+++ b/ctf/packages/web/components/contributions/contributions-public-shell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Heart, DollarSign, MessageSquare, Star, Lock, ChevronRight } from 'lucide-react';
+import { Gift, DollarSign, MessageSquare, Star, Lock, ChevronRight } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
@@ -97,7 +97,7 @@ function DesktopPublic({ signInUrl, verifyUrl, t }: { signInUrl: string; verifyU
       <div style={{ maxWidth: 580, width: '100%', padding: '48px 24px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 28 }}>
           <div style={{ width: 36, height: 36, borderRadius: 10, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Heart size={18} color="#fff" />
+            <Gift size={18} color="#fff" />
           </div>
           <div>
             <div style={{ fontSize: 18, fontWeight: 700, color: t.TITLE }}>Contributions</div>
@@ -137,7 +137,7 @@ function MobilePublic({ signInUrl, verifyUrl, t }: { signInUrl: string; verifyUr
       <div style={{ flex: 1, overflowY: 'auto', padding: '24px 18px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 20 }}>
           <div style={{ width: 36, height: 36, borderRadius: 10, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Heart size={18} color="#fff" />
+            <Gift size={18} color="#fff" />
           </div>
           <div>
             <div style={{ fontSize: 17, fontWeight: 700, color: t.TITLE }}>Contributions</div>

--- a/ctf/packages/web/components/contributions/contributions-shell.tsx
+++ b/ctf/packages/web/components/contributions/contributions-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Heart, Clock, ArrowLeft } from 'lucide-react';
+import { Gift, Clock, ArrowLeft } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import type { ContributionSubmission } from '@/lib/contributions/types';
@@ -264,7 +264,7 @@ function ContributionsSidebar({ t, active }: { t: ContributionsTokens; active: '
       <div style={{ padding: '18px 14px 14px', borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
           <div style={{ width: 28, height: 28, borderRadius: 8, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Heart size={14} color="#fff" />
+            <Gift size={14} color="#fff" />
           </div>
           <span style={{ fontWeight: 700, fontSize: 14, color: t.TITLE }}>Contributions</span>
         </div>
@@ -312,7 +312,7 @@ function MobileFrame({ t, children, tab, onTab }: { t: ContributionsTokens; chil
       <div style={{ padding: '12px 16px 10px', background: t.SURFACE, borderBottom: `1px solid ${t.BORDER_SOLID}`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
           <div style={{ width: 26, height: 26, borderRadius: 7, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Heart size={13} color="#fff" />
+            <Gift size={13} color="#fff" />
           </div>
           <span style={{ fontSize: 17, fontWeight: 700, color: t.TITLE }}>Contributions</span>
         </div>
@@ -340,7 +340,7 @@ function MobileFrame({ t, children, tab, onTab }: { t: ContributionsTokens; chil
 function ErrorState({ t, message, onRetry, isMobile }: { t: ContributionsTokens; message: string; onRetry: () => void; isMobile: boolean }) {
   const body = (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 40, textAlign: 'center', gap: 14 }}>
-      <Heart size={28} color={t.ACCENT} />
+      <Gift size={28} color={t.ACCENT} />
       <p style={{ margin: 0, fontSize: 14, color: t.MUTED, maxWidth: 360 }}>{message}</p>
       <button type="button" onClick={onRetry} style={{ padding: '9px 22px', borderRadius: 8, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
         Try again


### PR DESCRIPTION
The Contributions plugin used the `Heart` icon in its shell, public shell, banner, and admin header — duplicating the app brand logo, which is also a heart. Swapped to `Gift` (lucide), which is distinct and fits the fundraiser/gift-drive purpose.

Icon only — no copy, route, schema, or contract change. Inventory Change Log updated.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_