### PR TITLE
docs: open a follow-up PR when a PR merges with unaddressed CodeRabbit findings

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -251,6 +251,16 @@ migrations, new or changed API contracts, new stateful logic, a whole new plugin
 Net effect: **low-risk = ready + auto-merge (completes itself); risky = draft + label (workflow makes it
 ready hourly, owner merges after reading the review).**
 
+#### If a PR merges with unaddressed CodeRabbit actionable findings, open a follow-up PR (always)
+
+CodeRabbit's actionable findings are wanted, not optional. If a PR is merged (often accidentally, via
+auto-merge or a quick owner merge) **before** its CodeRabbit actionable items were applied, the agent
+**must open a small follow-up PR** that applies the still-valid findings — never leave them dropped on
+the floor (owner directive, 2026-06-19). Verify each finding against the merged code first: apply the
+ones that still hold, skip any that no longer apply with a one-line reason, keep the change minimal,
+and reference the original PR. (Worked example: #624 merged with five findings → follow-up #628 applied
+the resolve atomicity guard, error handling, a11y button, contract `dataAccess`, and the wording fix.)
+
 ### Updating `PRODUCTION_READINESS_PLAN.md` (avoid change-log merge conflicts)
 
 When several plugin PRs are open at once, all appending narrative to the **same** change-log section


### PR DESCRIPTION
Owner directive (2026-06-19): CodeRabbit's actionable findings are wanted, not optional. When a PR is merged — often accidentally, via auto-merge or a quick merge — **before** its CodeRabbit items were applied, agents must open a small follow-up PR that applies the still-valid findings, rather than dropping them.

Added this to the CodeRabbit workflow rules (`.github/instructions/copilot-instructions.md`), with the verify-then-apply guidance and the #624 → #628 worked example, so every agent follows it.

Docs only.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_