### PR TITLE
ci: rename GitHub Actions workflow display names for clarity

### DIFF
--- a/.github/workflows/backup-formance-supabase.yml
+++ b/.github/workflows/backup-formance-supabase.yml
@@ -1,4 +1,4 @@
-name: Backup Formance to Supabase
+name: Formance — Nightly Backup to Supabase
 
 # Nightly backup of Formance Postgres to Supabase Storage.
 # Runs daily at 3am UTC and on manual dispatch.

--- a/.github/workflows/bug-reports-build.yml
+++ b/.github/workflows/bug-reports-build.yml
@@ -1,4 +1,4 @@
-name: Bug Reports — Build Approved Fix
+name: Bug Reports — Open PR for Approved Fix
 
 # Implements ONE owner-approved bug fix and opens a pull request on this app repo.
 #

--- a/.github/workflows/bug-reports-create-issues.yml
+++ b/.github/workflows/bug-reports-create-issues.yml
@@ -1,4 +1,4 @@
-name: Bug Reports — Create Triage Issues
+name: Bug Reports — Create Github Issues
 
 # Drains clean, user-filed bug reports from the app database into the PRIVATE triage
 # repo as issues. Raw user text never leaves the database — only redacted text is

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,4 +1,4 @@
-name: Build and push Docker images
+name: Render — Build and push Docker images
 
 # Builds each service image on push to main (with path filtering so Ollama
 # only rebuilds when its Dockerfile changes) and pushes to GHCR. Render is

--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -1,4 +1,4 @@
-name: Cleanup Old Artifacts and Close CI Budget Issues
+name: Cleanup — Old Artifacts and Close CI Budget Issues
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cleanup-workflow-runs.yml
+++ b/.github/workflows/cleanup-workflow-runs.yml
@@ -1,4 +1,4 @@
-name: Cleanup deprecated workflow runs
+name: Cleanup — Deprecated Workflow Runs
 
 # One-shot cleanup: deletes all GitHub Actions runs for workflows whose .yml
 # files have been removed, removing them from the Actions sidebar.

--- a/.github/workflows/create-neon-branch.yml
+++ b/.github/workflows/create-neon-branch.yml
@@ -1,4 +1,4 @@
-name: Create Neon branch
+name: Neon — Create Branch
 
 # Creates a fresh Postgres branch in Neon (e.g. a clean clone of production) via the
 # Neon API, so the v2 -> v3 cutover can be applied to a throwaway copy.

--- a/.github/workflows/deploy-blog-gh-pages.yml
+++ b/.github/workflows/deploy-blog-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Blog to GitHub Pages
+name: Github Pages — Deploy Blog
 
 on:
   # Triggered by the product-update workflow after it publishes to wiki-site,

--- a/.github/workflows/expo-android-release.yml
+++ b/.github/workflows/expo-android-release.yml
@@ -1,4 +1,4 @@
-name: Expo Android Release
+name: Expo — Android Release
 
 # Builds a signed production Android APK in Expo's cloud (EAS) and attaches it to
 # a GitHub Release when a tag like `mobile-v1.2.3` is pushed. This is the "real

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -1,4 +1,4 @@
-name: Expo Preview APK
+name: Expo — Preview APK
 
 # Builds an installable Android APK in Expo's cloud (EAS) for a pull request that
 # touches the mobile app, then posts a comment with the install link so a

--- a/.github/workflows/expo-update.yml
+++ b/.github/workflows/expo-update.yml
@@ -1,4 +1,4 @@
-name: Expo Update (OTA)
+name: Expo — OTA Update
 
 # Publishes a JavaScript/asset-only over-the-air update via EAS Update when
 # `main` is pushed. This does NOT rebuild native code — installed apps pick it up

--- a/.github/workflows/generate-community-stats.yml
+++ b/.github/workflows/generate-community-stats.yml
@@ -1,4 +1,4 @@
-name: Generate Community Stats Draft
+name: Generate — Community Stats Draft
 
 # Weekly sibling of generate-product-update.yml. Instead of turning commits into
 # a product update, this turns privacy-safe, whole-community activity totals

--- a/.github/workflows/generate-product-update.yml
+++ b/.github/workflows/generate-product-update.yml
@@ -1,4 +1,4 @@
-name: Generate Product Update
+name: Generate — Product Update
 
 on:
   schedule:

--- a/.github/workflows/github-actions-billing-token-reminder.yml
+++ b/.github/workflows/github-actions-billing-token-reminder.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions Billing Token Rotation Reminder
+name: GitHub Actions — Billing Token Rotation Reminder
 on:
   schedule:
     - cron: "0 12 * * 1"

--- a/.github/workflows/github-actions-budget-monitor.yml
+++ b/.github/workflows/github-actions-budget-monitor.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions Budget Monitor
+name: GitHub Actions — Budget Monitor
 
 on:
   schedule:

--- a/.github/workflows/inspect-schema-drift.yml
+++ b/.github/workflows/inspect-schema-drift.yml
@@ -1,4 +1,4 @@
-name: Inspect schema drift (read-only)
+name: Inspect — Schema Drift (read-only)
 
 # Manually triggered, read-only diagnostic. It never writes. Reports, to the Actions log, the
 # tables whose id type still differs from the v3 canonical uuid (the v2 -> v3 drift), with row

