### PR TITLE
ci: run artifact cleanup weekly instead of daily

### DIFF
--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -3,7 +3,8 @@ name: Cleanup Old Artifacts and Close CI Budget Issues
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 2 * * *' # daily at 2am UTC
+    - cron: '0 2 * * 0' # weekly, Sundays at 2am UTC (was daily; the artifact-removal action paginates
+                        # every run/artifact in the repo each time, which was burning GitHub API rate limit)
 
 jobs:
   cleanup:


### PR DESCRIPTION
## What and why

The **Cleanup Old Artifacts and Close CI Budget Issues** workflow (`cleanup-artifacts.yml`) ran **daily**. The `c-hive/gha-remove-artifacts` action it uses paginates through every workflow run and artifact in the repo on each run — a heavy burst of GitHub API calls that was contributing to the API **rate limiting** the owner is hitting.

## Change

Schedule changed from daily (`0 2 * * *`) to **weekly**, Sundays 2am UTC (`0 2 * * 0`). `workflow_dispatch` is kept so it can still be run on demand. No behavior change otherwise (still deletes artifacts older than 1 day and closes `ci-budget-monitor` issues when it runs).

## Note (not changed here)

Two workflows run far more often and are the likelier main rate-limit contributors, but I left them alone since they're functional and weren't requested: **bug-reports-triage** (every 30 min) and **unlock-reward-reconciliation** (hourly). Happy to slow either if wanted.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_