### PR TITLE
chore: remove dual-source env fallbacks in CI monitor and mobile env check

### DIFF
--- a/.github/workflows/github-actions-budget-monitor.yml
+++ b/.github/workflows/github-actions-budget-monitor.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Evaluate GitHub Actions budget
         id: budget
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTIONS_MONITOR_TOKEN: ${{ secrets.GH_ACTIONS_BILLING_TOKEN }}
           GITHUB_ACTIONS_MONITOR_SCOPE: org
           GITHUB_ACTIONS_BUDGET_MINUTES: "2000"

--- a/ctf/packages/mobile/scripts/check-mobile-env.mjs
+++ b/ctf/packages/mobile/scripts/check-mobile-env.mjs
@@ -21,7 +21,7 @@ try {
 // runtime and API calls carry a verified bearer token. Profile is informational
 // only (preview and production both point at the same production config).
 
-const profile = process.env.MOBILE_ENV_TARGET || process.env.EAS_BUILD_PROFILE || 'preview';
+const profile = process.env.MOBILE_ENV_TARGET || 'preview';
 
 function requireVar(key) {
   if (!process.env[key]) {

--- a/ctf/scripts/githubActionsBudgetMonitor.mjs
+++ b/ctf/scripts/githubActionsBudgetMonitor.mjs
@@ -264,7 +264,7 @@ function buildSummaryMarkdown({
 
 async function main() {
   const [ownerFromRepo, repository] = (process.env.GITHUB_REPOSITORY ?? "/").split("/");
-  const owner = process.env.GITHUB_ACTIONS_MONITOR_OWNER || process.env.GITHUB_REPOSITORY_OWNER || ownerFromRepo;
+  const owner = process.env.GITHUB_ACTIONS_MONITOR_OWNER || ownerFromRepo;
 
   if (!owner) {
     throw new Error("Missing owner context. Set GITHUB_ACTIONS_MONITOR_OWNER or GITHUB_REPOSITORY.");
@@ -281,7 +281,7 @@ async function main() {
   };
 
   const degradedReasons = [];
-  const token = process.env.GITHUB_ACTIONS_MONITOR_TOKEN || process.env.GITHUB_TOKEN;
+  const token = process.env.GITHUB_ACTIONS_MONITOR_TOKEN;
 
   let usage;
   if (!token) {


### PR DESCRIPTION
Continues the env-config sweep: removes dual-source env reads (one value sourced from more than one name) where the source is set in a workflow file I can verify — so nothing here depends on a hidden secret store.

## What changed

- **`githubActionsBudgetMonitor.mjs` token** — reads only `GITHUB_ACTIONS_MONITOR_TOKEN` (the billing PAT the workflow already supplies via `GH_ACTIONS_BILLING_TOKEN`). The old `|| GITHUB_TOKEN` fallback was dead: the auto Actions token can't read the billing endpoints. Also removed the now-unused `GITHUB_TOKEN` from the budget step's `env:`.
- **`githubActionsBudgetMonitor.mjs` owner** — dropped `GITHUB_REPOSITORY_OWNER`, which duplicated the owner already derived from `GITHUB_REPOSITORY`. The explicit `GITHUB_ACTIONS_MONITOR_OWNER` override and that derived default stay.
- **`check-mobile-env.mjs`** — the informational profile label reads only `MOBILE_ENV_TARGET` (set by all three Expo workflows) plus the literal `'preview'` default; dropped the `EAS_BUILD_PROFILE` alias.

No secret-store value changes. The auth `CLERK_*`→generic-name cleanup and the `DATABASE_URL` secret-vs-variable case are deliberately **not** in this PR — those depend on Infisical/EAS values I can't read, and are being handled separately.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_