### PR TITLE
feat: SocketRelay Android resolve flow (requester-only outcomes + Direct Line context)

### DIFF
--- a/ctf/packages/mobile/src/features/socketrelay/SocketRelay.tsx
+++ b/ctf/packages/mobile/src/features/socketrelay/SocketRelay.tsx
@@ -23,8 +23,10 @@ import { deriveTagChips, requestTags, suggestTags } from './tags';
 import { SocketRelayTagInput } from './SocketRelayTagInput';
 import { SocketRelayLoading } from './SocketRelayLoading';
 import { SocketRelayEmpty } from './SocketRelayEmpty';
+import { SocketRelayDirectLines } from './SocketRelayDirectLines';
 import { CurrencySelect } from '../currency';
 import type { Currency } from '../currency';
+import { useAuth } from '../../auth/auth-context';
 
 // Design color — from MobileSocketRelay.tsx mockup
 const COLOR = '#FB923C';
@@ -32,9 +34,11 @@ const COLOR = '#FB923C';
 // SocketRelayRequest model (title/details/tags/city/status only).
 // Those mockup UI elements are omitted per real-data-only policy.
 
-type NavKey = 'feed' | 'post';
+type NavKey = 'feed' | 'post' | 'lines';
 
 export function SocketRelay() {
+  const { user } = useAuth();
+  const currentUserId = user?.id;
   const [activeNav, setActiveNav] = useState<NavKey>('feed');
   const [requests, setRequests] = useState<SocketRelayRequest[]>([]);
   const [myRequestIds, setMyRequestIds] = useState<string[]>([]);
@@ -445,14 +449,18 @@ export function SocketRelay() {
 
       {/* Body */}
       <View style={styles.body}>
-        {activeNav === 'feed' ? renderFeed() : renderPost()}
+        {activeNav === 'feed'
+          ? renderFeed()
+          : activeNav === 'lines'
+            ? <SocketRelayDirectLines currentUserId={currentUserId} />
+            : renderPost()}
       </View>
 
       {/* Bottom nav */}
       <View style={styles.bottomNav}>
-        {(['feed', 'post'] as NavKey[]).map((key) => {
-          const label = key === 'feed' ? 'Feed' : 'Post';
-          const icon = key === 'feed' ? '↗' : '+';
+        {(['feed', 'lines', 'post'] as NavKey[]).map((key) => {
+          const label = key === 'feed' ? 'Feed' : key === 'lines' ? 'Lines' : 'Post';
+          const icon = key === 'feed' ? '↗' : key === 'lines' ? '💬' : '+';
           const active = activeNav === key;
           return (
             <TouchableOpacity

--- a/ctf/packages/mobile/src/features/socketrelay/SocketRelayDirectLines.tsx
+++ b/ctf/packages/mobile/src/features/socketrelay/SocketRelayDirectLines.tsx
@@ -1,0 +1,234 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import {
+  listMyFulfillments,
+  resolveFulfillment,
+  type SocketRelayFulfillment,
+  type SocketRelayResolveOutcome,
+} from './api';
+import { SocketRelayLoading } from './SocketRelayLoading';
+
+// Design color — matches the SocketRelay shell accent.
+const COLOR = '#FB923C';
+
+// The four outcomes a requester can pick. Mirrors the web ResolveBar (sr-chat.tsx) exactly:
+// labels, colors, and the meaning of each outcome are kept in sync with the web Direct Line.
+const RESOLVE_ACTIONS: {
+  outcome: SocketRelayResolveOutcome;
+  label: string;
+  color: string;
+}[] = [
+  { outcome: 'successful', label: 'Mark successful', color: '#22C55E' },
+  { outcome: 'no_longer_needed', label: 'No longer needed', color: '#6B7280' },
+  { outcome: 'unsuccessful_reopen', label: "Didn't work — reopen for others", color: '#FBBF24' },
+  { outcome: 'unsuccessful_close', label: "Didn't work — close", color: '#EF4444' },
+];
+
+function fulfillmentTitle(f: SocketRelayFulfillment): string {
+  return f.requestTitle && f.requestTitle.trim().length > 0
+    ? f.requestTitle
+    : `Request ${f.id.slice(0, 8)}`;
+}
+
+// One Direct Line card: request title, the member's role (your request vs you're helping), and —
+// for the requester on an active line — the four resolve actions. The helper sees a short note.
+function DirectLineCard({
+  fulfillment,
+  isRequester,
+  resolving,
+  onResolve,
+}: {
+  fulfillment: SocketRelayFulfillment;
+  isRequester: boolean;
+  resolving: boolean;
+  onResolve: (_fulfillmentId: string, _outcome: SocketRelayResolveOutcome) => void;
+}) {
+  const isActive = fulfillment.status === 'active';
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>{fulfillmentTitle(fulfillment)}</Text>
+      <Text style={styles.cardRole}>
+        {isRequester
+          ? "Your request — you're talking with the helper."
+          : 'You offered to help — talking with the requester.'}
+      </Text>
+
+      {!isActive ? (
+        <Text style={styles.note}>
+          This request is{' '}
+          {fulfillment.requestStatus === 'open' ? 'open again' : 'closed'}.
+        </Text>
+      ) : !isRequester ? (
+        <Text style={styles.note}>
+          Only the person who posted this request can close it.
+        </Text>
+      ) : (
+        <View style={styles.actionRow}>
+          {RESOLVE_ACTIONS.map((a) => (
+            <TouchableOpacity
+              key={a.outcome}
+              style={[
+                styles.actionBtn,
+                { backgroundColor: `${a.color}14`, borderColor: `${a.color}40` },
+                resolving && styles.actionBtnDisabled,
+              ]}
+              onPress={() => onResolve(fulfillment.id, a.outcome)}
+              disabled={resolving}
+              accessibilityRole="button"
+              accessibilityLabel={a.label}
+            >
+              <Text style={[styles.actionBtnText, { color: a.color }]}>{a.label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+// The Direct Lines tab: lists the signed-in member's fulfillments and surfaces requester-only
+// resolve controls. `currentUserId` decides requester-vs-helper (from useAuth().user.id).
+export function SocketRelayDirectLines({ currentUserId }: { currentUserId?: string }) {
+  const [fulfillments, setFulfillments] = useState<SocketRelayFulfillment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+
+  const load = useCallback((showLoading = true) => {
+    if (showLoading) setLoading(true);
+    setError(null);
+    listMyFulfillments()
+      .then((res) => setFulfillments(res.items))
+      .catch(() => setError('Failed to load your Direct Lines.'))
+      .finally(() => {
+        if (showLoading) setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleResolve = useCallback(
+    async (fulfillmentId: string, outcome: SocketRelayResolveOutcome) => {
+      setResolving(true);
+      setResolveError(null);
+      try {
+        await resolveFulfillment(fulfillmentId, outcome);
+        // Refresh so the resolved/reopened state is reflected; do not show the full loading screen.
+        load(false);
+      } catch (e) {
+        setResolveError(
+          e instanceof Error ? e.message : "Couldn't resolve this request. Please try again.",
+        );
+      } finally {
+        setResolving(false);
+      }
+    },
+    [load],
+  );
+
+  if (loading) {
+    return <SocketRelayLoading />;
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centeredMsg}>
+        <Text style={styles.errorText}>{error}</Text>
+        <TouchableOpacity style={styles.retryBtn} onPress={() => load()}>
+          <Text style={styles.retryBtnText}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (fulfillments.length === 0) {
+    return (
+      <View style={styles.centeredMsg}>
+        <Text style={styles.emptyTitle}>No Direct Lines yet</Text>
+        <Text style={styles.emptyBody}>
+          When you offer to help on a request — or someone offers to help with yours — a private
+          Direct Line opens here.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.scroll} showsVerticalScrollIndicator={false}>
+      <View style={styles.pad}>
+        {resolving ? (
+          <View style={styles.resolvingRow}>
+            <ActivityIndicator size="small" color={COLOR} />
+            <Text style={styles.resolvingText}>Resolving…</Text>
+          </View>
+        ) : null}
+        {resolveError ? <Text style={styles.errorText}>{resolveError}</Text> : null}
+        {fulfillments.map((f) => (
+          <DirectLineCard
+            key={f.id}
+            fulfillment={f}
+            isRequester={Boolean(currentUserId && f.requesterUserId === currentUserId)}
+            resolving={resolving}
+            onResolve={(id, outcome) => void handleResolve(id, outcome)}
+          />
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: { flex: 1 },
+  pad: { padding: 16 },
+  card: {
+    padding: 14,
+    borderRadius: 14,
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    borderWidth: 1,
+    borderColor: `${COLOR}30`,
+    marginBottom: 10,
+  },
+  cardTitle: { fontSize: 14, fontWeight: '700', color: '#F0FDF4', marginBottom: 4, lineHeight: 20 },
+  cardRole: { fontSize: 12, color: '#6B7280', marginBottom: 10 },
+  note: { fontSize: 12, color: '#6B7280', lineHeight: 18 },
+  actionRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  actionBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  actionBtnDisabled: { opacity: 0.6 },
+  actionBtnText: { fontSize: 12, fontWeight: '600' },
+  centeredMsg: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  emptyTitle: { fontSize: 15, fontWeight: '600', color: '#9CA3AF', marginBottom: 8 },
+  emptyBody: {
+    fontSize: 13,
+    color: '#4B5563',
+    textAlign: 'center',
+    maxWidth: 320,
+    lineHeight: 20,
+  },
+  errorText: { color: '#F43F5E', textAlign: 'center', marginBottom: 12 },
+  retryBtn: {
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    borderRadius: 10,
+    backgroundColor: `${COLOR}20`,
+    borderWidth: 1,
+    borderColor: `${COLOR}40`,
+  },
+  retryBtnText: { color: COLOR, fontWeight: '700', fontSize: 13 },
+  resolvingRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 },
+  resolvingText: { color: COLOR, fontSize: 13, fontWeight: '600' },
+});

--- a/ctf/packages/mobile/src/features/socketrelay/api.ts
+++ b/ctf/packages/mobile/src/features/socketrelay/api.ts
@@ -56,12 +56,48 @@ export function socketRelayHandle(
   return username ? `@${username}` : `user-${id.slice(0, 8)}`;
 }
 
+// How the requester (the person who posted the request) resolves a claimed request. Only the
+// requester (or an admin) may resolve — a helper can chat but cannot close someone else's request.
+// Mirrors the web SocketRelayResolveOutcome / SrResolveOutcome union exactly.
+//   successful          -> the help happened; close the request.
+//   no_longer_needed     -> requester no longer needs it; close the request.
+//   unsuccessful_reopen  -> it didn't work out; cancel this helper and put the request back to open.
+//   unsuccessful_close   -> it didn't work out and the requester is done; close the request.
+export type SocketRelayResolveOutcome =
+  | 'successful'
+  | 'no_longer_needed'
+  | 'unsuccessful_reopen'
+  | 'unsuccessful_close';
+
+export type SocketRelayFulfillmentStatus = 'active' | 'closed' | 'cancelled';
+
+// Mirrors the web SrFulfillment. `requestTitle`/`requestStatus` are joined from the request by
+// GET /api/socketrelay/my-fulfillments so the Direct Line can show context; both are optional
+// because a single-fulfillment fetch does not join the request.
+export type SocketRelayFulfillment = {
+  id: string;
+  requestId: string;
+  requesterUserId: string;
+  fulfillerUserId: string;
+  status: SocketRelayFulfillmentStatus;
+  closeReason: string | null;
+  createdAtIso: string;
+  updatedAtIso: string;
+  requestTitle?: string;
+  requestStatus?: SocketRelayRequestStatus;
+};
+
 export type ListRequestsResponse = {
   ok: boolean;
   items: SocketRelayRequest[];
   page: number;
   pageSize: number;
   total: number;
+};
+
+export type ListMyFulfillmentsResponse = {
+  ok: boolean;
+  items: SocketRelayFulfillment[];
 };
 
 export async function listRequests(
@@ -124,4 +160,31 @@ export async function fulfillRequest(requestId: string): Promise<void> {
     body: JSON.stringify({}),
   });
   if (!res.ok) throw new Error('Failed to fulfill request');
+}
+
+// The signed-in member's Direct Lines: every fulfillment they're part of, whether they posted the
+// request (requester) or offered to help (fulfiller). The server joins requestTitle/requestStatus.
+export async function listMyFulfillments(): Promise<ListMyFulfillmentsResponse> {
+  return authedFetchJson<ListMyFulfillmentsResponse>(`${BASE}/my-fulfillments`);
+}
+
+// Resolve (close/reopen) a fulfillment. The server enforces that only the requester (or an admin)
+// may resolve; the mobile UI only surfaces these actions to the requester. Mirrors the web
+// handleResolve: POST /api/socketrelay/fulfillments/:id/close with { outcome }.
+export async function resolveFulfillment(
+  fulfillmentId: string,
+  outcome: SocketRelayResolveOutcome,
+): Promise<void> {
+  const res = await authedFetch(`${BASE}/fulfillments/${fulfillmentId}/close`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-ctf-csrf': '1',
+    },
+    body: JSON.stringify({ outcome }),
+  });
+  if (!res.ok) {
+    const payload = (await res.json().catch(() => null)) as { message?: string } | null;
+    throw new Error(payload?.message ?? "Couldn't resolve this request. Please try again.");
+  }
 }


### PR DESCRIPTION
Android (React Native) parity for the web SocketRelay resolve flow (#624). **Closes #623.**

- **`api.ts`** — `SocketRelayResolveOutcome` (the four outcome strings), the `SocketRelayFulfillment` type with optional `requestTitle`/`requestStatus`, `listMyFulfillments()` (`GET /api/socketrelay/my-fulfillments`), and `resolveFulfillment(id, outcome)` (`POST /fulfillments/:id/close` with `x-ctf-csrf` + `{ outcome }`; surfaces the server message on failure).
- **`SocketRelayDirectLines.tsx`** (new) — the member's Direct Lines list with request-title + role context. The four resolve actions (Mark successful / No longer needed / Didn't work — reopen / Didn't work — close) show **only when the member is the requester and the fulfillment is active**; helpers see a "only the requester can close" note. Refreshes on success, errors surfaced. Decomposed into a `DirectLineCard` per rule 116.
- **`SocketRelay.tsx`** — new "Lines" bottom-nav tab, passing `useAuth().user.id` as `currentUserId` (UI gating only; the route independently enforces requester/admin).

**Not mirrored (intentional):** the web embeds a Stream chat pane beside the resolve bar; the mobile shell has no per-fulfillment chat wired into this surface, so the resolve controls live on the Lines list (the prescribed fallback). Per-conversation mobile chat can be a separate item.

Mobile typecheck + eslint clean. No schema/contract/money change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_