### PR TITLE
feat: plugin-chat mentions, in-channel search, and link previews

### DIFF
--- a/ctf/docs/developer/STREAM_FEATURE_ADOPTION.md
+++ b/ctf/docs/developer/STREAM_FEATURE_ADOPTION.md
@@ -96,18 +96,18 @@ Legend — **Build**: in scope, not yet shipped · **Done**: shipped · **Exclud
 | 1 | Emoji reactions on messages | Build | All surfaces. The headline "inviting" feature. |
 | 2 | Threaded replies (thread panel) | Build | All surfaces. |
 | 3 | Quoted reply (inline "replying to…") | **Done (Commons)** / Build (plugin chats) | Commons shipped in PR #695. Plugin chats still to do. |
-| 4 | @mentions with autocomplete + highlight | Build | All surfaces. |
+| 4 | @mentions with autocomplete + highlight | Done (plugin chats) / Build (Commons) | Plugin chats shipped in the shared StreamChatPanel: typing `@` suggests channel members and mentions render highlighted, the Stream default once the channel is watched with its member list. Commons (custom UI) is a separate follow-up. |
 | 5 | Edit your own message | Build | All surfaces. |
 | 6 | Delete your own message | Build | All surfaces. |
 | 7 | Pin a message | **Admin-only** | Only admins may pin/unpin; everyone sees the pinned bar. |
 | 8 | Copy message text | Build | All surfaces. |
