### PR TITLE
fix: use authoritative server count in Chyme guest listen view

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-guest-listen.tsx
+++ b/ctf/packages/web/components/chyme/chyme-guest-listen.tsx
@@ -20,9 +20,11 @@ import { CHYME_CALL_TYPE, toCallIdForChyme } from './chyme-audio-room';
 // signing in.
 export function ChymeGuestListen({
   credentials,
+  participantCount,
   accent = '#22C55E',
 }: {
   credentials: StreamJoinCredentials;
+  participantCount: number;
   accent?: string;
 }) {
   const [client, setClient] = useState<StreamVideoClient | null>(null);
@@ -76,7 +78,7 @@ export function ChymeGuestListen({
   return (
     <StreamVideo client={client}>
       <StreamCall call={call}>
-        <GuestAudioSink accent={accent} />
+        <GuestAudioSink accent={accent} participantCount={participantCount} />
       </StreamCall>
     </StreamVideo>
   );
@@ -90,10 +92,14 @@ function GuestNote({ accent, text }: { accent: string; text: string }) {
   );
 }
 
-function GuestAudioSink({ accent }: { accent: string }) {
+function GuestAudioSink({ accent, participantCount }: { accent: string; participantCount: number }) {
   const { useParticipants } = useCallStateHooks();
   const participants = useParticipants();
-  const count = participants.length;
+  // Show the authoritative server-side count (the same number the room list shows). The Stream client
+  // participant list counts every connected identity — including the guest's own ephemeral session and
+  // any guest sessions Stream has not yet timed out — which over-counts and is inconsistent with the
+  // rest of the UI. The Stream list is still used below, but only to play each participant's audio.
+  const count = participantCount;
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 18px', borderRadius: 12, background: `${accent}14`, border: `1px solid ${accent}35`, color: '#F0FDF4', fontSize: 13, fontWeight: 600 }}>
       <Radio size={16} style={{ color: accent }} />

--- a/ctf/packages/web/components/chyme/chyme-public-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-public-shell.tsx
@@ -134,7 +134,7 @@ function DesktopChymePublic({ signInUrl, verifyUrl, live }: { signInUrl: string;
               <div style={{ marginBottom: 16 }}>
                 {live.roomName ? <div style={{ fontSize: 14, fontWeight: 700, color: TEXT, marginBottom: 2 }}>{live.roomName}</div> : null}
                 <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 8 }}>You&apos;re listening live — sign in to speak.</div>
-                <ChymeGuestListen credentials={live.credentials} accent={COLOR} />
+                <ChymeGuestListen credentials={live.credentials} participantCount={live.participantCount} accent={COLOR} />
               </div>
             ) : null}
             <div style={{ borderRadius: 12, border: `1px solid ${COLOR}25`, background: `${COLOR}08`, padding: '14px 20px', display: 'flex', alignItems: 'center', gap: 14 }}>
@@ -254,7 +254,7 @@ function MobileChymePublic({ signInUrl, verifyUrl, live }: { signInUrl: string; 
           <div>
             {live.roomName ? <div style={{ fontSize: 13, fontWeight: 700, color: TEXT, marginBottom: 2 }}>{live.roomName}</div> : null}
             <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 8 }}>You&apos;re listening live — sign in to speak.</div>
-            <ChymeGuestListen credentials={live.credentials} accent={COLOR} />
+            <ChymeGuestListen credentials={live.credentials} participantCount={live.participantCount} accent={COLOR} />
           </div>
         ) : null}
         {!live.isLive ? (


### PR DESCRIPTION
The signed-out Chyme room view's "Listening live · N people on stage" banner counted the Stream client's participant list, which includes the guest's own ephemeral session and any guest sessions Stream has not yet timed out. It over-counted (showed 3 when 2 were present) and disagreed with the room list, which already shows the server-side count.

This drives the banner from the same authoritative server `participantCount` the rest of the UI uses, and keeps the Stream participant list only to play each participant's audio.

Changes:
- Add a `participantCount` prop to `ChymeGuestListen` and pass it through to `GuestAudioSink`.
- Pass `live.participantCount` at both the desktop and mobile call sites in the public shell.
- Display the server count in the banner; keep the Stream list for audio playback only.

Parity Status: web + mobile-responsive + android complete

https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1