### PR TITLE
fix: clean up the Chyme guest listener experience

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-guest-listen.tsx
+++ b/ctf/packages/web/components/chyme/chyme-guest-listen.tsx
@@ -40,10 +40,12 @@ export function ChymeGuestListen({
 
     void (async () => {
       try {
-        // create: false — a guest only ever joins an existing live call, never starts one.
-        await activeCall.join({ create: false });
+        // Disable the mic and camera BEFORE joining so the browser never prompts a guest for device
+        // access — they can only listen, so there is nothing to publish and no reason to ask.
         try { await activeCall.camera.disable(); } catch { /* no camera */ }
         try { await activeCall.microphone.disable(); } catch { /* already muted */ }
+        // create: false — a guest only ever joins an existing live call, never starts one.
+        await activeCall.join({ create: false });
         if (cancelled) return;
         setClient(videoClient);
         setCall(activeCall);

--- a/ctf/packages/web/components/chyme/chyme-public-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-public-shell.tsx
@@ -11,7 +11,6 @@ import {
   ShieldCheck,
   Search,
   Heart,
-  Bell,
   Star,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -22,7 +21,7 @@ import { ChymeGuestListen } from '@/components/chyme/chyme-guest-listen';
 // Live state for the one default public Chyme room, fetched client-side from
 // /api/chyme/public/room. `credentials` is present only when the room is live
 // and Stream is configured, so a guest can actually listen.
-type LiveState = { isLive: boolean; participantCount: number; credentials?: StreamJoinCredentials };
+type LiveState = { isLive: boolean; participantCount: number; roomName?: string; credentials?: StreamJoinCredentials };
 
 // Chyme's brand is green. The signed-out (guest) shell must look like the signed-in app, not a
 // different purple product — so these mirror the deep-green chrome from chyme-shared (page #04160A,
@@ -100,7 +99,7 @@ function DesktopChymePublic({ signInUrl, verifyUrl, live }: { signInUrl: string;
               <div style={{ borderRadius: 10, border: `1px solid ${COLOR}40`, background: `${COLOR}10`, padding: '14px 16px', margin: '4px 0', display: 'flex', alignItems: 'center', gap: 10 }}>
                 <div style={{ width: 8, height: 8, borderRadius: '50%', background: COLOR, flexShrink: 0 }} />
                 <div style={{ flex: 1 }}>
-                  <div style={{ fontSize: 13, fontWeight: 700, color: TEXT }}>Chyme Main Room</div>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: TEXT }}>{live.roomName ?? 'Chyme Main Room'}</div>
                   <div style={{ fontSize: 12, color: SUBTLE, marginTop: 2 }}>{live.participantCount} listening/on stage</div>
                 </div>
               </div>
@@ -133,6 +132,7 @@ function DesktopChymePublic({ signInUrl, verifyUrl, live }: { signInUrl: string;
           <div style={{ flex: 1, overflowY: 'auto', padding: '24px 32px' }}>
             {live.credentials ? (
               <div style={{ marginBottom: 16 }}>
+                {live.roomName ? <div style={{ fontSize: 14, fontWeight: 700, color: TEXT, marginBottom: 2 }}>{live.roomName}</div> : null}
                 <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 8 }}>You&apos;re listening live — sign in to speak.</div>
                 <ChymeGuestListen credentials={live.credentials} accent={COLOR} />
               </div>
@@ -171,15 +171,9 @@ function DesktopChymePublic({ signInUrl, verifyUrl, live }: { signInUrl: string;
                 <Lock size={11} /><Icon size={14} /><span style={{ fontSize: 13 }}>{label}</span>
               </div>
             ))}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '8px 14px', borderRadius: 8, border: `1px solid ${COLOR}30`, color: COLOR, cursor: 'pointer' }}>
-              <Bell size={14} /><span style={{ fontSize: 13 }}>Notify me</span>
-            </div>
-            <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span style={{ fontSize: 12, color: SUBTLE }}>Want to speak?</span>
-              <a href={verifyUrl ?? signInUrl} style={{ padding: '8px 20px', borderRadius: 8, background: `linear-gradient(90deg,${ACCENT},${ACCENT_CYAN})`, border: 'none', color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>
-                {verifyUrl ? 'Finish verifying' : 'Sign In to Participate →'}
-              </a>
-            </div>
+            <a href={verifyUrl ?? signInUrl} style={{ marginLeft: 'auto', padding: '8px 20px', borderRadius: 8, background: `linear-gradient(90deg,${ACCENT},${ACCENT_CYAN})`, border: 'none', color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>
+              {verifyUrl ? 'Finish verifying' : 'Sign In to Participate →'}
+            </a>
           </div>
         </main>
       </div>
@@ -258,6 +252,7 @@ function MobileChymePublic({ signInUrl, verifyUrl, live }: { signInUrl: string; 
       <div style={{ flex: 1, overflowY: 'auto', padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
         {live.isLive && live.credentials ? (
           <div>
+            {live.roomName ? <div style={{ fontSize: 13, fontWeight: 700, color: TEXT, marginBottom: 2 }}>{live.roomName}</div> : null}
             <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 8 }}>You&apos;re listening live — sign in to speak.</div>
             <ChymeGuestListen credentials={live.credentials} accent={COLOR} />
           </div>
@@ -312,6 +307,7 @@ export function ChymePublicShell({ signInUrl, verifyUrl }: PublicVisitorShellPro
           setLive({
             isLive: !!data.isLive,
             participantCount: data.participantCount ?? 0,
+            roomName: typeof data.roomName === 'string' ? data.roomName : undefined,
             credentials: data.credentials,
           });
         }


### PR DESCRIPTION
## Why

Several rough edges on the signed-out Chyme guest listener experience.

## What changed

- **No device prompt for guests.** The guest listen client now disables the camera and microphone *before* joining the call, so the browser never asks a guest to enable their mic/camera — a guest can only listen, there's nothing to publish.
- **Real room name.** Guests now see the actual room name (e.g. "Chyme Main Room: Exit the Gauntlet") in the live room card and the listening header, on desktop and mobile (the public endpoint already returns it; the shell just wasn't using it).
- **Removed dead/redundant controls.** Dropped the "Notify me" button (it did nothing) and the redundant "Want to speak?" label that sat next to the "Sign In to Participate" button.

Not in this PR (need a follow-up / your call):
- Raise/lower hand for signed-in users uses Stream's transient *reactions*, which the SDK auto-clears after a few seconds, so a raised hand can't persist. Fixing it properly needs persistent hand-raise state — separate change.
- The guest "mic icon next to avatar": the current guest view shows no avatars/mic icons (just "Listening live · N on stage"), and you said the signed-in view looks fine, so I left the signed-in stage alone — let me know where you saw it.

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_