### PR TITLE
fix: list Beacon on the admin landing so its admin page is reachable

### DIFF
--- a/ctf/packages/web/app/admin/page.tsx
+++ b/ctf/packages/web/app/admin/page.tsx
@@ -28,6 +28,7 @@ const ADMIN_AREAS: { href: string; name: string; description: string }[] = [
   { href: '/admin/gdp', name: 'GDP', description: 'Manage GDP figures.' },
   { href: '/admin/gdp/rates', name: 'GDP Rates', description: 'Manage GDP exchange and conversion rates.' },
   { href: '/admin/feed-announcements', name: 'Feed Announcements', description: 'Post and manage announcements in the community feed.' },
+  { href: '/admin/beacon', name: 'Beacon', description: 'Go live and run broadcast events; manage recordings.' },
   { href: '/admin/bug-reports', name: 'Bug Reports', description: 'Review reports flagged for a human and track ones sent to triage.' },
 ];
 


### PR DESCRIPTION
## What and why

Beacon shipped its admin page at `/admin/beacon`, but it was never added to the admin landing's `ADMIN_AREAS` list — so an admin had no link to it and "saw nothing in the admin UI." That is why Beacon appeared missing even though it merged.

## Change

Add a Beacon row to `ADMIN_AREAS` in `app/admin/page.tsx`, matching the file's own note to add a row when a new admin area ships. One line.

Note: this only makes the existing Beacon admin reachable. Beacon's live broadcast still needs (a) a production deploy and (b) the `TODO(beacon)` Stream API field names confirmed against the Stream account before the livestream works end-to-end.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_