### PR TITLE
fix: keep Skills Hunt round date fields from overflowing on mobile

### DIFF
--- a/ctf/packages/web/components/skills-hunt/sha-round-manager.tsx
+++ b/ctf/packages/web/components/skills-hunt/sha-round-manager.tsx
@@ -16,7 +16,7 @@ function toLocalInputValue(source: string | Date): string {
 
 const field: React.CSSProperties = {
   width: "100%", padding: "9px 12px", borderRadius: 8, background: "rgba(255,255,255,0.04)",
-  border: "1px solid rgba(255,255,255,0.12)", color: "#E8EAF0", fontSize: 13, outline: "none", boxSizing: "border-box",
+  border: "1px solid rgba(255,255,255,0.12)", color: "#E8EAF0", fontSize: 13, outline: "none", boxSizing: "border-box", minWidth: 0,
 };
 const label: React.CSSProperties = { display: "block", fontSize: 12, fontWeight: 600, color: "#9CA3AF", marginBottom: 5 };
 const help: React.CSSProperties = { fontSize: 11, color: "#6B7280", marginTop: 4 };
@@ -107,7 +107,7 @@ function RoundForm({ initial, submitLabel, onSubmit, onCancel }: {
         <textarea id="shr-desc" style={{ ...field, minHeight: 60, resize: "vertical" }} value={v.description} onChange={(e) => set({ description: e.target.value })} placeholder="What this round is about" />
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 12 }}>
-        <div>
+        <div style={{ minWidth: 0 }}>
           <label style={label} htmlFor="shr-status">Status</label>
           <select id="shr-status" style={field} value={v.status} onChange={(e) => set({ status: e.target.value as SkillsHuntRoundStatus })}>
             <option value="draft">Draft</option>
@@ -116,11 +116,11 @@ function RoundForm({ initial, submitLabel, onSubmit, onCancel }: {
             <option value="archived">Archived</option>
           </select>
         </div>
-        <div>
+        <div style={{ minWidth: 0 }}>
           <label style={label} htmlFor="shr-start">Starts</label>
           <input id="shr-start" type="datetime-local" style={field} value={v.startsAt} onChange={(e) => set({ startsAt: e.target.value })} />
         </div>
-        <div>
+        <div style={{ minWidth: 0 }}>
           <label style={label} htmlFor="shr-end">Ends</label>
           <input id="shr-end" type="datetime-local" style={field} value={v.endsAt} onChange={(e) => set({ endsAt: e.target.value })} />
         </div>


### PR DESCRIPTION
On a phone, the round editor's "Starts"/"Ends" datetime fields spilled past the right edge of the page. The Status/Starts/Ends grid items were plain `<div>` wrappers with the default `min-width: auto`, so the wide native datetime-local control couldn't shrink below its content and overflowed.

Add `minWidth: 0` to the shared field style and to the grid item wrappers, so each control shrinks to its cell and stays within the page.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_