### PR TITLE
ci: persist code-review ledger on its own branch, not main

### DIFF
--- a/.github/workflows/code-review-sweep.yml
+++ b/.github/workflows/code-review-sweep.yml
@@ -42,6 +42,22 @@ jobs:
         with:
           node-version: '22'
 
+      # The rotation ledger lives on its own branch (`code-review-ledger`), never on main.
+      # main is gated by a ruleset that requires status checks, which a direct push can't
+      # satisfy, so the daily bot must not push there. Restore the latest ledger from its
+      # branch into the working tree before reviewing. First run (no branch yet): fall back
+      # to the in-repo stub checked out from main.
+      - name: Restore rotation ledger from its branch
+        run: |
+          set -euo pipefail
+          if git fetch --depth=1 origin code-review-ledger 2>/dev/null \
+            && git cat-file -e FETCH_HEAD:ctf/config/code-review-ledger.json 2>/dev/null; then
+            git show FETCH_HEAD:ctf/config/code-review-ledger.json > ctf/config/code-review-ledger.json
+            echo "Restored ledger from the code-review-ledger branch."
+          else
+            echo "No code-review-ledger branch yet; using the in-repo stub from main."
+          fi
+
       # ANTHROPIC_API_KEY is a runtime secret; Infisical is the single source of truth
       # (this matches the other AI workflows in this folder).
       - name: Inject secrets from Infisical
@@ -65,10 +81,13 @@ jobs:
           CODE_REVIEW_DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
         run: node ctf/scripts/reviewCodebaseSlice.mjs
 
-      # Persist the rotation pointer so the next run reviews a different slice. Uses GH_PAT
-      # so the push to main is allowed under branch protection (same approach as the
-      # product-update workflow). Skipped on a dry run and when nothing changed.
-      - name: Commit ledger
+      # Persist the rotation pointer so the next run reviews a different slice. Pushes to the
+      # dedicated `code-review-ledger` branch — never to main (main is PR-gated by a ruleset
+      # that a direct push can't satisfy). Force-push because this machine branch only carries
+      # the latest ledger on top of whatever main was checked out; its history is not
+      # meaningful. The script re-stamps the reviewed slice every run, so there is always a
+      # real change to commit. Skipped on a dry run.
+      - name: Commit ledger to its branch
         if: ${{ inputs.dry_run != true }}
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -83,4 +102,4 @@ jobs:
           git config user.email "ci@chargingthefuture.org"
           git add ctf/config/code-review-ledger.json
           git commit -m "chore: advance code-review sweep ledger"
-          git push "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+          git push --force "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git" HEAD:code-review-ledger


### PR DESCRIPTION
## Problem
The daily **Code Review — Sweep and File Issues** workflow has been failing at its final step. It advances the rotation ledger (`ctf/config/code-review-ledger.json`) and pushes the commit **straight to `main`**:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 5 of 5 required status checks are expected.
 ! [remote rejected]   HEAD -> main (push declined due to repository rule violations)
```

`main` is governed by a repository ruleset that requires status checks. A direct push can't provide PR-only checks, so it's rejected. The `GH_PAT` the step relied on is not a bypass actor, and the in-code claim that this mirrors the product-update workflow is wrong — no other workflow pushes to `main` this way.

## Fix
Keep the ledger off `main` entirely — it's machine-generated rotation state and never needed to live on the protected branch:

- **Restore** the latest ledger from a dedicated `code-review-ledger` branch into the working tree before reviewing (first run, before the branch exists, falls back to the in-repo stub checked out from `main`).
- **Commit** the advanced ledger back to that same `code-review-ledger` branch with a force-push (the branch only carries the latest ledger; its history isn't meaningful).

`main` stays strictly PR-gated; the bot never touches it. No repository-settings change is required.

## Alternative (not taken)
Adding the bot account to the `main` ruleset's bypass list would also unblock the push, but it weakens `main`'s protection for an automated job. Keeping the ledger off `main` is the safer default. If you'd rather it stay on `main`, say so and I'll switch to the bypass approach instead.

## Verification
Workflow YAML parses; step order is restore → review → commit; the only push target is `code-review-ledger` (no `HEAD:main` remains); file ends with a single newline.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_