### PR TITLE
fix: make the account hub scroll on desktop

### DIFF
--- a/ctf/packages/web/components/account/account-hub-shell.tsx
+++ b/ctf/packages/web/components/account/account-hub-shell.tsx
@@ -34,7 +34,7 @@ export function AccountHubShell({ username, trust }: { username: string | null; 
   };
 
   return (
-    <div style={{ minHeight: '100dvh', overflowY: 'auto', background: tok.BG, color: tok.TEXT, fontFamily: "'Inter',system-ui,-apple-system,sans-serif" }}>
+    <div style={{ height: '100dvh', overflowY: 'auto', background: tok.BG, color: tok.TEXT, fontFamily: "'Inter',system-ui,-apple-system,sans-serif" }}>
       <div style={{ maxWidth: 720, margin: '0 auto', padding: '32px 20px 64px' }}>
         <header style={{ marginBottom: 24 }}>
           <h1 style={{ fontSize: 24, fontWeight: 800, margin: '0 0 6px' }}>Your account</h1>


### PR DESCRIPTION
## What was broken

On desktop, `/account` could not scroll, so everything below the fold (Manage your profile, Data & privacy) was unreachable.

The document is intentionally locked on desktop (`html, body { height: 100vh; overflow: hidden }`) so each screen owns its own scrolling. The account hub's outer container used `minHeight: 100dvh` with `overflowY: auto` — but `minHeight` lets the container grow to fit its content, so `overflowY: auto` never had a constrained height to scroll within, and the body clipped the overflow.

## The fix

Use a fixed `height: 100dvh` for the scroll container so it is exactly one viewport tall and scrolls its own content. This matches the already-working account-data screen, which uses the same fixed-height + inner-scroll pattern. Mobile is unaffected (it still scrolls internally).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_