### PR TITLE
feat: show community posts read-only to signed-out visitors on the Commons

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -158,6 +158,10 @@ User routes:
 - `POST /api/feed/stream` — mint Stream chat credentials for the announcements channel (`ctf-feed-announcements`)
 - `POST /api/questions/stream` — mint Stream chat credentials for the questions channel (`ctf-feed-questions`); used by the mobile Questions screen
 
+Public (unauthenticated) routes:
+
+- `GET /api/feed/public/community` — read-only Commons for signed-out visitors. Returns `{ isPublic, posts }` where `posts` are community (peer) posts only — no announcements, AI answers, replies, per-user state, or author user ids. Returns `isPublic: false` (empty) unless `feed_render_config.is_public` is on and the community channel is enabled. Backs the signed-out home panel (community posts are public the way Quora posts are; visitors read but cannot post without signing in).
+
 Admin routes:
 
 - `GET /api/feed/admin/config`

--- a/ctf/packages/web/app/api/feed/public/community/route.ts
+++ b/ctf/packages/web/app/api/feed/public/community/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import type { PublicCommunityPost } from 'lib/feed/types';
+import { listPublicCommunityPosts } from 'lib/feed/repository';
+
+// Public, unauthenticated read of the Commons (peer community posts), so signed-out visitors can
+// read what members have posted — public the way Quora posts are. This route has no auth gate on
+// purpose; the data it returns is already public-by-design and gated server-side by
+// feed_render_config.is_public (see listPublicCommunityPosts). It exposes ONLY community posts and
+// no per-user state — never announcements, AI answers, replies, or author user ids.
+export const dynamic = 'force-dynamic';
+
+type PublicCommunityResponse = {
+  isPublic: boolean;
+  posts: PublicCommunityPost[];
+};
+
+export async function GET() {
+  try {
+    const { isPublic, posts } = await listPublicCommunityPosts();
+
+    // Stored newest-first; present oldest-first so the public stream reads top-to-bottom like a chat.
+    const response: PublicCommunityResponse = {
+      isPublic,
+      posts: [...posts].reverse(),
+    };
+
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    // A read failure must not break the public home; degrade to the sign-in prompt (isPublic:false).
+    Sentry.captureException(error, { tags: { area: 'feed', op: 'public_community' } });
+    return NextResponse.json({ isPublic: false, posts: [] }, { status: 200 });
+  }
+}

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AtSign } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
+import type { PublicCommunityPost } from '../../lib/feed/types';
 import type { ChatMessage, ComicStreamItem, ShellCurrentUser, ShellStats } from './shell-types';
 import { useHomeChat } from './use-home-chat';
 import { ComicAnswerCard, ComicPendingCard } from './comic-cards';
@@ -47,8 +48,52 @@ export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = 
     return <AuthenticatedChatPanel stats={stats} plugins={plugins} currentUser={currentUser} />;
   }
 
