### PR TITLE
feat: add a unified /account hub that gathers the one identity in one place

### DIFF
--- a/ctf/packages/web/app/account/page.tsx
+++ b/ctf/packages/web/app/account/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { getTrustUserExtension } from 'lib/trust/repository';
+import type { TrustUserExtension } from 'lib/trust/types';
+import { AccountHubShell } from '@/components/account/account-hub-shell';
+
+// Unified account hub. Rule 114 means there is no single profile table — each plugin extends the one
+// identity — so this page is not a single edit form: it is the one place that gathers everything that
+// makes up "you" and points to where each part is actually managed (Clerk identity, Quora
+// verification, Trust, the skills profile, housing listings, and data/deletion). Auth posture matches
+// /account/data: any signed-in identity, including unlock-pending users, can reach it.
+function buildFallbackTrust(userId: string): TrustUserExtension {
+  return {
+    userId,
+    trustStatus: 'unverified',
+    trustEvidence: [],
+    trustVisibility: 'public',
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export default async function AccountPage() {
+  const decision = await evaluatePluginAccess({
+    requireUsername: false,
+    minUnlockTier: 'any_authenticated',
+  });
+
+  if (!decision.allowed) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-12 space-y-4">
+        <h1 className="text-2xl font-semibold tracking-tight">Sign in to manage your account</h1>
+        <p className="text-sm text-muted-foreground">
+          You need to be signed in to see and update your account.
+        </p>
+        <p className="text-sm">
+          <Link className="underline underline-offset-4" href="/">Return to home</Link>
+        </p>
+      </main>
+    );
+  }
+
+  const trust = await getTrustUserExtension(decision.userId).catch(() => buildFallbackTrust(decision.userId));
+  const username = decision.username && decision.username !== 'guest' ? decision.username : null;
+
+  return <AccountHubShell username={username} trust={trust} />;
+}

