### PR TITLE
fix: make the Chyme refresh button actually refresh

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-header.tsx
+++ b/ctf/packages/web/components/chyme/chyme-header.tsx
@@ -8,10 +8,12 @@ export function ChymeHeader({
   participantCount,
   isLive,
   onRefresh,
+  refreshing = false,
 }: {
   participantCount: number;
   isLive: boolean;
   onRefresh: () => void;
+  refreshing?: boolean;
 }) {
   const isMobile = useIsMobile();
 
@@ -44,10 +46,12 @@ export function ChymeHeader({
       </span>
       <button
         onClick={onRefresh}
-        style={{ width: 36, height: 36, borderRadius: 10, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: '#6B7280' }}
-        title="Refresh messages"
+        disabled={refreshing}
+        style={{ width: 36, height: 36, borderRadius: 10, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: refreshing ? 'wait' : 'pointer', color: '#6B7280' }}
+        title="Refresh the room and chat"
+        aria-label="Refresh the room and chat"
       >
-        <RefreshCw size={16} />
+        <RefreshCw size={16} className={refreshing ? 'animate-spin' : undefined} />
       </button>
     </header>
   );

--- a/ctf/packages/web/components/chyme/chyme-live-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-live-shell.tsx
@@ -24,6 +24,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
   const [joinInfo, setJoinInfo] = useState<ChymeJoinResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showChat, setShowChat] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
   const { theme } = useTheme();
@@ -58,9 +59,25 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  async function refreshMessages(): Promise<void> {
-    const payload = await requestJson<{ roomKey: string; messages: ChymeMessage[] }>('/api/chyme/messages?limit=50');
-    setMessages(payload.messages);
+  // Refresh BOTH the room (live status + participant count) and the chat. The button used to refresh
+  // only the messages, so when there were no new messages it looked like nothing happened and the
+  // participant count never updated. `refreshing` drives the spinning icon so the press is visible.
+  async function refreshRoomAndMessages(): Promise<void> {
+    if (refreshing) return;
+    setRefreshing(true);
+    setError(null);
+    try {
+      const [roomPayload, messagePayload] = await Promise.all([
+        requestJson<ChymeRoomResponse>('/api/chyme/room'),
+        requestJson<{ roomKey: string; messages: ChymeMessage[] }>('/api/chyme/messages?limit=50'),
+      ]);
+      setRoom(roomPayload);
+      setMessages(messagePayload.messages);
+    } catch (refreshError) {
+      setError(refreshError instanceof Error ? refreshError.message : 'Unable to refresh the room.');
+    } finally {
+      setRefreshing(false);
+    }
   }
 
   async function handleSend(): Promise<void> {
@@ -121,7 +138,8 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
       <ChymeHeader
         participantCount={room?.participants.length ?? 0}
         isLive={Boolean(room)}
-        onRefresh={() => void refreshMessages()}
+        onRefresh={() => void refreshRoomAndMessages()}
+        refreshing={refreshing}
       />
 
       <div style={{ flex: 1, display: 'flex', flexDirection: isMobile ? 'column' : 'row', overflow: isMobile ? 'visible' : 'hidden' }}>
@@ -130,7 +148,8 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
           room={room}
           joinState={joinState}
           onJoin={() => void handleJoin()}
-          onRefresh={() => void refreshMessages()}
+          onRefresh={() => void refreshRoomAndMessages()}
+          refreshing={refreshing}
         />
 
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: isMobile ? 'visible' : 'hidden' }}>

--- a/ctf/packages/web/components/chyme/chyme-sidebar.tsx
+++ b/ctf/packages/web/components/chyme/chyme-sidebar.tsx
@@ -13,12 +13,14 @@ export function ChymeSidebar({
   joinState,
   onJoin,
   onRefresh,
+  refreshing = false,
 }: {
   loading: boolean;
   room: ChymeRoomResponse | null;
   joinState: JoinState;
   onJoin: () => void;
   onRefresh: () => void;
+  refreshing?: boolean;
 }) {
   const isMobile = useIsMobile();
   const joinLabel = joinState === 'joining' ? 'Joining…' : joinState === 'ready' ? '✓ Joined' : 'Join Room';
@@ -39,11 +41,12 @@ export function ChymeSidebar({
         {isMobile && (
           <button
             onClick={onRefresh}
-            aria-label="Refresh messages"
-            title="Refresh messages"
-            style={{ width: 44, height: 44, borderRadius: 12, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', color: '#6B7280', flexShrink: 0 }}
+            disabled={refreshing}
+            aria-label="Refresh the room and chat"
+            title="Refresh the room and chat"
+            style={{ width: 44, height: 44, borderRadius: 12, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: refreshing ? 'wait' : 'pointer', color: '#6B7280', flexShrink: 0 }}
           >
-            <RefreshCw size={16} />
+            <RefreshCw size={16} className={refreshing ? 'animate-spin' : undefined} />
           </button>
         )}
       </div>


### PR DESCRIPTION
## Why

The refresh button in the Chyme room header did nothing visible. Two reasons:
1. It only re-fetched chat **messages** (`/api/chyme/messages`), so when there were no new messages, the UI didn't change — and the participant count / live status (right next to the button) never refreshed at all.
2. There was no feedback, so a press looked ignored.

## What changed

- Refresh now re-fetches **both** the room state (live status + participant count via `/api/chyme/room`) **and** the chat, together.
- The icon **spins** while refreshing and the button is disabled, so the press is visibly acknowledged.
- Applies to both the desktop header button and the mobile refresh button.

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_