### PR TITLE
fix: add missing unique indexes so ServiceCredits mint idempotency/outbox upserts work

### DIFF
--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -3689,6 +3689,28 @@ ALTER TABLE IF EXISTS service_credits_command_idempotency ADD COLUMN IF NOT EXIS
 ALTER TABLE IF EXISTS service_credits_command_idempotency ADD COLUMN IF NOT EXISTS command_name TEXT;
 ALTER TABLE IF EXISTS service_credits_command_idempotency ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
 
+-- The governance mint/transfer code upserts idempotency + adapter-outbox rows with
+-- `ON CONFLICT (actor_id, command_name, idempotency_key)` and `ON CONFLICT (command_name,
+-- idempotency_key)`, but the matching unique indexes were never created — so every mint threw
+-- "no unique or exclusion constraint matching the ON CONFLICT specification" and the reward never
+-- landed (this blocked the Unlock approval reward + its "Retry pending rewards" drain). Add the two
+-- missing unique indexes, and relax the legacy `command` NOT NULL column (the code writes
+-- `command_name`, never `command`, so leaving it NOT NULL also blocks the insert).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_service_credits_adapter_outbox_command_idem
+  ON service_credits_adapter_outbox (command_name, idempotency_key);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_service_credits_command_idempotency_actor_command_idem
+  ON service_credits_command_idempotency (actor_id, command_name, idempotency_key);
+DO $sc_cmd_idem_command_nullable$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'service_credits_command_idempotency' AND column_name = 'command'
+  ) THEN
+    ALTER TABLE service_credits_command_idempotency ALTER COLUMN command DROP NOT NULL;
+  END IF;
+END
+$sc_cmd_idem_command_nullable$;
+
 -- service_credits_wallet_tombstones (2 missing)
 ALTER TABLE IF EXISTS service_credits_wallet_tombstones ADD COLUMN IF NOT EXISTS account_id TEXT;
 ALTER TABLE IF EXISTS service_credits_wallet_tombstones ADD COLUMN IF NOT EXISTS deletion_request_id UUID;


### PR DESCRIPTION
## Why

In Unlock Admin, "Retry pending rewards" fails with: *"there is no unique or exclusion constraint matching the ON CONFLICT specification"* (repeated per submission). Same reason the rewards never landed in the first place.

## Root cause

Every governance mint (`mintGrant` in `lib/service-credits/repository.ts`) upserts:
- a command-idempotency row with `ON CONFLICT (actor_id, command_name, idempotency_key)`, and
- an adapter-outbox row with `ON CONFLICT (command_name, idempotency_key)`.

But **neither unique index was ever created** (both tables were created with only `id/payload/updated_at` and had columns added later via `ALTER`). So Postgres rejects the `ON CONFLICT` at plan time, the whole mint transaction rolls back, and the reward never lands. The Unlock approval reward and its "Retry pending rewards" self-heal both hit this. The legacy `service_credits_command_idempotency.command NOT NULL` column would also block the insert (the code writes `command_name`, never `command`).

## Fix (additive migration, no data change)

- `CREATE UNIQUE INDEX IF NOT EXISTS` on `service_credits_adapter_outbox (command_name, idempotency_key)`.
- `CREATE UNIQUE INDEX IF NOT EXISTS` on `service_credits_command_idempotency (actor_id, command_name, idempotency_key)`.
- Relax the legacy `command` `NOT NULL` (guarded `DO` block).

These indexes are also what make the idempotency guarantee real (they prevent double-grants), so this is the correct fix, not just a workaround.

## Note for review

The index creation assumes no pre-existing duplicate rows in those two tables. Because the `ON CONFLICT` writers have always failed, the tables should be empty of rows written through this path — but please confirm against production before applying (a stray duplicate would make `CREATE UNIQUE INDEX` fail loudly at deploy, which is the safe outcome).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Service Credits operations by fixing transaction failures during retries. The system now correctly handles duplicate requests and ensures operations complete successfully even when automatically retried due to network issues or transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->