### PR TITLE
fix: remove the misleading static verified check mark in the directory

### DIFF
--- a/ctf/packages/web/components/directory/directory-browse.tsx
+++ b/ctf/packages/web/components/directory/directory-browse.tsx
@@ -3,7 +3,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { ArrowUpRight, CheckCircle, ChevronRight, Search } from "lucide-react";
+import { ArrowUpRight, ChevronRight, Search } from "lucide-react";
 import { COLOR, SKILLS_HUNT_COLOR, initials, type Member, type SkillsHuntRewardCard } from "./shared";
 import { DirectoryEmptyState } from "./directory-empty-state";
 
@@ -69,7 +69,6 @@ export function DirectoryBrowse({
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
                       <div style={{ fontSize: 15, fontWeight: 700, color: "#F9FAFB", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
-                      <CheckCircle size={14} style={{ color: COLOR, flexShrink: 0 }} />
                     </div>
                     <div style={{ fontSize: 12, color: "#9CA3AF", marginBottom: 4 }}>{p.jobTitle}</div>
                     <Badge style={{ background: `${COLOR}10`, color: COLOR, border: `1px solid ${COLOR}25`, fontSize: 11 }}>{p.sector}</Badge>

--- a/ctf/packages/web/components/directory/directory-right-panel.tsx
+++ b/ctf/packages/web/components/directory/directory-right-panel.tsx
@@ -31,7 +31,6 @@ export function DirectoryRightPanel({
             <div style={{ fontSize: 13, fontWeight: 600, color: "#E8EAF0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
             <div style={{ fontSize: 11, color: "#6B7280", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.jobTitle}</div>
           </div>
-          <CheckCircle size={12} style={{ color: COLOR, flexShrink: 0 }} />
         </div>
       ))}
       {members.length === 0 && !loadingMembers && (


### PR DESCRIPTION
## What and why

Each provider card and each Top Providers row in the Directory rendered a check-circle next to the person's name unconditionally — it was wired to no verification field, so it implied every person was individually verified when none were. The owner asked to delete it.

## Change

Removed the per-name check from the browse list (`directory-browse.tsx`) and the Top Providers panel (`directory-right-panel.tsx`), and dropped the now-unused import. Left untouched: the active-sector-filter check (a real selected-state indicator) and the network-level "Verified Network" header badge.

No API/schema/contract change. Typecheck, ESLint, and EOF pass.

Parity Ticket: #714

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_