### PR TITLE
fix: dark-theme the in-app chat and stop the share popup clipping

### DIFF
--- a/ctf/packages/web/components/shared/share-link.tsx
+++ b/ctf/packages/web/components/shared/share-link.tsx
@@ -64,6 +64,9 @@ export function ShareLink({
 }) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  // The popup opens above the trigger by default, but flips below when the trigger sits near the top
+  // of the viewport — otherwise the popup is clipped behind the header (the "modal doesn't fit" bug).
+  const [placement, setPlacement] = useState<"top" | "bottom">("top");
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const urlRef = useRef<HTMLInputElement>(null);
@@ -73,6 +76,11 @@ export function ShareLink({
 
   useEffect(() => {
     if (!open) return;
+    // Decide which way to open: if there isn't room for the popup above the trigger, open below.
+    // ~190px covers the popup (title + URL field + two rows + padding).
+    const POPUP_HEIGHT = 190;
+    const triggerTop = triggerRef.current?.getBoundingClientRect().top ?? POPUP_HEIGHT + 1;
+    setPlacement(triggerTop < POPUP_HEIGHT + 16 ? "bottom" : "top");
     // Focus the URL field so a keyboard/AT user lands on the link itself.
     urlRef.current?.focus();
     urlRef.current?.select();
@@ -151,7 +159,9 @@ export function ShareLink({
           onClick={(e) => e.stopPropagation()}
           style={{
             position: "absolute",
-            bottom: "calc(100% + 8px)",
+            ...(placement === "top"
+              ? { bottom: "calc(100% + 8px)" }
+              : { top: "calc(100% + 8px)" }),
             left: 0,
             zIndex: 50,
             width: 280,

--- a/ctf/packages/web/components/shared/stream-chat-panel.tsx
+++ b/ctf/packages/web/components/shared/stream-chat-panel.tsx
@@ -14,6 +14,8 @@ export interface StreamChatPanelProps {
   streamUserId: string;
   streamChannelId: string;
   channelType?: string;
+  /** Plugin brand color used to tint Stream's accent (send button, links, active states). */
+  accentColor?: string;
 }
 
 export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
@@ -22,6 +24,7 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
   streamUserId,
   streamChannelId,
   channelType = 'messaging',
+  accentColor,
 }) => {
   const [client, setClient] = useState<StreamChat | null>(null);
   // The Stream Channel type is generically parameterized and impractical to satisfy here; the value is
@@ -56,16 +59,29 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
     };
   }, [streamApiKey, streamToken, streamUserId, streamChannelId, channelType]);
 
-  if (loading) return <div>Loading chat…</div>;
-  if (error) return <div>{error}</div>;
-  if (!client || !channel) return <div>Chat unavailable.</div>;
+  if (loading) return <div style={{ padding: 16, color: '#9CA3AF', fontSize: 14 }}>Loading chat…</div>;
+  if (error) return <div style={{ padding: 16, color: '#EF4444', fontSize: 14 }}>{error}</div>;
+  if (!client || !channel) return <div style={{ padding: 16, color: '#9CA3AF', fontSize: 14 }}>Chat unavailable.</div>;
+
+  // The whole app is dark, so the chat must use Stream's dark theme (it used to render the light
+  // theme, which looked like a white widget dropped into a dark plugin). The wrapper carries the
+  // theme class and, when given, tints Stream's accent CSS variables to the plugin's brand color.
+  const themeVars = accentColor
+    ? ({
+        '--str-chat__primary-color': accentColor,
+        '--str-chat__active-primary-color': accentColor,
+        '--str-chat__message-send-color': accentColor,
+      } as React.CSSProperties)
+    : {};
 
   return (
-    <Chat client={client} theme="messaging light">
-      <Channel channel={channel}>
-        <MessageList />
-        <MessageInput />
-      </Channel>
-    </Chat>
+    <div className="str-chat__theme-dark" style={{ height: '100%', display: 'flex', flexDirection: 'column', ...themeVars }}>
+      <Chat client={client}>
+        <Channel channel={channel}>
+          <MessageList />
+          <MessageInput />
+        </Channel>
+      </Chat>
+    </div>
   );
 };

--- a/ctf/packages/web/components/socketrelay/sr-chat.tsx
+++ b/ctf/packages/web/components/socketrelay/sr-chat.tsx
@@ -92,6 +92,7 @@ function ChatPane({
             streamToken={chatCredentials.streamToken as string}
             streamUserId={chatCredentials.streamUserId as string}
             streamChannelId={chatCredentials.streamChannelId}
+            accentColor={COLOR}
           />
         ) : (
           <div style={{ flex: 1 }} />


### PR DESCRIPTION
## Why

Two issues reported in SocketRelay:
1. **Chat area off-brand.** The in-app chat rendered Stream's **light** theme — a white widget dropped into the dark app.
2. **Copy-link popup didn't fit.** The Share popup always opened *upward*, so when its trigger sits near the top of the page the popup was clipped behind the header.

## What changed

- **`StreamChatPanel` (shared)** now renders Stream's **dark** theme instead of light. This fixes the look everywhere the panel is used — SocketRelay, Lighthouse, TrustTransport, and Foundation (all dark plugins). Added an optional `accentColor` prop that tints Stream's accent (send button, links, active states) to the plugin's brand; **SocketRelay** passes its orange (`#FB923C`).
- **`ShareLink` (shared)** measures the trigger on open and **flips the popup to open downward** when there isn't room above it, so it's no longer clipped behind the header. Default behavior (open upward) is unchanged when there's room.

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_