### PR TITLE
fix: Peer Programming admin date field bleeding off the form

### DIFF
--- a/ctf/packages/web/components/peer-programming/pp-admin-topic-form.tsx
+++ b/ctf/packages/web/components/peer-programming/pp-admin-topic-form.tsx
@@ -15,6 +15,7 @@ const SUBTLE = '#6B7280';
 
 const inputStyle: React.CSSProperties = {
   width: '100%',
+  boxSizing: 'border-box',
   background: BG,
   border: `1px solid ${BORDER}`,
   color: TEXT,


### PR DESCRIPTION
## What and why

On the Peer Programming admin page, the weekly-topic form fields (most visibly the date field on a phone) bled past the right edge of the form. The shared input style used `width: 100%` with horizontal padding but no `box-sizing`, so each input was wider than its container by the padding.

## Change

Add `box-sizing: border-box` to the form's shared `inputStyle`, so the date, title, guidance, and revision-note fields all fit within the form. CSS-only. Typecheck and EOF pass.

Parity Ticket: #691

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_