### PR TITLE
fix: retype legacy login_events.created_at to timestamptz so the UTC-day index builds

### DIFF
--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -3023,6 +3023,26 @@ CREATE INDEX IF NOT EXISTS idx_login_events_created ON login_events(created_at);
 -- dedupe atomic at the database level (the app inserts with ON CONFLICT DO NOTHING), so two
 -- concurrent requests for the same member on the same UTC day cannot both write a row. The day
 -- is computed in UTC explicitly so the dedupe does not depend on the database session timezone.
+--
+-- Legacy guard: on databases cloned before `created_at` was a `timestamptz`, this column can be a
+-- plain `timestamp without time zone`. The guarded `ADD COLUMN IF NOT EXISTS` above does NOT retype
+-- an existing column, so it stays the legacy type. That breaks the UTC-day index below: with a
+-- timestamp-without-tz input, `created_at AT TIME ZONE 'UTC'` resolves to the STABLE overload of
+-- `timezone()` and the index build fails with "functions in index expression must be marked
+-- IMMUTABLE". Retype it to `timestamptz` first, interpreting the stored wall-clock as UTC. The
+-- block is conditional so it is a no-op (and does not shift values) once the column is timestamptz.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'login_events' AND column_name = 'created_at'
+      AND data_type = 'timestamp without time zone'
+  ) THEN
+    ALTER TABLE login_events
+      ALTER COLUMN created_at TYPE TIMESTAMPTZ USING (created_at AT TIME ZONE 'UTC');
+  END IF;
+END
+$$;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_login_events_user_utc_day
   ON login_events (user_id, ((created_at AT TIME ZONE 'UTC')::date));
 

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -3023,10 +3023,32 @@ ALTER TABLE IF EXISTS login_events ADD COLUMN IF NOT EXISTS user_id TEXT NOT NUL
 ALTER TABLE IF EXISTS login_events ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 CREATE INDEX IF NOT EXISTS idx_login_events_user ON login_events(user_id);
 CREATE INDEX IF NOT EXISTS idx_login_events_created ON login_events(created_at);
+-- Legacy guard: on databases cloned before `created_at` was a `timestamptz`, this column can be a
+-- plain `timestamp without time zone`. The guarded `ADD COLUMN IF NOT EXISTS` above does NOT retype
+-- an existing column, so it stays the legacy type. That breaks the UTC-day index below: with a
+-- timestamp-without-tz input, `created_at AT TIME ZONE 'UTC'` resolves to the STABLE overload of
+-- `timezone()` and the index build fails with "functions in index expression must be marked
+-- IMMUTABLE" (this is what stalled the Update Neon DB apply). Retype it to `timestamptz` first,
+-- interpreting the stored wall-clock as UTC. The block is conditional so it is a no-op (and does not
+-- shift values) once the column is already `timestamptz`.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'login_events' AND column_name = 'created_at'
+      AND data_type = 'timestamp without time zone'
+  ) THEN
+    ALTER TABLE login_events
+      ALTER COLUMN created_at TYPE TIMESTAMPTZ USING (created_at AT TIME ZONE 'UTC');
+  END IF;
+END
+$$;
 -- At most one row per member per UTC day. This makes the "record a sign-in once per day"
 -- dedupe atomic at the database level (the app inserts with ON CONFLICT DO NOTHING), so two
 -- concurrent requests for the same member on the same UTC day cannot both write a row. The day
 -- is computed in UTC explicitly so the dedupe does not depend on the database session timezone.
+-- Because `created_at` is guaranteed `timestamptz` by the block above, the `AT TIME ZONE 'UTC'`
+-- expression here resolves to the IMMUTABLE overload of `timezone()` and is index-safe.
 CREATE UNIQUE INDEX IF NOT EXISTS uq_login_events_user_utc_day
   ON login_events (user_id, ((created_at AT TIME ZONE 'UTC')::date));
 


### PR DESCRIPTION
## What this fixes

The **Update Neon DB** workflow has failed on every run since June 15. It stops at the `login_events` UTC-day unique index with:

```
ERROR:  functions in index expression must be marked IMMUTABLE
```

Because the apply runs with `ON_ERROR_STOP=1`, that one error aborts the whole `schema.sql` run, so **every schema change and post-migration after that line has never been applied** on the connected database. That is the real reason the Unlock verification submission returns a generic 503 for live members — the submission tables/columns the route needs were never migrated.

## Root cause

It is a column-type mismatch, not a bad index expression. `schema.sql` declares `login_events.created_at` as `timestamptz`, but on databases cloned before that was true the column is still `timestamp WITHOUT time zone`, and the guarded `ADD COLUMN IF NOT EXISTS` never retypes an existing column.

- With a `timestamp without time zone` input, `created_at AT TIME ZONE 'UTC'` resolves to the **STABLE** overload of `timezone()` → rejected in an index.
- With a `timestamptz` input, the same expression uses the **IMMUTABLE** overload → builds fine.

## The fix

Add a guarded, idempotent `DO` block before the index that retypes a legacy `timestamp`-without-tz `created_at` to `timestamptz` (interpreting the stored wall-clock as UTC), then keep the original index expression unchanged. Mirrored the same guard in `schema.demo.sql`. **No application code changes** — the existing `ON CONFLICT` keeps working.

## How it was verified

Ran a throwaway Postgres locally against both column types:

- Legacy `timestamp` column → block retypes it to `timestamptz`; running the block a second time is a no-op (no value shift); the legacy row is preserved as the same UTC instant.
- The original index then builds (`CREATE INDEX` OK).
- The app's existing `ON CONFLICT (user_id, ((created_at AT TIME ZONE 'UTC')::date))` dedupes to one row per member per UTC day.
- Confirmed the unpatched index reproduces the exact production error on a `timestamp`-without-tz column.

**Urgency:** this is the unblocker for the Update Neon DB pipeline and the 20 members blocked on Unlock submission. Once merged to `main` it triggers the Update Neon DB workflow, which will finally apply this and all the migrations stranded since June 15.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_