### PR TITLE
feat: add Beacon admin-only one-way livestream plugin (web)

### DIFF
--- a/ctf/config/plugin-parity-contracts.json
+++ b/ctf/config/plugin-parity-contracts.json
@@ -132,6 +132,12 @@
       "mobileFeatureDirs": ["bug-reporting"],
       "requiresMobileSurface": false,
       "requiresExplicitWebShell": false
+    },
+    {
+      "slug": "beacon",
+      "mobileFeatureDirs": ["beacon"],
+      "requiresMobileSurface": false,
+      "requiresExplicitWebShell": true
     }
   ]
 }

--- a/ctf/docs/contracts/BEACON_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/BEACON_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -1,0 +1,209 @@
+policies:
+  - pluginId: beacon
+    command: event.current.get
+    version: 1.0.0
+    requiredRoles:
+      - member
+      - guest
+      - unauthenticated
+    attributePolicies:
+      publicWatchAllowed: true
+      hlsPlaybackPublic: true
+    consentRequirements:
+      scopes: []
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions: []
+
+  - pluginId: beacon
+    command: event.chat-token.mint
+    version: 1.0.0
+    requiredRoles:
+      - member
+    attributePolicies:
+      signedInMemberRequired: true
+      anonymousChatForbidden: true
+    consentRequirements:
+      scopes:
+        - beacon_chat_participation
+      fallbackLawfulBasis: contract_performance
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - no_active_session
+      - event_not_live
+      - stream_not_configured
+
+  - pluginId: beacon
+    command: event.create
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnly: true
+    consentRequirements:
+      scopes:
+        - beacon_event_manage
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - invalid_payload
+
+  - pluginId: beacon
+    command: event.ingest.get
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnly: true
+      onlyHostMayPublish: true
+    consentRequirements:
+      scopes:
+        - beacon_event_manage
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - event_not_found
+      - stream_not_configured
+
+  - pluginId: beacon
+    command: event.go-live
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnly: true
+      singleLiveEvent: true
+      autoPostCommonsOnGoLive: true
+    consentRequirements:
+      scopes:
+        - beacon_event_manage
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - event_not_found
+      - stream_not_configured
+      - another_event_live
+
+  - pluginId: beacon
+    command: event.end
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnly: true
+      stopBillingOnEnd: true
+    consentRequirements:
+      scopes:
+        - beacon_event_manage
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - event_not_found
+
+  - pluginId: beacon
+    command: event.admin.list
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnly: true
+    consentRequirements:
+      scopes:
+        - beacon_event_manage
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - insufficient_role
+
+  - pluginId: beacon
+    command: event.moderate
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnly: true
+      channelModeratorRequired: true
+    consentRequirements:
+      scopes:
+        - beacon_chat_moderation
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - event_not_found
+      - invalid_action
+      - stream_not_configured
+
+  - pluginId: beacon
+    command: event.stream-webhook.ingest
+    version: 1.0.0
+    requiredRoles:
+      - system
+    attributePolicies:
+      signatureVerificationRequired: true
+      idempotentRecordingPost: true
+    consentRequirements:
+      scopes: []
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - invalid_signature
+      - unknown_event

--- a/ctf/docs/contracts/BEACON_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/BEACON_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -1,0 +1,130 @@
+auditEvents:
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: beacon
+    command: event.create
+    commandVersion: 1.0.0
+    purpose: event_lifecycle
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - beacon_event_record
+    targetContext:
+      eventId: beacon_event_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: beacon
+    command: event.ingest.get
+    commandVersion: 1.0.0
+    purpose: broadcast_ingest
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - beacon_event_record
+      - live_session_credential
+    targetContext:
+      eventId: beacon_event_identifier
+      streamCallId: stream_call_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: beacon
+    command: event.go-live
+    commandVersion: 1.0.0
+    purpose: event_lifecycle
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - beacon_event_record
+      - commons_post_reference
+    targetContext:
+      eventId: beacon_event_identifier
+      commonsLivePostId: feed_post_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: beacon
+    command: event.end
+    commandVersion: 1.0.0
+    purpose: event_lifecycle
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - beacon_event_record
+    targetContext:
+      eventId: beacon_event_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: beacon
+    command: event.moderate
+    commandVersion: 1.0.0
+    purpose: chat_moderation
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - beacon_event_record
+      - chat_moderation_action
+    targetContext:
+      eventId: beacon_event_identifier
+      moderationAction: mute_ban_or_slow_mode
+      targetUserId: moderated_member_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: beacon
+    command: event.stream-webhook.ingest
+    commandVersion: 1.0.0
+    purpose: recording_ingest
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - beacon_event_record
+      - recording_reference
+      - commons_post_reference
+    targetContext:
+      eventId: beacon_event_identifier
+      commonsRecordingPostId: feed_post_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class

--- a/ctf/docs/contracts/BEACON_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/BEACON_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -1,0 +1,194 @@
+contracts:
+  - pluginId: beacon
+    command: event.current.get
+    version: 1.0.0
+    description: Return the currently-live Beacon event (or null) and the public HLS playback URL. Open to the public; no sign-in required.
+    inputSchema: {}
+    outputSchema:
+      event:
+        type: object
+      hlsPlaybackUrl:
+        type: string
+    dataAccess:
+      - beacon_events
+    purpose: public_viewer
+    retentionClass: derived_short_lived
+    idempotency: true
+
+  - pluginId: beacon
+    command: event.chat-token.mint
+    version: 1.0.0
+    description: Mint a Stream Chat token for the live event chat channel. Requires a signed-in member, so only members can post; this is the sign-in-to-chat gate. Anonymous callers are denied.
+    inputSchema:
+      eventId:
+        type: string
+        required: true
+    outputSchema:
+      streamApiKey:
+        type: string
+      streamChannelId:
+        type: string
+      streamUserId:
+        type: string
+      streamToken:
+        type: string
+    dataAccess:
+      - beacon_events
+      - canonical_user_profile
+    purpose: member_chat
+    retentionClass: transactional_short_lived
+    idempotency: false
+
+  - pluginId: beacon
+    command: event.create
+    version: 1.0.0
+    description: Create a draft Beacon event (title plus optional description). Admin-only.
+    inputSchema:
+      title:
+        type: string
+        required: true
+      description:
+        type: string
+        required: false
+    outputSchema:
+      event:
+        type: object
+    dataAccess:
+      - beacon_events
+      - beacon_events_admin_audit_trail
+    purpose: event_lifecycle
+    retentionClass: transactional_long_lived
+    idempotency: false
+
+  - pluginId: beacon
+    command: event.ingest.get
+    version: 1.0.0
+    description: Return the per-event RTMP ingest URL plus stream key (for a phone broadcaster app) and a host token (for desktop in-browser screen-share). Admin-only. Only the host token can publish.
+    inputSchema:
+      eventId:
+        type: string
+        required: true
+    outputSchema:
+      rtmpIngestUrl:
+        type: string
+      streamKey:
+        type: string
+      streamApiKey:
+        type: string
+      streamCallType:
+        type: string
+      streamCallId:
+        type: string
+      streamUserId:
+        type: string
+      hostToken:
+        type: string
+    dataAccess:
+      - beacon_events
+      - beacon_events_admin_audit_trail
+    purpose: broadcast_ingest
+    retentionClass: transactional_short_lived
+    idempotency: false
+
+  - pluginId: beacon
+    command: event.go-live
+    version: 1.0.0
+    description: Flip the event to live (Stream goLive on the livestream call) and auto-post a live-now notice to the Commons. Admin-only. Idempotent on the Commons post (stored on the event row).
+    inputSchema:
+      eventId:
+        type: string
+        required: true
+    outputSchema:
+      event:
+        type: object
+    dataAccess:
+      - beacon_events
+      - feed_community_posts
+      - feed_items
+      - beacon_events_admin_audit_trail
+    purpose: event_lifecycle
+    idempotency: true
+
+  - pluginId: beacon
+    command: event.end
+    version: 1.0.0
+    description: End the broadcast, stop the Stream call so video billing stops, and flip the event to ended. Admin-only.
+    inputSchema:
+      eventId:
+        type: string
+        required: true
+    outputSchema:
+      event:
+        type: object
+    dataAccess:
+      - beacon_events
+      - beacon_events_admin_audit_trail
+    purpose: event_lifecycle
+    idempotency: true
+
+  - pluginId: beacon
+    command: event.admin.list
+    version: 1.0.0
+    description: List Beacon events newest-first, including past events and their recordings. Admin-only.
+    inputSchema: {}
+    outputSchema:
+      events:
+        type: array
+    dataAccess:
+      - beacon_events
+    purpose: event_administration
+    retentionClass: derived_medium_lived
+    idempotency: true
+
+  - pluginId: beacon
+    command: event.moderate
+    version: 1.0.0
+    description: Moderate the live event chat — mute a member, ban a member from the event channel, or toggle slow-mode. Admin-only; targets the Stream Chat channel for the event.
+    inputSchema:
+      eventId:
+        type: string
+        required: true
+      action:
+        type: string
+        required: true
+        enum:
+          - mute
+          - ban
+          - slow_mode
+      targetUserId:
+        type: string
+        required: false
+      cooldownSeconds:
+        type: integer
+        required: false
+    outputSchema:
+      status:
+        type: string
+    dataAccess:
+      - beacon_events
+      - beacon_events_admin_audit_trail
+    purpose: chat_moderation
+    retentionClass: audit_long_lived
+    idempotency: false
+
+  - pluginId: beacon
+    command: event.stream-webhook.ingest
+    version: 1.0.0
+    description: Ingest Stream Video webhook events (recording-ready and call lifecycle). Verifies the Stream signature, stores the recording URL on the event, and posts the replay to the Commons. Idempotent — never double-posts the replay.
+    inputSchema:
+      type:
+        type: string
+        required: true
+      call_cid:
+        type: string
+        required: false
+    outputSchema:
+      ok:
+        type: boolean
+    dataAccess:
+      - beacon_events
+      - feed_community_posts
+      - feed_items
+    purpose: recording_ingest
+    retentionClass: transactional_long_lived
+    idempotency: true

--- a/ctf/docs/contracts/BEACON_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/BEACON_PROFILE_AND_DELETION_CONTRACT.md
@@ -1,0 +1,104 @@
+# Beacon Profile and Deletion Contract
+
+## 1) Plugin Metadata
+
+- Plugin Name: Beacon
+- Service Key (lowercase, stable): `beacon`
+- Owner Team: chargingthefuture
+- Rollout Stage: v1 build
+
+## 2) Canonical Profile Usage
+
+Rule 114 baseline: Beacon uses one canonical profile by `user_id`. There is no Beacon-local profile.
+
+- Read fields:
+  - `user_id` (the admin host on an event; the signed-in member when minting a chat token)
+  - display name (for the Stream Chat/Video user record)
+- Write fields:
+  - none to canonical profile
+
+## Identity Handle Baseline
+
+- Canonical handle source: the active auth provider's canonical `username` or equivalent handle field
+  (see `ctf/docs/contracts/PLUGIN_IDENTITY_HANDLE_BASELINE.md`).
+- Beacon must not create a plugin-local username model. If the canonical handle is missing, a
+  non-handle display fallback is used.
+
+## 3) Plugin Extension Fields
+
+Beacon has no per-member extension table. It does not store any per-member rows. The live chat and
+reactions are ephemeral and held only by Stream, never in our database.
+
+## 4) Domain Data Owned by Plugin
+
+- Table/entity: `beacon_events`
+  - Contains personal data? minimal — `host_user_id` (an admin) and the saved public recording URL.
+    No viewer or chatter identities are stored (chat is ephemeral in Stream).
+  - Retention period: long-lived (event history and replay links).
+  - Legal/compliance note: the broadcast and its recording are public by design; the replay is posted
+    publicly to the Commons. No private member content is stored here.
+- Table/entity: `beacon_events_admin_audit_trail`
+  - Contains personal data? minimal — `actor_id` (the admin) and an optional moderated `target_id`.
+  - Retention period: compliance retention window.
+  - Legal/compliance note: admin-action audit trail (create, go-live, end, moderate, recording-ingest).
+
+## 5) Service-Scoped Deletion Contract
+
+Beacon stores no per-member profile or per-member content, so there is no member-facing "delete my
+Beacon data" surface. A member who never wants to appear simply never chats — anonymous public
+watching leaves no stored identity, and members are never on camera (the admin is the sole publisher).
+
+- Delete immediately: nothing member-scoped exists to delete.
+- Anonymize/pseudonymize: not applicable — no per-member rows are stored.
+- Retain for compliance: `beacon_events_admin_audit_trail` (admin actions only).
+- Never touch: canonical profile; other plugins' data; Chyme.
+
+## 6) Full-Account Deletion Contract
+
+When a member requests full account deletion:
+
+- No member-scoped Beacon rows exist, so nothing is removed from Beacon tables for an ordinary member.
+- An admin's `host_user_id` references on past events are retained as event history (the events are
+  public broadcasts already posted to the Commons); the orchestrator does not hard-delete public
+  broadcast history.
+- Final expected state: no recoverable member-scoped Beacon data (there was none to begin with).
+
+## 7) Rejoin/Re-enable Behavior
+
+Not applicable — Beacon keeps no per-member state to recreate.
+
+## 8) Audit and Events
+
+- Admin actions are written to `beacon_events_admin_audit_trail` (`actor_id`, `command`,
+  `policy_status`, `reason`, `target_type`, `target_id`, `metadata`, `created_at`).
+- Who can trigger event lifecycle changes: an admin (create/go-live/end/moderate); the Stream webhook
+  (system actor) on recording-ready.
+
+## 9) API and UX Surface
+
+- No member deletion endpoint is required (no member-scoped data).
+- Full account delete endpoint (orchestrator): `DELETE /api/account/full-account` — no Beacon-specific
+  member rows to remove.
+
+## 10) Migration and Rollback
+
+- Migration file(s): all schema changes are in `ctf/schema.sql` (canonical source of truth):
+  `beacon_events`, `beacon_events_admin_audit_trail`.
+- Rollback approach: dropping Beacon tables removes only event history and the admin audit trail; no
+  member-scoped data is affected. Unsetting the Stream credentials degrades the plugin gracefully
+  (the viewer shows the idle/replay state and chat is unavailable) without data loss.
+- Backfill required? no.
+
+## 11) Sign-off Checklist
+
+- [ ] Product approved data behavior
+- [ ] Engineering reviewed schema boundaries
+- [ ] Compliance/privacy reviewed retention and deletion
+- [ ] Observability added (without sensitive payloads)
+- [ ] Web and Android parity confirmed (Android viewer parity deferred via a parity ticket)
+
+## Change Log
+
+- 2026-06-21: Created for the Beacon v1 build. No per-member data is stored (live chat ephemeral in
+  Stream; viewers anonymous over HLS). Owned tables: `beacon_events`,
+  `beacon_events_admin_audit_trail`.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -1,8 +1,8 @@
 # Beacon Plugin Feature Inventory (CTF v3)
 
