### PR TITLE
fix: land sign-in on the chat, attribute each chat post, de-dupe the right-rail handle

### DIFF
--- a/ctf/packages/web/app/layout.tsx
+++ b/ctf/packages/web/app/layout.tsx
@@ -31,8 +31,10 @@ export default function RootLayout({
   const clerkOptions = getClerkRuntimeOptions();
 
   // Point Clerk at its hosted Account Portal (accounts.<domain>) for sign-in and
-  // sign-up rather than a page rendered on this app's own domain. After a
-  // completed flow, Clerk returns the user to the app (signInFallbackRedirectUrl).
+  // sign-up rather than a page rendered on this app's own domain. After a completed
+  // flow, force the return to the app home (the chat) regardless of which page started
+  // sign-in — a *force* redirect (not fallback) so signing in from a deep page like
+  // /apps still lands on the calmer chat home, which then routes by unlock tier.
   const signInUrl = getHostedSignInUrl();
   const signUpUrl = getHostedSignUpUrl();
   const afterSignOutUrl = getHostedAfterSignOutUrl();
@@ -57,7 +59,7 @@ export default function RootLayout({
           {...(signInUrl ? { signInUrl } : {})}
           {...(signUpUrl ? { signUpUrl } : {})}
           {...(appHomeUrl
-            ? { signInFallbackRedirectUrl: appHomeUrl, signUpFallbackRedirectUrl: appHomeUrl }
+            ? { signInForceRedirectUrl: appHomeUrl, signUpForceRedirectUrl: appHomeUrl }
             : {})}
           {...(afterSignOutUrl ? { afterSignOutUrl } : {})}
         >

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -531,6 +531,13 @@
   text-align: right;
 }
 
+.chatSender {
+  font-size: 11px;
+  font-weight: 700;
+  color: #9CA3AF;
+  margin-bottom: 3px;
+}
+
 .chatSuggestions {
   padding: 0 20px 8px;
   display: flex;

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -13,6 +13,15 @@ import styles from './community-shell.module.css';
 
 const ECONOMY_TARGET_USD = 300_000_000_000;
 
+// Avatar glyph for a chat sender: "SH" for the Survivor Hub system/AI, otherwise the first letter of
+// the member's handle. Keeps each post attributable instead of every row reading as the same "SH".
+function avatarFromSender(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'survivor hub') return 'SH';
+  const handle = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
+  return handle.charAt(0).toUpperCase() || 'SH';
+}
+
 function formatScaledValue(value: number | null, prefix = ''): string {
   if (!value) return `${prefix}0`;
   if (value >= 1_000_000_000) return `${prefix}${(value / 1_000_000_000).toFixed(0)}B`;
@@ -247,13 +256,15 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
           }
 
           const msg = entry.message;
+          const senderName = msg.senderLabel ?? 'Survivor Hub';
           return (
             <div
               key={msg.id}
               className={msg.from === 'user' ? `${styles.chatRow} ${styles.chatRowUser}` : styles.chatRow}
             >
-              {msg.from === 'hub' ? <div className={styles.chatAvatar} aria-hidden="true">SH</div> : null}
+              {msg.from === 'hub' ? <div className={styles.chatAvatar} aria-hidden="true">{avatarFromSender(senderName)}</div> : null}
               <div className={styles.chatBubbleGroup}>
+                {msg.from === 'hub' ? <span className={styles.chatSender}>{senderName}</span> : null}
                 <div className={msg.from === 'user' ? `${styles.chatBubble} ${styles.chatBubbleUser}` : `${styles.chatBubble} ${styles.chatBubbleHub}`}>
                   {msg.text}
                 </div>

--- a/ctf/packages/web/components/community-shell/shell-right-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-right-rail.tsx
@@ -14,7 +14,6 @@ type ShellRightRailProps = {
 };
 
 export function ShellRightRail({ currentUser, trust, isAuthenticated = false, signInUrl = '/sign-in' }: ShellRightRailProps) {
-  const displayName = currentUser.displayName;
   const initial = currentUser.initial;
 
   if (!isAuthenticated) {
@@ -44,7 +43,9 @@ export function ShellRightRail({ currentUser, trust, isAuthenticated = false, si
     <aside className={`${styles.panel} ${styles.rightRail}`}>
       <section className={styles.profileCard}>
         <div className={styles.profileAvatar} aria-hidden="true">{initial}</div>
-        <p className={styles.profileName}>Welcome, {displayName}</p>
+        {/* The greeting deliberately carries no handle: displayName is already "@username", so
+            "Welcome, @username" plus the @username meta line below repeated the handle twice. */}
+        <p className={styles.profileName}>Welcome back</p>
         <p className={styles.profileMeta}>{currentUser.username ? `@${currentUser.username}` : 'Member'}</p>
         <span className={styles.profileBadge}>Verified Community ✓</span>
       </section>


### PR DESCRIPTION
Three signed-in home fixes reported from the live app:

1. **Sign-in lands on the chat, not the Apps grid.** Signing in (e.g. from `/apps`) dropped the user on the busy All Apps page. Clerk is switched from a *fallback* redirect to a *force* redirect to the app home (the chat), so every completed sign-in lands on the calmer chat home — which then routes by unlock tier (pending → unlock, approved → chat).
2. **Right-rail handle shown once.** The profile card read "Welcome, @name" **and** a separate "@name" line, because `displayName` already includes the handle. The greeting is now "Welcome back" (no handle) and the handle shows once on the meta line.
3. **Each chat post is attributable.** Every message in the home chat rendered the same "SH" avatar with no author. Each hub/peer row now shows the sender's name (the `senderLabel` already carried in the message) and an avatar initial derived from it; "SH" remains only for the Survivor Hub system/AI replies.

UI/config only — no schema, API, or contract changes. Web typecheck passes.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_