### PR TITLE
fix: attribute the sender's own messages in the Commons chat

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -538,6 +538,11 @@
   margin-bottom: 3px;
 }
 
+/* Your own messages sit on the right, so their author label aligns right to match. */
+.chatSenderUser {
+  text-align: right;
+}
+
 /* Footer row under a chat bubble: the timestamp plus the per-message "Reply" affordance.
    The reply button is faint until the row is hovered/focused so it does not crowd the chat. */
 .chatMetaRow {

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -352,7 +352,11 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
           }
 
           const msg = entry.message;
-          const senderName = msg.senderLabel ?? 'Survivor Hub';
+          // The author shown above the bubble. Your own messages are attributed to you (handle when
+          // we have it) so every message has a visible author, not just other people's — peer posts
+          // were rendering with no name on the sender's own side.
+          const ownLabel = currentUser.username ? `@${currentUser.username}` : currentUser.displayName;
+          const senderName = msg.from === 'user' ? ownLabel : (msg.senderLabel ?? 'Survivor Hub');
           // A peer post (it carries a community post id) can be replied to Signal-style.
           const canReply = Boolean(msg.communityPostId);
           return (
@@ -363,7 +367,7 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
               >
                 {msg.from === 'hub' ? <div className={styles.chatAvatar} aria-hidden="true">{avatarFromSender(senderName)}</div> : null}
                 <div className={styles.chatBubbleGroup}>
-                  {msg.from === 'hub' ? <span className={styles.chatSender}>{senderName}</span> : null}
+                  <span className={msg.from === 'user' ? `${styles.chatSender} ${styles.chatSenderUser}` : styles.chatSender}>{senderName}</span>
                   {msg.quotedMessage ? (
                     <div className={styles.chatQuotedBlock}>
                       <span className={styles.chatQuotedAuthor}>{msg.quotedMessage.author}</span>


### PR DESCRIPTION
## The bug

In the Commons chat, a peer message you sent (e.g. "hello everyone") showed the bubble and timestamp but **no author name**. Other people's messages were attributed; your own were not.

## Cause

The author label was rendered only for `from === 'hub'` messages (other people / the hub). Your own messages (`from === 'user'`) skipped the sender label entirely.

## Fix

Render the author for your own messages too — your handle (`@username`) when we have it, otherwise your display name — right-aligned to match the right-aligned bubble. Added a small `.chatSenderUser` style for the alignment. Now every message has a visible author.

No API/schema/contract change. Typecheck, ESLint, and EOF checks pass locally.

This is the web Commons custom chat (desktop + mobile-responsive, which is what the report's phone-width screenshot shows). The Android hub chat is a separate Stream-based surface and is not affected by this rendering path.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_