### PR TITLE
fix: make unlock left rail functional and reword "what you unlock" in plain language

### DIFF
--- a/ctf/packages/web/components/unlock/unlock-icon-rail.tsx
+++ b/ctf/packages/web/components/unlock/unlock-icon-rail.tsx
@@ -1,27 +1,41 @@
 "use client";
 
-import { Bell, Settings, Shield, Unlock as UnlockIcon, Users } from "lucide-react";
+import Link from "next/link";
+import { UserButton } from "@clerk/nextjs";
+import { Shield, Unlock as UnlockIcon } from "lucide-react";
+import { HelpControl } from "../bug-reports/help-control";
 import { BORDER, BRAND, SUBTLE } from "./unlock-shared";
 
-// Hub icon-rail chrome. Unlock is a single-view surface, so the nav glyphs
-// are presentational (matching the mockup); the brand mark anchors the rail.
-const NAV = [UnlockIcon, Shield, Users];
-
+// Unlock is a gate, not a multi-view hub. The old rail mimicked the main hub chrome with decorative
+// glyphs that did nothing (and repeated the lock mark), which reads as broken. Keep it deliberately
+// minimal: one brand mark, and only controls that genuinely work for a member who is still waiting on
+// review — see/delete their data, report a problem, and the account menu (sign out / edit profile).
 export function UnlockIconRail() {
   return (
     <aside style={{ width: 72, background: "#090B0F", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${BRAND}25`, border: `1px solid ${BRAND}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
+      {/* Brand mark only — a single lock, not a button. */}
+      <div style={{ width: 40, height: 40, borderRadius: 12, background: `${BRAND}25`, border: `1px solid ${BRAND}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }} aria-hidden="true">
         <UnlockIcon size={20} color={BRAND} />
       </div>
-      {NAV.map((Ic, i) => (
-        <div key={i} style={{ width: 44, height: 44, borderRadius: 12, background: i === 0 ? `${BRAND}20` : "transparent", border: i === 0 ? `1px solid ${BRAND}40` : "1px solid transparent", display: "flex", alignItems: "center", justifyContent: "center", color: i === 0 ? BRAND : SUBTLE }}>
-          <Ic size={20} />
-        </div>
-      ))}
+
+      <Link
+        href="/account/data"
+        aria-label="Account and data"
+        title="Account & Data — see and delete your data"
+        style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE, border: "1px solid transparent" }}
+      >
+        <Shield size={20} />
+      </Link>
+
       <div style={{ flex: 1 }} />
-      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Bell size={18} /></div>
-      <div style={{ width: 44, height: 44, borderRadius: 12, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE }}><Settings size={18} /></div>
-      <div style={{ width: 32, height: 32, borderRadius: "50%", background: `${BRAND}20`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, color: BRAND }}>S</div>
+
+      {/* Report a problem (opens the bug-report flow) — useful for a member stuck at the gate. */}
+      <HelpControl />
+
+      {/* Clerk account menu: sign out or edit name/username/email. */}
+      <span title="Your account — sign out or manage your profile" style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <UserButton />
+      </span>
     </aside>
   );
 }

--- a/ctf/packages/web/components/unlock/unlock-shared.ts
+++ b/ctf/packages/web/components/unlock/unlock-shared.ts
@@ -49,10 +49,16 @@ export function toDisplayStatus(reviewStatus: UnlockReviewStatus | null): Displa
   return "pending";
 }
 
+// What full access actually means, in plain language — outcomes a new member cares about, not a
+// list of plugin/feature names (which read as jargon and feel both overwhelming and incomplete).
+// These read like the home-page prompts: each line quietly stands in for one or more plugins
+// (housing → LightHouse, rides → TrustTransport, work/earn → Workforce + Directory + ServiceCredits,
+// skills → Skills Hunt + LevelUp, "ask for anything" → the Commons + AI assistant).
 export const UNLOCK_BENEFITS = [
-  "Full Directory access",
-  "Skills Hunt participation",
-  "ServiceCredits trading",
-  "Plugin marketplace",
-  "GDP contribution",
+  "A real community of survivors — and growing",
+  "Find safe housing",
+  "Get help with rides and transportation",
+  "Find work and ways to earn",
+  "Build skills with people who get it",
+  "Ask for anything you need, anytime",
 ];

--- a/ctf/packages/web/components/unlock/unlock-submission-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-submission-view.tsx
@@ -3,7 +3,7 @@
 import { CheckCircle, ExternalLink, Send, Shield, Unlock as UnlockIcon } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
-import { getUnlockTokens } from "./unlock-shared";
+import { getUnlockTokens, UNLOCK_BENEFITS } from "./unlock-shared";
 
 const WHY = [
   { icon: "🔗", t: "Real-person proof", d: "Quora activity proves you're a real person with history online." },
@@ -11,7 +11,8 @@ const WHY = [
   { icon: "✅", t: "Admin-reviewed", d: "A human reviews every submission — no automated rejection." },
 ];
 
-const UNLOCKS = ["Full Directory", "Skills Hunt", "ServiceCredits", "All plugins"];
+// Single source of truth with the status-view right rail, in plain outcome language.
+const UNLOCKS = UNLOCK_BENEFITS;
 
 export function UnlockSubmissionView({
   url,


### PR DESCRIPTION
## What and why

Two problems on the live `/plugin/unlock` page, reported with screenshots:

1. **Left rail.** A lock icon appeared twice (the brand mark plus a duplicate lock in the decorative nav), and none of the rail glyphs were clickable — icons styled like buttons that do nothing read as broken. Unlock is a gate, not a multi-view hub, so the rail is now minimal and every interactive glyph is a real control that actually works for a member still waiting on review:
   - **Account & Data** (`/account/data`) — see and delete your data
   - **Report a problem** (the existing Help control)
   - **Account menu** (Clerk `UserButton`) — sign out / edit profile
   
   The lock now appears once, as the brand mark only.

2. **"What you unlock" copy.** It listed plugin/feature names — *Full Directory, Skills Hunt, ServiceCredits, Plugin marketplace, GDP contribution* — which is jargon that felt both overwhelming and incomplete to someone new, and it diverged from the submission view's own separate list. Both views now share one list of plain-language **outcomes** that quietly span the plugins, the way the home-page prompts do:
   - A real community of survivors — and growing
   - Find safe housing
   - Get help with rides and transportation
   - Find work and ways to earn
   - Build skills with people who get it
   - Ask for anything you need, anytime

Single source of truth: `UNLOCK_BENEFITS` in `unlock-shared.ts`, used by both the submission view and the status-view right rail.

## Notes

- UI/copy only — no schema, API, or contract changes. Web typecheck passes.
- I deliberately avoided hard-coding a member count (e.g. "60+") since it would go stale; the first line conveys scale and momentum without a number that rots. If you'd prefer the live count shown there, say so and I'll wire the real figure through.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_