### PR TITLE
fix: hide blank fields on Lighthouse listing card and detail

### DIFF
--- a/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
@@ -38,14 +38,24 @@ export function LighthouseBrowse({
                     <Heart size={16} style={{ color: saved.includes(p.id) ? "#EC4899" : "#4B5563" }} fill={saved.includes(p.id) ? "#EC4899" : "none"} />
                   </button>
                 </div>
-                <div style={{ fontSize: 12, color: "#6B7280", marginBottom: 8, display: "flex", alignItems: "center", gap: 4 }}><MapPin size={11} /> {p.city}, {p.state}</div>
-                <div style={{ display: "flex", gap: 10, fontSize: 12, color: "#9CA3AF", marginBottom: 12 }}>
-                  <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bed size={11} /> {p.bedrooms === 0 ? "Studio" : `${p.bedrooms}bd`}</span>
-                  <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bath size={11} /> {p.bathrooms}ba</span>
-                </div>
+                {([p.city, p.state].filter((s) => s && String(s).trim().length > 0).join(", ")) ? (
+                  <div style={{ fontSize: 12, color: "#6B7280", marginBottom: 8, display: "flex", alignItems: "center", gap: 4 }}><MapPin size={11} /> {[p.city, p.state].filter((s) => s && String(s).trim().length > 0).join(", ")}</div>
+                ) : null}
+                {(Number.isFinite(p.bedrooms) || Number.isFinite(p.bathrooms)) ? (
+                  <div style={{ display: "flex", gap: 10, fontSize: 12, color: "#9CA3AF", marginBottom: 12 }}>
+                    {Number.isFinite(p.bedrooms) ? (
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bed size={11} /> {p.bedrooms === 0 ? "Studio" : `${p.bedrooms}bd`}</span>
+                    ) : null}
+                    {Number.isFinite(p.bathrooms) ? (
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bath size={11} /> {p.bathrooms}ba</span>
+                    ) : null}
+                  </div>
+                ) : null}
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
                   <div>
-                    <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>${p.monthlyRent || "—"}<span style={{ fontSize: 11, color: "#6B7280", fontWeight: 400 }}>/mo</span></div>
+                    {Number.isFinite(p.monthlyRent) ? (
+                      <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>{p.monthlyRent > 0 ? <>${p.monthlyRent}<span style={{ fontSize: 11, color: "#6B7280", fontWeight: 400 }}>/mo</span></> : "Free"}</div>
+                    ) : null}
                     {p.credits && <div style={{ fontSize: 10, color: "#F59E0B" }}>Credits ✓</div>}
                   </div>
                   <button onClick={() => onSelect(p)} style={{ padding: "8px 16px", borderRadius: 8, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 12, fontWeight: 600, cursor: "pointer" }}>View</button>

--- a/ctf/packages/web/components/lighthouse/lighthouse-property-detail.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-property-detail.tsx
@@ -17,13 +17,21 @@ export function LighthousePropertyDetail({ property, onBack }: { property: Prope
           <div style={{ flex: 1, minWidth: 280 }}>
             <div style={{ fontSize: 24, fontWeight: 800, color: "#F9FAFB", marginBottom: 8 }}>{l.title || l.id}</div>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginBottom: 16 }}>
-              <span style={{ background: "rgba(255,255,255,0.05)", color: "#9CA3AF", border: "1px solid rgba(255,255,255,0.08)", fontSize: 12, borderRadius: 8, padding: "3px 10px", display: "inline-flex", alignItems: "center", gap: 4 }}><MapPin size={11} />{l.city}, {l.state}</span>
+              {([l.city, l.state].filter((s) => s && String(s).trim().length > 0).join(", ")) ? (
+                <span style={{ background: "rgba(255,255,255,0.05)", color: "#9CA3AF", border: "1px solid rgba(255,255,255,0.08)", fontSize: 12, borderRadius: 8, padding: "3px 10px", display: "inline-flex", alignItems: "center", gap: 4 }}><MapPin size={11} />{[l.city, l.state].filter((s) => s && String(s).trim().length > 0).join(", ")}</span>
+              ) : null}
               {l.credits && <span style={{ background: "#F59E0B15", color: "#F59E0B", border: "1px solid #F59E0B30", fontSize: 12, borderRadius: 8, padding: "3px 10px" }}>Credits ✓</span>}
             </div>
             <div style={{ display: "flex", gap: 16, marginBottom: 20, fontSize: 14, color: "#9CA3AF", flexWrap: "wrap" }}>
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bed size={14} />{l.bedrooms === 0 ? "Studio" : `${l.bedrooms} bed`}</span>
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bath size={14} />{l.bathrooms} bath</span>
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Calendar size={14} />Available {l.availableFromIso ? new Date(l.availableFromIso).toLocaleDateString() : "—"}</span>
+              {Number.isFinite(l.bedrooms) ? (
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bed size={14} />{l.bedrooms === 0 ? "Studio" : `${l.bedrooms} bed`}</span>
+              ) : null}
+              {Number.isFinite(l.bathrooms) ? (
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Bath size={14} />{l.bathrooms} bath</span>
+              ) : null}
+              {l.availableFromIso ? (
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}><Calendar size={14} />Available {new Date(l.availableFromIso).toLocaleDateString()}</span>
+              ) : null}
             </div>
             {l.description && (
               <>
@@ -41,7 +49,9 @@ export function LighthousePropertyDetail({ property, onBack }: { property: Prope
           </div>
           <div style={{ width: 280, flexShrink: 0 }}>
             <div style={{ padding: "24px", borderRadius: 16, background: "rgba(255,255,255,0.03)", border: `1px solid ${COLOR}25` }}>
-              <div style={{ fontSize: 32, fontWeight: 800, color: COLOR, marginBottom: 4 }}>${l.monthlyRent || "—"}<span style={{ fontSize: 14, color: "#6B7280", fontWeight: 400 }}>/mo</span></div>
+              {Number.isFinite(l.monthlyRent) ? (
+                <div style={{ fontSize: 32, fontWeight: 800, color: COLOR, marginBottom: 4 }}>{l.monthlyRent > 0 ? <>${l.monthlyRent}<span style={{ fontSize: 14, color: "#6B7280", fontWeight: 400 }}>/mo</span></> : "Free"}</div>
+              ) : null}
               {l.credits && <div style={{ fontSize: 12, color: "#F59E0B", marginBottom: 16 }}>✓ Accepts Service Credits</div>}
               <button style={{ width: "100%", padding: "12px", borderRadius: 10, background: COLOR, border: "none", color: "#0F1117", fontWeight: 800, fontSize: 15, cursor: "pointer", marginBottom: 10 }}>Apply Now</button>
               <button style={{ width: "100%", padding: "12px", borderRadius: 10, background: "rgba(255,255,255,0.04)", border: `1px solid ${COLOR}35`, color: COLOR, fontWeight: 600, fontSize: 14, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}><MessageSquare size={14} /> Message Host</button>


### PR DESCRIPTION
## Why

A Lighthouse listing with empty fields looked unprofessional: the card/detail rendered `null bd`, an empty `ba`, a lone location pin, `Available —`, and `$—/mo`.

## What changed

On both the browse card (`lighthouse-browse.tsx`) and the property detail (`lighthouse-property-detail.tsx`), each field renders only when it has a value:
- **Location** — shown only if city and/or state is set (no lone pin, no dangling comma).
- **Bedrooms / bathrooms** — shown only when set (0 bedrooms still shows "Studio").
- **Availability** (detail) — shown only when a date is set.
- **Rent** — shown as `$N/mo` when > 0, "Free" when 0 (Service Credits), and omitted when unset (no more `$—`).

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_