### PR TITLE
fix: send CSRF header when submitting a Skills Hunt nomination

### DIFF
--- a/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
+++ b/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
@@ -46,7 +46,7 @@ export function useNominationForm(activeRound: SkillsHuntRound | null): {
     try {
       const res = await fetch(`/api/skills-hunt/rounds/${activeRound.id}/submissions`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
         body: JSON.stringify({
           fullName: fullName.trim(),
           bio: bio.trim(),


### PR DESCRIPTION
The Skills Hunt nomination form failed to submit with "Missing CSRF confirmation header." The submit POST in `sh-use-nomination-form.ts` sent only `Content-Type` and omitted the `x-ctf-csrf: 1` header that the server's `ensureMutationCsrf` requires (every other Skills Hunt mutation already sends it). Added the header so nominations submit.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_