-| 9 | Message search (in-channel) | Build | All surfaces. |
+| 9 | Message search (in-channel) | Done (plugin chats) / Build (Commons) | Plugin chats shipped in the shared StreamChatPanel: a compact search strip at the top of the conversation calls `channel.search`, which scopes to the open channel, and lets a member jump to a result. Commons (custom UI) is a separate follow-up. |
 | 10 | Slash commands | Deferred | The only configured command is `giphy`, which is excluded (#16). No active command to surface; revisit if we add non-giphy commands. |
 | 11 | Emoji picker in the composer | Build | All surfaces. |
 | 12 | Voice / audio messages | **PP-only** | Excluded everywhere except Peer Programming. PP is a scoped async+sync environment that is easier to moderate, so voice is allowed there only. |
 | 13 | Image upload + inline preview | **Excluded** | — |
 | 14 | File upload (docs/PDFs) | **Excluded** | — |
-| 15 | Link preview cards (URL enrichment) | Build | All surfaces. Capability already enabled in the dashboard; just render the cards. |
+| 15 | Link preview cards (URL enrichment) | Done (plugin chats) / Build (Commons) | Plugin chats shipped in the shared StreamChatPanel: URL enrichment is on in the composer (`enrichURLForPreview`) and the og-scrape attachment renders through Stream's default Attachment card in the message list. Commons (custom UI) is a separate follow-up. |
 | 16 | Giphy picker | **Excluded** | Remove/skip the `giphy` command surface. |
 | 17 | Typing indicators | Build | All surfaces. |
 | 18 | Read receipts (who's seen it) | Build | All surfaces. |
@@ -188,3 +188,9 @@ Programming.
 - 2026-06-21: Added the "why `messaging`-style text + `default` video, not `livestream`" note for Peer
   Programming, with the one trigger (broadcasting cohort video to listen-in watchers) that would
   justify the `livestream` video call type.
+- 2026-06-21: Plugin-chat portions of @mentions (#4), in-channel message search (#9), and link
+  preview cards (#15) shipped in the shared StreamChatPanel, so every Direct Line chat (TrustTransport,
+  SocketRelay, LightHouse, Foundation) gets them. @mentions and link previews are Stream v12 defaults
+  switched on by watching the channel with members and setting `enrichURLForPreview`; search is a
+  compact strip calling `channel.search`. The Commons versions of all three remain separate follow-ups
+  because Commons uses our own custom UI, not the Stream component.

--- a/ctf/docs/quota-impact/2026-06-21-plugin-chat-mentions-search-link-previews.md
+++ b/ctf/docs/quota-impact/2026-06-21-plugin-chat-mentions-search-link-previews.md
@@ -1,0 +1,65 @@
+# Stream Quota Impact Note — plugin chat @mentions, message search, link previews
+
+## Summary
+
+- Feature/Change: Turns on three already-permitted Stream Chat features in the shared plugin-chat
+  panel (`StreamChatPanel`, used by the Direct Line chats: TrustTransport, SocketRelay, LightHouse,
+  Foundation). The change is presentation/feature-enable only in one client component plus a small CSS
+  addition. The three features:
+  - @mention autocomplete in the composer and mention highlighting in messages (Stream's default once
+    the channel's member list is loaded; the panel now watches with presence so members are present).
+  - In-channel message search: a compact search strip that calls `channel.search(query, options)`,
+    which the Stream SDK scopes to this one channel, and lets a member jump to a result. This is a
+    read-only query, made only when a member types a term and presses search.
+  - Link preview cards for pasted links: URL enrichment is turned on in the composer
+    (`enrichURLForPreview`), and the resulting og-scrape attachment renders through Stream's default
+    Attachment card in the message list. No new message volume.
+- PR: plugin chat @mentions, message search, link previews (branch only; no PR opened)
+- Owner: farah
+- Date: 2026-06-21
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: Chat only — presentation and feature-enable. The
+  gate fires because the changed file paths contain "stream". No new channels, no new message volume,
+  no new toggles in the dashboard; all three capabilities are already permitted on the `messaging`
+  channel type.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: 0 — the same members already use these chats; no new active users.
+- Activity Feed API calls estimate: 0 — no Activity Feeds usage.
+- Video participant-minutes estimate: 0 — no video.
+- AI Moderation credits estimate: 0 — no moderation calls added.
+- Incremental Chat API calls: near-zero. The only added call pattern is `channel.search`, made on
+  demand when a member runs a search; URL enrichment is a scrape Stream already performs server-side
+  for links and is metered as part of normal Chat usage, not a separate add-on.
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): Green — near-zero incremental
+  consumption; no change to message volume or active-user counts.
+- Peak scenario estimate: A member repeatedly running searches issues a handful of extra read queries;
+  this is bounded by manual interaction and is negligible against normal message traffic.
+
+## Fallback and Degradation Plan
+
+- What degrades first: If a search request fails, the panel shows "No messages found" and the rest of
+  the chat keeps working. If URL enrichment is unavailable, links simply send as plain text. Mentions
+  fall back to plain text if members are not loaded.
+- User-visible messaging behavior: Unchanged for sending/receiving; the three features are additive.
+- Kill switch / feature flag: Not applicable. Removing `enrichURLForPreview` or the search strip
+  reverts each feature independently; the panel still renders when Stream env is absent (it shows
+  "Chat unavailable.").
+
+## Observability
+
+- Metrics and alerts added/updated: None.
+- Dashboard link (if available): N/A.
+
+## Validation
+
+- Tests added for degraded mode: None required (client presentation only). Typecheck, ESLint, and EOF
+  formatting pass on the touched files; the panel still degrades to its loading/error/unavailable
+  states when Stream env is missing.
+- Rollback strategy: Revert the panel and CSS change; no runtime or data impact either way.

--- a/ctf/packages/web/components/shared/stream-chat-panel.css
+++ b/ctf/packages/web/components/shared/stream-chat-panel.css
@@ -19,3 +19,129 @@
 .str-chat__theme-dark .str-chat__message--me .str-chat__message-bubble {
   background-color: var(--ctf-chat-own-bg, var(--str-chat__message-bubble-background-color));
 }
+
+/* In-channel search bar (ChannelSearchBar in stream-chat-panel.tsx). It is a compact strip at the
+ * top of the Window: when collapsed it is just a small "Search" button; when open it shows an input
+ * plus a scrollable results list. The results list is height-capped so it never grows tall enough to
+ * push the message input off screen. Colors use the plugin accent variable when present and fall
+ * back to neutral dark tones, matching the rest of the dark panel. */
+.ctf-chat-search {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background-color: rgba(0, 0, 0, 0.18);
+}
+
+.ctf-chat-search--collapsed {
+  align-items: flex-end;
+  padding: 6px 10px;
+}
+
+.ctf-chat-search__form {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ctf-chat-search__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #F3F4F6;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.ctf-chat-search__input::placeholder {
+  color: #9CA3AF;
+}
+
+.ctf-chat-search__input:focus {
+  outline: none;
+  border-color: var(--str-chat__primary-color, rgba(255, 255, 255, 0.3));
+}
+
+.ctf-chat-search__toggle,
+.ctf-chat-search__submit,
+.ctf-chat-search__close {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #E5E7EB;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.ctf-chat-search__toggle:hover,
+.ctf-chat-search__submit:hover,
+.ctf-chat-search__close:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.ctf-chat-search__submit {
+  border-color: var(--str-chat__primary-color, rgba(255, 255, 255, 0.14));
+  color: var(--ctf-chat-other-fg, #E5E7EB);
+  background-color: var(--str-chat__primary-color, rgba(255, 255, 255, 0.06));
+}
+
+.ctf-chat-search__submit:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.ctf-chat-search__close {
+  line-height: 1;
+  font-size: 16px;
+}
+
+.ctf-chat-search__results {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.ctf-chat-search__empty {
+  padding: 8px 4px;
+  color: #9CA3AF;
+  font-size: 13px;
+}
+
+.ctf-chat-search__hit {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 8px;
+  background-color: transparent;
+  color: #E5E7EB;
+  cursor: pointer;
+}
+
+.ctf-chat-search__hit:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.ctf-chat-search__hit-author {
+  font-size: 12px;
+  color: #9CA3AF;
+}
+
+.ctf-chat-search__hit-text {
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/ctf/packages/web/components/shared/stream-chat-panel.tsx
+++ b/ctf/packages/web/components/shared/stream-chat-panel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StreamChat } from 'stream-chat';
 import {
   Chat,
@@ -7,6 +7,8 @@ import {
   MessageInput,
   Thread,
   Window,
+  useChannelActionContext,
+  useChannelStateContext,
 } from 'stream-chat-react';
 import 'stream-chat-react/dist/css/v2/index.css';
 import './stream-chat-panel.css';
@@ -25,6 +27,148 @@ function readableTextOn(color: string): string {
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
   return luminance > 0.6 ? '#111827' : '#FFFFFF';
 }
+
+// One in-channel search hit: enough to render a result row and jump to that message in the open list.
+interface SearchHit {
+  id: string;
+  text: string;
+  authorName: string;
+}
+
+// The fields read off each search result's message. channel.search returns Stream's MessageResponse;
+// only these are needed here, so the result rows are narrowed to this local shape.
+interface SearchResultMessage {
+  id: string;
+  text?: string;
+  user?: { id: string; name?: string } | null;
+}
+
+// In-channel message search. It sits at the top of the Window, above the message list, so a member
+// can search the conversation they are already reading. It takes the live channel from
+// ChannelStateContext and jumps to a chosen result through ChannelActionContext — both are provided
+// by the surrounding <Channel>. channel.search(query, options) scopes to this channel's own id
+// automatically (stream-chat 8.x), so no cross-channel filter is needed; passing a string runs a
+// full-text search within just this channel and returns { results: [{ message }] }.
+const ChannelSearchBar: React.FC = () => {
+  const { channel } = useChannelStateContext('ChannelSearchBar');
+  const { jumpToMessage } = useChannelActionContext('ChannelSearchBar');
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const [searched, setSearched] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const runSearch = useCallback(async () => {
+    const term = query.trim();
+    if (!term) {
+      setHits([]);
+      setSearched(false);
+      return;
+    }
+    setSearching(true);
+    try {
+      const response = await channel.search(term, { limit: 25, sort: { created_at: -1 } });
+      // channel.search returns SearchAPIResponse: { results: [{ message }] }. The channel value is
+      // loosely typed in this panel, so the relevant fields are narrowed to a small local shape here
+      // rather than the full Stream generic — only id, text, and the author are read.
+      const results = response.results as Array<{ message: SearchResultMessage }>;
+      const next: SearchHit[] = results.map((result) => {
+        const message = result.message;
+        const authorName = message.user?.name || message.user?.id || 'Member';
+        return { id: message.id, text: message.text || '(no text)', authorName };
+      });
+      setHits(next);
+      setSearched(true);
+    } catch {
+      setHits([]);
+      setSearched(true);
+    } finally {
+      setSearching(false);
+    }
+  }, [channel, query]);
+
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    void runSearch();
+  };
+
+  const onPickHit = (messageId: string) => {
+    void jumpToMessage(messageId);
+    setOpen(false);
+  };
+
+  if (!open) {
+    return (
+      <div className="ctf-chat-search ctf-chat-search--collapsed">
+        <button
+          type="button"
+          className="ctf-chat-search__toggle"
+          onClick={() => {
+            setOpen(true);
+            // Focus the input on the next paint, once it is rendered.
+            window.requestAnimationFrame(() => inputRef.current?.focus());
+          }}
+          aria-label="Search this conversation"
+        >
+          Search
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ctf-chat-search">
+      <form className="ctf-chat-search__form" onSubmit={onSubmit}>
+        <input
+          ref={inputRef}
+          className="ctf-chat-search__input"
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search this conversation"
+          aria-label="Search this conversation"
+        />
+        <button type="submit" className="ctf-chat-search__submit" disabled={searching}>
+          {searching ? '…' : 'Go'}
+        </button>
+        <button
+          type="button"
+          className="ctf-chat-search__close"
+          onClick={() => {
+            setOpen(false);
+            setQuery('');
+            setHits([]);
+            setSearched(false);
+          }}
+          aria-label="Close search"
+        >
+          ×
+        </button>
+      </form>
+      {searched && (
+        <div className="ctf-chat-search__results" role="listbox">
+          {hits.length === 0 ? (
+            <div className="ctf-chat-search__empty">No messages found.</div>
+          ) : (
+            hits.map((hit) => (
+              <button
+                key={hit.id}
+                type="button"
+                className="ctf-chat-search__hit"
+                role="option"
+                onClick={() => onPickHit(hit.id)}
+              >
+                <span className="ctf-chat-search__hit-author">{hit.authorName}</span>
+                <span className="ctf-chat-search__hit-text">{hit.text}</span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export interface StreamChatPanelProps {
   streamApiKey: string;
@@ -59,7 +203,10 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
       .connectUser({ id: streamUserId }, streamToken)
       .then(() => {
         const ch = chatClient.channel(channelType, streamChannelId);
-        return ch.watch().then(() => {
+        // Watch with presence so the channel state carries its member list. The default '@' mention
+        // trigger in MessageInput reads the channel members to suggest people, so members must be
+        // loaded for autocomplete to offer anyone; watch() populates channel.state.members.
+        return ch.watch({ presence: true }).then(() => {
           if (!isMounted) return;
           setChannel(ch);
           setClient(chatClient);
@@ -101,13 +248,23 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
   return (
     <div className="str-chat__theme-dark" style={{ height: '100%', display: 'flex', flexDirection: 'column', ...themeVars }}>
       <Chat client={client}>
-        <Channel channel={channel}>
+        {/* enrichURLForPreview turns on URL enrichment in the composer: as a member types or pastes a
+            link, Stream scrapes it and MessageInput shows a LinkPreviewList card before sending. The
+            sent message then carries an og-scrape attachment, which the default Attachment renderer
+            (Card) draws as a preview card in the MessageList — so pasted links get preview cards both
+            while composing and in the conversation. The messaging channel type already permits URL
+            enrichment in the dashboard, so no dashboard change is needed. */}
+        <Channel channel={channel} enrichURLForPreview>
           {/* Window holds the main conversation; it yields to the Thread panel when a reply thread is
               open (the thread slides over on phone-width, sits beside on desktop). Wrapping the list +
               input in Window — and rendering a sibling Thread — is what turns on Stream's threaded
               replies. Reactions, the typing indicator, and read state come with the v12 MessageList
-              defaults once the channel type allows them (the messaging type does). */}
+              defaults once the channel type allows them (the messaging type does).
+              ChannelSearchBar sits at the top of the Window so in-channel search lives above the list.
+              @mention autocomplete is the MessageInput default once members are loaded (see watch()
+              above), and link preview cards render in the MessageList via the default Attachment Card. */}
           <Window>
+            <ChannelSearchBar />
             <MessageList />
             <MessageInput />
           </Window>


### PR DESCRIPTION
## What and why

Three more Stream features for the Direct Line plugin chats (TrustTransport, SocketRelay, LightHouse, Foundation), all added to the one shared `StreamChatPanel` so every plugin chat gets them at once.

## Changes (stream-chat-react v12)

- @mention autocomplete: the channel is now watched with `{ presence: true }` so member data is available; the v12 `MessageInput` default `@` trigger then suggests people, and the message list renders/highlights mentions by default.
- In-channel message search: a compact, collapsible search strip at the top of the conversation calls `channel.search(...)` (auto-scoped to the open channel) and jumps to a result via `jumpToMessage`. Height-capped so it never pushes the composer off screen.
- Link previews: the `enrichURLForPreview` flag on `<Channel>` turns on URL-enrichment, so pasted links show a preview card while composing and the sent message renders the card via the default attachment renderer.

Client-only (the shared panel plus a small CSS addition). No backend, schema, or contract change. Preserves the existing accent theming and bubble-color convention. Quota-impact note included (feature-enable only, near-zero incremental quota). `STREAM_FEATURE_ADOPTION.md` updated (plugin-chat portions of these items marked done; Commons versions remain separate follow-ups).

Typecheck, ESLint, EOF, and the web build pass; the panel still degrades when Stream env is absent.

Parity Ticket: #734

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_