### PR TITLE
fix: dedupe login_events per member per UTC day before building the unique index

### DIFF
--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -3043,6 +3043,20 @@ BEGIN
   END IF;
 END
 $$;
+-- One-time dedupe so the unique index below can be built on legacy data: a database cloned from
+-- before the index existed can hold duplicate (user_id, UTC-day) rows. Keep the earliest sign-in of
+-- each day and drop the rest. Naturally idempotent — once deduped it removes nothing.
+DELETE FROM login_events
+WHERE ctid IN (
+  SELECT ctid FROM (
+    SELECT ctid, ROW_NUMBER() OVER (
+      PARTITION BY user_id, (created_at AT TIME ZONE 'UTC')::date
+      ORDER BY created_at ASC, ctid ASC
+    ) AS rn
+    FROM login_events
+  ) ranked
+  WHERE ranked.rn > 1
+);
 CREATE UNIQUE INDEX IF NOT EXISTS uq_login_events_user_utc_day
   ON login_events (user_id, ((created_at AT TIME ZONE 'UTC')::date));
 

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -3043,6 +3043,23 @@ BEGIN
   END IF;
 END
 $$;
+-- One-time dedupe so the unique index below can be built on legacy data. Before that index existed
+-- the app could write more than one row per member per UTC day (every sign-in, across instances),
+-- so a database cloned from that era has duplicate (user_id, UTC-day) rows. Collapse each group to a
+-- single row — keep the earliest sign-in of the day — before creating the index. `login_events` is
+-- only a daily activity signal (the 7-day "active members" window reads DISTINCT user_id), so which
+-- row survives does not matter. This DELETE is naturally idempotent: once deduped it removes nothing.
+DELETE FROM login_events
+WHERE ctid IN (
+  SELECT ctid FROM (
+    SELECT ctid, ROW_NUMBER() OVER (
+      PARTITION BY user_id, (created_at AT TIME ZONE 'UTC')::date
+      ORDER BY created_at ASC, ctid ASC
+    ) AS rn
+    FROM login_events
+  ) ranked
+  WHERE ranked.rn > 1
+);
 -- At most one row per member per UTC day. This makes the "record a sign-in once per day"
 -- dedupe atomic at the database level (the app inserts with ON CONFLICT DO NOTHING), so two
 -- concurrent requests for the same member on the same UTC day cannot both write a row. The day


### PR DESCRIPTION
## Why a second fix

The first fix (#608, merged) corrected the column type, and that worked — the Update Neon DB apply got **past** the "must be marked IMMUTABLE" error. But it then reached the unique index and failed on the connected database for a *different, data-level* reason:

```
could not create unique index "uq_login_events_user_utc_day"
DETAIL: Key (user_id, ((created_at AT TIME ZONE 'UTC')::date))=(user_…, 2025-12-15) is duplicated.
```

The live `login_events` table holds **more than one row per member per UTC day**, accumulated before this unique index ever existed (every sign-in wrote a row, across server instances). The unique index can't be built until those duplicates are collapsed. Because the apply runs with `ON_ERROR_STOP=1`, this one statement still aborts the whole run, so the pipeline remains stuck.

## The fix

Add a one-time, idempotent dedupe immediately after the retype and before the index: keep the **earliest** sign-in of each `(user_id, UTC-day)` group and delete the rest. `login_events` is only a daily activity signal (the active-members window reads `DISTINCT user_id`), so which row survives doesn't matter. Mirrored in `schema.demo.sql`. **No application code change.**

## Verified locally

On a throwaway Postgres seeded with legacy data (timestamp-without-tz column + duplicate same-day rows):
- apply #1: column retypes, the `DELETE` collapses duplicates, the unique index builds;
- apply #2: clean no-op — the `DELETE` matches nothing and the index is skipped (idempotent);
- final state is exactly one row per member per UTC day.

Once merged this triggers the Update Neon DB workflow, which should now complete and apply everything stranded since June 15 — unblocking the Unlock submission for the waiting members.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_