-> **Status: PLANNED — not yet built.** This document is the agreed plan and the single source of
-> truth for the Beacon plugin. All owner decisions below are locked (2026-06-21). The build follows
-> the Build Checklist at the bottom, in dependency order, after the in-flight Commons work merges.
+> Status: web built (admin broadcaster + public viewer); Android viewer parity deferred. This
+> document is the single source of truth for the Beacon plugin. All owner decisions below are locked
+> (2026-06-21).
 
 ## Scope and Boundary
 
@@ -137,14 +137,19 @@ default on the ALTER (the `id` default lesson from the announcements fix). Regen
 
 ## Web and Android Delivery Status
 
-- Web (desktop + mobile-responsive): **planned, not started.**
-- Android (React Native): **deferred** — viewer parity tracked by a parity ticket opened with the
-  build PR.
+- Web (desktop + mobile-responsive): built. Admin broadcaster at `/admin/beacon` (create, go-live
+  with RTMP url/key plus desktop screen-share, live chat + moderation, end, history). Public viewer
+  at `/apps/beacon` (HLS player, "live and public" indicator, member live chat, idle/replay state).
+  Both are mobile-responsive.
+- Android (React Native): deferred — viewer parity tracked by a parity ticket opened with the build
+  PR.
 
 ## Seed Coverage Status
 
-Planned: a seed for one past `ended` event with a recording URL, so the viewer idle state and the
-admin history list render with real data in demos.
+`ctf/scripts/seedBeaconPhase0.mjs` inserts one past `ended` event ("State of the TI Skills Economy")
+with a recording URL and a deterministic UUID, plus one matching admin audit row. This makes the
+viewer idle/replay state and the admin history list render with real data in demos. Re-runnable
+(`ON CONFLICT (id) DO NOTHING`). No per-member rows are seeded (Beacon stores none).
 
 ## Trust Signal
 
@@ -198,3 +203,15 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
   chat/react; ephemeral chat; one-way `livestream` broadcast; recording auto-posts to Commons; admin
   moderation + "live and public" indicator; Chyme untouched). Flagship event = the State of the TI
   Skills Economy address. Not yet built.
+- 2026-06-21: Web build shipped on branch `feat/beacon-plugin`. Added the `beacon` registry entry; the
+  `beacon_events` and `beacon_events_admin_audit_trail` tables (CREATE/ALTER pattern, regenerated
+  `schema.demo.sql`); the four `BEACON_*` contracts; the server lib (`lib/beacon/` — Stream Video
+  livestream lifecycle over the REST API, host token, public HLS URL, per-event RTMP ingest, member
+  Stream Chat token, recording handling, webhook signature verify, Commons auto-post helpers); the API
+  routes (`current`, `[id]/chat-token`, create, `[id]/ingest`, `[id]/go-live`, `[id]/end`, `admin`
+  list, `[id]/moderate`, `stream-webhook`); idempotent Commons auto-post on go-live and
+  recording-ready (post ids stored on the event row); the admin UI (`/admin/beacon`) and public viewer
+  (`/apps/beacon`); the seed script; and the quota-impact note. A few Stream Video REST field/endpoint
+  names are marked `TODO(beacon)` to confirm against the live dashboard before the first real
+  broadcast; no URLs are fabricated when a field is absent. Android viewer parity deferred via a
+  parity ticket.

--- a/ctf/docs/quota-impact/2026-06-21-beacon-livestream-video.md
+++ b/ctf/docs/quota-impact/2026-06-21-beacon-livestream-video.md
@@ -1,0 +1,78 @@
+# Stream Quota Impact Note — Beacon livestream video
+
+## Summary
+
+- Feature/Change: Beacon, an admin-only one-way livestream plugin. An admin goes live ad hoc to
+  broadcast a live demo (screen content); the flagship use is the "State of the TI Skills Economy"
+  address. Watching is public over HLS (no sign-in); chatting/reacting needs a signed-in member
+  (Stream Chat). Recording is on; the replay is posted to the Commons.
+- PR: branch `feat/beacon-plugin` (no PR opened yet)
+- Owner: chargingthefuture
+- Date: 2026-06-21
+
+## Stream Surfaces Affected
+
+- Video. One Stream `livestream` call per event (call id `beacon-<eventId>`). The admin is the only
+  publisher (RTMP ingest from a phone broadcaster app, or in-browser desktop screen-share). Public
+  viewers watch over HLS, which does not multiply WebRTC participant cost. Recording is enabled, which
+  adds recording storage and a recording-ready webhook.
+- Chat. One Stream `livestream` chat channel per event (same id). Only signed-in members get a token,
+  so chat MAU is bounded by members who choose to chat during an event, not by total viewers.
+- Activity Feed / AI Moderation: none.
+
+## Estimated Monthly Impact
+
+- Video minutes are the most cost-sensitive Stream usage here, and cost scales with viewers ×
+  duration. Public viewing is served over HLS (a single broadcast distributed to many viewers) rather
+  than per-viewer WebRTC, so it does not fan out into per-participant WebRTC minutes. Events are ad
+  hoc and infrequent (no fixed cadence), so total minutes stay low: a handful of broadcasts a month,
+  each tens of minutes, over a single publisher.
+- Recording storage: one recording per event, retained as the replay link. Small at current cadence.
+- Chat MAU: only members who actually post chat count; watchers who never chat add nothing. Bounded
+  and low.
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout: Green. Single publisher, HLS distribution for viewers, infrequent
+  ad hoc events. The dominant lever is event duration, which the admin controls and ends explicitly.
+- Peak scenario: a long, heavily-watched broadcast. Even then, HLS keeps the cost off per-viewer
+  WebRTC, and there is at most one live event at a time (enforced by a partial unique index on the
+  events table). Re-evaluate if event frequency or duration grows substantially.
+
+## Fallback and Degradation Plan
+
+- What degrades first: if Stream is not configured (no API key/secret), `resolveStreamCredentials()`
+  returns null and every Beacon Stream call degrades safely — `current` shows the idle/replay state,
+  the ingest/go-live routes return 503, and the chat-token route returns 503. Nothing crashes.
+- The End-event path is the billing kill switch: ending an event calls `endBeaconCall`, which stops
+  the Stream call so distribution and billing stop. The End route stops the call before marking the
+  event ended, and reports (does not swallow) a stop failure so it can be followed up.
+- Demo mode already routes Stream to the staging app (`resolveStreamCredentials`), so recording
+  sessions never consume production quota.
+
+## Observability
+
+- Server errors are reported to Sentry via `reportError` (`area: 'beacon'`, ops: `current`, `ingest`,
+  `go_live`, `end`, `end_stop_call`, `moderate`, `chat_token`, `stream_webhook`, and client
+  `host_join_client`).
+- Admin actions (create, go-live, end, moderate, ingest) are written to
+  `beacon_events_admin_audit_trail`.
+
+## Validation
+
+- Tests added for degraded mode: covered by each route's explicit 503 branch when Stream is not
+  configured, and by the viewer's idle state when `current` returns no live event. No automated test
+  harness for live Stream calls (consistent with the existing Chyme / Peer Programming video
+  surfaces).
+- Rollback strategy: revert the branch, or unset the production Stream credentials to disable the
+  broadcast path while leaving the rest of the app intact.
+
+## Open confirmations (TODO before first real broadcast)
+
+- Confirm the Stream Video `livestream` call-type config in the dashboard (host-only publish; viewer
+  role cannot publish) and that recording is enabled (or set via `settings_override.recording`).
+- Confirm the exact Video REST field names this build reads defensively: `call.ingress.rtmp.address`
+  / `stream_key`, the HLS `call.egress.hls.playlist_url`, the `go_live` / `stop_live` endpoints, and
+  the `call.recording_ready` webhook payload (`call_cid`, `call_recording.url`). These are marked
+  `TODO(beacon)` in `lib/beacon/stream.ts` and the webhook route; no URLs are fabricated when a field
+  is absent.

--- a/ctf/packages/web/app/admin/beacon/page.tsx
+++ b/ctf/packages/web/app/admin/beacon/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { BeaconAdminShell } from '@/components/beacon/beacon-admin-shell';
+
+export const dynamic = 'force-dynamic';
+
+export default async function BeaconAdminPage() {
+  const decision = await evaluatePluginAccess({ requireUsername: false });
+  if (!decision.allowed || !decision.isAdmin) {
+    redirect('/apps/beacon');
+  }
+
+  return <BeaconAdminShell />;
+}

--- a/ctf/packages/web/app/api/beacon/[id]/chat-token/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/chat-token/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { buildIdentityDisplayName } from 'lib/auth/request-identity';
+import { ensureBeaconMutationCsrf, requireBeaconMemberAccess } from 'lib/beacon/_lib';
+import { BEACON_ERROR_CODE } from 'lib/beacon/constants';
+import { getBeaconEvent } from 'lib/beacon/repository';
+import { createBeaconMemberChatCredentials } from 'lib/beacon/stream';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Mint a Stream Chat token for the live event chat. Requires a signed-in member — this is the
+// sign-in-to-chat gate. Anonymous callers get 401 from the member gate and can only watch.
+export async function POST(request: Request, context: RouteContext) {
+  const csrfDeny = ensureBeaconMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireBeaconMemberAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { id } = await context.params;
+
+  try {
+    const event = await getBeaconEvent(id);
+    if (!event) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
+        { status: 404 },
+      );
+    }
+
+    const displayName = buildIdentityDisplayName(gate.auth.username, gate.auth.userId);
+    const credentials = await createBeaconMemberChatCredentials({
+      userId: gate.auth.userId,
+      name: displayName,
+      eventId: event.id,
+    });
+
+    if (!credentials) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Live chat is not configured.' },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json({ ok: true, displayName, ...credentials }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'chat_token', extra: { eventId: id } });
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Live chat unavailable.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/beacon/[id]/end/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/end/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { beaconErrorResponse, ensureBeaconMutationCsrf, requireBeaconAdminAccess } from 'lib/beacon/_lib';
+import { BEACON_ERROR_CODE } from 'lib/beacon/constants';
+import { getBeaconEvent, insertBeaconAudit, markBeaconEventEnded } from 'lib/beacon/repository';
+import { endBeaconCall } from 'lib/beacon/stream';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Admin: end the broadcast. This is the cost-critical path — it stops the Stream call so video
+// billing stops, then flips the event to ended. The recording-ready webhook posts the replay later.
+export async function POST(request: Request, context: RouteContext) {
+  const csrfDeny = ensureBeaconMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireBeaconAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { id } = await context.params;
+
+  try {
+    const event = await getBeaconEvent(id);
+    if (!event) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
+        { status: 404 },
+      );
+    }
+
+    // Stop the call first so billing stops even if the DB update were to fail. A null return means
+    // Stream is not configured, in which case there is nothing to stop — proceed to mark ended.
+    try {
+      await endBeaconCall(event.id);
+    } catch (streamError) {
+      // Do not block ending the event if the stop call fails; the operator still needs the event
+      // marked ended. Surface the failure for follow-up.
+      reportError(streamError, { area: 'beacon', op: 'end_stop_call', extra: { eventId: event.id } });
+    }
+
+    const endedEvent = (await markBeaconEventEnded(event.id)) ?? event;
+
+    await insertBeaconAudit({
+      actorId: gate.auth.userId,
+      command: 'beacon.event.end',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'event',
+      targetId: event.id,
+    });
+
+    return NextResponse.json({ ok: true, event: endedEvent }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'end', extra: { eventId: id } });
+    return beaconErrorResponse('Could not end the broadcast.');
+  }
+}

--- a/ctf/packages/web/app/api/beacon/[id]/go-live/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/go-live/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { beaconErrorResponse, ensureBeaconMutationCsrf, requireBeaconAdminAccess } from 'lib/beacon/_lib';
+import { BEACON_ERROR_CODE } from 'lib/beacon/constants';
+import {
+  getBeaconEvent,
+  getLiveBeaconEvent,
+  insertBeaconAudit,
+  markBeaconEventLive,
+  postBeaconLiveNotice,
+} from 'lib/beacon/repository';
+import { goLiveBeaconCall } from 'lib/beacon/stream';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Admin: flip the event to live (Stream goLive) and auto-post the live-now notice to the Commons.
+export async function POST(request: Request, context: RouteContext) {
+  const csrfDeny = ensureBeaconMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireBeaconAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { id } = await context.params;
+
+  try {
+    const event = await getBeaconEvent(id);
+    if (!event) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
+        { status: 404 },
+      );
+    }
+
+    // At most one live event at a time (also enforced by a partial unique index). Block go-live when
+    // a different event is already live so the public viewer is never ambiguous.
+    const alreadyLive = await getLiveBeaconEvent();
+    if (alreadyLive && alreadyLive.id !== event.id) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.conflict, message: 'Another event is already live. End it first.' },
+        { status: 409 },
+      );
+    }
+
+    const started = await goLiveBeaconCall(event.id);
+    if (!started) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Live video is not configured.' },
+        { status: 503 },
+      );
+    }
+
+    const liveEvent = (await markBeaconEventLive(event.id)) ?? event;
+    const livePostId = await postBeaconLiveNotice(liveEvent);
+
+    await insertBeaconAudit({
+      actorId: gate.auth.userId,
+      command: 'beacon.event.go-live',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'event',
+      targetId: event.id,
+      metadata: { commonsLivePostId: livePostId },
+    });
+
+    return NextResponse.json({ ok: true, event: { ...liveEvent, commonsLivePostId: livePostId } }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'go_live', extra: { eventId: id } });
+    return beaconErrorResponse('Could not start the broadcast.');
+  }
+}

