### PR TITLE
feat: optional profession-based skill pre-fill in Skills Hunt nominations

### DIFF
--- a/ctf/packages/web/components/skills-hunt/sh-scout-tab.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-scout-tab.tsx
@@ -20,6 +20,7 @@ export interface ScoutFormModel {
   onBio: (v: string) => void;
   onQuora: (v: string) => void;
   onToggleSkill: (s: string) => void;
+  onAddOccupationSkills: (skillNames: string[]) => void;
   onRemoveProposed: (s: string) => void;
   onOpenCategory: (c: string | null) => void;
   onFreeText: (v: string) => void;
@@ -147,6 +148,7 @@ function NominationForm({ form }: { form: ScoutFormModel }) {
           canAddMore={form.canAddMore}
           allSkillCount={form.allSkillCount}
           onToggleSkill={form.onToggleSkill}
+          onAddOccupationSkills={form.onAddOccupationSkills}
           onRemoveProposed={form.onRemoveProposed}
           onOpenCategory={form.onOpenCategory}
           onFreeText={form.onFreeText}

--- a/ctf/packages/web/components/skills-hunt/sh-shared.ts
+++ b/ctf/packages/web/components/skills-hunt/sh-shared.ts
@@ -35,12 +35,38 @@ export function getSkillsHuntTokens(theme: ThemeName): SkillsHuntTokens {
   return getPluginShellTokens(accent, theme);
 }
 
-// Shape of one row from GET /api/skills-taxonomy/flattened. The picker only needs the
-// sector and skill names; the full row type lives in lib/skills-taxonomy/types.ts.
+// Shape of one row from GET /api/skills-taxonomy/flattened. The picker needs the sector and skill
+// names for its category list, and the job-title (occupation) name for the "add a profession's
+// skills" shortcut; the full row type lives in lib/skills-taxonomy/types.ts.
 export type TaxonomyFlattenedRow = {
   sectorName: string;
+  jobTitleName: string;
   skillName: string;
 };
+
+// Group flattened taxonomy rows by occupation (job title) → de-duped, sorted skill names. Powers the
+// optional "add a profession's skills" shortcut: picking a profession adds all of its skills at once.
+export function groupSkillsByOccupation(rows: TaxonomyFlattenedRow[]): Record<string, string[]> {
+  const byOccupation = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const occupation = row.jobTitleName?.trim();
+    const skill = row.skillName?.trim();
+    if (!occupation || !skill) continue;
+    let set = byOccupation.get(occupation);
+    if (!set) {
+      set = new Set<string>();
+      byOccupation.set(occupation, set);
+    }
+    set.add(skill);
+  }
+  const result: Record<string, string[]> = {};
+  for (const occupation of [...byOccupation.keys()].sort((a, b) => a.localeCompare(b))) {
+    const skills = byOccupation.get(occupation);
+    if (!skills) continue;
+    result[occupation] = [...skills].sort((a, b) => a.localeCompare(b));
+  }
+  return result;
+}
 
 // Group flattened taxonomy rows into the picker's category → skills shape:
 // sectorName → de-duped, sorted list of skill names. A skill that appears under

--- a/ctf/packages/web/components/skills-hunt/sh-skills-picker.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-skills-picker.tsx
@@ -2,28 +2,31 @@
 
 import { useEffect, useState } from "react";
 import { X, ChevronDown } from "lucide-react";
-import { COLOR, groupTaxonomyBySector, type TaxonomyFlattenedRow } from "./sh-shared";
+import { COLOR, groupSkillsByOccupation, groupTaxonomyBySector, type TaxonomyFlattenedRow } from "./sh-shared";
 
 type TaxonomyLoadState =
   | { status: "loading" }
-  | { status: "ready"; categories: Record<string, string[]> }
+  | { status: "ready"; categories: Record<string, string[]>; occupations: Record<string, string[]> }
   | { status: "error" };
 
 // Cache the grouped taxonomy for the page session so the picker never has to show "Loading…"
 // again after the first fetch. Re-showing the loading state would collapse the category list,
 // which on a phone makes the page shrink and the scroll jump — the exact symptom of selecting a
-// skill re-rendering the picker.
+// skill re-rendering the picker. Both groupings come from the one flattened fetch.
 let cachedCategories: Record<string, string[]> | null = null;
+let cachedOccupations: Record<string, string[]> | null = null;
 
 // Fetch the canonical skills taxonomy once and group it by sector for the picker. On error or an
 // empty result the picker still renders the free-text proposed-skills box so a scout can proceed.
 function useTaxonomy(): TaxonomyLoadState {
   const [state, setState] = useState<TaxonomyLoadState>(
-    cachedCategories ? { status: "ready", categories: cachedCategories } : { status: "loading" },
+    cachedCategories && cachedOccupations
+      ? { status: "ready", categories: cachedCategories, occupations: cachedOccupations }
+      : { status: "loading" },
   );
 
   useEffect(() => {
-    if (cachedCategories) return;
+    if (cachedCategories && cachedOccupations) return;
     let active = true;
     void (async () => {
       try {
@@ -31,9 +34,12 @@ function useTaxonomy(): TaxonomyLoadState {
         if (!res.ok) throw new Error(`Taxonomy request failed (${res.status})`);
         const data = (await res.json()) as { items?: TaxonomyFlattenedRow[] };
         if (!active) return;
-        const categories = groupTaxonomyBySector(data.items ?? []);
+        const rows = data.items ?? [];
+        const categories = groupTaxonomyBySector(rows);
+        const occupations = groupSkillsByOccupation(rows);
         cachedCategories = categories;
-        setState({ status: "ready", categories });
+        cachedOccupations = occupations;
+        setState({ status: "ready", categories, occupations });
       } catch {
         if (active) setState({ status: "error" });
       }
@@ -54,6 +60,7 @@ interface SkillsPickerProps {
   canAddMore: boolean;
   allSkillCount: number;
   onToggleSkill: (s: string) => void;
+  onAddOccupationSkills: (skillNames: string[]) => void;
   onRemoveProposed: (s: string) => void;
   onOpenCategory: (c: string | null) => void;
   onFreeText: (v: string) => void;
@@ -120,10 +127,12 @@ function CategoryRow({ category, categorySkills, skills, isOpen, canAddMore, onO
 }
 
 export function SkillsPicker(props: SkillsPickerProps) {
-  const { skills, proposedSkills, freeText, openCategory, canAddMore, allSkillCount, onToggleSkill, onRemoveProposed, onOpenCategory, onFreeText, onAddProposed } = props;
+  const { skills, proposedSkills, freeText, openCategory, canAddMore, allSkillCount, onToggleSkill, onAddOccupationSkills, onRemoveProposed, onOpenCategory, onFreeText, onAddProposed } = props;
   const taxonomy = useTaxonomy();
   const categories = taxonomy.status === "ready" ? taxonomy.categories : {};
+  const occupations = taxonomy.status === "ready" ? taxonomy.occupations : {};
   const hasCategories = Object.keys(categories).length > 0;
+  const occupationNames = Object.keys(occupations);
   return (
     <div>
       <label style={{ fontSize: 12, fontWeight: 600, color: "#9CA3AF", display: "block", marginBottom: 6 }}>
@@ -132,6 +141,26 @@ export function SkillsPicker(props: SkillsPickerProps) {
       </label>
 
       <SelectedChips skills={skills} proposedSkills={proposedSkills} onToggleSkill={onToggleSkill} onRemoveProposed={onRemoveProposed} />
+
+      {taxonomy.status === "ready" && occupationNames.length > 0 && (
+        <div style={{ marginBottom: 10 }}>
+          <label htmlFor="sh-occupation-prefill" style={{ fontSize: 11, color: "#9CA3AF", display: "block", marginBottom: 4 }}>
+            Know their profession? Add its skills <span style={{ color: "#4B5563" }}>(optional — fills the skills in for you)</span>
+          </label>
+          <select
+            id="sh-occupation-prefill"
+            value=""
+            disabled={!canAddMore}
+            onChange={(e) => { const occ = e.target.value; if (occ && occupations[occ]) onAddOccupationSkills(occupations[occ]); }}
+            style={{ width: "100%", padding: "8px 12px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: "#E8EAF0", outline: "none", cursor: canAddMore ? "pointer" : "default", opacity: canAddMore ? 1 : 0.5 }}
+          >
+            <option value="">Select a profession…</option>
+            {occupationNames.map((occ) => (
+              <option key={occ} value={occ}>{occ}</option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {taxonomy.status === "loading" && (
         <div style={{ fontSize: 12, color: "#6B7280", padding: "10px 0" }}>Loading skills…</div>

--- a/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
+++ b/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
@@ -39,6 +39,21 @@ export function useNominationForm(activeRound: SkillsHuntRound | null): {
     setFreeText("");
   }
 
+  // Bulk-add the skills of a chosen profession (occupation). A convenience so a scout who knows
+  // someone is, say, a Pharmacist does not have to remember every skill: picking the profession
+  // fills its taxonomy skills into the existing skills field (deduped, and only up to the cap),
+  // which the scout can then trim. Nothing new is stored — the skills remain the source of truth.
+  function addOccupationSkills(skillNames: string[]) {
+    setSkills((prev) => {
+      const next = [...prev];
+      for (const name of skillNames) {
+        if (next.length + proposedSkills.length >= MAX_SKILLS) break;
+        if (!next.includes(name)) next.push(name);
+      }
+      return next;
+    });
+  }
+
   async function handleSubmit() {
     if (!activeRound || fullName.trim().length < 2 || allSkillCount === 0) return;
     setSubmitting(true);
@@ -79,6 +94,7 @@ export function useNominationForm(activeRound: SkillsHuntRound | null): {
     submitting, submitError, allSkillCount, canAddMore,
     onFullName: setFullName, onBio: setBio, onQuora: setQuora,
     onToggleSkill: toggleSkill,
+    onAddOccupationSkills: addOccupationSkills,
     onRemoveProposed: (s) => setProposed((prev) => prev.filter((x) => x !== s)),
     onOpenCategory: setOpenCategory, onFreeText: setFreeText, onAddProposed: addProposed,
     onSubmit: () => void handleSubmit(),


### PR DESCRIPTION
## What and why

A scout often knows someone's profession from their Quora profile (for example "Pharmacist") but does not remember every skill that profession entails. This adds an optional "Know their profession? Add its skills" picker to the Skills Hunt nomination form: choosing a profession fills that occupation's taxonomy skills into the skills field automatically, which the scout can then trim.

## Approach (Option A, owner-chosen)

It stays bottom-up — the occupation is a convenience that bulk-adds skills, not a new parallel system:

- The picker lists occupations (job titles) built from the same `/api/skills-taxonomy/flattened` data the skills picker already loads (the flattened rows carry `jobTitleName`).
- Selecting a profession adds its skills into the existing skills field, deduped and capped at the same 10-skill limit.
- Nothing new is stored and no attribution path changes: skills remain the source of truth, so the job-title/sector inference and the accept-time attribution all work exactly as before.

No new endpoint, schema, or contract — reuses the existing flattened taxonomy. Client-only, so not an inventory drift vector. Typecheck, ESLint, and EOF pass.

Parity Ticket: #721

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_