### PR TITLE
ci: use existing NEXT_PUBLIC_APP_URL in Unlock reconciliation cron

### DIFF
--- a/.github/workflows/unlock-reward-reconciliation.yml
+++ b/.github/workflows/unlock-reward-reconciliation.yml
@@ -6,8 +6,8 @@ name: Unlock — Reward Reconciliation
 # still pending. The mint is idempotent, so this can never double-grant.
 #
 # What it needs (Settings → Secrets and variables → Actions):
-#   App URL  — the workflow reads the APP_BASE_URL variable, then the NEXT_PUBLIC_APP_URL secret. Set
-#              either one to your production base URL (e.g. https://app.example.com).
+#   NEXT_PUBLIC_APP_URL secret — your production base URL (e.g. https://app.example.com). This is the
+#              same secret the image build already uses; nothing new to add.
 #   CRON_SECRET secret — must match the CRON_SECRET the app reads at runtime (set the SAME value in the
 #              app's runtime secrets, e.g. Infisical). The route rejects the call without it.
 #
@@ -34,12 +34,12 @@ jobs:
     steps:
       - name: Call the reconciliation route
         env:
-          APP_BASE_URL: ${{ vars.APP_BASE_URL || secrets.NEXT_PUBLIC_APP_URL }}
+          APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
           set -euo pipefail
-          if [ -z "${APP_BASE_URL:-}" ]; then
-            echo "::warning::Unlock reward reconciliation skipped: no app URL configured (set the APP_BASE_URL variable or the NEXT_PUBLIC_APP_URL secret)."
+          if [ -z "${APP_URL:-}" ]; then
+            echo "::warning::Unlock reward reconciliation skipped: NEXT_PUBLIC_APP_URL is not set in GitHub Actions secrets."
             echo "Skipped: app URL not configured." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
@@ -49,7 +49,7 @@ jobs:
             exit 0
           fi
           code=$(curl -sS -o /tmp/reconcile.json -w '%{http_code}' -X POST \
-            "${APP_BASE_URL%/}/api/internal/unlock/reconcile-rewards" \
+            "${APP_URL%/}/api/internal/unlock/reconcile-rewards" \
             -H "Authorization: Bearer ${CRON_SECRET}" \
             -H 'Content-Type: application/json' \
             -d '{}')


### PR DESCRIPTION
Follow-up to #747, applying the same cleanup to the Unlock reward-reconciliation workflow.

## What changed

`.github/workflows/unlock-reward-reconciliation.yml` previously used `${{ vars.APP_BASE_URL || secrets.NEXT_PUBLIC_APP_URL }}` — a dual-source fallback that invents an `APP_BASE_URL` variable for a value that already exists as the `NEXT_PUBLIC_APP_URL` secret. This was the original source of the pattern #747 cleaned up in the Peer Programming cron.

Now it reads `${{ secrets.NEXT_PUBLIC_APP_URL }}` directly into a local `APP_URL` step variable. No new variable, no fallback. The skip-when-missing behavior and warning are unchanged.

This brings the workflow in line with the no-new-variant / no-dual-source rule added to `123-environment-configuration-rules.mdc` in #747. No other workflow still uses the `vars.APP_BASE_URL` fallback.

No app code, schema, or auth-logic change.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_