### PR TITLE
feat: show the fuller AI-engine status snippet on the @comic admin page

### DIFF
--- a/ctf/packages/web/components/comic/comic-review-dashboard.tsx
+++ b/ctf/packages/web/components/comic/comic-review-dashboard.tsx
@@ -25,12 +25,14 @@ function statusLabel(s: ServiceStatus): { text: string; color: string } {
   return { text: `reachable${s.latencyMs !== null ? ` · ${s.latencyMs}ms` : ''}`, color: '#22C55E' };
 }
 
-function ServiceStatusBadge({ name, status }: { name: string; status: ServiceStatus }) {
+function ServiceStatusBadge({ name, status, model }: { name: string; status: ServiceStatus; model?: string | null }) {
   const { text, color } = statusLabel(status);
   return (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, color: '#9CA3AF' }}>
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, color: '#9CA3AF', flexWrap: 'wrap' }}>
       <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} aria-hidden="true" />
-      <strong style={{ color: '#E5E7EB', fontWeight: 600 }}>{name}</strong> {text}
+      <strong style={{ color: '#E5E7EB', fontWeight: 600 }}>{name}:</strong>{' '}
+      <span style={{ color, fontWeight: 600 }}>{text}</span>
+      {model ? <span style={{ color: '#4B5563' }}>· {model}</span> : null}
     </span>
   );
 }
@@ -280,7 +282,7 @@ export function ComicReviewDashboard() {
           <div className={styles.queueSub}>AI Assistant drafts awaiting human review</div>
           {aiStatus ? (
             <div style={{ margin: '8px 0 4px' }}>
-              <ServiceStatusBadge name="Ollama" status={aiStatus.ollama} />
+              <ServiceStatusBadge name="Chat AI engine (RunPod / Ollama)" status={aiStatus.ollama} model={aiStatus.ollama.model} />
             </div>
           ) : null}
           {pendingCount > 0 ? (


### PR DESCRIPTION
Makes the `/admin/comic` review dashboard's engine-status line as informative as the one on the admin landing: it now reads "Chat AI engine (RunPod / Ollama): reachable · 48ms · qwen2.5:32b" (status coloured, model shown, failure reason shown on error) instead of a bare "Ollama reachable". Reuses the data the dashboard already fetches — no new request, no new endpoint. The admin-landing badge is unchanged.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_