--- a/.github/workflows/provision-demo-schema.yml
+++ b/.github/workflows/provision-demo-schema.yml
@@ -1,4 +1,4 @@
-name: Provision demo schema in Neon
+name: Neon — Provision Demo Schema
 
 on:
   workflow_dispatch:

--- a/.github/workflows/render-debug-agent.yml
+++ b/.github/workflows/render-debug-agent.yml
@@ -1,4 +1,4 @@
-name: Render Debug Agent
+name: Render — Debug Agent
 
 on:
   workflow_dispatch:

--- a/.github/workflows/render-deploy-watch.yml
+++ b/.github/workflows/render-deploy-watch.yml
@@ -1,4 +1,4 @@
-name: Render Deploy Watch
+name: Render — Watch Deploy
 
 # When a commit lands on main, Render auto-deploys it. For each service in the
 # matrix, this finds that commit's deploy through the Render API and follows it

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,4 +1,4 @@
-name: Render deploy
+name: Render — Deploy Re-fresh (not an image rebuild)
 
 # Redeploys a Render service without rebuilding the Docker image (it re-pulls
 # the existing …:latest image from GHCR). Use this to ship images that were
@@ -17,8 +17,6 @@ on:
         type: choice
         options:
           - ctf-web
-          - ctf-ollama
-          - ctf-formance-ledger
           - all
 
 jobs:
@@ -32,8 +30,6 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID_CTF_WEB: ${{ secrets.RENDER_SERVICE_ID_CTF_WEB }}
-          RENDER_SERVICE_ID_OLLAMA: ${{ secrets.RENDER_SERVICE_ID_OLLAMA }}
-          RENDER_SERVICE_ID_CTF_FORMANCE: ${{ secrets.RENDER_SERVICE_ID_CTF_FORMANCE }}
           SERVICE: ${{ inputs.service }}
         run: |
           deploy() {
@@ -43,11 +39,7 @@ jobs:
 
           case "$SERVICE" in
             ctf-web)             deploy ctf-web             "$RENDER_SERVICE_ID_CTF_WEB" ;;
-            ctf-ollama)          deploy ctf-ollama          "$RENDER_SERVICE_ID_OLLAMA" ;;
-            ctf-formance-ledger) deploy ctf-formance-ledger "$RENDER_SERVICE_ID_CTF_FORMANCE" ;;
             all)
               deploy ctf-web             "$RENDER_SERVICE_ID_CTF_WEB"
-              deploy ctf-ollama          "$RENDER_SERVICE_ID_OLLAMA"
-              deploy ctf-formance-ledger "$RENDER_SERVICE_ID_CTF_FORMANCE"
               ;;
           esac

--- a/.github/workflows/restore-formance-supabase.yml
+++ b/.github/workflows/restore-formance-supabase.yml
@@ -1,4 +1,4 @@
-name: Restore Formance from Supabase
+name: Formance — Restore from Supabase
 
 # On-demand restore of a Formance pg_dump backup (produced by
 # backup-formance-supabase.yml) into a TARGET database — for disaster recovery or

--- a/.github/workflows/route-weather-briefing.yml
+++ b/.github/workflows/route-weather-briefing.yml
@@ -1,4 +1,4 @@
-name: Route weather briefing
+name: Route Weather Briefing
 
 # Builds the plain-text route weather report for a fixed route and pushes it to
 # your phone via ntfy.sh. Free: runs on a GitHub Actions cron, no always-on

--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -1,4 +1,4 @@
-name: Seed demo schema
+name: Demo — Seed Schema
 
 on:
   workflow_dispatch:

--- a/.github/workflows/unlock-reward-reconciliation.yml
+++ b/.github/workflows/unlock-reward-reconciliation.yml
@@ -1,4 +1,4 @@
-name: Unlock reward reconciliation
+name: Unlock — Reward Reconciliation
 
 # Self-heals missed Unlock approval rewards. The approval handler mints the 100-credit ServiceCredits
 # reward as a best-effort follow-up; if that mint fails, the approval still stands but the reward never

--- a/.github/workflows/update-neon-db.yml
+++ b/.github/workflows/update-neon-db.yml
@@ -1,4 +1,4 @@
-name: Update Neon DB (migrations + schema.sql)
+name: Neon — Update DB (Migrations + schema.sql)
 
 # Brings the database referenced by DATABASE_URL up to the v3 spec, in order:
 #   1. ctf/db/migrations/pre/*.sql   (structural fixes that must precede the canonical schema)

--- a/.github/workflows/workflow-health-check.yml
+++ b/.github/workflows/workflow-health-check.yml
@@ -1,4 +1,4 @@
-name: Workflow Health Check
+name: Github Actions — Workflow Health Check
 
 # Surfaces failing workflows so they don't go unnoticed. Every 8 hours (and on demand) it asks the
 # GitHub API for every active workflow's most recent run on `main`; any whose latest run failed or


### PR DESCRIPTION
Renames the `name:` display field across 26 GitHub Actions workflow files so each workflow is easier to identify in the Actions tab. No trigger, job, or step logic changes for the renamed workflows.

One functional change is bundled in: `render-deploy.yml` drops the `ctf-ollama` and `ctf-formance-ledger` deploy targets (and their service-id env vars), leaving only `ctf-web` and `all`.

Parity Status: web + mobile-responsive + android complete