### PR TITLE
fix: unlock submission no longer 503s on a config-read failure

### DIFF
--- a/ctf/packages/web/lib/unlock/repository.ts
+++ b/ctf/packages/web/lib/unlock/repository.ts
@@ -77,18 +77,29 @@ function mapUnlockRuntimeConfig(row: UnlockRuntimeConfigRow | undefined): Unlock
 }
 
 export async function getUnlockRuntimeConfig(): Promise<UnlockRuntimeConfig> {
-  const result = await queryDb<UnlockRuntimeConfigRow>(
-    `SELECT
-       submission_window_hours,
-       reminder_schedule_hours,
-       incentive_amount::text,
-       support_only_after_expiry
-     FROM unlock_runtime_config
-     WHERE singleton_id = 1
-     LIMIT 1`,
-  );
+  // Resilience: never let the runtime-config read block a member's verification. This runs before
+  // the submission INSERT, so if `unlock_runtime_config` is missing/unmigrated (or a column it reads
+  // — e.g. incentive_amount/support_only_after_expiry — does not yet exist on the connected DB) the
+  // query would throw and surface as a generic 503 ("Unlock submission unavailable."). Fall back to
+  // the documented defaults instead. (If you hit this, the real fix is running the Update Neon DB
+  // action so the guarded ALTERs are applied; this just stops it from blocking submissions.)
+  try {
+    const result = await queryDb<UnlockRuntimeConfigRow>(
+      `SELECT
+         submission_window_hours,
+         reminder_schedule_hours,
+         incentive_amount::text,
+         support_only_after_expiry
+       FROM unlock_runtime_config
+       WHERE singleton_id = 1
+       LIMIT 1`,
+    );
 
-  return mapUnlockRuntimeConfig(result.rows[0]);
+    return mapUnlockRuntimeConfig(result.rows[0]);
+  } catch (error) {
+    console.error('[unlock] runtime config read failed; using defaults', error);
+    return mapUnlockRuntimeConfig(undefined);
+  }
 }
 
 export async function getEffectiveUnlockAccessTier(userId: string): Promise<UnlockAccessTier | null> {


### PR DESCRIPTION
**Urgent** — members were blocked from submitting Quora verification with a generic 503 "Unlock submission unavailable."

Root cause: `getUnlockRuntimeConfig()` runs **before** the submission INSERT. If `unlock_runtime_config` is missing/unmigrated on the connected DB (or a column it `SELECT`s — `incentive_amount` / `support_only_after_expiry` — doesn't exist yet), that query throws and surfaces as the generic 503, blocking submission. `mapUnlockRuntimeConfig` already defaults a missing *row*, but a thrown query was not caught.

Fix: wrap the read in try/catch and fall back to the documented defaults so a config-read failure can't block verification submissions.

Note: the underlying issue is an **unmigrated connected DB** — the real fix is running the **Update Neon DB** action so the guarded `ALTER … ADD COLUMN IF NOT EXISTS` statements apply (both `unlock_runtime_config` and `unlock_verification_submissions`). This PR just prevents a config-read failure from blocking members in the meantime; if the *submissions* table is also missing columns, the INSERT still needs the migration.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_