### PR TITLE
feat: show normalized Quora URL in Unlock admin queue

### DIFF
--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -301,6 +301,17 @@ export function UnlockAdminShell({
                     </>
                   )}
                 </div>
+                {s.quoraProfileUrlNormalized ? (
+                  <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 4, display: 'flex', gap: 6, alignItems: 'baseline', flexWrap: 'wrap' }}>
+                    <span>Normalized:</span>
+                    <a href={s.quoraProfileUrlNormalized} target="_blank" rel="noopener noreferrer" style={{ color: COLOR, fontWeight: 600, wordBreak: 'break-all' }}>
+                      {s.quoraProfileUrlNormalized}
+                    </a>
+                    {s.quoraProfileUrlNormalized !== s.quoraProfileUrl ? (
+                      <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>(cleaned from submitted link)</span>
+                    ) : null}
+                  </div>
+                ) : null}
                 <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 4 }}>User: {s.userId}</div>
                 <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 10 }}>
                   Submitted {new Date(s.createdAt).toLocaleDateString()} · window expires {new Date(s.unlockWindowExpiresAt).toLocaleDateString()} · tier {s.accessTier}


### PR DESCRIPTION
## Why

You noticed the database already stores a **normalized** (cleaned/canonical) Quora URL — `quora_profile_url_normalized` — which is the value the system actually verifies against. The admin queue only showed the raw submitted URL, so that cleaned value was invisible.

## What changed

In the Unlock admin review queue, each submission now shows the **normalized URL** on its own line beneath the raw URL — clickable, and flagged `(cleaned from submitted link)` when it differs from what the member typed.

Display-only: `quoraProfileUrlNormalized` already flows through `UnlockSubmission` and the admin API, so no type, schema, route, or contract changes — only `unlock-admin-shell.tsx`.

Verified: web typecheck + lint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_