### PR TITLE
ci: one-time manual workflow to backfill member presence

### DIFF
--- a/.github/workflows/backfill-member-presence.yml
+++ b/.github/workflows/backfill-member-presence.yml
@@ -8,6 +8,11 @@ name: Backfill member presence (one-time)
 on:
   workflow_dispatch:
 
+# Minimal token scope: this workflow only reads the repo and runs a script against the database
+# secret; it never writes back to the repository.
+permissions:
+  contents: read
+
 jobs:
   backfill:
     runs-on: ubuntu-latest

--- a/.github/workflows/backfill-member-presence.yml
+++ b/.github/workflows/backfill-member-presence.yml
@@ -1,0 +1,43 @@
+name: Backfill member presence (one-time)
+
+# One-time backfill of the member_plugin_presence index from existing member-owned listings, so the
+# Directory "Also active in" surface is populated for listings created before the live write-hooks
+# shipped. Run it once from the Actions tab (Run workflow) after deploy. It is idempotent, so a
+# re-run is safe. This workflow and the script it runs are removed in a follow-up once it has run.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: |
+          cd ctf
+          pnpm install
+
+      - name: Run the presence backfill
+        env:
+          DATABASE_URL_DIRECT: ${{ secrets.DATABASE_URL_DIRECT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          DB="${DATABASE_URL_DIRECT:-$DATABASE_URL}"
+          if [ -z "$DB" ]; then
+            echo "DATABASE_URL_DIRECT or DATABASE_URL secret is not set."
+            exit 1
+          fi
+          cd ctf
+          DATABASE_URL="$DB" node scripts/backfillMemberPresence.mjs
+          echo "Member presence backfill complete."


### PR DESCRIPTION
## What and why

You don't have terminal access, so this is the one-time presence backfill as a manual GitHub Action. After deploy, go to the Actions tab, pick "Backfill member presence (one-time)", and Run workflow — it runs `ctf/scripts/backfillMemberPresence.mjs` against the `DATABASE_URL` secret and populates `member_plugin_presence` from existing listings (LightHouse, TrustTransport, Foundation, SocketRelay). It's idempotent, so a re-run is safe.

It mirrors the existing demo-seed workflow (Node 20, pnpm install, the `DATABASE_URL_DIRECT`/`DATABASE_URL` secret).

Per your instruction, once you've run it, I'll open a small follow-up that deletes this workflow and the `backfillMemberPresence.mjs` script, since it's one-time. The live write-hooks (PR #732) keep presence current after that.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_