### PR TITLE
fix: route the directory Quora link through the external-link confirmation

### DIFF
--- a/ctf/packages/web/components/directory/directory-profile-detail.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-detail.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft, ExternalLink, Sparkles } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { useTheme } from "@/hooks/useTheme";
+import { useExternalLink } from "@/components/hooks/useExternalLink";
 import { getDirectoryTokens, initials, type Member } from "./shared";
 
 export function DirectoryProfileDetail({
@@ -24,6 +25,10 @@ export function DirectoryProfileDetail({
   const p = member;
   const { theme } = useTheme();
   const t = getDirectoryTokens(theme);
+  // Outbound links go through the shared confirmation (you are about to leave for an external site,
+  // with a copy-URL option) — required for accessibility and trauma-informed practice, so nobody is
+  // sent off-app to Quora without a clear, dismissible heads-up.
+  const { openExternal, ExternalLinkDialog } = useExternalLink();
   const [attachInput, setAttachInput] = useState("");
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
@@ -92,17 +97,17 @@ export function DirectoryProfileDetail({
 
           {/* Quora profile — every directory profile is sourced from Quora, so this is the social
               proof and the way to learn more before bartering, trading, or exchanging credits. */}
-          <a
-            href={profileUrl ?? undefined}
-            target={profileUrl ? "_blank" : undefined}
-            rel={profileUrl ? "noopener noreferrer" : undefined}
-            aria-disabled={profileUrl ? undefined : true}
+          <button
+            type="button"
+            onClick={() => { if (profileUrl) openExternal(profileUrl); }}
+            disabled={!profileUrl}
+            aria-label={profileUrl ? "View Quora profile — opens a confirmation before leaving for the external site" : "Quora profile not linked yet"}
             style={{
               display: "flex", alignItems: "center", gap: 12, padding: "14px 18px", borderRadius: 12,
               background: profileUrl ? `${t.ACCENT}12` : "rgba(255,255,255,0.02)",
               border: `1px solid ${profileUrl ? `${t.ACCENT}35` : t.BORDER}`,
-              textDecoration: "none", color: t.TEXT, marginBottom: 24,
-              pointerEvents: profileUrl ? "auto" : "none", opacity: profileUrl ? 1 : 0.6,
+              color: t.TEXT, marginBottom: 24, width: "100%", textAlign: "left",
+              cursor: profileUrl ? "pointer" : "default", opacity: profileUrl ? 1 : 0.6,
             }}
           >
             <ExternalLink size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
@@ -114,7 +119,8 @@ export function DirectoryProfileDetail({
                 {profileUrl ? "Their Quora profile is the social proof — read more before you reach out." : "This profile has no Quora link on file."}
               </div>
             </div>
-          </a>
+          </button>
+          <ExternalLinkDialog />
 
           {/* About */}
           {bio && (


### PR DESCRIPTION
## What and why

On the directory provider profile, "View Quora profile" was a bare new-tab anchor (`<a target="_blank">`), so a member was sent off-app with no heads-up. That misses the platform's required external-link handling.

## Change

The link now goes through the shared `useExternalLink` confirmation: clicking it opens a dismissible "you are about to open an external site" dialog with a Copy URL option and Cancel, before anything leaves the app. Required for accessibility and trauma-informed practice — nobody is navigated off to Quora without a clear, cancelable heads-up. The not-linked-yet state is unchanged (disabled, no action).

No API/schema/contract change. Typecheck, ESLint, and EOF pass.

## Heads-up

This touches `directory-profile-detail.tsx`, which the open presence PR (#720) also edits. Whichever merges second will need a small conflict resolution in this file; I'll handle it.

Parity Ticket: #714

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_