### PR TITLE
fix: connect plugin Direct Line chat by using one channel id key

### DIFF
--- a/ctf/docs/quota-impact/2026-06-19-chat-channel-id-key-consolidation.md
+++ b/ctf/docs/quota-impact/2026-06-19-chat-channel-id-key-consolidation.md
@@ -1,0 +1,61 @@
+# Stream Quota Impact Note
+
+## Summary
+
+- Feature/Change: Consolidate the chat channel id on one response key (`streamChannelId`) across
+  SocketRelay, LightHouse, and TrustTransport chat routes and their web/mobile clients. The routes
+  previously returned the channel id under `channelId` while every web client read `streamChannelId`,
+  so the web chat tabs fell back to the bare row id (a fulfillment/match/trip UUID), which is not a
+  Stream channel — `watch()` failed and the panel showed "Failed to connect to chat." Now the routes
+  return only `streamChannelId` and all clients read that one key.
+- PR: fix/stream-chat-channel-id-key
+- Owner: platform
+- Date: 2026-06-19
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: Chat only (plugin-paired "Direct Line" threads for
+  SocketRelay, LightHouse, TrustTransport). No Activity Feeds, Video, or AI Moderation changes.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: None on its own. This is a bug fix to a key name in an existing response;
+  it does not create users or channels beyond what the already-shipped flows create. The only behavior
+  change is that the web chat tabs now connect to the channel they were always meant to connect to
+  (it was failing before), so there is no new channel creation — the channels were already created
+  server-side; only the client connection was broken.
+- Activity Feed API calls estimate: 0 (no feed changes).
+- Video participant-minutes estimate: 0 (no video).
+- AI Moderation credits estimate: 0 (no moderation changes).
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): Green. No new Stream object creation;
+  the fix lets existing channels be watched instead of erroring.
+- Peak scenario estimate: Bounded by existing fulfillment/match/trip volume, which is unchanged by
+  this PR.
+
+## Fallback and Degradation Plan
+
+- What degrades first: If `streamChannelId` is ever absent from the response (e.g. Stream
+  credentials unconfigured server-side, so `ensureChannel` returns null), the web clients now render
+  nothing for the chat body and the surrounding loading/error states still apply — they no longer
+  attempt to watch an invalid bare-id channel and surface a misleading "Failed to connect to chat."
+- User-visible messaging behavior: When the channel id is present (normal case) chat connects; when
+  Stream is unconfigured the route returns the existing "Unable to create chat channel" error path.
+- Kill switch / feature flag: Stream remains gated by the presence of server-side Stream credentials
+  (`resolveStreamCredentials` returns null when unset); unchanged by this PR.
+
+## Observability
+
+- Metrics and alerts added/updated: None added. Existing `reportError` calls on the chat routes
+  (areas `socketrelay`, `lighthouse`, `trusttransport`) are unchanged.
+- Dashboard link (if available): n/a.
+
+## Validation
+
+- Tests added for degraded mode: Manual — the web clients now only mount `StreamChatPanel` when both
+  `streamApiKey` and `streamChannelId` are present, so a missing channel id no longer reaches
+  `watch()`. Typecheck and lint pass.
+- Rollback strategy: Revert the PR; the prior `channelId`-only responses are restored. No data or
+  schema changes are involved.

--- a/ctf/packages/mobile/src/features/lighthouse/fetchLighthouseStreamCredentials.ts
+++ b/ctf/packages/mobile/src/features/lighthouse/fetchLighthouseStreamCredentials.ts
@@ -33,7 +33,6 @@ export async function fetchLighthouseStreamCredentials(): Promise<LighthouseStre
     streamApiKey: data.streamApiKey,
     streamToken: data.streamToken,
     streamUserId: data.streamUserId,
-    // The route returns the channel id as `channelId`.
-    streamChannelId: data.channelId,
+    streamChannelId: data.streamChannelId,
   };
 }

--- a/ctf/packages/mobile/src/features/socketrelay/fetchSocketRelayStreamCredentials.ts
+++ b/ctf/packages/mobile/src/features/socketrelay/fetchSocketRelayStreamCredentials.ts
@@ -39,7 +39,6 @@ export async function fetchSocketRelayStreamCredentials(): Promise<SocketRelaySt
     streamApiKey: data.streamApiKey,
     streamToken: data.streamToken,
     streamUserId: data.streamUserId,
-    // The route returns the channel id as `channelId`.
-    streamChannelId: data.channelId,
+    streamChannelId: data.streamChannelId,
   };
 }

--- a/ctf/packages/mobile/src/features/trusttransport/fetchTrustTransportStreamCredentials.ts
+++ b/ctf/packages/mobile/src/features/trusttransport/fetchTrustTransportStreamCredentials.ts
@@ -1,6 +1,6 @@
 // Stream chat credentials for a trip thread. A trip is text chat only — there is no video.
 // The web route is POST /api/trusttransport/trips/[tripId]/chat; it returns
