### PR TITLE
fix: make plugin screens scroll on desktop

### DIFF
--- a/ctf/packages/web/components/clicklog/clicklog-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-shell.tsx
@@ -187,11 +187,11 @@ export function ClicklogShell() {
   }
 
   return (
-    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100dvh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
       <ClicklogIconRail />
       <ClicklogSidebar total={stats.total} weekdayCounts={stats.weekdayCounts} />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <AlertTriangle size={18} color={t.ACCENT} />
           <div style={{ flex: 1 }}>
@@ -200,7 +200,7 @@ export function ClicklogShell() {
           </div>
         </header>
 
-        <div style={{ flex: 1, overflowY: "auto", padding: "32px 48px" }}>
+        <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: "32px 48px" }}>
           {content}
         </div>
       </div>

--- a/ctf/packages/web/components/directory/directory-admin-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-admin-shell.tsx
@@ -465,7 +465,7 @@ export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }
 
   // ── Desktop layout ───────────────────────────────────────────────────────
   return (
-    <div style={{ display: "flex", height: "100vh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100dvh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
       {/* Icon rail */}
       <aside style={{ width: 72, background: "#090B0F", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
         <Link href="/apps/directory" aria-label="Back to Directory" style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}25`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12, color: COLOR }}>

--- a/ctf/packages/web/components/directory/directory-browse.tsx
+++ b/ctf/packages/web/components/directory/directory-browse.tsx
@@ -31,7 +31,7 @@ export function DirectoryBrowse({
   }
 
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: isMobile ? "16px" : "24px" }}>
         {rewardCard && rewardCard.isActive && (
           <a href={rewardCard.ctaUrl} style={{ display: "block", marginBottom: 16, padding: "18px 22px", borderRadius: 14, background: `${SKILLS_HUNT_COLOR}10`, border: `1px solid ${SKILLS_HUNT_COLOR}30`, textDecoration: "none", color: "inherit" }}>

--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -230,7 +230,7 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       {/* Icon rail */}
       <aside style={{ width: 72, background: t.RAIL, borderRight: `1px solid ${t.BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
         <div style={{ width: 40, height: 40, borderRadius: 12, background: `${t.ACCENT}30`, border: `1px solid ${t.ACCENT}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12 }}>
@@ -286,7 +286,7 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
       </aside>
 
       {/* Main */}
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <BookOpen size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>

--- a/ctf/packages/web/components/foundation/foundation-offer-skills.tsx
+++ b/ctf/packages/web/components/foundation/foundation-offer-skills.tsx
@@ -68,7 +68,7 @@ export function OfferSkillsPanel() {
   const offeredCount = skills.filter((s) => s.offered).length;
 
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <div style={{ marginBottom: 20, padding: "20px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(239,68,68,0.05) 100%)`, border: `1px solid ${COLOR}20` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>

--- a/ctf/packages/web/components/foundation/foundation-panels.tsx
+++ b/ctf/packages/web/components/foundation/foundation-panels.tsx
@@ -37,7 +37,7 @@ export function BrowsePanel({
       : null);
 
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <div style={{ marginBottom: 20, padding: "20px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(239,68,68,0.05) 100%)`, border: `1px solid ${COLOR}20` }}>
           <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Find providers offering a skill</div>
@@ -107,7 +107,7 @@ export function QuotesPanel({
   onBrowse: () => void;
 }) {
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>My Quote Requests</div>
         <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>Track your service requests and responses</div>

--- a/ctf/packages/web/components/foundation/foundation-panels.tsx
+++ b/ctf/packages/web/components/foundation/foundation-panels.tsx
@@ -165,8 +165,8 @@ export function ChatPanel({
   onBrowse: () => void;
 }) {
   return (
-    <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
-      <ScrollArea style={{ flex: 1, padding: "16px 24px" }}>
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+      <ScrollArea style={{ flex: 1, minHeight: 0, padding: "16px 24px" }}>
         <div style={{ paddingBottom: 8 }}>
           {INFO_MSGS.map((msg) => (
             <div key={msg.id} style={{ display: "flex", gap: 10, alignItems: "flex-end", marginBottom: 12 }}>

--- a/ctf/packages/web/components/foundation/foundation-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-shell.tsx
@@ -191,10 +191,10 @@ export function FoundationShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: FONT, color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: FONT, color: t.TEXT, display: "flex" }}>
       <IconRail tab={tab} onTab={setTab} />
       <FilterSidebar query={query} onQuery={setQuery} trade={trade} onTrade={setTrade} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <Hammer size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>

--- a/ctf/packages/web/components/gdp/gdp-dashboard.tsx
+++ b/ctf/packages/web/components/gdp/gdp-dashboard.tsx
@@ -129,7 +129,7 @@ export function GdpDashboard({
   const hasSectors = sectors.length > 0;
   const hasCountries = countries.length > 0;
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <GdpHero metrics={metrics} />
         <div style={{ display: "grid", gridTemplateColumns: hasSectors && hasCountries ? "3fr 2fr" : "1fr", gap: 20 }}>

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -149,10 +149,10 @@ export default function GdpShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <GdpIconRail tab={tab} onTab={setTab} />
       <GdpSidebar metrics={metrics} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <ShellHeader t={t} metrics={metrics} />
         <GdpContent t={t} error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
       </div>

--- a/ctf/packages/web/components/gentlepulse/gentlepulse-shell.tsx
+++ b/ctf/packages/web/components/gentlepulse/gentlepulse-shell.tsx
@@ -147,7 +147,7 @@ export function GentlePulseShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <GentlePulseIconRail tab={tab} onTab={setTab} />
       <GentlePulseSidebar
         categories={categories}
@@ -157,7 +157,7 @@ export function GentlePulseShell() {
         favoriteCount={favorites.size}
       />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <Heart size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>

--- a/ctf/packages/web/components/gentlepulse/gp-sessions.tsx
+++ b/ctf/packages/web/components/gentlepulse/gp-sessions.tsx
@@ -82,7 +82,7 @@ export function GentlePulseSessions({
   onToggleFavorite: (id: string, isFav: boolean) => void;
 }) {
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <div style={{ marginBottom: 20, padding: "20px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(20,184,166,0.03) 100%)`, border: `1px solid ${COLOR}20` }}>
           <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Your Space to Breathe</div>

--- a/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
@@ -172,11 +172,11 @@ export function LighthouseShell({ userId, username }: { userId: string; username
   }
 
   return (
-    <div style={{ width: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <LighthouseIconRail tab={tab} onTab={setTab} />
       <LighthouseFilterSidebar properties={properties} search={search} onSearch={setSearch} filter={filter} onFilter={setFilter} />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <div style={{ flex: 1 }}>
             <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>🏠 LightHouse — Safe Housing</div>
@@ -185,7 +185,7 @@ export function LighthouseShell({ userId, username }: { userId: string; username
           <span style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>✓ Privacy Protected</span>
         </header>
 
-        <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflowY: "auto" }}>
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflowY: "auto", minHeight: 0 }}>
           {content}
         </div>
       </div>

--- a/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
@@ -222,10 +222,10 @@ export function PeerProgrammingShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <PeerProgrammingIconRail tab={tab} onTab={setTab} />
       <PeerProgrammingSidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <ShellHeader active={Boolean(room?.cohortId)} t={t} />
         {content}
       </div>

--- a/ctf/packages/web/components/peer-programming/pp-cohorts-tab.tsx
+++ b/ctf/packages/web/components/peer-programming/pp-cohorts-tab.tsx
@@ -71,7 +71,7 @@ export function PeerProgrammingCohortsTab({
   feedback: FeedbackFormProps;
 }) {
   return (
-    <div style={{ flex: 1, overflowY: "auto", padding: 24 }}>
+    <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: 24 }}>
       <div style={{ marginBottom: 20, padding: "18px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(139,92,246,0.05) 100%)`, border: `1px solid ${COLOR}25` }}>
         <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Weekly Global Masterminds</div>
         <div style={{ fontSize: 14, color: "#9CA3AF" }}>Deterministic placement — you always get a cohort. No one left behind.</div>

--- a/ctf/packages/web/components/peer-programming/pp-session-tab.tsx
+++ b/ctf/packages/web/components/peer-programming/pp-session-tab.tsx
@@ -42,7 +42,7 @@ export function PeerProgrammingSessionTab({ room, participants }: { room: Room |
   }
 
   return (
-    <div style={{ flex: 1, padding: 24, overflowY: "auto" }}>
+    <div style={{ flex: 1, padding: 24, overflowY: "auto", minHeight: 0 }}>
       <div style={{ marginBottom: 20, padding: "18px 24px", borderRadius: 16, background: `linear-gradient(135deg,${COLOR}15 0%,rgba(139,92,246,0.05) 100%)`, border: `1px solid ${COLOR}25` }}>
         <div style={{ fontSize: 20, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Live Session</div>
         <div style={{ fontSize: 14, color: "#9CA3AF" }}>{room?.name || "Your Cohort"} · {participants.length} participants</div>

--- a/ctf/packages/web/components/service-credits/sc-circulation-tab.tsx
+++ b/ctf/packages/web/components/service-credits/sc-circulation-tab.tsx
@@ -65,7 +65,7 @@ export function ServiceCreditsCirculationTab() {
   }, []);
 
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <div style={{ fontSize: 18, fontWeight: 700, color: "#F9FAFB", marginBottom: 4 }}>The economy</div>
         <div style={{ fontSize: 13, color: "#6B7280", lineHeight: 1.6, marginBottom: 20 }}>

--- a/ctf/packages/web/components/service-credits/sc-earn-tab.tsx
+++ b/ctf/packages/web/components/service-credits/sc-earn-tab.tsx
@@ -11,7 +11,7 @@ import { PEER_TO_PEER_AREAS, PLATFORM_EARN_METHODS } from "./service-credits.con
 // being paid by another member. Platform-reward cards link to where they happen.
 export function ServiceCreditsEarnTab() {
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Earn ServiceCredits</div>
         <div style={{ fontSize: 14, color: "#6B7280", marginBottom: 20 }}>A few rewards come from the platform. The rest you earn from other members.</div>

--- a/ctf/packages/web/components/service-credits/sc-wallet-tab.tsx
+++ b/ctf/packages/web/components/service-credits/sc-wallet-tab.tsx
@@ -49,7 +49,7 @@ function TransactionsEmpty() {
 
 export function ServiceCreditsWalletTab({ balance, escrow }: { balance: number; escrow: number }) {
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "24px" }}>
         <BalanceCard balance={balance} />
         <StatsRow balance={balance} escrow={escrow} />

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -110,10 +110,10 @@ export function ServiceCreditsShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <ServiceCreditsIconRail tab={tab} onTab={setTab} />
       <ServiceCreditsSidebar tab={tab} onTab={setTab} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <ShellHeader balance={balance} t={t} />
         {content}
       </div>

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { SkillsHuntRound, SkillsHuntSubmission, SkillsHuntSubmissionStatus } from "lib/skills-hunt/types";
 import { COLOR, promptRejectReason, type ReviewAction } from "./sha-shared";
 import { SkillsHuntAdminFilters, SkillsHuntAdminBulkBar } from "./sha-filters";
@@ -22,6 +23,7 @@ function AdminHeader() {
 }
 
 export function SkillsHuntAdminShell({ rounds }: Props) {
+  const isMobile = useIsMobile();
   const [activeRoundId, setActiveRoundId] = useState<string | null>(rounds[0]?.id ?? null);
   const [statusFilter, setStatusFilter] = useState<SkillsHuntSubmissionStatus>("pending");
   const [submissions, setSubmissions] = useState<SkillsHuntSubmission[]>([]);
@@ -112,7 +114,7 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
   const allPendingSelected = pendingCount > 0 && selected.size === pendingCount;
 
   return (
-    <div style={{ minHeight: "100vh", background: "#0F1117", color: "#E8EAF0", fontFamily: "'Inter', system-ui, sans-serif", padding: "clamp(12px, 4vw, 24px)" }}>
+    <div style={{ ...(isMobile ? { minHeight: "100vh" } : { height: "100dvh", overflowY: "auto" }), background: "#0F1117", color: "#E8EAF0", fontFamily: "'Inter', system-ui, sans-serif", padding: "clamp(12px, 4vw, 24px)" }}>
       <AdminHeader />
       <SkillsHuntCreateRound />
       {rounds.length === 0 ? (

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -287,15 +287,15 @@ export function SkillsHuntShell({
   }
 
   return (
-    <div style={{ position: "relative", width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ position: "relative", width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <SkillsHuntIconRail tab={tab} onTab={setTab} notifOpen={notifOpen} onToggleNotif={() => setNotifOpen((o) => !o)} unreadCount={unreadCount} />
       {notifOpen && (
         <SkillsHuntNotifications notifications={notifications} onClose={() => setNotifOpen(false)} onMarkRead={(id) => void markRead(id)} />
       )}
       <SkillsHuntSidebar tab={tab} onTab={setTab} achievements={achievements} currentUserEntry={currentUserEntry} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <ShellHeader t={t} activeRound={activeRound} />
-        <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
+        <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: "24px" }}>
           {content}
         </div>
       </div>

--- a/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
@@ -342,7 +342,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
   }
 
   return (
-    <div style={{ width: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <SocketRelayIconRail tab={tab} onTab={setTab} />
       <SocketRelaySidebar
         categories={categories}
@@ -355,7 +355,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
         fulfillmentCount={fulfillments.length}
       />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <Share2 size={18} style={{ color: t.ACCENT }} />
           <div style={{ flex: 1 }}>

--- a/ctf/packages/web/components/socketrelay/sr-feed.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-feed.tsx
@@ -87,7 +87,7 @@ export function SocketRelayFeed({
   onEdit: (request: SrRequest) => void;
 }) {
   return (
-    <ScrollArea style={{ flex: 1 }}>
+    <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "20px 24px" }}>
         {requests.length === 0 ? (
           <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>

--- a/ctf/packages/web/components/socketrelay/sr-post.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-post.tsx
@@ -119,7 +119,7 @@ export function SocketRelayPost({
     onChange(needsAmount ? { priceCurrency: code, requiresAmount: true } : { priceCurrency: code, priceAmount: "", requiresAmount: false });
   }
   return (
-    <div style={{ flex: 1, padding: "32px 40px", overflowY: "auto" }}>
+    <div style={{ flex: 1, padding: "32px 40px", overflowY: "auto", minHeight: 0 }}>
       <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 20 }}>{editing ? "Edit Your Request" : "Post a Request"}</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 14, maxWidth: 620 }}>
         <FormField label="Title">

--- a/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
+++ b/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
@@ -247,10 +247,10 @@ export function TrustTransportShell() {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
+    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
       <TrustTransportIconRail tab={tab} onTab={setTab} />
       <TrustTransportSidebar rideTypes={rideTypes} rideType={rideType} onRideType={setRideType} requests={requests} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <ShellHeader t={t} />
         {content}
       </div>

--- a/ctf/packages/web/components/trusttransport/tt-book-tab.tsx
+++ b/ctf/packages/web/components/trusttransport/tt-book-tab.tsx
@@ -47,8 +47,8 @@ export function TrustTransportBookTab(props: BookTabProps) {
   const parsedAmount = Number(priceAmount);
   const hasValidAmount = !requiresAmount || (Number.isFinite(parsedAmount) && parsedAmount > 0);
   return (
-    <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
-      <div style={{ flex: 1, padding: "24px", display: "flex", flexDirection: "column", gap: 16, overflowY: "auto" }}>
+    <div style={{ flex: 1, display: "flex", overflow: "hidden", minHeight: 0 }}>
+      <div style={{ flex: 1, padding: "24px", display: "flex", flexDirection: "column", gap: 16, overflowY: "auto", minHeight: 0 }}>
         <div style={{ padding: "20px 24px", borderRadius: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}20` }}>
           <div style={{ fontSize: 18, fontWeight: 800, color: "#F9FAFB", marginBottom: 4 }}>Book a {name}</div>
           <div style={{ fontSize: 13, color: "#9CA3AF" }}>Community mutual aid · Trauma-informed · Service Credits accepted</div>

--- a/ctf/packages/web/components/trusttransport/tt-tracking-tab.tsx
+++ b/ctf/packages/web/components/trusttransport/tt-tracking-tab.tsx
@@ -69,7 +69,7 @@ export function TrustTransportTrackingTab({
   onChat: (r: TripRequest) => void;
 }) {
   return (
-    <div style={{ flex: 1, padding: "24px", overflowY: "auto" }}>
+    <div style={{ flex: 1, padding: "24px", overflowY: "auto", minHeight: 0 }}>
       <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 20 }}>Tracking</div>
       {requests.length === 0
         ? <TrackingEmpty onBook={onBook} />

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
@@ -154,7 +154,7 @@ export function WeeklyPerformanceShell({ isAdmin }: WeeklyPerformanceShellProps)
   }
 
   return (
-    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
+    <div style={{ display: "flex", height: "100dvh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
       <WeeklyPerformanceIconRail />
       <WeeklyPerformanceSidebar
         weeks={weeks}

--- a/ctf/packages/web/components/weekly-performance/wp-admin-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-admin-shell.tsx
@@ -242,7 +242,10 @@ export function WeeklyPerformanceAdminShell() {
   return (
     <main
       style={{
-        minHeight: "100vh",
+        // Mobile relies on the document scrolling, so keep minHeight there. On
+        // desktop the document is locked (globals.css), so bound this surface to
+        // one viewport and let it scroll its own content.
+        ...(isMobile ? { minHeight: "100vh" } : { height: "100dvh", overflowY: "auto" }),
         background: BG,
         color: TEXT,
         fontFamily: "'Inter', system-ui, sans-serif",

--- a/ctf/packages/web/components/weekly-performance/wp-dashboard-main.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-dashboard-main.tsx
@@ -23,7 +23,7 @@ export function WeeklyPerformanceDashboardMain({
 }) {
   const live = isLiveWeek(week);
   return (
-    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
       {/* The phone shell already renders the title, the week selector, and an Export
           button in its own sticky header, so this desktop header is redundant — and
           its fixed flex row squeezes the title on a narrow screen. Show it on desktop
@@ -49,7 +49,7 @@ export function WeeklyPerformanceDashboardMain({
       {metrics.length === 0 ? (
         <WeeklyPerformanceEmptyMain week={week} />
       ) : (
-        <div style={{ flex: 1, overflowY: "auto", padding: "24px" }}>
+        <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: "24px" }}>
           <WeeklyPerformanceMetricCards metrics={metrics} comparison={comparison} />
           <WeeklyPerformanceComparisonChart comparison={comparison} />
         </div>

--- a/ctf/packages/web/components/weekly-performance/wp-empty-main.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-empty-main.tsx
@@ -9,7 +9,7 @@ import { BORDER, BRAND, SUBTLE, SURFACE, TEXT, type WpWeek, formatWeekRange, isL
 export function WeeklyPerformanceEmptyMain({ week }: { week: WpWeek | null }) {
   const inProgress = isLiveWeek(week);
   return (
-    <div style={{ flex: 1, overflowY: "auto", padding: "40px 48px" }}>
+    <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: "40px 48px" }}>
       <div style={{ padding: "28px 32px", borderRadius: 16, background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 32 }}>
         <div style={{ textAlign: "center", padding: "32px 0", display: "flex", flexDirection: "column", alignItems: "center", gap: 14 }}>
           <div style={{ width: 64, height: 64, borderRadius: 18, background: `${BRAND}10`, border: `1px dashed ${BRAND}25`, display: "flex", alignItems: "center", justifyContent: "center" }}>


### PR DESCRIPTION
## What was broken

On desktop, many plugin screens could not scroll — anything below the fold (more directory providers, more of a dashboard, etc.) was unreachable.

The document is intentionally locked on desktop (`html, body { height: 100vh; overflow: hidden }`) so each screen owns its own scrolling. But several shells set their desktop outer container to `minHeight: 100vh`, which grows with content instead of being bounded to one viewport, so the inner `overflow:auto` region never had a constrained height to scroll within and the body clipped everything past the fold.

## The fix

Across the plugin shells (and the content panels they render), apply the standard bounded scroll chain:
- desktop outer container → `height: 100dvh` + `overflow: hidden` (bounded to one viewport)
- the main content column → `minHeight: 0` (so the flex child can shrink below its content)
- the scroll leaf (a `ScrollArea` / `overflowY:auto` div) → `minHeight: 0` so it scrolls instead of overflowing

Single-column admin shells (weekly-performance, skills-hunt) keep document scrolling on mobile and scroll internally on desktop. Mobile branches and short centered loading/error views were left as-is.

Shells touched: directory, service-credits, skills-hunt (+admin), socketrelay, trusttransport, lighthouse, foundation, gdp, gentlepulse, peer-programming, weekly-performance (+admin), clicklog, directory-admin — plus their content tabs/panels.

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_