--- a/ctf/packages/web/components/account/account-hub-shell.tsx
+++ b/ctf/packages/web/components/account/account-hub-shell.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import Link from 'next/link';
+import type { CSSProperties, ReactNode } from 'react';
+import { UserButton } from '@clerk/nextjs';
+import { ChevronRight, Database, Home, ShieldCheck, Sparkles, UserCircle } from 'lucide-react';
+import { useTheme } from '@/hooks/useTheme';
+import { getAccountDataTokens } from '@/components/account-data/account-data-shared';
+import { TrustRightRailCard } from '@/components/shared/trust/TrustRightRailCard';
+import type { TrustUserExtension } from 'lib/trust/types';
+
+// One identity, shown wherever it lives. This hub does not store a profile — it routes the member to
+// the real place each part is edited, so they never feel like they are filling in "another profile".
+export function AccountHubShell({ username, trust }: { username: string | null; trust: TrustUserExtension }) {
+  const { theme } = useTheme();
+  const tok = getAccountDataTokens(theme);
+  const handle = username ? `@${username}` : 'Member';
+  const initial = username ? username.charAt(0).toUpperCase() : 'S';
+
+  const cardStyle: CSSProperties = {
+    background: tok.SURFACE,
+    border: `1px solid ${tok.BORDER}`,
+    borderRadius: 14,
+    padding: '18px 20px',
+    marginBottom: 16,
+  };
+  const sectionLabel: CSSProperties = {
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: tok.SUBTLE,
+    marginBottom: 10,
+  };
+
+  return (
+    <div style={{ minHeight: '100dvh', overflowY: 'auto', background: tok.BG, color: tok.TEXT, fontFamily: "'Inter',system-ui,-apple-system,sans-serif" }}>
+      <div style={{ maxWidth: 720, margin: '0 auto', padding: '32px 20px 64px' }}>
+        <header style={{ marginBottom: 24 }}>
+          <h1 style={{ fontSize: 24, fontWeight: 800, margin: '0 0 6px' }}>Your account</h1>
+          <p style={{ fontSize: 14, color: tok.SUBTLE, lineHeight: 1.6, margin: 0 }}>
+            You have one identity across Survivor Hub. Here is everywhere it shows up — update each part where it lives.
+          </p>
+        </header>
+
+        {/* Identity — name, username, photo, email (managed by the account provider) */}
+        <section style={cardStyle}>
+          <div style={sectionLabel}>Identity</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+            <div style={{ width: 48, height: 48, borderRadius: 12, background: `${tok.BRAND}22`, border: `1px solid ${tok.BRAND}44`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18, fontWeight: 800, color: tok.BRAND, flexShrink: 0 }}>
+              {initial}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 16, fontWeight: 700 }}>{handle}</div>
+              <div style={{ fontSize: 13, color: tok.SUBTLE }}>Your name, username, photo, and email</div>
+            </div>
+            {/* Clerk's account menu is the one place identity basics are edited. */}
+            <span title="Manage your name, username, photo, and email" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+              <UserButton />
+            </span>
+          </div>
+        </section>
+
+        {/* Trust — earned through participation, not a form */}
+        <section style={cardStyle}>
+          <div style={{ ...sectionLabel, display: 'flex', alignItems: 'center', gap: 6 }}>
+            <Sparkles size={12} /> Trust
+          </div>
+          <TrustRightRailCard trust={trust} />
+          <p style={{ fontSize: 12, color: tok.SUBTLE, lineHeight: 1.6, margin: 0 }}>
+            Trust is earned by taking part — completing your profile, making a transaction, and using the plugins. There is nothing to fill in here.
+          </p>
+        </section>
+
+        {/* Manage each part of the profile where it lives */}
+        <section style={cardStyle}>
+          <div style={sectionLabel}>Manage your profile</div>
+          <AccountLinkRow
+            href="/plugin/unlock"
+            icon={<ShieldCheck size={18} />}
+            title="Verification"
+            desc="Confirm you are a real person with your Quora profile to unlock full access."
+            tok={tok}
+          />
+          <AccountLinkRow
+            href="/apps/directory"
+            icon={<UserCircle size={18} />}
+            title="Your skills profile"
+            desc="Your headline, skills, and how people can reach and pay you."
+            tok={tok}
+          />
+          <AccountLinkRow
+            href="/apps/lighthouse"
+            icon={<Home size={18} />}
+            title="Your housing listings"
+            desc="Places you host and offer to the community."
+            tok={tok}
+            last
+          />
+        </section>
+
+        {/* Data & privacy */}
+        <section style={cardStyle}>
+          <div style={sectionLabel}>Data &amp; privacy</div>
+          <AccountLinkRow
+            href="/account/data"
+            icon={<Database size={18} />}
+            title="Your data &amp; deletion"
+            desc="See everything the platform stores about you, and delete it — one service or your whole account."
+            tok={tok}
+            last
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function AccountLinkRow({
+  href,
+  icon,
+  title,
+  desc,
+  tok,
+  last = false,
+}: {
+  href: string;
+  icon: ReactNode;
+  title: string;
+  desc: string;
+  tok: ReturnType<typeof getAccountDataTokens>;
+  last?: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '12px 4px',
+        borderBottom: last ? 'none' : `1px solid ${tok.BORDER}`,
+        textDecoration: 'none',
+        color: tok.TEXT,
+      }}
+    >
+      <span style={{ color: tok.BRAND, flexShrink: 0, display: 'flex' }}>{icon}</span>
+      <span style={{ flex: 1, minWidth: 0 }}>
+        <span style={{ display: 'block', fontSize: 14, fontWeight: 600 }}>{title}</span>
+        <span style={{ display: 'block', fontSize: 12, color: tok.SUBTLE, lineHeight: 1.5 }}>{desc}</span>
+      </span>
+      <ChevronRight size={16} style={{ color: tok.SUBTLE, flexShrink: 0 }} />
+    </Link>
+  );
+}

--- a/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
@@ -57,10 +57,10 @@ export function ShellIconRail({ section, onSectionChange, initial = 'S', isAuthe
       ) : null}
 
       <Link
-        href="/account/data"
+        href="/account"
         className={styles.iconRailBtn}
-        aria-label="Account and data"
-        title="Account & Data — see and delete your data"
+        aria-label="Account"
+        title="Account — your identity, trust, profile, and data"
       >
         <Shield size={18} />
       </Link>


### PR DESCRIPTION
Answers the original "how do I update my profile?" question without contradicting rule 114 (there is no single profile table — each plugin extends the one identity). `/account` is **not** a new form; it's one place that shows everything that makes up "you" and routes to where each part is actually managed, so a member never feels like they're filling in yet another profile:

- **Identity** (name, username, photo, email) via the account provider's menu.
- **Verification** (Quora) → `/plugin/unlock`.
- **Trust** — shown read-only with a plain note that it's earned by taking part, not a form.
- **Skills profile** → `/apps/directory`; **housing listings** → `/apps/lighthouse`.
- **Data & deletion** → `/account/data`.

The desktop nav's account icon now opens this hub (which links onward to data & deletion) instead of going straight to deletion. Auth posture matches `/account/data` (any signed-in identity, including unlock-pending). Theme-aware via the shared account tokens; single-column and scrollable on mobile.

No schema, API, or contract changes — it reuses existing routes. Web typecheck passes.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_