### PR TITLE
fix: give unlock submission a user_id conflict target and stop audit writes from blocking it

### DIFF
--- a/ctf/packages/web/lib/unlock/repository.ts
+++ b/ctf/packages/web/lib/unlock/repository.ts
@@ -363,25 +363,33 @@ export async function insertUnlockAudit(input: {
   requestId?: string | null;
   metadata?: Record<string, unknown>;
 }) {
-  await queryDb(
-    `INSERT INTO unlock_audit_log (
-       actor_user_id,
-       command,
-       policy_status,
-       reason,
-       target_user_id,
-       request_id,
-       metadata
-     )
-     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
-    [
-      input.actorUserId,
-      input.command,
-      input.policyStatus,
-      input.reason,
-      input.targetUserId ?? null,
-      input.requestId ?? null,
-      JSON.stringify(input.metadata ?? {}),
-    ],
-  );
+  // Best-effort: the audit row is a secondary record, but the submission route awaits this call, so
+  // a throw here (e.g. a legacy unlock_audit_log missing a column, or its user_id/action still NOT
+  // NULL) would turn an otherwise-successful submission into a generic 503 for the member. Never let
+  // the audit write block the member flow — log the real cause and move on.
+  try {
+    await queryDb(
+      `INSERT INTO unlock_audit_log (
+         actor_user_id,
+         command,
+         policy_status,
+         reason,
+         target_user_id,
+         request_id,
+         metadata
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+      [
+        input.actorUserId,
+        input.command,
+        input.policyStatus,
+        input.reason,
+        input.targetUserId ?? null,
+        input.requestId ?? null,
+        JSON.stringify(input.metadata ?? {}),
+      ],
+    );
+  } catch (error) {
+    console.error('[unlock] audit write failed (non-blocking)', error);
+  }
 }

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -957,11 +957,29 @@ ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS r
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS review_note TEXT;
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
--- Add prod unlock audit/config tables if missing
+-- createOrUpdateUnlockSubmission upserts with ON CONFLICT (user_id); guarantee a unique conflict
+-- target on user_id regardless of which column is the primary key. Dedupe first (keep the most
+-- recently updated row per member) so the index can build; idempotent once one row per member.
+DELETE FROM unlock_verification_submissions
+WHERE ctid IN (
+  SELECT ctid FROM (
+    SELECT ctid, ROW_NUMBER() OVER (
+      PARTITION BY user_id
+      ORDER BY updated_at DESC, id DESC
+    ) AS rn
+    FROM unlock_verification_submissions
+  ) ranked
+  WHERE ranked.rn > 1
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_unlock_verification_submissions_user_id
+  ON unlock_verification_submissions (user_id);
+
+-- Add prod unlock audit/config tables if missing. user_id/action are nullable because the writer
+-- (insertUnlockAudit) populates actor_user_id/command/... and not the legacy user_id/action columns.
 CREATE TABLE IF NOT EXISTS unlock_audit_log (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,
-  action TEXT NOT NULL,
+  user_id TEXT,
+  action TEXT,
   details JSONB DEFAULT '{}'::jsonb NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -973,6 +991,15 @@ CREATE TABLE IF NOT EXISTS unlock_audit_log (
   request_id TEXT,
   target_user_id TEXT
 );
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS actor_user_id TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS command TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::jsonb NOT NULL;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS policy_status TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS reason TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS request_id TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS target_user_id TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE IF EXISTS unlock_audit_log ALTER COLUMN action DROP NOT NULL;
 
 CREATE TABLE IF NOT EXISTS unlock_runtime_config (
   singleton_id INTEGER PRIMARY KEY DEFAULT 1,

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -959,11 +959,37 @@ ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS r
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS review_note TEXT;
 ALTER TABLE IF EXISTS unlock_verification_submissions ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
--- Add prod unlock audit/config tables if missing
+-- The app upserts a submission with `ON CONFLICT (user_id)` (createOrUpdateUnlockSubmission). That
+-- requires a unique constraint on user_id as the conflict target. schema.sql declares user_id as the
+-- PRIMARY KEY, but on databases cloned with the primary key on `id` instead, the conflict target is
+-- missing and every submission INSERT fails with "there is no unique or exclusion constraint matching
+-- the ON CONFLICT specification" — which surfaces to members as the generic 503 "Unlock submission
+-- unavailable." A unique index on user_id is a valid conflict target regardless of which column is
+-- the primary key. Dedupe first (keep the most recently updated row per member) so the index can
+-- build even if a legacy row pair slipped in; idempotent once there is one row per member.
+DELETE FROM unlock_verification_submissions
+WHERE ctid IN (
+  SELECT ctid FROM (
+    SELECT ctid, ROW_NUMBER() OVER (
+      PARTITION BY user_id
+      ORDER BY updated_at DESC, id DESC
+    ) AS rn
+    FROM unlock_verification_submissions
+  ) ranked
+  WHERE ranked.rn > 1
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_unlock_verification_submissions_user_id
+  ON unlock_verification_submissions (user_id);
+
+-- Add prod unlock audit/config tables if missing.
+-- `user_id` and `action` are nullable: the current writer (insertUnlockAudit) records the
+-- actor_user_id/command/policy_status/reason columns and does NOT populate the legacy user_id/action
+-- columns, so requiring them NOT NULL would make every audit INSERT fail (and, because the submission
+-- route awaits the audit write, would turn an otherwise-successful submission into the same 503).
 CREATE TABLE IF NOT EXISTS unlock_audit_log (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,
-  action TEXT NOT NULL,
+  user_id TEXT,
+  action TEXT,
   details JSONB DEFAULT '{}'::jsonb NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -975,6 +1001,17 @@ CREATE TABLE IF NOT EXISTS unlock_audit_log (
   request_id TEXT,
   target_user_id TEXT
 );
+-- Guarded DDL for legacy unlock_audit_log tables: make sure the columns the writer uses exist, and
+-- drop the legacy NOT NULL on user_id/action (the writer does not populate them).
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS actor_user_id TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS command TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::jsonb NOT NULL;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS policy_status TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS reason TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS request_id TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ADD COLUMN IF NOT EXISTS target_user_id TEXT;
+ALTER TABLE IF EXISTS unlock_audit_log ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE IF EXISTS unlock_audit_log ALTER COLUMN action DROP NOT NULL;
 
 CREATE TABLE IF NOT EXISTS unlock_runtime_config (
   singleton_id INTEGER PRIMARY KEY DEFAULT 1,


### PR DESCRIPTION
## Why unlock still 503s after the migration

The Update Neon DB run is green and the unlock tables exist — the page renders and the submission **status read** works. But submitting a Quora URL still returns "Unlock submission unavailable." Two table-shape problems in the *submission write path* (not covered by the existing guarded DDL) cause it:

1. **No `ON CONFLICT (user_id)` target.** `createOrUpdateUnlockSubmission` upserts with `ON CONFLICT (user_id)`, which needs a unique constraint on `user_id`. `schema.sql` declares `user_id` as the PRIMARY KEY, but the live table was cloned with the primary key on `id`, so there's no unique constraint on `user_id`. Every submission INSERT then fails with `there is no unique or exclusion constraint matching the ON CONFLICT specification` → the generic 503. Reproduced locally.

2. **Audit insert can throw and bubble up.** `insertUnlockAudit` writes `unlock_audit_log` without `user_id`/`action`, which are `NOT NULL` in the schema. The submission route awaits that write, so even once the submission row is created, the audit INSERT can throw and turn a successful submission into the same 503.

## Fixes

- Add a guarded unique index on `unlock_verification_submissions(user_id)` — a valid `ON CONFLICT` target no matter which column is the primary key — with a defensive, idempotent dedupe first so it builds on any legacy rows.
- Make `unlock_audit_log.user_id`/`action` nullable (the writer doesn't populate them) and add guarded `ADD COLUMN` for the columns the writer uses, for legacy tables.
- Make `insertUnlockAudit` best-effort (catch + log) so a secondary audit-write failure can never block a member's submission again.

## Verified locally

Against a legacy-shaped database (submissions PK on `id`; `audit_log` with `NOT NULL` `user_id`/`action` and missing columns): reproduced the exact `ON CONFLICT` error, then confirmed the fix applies **idempotently** and both the app's submission upsert and the audit insert succeed. Mirrored the schema guards in `schema.demo.sql`. No app-facing behavior change beyond the audit write becoming non-blocking.

Once merged this triggers the Update Neon DB workflow; after it applies, the 20 waiting members should be able to submit.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_