--- a/ctf/packages/web/app/api/beacon/[id]/ingest/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/ingest/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { buildIdentityDisplayName } from 'lib/auth/request-identity';
+import { requireBeaconAdminAccess } from 'lib/beacon/_lib';
+import { BEACON_ERROR_CODE } from 'lib/beacon/constants';
+import { getBeaconEvent, insertBeaconAudit } from 'lib/beacon/repository';
+import { createBeaconHostCredentials, ensureBeaconCallAndIngest } from 'lib/beacon/stream';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Admin: the per-event RTMP ingest URL + stream key (for a phone broadcaster app) and a host token
+// (for desktop in-browser screen-share). Only the host token can publish.
+export async function GET(_request: Request, context: RouteContext) {
+  const gate = await requireBeaconAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { id } = await context.params;
+
+  try {
+    const event = await getBeaconEvent(id);
+    if (!event) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
+        { status: 404 },
+      );
+    }
+
+    const credentials = await createBeaconHostCredentials({
+      userId: gate.auth.userId,
+      name: buildIdentityDisplayName(gate.auth.username, gate.auth.userId),
+      eventId: event.id,
+    });
+    if (!credentials) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Live video is not configured.' },
+        { status: 503 },
+      );
+    }
+
+    const ingest = await ensureBeaconCallAndIngest({ eventId: event.id, hostUserId: gate.auth.userId });
+    if (!ingest) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Live video is not configured.' },
+        { status: 503 },
+      );
+    }
+
+    await insertBeaconAudit({
+      actorId: gate.auth.userId,
+      command: 'beacon.event.ingest',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'event',
+      targetId: event.id,
+      metadata: { streamCallId: credentials.streamCallId },
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        rtmpIngestUrl: ingest.rtmpIngestUrl,
+        streamKey: ingest.streamKey,
+        streamApiKey: credentials.streamApiKey,
+        streamCallType: credentials.streamCallType,
+        streamCallId: credentials.streamCallId,
+        streamUserId: credentials.streamUserId,
+        hostToken: credentials.hostToken,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'ingest', extra: { eventId: id } });
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Broadcast input unavailable.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/beacon/[id]/moderate/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/moderate/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { beaconErrorResponse, ensureBeaconMutationCsrf, requireBeaconAdminAccess } from 'lib/beacon/_lib';
+import { BEACON_ERROR_CODE, BEACON_DEFAULT_SLOW_MODE_SECONDS } from 'lib/beacon/constants';
+import { getBeaconEvent, insertBeaconAudit } from 'lib/beacon/repository';
+import { moderateBeaconChat, type BeaconModerationAction } from 'lib/beacon/stream';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+type ModerateBody = {
+  action?: string;
+  targetUserId?: string | null;
+  cooldownSeconds?: number | null;
+};
+
+const VALID_ACTIONS: BeaconModerationAction[] = ['mute', 'ban', 'slow_mode'];
+
+// Admin: moderate the live event chat — mute a member, ban a member from the event channel, or
+// toggle slow-mode.
+export async function POST(request: Request, context: RouteContext) {
+  const csrfDeny = ensureBeaconMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireBeaconAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { id } = await context.params;
+
+  let body: ModerateBody;
+  try {
+    body = (await request.json()) as ModerateBody;
+  } catch {
+    return NextResponse.json({ ok: false, code: BEACON_ERROR_CODE.invalidJson, message: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const action = body.action as BeaconModerationAction | undefined;
+  if (!action || !VALID_ACTIONS.includes(action)) {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.invalidPayload, message: 'action must be one of mute, ban, slow_mode.' },
+      { status: 400 },
+    );
+  }
+  if ((action === 'mute' || action === 'ban') && !body.targetUserId) {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.invalidPayload, message: 'targetUserId is required to mute or ban.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const event = await getBeaconEvent(id);
+    if (!event) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
+        { status: 404 },
+      );
+    }
+
+    const cooldownSeconds =
+      action === 'slow_mode'
+        ? body.cooldownSeconds === 0
+          ? 0
+          : body.cooldownSeconds ?? BEACON_DEFAULT_SLOW_MODE_SECONDS
+        : null;
+
+    const applied = await moderateBeaconChat({
+      eventId: event.id,
+      hostUserId: gate.auth.userId,
+      action,
+      targetUserId: body.targetUserId ?? null,
+      cooldownSeconds,
+    });
+
+    if (!applied) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Chat moderation is not configured.' },
+        { status: 503 },
+      );
+    }
+
+    await insertBeaconAudit({
+      actorId: gate.auth.userId,
+      command: 'beacon.event.moderate',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: action === 'slow_mode' ? 'channel' : 'member',
+      targetId: body.targetUserId ?? event.id,
+      metadata: { action, cooldownSeconds },
+    });
+
+    return NextResponse.json({ ok: true, status: 'applied' }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'moderate', extra: { eventId: id } });
+    return beaconErrorResponse('Could not apply moderation.');
+  }
+}

--- a/ctf/packages/web/app/api/beacon/admin/route.ts
+++ b/ctf/packages/web/app/api/beacon/admin/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { beaconErrorResponse, requireBeaconAdminAccess } from 'lib/beacon/_lib';
+import { listBeaconEvents } from 'lib/beacon/repository';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+// Admin: list events newest-first (history + recordings).
+export async function GET() {
+  const gate = await requireBeaconAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const events = await listBeaconEvents();
+    return NextResponse.json({ ok: true, events }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'admin_list' });
+    return beaconErrorResponse('Could not load events.');
+  }
+}

--- a/ctf/packages/web/app/api/beacon/current/route.ts
+++ b/ctf/packages/web/app/api/beacon/current/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getBeaconHlsPlaybackUrl } from 'lib/beacon/stream';
+import { getLatestReplayBeaconEvent, getLiveBeaconEvent } from 'lib/beacon/repository';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+// Public: the currently-live event (or null) plus the public HLS playback URL, and the last replay
+// for the idle state. No sign-in required — this is what lets anyone watch with just a link.
+export async function GET() {
+  try {
+    const liveEvent = await getLiveBeaconEvent();
+    const replayEvent = await getLatestReplayBeaconEvent();
+    let hlsPlaybackUrl: string | null = null;
+    if (liveEvent) {
+      try {
+        hlsPlaybackUrl = await getBeaconHlsPlaybackUrl(liveEvent.id);
+      } catch (error) {
+        // A Stream lookup failure must not break the public viewer; show the event without the URL.
+        reportError(error, { area: 'beacon', op: 'current_hls', extra: { eventId: liveEvent.id } });
+      }
+    }
+    return NextResponse.json({ ok: true, event: liveEvent, hlsPlaybackUrl, replay: replayEvent }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'current' });
+    return NextResponse.json({ ok: true, event: null, hlsPlaybackUrl: null, replay: null }, { status: 200 });
+  }
+}

--- a/ctf/packages/web/app/api/beacon/route.ts
+++ b/ctf/packages/web/app/api/beacon/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { beaconErrorResponse, ensureBeaconMutationCsrf, requireBeaconAdminAccess } from 'lib/beacon/_lib';
+import { BEACON_ERROR_CODE, BEACON_MAX_TITLE_LENGTH } from 'lib/beacon/constants';
+import { createBeaconEvent, insertBeaconAudit } from 'lib/beacon/repository';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+type CreateBody = { title?: string; description?: string };
+
+// Admin: create a draft Beacon event.
+export async function POST(request: Request) {
+  const csrfDeny = ensureBeaconMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireBeaconAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  let body: CreateBody;
+  try {
+    body = (await request.json()) as CreateBody;
+  } catch {
+    return NextResponse.json({ ok: false, code: BEACON_ERROR_CODE.invalidJson, message: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const title = (body.title ?? '').trim();
+  if (title.length === 0 || title.length > BEACON_MAX_TITLE_LENGTH) {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.invalidPayload, message: 'A title between 1 and 160 characters is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const event = await createBeaconEvent({
+      hostUserId: gate.auth.userId,
+      title,
+      description: body.description ?? '',
+    });
+    await insertBeaconAudit({
+      actorId: gate.auth.userId,
+      command: 'beacon.event.create',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'event',
+      targetId: event.id,
+    });
+    return NextResponse.json({ ok: true, event }, { status: 201 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'event_create' });
+    return beaconErrorResponse('Could not create the event.');
+  }
+}

--- a/ctf/packages/web/app/api/beacon/stream-webhook/route.ts
+++ b/ctf/packages/web/app/api/beacon/stream-webhook/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { BEACON_ERROR_CODE } from 'lib/beacon/constants';
+import {
+  getBeaconEventByCallId,
+  postBeaconReplayNotice,
+  recordBeaconRecording,
+} from 'lib/beacon/repository';
+import { verifyBeaconWebhookSignature } from 'lib/beacon/stream';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+// Stream Video webhook. Verifies the signature, and on a recording-ready event stores the recording
+// URL and posts the replay to the Commons. Idempotent: the recording URL and the Commons post id are
+// each written only when still null, so a redelivered webhook never double-posts the replay.
+//
+// TODO(beacon): confirm the exact Stream webhook event name and recording payload shape. Stream
+// documents `call.recording_ready` carrying `call_cid` (e.g. "livestream:beacon-<id>") and a
+// `call_recording.url`. We read those defensively and never fabricate a URL.
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  const signature = request.headers.get('x-signature');
+
+  const verified = await verifyBeaconWebhookSignature(rawBody, signature);
+  if (!verified) {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.webhookSignatureInvalid, message: 'Invalid webhook signature.' },
+      { status: 401 },
+    );
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = rawBody.length > 0 ? (JSON.parse(rawBody) as Record<string, unknown>) : {};
+  } catch {
+    return NextResponse.json({ ok: false, code: BEACON_ERROR_CODE.invalidJson, message: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  try {
+    const type = typeof payload.type === 'string' ? payload.type : '';
+    if (type !== 'call.recording_ready') {
+      // Acknowledge other lifecycle events so Stream stops retrying; only recording-ready acts.
+      return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+    }
+
+    const callCid = typeof payload.call_cid === 'string' ? payload.call_cid : '';
+    const callId = callCid.includes(':') ? callCid.split(':').slice(1).join(':') : callCid;
+    const recording = (payload.call_recording ?? {}) as Record<string, unknown>;
+    const recordingUrl = typeof recording.url === 'string' ? recording.url : '';
+
+    if (callId.length === 0 || recordingUrl.length === 0) {
+      return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+    }
+
+    const event = await getBeaconEventByCallId(callId);
+    if (!event) {
+      return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+    }
+
+    // Store the URL (no-op when already set), then re-read so the post helper sees the URL even if
+    // this delivery raced an earlier one.
+    const updated = (await recordBeaconRecording(event.id, recordingUrl)) ?? {
+      ...event,
+      recordingUrl,
+    };
+    await postBeaconReplayNotice(updated);
+
+    return NextResponse.json({ ok: true, handled: true }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'stream_webhook' });
+    // Return 200 so Stream does not hammer retries on our transient failure; we logged it.
+    return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+  }
+}

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -3,6 +3,7 @@ import { getHostedSignInUrl } from 'lib/auth/provider-env';
 import { canonicalizePluginSlug, getPluginBySlug, isAdminOnlyPlugin } from 'lib/plugins/repository';
 import { getPublicVisitorShell } from '@/components/plugins/public-visitor-registry';
 import { PublicShellFrame } from '@/components/plugins/public-shell-frame';
+import { BeaconShell } from '@/components/beacon/beacon-shell';
 import { ChymeShell } from '@/components/chyme/chyme-shell';
 import { DirectoryShell } from '@/components/directory/directory-shell';
 import { FoundationShell } from '@/components/foundation/foundation-shell';
@@ -143,8 +144,10 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   // shown the plugin's public landing page below (not the access-denied view), which
   // nudges them toward the Unlock flow; the Hub general channel is their support
   // surface. Chyme does not require a username so its anonymous public shell still works.
+  // Chyme and Beacon are watch-first surfaces that do not require a username to view, so anonymous
+  // and not-yet-named members can still watch the public broadcast.
   const decision = await evaluatePluginAccess({
-    requireUsername: selectedPlugin.slug !== 'chyme',
+    requireUsername: selectedPlugin.slug !== 'chyme' && selectedPlugin.slug !== 'beacon',
   });
 
   // Operator-only plugins (e.g. Weekly Performance) are admin-only: a non-admin gets a 404 for the
@@ -192,6 +195,10 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
         requestedPluginSlug={selectedPlugin.slug}
       />
     );
