### PR TITLE
chore: add hls.js to pnpm-lock.yaml so frozen installs work

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
       getstream:
         specifier: ^8.7.0
         version: 8.12.1(@types/node@22.19.17)
+      hls.js:
+        specifier: ^1.5.18
+        version: 1.6.16
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -5209,6 +5212,9 @@ packages:
 
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -14141,6 +14147,8 @@ snapshots:
   hermes-parser@0.35.0:
     dependencies:
       hermes-estree: 0.35.0
+
+  hls.js@1.6.16: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:


### PR DESCRIPTION
`ctf/packages/web/package.json` lists `hls.js` (`^1.5.18`, from the Beacon HLS viewer) but `pnpm-lock.yaml` was never updated to match. So every workflow that runs `pnpm install --frozen-lockfile` fails with `ERR_PNPM_OUTDATED_LOCKFILE` — which is what broke the v2 Quora port **dry run**.

Regenerated the lockfile with `pnpm install --lockfile-only`. The only change is the `hls.js` resolution (`^1.5.18` → `1.6.16`), +8 lines in `pnpm-lock.yaml`; nothing else moved.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_