+  return <PublicCommunityPanel stats={stats} plugins={plugins} signInUrl={signInUrl} />;
+}
+
+function formatPostTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+// Signed-out Commons: community (peer) posts are public the way Quora posts are, so a not-signed-in
+// visitor reads them here — read-only and nothing else (no AI assistant, no concierge chips, no
+// composer). Posts come from the public, unauthenticated endpoint, which itself only returns posts
+// when an admin has turned public viewing on. When public viewing is off (or the read fails), we fall
+// back to the plain sign-in prompt. A single sign-in call-to-action lets a visitor join to take part.
+function PublicCommunityPanel({ stats, plugins, signInUrl }: { stats: ShellStats; plugins: PluginRegistryItem[]; signInUrl: string }) {
   const implementedCount = plugins.filter((plugin) => plugin.availabilityState === 'implemented_shell').length;
   const opportunityValue = Math.max(ECONOMY_TARGET_USD - (stats.gdpValueUsd ?? 0), 0);
+
+  const [posts, setPosts] = useState<PublicCommunityPost[]>([]);
+  const [isPublic, setIsPublic] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const res = await fetch('/api/feed/public/community', { cache: 'no-store' });
+        if (!res.ok) throw new Error('public_community_unavailable');
+        const data = (await res.json()) as { isPublic: boolean; posts: PublicCommunityPost[] };
+        if (!active) return;
+        setIsPublic(Boolean(data.isPublic));
+        setPosts(Array.isArray(data.posts) ? data.posts : []);
+      } catch {
+        if (!active) return;
+        setIsPublic(false);
+        setPosts([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const hasPosts = isPublic && posts.length > 0;
 
   return (
     <div className={styles.chatPanelWrap}>
@@ -81,11 +126,31 @@ export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = 
       </div>
 
       <div className={styles.chatMessages}>
-        <div className={styles.chatBubbleGroup}>
-          <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
-            To start connecting with Survivor Hub and accessing community support, please sign in.
+        {loading ? (
+          <p className={styles.chatFootnote}>Loading community posts…</p>
+        ) : hasPosts ? (
+          posts.map((post) => {
+            const authorLabel = post.authorUsername ? `@${post.authorUsername}` : 'Community member';
+            const initial = post.authorUsername ? post.authorUsername.charAt(0).toUpperCase() : 'C';
+            return (
+              <div key={post.id} className={styles.chatRow}>
+                <div className={styles.chatAvatar} aria-hidden="true">{initial}</div>
+                <div className={styles.chatBubbleGroup}>
+                  <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>{post.body}</div>
+                  <span className={styles.chatTime}>{authorLabel} · {formatPostTime(post.createdAtIso)}</span>
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <div className={styles.chatBubbleGroup}>
+            <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
+              {isPublic
+                ? 'No community posts yet. Sign in to start the conversation.'
+                : 'To start connecting with Survivor Hub and accessing community support, please sign in.'}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       <div className={styles.chatSuggestions}>
@@ -93,15 +158,10 @@ export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = 
           Sign In to Get Started
         </Link>
         <p className={styles.chatSuggestionsInfo}>
-          Survivor Hub is free and helps you access housing, work, safety resources, and connect with others in the community.
+          {hasPosts
+            ? 'You are reading the community. Sign in — free — to post, reply, and access housing, work, and safety resources.'
+            : 'Survivor Hub is free and helps you access housing, work, safety resources, and connect with others in the community.'}
         </p>
-      </div>
-
-      {/* Locked composer — read-only stream; sign in (or @comic) to participate. */}
-      <div className={styles.comicLockedComposer}>
-        <span className={styles.comicLockedLock} aria-hidden="true">🔒</span>
-        <span className={styles.comicLockedText}>Sign in to post — or type @comic to ask the AI Assistant…</span>
-        <Link href={signInUrl} className={styles.comicLockedJoinBtn}>Join Free →</Link>
       </div>
     </div>
   );

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -37,6 +37,7 @@ import type {
   FeedQuestionInput,
   FeedTimelineItem,
   MembershipEventType,
+  PublicCommunityPost,
 } from 'lib/shared/feed-primitives/types';
 
 type FeedConfigRow = {
@@ -569,6 +570,67 @@ export async function getFeedConfig(): Promise<FeedConfig> {
   }
 
   return mapFeedConfig(result.rows[0]);
+}
+
+// Read-only Commons for signed-out visitors. Community (peer) posts are public the way Quora posts
+// are, so an anonymous visitor can read them — but only community posts (never announcements or AI
+// Q&A), and only when an admin has turned public viewing on (feed_render_config.is_public) and the
+// community channel is enabled. Returns `isPublic: false` (and no posts) when public viewing is off,
+// the config row is missing, or community is disabled — the caller then shows the sign-in prompt
+// instead. Mirrors the member-visible filter (active, published, not expired, targeted to the
+// general audience) but carries no per-user state and no author user id.
+export async function listPublicCommunityPosts(
+  limit = FEED_DEFAULT_PAGE_SIZE,
+): Promise<{ isPublic: boolean; posts: PublicCommunityPost[] }> {
+  const safeLimit = Math.min(Math.max(limit, 1), FEED_MAX_PAGE_SIZE);
+
+  let config: FeedConfig | null = null;
+  try {
+    config = await getFeedConfig();
+  } catch {
+    config = null;
+  }
+
+  if (!config || !config.isPublic || !config.enabledChannels.includes('community')) {
+    return { isPublic: false, posts: [] };
+  }
+
+  const result = await queryDb<{
+    id: string;
+    author_username: string | null;
+    body: string;
+    category: FeedCommunityCategory;
+    created_at: Date;
+  }>(
+    `
+      SELECT c.id, c.author_username, c.body, c.category, c.created_at
+      FROM feed_items f
+      JOIN feed_community_posts c ON c.id = f.source_community_post_id
+      WHERE f.item_type = 'community'
+        AND f.is_active = TRUE
+        AND f.published_at <= NOW()
+        AND (f.expires_at IS NULL OR f.expires_at > NOW())
+        AND EXISTS (
+          SELECT 1
+          FROM feed_item_targets t
+          WHERE t.item_id = f.id
+            AND t.target_role IN ('member', 'admin', 'all')
+        )
+      ORDER BY f.published_at DESC, f.id DESC
+      LIMIT $1
+    `,
+    [safeLimit],
+  );
+
+  const posts: PublicCommunityPost[] = result.rows.map((row) => ({
+    id: row.id,
+    authorUsername: row.author_username,
+    body: row.body,
+    category: row.category,
+    createdAtIso: toIso(row.created_at),
+  }));
+
+  return { isPublic: true, posts };
 }
 
 export async function updateFeedConfig(actorId: string, input: FeedConfigInput): Promise<FeedConfig> {

--- a/ctf/packages/web/lib/feed/types.ts
+++ b/ctf/packages/web/lib/feed/types.ts
@@ -63,6 +63,17 @@ export type FeedCommunityDetail = {
   replies: FeedCommunityReply[];
 };
 
+// The read-only shape shown to signed-out visitors on the public Commons. Community (peer) posts are
+// public the way Quora posts are, so a not-signed-in visitor can read them — but nothing identifying
+// beyond the author's chosen @username, and no replies/compose. Deliberately omits author_user_id.
+export type PublicCommunityPost = {
+  id: string;
+  authorUsername: string | null;
+  body: string;
+  category: FeedCommunityCategory;
+  createdAtIso: string;
+};
+
 export type FeedPagination = {
   page: number;
   pageSize: number;

--- a/ctf/packages/web/lib/shared/feed-primitives/types.ts
+++ b/ctf/packages/web/lib/shared/feed-primitives/types.ts
@@ -14,6 +14,7 @@ export type {
   FeedQuestionDetail,
   FeedCommunityReply,
   FeedCommunityDetail,
+  PublicCommunityPost,
   FeedPagination,
   FeedTimelineItem,
   FeedConfig,


### PR DESCRIPTION
## What

Signed-out home was a static "please sign in" placeholder. But community (peer) posts in the Commons are public the way posts on Quora are — a not-signed-in visitor should be able to **read** them. This wires that up, and **nothing else**: the signed-out panel shows community posts read-only, with no AI assistant, no concierge chips, and no composer. A single sign-in call-to-action invites visitors to join to post or reply.

## How

- **New public, unauthenticated endpoint** `GET /api/feed/public/community` returning `{ isPublic, posts }`. It exposes **only** community posts — never announcements, AI answers, replies, per-user state, or author user ids — and only when an admin has turned public viewing on (`feed_render_config.is_public`) and the community channel is enabled. Otherwise `isPublic: false` and the panel falls back to the sign-in prompt. Read failures degrade to the same safe fallback.
- `listPublicCommunityPosts` in the feed repository mirrors the member-visible filter (active, published, not expired, general-audience target) with no per-user state.
- Signed-out `ShellChatPanel` now renders a fetching, read-only `PublicCommunityPanel` with loading / empty / public-off / populated states; each post shows the author's `@username` (or "Community member") and time.
- Added the `PublicCommunityPost` type and documented the new route in the feed inventory's API Surface section.

## Why this is in the review lane

It adds a **new public API contract** and changes **data visibility** (exposing member posts to anonymous visitors). Labeled `coderabbit` and opened as a draft for review before merge. Two things worth a careful look:
1. The endpoint has no auth gate by design — confirm the gating (`is_public` + community-channel + general-audience target filter) is the right boundary and leaks nothing beyond `@username`/body/category/time.
2. Whether `feed_render_config.is_public` is already set the way you want in production (if it's off, signed-out visitors keep seeing the sign-in prompt — the safe default).

Web typecheck passes; the query columns match the existing `listFeedTimeline` read.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public community posts feed accessible to signed-out users on the home panel. The feed displays community-authored posts with usernames, timestamps, and categories, while respecting public visibility configuration settings. Sign-in prompts appear when public viewing is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->