### PR TITLE
fix: foundation left rail uses the shared bottom footer like every other plugin

### DIFF
--- a/ctf/packages/web/components/foundation/foundation-rails.tsx
+++ b/ctf/packages/web/components/foundation/foundation-rails.tsx
@@ -3,8 +3,9 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
-  Hammer, Search, Shield, Bell, Settings, MessageCircle, Wrench, FileText,
+  Hammer, Search, Shield, MessageCircle, Wrench, FileText,
 } from "lucide-react";
+import { PluginRailFooter } from "@/components/shared/plugin-rail-footer";
 import { COLOR, TRADES, initials, type FoundationTab, type ProviderView } from "./foundation-ui";
 
 const TABS: { icon: React.ElementType; key: FoundationTab; label: string }[] = [
@@ -25,16 +26,7 @@ export function IconRail({ tab, onTab }: { tab: FoundationTab; onTab: (t: Founda
           <Icon size={20} />
         </button>
       ))}
-      <div style={{ flex: 1 }} />
-      <button aria-label="Notifications" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
-        <Bell size={18} />
-      </button>
-      <button aria-label="Settings" style={{ width: 44, height: 44, borderRadius: 12, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: "#6B7280" }}>
-        <Settings size={18} />
-      </button>
-      <Avatar style={{ width: 36, height: 36 }}>
-        <AvatarFallback style={{ background: `${COLOR}30`, color: COLOR, fontSize: 14, fontWeight: 700 }}>S</AvatarFallback>
-      </Avatar>
+      <PluginRailFooter />
     </aside>
   );
 }


### PR DESCRIPTION
## Why

You reported the bottom of the left icon rail isn't uniform across pages. After checking every plugin rail: 15 of them already use the shared `PluginRailFooter` (back to all apps, account settings, real account menu). The outlier is **Foundation**.

## What changed

Foundation's rail had a bespoke bottom — a **dead Notifications button**, a **dead Settings button** (neither linked anywhere), and a **fake "S" avatar** — and no "back to all apps" control. Swapped it for the shared `PluginRailFooter`, so Foundation's rail bottom now matches every other plugin: back to apps, account/settings, and the real Clerk account menu.

Note (not changed here): `community-shell` (the Survivor Hub home) intentionally has its own rail — it's the hub, so "back to all apps" doesn't apply, and it already shows the real account menu. Chyme has an extra back arrow at the *top* of its rail (its bottom already uses the shared footer); happy to remove that separately if you want the tops uniform too.

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_