### PR TITLE
ci: drop _FALLBACK dual-source secrets from Formance backup/restore

### DIFF
--- a/.github/workflows/backup-formance-supabase.yml
+++ b/.github/workflows/backup-formance-supabase.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Formance Postgres connection string (service-level, read access)
-      FORMANCE_DATABASE_URL: ${{ secrets.FORMANCE_DATABASE_URL || secrets.FORMANCE_DATABASE_URL_FALLBACK }}
+      FORMANCE_DATABASE_URL: ${{ secrets.FORMANCE_DATABASE_URL }}
       # Supabase project URL (https://xyzcompany.supabase.co)
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL || secrets.SUPABASE_URL_FALLBACK }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       # Supabase service role key (write access to storage)
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY_FALLBACK }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/restore-formance-supabase.yml
+++ b/.github/workflows/restore-formance-supabase.yml
@@ -24,8 +24,8 @@ jobs:
     env:
       # TARGET DB to restore INTO — a new/recovery database, never production.
       FORMANCE_DATABASE_URL: ${{ secrets.FORMANCE_RESTORE_TARGET_DATABASE_URL }}
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL || secrets.SUPABASE_URL_FALLBACK }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY_FALLBACK }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       FORMANCE_BACKUP_FILE: ${{ inputs.backup_file }}
       FORMANCE_RESTORE_CONFIRM: '1'
     steps:


### PR DESCRIPTION
Follow-up to the env-config sweep (#747, #750), finishing the same cleanup.

## What changed

The Formance backup and restore workflows used `secrets.X || secrets.X_FALLBACK` for three secrets:
- `FORMANCE_DATABASE_URL` / `FORMANCE_DATABASE_URL_FALLBACK`
- `SUPABASE_URL` / `SUPABASE_URL_FALLBACK`
- `SUPABASE_SERVICE_ROLE_KEY` / `SUPABASE_SERVICE_ROLE_KEY_FALLBACK`

Each `_FALLBACK` is a second secret name invented for a value that already has a canonical name — the same dual-source pattern banned by rule 123. Both workflows now read the canonical secret directly. No `_FALLBACK` reference remains anywhere in the repo.

This assumes the canonical secrets (`FORMANCE_DATABASE_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) are the ones actually set. If anything was relying only on a `_FALLBACK` value, set the canonical name instead — that's the intended single source.

No app code, schema, or auth-logic change.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_