### PR TITLE
fix: hide the SH logo badge in the Survivor Hub mobile top bar

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -250,7 +250,6 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
           <Menu size={18} />
         </button>
         <div className={styles.mobileBarBrand}>
-          <span className={styles.mobileBarLogo} aria-hidden="true">SH</span>
           <span className={styles.mobileBarTitle}>Survivor Hub</span>
         </div>
         <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">


### PR DESCRIPTION
## Why

On phone widths, the small "SH" badge sat next to the (truncated) "Survivor Hub" title in the top bar and added no value — it's barely legible and redundant with the title.

## What changed

Removed the `SH` logo badge from the Survivor Hub **mobile** top bar (`community-shell.tsx`). The "Survivor Hub" title stays. This bar is mobile-only (`styles.mobileBar`, hidden on desktop), so the desktop layout is unchanged.

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_