### PR TITLE
feat: add admin-only header button to each plugin shell

### DIFF
--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -230,11 +230,11 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (selectedPlugin.slug === 'foundation') {
-    return <FoundationShell />;
+    return <FoundationShell isAdmin={decision.isAdmin} />;
   }
 
   if (selectedPlugin.slug === 'lighthouse') {
-    return <LighthouseShell userId={decision.userId} username={decision.username} />;
+    return <LighthouseShell userId={decision.userId} username={decision.username} isAdmin={decision.isAdmin} />;
   }
 
   if (selectedPlugin.slug === 'socketrelay') {
@@ -242,11 +242,11 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (selectedPlugin.slug === 'trusttransport') {
-    return <TrustTransportShell />;
+    return <TrustTransportShell isAdmin={decision.isAdmin} />;
   }
 
   if (selectedPlugin.slug === 'peer-programming') {
-    return <PeerProgrammingShell />;
+    return <PeerProgrammingShell isAdmin={decision.isAdmin} />;
   }
 
   if (selectedPlugin.slug === 'mood') {
@@ -262,11 +262,11 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (selectedPlugin.slug === 'gdp') {
-    return <GdpShell />;
+    return <GdpShell isAdmin={decision.isAdmin} />;
   }
 
   if (selectedPlugin.slug === 'service-credits') {
-    return <ServiceCreditsShell />;
+    return <ServiceCreditsShell isAdmin={decision.isAdmin} />;
   }
 
   if (selectedPlugin.slug === 'levelup') {

--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -13,6 +13,7 @@ import { DirectoryProfileDetail } from "./directory-profile-detail";
 import { DirectoryLoadingSkeleton } from "./directory-loading-skeleton";
 import { DirectoryBrowse } from "./directory-browse";
 import { DirectoryRightPanel } from "./directory-right-panel";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 const DEFAULT_REWARD_CARD: SkillsHuntRewardCard = {
   title: "Help grow the Directory",
@@ -217,6 +218,7 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
             </Link>
             <BookOpen size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Directory</span>
+            <PluginAdminButton href="/admin/directory" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
             <div style={{ position: "relative" }}>
@@ -302,6 +304,7 @@ export function DirectoryShell({ userId, isAdmin }: { userId: string; isAdmin: b
           <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
             ✓ Verified Network
           </Badge>
+          <PluginAdminButton href="/admin/directory" isAdmin={isAdmin} accent={t.ACCENT} />
         </header>
 
         {content}

--- a/ctf/packages/web/components/foundation/foundation-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-shell.tsx
@@ -11,6 +11,7 @@ import { IconRail, FilterSidebar, RightRail } from "./foundation-rails";
 import { BrowsePanel, QuotesPanel, ChatPanel } from "./foundation-panels";
 import { OfferSkillsPanel } from "./foundation-offer-skills";
 import { ProviderProfile } from "./foundation-profile";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 const CSRF_HEADERS = { "Content-Type": "application/json", "x-ctf-csrf": "1" };
 
@@ -22,7 +23,7 @@ function Centered({ color, children }: { color: string; children: React.ReactNod
   );
 }
 
-export function FoundationShell() {
+export function FoundationShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [providers, setProviders] = useState<ProviderView[]>([]);
@@ -170,6 +171,7 @@ export function FoundationShell() {
             </Link>
             <Hammer size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Foundation</span>
+            <PluginAdminButton href="/admin/foundation" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
@@ -201,6 +203,7 @@ export function FoundationShell() {
             <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>Foundation — Trade Services</div>
             <div style={{ fontSize: 12, color: t.MUTED }}>Community trade providers · Trauma-informed</div>
           </div>
+          <PluginAdminButton href="/admin/foundation" isAdmin={isAdmin} accent={t.ACCENT} />
         </header>
         {content}
       </div>

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -12,8 +12,9 @@ import { GdpIconRail } from "./gdp-icon-rail";
 import { GdpSidebar } from "./gdp-sidebar";
 import { GdpDashboard } from "./gdp-dashboard";
 import { GdpMap } from "./gdp-map";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
-function ShellHeader({ t, metrics }: { t: GdpTokens; metrics: GdpMetrics }) {
+function ShellHeader({ t, metrics, isAdmin }: { t: GdpTokens; metrics: GdpMetrics; isAdmin?: boolean }) {
   return (
     <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
       <Globe size={18} style={{ color: t.ACCENT }} />
@@ -24,6 +25,7 @@ function ShellHeader({ t, metrics }: { t: GdpTokens; metrics: GdpMetrics }) {
         </div>
       </div>
       <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>↑ Live</Badge>
+      <PluginAdminButton href="/admin/gdp" isAdmin={isAdmin} accent={t.ACCENT} />
     </header>
   );
 }
@@ -76,7 +78,7 @@ function deriveIsEstimate(rawMetrics: unknown): boolean {
   );
 }
 
-export default function GdpShell() {
+export default function GdpShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [tab, setTab] = useState<GdpTab>("dashboard");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -136,6 +138,7 @@ export default function GdpShell() {
             <Globe size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>GDP</span>
             <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>↑ Live</Badge>
+            <PluginAdminButton href="/admin/gdp" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
@@ -153,7 +156,7 @@ export default function GdpShell() {
       <GdpIconRail tab={tab} onTab={setTab} />
       <GdpSidebar metrics={metrics} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader t={t} metrics={metrics} />
+        <ShellHeader t={t} metrics={metrics} isAdmin={isAdmin} />
         <GdpContent t={t} error={error} report={report} tab={tab} sectors={sectors} countries={countries} metrics={metrics} metricRows={metricRows} />
       </div>
     </div>

--- a/ctf/packages/web/components/levelup/levelup-shell.tsx
+++ b/ctf/packages/web/components/levelup/levelup-shell.tsx
@@ -14,6 +14,7 @@ import { LevelUpLoading } from "./lu-loading";
 import { LevelUpTrainers } from "./lu-trainers";
 import { LevelUpAchievements } from "./lu-achievements";
 import { LevelUpWallet } from "./lu-wallet";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 const HEADINGS: Record<NavKey, string> = {
   browse: "Browse Cohorts",
@@ -68,7 +69,7 @@ async function fetchWalletView(signal: AbortSignal): Promise<WalletView | null> 
   return data.wallet ?? null;
 }
 
-function ShellHeader({ nav, isAdmin, t }: { nav: NavKey; isAdmin: boolean; t: LevelupTokens }) {
+function ShellHeader({ nav, isAdmin, t, showAdminButton = false }: { nav: NavKey; isAdmin: boolean; t: LevelupTokens; showAdminButton?: boolean }) {
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 24 }}>
       <div>
@@ -77,12 +78,15 @@ function ShellHeader({ nav, isAdmin, t }: { nav: NavKey; isAdmin: boolean; t: Le
           {SUBHEADINGS[nav]}
         </div>
       </div>
-      {nav === "browse" && (
-        <button type="button" disabled={!isAdmin}
-          style={{ display: "flex", alignItems: "center", gap: 6, background: "rgba(255,255,255,0.05)", color: t.TEXT_SUBTLE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 8, padding: "9px 18px", fontSize: 13, fontWeight: 600, cursor: isAdmin ? "pointer" : "not-allowed", opacity: isAdmin ? 1 : 0.5 }}>
-          <Plus size={14} /> Create Cohort
-        </button>
-      )}
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        {nav === "browse" && (
+          <button type="button" disabled={!isAdmin}
+            style={{ display: "flex", alignItems: "center", gap: 6, background: "rgba(255,255,255,0.05)", color: t.TEXT_SUBTLE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 8, padding: "9px 18px", fontSize: 13, fontWeight: 600, cursor: isAdmin ? "pointer" : "not-allowed", opacity: isAdmin ? 1 : 0.5 }}>
+            <Plus size={14} /> Create Cohort
+          </button>
+        )}
+        {showAdminButton && <PluginAdminButton href="/admin/levelup" isAdmin={isAdmin} accent={t.ACCENT} />}
+      </div>
     </div>
   );
 }
@@ -245,7 +249,7 @@ export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: b
 
   const content = (
     <>
-      <ShellHeader nav={nav} isAdmin={isAdmin} t={t} />
+      <ShellHeader nav={nav} isAdmin={isAdmin} t={t} showAdminButton={!isMobile} />
       <ShellContent
         nav={nav}
         loading={loading}
@@ -292,6 +296,7 @@ export function LevelupShell({ isAdmin = false }: { userId?: string; isAdmin?: b
               <ChevronLeft size={20} />
             </Link>
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>LevelUp</span>
+            <PluginAdminButton href="/admin/levelup" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px", overflowX: "auto" }}>
             {navItems.map(({ key, label }) => (

--- a/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
@@ -16,8 +16,9 @@ import { LighthouseChat } from "./lighthouse-chat";
 import { LighthouseHost } from "./lighthouse-host";
 import { LighthousePropertyDetail } from "./lighthouse-property-detail";
 import { LighthouseLoadingSkeleton } from "./lighthouse-loading-skeleton";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
-export function LighthouseShell({ userId, username }: { userId: string; username: string | null }) {
+export function LighthouseShell({ userId, username, isAdmin }: { userId: string; username: string | null; isAdmin?: boolean }) {
   const [loading, setLoading] = useState(true);
   const [properties, setProperties] = useState<Property[]>([]);
   const [matches, setMatches] = useState<Match[]>([]);
@@ -177,6 +178,7 @@ export function LighthouseShell({ userId, username }: { userId: string; username
               <ChevronLeft size={20} />
             </Link>
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>🏠 LightHouse</span>
+            <PluginAdminButton href="/admin/lighthouse" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
@@ -213,6 +215,7 @@ export function LighthouseShell({ userId, username }: { userId: string; username
             <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>🏠 LightHouse — Safe Housing</div>
             <div style={{ fontSize: 12, color: t.MUTED }}>Verified listings · Privacy-first</div>
           </div>
+          <PluginAdminButton href="/admin/lighthouse" isAdmin={isAdmin} accent={t.ACCENT} />
         </header>
 
         <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflowY: "auto", minHeight: 0 }}>

--- a/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
@@ -13,6 +13,7 @@ import { PeerProgrammingCohortsTab } from "./pp-cohorts-tab";
 import { PeerProgrammingSessionTab } from "./pp-session-tab";
 import { PeerProgrammingChatTab } from "./pp-chat-tab";
 import { PeerProgrammingRightPanel } from "./pp-right-panel";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 // Shape returned by GET /api/peer-programming/room. The shell's view models (Room,
 // Message) differ from the API, so map explicitly here rather than casting.
@@ -45,7 +46,7 @@ async function fetchRoomData(signal: AbortSignal): Promise<{ room: Room; message
   return { room, messages: mapMessages(data.messages ?? []) };
 }
 
-function ShellHeader({ active, t }: { active: boolean; t: PeerProgrammingTokens }) {
+function ShellHeader({ active, t, isAdmin }: { active: boolean; t: PeerProgrammingTokens; isAdmin?: boolean }) {
   return (
     <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
       <Users size={18} style={{ color: t.ACCENT }} />
@@ -58,11 +59,12 @@ function ShellHeader({ active, t }: { active: boolean; t: PeerProgrammingTokens 
           Cohort Active
         </span>
       )}
+      <PluginAdminButton href="/admin/peer-programming" isAdmin={isAdmin} accent={t.ACCENT} />
     </header>
   );
 }
 
-export function PeerProgrammingShell() {
+export function PeerProgrammingShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [room, setRoom] = useState<Room | null>(null);
@@ -209,6 +211,7 @@ export function PeerProgrammingShell() {
             </Link>
             <Users size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Peer Programming</span>
+            <PluginAdminButton href="/admin/peer-programming" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
@@ -226,7 +229,7 @@ export function PeerProgrammingShell() {
       <PeerProgrammingIconRail tab={tab} onTab={setTab} />
       <PeerProgrammingSidebar />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader active={Boolean(room?.cohortId)} t={t} />
+        <ShellHeader active={Boolean(room?.cohortId)} t={t} isAdmin={isAdmin} />
         {content}
       </div>
       <PeerProgrammingRightPanel room={room} participants={participants} onJoinSession={() => setTab("session")} />

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -14,6 +14,7 @@ import { ServiceCreditsWalletTab } from "./sc-wallet-tab";
 import { ServiceCreditsEarnTab } from "./sc-earn-tab";
 import { ServiceCreditsCirculationTab } from "./sc-circulation-tab";
 import { ServiceCreditsSendPanel } from "./sc-send-panel";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 function CenteredNote({ color, children }: { color: string; children: React.ReactNode }) {
   return (
@@ -23,7 +24,7 @@ function CenteredNote({ color, children }: { color: string; children: React.Reac
   );
 }
 
-function ShellHeader({ balance, t }: { balance: number; t: ServiceCreditsTokens }) {
+function ShellHeader({ balance, t, isAdmin }: { balance: number; t: ServiceCreditsTokens; isAdmin?: boolean }) {
   return (
     <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
       <Coins size={18} style={{ color: t.ACCENT }} />
@@ -34,11 +35,12 @@ function ShellHeader({ balance, t }: { balance: number; t: ServiceCreditsTokens 
       <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
         {fmtCredits(balance)} credits
       </Badge>
+      <PluginAdminButton href="/admin/service-credits" isAdmin={isAdmin} accent={t.ACCENT} />
     </header>
   );
 }
 
-export function ServiceCreditsShell() {
+export function ServiceCreditsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [wallet, setWallet] = useState<WalletData | null>(null);
@@ -96,6 +98,7 @@ export function ServiceCreditsShell() {
             <Coins size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>ServiceCredits</span>
             <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{fmtCredits(balance)}</Badge>
+            <PluginAdminButton href="/admin/service-credits" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
@@ -114,7 +117,7 @@ export function ServiceCreditsShell() {
       <ServiceCreditsIconRail tab={tab} onTab={setTab} />
       <ServiceCreditsSidebar tab={tab} onTab={setTab} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader balance={balance} t={t} />
+        <ShellHeader balance={balance} t={t} isAdmin={isAdmin} />
         {content}
       </div>
       <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} />

--- a/ctf/packages/web/components/shared/plugin-admin-button.tsx
+++ b/ctf/packages/web/components/shared/plugin-admin-button.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+
+// Admin shortcut shown in a plugin's header — visible only to admins. Links to that
+// plugin's /admin page. Matches the Skills Hunt admin pill: a small accent-tinted
+// rounded button. `accent` lets each plugin tint it to match its own header. Renders
+// nothing for non-admins, so callers can place it unconditionally.
+export function PluginAdminButton({
+  href,
+  isAdmin,
+  accent = '#C8A84B',
+  label = 'Admin',
+}: {
+  href: string;
+  isAdmin?: boolean;
+  accent?: string;
+  label?: string;
+}) {
+  if (!isAdmin) return null;
+  return (
+    <Link
+      href={href}
+      aria-label={`${label} panel`}
+      style={{
+        height: 34,
+        padding: '0 12px',
+        borderRadius: 10,
+        background: `${accent}1A`,
+        border: `1px solid ${accent}40`,
+        color: accent,
+        display: 'inline-flex',
+        alignItems: 'center',
+        fontSize: 13,
+        fontWeight: 700,
+        textDecoration: 'none',
+        flexShrink: 0,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -6,6 +6,7 @@ import { Bell, ChevronLeft, Search } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { AppLoading } from "@/components/shared/app-loading";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 import {
   getSkillsHuntTokens, TABS, type SkillsHuntTokens, type Tab,
   type SkillsHuntRound, type SkillsHuntLeaderboardItem, type SkillsHuntAchievement,
@@ -262,11 +263,7 @@ export function SkillsHuntShell({
             </Link>
             <Search size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Skills Hunt</span>
-            {showModeratorTools && (
-              <Link href="/admin/skills-hunt" aria-label="Skills Hunt admin" style={{ height: 38, padding: "0 12px", borderRadius: 10, background: `${t.ACCENT}1A`, border: `1px solid ${t.ACCENT}40`, color: t.ACCENT, display: "flex", alignItems: "center", fontSize: 13, fontWeight: 700, textDecoration: "none", flexShrink: 0 }}>
-                Admin
-              </Link>
-            )}
+            <PluginAdminButton href="/admin/skills-hunt" isAdmin={showModeratorTools} accent={t.ACCENT} />
             <button type="button" onClick={() => setNotifOpen((o) => !o)} aria-label="Notifications" style={{ position: "relative", width: 38, height: 38, borderRadius: 10, background: t.INPUT_BG, border: `1px solid ${t.BORDER_STRONG}`, color: t.SUBTLE, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0 }}>
               <Bell size={18} />
               {unreadCount > 0 && <span style={{ position: "absolute", top: 5, right: 5, width: 8, height: 8, borderRadius: "50%", background: "#EF4444" }} />}

--- a/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
+++ b/ctf/packages/web/components/socketrelay/socketrelay-shell.tsx
@@ -27,6 +27,7 @@ import { SocketRelayFeed } from "./sr-feed";
 import { SocketRelayPost, type PostDraft } from "./sr-post";
 import { SocketRelayChat } from "./sr-chat";
 import { SocketRelayRightPanel } from "./sr-right-panel";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 const EMPTY_DRAFT: PostDraft = { title: "", details: "", tags: [], city: "", isPublic: false, priceCurrency: "FREE", priceAmount: "", requiresAmount: false };
 
@@ -57,7 +58,7 @@ type SocketRelayShellProps = {
   role?: string | null;
 };
 
-export function SocketRelayShell({ userId }: SocketRelayShellProps) {
+export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [requests, setRequests] = useState<SrRequest[]>([]);
@@ -319,6 +320,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
             <Share2 size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TEXT, flex: 1 }}>SocketRelay</span>
             <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{openCount} open</Badge>
+            <PluginAdminButton href="/admin/socketrelay" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
@@ -365,6 +367,7 @@ export function SocketRelayShell({ userId }: SocketRelayShellProps) {
           <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
             {openCount} open
           </Badge>
+          <PluginAdminButton href="/admin/socketrelay" isAdmin={isAdmin} accent={t.ACCENT} />
         </header>
 
         {content}

--- a/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
+++ b/ctf/packages/web/components/trusttransport/trusttransport-shell.tsx
@@ -14,8 +14,9 @@ import { TrustTransportBookTab } from "./tt-book-tab";
 import { TrustTransportTrackingTab } from "./tt-tracking-tab";
 import { TrustTransportChatTab } from "./tt-chat-tab";
 import { TrustTransportRightPanel } from "./tt-right-panel";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
-function ShellHeader({ t }: { t: TrustTransportTokens }) {
+function ShellHeader({ t, isAdmin }: { t: TrustTransportTokens; isAdmin?: boolean }) {
   return (
     <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
       <Car size={18} style={{ color: t.ACCENT }} />
@@ -26,11 +27,12 @@ function ShellHeader({ t }: { t: TrustTransportTokens }) {
       <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
         Community
       </Badge>
+      <PluginAdminButton href="/admin/trusttransport" isAdmin={isAdmin} accent={t.ACCENT} />
     </header>
   );
 }
 
-export function TrustTransportShell() {
+export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [modes, setModes] = useState<Mode[]>([]);
@@ -234,6 +236,7 @@ export function TrustTransportShell() {
             </Link>
             <Car size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>TrustTransport</span>
+            <PluginAdminButton href="/admin/trusttransport" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
@@ -251,7 +254,7 @@ export function TrustTransportShell() {
       <TrustTransportIconRail tab={tab} onTab={setTab} />
       <TrustTransportSidebar rideTypes={rideTypes} rideType={rideType} onRideType={setRideType} requests={requests} />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader t={t} />
+        <ShellHeader t={t} isAdmin={isAdmin} />
         {content}
       </div>
       <TrustTransportRightPanel requestCount={requests.length} modeCount={modes.length || rideTypes.length} onBook={() => setTab("book")} />

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
@@ -20,6 +20,7 @@ import { WeeklyPerformanceIconRail } from "./wp-icon-rail";
 import { WeeklyPerformanceSidebar } from "./wp-sidebar";
 import { WeeklyPerformanceDashboardMain } from "./wp-dashboard-main";
 import { WeeklyPerformanceRightRail } from "./wp-right-rail";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 type WeeklyPerformanceShellProps = {
   isAdmin: boolean;
@@ -136,6 +137,7 @@ export function WeeklyPerformanceShell({ isAdmin }: WeeklyPerformanceShellProps)
               <ChevronLeft size={20} />
             </Link>
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Weekly Performance</span>
+            <PluginAdminButton href="/admin/weekly-performance" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: "flex", gap: 8, padding: "0 12px 10px" }}>
             <select value={selectedWeekStart ?? ""} onChange={(e) => setSelectedWeekStart(e.target.value)} style={{ flex: 1, padding: "8px 10px", background: t.INPUT_BG, border: `1px solid ${t.BORDER_HI}`, borderRadius: 8, color: t.TEXT, fontSize: 13 }}>

--- a/ctf/packages/web/components/weekly-performance/wp-dashboard-main.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-dashboard-main.tsx
@@ -5,6 +5,7 @@ import { BORDER, BRAND, SUBTLE, TEXT, type WpComparison, type WpMetric, type WpW
 import { WeeklyPerformanceMetricCards } from "./wp-metric-cards";
 import { WeeklyPerformanceComparisonChart } from "./wp-comparison-chart";
 import { WeeklyPerformanceEmptyMain } from "./wp-empty-main";
+import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 
 export function WeeklyPerformanceDashboardMain({
   week,
@@ -43,6 +44,7 @@ export function WeeklyPerformanceDashboardMain({
               <Download size={14} /> Export
             </button>
           )}
+          <PluginAdminButton href="/admin/weekly-performance" isAdmin={isAdmin} accent={BRAND} />
         </header>
       )}
 

--- a/ctf/packages/web/components/workforce/workforce-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-shell.tsx
@@ -16,6 +16,7 @@ import { WorkforceHeroStats } from './workforce-hero-stats';
 import { WorkforceSkillDistribution } from './workforce-skill-distribution';
 import { WorkforceSectorGaps } from './workforce-sector-gaps';
 import { WorkforceProfilePanel } from './workforce-profile-panel';
+import { PluginAdminButton } from '@/components/shared/plugin-admin-button';
 
 const COLOR = '#F97316';
 
@@ -195,9 +196,7 @@ function WorkforceDashboardContent({
   );
 }
 
-// isAdmin is accepted to match the call site signature; admin-specific UI is not yet implemented
 export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
-  void isAdmin;
   const [tab] = useState<Tab>('dashboard');
   const [view, setView] = useState<SidebarView>('overview');
   const [loading, setLoading] = useState(true);
@@ -316,6 +315,7 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
             </Link>
             <BarChart2 size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>Workforce</span>
+            <PluginAdminButton href="/admin/workforce" isAdmin={isAdmin} accent={t.ACCENT} />
           </div>
           <div style={{ display: 'flex', gap: 6, padding: '0 12px 8px', overflowX: 'auto' }}>
             {views.map(({ key, label }) => (
@@ -375,6 +375,7 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
                 : 'Live workforce tracker'}
             </div>
           </div>
+          <PluginAdminButton href="/admin/workforce" isAdmin={isAdmin} accent={t.ACCENT} />
         </header>
 
         {content}


### PR DESCRIPTION
Adds an admin-only "Admin" button to each plugin's header that has an `/admin/<slug>` page, matching the Skills Hunt admin pill. Shown only to admins; links to that plugin's admin page.

- New shared component `components/shared/plugin-admin-button.tsx` — renders nothing for non-admins, so shells place it unconditionally; takes `href`, `isAdmin`, `accent` (tinted to each plugin), `label`.
- Threaded `isAdmin` from `app/apps/[pluginSlug]/page.tsx` into the shells that didn't already receive it (foundation, lighthouse, trusttransport, peer-programming, gdp, service-credits).
- Button added to both desktop and mobile headers of: directory, workforce, socketrelay, weekly-performance, levelup, lighthouse, foundation, trusttransport, peer-programming, gdp, service-credits. Skills Hunt's existing inline button was switched to the shared component.
- whatworks already renders its own admin button (from its own viewer.isAdmin), so it was left as-is. Plugins with no admin page (clicklog, chyme, mood, gentlepulse, skills-taxonomy) were not touched.

The admin routes remain server-gated; this button is navigation only. Typecheck and the web build pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_