+  }
+
+  if (selectedPlugin.slug === 'beacon') {
+    return <BeaconShell />;
   }
 
   if (selectedPlugin.slug === 'clicklog') {

--- a/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
+++ b/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+// Beacon admin broadcaster + controls. Dark admin design system (rule 131). One column, mobile
+// responsive. The admin can:
+//   - create an event (title + description)
+//   - go live: see the per-event RTMP url/key (for a phone broadcaster app) and a "Share screen"
+//     button (desktop in-browser screen-share), both feeding the same livestream call
+//   - read the live chat and moderate (mute / ban / slow-mode)
+//   - end the event (stops the broadcast and billing)
+//   - see event history with recordings
+//
+// Binds the Beacon API routes: POST /api/beacon, GET /api/beacon/admin, GET /api/beacon/[id]/ingest,
+// POST /api/beacon/[id]/go-live, POST /api/beacon/[id]/end, POST /api/beacon/[id]/moderate, and the
+// member chat token route for the admin's own chat view.
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Radio, Copy, Check } from 'lucide-react';
+import { StreamChatPanel } from '@/components/shared/stream-chat-panel';
+import { BeaconHostStage, type BeaconHostCredentials } from './beacon-host-stage';
+import { BEACON_COLOR } from 'lib/beacon/constants';
+
+const BG = '#0F1117';
+const PANEL = '#0D0F14';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#9CA3AF';
+
+type BeaconEvent = {
+  id: string;
+  title: string;
+  description: string;
+  status: 'draft' | 'live' | 'ended';
+  startedAtIso: string | null;
+  endedAtIso: string | null;
+  recordingUrl: string | null;
+  commonsLivePostId: string | null;
+  commonsRecordingPostId: string | null;
+  createdAtIso: string;
+};
+
+type IngestResponse = {
+  ok: boolean;
+  rtmpIngestUrl: string;
+  streamKey: string;
+  streamApiKey: string;
+  streamCallType: string;
+  streamCallId: string;
+  streamUserId: string;
+  hostToken: string;
+};
+
+type ChatCredentials = {
+  streamApiKey: string;
+  streamChannelType: string;
+  streamChannelId: string;
+  streamUserId: string;
+  streamToken: string;
+};
+
+async function adminMutate<T = unknown>(url: string, method: 'POST', body?: unknown): Promise<{ ok: boolean; data: T | null; message?: string }> {
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const data = (await res.json().catch(() => null)) as (T & { message?: string; code?: string }) | null;
+    if (res.ok) return { ok: true, data: data as T };
+    return { ok: false, data: null, message: data?.message ?? data?.code ?? `Request failed (${res.status}).` };
+  } catch {
+    return { ok: false, data: null, message: 'Network error. Try again.' };
+  }
+}
+
+export function BeaconAdminShell() {
+  const [events, setEvents] = useState<BeaconEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const [activeEventId, setActiveEventId] = useState<string | null>(null);
+  const [ingest, setIngest] = useState<IngestResponse | null>(null);
+  const [host, setHost] = useState<BeaconHostCredentials | null>(null);
+  const [chat, setChat] = useState<ChatCredentials | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [moderateTarget, setModerateTarget] = useState('');
+
+  const loadEvents = useCallback(async () => {
+    const res = await fetch('/api/beacon/admin', { cache: 'no-store' });
+    if (!res.ok) throw new Error('Could not load events.');
+    const data = (await res.json()) as { ok: boolean; events: BeaconEvent[] };
+    setEvents(data.events ?? []);
+  }, []);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        await loadEvents();
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Could not load the admin data.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [loadEvents]);
+
+  const activeEvent = events.find((event) => event.id === activeEventId) ?? null;
+
+  const createEvent = useCallback(async () => {
+    if (title.trim().length === 0) {
+      setError('Add a title first.');
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    setNotice(null);
+    const result = await adminMutate<{ event: BeaconEvent }>('/api/beacon', 'POST', {
+      title: title.trim(),
+      description: description.trim(),
+    });
+    if (!result.ok || !result.data) {
+      setError(result.message ?? 'Could not create the event.');
+    } else {
+      setNotice('Event created.');
+      setTitle('');
+      setDescription('');
+      setActiveEventId(result.data.event.id);
+      try { await loadEvents(); } catch { /* non-fatal */ }
+    }
+    setCreating(false);
+  }, [title, description, loadEvents]);
+
+  // Fetch the RTMP ingest + host token. Used to populate the broadcaster panel before going live.
+  const loadIngest = useCallback(async (eventId: string) => {
+    const res = await fetch(`/api/beacon/${eventId}/ingest`, { cache: 'no-store' });
+    if (!res.ok) {
+      const data = (await res.json().catch(() => null)) as { message?: string } | null;
+      setError(data?.message ?? 'Broadcast input is unavailable.');
+      return null;
+    }
+    const data = (await res.json()) as IngestResponse;
+    setIngest(data);
+    return data;
+  }, []);
+
+  const goLive = useCallback(async (eventId: string) => {
+    setError(null);
+    setNotice(null);
+    const data = await loadIngest(eventId);
+    const result = await adminMutate<{ event: BeaconEvent }>(`/api/beacon/${eventId}/go-live`, 'POST');
+    if (!result.ok) {
+      setError(result.message ?? 'Could not start the broadcast.');
+      return;
+    }
+    setNotice('You are live. A "live now" notice was posted to the Commons.');
+    if (data) {
+      setHost({
+        streamApiKey: data.streamApiKey,
+        streamCallType: data.streamCallType,
+        streamCallId: data.streamCallId,
+        streamUserId: data.streamUserId,
+        hostToken: data.hostToken,
+        displayName: 'Beacon host',
+      });
+    }
+    // Connect the admin's own chat view (the admin is a signed-in member; this is the moderator seat).
+    try {
+      const chatRes = await fetch(`/api/beacon/${eventId}/chat-token`, { method: 'POST', headers: { 'x-ctf-csrf': '1' } });
+      if (chatRes.ok) {
+        const chatData = (await chatRes.json()) as ChatCredentials;
+        setChat({
+          streamApiKey: chatData.streamApiKey,
+          streamChannelType: chatData.streamChannelType,
+          streamChannelId: chatData.streamChannelId,
+          streamUserId: chatData.streamUserId,
+          streamToken: chatData.streamToken,
+        });
+      }
+    } catch { /* chat is additive; broadcast still works */ }
+    try { await loadEvents(); } catch { /* non-fatal */ }
+  }, [loadIngest, loadEvents]);
+
+  const endEvent = useCallback(async (eventId: string) => {
+    setError(null);
+    const result = await adminMutate(`/api/beacon/${eventId}/end`, 'POST');
+    if (!result.ok) {
+      setError(result.message ?? 'Could not end the broadcast.');
+      return;
+    }
+    setNotice('Broadcast ended. The replay posts to the Commons when the recording is ready.');
+    setHost(null);
+    setChat(null);
+    setIngest(null);
+    try { await loadEvents(); } catch { /* non-fatal */ }
+  }, [loadEvents]);
+
+  const moderate = useCallback(async (eventId: string, action: 'mute' | 'ban' | 'slow_mode', extra?: { targetUserId?: string; cooldownSeconds?: number }) => {
+    setError(null);
+    const result = await adminMutate(`/api/beacon/${eventId}/moderate`, 'POST', { action, ...extra });
+    if (!result.ok) {
+      setError(result.message ?? 'Could not apply moderation.');
+      return;
+    }
+    setNotice(action === 'slow_mode' ? 'Slow-mode updated.' : `Member ${action === 'mute' ? 'muted' : 'banned'}.`);
+  }, []);
+
+  const copy = useCallback((label: string, value: string) => {
+    void navigator.clipboard?.writeText(value).then(() => {
+      setCopied(label);
+      setTimeout(() => setCopied(null), 1500);
+    });
+  }, []);
+
+  return (
+    <main style={{ background: BG, minHeight: '100vh', color: TEXT }}>
+      <div style={{ maxWidth: 980, margin: '0 auto', padding: '32px 20px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <Radio size={22} style={{ color: BEACON_COLOR }} />
+          <h1 style={{ fontSize: 22, fontWeight: 700, margin: 0 }}>Beacon admin</h1>
+        </div>
+        <p style={{ color: SUBTLE, fontSize: 14, marginTop: 4 }}>
+          Go live with a one-way broadcast. Watching is public; chatting needs a signed-in member.
+          {' '}<Link href="/apps/beacon" style={{ color: BEACON_COLOR }}>Open the public viewer</Link>.
+        </p>
+
+        {error ? <div style={{ ...bannerStyle, color: '#F87171', borderColor: 'rgba(239,68,68,0.35)' }}>{error}</div> : null}
+        {notice ? <div style={{ ...bannerStyle, color: BEACON_COLOR, borderColor: `${BEACON_COLOR}55` }}>{notice}</div> : null}
+
+        <section style={cardStyle}>
+          <h2 style={cardTitleStyle}>Create an event</h2>
+          <label style={labelStyle}>Title</label>
+          <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="State of the TI Skills Economy" style={inputStyle} />
+          <label style={labelStyle}>Description</label>
+          <textarea value={description} onChange={(event) => setDescription(event.target.value)} rows={3} style={{ ...inputStyle, resize: 'vertical' }} />
+          <button type="button" onClick={() => void createEvent()} disabled={creating} style={primaryButtonStyle}>
+            {creating ? 'Creating…' : 'Create draft'}
+          </button>
+        </section>
+
+        {activeEvent && activeEvent.status !== 'ended' ? (
+          <section style={cardStyle}>
+            <h2 style={cardTitleStyle}>Broadcast: {activeEvent.title}</h2>
+            {activeEvent.status === 'draft' ? (
+              <button type="button" onClick={() => void goLive(activeEvent.id)} style={primaryButtonStyle}>Go live</button>
+            ) : (
+              <button type="button" onClick={() => void endEvent(activeEvent.id)} style={{ ...primaryButtonStyle, background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.35)', color: '#F87171' }}>End broadcast</button>
+            )}
+
+            {ingest ? (
+              <div style={{ marginTop: 18 }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: SUBTLE, marginBottom: 8 }}>Phone demo — push to this RTMP target from a broadcaster app</div>
+                <CopyRow label="RTMP URL" value={ingest.rtmpIngestUrl} copied={copied === 'RTMP URL'} onCopy={() => copy('RTMP URL', ingest.rtmpIngestUrl)} />
+                <CopyRow label="Stream key" value={ingest.streamKey} copied={copied === 'Stream key'} onCopy={() => copy('Stream key', ingest.streamKey)} masked />
+              </div>
+            ) : null}
+
+            {host ? (
+              <div style={{ marginTop: 18 }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: SUBTLE, marginBottom: 8 }}>Computer demo — share a screen or window from this browser</div>
+                <BeaconHostStage credentials={host} />
+              </div>
+            ) : null}
+
+            {activeEvent.status === 'live' ? (
+              <div style={{ marginTop: 18 }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: SUBTLE, marginBottom: 8 }}>Moderate the chat</div>
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+                  <input value={moderateTarget} onChange={(event) => setModerateTarget(event.target.value)} placeholder="member user id" style={{ ...inputStyle, marginBottom: 0, maxWidth: 240 }} />
+                  <button type="button" onClick={() => moderateTarget && void moderate(activeEvent.id, 'mute', { targetUserId: moderateTarget })} style={chipButtonStyle}>Mute</button>
+                  <button type="button" onClick={() => moderateTarget && void moderate(activeEvent.id, 'ban', { targetUserId: moderateTarget })} style={chipButtonStyle}>Ban</button>
+                  <button type="button" onClick={() => void moderate(activeEvent.id, 'slow_mode', { cooldownSeconds: 10 })} style={chipButtonStyle}>Slow-mode 10s</button>
+                  <button type="button" onClick={() => void moderate(activeEvent.id, 'slow_mode', { cooldownSeconds: 0 })} style={chipButtonStyle}>Slow-mode off</button>
+                </div>
+                {chat ? (
+                  <div style={{ marginTop: 14, height: 360, borderRadius: 12, border: `1px solid ${BORDER}`, overflow: 'hidden' }}>
+                    <StreamChatPanel
+                      streamApiKey={chat.streamApiKey}
+                      streamToken={chat.streamToken}
+                      streamUserId={chat.streamUserId}
+                      streamChannelId={chat.streamChannelId}
+                      channelType={chat.streamChannelType}
+                      accentColor={BEACON_COLOR}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </section>
+        ) : null}
+
+        <section style={cardStyle}>
+          <h2 style={cardTitleStyle}>Event history</h2>
+          {loading ? (
+            <div style={{ color: SUBTLE, fontSize: 14 }}>Loading…</div>
+          ) : events.length === 0 ? (
+            <div style={{ color: SUBTLE, fontSize: 14 }}>No events yet. Create one above.</div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {events.map((event) => (
+                <div key={event.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, padding: '10px 12px', borderRadius: 10, background: SURFACE, border: `1px solid ${BORDER}` }}>
+                  <div style={{ minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{event.title}</div>
+                    <div style={{ fontSize: 12, color: SUBTLE }}>
+                      {event.status}
+                      {event.recordingUrl ? ' · recording ready' : ''}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    {event.recordingUrl ? (
+                      <a href={event.recordingUrl} target="_blank" rel="noreferrer" style={chipButtonStyle}>Replay</a>
+                    ) : null}
+                    {event.status !== 'ended' ? (
+                      <button type="button" onClick={() => setActiveEventId(event.id)} style={chipButtonStyle}>Open</button>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function CopyRow({ label, value, copied, onCopy, masked }: { label: string; value: string; copied: boolean; onCopy: () => void; masked?: boolean }) {
+  const shown = value.length === 0 ? '(not provided by Stream)' : masked ? '••••••••••••' : value;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+      <span style={{ fontSize: 12, color: SUBTLE, width: 88, flexShrink: 0 }}>{label}</span>
+      <code style={{ flex: 1, fontSize: 12, color: TEXT, background: PANEL, border: `1px solid ${BORDER}`, borderRadius: 8, padding: '8px 10px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{shown}</code>
+      <button type="button" onClick={onCopy} disabled={value.length === 0} style={{ ...chipButtonStyle, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        {copied ? <Check size={14} /> : <Copy size={14} />}{copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = { marginTop: 18, borderRadius: 14, background: PANEL, border: `1px solid ${BORDER}`, padding: 18 };
+const cardTitleStyle: React.CSSProperties = { fontSize: 16, fontWeight: 700, margin: '0 0 12px' };
+const labelStyle: React.CSSProperties = { display: 'block', fontSize: 12, fontWeight: 600, color: SUBTLE, margin: '8px 0 4px' };
+const inputStyle: React.CSSProperties = { width: '100%', boxSizing: 'border-box', background: SURFACE, border: `1px solid ${BORDER}`, borderRadius: 10, padding: '10px 12px', color: TEXT, fontSize: 14, marginBottom: 8 };
+const primaryButtonStyle: React.CSSProperties = { marginTop: 8, padding: '10px 18px', borderRadius: 10, background: `${BEACON_COLOR}20`, border: `1px solid ${BEACON_COLOR}55`, color: BEACON_COLOR, fontSize: 14, fontWeight: 700, cursor: 'pointer' };
+const chipButtonStyle: React.CSSProperties = { padding: '7px 12px', borderRadius: 8, background: SURFACE, border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' };
+const bannerStyle: React.CSSProperties = { marginTop: 14, padding: '10px 14px', borderRadius: 10, background: SURFACE, border: '1px solid', fontSize: 14 };

--- a/ctf/packages/web/components/beacon/beacon-host-stage.tsx
+++ b/ctf/packages/web/components/beacon/beacon-host-stage.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+// Desktop in-browser screen-share publisher for the Beacon host. The admin captures a screen/window
+// with the browser and publishes it into the same livestream call as the host. This is the
+// computer-demo input path; the phone-demo path uses the RTMP url/key shown in the admin shell.
+import { useEffect, useState } from 'react';
+import {
+  StreamVideo,
+  StreamVideoClient,
+  StreamCall,
+  useCallStateHooks,
+  type Call,
+} from '@stream-io/video-react-sdk';
+import { ScreenShare, ScreenShareOff } from 'lucide-react';
+import { BEACON_COLOR } from 'lib/beacon/constants';
+import { reportError } from 'lib/observability/report';
+
+export type BeaconHostCredentials = {
+  streamApiKey: string;
+  streamCallType: string;
+  streamCallId: string;
+  streamUserId: string;
+  hostToken: string;
+  displayName: string;
+};
+
+const SUBTLE = '#9CA3AF';
+
+export function BeaconHostStage({ credentials }: { credentials: BeaconHostCredentials }) {
+  const [client, setClient] = useState<StreamVideoClient | null>(null);
+  const [call, setCall] = useState<Call | null>(null);
+  const [status, setStatus] = useState<'connecting' | 'joined' | 'error'>('connecting');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const videoClient = new StreamVideoClient({
+      apiKey: credentials.streamApiKey,
+      user: { id: credentials.streamUserId, name: credentials.displayName },
+      token: credentials.hostToken,
+    });
+    const activeCall = videoClient.call(credentials.streamCallType, credentials.streamCallId);
+
+    void (async () => {
+      try {
+        // Join as the host. The server has already created the call and gone live; joining here lets
+        // the host publish the screen-share track into it.
+        await activeCall.join();
+        if (cancelled) return;
+        setClient(videoClient);
+        setCall(activeCall);
+        setStatus('joined');
+      } catch (error) {
+        if (cancelled) return;
+        reportError(error, { area: 'beacon', op: 'host_join_client', extra: { callId: credentials.streamCallId } });
+        setErrorMessage(error instanceof Error ? error.message : 'Could not connect to the broadcast.');
+        setStatus('error');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      void (async () => {
+        try { await activeCall.leave(); } catch { /* already left */ }
+        try { await videoClient.disconnectUser(); } catch { /* ignore */ }
+      })();
+    };
+  }, [credentials.streamApiKey, credentials.streamCallType, credentials.streamCallId, credentials.streamUserId, credentials.hostToken, credentials.displayName]);
+
+  if (status !== 'joined' || !client || !call) {
+    return (
+      <div style={{ padding: '24px 0', color: status === 'error' ? '#F87171' : SUBTLE, fontSize: 14 }}>
+        {status === 'error' ? (errorMessage ?? 'Could not connect to the broadcast.') : 'Connecting to the broadcast…'}
+      </div>
+    );
+  }
+
+  return (
+    <StreamVideo client={client}>
+      <StreamCall call={call}>
+        <ScreenShareControls />
+      </StreamCall>
+    </StreamVideo>
+  );
+}
+
+function ScreenShareControls() {
+  const { useScreenShareState, useHasOngoingScreenShare } = useCallStateHooks();
+  const { screenShare, isMute } = useScreenShareState();
+  const isSharing = useHasOngoingScreenShare();
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+      <button
+        type="button"
+        onClick={() => void screenShare.toggle()}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '10px 16px',
+          borderRadius: 10,
+          background: isMute ? `${BEACON_COLOR}20` : 'rgba(239,68,68,0.14)',
+          border: `1px solid ${isMute ? `${BEACON_COLOR}55` : 'rgba(239,68,68,0.35)'}`,
+          color: isMute ? BEACON_COLOR : '#F87171',
+          fontSize: 14,
+          fontWeight: 700,
+          cursor: 'pointer',
+        }}
+      >
+        {isMute ? <ScreenShare size={18} /> : <ScreenShareOff size={18} />}
+        {isMute ? 'Share screen' : 'Stop sharing'}
+      </button>
+      <span style={{ fontSize: 13, color: SUBTLE }}>
+        {isSharing ? 'Your screen is live to the broadcast.' : 'Pick a screen or window to demo from this computer.'}
+      </span>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/beacon/beacon-public-shell.tsx
+++ b/ctf/packages/web/components/beacon/beacon-public-shell.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+// Beacon viewer for an anonymous (signed-out) visitor. Watching is public over HLS — this is the
+// no-account path. The viewer shows the player and a "sign in to chat" prompt; an anonymous visitor
+// cannot obtain a chat token, so the chat stays read/sign-in-gated on the server side too.
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+import { BeaconViewer } from './beacon-viewer';
+
+export function BeaconPublicShell({ signInUrl }: PublicVisitorShellProps) {
+  return <BeaconViewer signInUrl={signInUrl} isMember={false} />;
+}

--- a/ctf/packages/web/components/beacon/beacon-shell.tsx
+++ b/ctf/packages/web/components/beacon/beacon-shell.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+// Beacon viewer for a signed-in member. Watching is public; a member additionally gets the live
+// chat. Members are already authenticated, so the sign-in CTA is never shown to them.
+import { BeaconViewer } from './beacon-viewer';
+
+export function BeaconShell() {
+  return <BeaconViewer signInUrl="/sign-in" isMember />;
+}

--- a/ctf/packages/web/components/beacon/beacon-viewer.tsx
+++ b/ctf/packages/web/components/beacon/beacon-viewer.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+// Beacon public viewer. Watching is public over HLS (no sign-in); chatting/reacting needs a
+// signed-in member. This one component serves both: an anonymous visitor sees the player plus a
+// "sign in to chat" prompt; a member additionally gets the live chat panel. It polls the public
+// /api/beacon/current endpoint for the live event + HLS URL and falls back to a calm idle state or
+// the last replay when nothing is live.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Radio, Lock } from 'lucide-react';
+import { StreamChatPanel } from '@/components/shared/stream-chat-panel';
+import { BEACON_COLOR } from 'lib/beacon/constants';
+
+type BeaconEventLike = {
+  id: string;
+  title: string;
+  description: string;
+  status: 'draft' | 'live' | 'ended';
+  recordingUrl: string | null;
+};
+
+type CurrentResponse = {
+  ok: boolean;
+  event: BeaconEventLike | null;
+  hlsPlaybackUrl: string | null;
+  replay: BeaconEventLike | null;
+};
+
+type ChatCredentials = {
+  streamApiKey: string;
+  streamChannelType: string;
+  streamChannelId: string;
+  streamUserId: string;
+  streamToken: string;
+};
+
+const PANEL = '#0D0F14';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#9CA3AF';
+
+export function BeaconViewer({ signInUrl, isMember }: { signInUrl: string; isMember: boolean }) {
+  const [current, setCurrent] = useState<CurrentResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [chat, setChat] = useState<ChatCredentials | null>(null);
+  const [chatError, setChatError] = useState<string | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const loadCurrent = useCallback(async () => {
+    try {
+      const res = await fetch('/api/beacon/current', { cache: 'no-store' });
+      if (res.ok) {
+        const data = (await res.json()) as CurrentResponse;
+        setCurrent(data);
+      }
+    } catch {
+      // Network blip — keep the last known state and try again on the next poll.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadCurrent();
+    const timer = setInterval(() => void loadCurrent(), 15000);
+    return () => clearInterval(timer);
+  }, [loadCurrent]);
+
+  const liveEvent = current?.event && current.event.status === 'live' ? current.event : null;
+  const hlsUrl = liveEvent ? current?.hlsPlaybackUrl ?? null : null;
+  const replay = current?.replay ?? null;
+
+  // Attach the HLS source. Safari/iOS play HLS natively; other browsers need hls.js, which is not a
+  // dependency here, so we set the source directly and note the limitation rather than failing.
+  // TODO(beacon): add hls.js (or a lightweight HLS player) for non-Safari browsers if telemetry shows
+  // viewers on Chrome/Firefox cannot play the native source.
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !hlsUrl) return;
+    if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      video.src = hlsUrl;
+    } else {
+      video.src = hlsUrl;
+    }
+  }, [hlsUrl]);
+
+  // A member opts into chat by requesting a token (this is the sign-in-to-chat gate server-side).
+  const joinChat = useCallback(async () => {
+    if (!liveEvent) return;
+    setChatError(null);
+    try {
+      const res = await fetch(`/api/beacon/${liveEvent.id}/chat-token`, {
+        method: 'POST',
+        headers: { 'x-ctf-csrf': '1' },
+      });
+      if (!res.ok) {
+        setChatError('Live chat is unavailable right now.');
+        return;
+      }
+      const data = (await res.json()) as { ok: boolean } & ChatCredentials;
+      setChat({
+        streamApiKey: data.streamApiKey,
+        streamChannelType: data.streamChannelType,
+        streamChannelId: data.streamChannelId,
+        streamUserId: data.streamUserId,
+        streamToken: data.streamToken,
+      });
+    } catch {
+      setChatError('Live chat is unavailable right now.');
+    }
+  }, [liveEvent]);
+
+  useEffect(() => {
+    if (isMember && liveEvent && !chat) {
+      void joinChat();
+    }
+    // When the event ends, drop the chat connection.
+    if (!liveEvent && chat) {
+      setChat(null);
+    }
+  }, [isMember, liveEvent, chat, joinChat]);
+
+  return (
+    <main style={{ maxWidth: 1100, margin: '0 auto', padding: '32px 20px', color: TEXT }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+        <Radio size={22} style={{ color: BEACON_COLOR }} />
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>Beacon</h1>
+      </div>
+      <p style={{ color: SUBTLE, fontSize: 14, marginTop: 0 }}>
+        Live broadcasts from the team. Watch with just a link; sign in to chat and react.
+      </p>
+
+      {loading ? (
+        <div style={panelStyle}>Loading…</div>
+      ) : liveEvent ? (
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 16 }}>
+          <div style={{ display: 'grid', gap: 16, gridTemplateColumns: '1fr', alignItems: 'start' }} className="beacon-live-grid">
+            <section>
+              <div
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  background: 'rgba(245,158,11,0.14)',
+                  border: `1px solid ${BEACON_COLOR}55`,
+                  color: BEACON_COLOR,
+                  borderRadius: 999,
+                  padding: '4px 12px',
+                  fontSize: 12,
+                  fontWeight: 700,
+                  letterSpacing: '0.04em',
+                  marginBottom: 12,
+                }}
+              >
+                <span style={{ width: 8, height: 8, borderRadius: '50%', background: BEACON_COLOR, display: 'inline-block' }} />
+                LIVE AND PUBLIC
+              </div>
+              <h2 style={{ fontSize: 20, fontWeight: 700, margin: '0 0 6px' }}>{liveEvent.title}</h2>
+              {liveEvent.description ? (
+                <p style={{ color: SUBTLE, fontSize: 14, margin: '0 0 12px' }}>{liveEvent.description}</p>
+              ) : null}
+              <div style={{ borderRadius: 12, overflow: 'hidden', background: '#000', border: `1px solid ${BORDER}`, aspectRatio: '16 / 9' }}>
+                {hlsUrl ? (
+                  <video ref={videoRef} controls autoPlay playsInline muted style={{ width: '100%', height: '100%' }} />
+                ) : (
+                  <div style={{ ...centeredStyle, height: '100%' }}>The broadcast is starting…</div>
+                )}
+              </div>
+              <p style={{ color: SUBTLE, fontSize: 12, marginTop: 10 }}>
+                This broadcast and its chat are public. The event is recorded; the replay is posted to the Commons.
+              </p>
+            </section>
+
+            <aside style={{ ...panelStyle, padding: 0, minHeight: 420, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+              <div style={{ padding: '12px 16px', borderBottom: `1px solid ${BORDER}`, fontWeight: 700, fontSize: 14 }}>Live chat</div>
+              {isMember ? (
+                chat ? (
+                  <div style={{ flex: 1, minHeight: 0 }}>
+                    <StreamChatPanel
+                      streamApiKey={chat.streamApiKey}
+                      streamToken={chat.streamToken}
+                      streamUserId={chat.streamUserId}
+                      streamChannelId={chat.streamChannelId}
+                      channelType={chat.streamChannelType}
+                      accentColor={BEACON_COLOR}
+                    />
+                  </div>
+                ) : (
+                  <div style={{ ...centeredStyle, flex: 1 }}>{chatError ?? 'Connecting to chat…'}</div>
+                )
+              ) : (
+                <div style={{ ...centeredStyle, flex: 1, flexDirection: 'column', gap: 12, padding: 24, textAlign: 'center' }}>
+                  <Lock size={28} style={{ color: SUBTLE }} />
+                  <div style={{ fontSize: 14, color: SUBTLE }}>Sign in to chat and react. Anyone can watch — chatting is for members.</div>
+                  <a href={signInUrl} style={ctaStyle}>Sign in to chat</a>
+                </div>
+              )}
+            </aside>
+          </div>
+        </div>
+      ) : (
+        <div style={{ ...panelStyle, textAlign: 'center', padding: '48px 24px' }}>
+          <Radio size={40} style={{ color: SUBTLE, display: 'block', margin: '0 auto 12px' }} />
+          <div style={{ fontSize: 16, fontWeight: 600 }}>No live event right now</div>
+          <p style={{ color: SUBTLE, fontSize: 14, marginTop: 6 }}>When the team goes live, it will appear here.</p>
+          {replay?.recordingUrl ? (
+            <div style={{ marginTop: 20, textAlign: 'left' }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: SUBTLE, marginBottom: 8 }}>Last replay</div>
+              <div style={{ borderRadius: 12, overflow: 'hidden', background: '#000', border: `1px solid ${BORDER}`, aspectRatio: '16 / 9' }}>
+                <video controls playsInline src={replay.recordingUrl} style={{ width: '100%', height: '100%' }} />
+              </div>
+              <div style={{ fontSize: 14, fontWeight: 600, marginTop: 8 }}>{replay.title}</div>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      <style>{`
+        @media (min-width: 860px) {
+          .beacon-live-grid { grid-template-columns: minmax(0, 2fr) minmax(300px, 1fr) !important; }
+        }
+      `}</style>
+    </main>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  marginTop: 20,
+  borderRadius: 14,
+  background: PANEL,
+  border: `1px solid ${BORDER}`,
+  padding: 20,
+  color: TEXT,
+};
+
+const centeredStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: SUBTLE,
+  fontSize: 14,
+  background: SURFACE,
+};
+
+const ctaStyle: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '9px 18px',
+  borderRadius: 10,
+  background: `${BEACON_COLOR}20`,
+  border: `1px solid ${BEACON_COLOR}55`,
+  color: BEACON_COLOR,
+  fontSize: 14,
+  fontWeight: 700,
+  textDecoration: 'none',
+};

--- a/ctf/packages/web/components/plugins/public-visitor-registry.tsx
+++ b/ctf/packages/web/components/plugins/public-visitor-registry.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import { BeaconPublicShell } from '@/components/beacon/beacon-public-shell';
 import { ChymePublicShell } from '@/components/chyme/chyme-public-shell';
 import { ClicklogPublicShell } from '@/components/clicklog/clicklog-public-shell';
 import { ContributionsPublicShell } from '@/components/contributions/contributions-public-shell';
@@ -56,6 +57,7 @@ export type PublicVisitorShell = ComponentType<PublicVisitorShellProps>;
  * the access-denied wall.
  */
 const PUBLIC_VISITOR_SHELLS: Record<string, PublicVisitorShell> = {
+  beacon: BeaconPublicShell,
   chyme: ChymePublicShell,
   clicklog: ClicklogPublicShell,
   contributions: ContributionsPublicShell,

--- a/ctf/packages/web/lib/beacon/_lib.ts
+++ b/ctf/packages/web/lib/beacon/_lib.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
+import { checkMutationOrigin } from 'lib/auth/csrf';
+import { pluginAuthDeny, type PluginDenyResponse } from 'lib/auth/deny-taxonomy';
+import { BEACON_ERROR_CODE } from './constants';
+
+export type BeaconApiGate =
+  | { allowed: true; auth: AllowDecision }
+  | { allowed: false; response: NextResponse };
+
+// Any signed-in member. Used by the chat-token route — posting requires an account (no anonymous
+// chat), so an anonymous caller is denied here with 401.
+export async function requireBeaconMemberAccess(): Promise<BeaconApiGate> {
+  const decision = await evaluatePluginAccess({ requireUsername: false });
+  if (!decision.allowed) {
+    return { allowed: false, response: NextResponse.json(decision, { status: decision.status }) };
+  }
+  return { allowed: true, auth: decision };
+}
+
+// Admin-gated. Every Beacon control (create/ingest/go-live/end/list/moderate) requires admin.
+export async function requireBeaconAdminAccess(): Promise<BeaconApiGate> {
+  const gate = await requireBeaconMemberAccess();
+  if (!gate.allowed) {
+    return gate;
+  }
+  if (!gate.auth.isAdmin) {
+    const deny: PluginDenyResponse = pluginAuthDeny.forbiddenRole(['admin']);
+    return { allowed: false, response: NextResponse.json(deny, { status: deny.status }) };
+  }
+  return gate;
+}
+
+export function ensureBeaconMutationCsrf(request: Request): NextResponse | null {
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return null;
+  }
+  if (request.headers.get('x-ctf-csrf') !== '1') {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.csrfDenied, message: 'Missing CSRF confirmation header.' },
+      { status: 403 },
+    );
+  }
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
+      { status: 403 },
+    );
+  }
+  return null;
+}
+
+export function beaconErrorResponse(message: string) {
+  return NextResponse.json(
+    { ok: false, code: BEACON_ERROR_CODE.persistenceUnavailable, message },
+    { status: 503 },
+  );
+}

--- a/ctf/packages/web/lib/beacon/constants.ts
+++ b/ctf/packages/web/lib/beacon/constants.ts
@@ -1,0 +1,29 @@
+// Stable identifiers and limits for the Beacon plugin (admin-only one-way livestream).
+export const BEACON_ERROR_CODE = {
+  invalidPayload: 'beacon_invalid_payload',
+  invalidJson: 'beacon_invalid_json',
+  policyDenied: 'beacon_policy_denied',
+  notFound: 'beacon_not_found',
+  csrfDenied: 'beacon_csrf_denied',
+  persistenceUnavailable: 'beacon_persistence_unavailable',
+  streamUnavailable: 'beacon_stream_unavailable',
+  conflict: 'beacon_conflict',
+  webhookSignatureInvalid: 'beacon_webhook_signature_invalid',
+} as const;
+
+// The Stream Video call type Beacon uses. `livestream` gives one publisher (the host) and many
+// HLS/WebRTC viewers, which is exactly the one-way broadcast model.
+export const BEACON_STREAM_CALL_TYPE = 'livestream';
+
+// The Stream Chat channel type for the live event chat. `livestream` channels are built for a large
+// read-heavy audience where only members post, which matches the sign-in-to-chat rule.
+export const BEACON_CHAT_CHANNEL_TYPE = 'livestream';
+
+// Brand accent for the Beacon surfaces (amber — a warm "we are on air" signal).
+export const BEACON_COLOR = '#F59E0B';
+
+export const BEACON_MAX_TITLE_LENGTH = 160;
+export const BEACON_MAX_DESCRIPTION_LENGTH = 2000;
+
+// Slow-mode default cooldown (seconds) when the admin enables it without naming a value.
+export const BEACON_DEFAULT_SLOW_MODE_SECONDS = 10;

--- a/ctf/packages/web/lib/beacon/repository.ts
+++ b/ctf/packages/web/lib/beacon/repository.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from 'crypto';
+import { queryDb } from 'lib/db/postgres';
+import { createFeedCommunityPost } from 'lib/feed/repository';
+import { reportError } from 'lib/observability/report';
+import { BEACON_MAX_DESCRIPTION_LENGTH, BEACON_MAX_TITLE_LENGTH, BEACON_STREAM_CALL_TYPE } from './constants';
+import { beaconCallIdForEvent } from './stream';
+
+export type BeaconEventStatus = 'draft' | 'live' | 'ended';
+
+export type BeaconEvent = {
+  id: string;
+  title: string;
+  description: string;
+  status: BeaconEventStatus;
+  hostUserId: string;
+  streamCallType: string;
+  streamCallId: string;
+  startedAtIso: string | null;
+  endedAtIso: string | null;
+  recordingUrl: string | null;
+  recordingReadyAtIso: string | null;
+  commonsLivePostId: string | null;
+  commonsRecordingPostId: string | null;
+  createdAtIso: string;
+  updatedAtIso: string;
+};
+
+type BeaconEventRow = {
+  id: string;
+  title: string;
+  description: string;
+  status: BeaconEventStatus;
+  host_user_id: string;
+  stream_call_type: string;
+  stream_call_id: string;
+  started_at: Date | null;
+  ended_at: Date | null;
+  recording_url: string | null;
+  recording_ready_at: Date | null;
+  commons_live_post_id: string | null;
+  commons_recording_post_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function toIso(value: Date | null): string | null {
+  return value ? new Date(value).toISOString() : null;
+}
+
+function mapEventRow(row: BeaconEventRow): BeaconEvent {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    hostUserId: row.host_user_id,
+    streamCallType: row.stream_call_type,
+    streamCallId: row.stream_call_id,
+    startedAtIso: toIso(row.started_at),
+    endedAtIso: toIso(row.ended_at),
+    recordingUrl: row.recording_url,
+    recordingReadyAtIso: toIso(row.recording_ready_at),
+    commonsLivePostId: row.commons_live_post_id,
+    commonsRecordingPostId: row.commons_recording_post_id,
+    createdAtIso: new Date(row.created_at).toISOString(),
+    updatedAtIso: new Date(row.updated_at).toISOString(),
+  };
+}
+
+const EVENT_COLUMNS = `id, title, description, status, host_user_id, stream_call_type, stream_call_id,
+  started_at, ended_at, recording_url, recording_ready_at, commons_live_post_id,
+  commons_recording_post_id, created_at, updated_at`;
+
+export async function createBeaconEvent(input: {
+  hostUserId: string;
+  title: string;
+  description: string;
+}): Promise<BeaconEvent> {
+  const id = randomUUID();
+  const title = input.title.trim().slice(0, BEACON_MAX_TITLE_LENGTH);
+  const description = input.description.trim().slice(0, BEACON_MAX_DESCRIPTION_LENGTH);
+  const result = await queryDb<BeaconEventRow>(
+    `INSERT INTO beacon_events (id, title, description, status, host_user_id, stream_call_type, stream_call_id)
+     VALUES ($1, $2, $3, 'draft', $4, $5, $6)
+     RETURNING ${EVENT_COLUMNS}`,
+    [id, title, description, input.hostUserId, BEACON_STREAM_CALL_TYPE, beaconCallIdForEvent(id)],
+  );
+  return mapEventRow(result.rows[0]);
+}
+
+export async function getBeaconEvent(eventId: string): Promise<BeaconEvent | null> {
+  const result = await queryDb<BeaconEventRow>(
+    `SELECT ${EVENT_COLUMNS} FROM beacon_events WHERE id = $1::uuid LIMIT 1`,
+    [eventId],
+  );
+  return result.rows[0] ? mapEventRow(result.rows[0]) : null;
+}
+
+// The single currently-live event (the schema enforces at most one). Null when nothing is live.
+export async function getLiveBeaconEvent(): Promise<BeaconEvent | null> {
+  const result = await queryDb<BeaconEventRow>(
+    `SELECT ${EVENT_COLUMNS} FROM beacon_events WHERE status = 'live' ORDER BY started_at DESC NULLS LAST LIMIT 1`,
+  );
+  return result.rows[0] ? mapEventRow(result.rows[0]) : null;
+}
+
+// The most recent ended event that has a recording, for the viewer's "watch the last replay" state.
+export async function getLatestReplayBeaconEvent(): Promise<BeaconEvent | null> {
+  const result = await queryDb<BeaconEventRow>(
+    `SELECT ${EVENT_COLUMNS} FROM beacon_events
+     WHERE status = 'ended' AND recording_url IS NOT NULL
+     ORDER BY ended_at DESC NULLS LAST LIMIT 1`,
+  );
+  return result.rows[0] ? mapEventRow(result.rows[0]) : null;
+}
+
+export async function listBeaconEvents(limit = 50): Promise<BeaconEvent[]> {
+  const result = await queryDb<BeaconEventRow>(
+    `SELECT ${EVENT_COLUMNS} FROM beacon_events ORDER BY created_at DESC LIMIT $1`,
+    [limit],
+  );
+  return result.rows.map(mapEventRow);
+}
+
+export async function markBeaconEventLive(eventId: string): Promise<BeaconEvent | null> {
+  const result = await queryDb<BeaconEventRow>(
+    `UPDATE beacon_events
+     SET status = 'live', started_at = COALESCE(started_at, NOW()), updated_at = NOW()
+     WHERE id = $1::uuid
+     RETURNING ${EVENT_COLUMNS}`,
+    [eventId],
+  );
+  return result.rows[0] ? mapEventRow(result.rows[0]) : null;
+}
+
+export async function markBeaconEventEnded(eventId: string): Promise<BeaconEvent | null> {
+  const result = await queryDb<BeaconEventRow>(
+    `UPDATE beacon_events
+     SET status = 'ended', ended_at = COALESCE(ended_at, NOW()), updated_at = NOW()
+     WHERE id = $1::uuid
+     RETURNING ${EVENT_COLUMNS}`,
+    [eventId],
+  );
+  return result.rows[0] ? mapEventRow(result.rows[0]) : null;
+}
+
+// Store the live-now Commons post id on the event. Idempotent — only sets it when still null, so a
+// retried go-live never double-posts.
+export async function setBeaconLivePostId(eventId: string, postId: string): Promise<void> {
+  await queryDb(
+    `UPDATE beacon_events SET commons_live_post_id = $2::uuid, updated_at = NOW()
+     WHERE id = $1::uuid AND commons_live_post_id IS NULL`,
+    [eventId, postId],
+  );
+}
+
+export async function recordBeaconRecording(eventId: string, recordingUrl: string): Promise<BeaconEvent | null> {
+  const result = await queryDb<BeaconEventRow>(
+    `UPDATE beacon_events
+     SET recording_url = $2, recording_ready_at = NOW(), updated_at = NOW()
+     WHERE id = $1::uuid AND recording_url IS NULL
+     RETURNING ${EVENT_COLUMNS}`,
+    [eventId, recordingUrl],
+  );
+  return result.rows[0] ? mapEventRow(result.rows[0]) : null;
+}
+
+export async function setBeaconRecordingPostId(eventId: string, postId: string): Promise<void> {
+  await queryDb(
+    `UPDATE beacon_events SET commons_recording_post_id = $2::uuid, updated_at = NOW()
+     WHERE id = $1::uuid AND commons_recording_post_id IS NULL`,
+    [eventId, postId],
+  );
+}
+
+// Find the event a Stream call id belongs to (the webhook carries the call id, not our event id).
+export async function getBeaconEventByCallId(streamCallId: string): Promise<BeaconEvent | null> {
+  const result = await queryDb<BeaconEventRow>(
+    `SELECT ${EVENT_COLUMNS} FROM beacon_events WHERE stream_call_id = $1 ORDER BY created_at DESC LIMIT 1`,
+    [streamCallId],
+  );
+  return result.rows[0] ? mapEventRow(result.rows[0]) : null;
+}
+
+export async function insertBeaconAudit(input: {
+  actorId: string;
+  command: string;
+  policyStatus: 'allow' | 'deny';
+  reason: string;
+  targetType: string;
+  targetId: string;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await queryDb(
+    `INSERT INTO beacon_events_admin_audit_trail
+      (id, actor_id, command, policy_status, reason, target_type, target_id, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+    [
+      randomUUID(),
+      input.actorId,
+      input.command,
+      input.policyStatus,
+      input.reason,
+      input.targetType,
+      input.targetId,
+      JSON.stringify(input.metadata ?? {}),
+    ],
+  );
+}
+
+const BEACON_APP_PATH = '/apps/beacon';
+
+// Auto-post a "live now" notice to the Commons on go-live. Idempotent: if the event already carries a
+// live-post id we skip. Returns the post id (or null when nothing was posted). A Commons failure is
+// reported but never blocks go-live — the broadcast matters more than the notice.
+export async function postBeaconLiveNotice(event: BeaconEvent): Promise<string | null> {
+  if (event.commonsLivePostId) {
+    return event.commonsLivePostId;
+  }
+  try {
+    const body = `🔴 Live now: ${event.title}. Watch the broadcast at ${BEACON_APP_PATH} — no sign-in needed to watch; sign in to chat.`;
+    const post = await createFeedCommunityPost(event.hostUserId, { body, category: 'event' });
+    await setBeaconLivePostId(event.id, post.postId);
+    return post.postId;
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'commons_live_post', extra: { eventId: event.id } });
+    return null;
+  }
+}
+
+// Auto-post the replay to the Commons when the recording is ready. Idempotent on the stored post id.
+export async function postBeaconReplayNotice(event: BeaconEvent): Promise<string | null> {
+  if (event.commonsRecordingPostId) {
+    return event.commonsRecordingPostId;
+  }
+  if (!event.recordingUrl) {
+    return null;
+  }
+  try {
+    const body = `▶️ Watch the replay: ${event.title}. The recording is available at ${BEACON_APP_PATH}.`;
+    const post = await createFeedCommunityPost(event.hostUserId, { body, category: 'event' });
+    await setBeaconRecordingPostId(event.id, post.postId);
+    return post.postId;
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'commons_replay_post', extra: { eventId: event.id } });
+    return null;
+  }
+}

--- a/ctf/packages/web/lib/beacon/stream.ts
+++ b/ctf/packages/web/lib/beacon/stream.ts
@@ -1,0 +1,318 @@
+import { createHmac } from 'crypto';
+import { StreamChat } from 'stream-chat';
+import { resolveStreamCredentials } from 'lib/integrations/stream-credentials';
+import { BEACON_CHAT_CHANNEL_TYPE, BEACON_STREAM_CALL_TYPE } from './constants';
+
+// Beacon's Stream Video integration. Beacon is a one-way `livestream`: only the admin host
+// publishes; everyone else watches. Watching is public over HLS (no user token needed), which is
+// what lets anonymous viewers in and keeps cost off WebRTC fan-out. Chatting needs a signed-in
+// member (a Stream Chat token, minted only for members).
+//
+// There is no @stream-io/node-sdk in the workspace, so server-side call lifecycle (create, goLive,
+// end), the per-event RTMP ingest, and the HLS playback URL are driven against Stream's documented
+// Video REST API using a server-auth JWT signed with the app secret. Every entry point degrades to
+// null/throw-free behavior when Stream is not configured (resolveStreamCredentials() returns null),
+// exactly like the Peer Programming stream helper.
+
+const STREAM_VIDEO_BASE_URL = 'https://video.stream-io-api.com';
+
+// A Stream call id accepts [0-9a-zA-Z_-]; event ids are UUIDs (already safe) but coerce defensively.
+export function beaconCallIdForEvent(eventId: string): string {
+  const cleaned = `beacon-${eventId}`.replace(/[^0-9a-zA-Z_-]/g, '-');
+  return cleaned.length > 0 ? cleaned : 'beacon-event';
+}
+
+function beaconStreamUserId(userId: string): string {
+  return `beacon-${userId}`.replace(/[^0-9a-zA-Z_@.-]/g, '-');
+}
+
+function base64Url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+// Mint a Stream server-auth JWT (no user; `server` audience) signed with the app secret, for
+// server-to-server Video REST calls. Stream's server SDKs send exactly this token.
+function mintServerToken(apiSecret: string): string {
+  const header = base64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64Url(JSON.stringify({ server: true, iat: Math.floor(Date.now() / 1000) }));
+  const signature = base64Url(createHmac('sha256', apiSecret).update(`${header}.${payload}`).digest());
+  return `${header}.${payload}.${signature}`;
+}
+
+type StreamRestContext = {
+  apiKey: string;
+  apiSecret: string;
+  serverToken: string;
+};
+
+async function resolveStreamRest(): Promise<StreamRestContext | null> {
+  const credentials = await resolveStreamCredentials();
+  if (!credentials) {
+    return null;
+  }
+  return {
+    apiKey: credentials.apiKey,
+    apiSecret: credentials.apiSecret,
+    serverToken: mintServerToken(credentials.apiSecret),
+  };
+}
+
+async function streamVideoFetch(
+  ctx: StreamRestContext,
+  path: string,
+  init: { method: string; body?: unknown },
+): Promise<Record<string, unknown>> {
+  const url = `${STREAM_VIDEO_BASE_URL}${path}${path.includes('?') ? '&' : '?'}api_key=${encodeURIComponent(ctx.apiKey)}`;
+  const response = await fetch(url, {
+    method: init.method,
+    headers: {
+      Authorization: ctx.serverToken,
+      'stream-auth-type': 'jwt',
+      'Content-Type': 'application/json',
+    },
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    cache: 'no-store',
+  });
+  const text = await response.text();
+  const parsed = text.length > 0 ? (JSON.parse(text) as Record<string, unknown>) : {};
+  if (!response.ok) {
+    const message = typeof parsed.message === 'string' ? parsed.message : `Stream Video request failed (${response.status}).`;
+    throw new Error(message);
+  }
+  return parsed;
+}
+
+export type BeaconHostCredentials = {
+  streamApiKey: string;
+  streamCallType: string;
+  streamCallId: string;
+  streamUserId: string;
+  hostToken: string;
+};
+
+// Mint a host (publisher) token scoped to the host user id. The Stream JWT works for both Video and
+// Chat (same app secret), so this token lets the admin publish the in-browser screen-share and act
+// as the chat channel moderator. Viewers never receive this token — they watch over public HLS.
+export async function createBeaconHostCredentials(input: {
+  userId: string;
+  name: string;
+  eventId: string;
+}): Promise<BeaconHostCredentials | null> {
+  const credentials = await resolveStreamCredentials();
+  if (!credentials) {
+    return null;
+  }
+  const chatClient = new StreamChat(credentials.apiKey, credentials.apiSecret);
+  try {
+    const streamUserId = beaconStreamUserId(input.userId);
+    await chatClient.upsertUser({ id: streamUserId, name: input.name, role: 'admin' });
+    return {
+      streamApiKey: credentials.apiKey,
+      streamCallType: BEACON_STREAM_CALL_TYPE,
+      streamCallId: beaconCallIdForEvent(input.eventId),
+      streamUserId,
+      hostToken: chatClient.createToken(streamUserId),
+    };
+  } finally {
+    await chatClient.disconnectUser();
+  }
+}
+
+export type BeaconMemberChatCredentials = {
+  streamApiKey: string;
+  streamChannelType: string;
+  streamChannelId: string;
+  streamUserId: string;
+  streamToken: string;
+};
+
+// Mint a Stream Chat token for a signed-in member so they can post in the live event chat. Anonymous
+// viewers never reach this path (the route requires a member), which is the sign-in-to-chat gate.
+export async function createBeaconMemberChatCredentials(input: {
+  userId: string;
+  name: string;
+  eventId: string;
+}): Promise<BeaconMemberChatCredentials | null> {
+  const credentials = await resolveStreamCredentials();
+  if (!credentials) {
+    return null;
+  }
+  const chatClient = new StreamChat(credentials.apiKey, credentials.apiSecret);
+  try {
+    const streamUserId = beaconStreamUserId(input.userId);
+    await chatClient.upsertUser({ id: streamUserId, name: input.name });
+    return {
+      streamApiKey: credentials.apiKey,
+      streamChannelType: BEACON_CHAT_CHANNEL_TYPE,
+      streamChannelId: beaconCallIdForEvent(input.eventId),
+      streamUserId,
+      streamToken: chatClient.createToken(streamUserId),
+    };
+  } finally {
+    await chatClient.disconnectUser();
+  }
+}
+
+export type BeaconIngest = {
+  rtmpIngestUrl: string;
+  streamKey: string;
+};
+
+// Create (or get) the Beacon livestream call and return its per-event RTMP ingest URL + stream key
+// for a phone broadcaster app. Recording is enabled so Stream delivers a recording-ready webhook
+// after the event ends. Returns null when Stream is not configured.
+//
+// TODO(beacon): confirm against the live Stream dashboard/SDK that GetCall with create=true on a
+// `livestream` call returns `call.ingress.rtmp.{address,stream_key}` and that the call type has
+// recording enabled (or set `settings_override.recording` here). The shape below follows Stream's
+// documented Video API; verify field names before the first real broadcast.
+export async function ensureBeaconCallAndIngest(input: {
+  eventId: string;
+  hostUserId: string;
+}): Promise<BeaconIngest | null> {
+  const ctx = await resolveStreamRest();
+  if (!ctx) {
+    return null;
+  }
+  const callId = beaconCallIdForEvent(input.eventId);
+  const created = await streamVideoFetch(ctx, `/api/v2/video/call/${BEACON_STREAM_CALL_TYPE}/${callId}`, {
+    method: 'POST',
+    body: {
+      data: {
+        created_by_id: beaconStreamUserId(input.hostUserId),
+        settings_override: {
+          // Backstage on: the call is not visible to viewers until goLive() is called.
+          backstage: { enabled: true },
+          recording: { mode: 'available' },
+        },
+      },
+    },
+  });
+  const call = (created.call ?? {}) as Record<string, unknown>;
+  const ingress = (call.ingress ?? {}) as Record<string, unknown>;
+  const rtmp = (ingress.rtmp ?? {}) as Record<string, unknown>;
+  const address = typeof rtmp.address === 'string' ? rtmp.address : '';
+  const streamKey = typeof rtmp.stream_key === 'string' ? rtmp.stream_key : '';
+  return { rtmpIngestUrl: address, streamKey };
+}
+
+// Flip the call out of backstage so viewers can watch. Returns false when Stream is not configured.
+export async function goLiveBeaconCall(eventId: string): Promise<boolean> {
+  const ctx = await resolveStreamRest();
+  if (!ctx) {
+    return false;
+  }
+  const callId = beaconCallIdForEvent(eventId);
+  // TODO(beacon): confirm the goLive endpoint path; Stream documents
+  // POST /api/v2/video/call/{type}/{id}/go_live with optional start_hls/start_recording flags.
+  await streamVideoFetch(ctx, `/api/v2/video/call/${BEACON_STREAM_CALL_TYPE}/${callId}/go_live`, {
+    method: 'POST',
+    body: { start_hls: true, start_recording: true },
+  });
+  return true;
+}
+
+// Return the public HLS playback URL for the live call so anonymous viewers can watch with no token.
+// TODO(beacon): confirm the field — Stream exposes HLS playlist URL on the call response (commonly
+// `call.egress.hls.playlist_url`). We never fabricate a URL: when absent this returns null and the
+// viewer shows the idle state.
+export async function getBeaconHlsPlaybackUrl(eventId: string): Promise<string | null> {
+  const ctx = await resolveStreamRest();
+  if (!ctx) {
+    return null;
+  }
+  const callId = beaconCallIdForEvent(eventId);
+  const result = await streamVideoFetch(ctx, `/api/v2/video/call/${BEACON_STREAM_CALL_TYPE}/${callId}`, {
+    method: 'GET',
+  });
+  const call = (result.call ?? {}) as Record<string, unknown>;
+  const egress = (call.egress ?? {}) as Record<string, unknown>;
+  const hls = (egress.hls ?? {}) as Record<string, unknown>;
+  const playlistUrl = typeof hls.playlist_url === 'string' ? hls.playlist_url : '';
+  return playlistUrl.length > 0 ? playlistUrl : null;
+}
+
+// End the call so Stream stops distribution and billing stops. This is the cost-critical path: the
+// End-event route must call this. Returns false when Stream is not configured (nothing to stop).
+export async function endBeaconCall(eventId: string): Promise<boolean> {
+  const ctx = await resolveStreamRest();
+  if (!ctx) {
+    return false;
+  }
+  const callId = beaconCallIdForEvent(eventId);
+  // TODO(beacon): confirm the end endpoint path; Stream documents
+  // POST /api/v2/video/call/{type}/{id}/mark_ended (or stop_live) to end a livestream.
+  await streamVideoFetch(ctx, `/api/v2/video/call/${BEACON_STREAM_CALL_TYPE}/${callId}/stop_live`, {
+    method: 'POST',
+    body: {},
+  });
+  return true;
+}
+
+export type BeaconModerationAction = 'mute' | 'ban' | 'slow_mode';
+
+// Moderate the event chat channel: mute or ban a member, or toggle slow-mode. The admin host is the
+// channel's server-side moderator. Returns false when Stream is not configured.
+export async function moderateBeaconChat(input: {
+  eventId: string;
+  hostUserId: string;
+  action: BeaconModerationAction;
+  targetUserId?: string | null;
+  cooldownSeconds?: number | null;
+}): Promise<boolean> {
+  const credentials = await resolveStreamCredentials();
+  if (!credentials) {
+    return false;
+  }
+  const chatClient = new StreamChat(credentials.apiKey, credentials.apiSecret);
+  try {
+    const channelId = beaconCallIdForEvent(input.eventId);
+    const channel = chatClient.channel(BEACON_CHAT_CHANNEL_TYPE, channelId);
+    const target = input.targetUserId ? beaconStreamUserId(input.targetUserId) : null;
+    if (input.action === 'mute' && target) {
+      await chatClient.muteUser(target, beaconStreamUserId(input.hostUserId));
+      return true;
+    }
+    if (input.action === 'ban' && target) {
+      // Ban from this event's channel only — Beacon is per-event, not a global ban. The channel-level
+      // banUser scopes the ban to this channel.
+      await channel.banUser(target, { banned_by_id: beaconStreamUserId(input.hostUserId) });
+      return true;
+    }
+    if (input.action === 'slow_mode') {
+      const seconds = input.cooldownSeconds && input.cooldownSeconds > 0 ? input.cooldownSeconds : 0;
+      if (seconds > 0) {
+        await channel.enableSlowMode(seconds);
+      } else {
+        await channel.disableSlowMode();
+      }
+      return true;
+    }
+    return false;
+  } finally {
+    await chatClient.disconnectUser();
+  }
+}
+
+// Verify the Stream webhook signature. Stream signs the raw body with the app secret (HMAC-SHA256)
+// and sends it in the `x-signature` header. A request whose signature does not match is rejected.
+export async function verifyBeaconWebhookSignature(rawBody: string, signature: string | null): Promise<boolean> {
+  if (!signature) {
+    return false;
+  }
+  const credentials = await resolveStreamCredentials();
+  if (!credentials) {
+    return false;
+  }
+  const expected = createHmac('sha256', credentials.apiSecret).update(rawBody).digest('hex');
+  // Length-guard before compare so a malformed signature can't throw.
+  if (expected.length !== signature.length) {
+    return false;
+  }
+  // Constant-time-ish compare.
+  let mismatch = 0;
+  for (let i = 0; i < expected.length; i += 1) {
+    mismatch |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -218,6 +218,14 @@ const fallbackPluginRegistry: PluginRegistryItem[] = [
     navRank: 220,
     isVisible: false,
   },
+  {
+    slug: 'beacon',
+    name: 'Beacon',
+    summary: 'Live one-way broadcasts from the team. Watch publicly with just a link; sign in to chat and react.',
+    availabilityState: 'implemented_shell',
+    navRank: 230,
+    isVisible: true,
+  },
 ];
 
 const pluginAliasMap: Record<string, string> = {

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -4436,6 +4436,79 @@ FROM service_credits_wallets
 WHERE is_frozen = TRUE
 ON CONFLICT (user_id) DO NOTHING;
 
+-- === beacon-plugin ===
+-- Beacon: admin-only one-way livestream. An admin goes live ad hoc to broadcast a live demo
+-- (screen content), flagship use the "State of the TI Skills Economy" address. Watching is public
+-- (HLS, no sign-in); chatting/reacting needs a signed-in member (Stream Chat). Live chat is
+-- ephemeral (Stream only) and is NOT stored here — only the event lifecycle and the saved recording.
+BEGIN;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE TABLE IF NOT EXISTS beacon_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'live', 'ended')),
+  host_user_id TEXT NOT NULL,
+  stream_call_type TEXT NOT NULL DEFAULT 'livestream',
+  stream_call_id TEXT NOT NULL,
+  started_at TIMESTAMPTZ,
+  ended_at TIMESTAMPTZ,
+  recording_url TEXT,
+  recording_ready_at TIMESTAMPTZ,
+  commons_live_post_id UUID,
+  commons_recording_post_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Guarded DDL so legacy DBs gain every column. Every ALTER carries a default (the id-default lesson
+-- from the announcements fix) so adding a column to a table with existing rows never fails.
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS description TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'draft';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS host_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS stream_call_type TEXT NOT NULL DEFAULT 'livestream';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS stream_call_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS ended_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS recording_url TEXT;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS recording_ready_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS commons_live_post_id UUID;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS commons_recording_post_id UUID;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- At most one live event at a time keeps the public viewer unambiguous and bounds Stream video cost.
+CREATE UNIQUE INDEX IF NOT EXISTS beacon_events_one_live_idx ON beacon_events ((status = 'live')) WHERE status = 'live';
+CREATE INDEX IF NOT EXISTS beacon_events_status_idx ON beacon_events (status);
+CREATE INDEX IF NOT EXISTS beacon_events_created_at_idx ON beacon_events (created_at DESC);
+
+CREATE TABLE IF NOT EXISTS beacon_events_admin_audit_trail (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_id TEXT NOT NULL,
+  command TEXT NOT NULL,
+  policy_status TEXT NOT NULL DEFAULT 'allow' CHECK (policy_status IN ('allow', 'deny')),
+  reason TEXT NOT NULL DEFAULT '',
+  target_type TEXT NOT NULL DEFAULT '',
+  target_id TEXT NOT NULL DEFAULT '',
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS actor_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS command TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS policy_status TEXT NOT NULL DEFAULT 'allow';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS reason TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS target_type TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS target_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS beacon_events_admin_audit_trail_created_at_idx ON beacon_events_admin_audit_trail (created_at DESC);
+COMMIT;
+
 -- ── post migration: 0001_directory_display_name_to_first_last.sql ──
 -- Directory: move the single v2 `display_name` field to honest v3
 -- `first_name` + `last_name` columns, then drop `display_name`.

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -4437,3 +4437,76 @@ SELECT user_id, TRUE, 'trading', COALESCE(frozen_at, NOW()), frozen_by_user_id, 
 FROM service_credits_wallets
 WHERE is_frozen = TRUE
 ON CONFLICT (user_id) DO NOTHING;
+
+-- === beacon-plugin ===
+-- Beacon: admin-only one-way livestream. An admin goes live ad hoc to broadcast a live demo
+-- (screen content), flagship use the "State of the TI Skills Economy" address. Watching is public
+-- (HLS, no sign-in); chatting/reacting needs a signed-in member (Stream Chat). Live chat is
+-- ephemeral (Stream only) and is NOT stored here — only the event lifecycle and the saved recording.
+BEGIN;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE TABLE IF NOT EXISTS beacon_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'live', 'ended')),
+  host_user_id TEXT NOT NULL,
+  stream_call_type TEXT NOT NULL DEFAULT 'livestream',
+  stream_call_id TEXT NOT NULL,
+  started_at TIMESTAMPTZ,
+  ended_at TIMESTAMPTZ,
+  recording_url TEXT,
+  recording_ready_at TIMESTAMPTZ,
+  commons_live_post_id UUID,
+  commons_recording_post_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Guarded DDL so legacy DBs gain every column. Every ALTER carries a default (the id-default lesson
+-- from the announcements fix) so adding a column to a table with existing rows never fails.
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS description TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'draft';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS host_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS stream_call_type TEXT NOT NULL DEFAULT 'livestream';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS stream_call_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS ended_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS recording_url TEXT;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS recording_ready_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS commons_live_post_id UUID;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS commons_recording_post_id UUID;
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS beacon_events ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- At most one live event at a time keeps the public viewer unambiguous and bounds Stream video cost.
+CREATE UNIQUE INDEX IF NOT EXISTS beacon_events_one_live_idx ON beacon_events ((status = 'live')) WHERE status = 'live';
+CREATE INDEX IF NOT EXISTS beacon_events_status_idx ON beacon_events (status);
+CREATE INDEX IF NOT EXISTS beacon_events_created_at_idx ON beacon_events (created_at DESC);
+
+CREATE TABLE IF NOT EXISTS beacon_events_admin_audit_trail (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_id TEXT NOT NULL,
+  command TEXT NOT NULL,
+  policy_status TEXT NOT NULL DEFAULT 'allow' CHECK (policy_status IN ('allow', 'deny')),
+  reason TEXT NOT NULL DEFAULT '',
+  target_type TEXT NOT NULL DEFAULT '',
+  target_id TEXT NOT NULL DEFAULT '',
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS actor_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS command TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS policy_status TEXT NOT NULL DEFAULT 'allow';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS reason TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS target_type TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS target_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS beacon_events_admin_audit_trail ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS beacon_events_admin_audit_trail_created_at_idx ON beacon_events_admin_audit_trail (created_at DESC);
+COMMIT;

--- a/ctf/scripts/seedBeaconPhase0.mjs
+++ b/ctf/scripts/seedBeaconPhase0.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+// Seeds one past, ended Beacon event with a recording URL so the viewer's idle/replay state and the
+// admin history list render with real data in demos. Deterministic UUIDs keep re-runs idempotent.
+import { Pool } from 'pg';
+import crypto from 'crypto';
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+const pool = new Pool({
+  connectionString: requireEnv('DATABASE_URL'),
+  ssl: {
+    rejectUnauthorized: false,
+  },
+});
+
+async function queryDb(text, values = []) {
+  return pool.query(text, values);
+}
+
+// Deterministic UUID v4-shaped id from a stable seed string.
+function deterministicUuid(input) {
+  const hash = crypto.createHash('sha256').update(input).digest('hex');
+  return [
+    hash.slice(0, 8),
+    hash.slice(8, 12),
+    `4${hash.slice(13, 16)}`,
+    `${((parseInt(hash.slice(16, 18), 16) & 0x3f) | 0x80).toString(16)}${hash.slice(18, 20)}`,
+    hash.slice(20, 32),
+  ].join('-');
+}
+
+const HOST_USER_ID = 'user-00000001';
+const EVENT_ID = deterministicUuid('beacon-event-state-of-the-ti-skills-economy-2026-05-30');
+const RECORDING_URL = 'https://stream-recordings.example/beacon/state-of-the-ti-skills-economy-2026-05-30.m3u8';
+
+async function seed() {
+  await queryDb('BEGIN');
+  try {
+    await queryDb(
+      `INSERT INTO beacon_events
+         (id, title, description, status, host_user_id, stream_call_type, stream_call_id,
+          started_at, ended_at, recording_url, recording_ready_at)
+       VALUES
+         ($1, $2, $3, 'ended', $4, 'livestream', $5,
+          NOW() - INTERVAL '22 days', NOW() - INTERVAL '22 days' + INTERVAL '38 minutes',
+          $6, NOW() - INTERVAL '22 days' + INTERVAL '50 minutes')
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        EVENT_ID,
+        'State of the TI Skills Economy',
+        'A live walkthrough of where the survivor skills economy stands and what is shipping next.',
+        HOST_USER_ID,
+        `beacon-${EVENT_ID}`,
+        RECORDING_URL,
+      ],
+    );
+
+    await queryDb(
+      `INSERT INTO beacon_events_admin_audit_trail
+         (id, actor_id, command, policy_status, reason, target_type, target_id, metadata)
+       VALUES ($1, $2, 'beacon.event.create', 'allow', 'seed', 'event', $3, '{}'::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+      [deterministicUuid(`beacon-audit-${EVENT_ID}`), HOST_USER_ID, EVENT_ID],
+    );
+
+    await queryDb('COMMIT');
+    console.log(`Seeded Beacon event ${EVENT_ID} (ended, with recording).`);
+  } catch (error) {
+    await queryDb('ROLLBACK');
+    throw error;
+  } finally {
+    await pool.end();
+  }
+}
+
+seed().catch((error) => {
+  console.error('seedBeaconPhase0 failed:', error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Beacon plugin v1 (web), built to the locked plan in `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md`. An admin goes live ad hoc to broadcast a live demo (flagship use: the State of the TI Skills Economy address). Watching is public over HLS, no sign-in; chatting and reacting require a signed-in member. Going live auto-posts a notice to the Commons; the recording auto-posts as a replay. One-way only; Chyme untouched.

## How it works

- Video: Stream Video `livestream` call. Public viewers watch via the HLS playback URL (no token, so anonymous works). Broadcast input is per-event RTMP ingest (admin pushes their phone screen from a mobile broadcaster app) plus desktop in-browser screen-share.
- Chat: a Stream Chat token is only issued to signed-in members (`POST /api/beacon/[id]/chat-token` is member-gated; anonymous gets 401 and sees a "sign in to chat" prompt). Admin moderation: mute, ban, slow-mode.
- Commons auto-post on go-live and on recording-ready, both idempotent (the post ids are stored on the event row so a retry or a redelivered webhook never double-posts).
- The webhook verifies the Stream `x-signature` HMAC and returns 401 otherwise.
- Graceful degradation: with Stream env vars absent every Stream call returns null/503 and the app still builds and runs.

## Data and routes

New tables: `beacon_events` (with a partial unique index allowing at most one live event) and `beacon_events_admin_audit_trail`. Routes: `current`, `[id]/chat-token`, create, `[id]/ingest`, `[id]/go-live`, `[id]/end`, `admin` list, `[id]/moderate`, `stream-webhook`. CSRF on every mutation. Contracts, seed, inventory, and a quota-impact note are included.

## Needs your verification before the livestream works end to end

The build, typecheck, lint, EOF, and schema-drift gates all pass, but a few exact Stream API specifics could not be confirmed without your Stream dashboard/account and are marked `TODO(beacon)` in the code (no fake values are emitted — missing fields fall back to the idle state):

- `lib/beacon/stream.ts`: the `livestream` call-type config (host-only publish, recording enabled), the RTMP ingest fields (`call.ingress.rtmp.address` / `stream_key`), the go-live/stop endpoints, and the HLS field (`call.egress.hls.playlist_url`).
- `app/api/beacon/stream-webhook/route.ts`: the `call.recording_ready` event name and the recording URL payload shape.
- `components/beacon/beacon-viewer.tsx`: non-Safari browsers may need `hls.js` to play HLS (noted, not yet added as a dependency).

I can confirm these against Stream's docs and wire them up in a follow-up once you point me at the Stream project, or we can verify together.

## Lane

Owner-review lane (new plugin, schema, Stream Video, webhook, and the app's most cost-sensitive Stream usage). Opened ready, no auto-merge. The End-event path stops the call so livestream billing stops.

Parity Ticket: #712

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_