### PR TITLE
feat: richer Stream chat UI for plugin chats (threads, reactions, typing)

### DIFF
--- a/ctf/packages/web/components/shared/stream-chat-panel.tsx
+++ b/ctf/packages/web/components/shared/stream-chat-panel.tsx
@@ -5,6 +5,8 @@ import {
   Channel,
   MessageList,
   MessageInput,
+  Thread,
+  Window,
 } from 'stream-chat-react';
 import 'stream-chat-react/dist/css/v2/index.css';
 
@@ -78,8 +80,16 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
     <div className="str-chat__theme-dark" style={{ height: '100%', display: 'flex', flexDirection: 'column', ...themeVars }}>
       <Chat client={client}>
         <Channel channel={channel}>
-          <MessageList />
-          <MessageInput />
+          {/* Window holds the main conversation; it yields to the Thread panel when a reply thread is
+              open (the thread slides over on phone-width, sits beside on desktop). Wrapping the list +
+              input in Window — and rendering a sibling Thread — is what turns on Stream's threaded
+              replies. Reactions, the typing indicator, and read state come with the v12 MessageList
+              defaults once the channel type allows them (the messaging type does). */}
+          <Window>
+            <MessageList />
+            <MessageInput />
+          </Window>
+          <Thread />
         </Channel>
       </Chat>
     </div>


### PR DESCRIPTION
## What and why

First build of the Stream feature-adoption initiative (`ctf/docs/developer/STREAM_FEATURE_ADOPTION.md`), starting with the lowest-risk, no-dependency win: the plugin chats already run Stream but the shared `StreamChatPanel` rendered only a bare `<MessageList/>` + `<MessageInput/>`, so reply threads could not open.

This wraps the list + input in Stream's `<Window>` and adds a sibling `<Thread>` — the canonical stream-chat-react v12 layout. That turns on **threaded replies**, and **reactions**, the **typing indicator**, and **read state** come with the v12 `MessageList` defaults now that the conversation can host them (the `messaging` channel type already allows them).

Upgrades all four `StreamChatPanel` consumers at once: TrustTransport, SocketRelay, LightHouse, Foundation.

No API, schema, or contract change — client UI only. Typecheck, ESLint, and EOF checks pass locally.

This is a low-risk UI change (richer Stream UI for already-Stream plugin chats, per the approved approach), so it's opened ready with auto-merge.

Parity Ticket: #699

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_