### PR TITLE
fix: Chyme lower-hand toggle, signed-out green branding, complete left rail

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-audio-room.tsx
+++ b/ctf/packages/web/components/chyme/chyme-audio-room.tsx
@@ -325,11 +325,15 @@ function ChymeAudioControls({ onLeave }: { onLeave: () => void }) {
       onToggleMute={() => void microphone.toggle()}
       handRaised={handRaised}
       onToggleHand={() => {
-        // Broadcast a raised-hand reaction to everyone in the room, then clear
-        // the local pressed state shortly after (the reaction is transient).
+        // A real toggle: lower if already raised, raise otherwise. Previously this only ever
+        // raised (and auto-cleared after 2.5s), so pressing "Lower Hand" did nothing.
+        if (handRaised) {
+          void call?.sendReaction({ type: 'lower_hand', emoji_code: ':hand:' });
+          setHandRaised(false);
+          return;
+        }
         void call?.sendReaction({ type: 'raised_hand', emoji_code: ':raised_hand:' });
         setHandRaised(true);
-        window.setTimeout(() => setHandRaised(false), 2500);
       }}
       joinReady
       onLeave={onLeave}

--- a/ctf/packages/web/components/chyme/chyme-public-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-public-shell.tsx
@@ -16,15 +16,18 @@ import {
 } from 'lucide-react';
 import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
 
-// Palette from the ChymePublic / MobileChymePublic design mockups.
-const BG = '#0F1117';
-const SURFACE = '#161B27';
-const BORDER = '#1E2A3A';
-const TEXT = '#F9FAFB';
+// Chyme's brand is green. The signed-out (guest) shell must look like the signed-in app, not a
+// different purple product — so these mirror the deep-green chrome from chyme-shared (page #04160A,
+// card #041a0b, divider #052e16, mint-white title) and the green accent. The old purple/cyan accent
+// made the guest view look like a separate app.
+const BG = '#04160A';
+const SURFACE = '#041a0b';
+const BORDER = '#052e16';
+const TEXT = '#F0FDF4';
 const SUBTLE = '#6B7280';
 const COLOR = '#22C55E';
-const ACCENT = '#7C3AED';
-const ACCENT_CYAN = '#0EA5E9';
+const ACCENT = '#22C55E';
+const ACCENT_CYAN = '#16A34A';
 
 // Locked participation controls shown on the desktop bottom bar. Each requires a
 // signed-in account, so for a visitor they render disabled with a lock glyph.

--- a/ctf/packages/web/components/chyme/chyme-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-shell.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, Radio } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import { ChymeLiveShell } from '@/components/chyme/chyme-live-shell';
+import { PluginRailFooter } from '@/components/shared/plugin-rail-footer';
 import { getChymeTokens } from './chyme-shared';
 
 type ChymeShellProps = {
@@ -58,34 +59,6 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
           flexShrink: 0,
         }}
       >
-        {/* Back button */}
-        <Link
-          href="/apps"
-          aria-label="Back to apps"
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: 10,
-            background: t.ACCENT_TINT_10,
-            border: `1px solid ${t.ACCENT_TINT_30}`,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: 'pointer',
-            color: t.ACCENT,
-            textDecoration: 'none',
-            transition: 'all 0.2s',
-          }}
-          onMouseEnter={(e) => {
-            (e.currentTarget as HTMLElement).style.background = t.ACCENT_TINT_15;
-          }}
-          onMouseLeave={(e) => {
-            (e.currentTarget as HTMLElement).style.background = t.ACCENT_TINT_10;
-          }}
-        >
-          <ChevronLeft size={20} />
-        </Link>
-
         {/* Chyme logo/icon */}
         <div
           style={{
@@ -103,6 +76,10 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
         >
           <Radio size={20} />
         </div>
+
+        {/* Shared bottom: back to all apps, account and settings, and the account avatar —
+            identical to every other plugin rail. */}
+        <PluginRailFooter />
       </aside>
 
       {/* Main Chyme component */}


### PR DESCRIPTION
Three Chyme fixes from desktop testing:

- **Lower Hand did nothing.** The control only ever *raised* a hand (sent a reaction, then auto-cleared after 2.5s), so pressing "Lower Hand" just re-raised. It's now a real toggle: raise when down, lower when up.
- **Signed-out Chyme looked like a different product.** The guest shell used a purple/cyan accent and neutral dark chrome, while signed-in Chyme is green. Recolored the guest shell to Chyme's green deep-green chrome so signed-out matches signed-in.
- **The desktop left rail was incomplete.** It only had a back button and the brand mark. It now uses the shared `PluginRailFooter` (back to all apps, account & settings, avatar), matching every other plugin rail.

Not included (separate, follow-up): making the default room publicly *listenable* when signed out — the main room is currently "Members-Only" so guests see "No public rooms streaming," which contradicts the "Free to listen" copy. That's a room-visibility/config change I'll handle separately.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_