### PR TITLE
fix: allow long taxonomy skill names in a Skills Hunt nomination

### DIFF
--- a/ctf/packages/web/lib/skills-hunt/constants.ts
+++ b/ctf/packages/web/lib/skills-hunt/constants.ts
@@ -18,6 +18,10 @@ export const SKILLS_HUNT_MAX_REVIEW_NOTES_LENGTH = 1000;
 export const SKILLS_HUNT_MAX_SKILLS_PER_SUBMISSION = 10;
 export const SKILLS_HUNT_MAX_PROPOSED_SKILLS_PER_SUBMISSION = 10;
 export const SKILLS_HUNT_MAX_SKILL_LABEL_LENGTH = 40;
+// Taxonomy-picked skills carry the canonical taxonomy name, which may be longer than the
+// short free-text cap above (the taxonomy allows up to 120 chars). Validate picked skills
+// against this larger bound so a legitimate long skill name does not fail the submission.
+export const SKILLS_HUNT_MAX_TAXONOMY_SKILL_LABEL_LENGTH = 120;
 
 export const SKILLS_HUNT_SUBMISSION_LIMIT_7D = 10;
 export const SKILLS_HUNT_REJECTION_GUARD_SAMPLE_SIZE = 10;

--- a/ctf/packages/web/lib/skills-hunt/repository.ts
+++ b/ctf/packages/web/lib/skills-hunt/repository.ts
@@ -66,6 +66,7 @@ import {
   SKILLS_HUNT_MAX_PROPOSED_SKILLS_PER_SUBMISSION,
   SKILLS_HUNT_MAX_SKILLS_PER_SUBMISSION,
   SKILLS_HUNT_MAX_SKILL_LABEL_LENGTH,
+  SKILLS_HUNT_MAX_TAXONOMY_SKILL_LABEL_LENGTH,
   SKILLS_HUNT_MIN_FULL_NAME_LENGTH,
   SKILLS_HUNT_MAX_PAGE_SIZE,
   SKILLS_HUNT_MAX_REVIEW_NOTES_LENGTH,
@@ -520,16 +521,22 @@ export function validateSubmissionInput(input: SkillsHuntSubmissionInput): boole
   const quoraProfileUrl = typeof input.quoraProfileUrl === 'string' ? input.quoraProfileUrl.trim() : '';
   const hasValidUrl = isLengthInRange(quoraProfileUrl, 1, SKILLS_HUNT_MAX_URL_LENGTH);
 
-  // Spec §2.1: ≥1 taxonomy-or-proposed skill, sum capped at 10, each ≤ 40 chars.
+  // Spec §2.1: ≥1 skill, sum capped at 10. Free-text proposed skills keep the short 40-char
+  // cap; taxonomy-picked skills carry the canonical taxonomy name and may be longer (up to the
+  // taxonomy's 120-char max), so a legitimate long skill name no longer fails the submission.
   const totalSkills = skills.length + proposedSkills.length;
-  const allSkillsWithinLabelLimit = [...skills, ...proposedSkills].every(
+  const pickedWithinLabelLimit = skills.every(
+    (label) => label.length <= SKILLS_HUNT_MAX_TAXONOMY_SKILL_LABEL_LENGTH,
+  );
+  const proposedWithinLabelLimit = proposedSkills.every(
     (label) => label.length <= SKILLS_HUNT_MAX_SKILL_LABEL_LENGTH,
   );
   const hasValidSkills =
     totalSkills > 0
     && totalSkills <= SKILLS_HUNT_MAX_SKILLS_PER_SUBMISSION
     && proposedSkills.length <= SKILLS_HUNT_MAX_PROPOSED_SKILLS_PER_SUBMISSION
-    && allSkillsWithinLabelLimit;
+    && pickedWithinLabelLimit
+    && proposedWithinLabelLimit;
 
   const hasValidClaimedProfessions = claimedProfessions.length <= 20;
   const hasUnsafeText = hasUnsafeCollectionText([


### PR DESCRIPTION
A nomination failed with "Invalid submission payload" after picking the skill "Customer service and signature collection" (41 chars). Submission validation capped every skill label at 40, but taxonomy skill names are allowed up to 120 — so picking a longer canonical skill was rejected.

Keep the 40-char cap for free-text proposed skills (short by design), and validate taxonomy-picked skills against the taxonomy's 120-char bound (new `SKILLS_HUNT_MAX_TAXONOMY_SKILL_LABEL_LENGTH`).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_