-// { ok, channelId, streamApiKey, streamUserId, streamToken }, mapped here to the
+// { ok, streamChannelId, streamApiKey, streamUserId, streamToken }, mapped here to the
 // shape the Stream client components consume. Goes through authedFetch so the
 // Clerk bearer token is attached and the base URL comes from runtime config.
 import { Platform } from 'react-native';
@@ -16,7 +16,6 @@ export interface TrustTransportStreamCredentials {
 type TripChatResponse = {
   ok: boolean;
   message?: string;
-  channelId?: string;
   streamChannelId?: string;
   streamApiKey: string;
   streamUserId: string;
@@ -35,7 +34,7 @@ export async function fetchTrustTransportStreamCredentials(tripId: string): Prom
   if (!data.ok) {
     throw new Error(data.message || 'Unable to load TrustTransport chat credentials');
   }
-  const chatChannelId = data.streamChannelId ?? data.channelId;
+  const chatChannelId = data.streamChannelId;
   if (!chatChannelId) {
     throw new Error('TrustTransport chat credentials response is missing the channel id');
   }

--- a/ctf/packages/web/app/api/lighthouse/matches/[matchId]/chat/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/[matchId]/chat/route.ts
@@ -26,14 +26,14 @@ export async function POST(_request: Request, { params }: { params: Promise<{ ma
   }
 
   try {
-    const channelId = await ensureLighthouseMatchChannel({
+    const streamChannelId = await ensureLighthouseMatchChannel({
       matchId: match.id,
       seekerUserId: match.seekerUserId,
       seekerDisplayName: buildIdentityDisplayName(null, match.seekerUserId),
       hostUserId: match.hostUserId,
       hostDisplayName: buildIdentityDisplayName(null, match.hostUserId),
     });
-    if (!channelId) {
+    if (!streamChannelId) {
       return NextResponse.json({ ok: false, message: 'Unable to create chat channel' }, { status: 500 });
     }
     const credentials = await createLighthouseParticipantToken(
@@ -43,7 +43,9 @@ export async function POST(_request: Request, { params }: { params: Promise<{ ma
     if (!credentials) {
       return NextResponse.json({ ok: false, message: 'Unable to create participant token' }, { status: 500 });
     }
-    return NextResponse.json({ ok: true, channelId, ...credentials });
+    // Single canonical key: `streamChannelId` is the real Stream channel id. Web and mobile both
+    // read this one key.
+    return NextResponse.json({ ok: true, streamChannelId, ...credentials });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
     reportError(e, { area: 'lighthouse', op: 'matches_matchid_chat' });

--- a/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/chat/route.ts
+++ b/ctf/packages/web/app/api/socketrelay/fulfillments/[id]/chat/route.ts
@@ -24,14 +24,14 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
   }
 
   try {
-    const channelId = await ensureSocketRelayFulfillmentChannel({
+    const streamChannelId = await ensureSocketRelayFulfillmentChannel({
       fulfillmentId: fulfillment.id,
       requesterUserId: fulfillment.requesterUserId,
       requesterDisplayName: buildIdentityDisplayName(null, fulfillment.requesterUserId),
       fulfillerUserId: fulfillment.fulfillerUserId,
       fulfillerDisplayName: buildIdentityDisplayName(null, fulfillment.fulfillerUserId),
     });
-    if (!channelId) {
+    if (!streamChannelId) {
       return NextResponse.json({ ok: false, message: 'Unable to create chat channel' }, { status: 500 });
     }
     const credentials = await createSocketRelayParticipantToken(
@@ -41,7 +41,9 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
     if (!credentials) {
       return NextResponse.json({ ok: false, message: 'Unable to create participant token' }, { status: 500 });
     }
-    return NextResponse.json({ ok: true, channelId, ...credentials });
+    // Single canonical key: `streamChannelId` is the real Stream channel id
+    // (`socketrelay-fulfillment-<id>`). Web and mobile both read this one key.
+    return NextResponse.json({ ok: true, streamChannelId, ...credentials });
   } catch (error: unknown) {
     reportError(error, { area: 'socketrelay', op: 'fulfillments_id_chat' });
     const message = error instanceof Error ? error.message : 'Error creating chat channel';

--- a/ctf/packages/web/app/api/trusttransport/trips/[tripId]/chat/route.ts
+++ b/ctf/packages/web/app/api/trusttransport/trips/[tripId]/chat/route.ts
@@ -23,22 +23,21 @@ export async function POST(_request: Request, { params }: { params: Promise<{ tr
   }
 
   try {
-    const channelId = await ensureTrustTransportTripChannel({
+    const streamChannelId = await ensureTrustTransportTripChannel({
       tripId: trip.id,
       requesterUserId: trip.requesterUserId,
       providerUserId: trip.providerUserId,
     });
-    if (!channelId) {
+    if (!streamChannelId) {
       return NextResponse.json({ ok: false, message: 'Unable to create chat channel' }, { status: 500 });
     }
     const credentials = await createTrustTransportParticipantToken(userId);
     if (!credentials) {
       return NextResponse.json({ ok: false, message: 'Unable to create participant token' }, { status: 500 });
     }
-    // `streamChannelId` is returned (in addition to `channelId`) so the web chat tab connects to the
-    // real trip channel instead of falling back to the raw trip id. A trip is text chat only — there is
-    // deliberately no video room (the transport plugin does not do video).
-    return NextResponse.json({ ok: true, channelId, streamChannelId: channelId, ...credentials });
+    // Single canonical key: `streamChannelId` is the real Stream channel id. Web and mobile both read
+    // this one key. A trip is text chat only — there is deliberately no video room.
+    return NextResponse.json({ ok: true, streamChannelId, ...credentials });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
     reportError(e, { area: 'trusttransport', op: 'trips_tripid_chat' });

--- a/ctf/packages/web/components/foundation/Foundation.tsx
+++ b/ctf/packages/web/components/foundation/Foundation.tsx
@@ -100,14 +100,14 @@ export function Foundation() {
         {connectionStatus && <div style={{ marginTop: 12 }}>{connectionStatus}</div>}
         {chatLoading && <div>Loading chat…</div>}
         {chatError && <div style={{ color: 'red' }}>{chatError}</div>}
-        {chatCredentials && (
+        {chatCredentials?.streamChannelId && (
           <div style={{ marginTop: 24 }}>
             <h3>Live Chat</h3>
             <StreamChatPanel
               streamApiKey={chatCredentials.streamApiKey}
               streamToken={chatCredentials.streamToken}
               streamUserId={chatCredentials.streamUserId}
-              streamChannelId={chatCredentials.streamChannelId || ''}
+              streamChannelId={chatCredentials.streamChannelId}
             />
           </div>
         )}

--- a/ctf/packages/web/components/lighthouse/lighthouse-chat.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-chat.tsx
@@ -45,12 +45,12 @@ export function LighthouseChat({
           <div>Loading chat…</div>
         ) : chatError ? (
           <div style={{ color: "#EF4444" }}>{chatError}</div>
-        ) : chatCredentials ? (
+        ) : chatCredentials?.streamChannelId ? (
           <StreamChatPanel
             streamApiKey={chatCredentials.streamApiKey}
             streamToken={chatCredentials.streamToken}
             streamUserId={chatCredentials.streamUserId}
-            streamChannelId={chatCredentials.streamChannelId || selectedMatch.id}
+            streamChannelId={chatCredentials.streamChannelId}
           />
         ) : null}
       </div>

--- a/ctf/packages/web/components/socketrelay/sr-chat.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-chat.tsx
@@ -86,12 +86,12 @@ function ChatPane({
           <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: SUBTLE, fontSize: 14 }}>Loading chat…</div>
         ) : chatError ? (
           <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF4444", fontSize: 14 }}>{chatError}</div>
-        ) : chatCredentials?.streamApiKey ? (
+        ) : chatCredentials?.streamApiKey && chatCredentials.streamChannelId ? (
           <StreamChatPanel
             streamApiKey={chatCredentials.streamApiKey}
             streamToken={chatCredentials.streamToken as string}
             streamUserId={chatCredentials.streamUserId as string}
-            streamChannelId={chatCredentials.streamChannelId || selected.id}
+            streamChannelId={chatCredentials.streamChannelId}
           />
         ) : (
           <div style={{ flex: 1 }} />

--- a/ctf/packages/web/components/trusttransport/tt-chat-tab.tsx
+++ b/ctf/packages/web/components/trusttransport/tt-chat-tab.tsx
@@ -38,13 +38,13 @@ function ChatPane({ selected, creds, loading, error }: { selected: TripRequest |
   if (error) {
     return <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF4444", fontSize: 14, padding: 24, textAlign: "center" }}>{error}</div>;
   }
-  if (creds) {
+  if (creds?.streamChannelId) {
     return (
       <StreamChatPanel
         streamApiKey={creds.streamApiKey}
         streamToken={creds.streamToken}
         streamUserId={creds.streamUserId}
-        streamChannelId={creds.streamChannelId ?? selected.id}
+        streamChannelId={creds.streamChannelId}
       />
     );
   }


### PR DESCRIPTION
## What was broken

On the web, the SocketRelay / LightHouse / TrustTransport "Direct Line" chat showed **"Failed to connect to chat."**

The chat routes returned the Stream channel id under the key `channelId`, but every web chat client read `streamChannelId` and, when it was missing, fell back to the bare row id (a fulfillment / match / trip UUID). A bare UUID is not a Stream channel, so `watch()` failed and the panel errored. The mobile apps read `channelId` directly — so web and mobile had quietly diverged on two different key names for the same value.

## The fix

Standardize on one key everywhere: `streamChannelId` (the name the shared `StreamChatPanel` prop and the feed/stream lib already use).

- The three chat routes now return only `streamChannelId`.
- The mobile fetchers read `streamChannelId`.
- The web clients drop the misleading bare-id fallback and only mount the chat panel once a real channel id is present, so a missing id can no longer silently produce a phantom-channel connect failure.

Foundation already used `streamChannelId` end to end and is unchanged except for the same render guard.

Verified: web and mobile typecheck clean, web and mobile lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_