### PR TITLE
fix: LightHouse right panel — keep only Emergency Housing (linked to homepage support chat)

### DIFF
--- a/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Shield } from "lucide-react";
 import { COLOR } from "./shared";
 
 const PRICING: { range: string; l: string; c: string }[] = [
@@ -12,14 +11,6 @@ const PRICING: { range: string; l: string; c: string }[] = [
 export function LighthouseRightPanel() {
   return (
     <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
-      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Emergency Housing</div>
-      <div style={{ padding: "14px 16px", borderRadius: 12, background: "#EF444410", border: "1px solid #EF444430", marginBottom: 16 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
-          <Shield size={14} style={{ color: "#EF4444" }} />
-          <span style={{ fontSize: 12, fontWeight: 700, color: "#EF4444" }}>Immediate placement</span>
-        </div>
-        <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.6 }}>If you need housing right now, reach out through the chat — emergency placements are confidential and prioritized.</div>
-      </div>
       <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Pricing Guide</div>
       {PRICING.map(({ range, l, c }) => (
         <div key={range} style={{ padding: "10px 12px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.05)", marginBottom: 6 }}>

--- a/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
@@ -4,17 +4,11 @@ import Link from "next/link";
 import { Shield } from "lucide-react";
 import { COLOR } from "./shared";
 
-const PRICING: { range: string; l: string; c: string }[] = [
-  { range: "$500–800", l: "Emergency/Studio", c: "#22C55E" },
-  { range: "$800–1,200", l: "1 Bedroom", c: COLOR },
-  { range: "$1,200+", l: "2+ Bedrooms", c: "#6B7280" },
-];
-
 export function LighthouseRightPanel() {
   return (
     <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
       <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Emergency Housing</div>
-      <div style={{ padding: "14px 16px", borderRadius: 12, background: "#EF444410", border: "1px solid #EF444430", marginBottom: 16 }}>
+      <div style={{ padding: "14px 16px", borderRadius: 12, background: "#EF444410", border: "1px solid #EF444430" }}>
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
           <Shield size={14} style={{ color: "#EF4444" }} />
           <span style={{ fontSize: 12, fontWeight: 700, color: "#EF4444" }}>Immediate placement</span>
@@ -24,13 +18,6 @@ export function LighthouseRightPanel() {
           <Link href="/" style={{ color: COLOR, fontWeight: 600 }}>Go to the support chat →</Link>
         </div>
       </div>
-      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Pricing Guide</div>
-      {PRICING.map(({ range, l, c }) => (
-        <div key={range} style={{ padding: "10px 12px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.05)", marginBottom: 6 }}>
-          <div style={{ fontSize: 14, fontWeight: 700, color: c }}>{range}</div>
-          <div style={{ fontSize: 11, color: "#6B7280" }}>{l}</div>
-        </div>
-      ))}
     </aside>
   );
 }

--- a/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+import { Shield } from "lucide-react";
 import { COLOR } from "./shared";
 
 const PRICING: { range: string; l: string; c: string }[] = [
@@ -11,6 +13,17 @@ const PRICING: { range: string; l: string; c: string }[] = [
 export function LighthouseRightPanel() {
   return (
     <aside style={{ width: 280, borderLeft: "1px solid rgba(255,255,255,0.06)", background: "#0D0F14", padding: "20px 16px", flexShrink: 0 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 12 }}>Emergency Housing</div>
+      <div style={{ padding: "14px 16px", borderRadius: 12, background: "#EF444410", border: "1px solid #EF444430", marginBottom: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+          <Shield size={14} style={{ color: "#EF4444" }} />
+          <span style={{ fontSize: 12, fontWeight: 700, color: "#EF4444" }}>Immediate placement</span>
+        </div>
+        <div style={{ fontSize: 12, color: "#9CA3AF", lineHeight: 1.6 }}>
+          If you need housing right now, reach out in the community support chat on the home page — emergency placements are confidential and prioritized.{" "}
+          <Link href="/" style={{ color: COLOR, fontWeight: 600 }}>Go to the support chat →</Link>
+        </div>
+      </div>
       <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase", marginBottom: 10 }}>Pricing Guide</div>
       {PRICING.map(({ range, l, c }) => (
         <div key={range} style={{ padding: "10px 12px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.05)", marginBottom: 6 }}>

--- a/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-right-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Eye, Shield } from "lucide-react";
+import { Shield } from "lucide-react";
 import { COLOR } from "./shared";
 
 const PRICING: { range: string; l: string; c: string }[] = [
@@ -27,13 +27,6 @@ export function LighthouseRightPanel() {
           <div style={{ fontSize: 11, color: "#6B7280" }}>{l}</div>
         </div>
       ))}
-      <div style={{ marginTop: 16, padding: "14px 16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-          <Eye size={12} style={{ color: COLOR }} />
-          <span style={{ fontSize: 12, fontWeight: 600, color: COLOR }}>Privacy by Design</span>
-        </div>
-        <div style={{ fontSize: 12, color: "#6B7280", lineHeight: 1.6 }}>Your location is never exposed to landlords without your consent.</div>
-      </div>
     </aside>
   );
 }


### PR DESCRIPTION
Trims the LightHouse right panel (`lighthouse-right-panel.tsx`) to only what has substance:

- **Removed** the "Privacy by Design" filler card and the whole **Pricing Guide** section.
- **Kept** the **Emergency Housing / Immediate placement** card, reworded so it points at the homepage support chat ("reach out in the community support chat on the home page") with a `Go to the support chat →` link to `/` — so it isn't confused with the LightHouse *match* chat.

The panel now shows only the Emergency Housing card.

Separately tracked (owner-approved direction): coined chat terms **"Commons"** (homepage chat) + **"Direct Line"** (plugin-paired chats), added to the brand language guide and rolled through the app with distinct icons; and the larger idea of nesting plugin chats inside their transactions. Those are a follow-up initiative, not in this PR.

Presentation only — no API/route/schema change.

Parity Status: web + mobile-responsive + android complete