### PR TITLE
feat: add member block/unblock API and blocked-members manage UI (#809 task 2)

### DIFF
--- a/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -1,0 +1,77 @@
+policies:
+  - pluginId: member-blocks
+    command: member.block.create
+    version: 1.0.0
+    requiredRoles:
+      - member
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      selfBlockForbidden: enforced
+      unlockGated: false
+    consentRequirements:
+      scopes:
+        - member_safety_boundary
+      fallbackLawfulBasis: legitimate_interest_safety_support
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - actor_not_authenticated
+      - self_block
+      - missing_csrf_confirmation
+      - cross_origin_request
+
+  - pluginId: member-blocks
+    command: member.block.remove
+    version: 1.0.0
+    requiredRoles:
+      - member
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      blockOwnershipRequired: enforced
+      unlockGated: false
+    consentRequirements:
+      scopes:
+        - member_safety_boundary
+      fallbackLawfulBasis: legitimate_interest_safety_support
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - actor_not_authenticated
+      - missing_csrf_confirmation
+      - cross_origin_request
+
+  - pluginId: member-blocks
+    command: member.block.list
+    version: 1.0.0
+    requiredRoles:
+      - member
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      ownBlocksOnly: enforced
+      unlockGated: false
+    consentRequirements:
+      scopes:
+        - member_safety_boundary
+      fallbackLawfulBasis: legitimate_interest_safety_support
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - actor_not_authenticated

--- a/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -1,0 +1,49 @@
+contracts:
+  - pluginId: member-blocks
+    command: member.block.create
+    version: 1.0.0
+    description: Create a one-way, private block of another member. Idempotent; rejects a self-block.
+    inputSchema:
+      blockedUserId:
+        type: string
+        required: true
+    outputSchema:
+      ok:
+        type: boolean
+    dataAccess:
+      - member_blocks
+    purpose: member_safety_boundary
+    retentionClass: transactional_long_lived
+    idempotency: true
+
+  - pluginId: member-blocks
+    command: member.block.remove
+    version: 1.0.0
+    description: Remove (unblock) a block the member created. Idempotent; succeeds even if no block existed.
+    inputSchema:
+      blockedUserId:
+        type: string
+        required: true
+    outputSchema:
+      ok:
+        type: boolean
+    dataAccess:
+      - member_blocks
+    purpose: member_safety_boundary
+    retentionClass: transactional_long_lived
+    idempotency: true
+
+  - pluginId: member-blocks
+    command: member.block.list
+    version: 1.0.0
+    description: List the blocks the signed-in member created, newest first, each with the blocked member's resolved display label.
+    inputSchema: {}
+    outputSchema:
+      blocks:
+        type: array
+    dataAccess:
+      - member_blocks
+      - directory_profiles
+    purpose: member_safety_boundary
+    retentionClass: derived_short_lived
+    idempotency: true

--- a/ctf/docs/contracts/MEMBER_BLOCKS_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/MEMBER_BLOCKS_PROFILE_AND_DELETION_CONTRACT.md
@@ -1,0 +1,54 @@
+# Member Blocks Profile and Deletion Contract
+
+## 1) Metadata
+
+- Feature Name: Member Blocking (cross-cutting safety control, not a plugin)
+- Service Key (lowercase, stable): `member-blocks`
+- Issue: #809 (owner-signed model, 2026-06-24)
+- Rollout Stage: API + manage-list UI (task 2). Enforcement across surfaces (task 4) and the optional
+  safety escalation (task 3) are separate, later tasks.
+
+## 2) What this stores
+
+- Table: `member_blocks`
+  - `id` (uuid, primary key)
+  - `blocker_user_id` (text) — the member who created the block.
+  - `blocked_user_id` (text) — the member who is blocked.
+  - `created_at` (timestamptz) — when the block was created.
+  - Unique on `(blocker_user_id, blocked_user_id)`; CHECK forbids a self-block.
+- No `reason` column. Ordinary blocks are private; the admin never reads them. A member may block
+  anyone for any reason and none is recorded. The optional "report as suspected predator/trafficker"
+  escalation is a separate mechanism (a member safety report kept apart from this table), built in a
+  later task, so ordinary blocks stay out of the admin's view.
+
+## 3) Resolving the blocked member's display label
+
+The manage-list resolves `blocked_user_id` to a human label by a LEFT JOIN to `directory_profiles`
+on `claimed_by_user_id` (active profiles only, `deleted_at IS NULL`), using
+`TRIM(first_name || ' ' || last_name)`. When there is no claimed profile, the label falls back to the
+neutral word "Member" so every row still names someone the viewer can recognize and unblock.
+
+## 4) Deletion behavior
+
+On full-account deletion, the member's own blocks are removed. This is wired into the account
+deletion registry (`ctf/packages/web/lib/account/deletion-registry.ts`) as the `member-blocks` entry:
+
+- `member_blocks` — `delete` where `blocker_user_id = <user>` (the blocks the member created).
+
+Scope notes:
+
+- The member may also clear all their own blocks on their own via the standard service-scope delete
+  (`DELETE /api/account/services/member-blocks`), since `serviceScopeSupported` is `true`.
+- Rows where someone ELSE blocked this member (`blocked_user_id = <user>`) are that other member's
+  private boundary and are NOT cleared by this member's deletion — they are removed when the other
+  member deletes their account (their own `blocker_user_id` rows). A leftover reverse-direction row
+  that points at a deleted user is harmless (the user is gone). Cleaning up such orphaned reverse rows
+  is a noted follow-up, deliberately not done here so service-scope deletion can never touch another
+  member's blocks.
+
+## 5) Access and CSRF
+
+- Auth: any signed-in member (`any_authenticated`), the same posture as account deletion. Blocking is
+  a baseline safety control, never unlock-gated.
+- CSRF: every state-changing request (POST create, DELETE remove) requires the `x-ctf-csrf: 1` header
+  and a same-origin check, via the shared account `ensureMutationCsrf` helper.

--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -595,3 +595,22 @@ known-open item — sign-in via Clerk (auth) — is owned by the owner's separat
   indexed query per call). This is the foundational layer only: no API routes, UI, or surface wiring
   yet (tasks 2–5 — block/unblock API + manage-list, the optional safety-report escalation, wiring the
   check into each member-to-member surface, and admin global-ban tooling). Owner-review lane.
+- 2026-06-24: **Member blocking — block/unblock API + manage-list UI landed (issue #809, task 2 of 5).**
+  Built on the task-1 core. Added three repository functions to
+  `ctf/packages/web/lib/blocks/repository.ts` — `blockUser` (idempotent insert with
+  `ON CONFLICT DO NOTHING`, rejects a self-block), `unblockUser` (idempotent delete), and
+  `listBlocksForUser` (the member's own blocks, newest first, each resolved to a Directory display
+  name with a neutral "Member" fallback). Added the cross-cutting API under `/api/account/blocks`
+  (`GET` list + `POST` create) and `/api/account/blocks/[blockedUserId]` (`DELETE` unblock), reusing
+  the account-area `requireAccountAccess` (any signed-in member, not unlock-gated) and the shared
+  `ensureMutationCsrf` (`x-ctf-csrf` header + same-origin) on every state-changing call. Added a
+  reusable `BlockMemberButton` (with a plain-language confirm dialog) under `components/blocks/`, a
+  mobile-responsive "Blocked members" manage-list at `/account/blocks` (loading / empty / error /
+  populated states, an Unblock control per row), one create-entry-point on the Directory profile
+  detail of another member, and a "Blocked members" link in the account hub's Data & privacy section.
+  Wired `member_blocks` into the account deletion registry (a member's own blocks are removed on
+  account deletion). Added the `member.block.create` / `member.block.remove` / `member.block.list`
+  command and access-policy contracts plus a profile/deletion contract under `ctf/docs/contracts/`.
+  Android parity deferred (Parity Ticket #809). Still to come: task 3 (optional safety-report
+  escalation), task 4 (wiring `isBlockedBetween` into each surface), task 5 (admin global ban).
+  Owner-review lane.

--- a/ctf/packages/web/app/account/blocks/page.tsx
+++ b/ctf/packages/web/app/account/blocks/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { BlockedMembersShell } from '@/components/blocks/blocked-members-shell';
+
+// Blocked members surface: the signed-in member sees who they have blocked and can unblock anyone
+// (issue #809, task 2). Auth posture matches the rest of the account area (`any_authenticated`):
+// blocking is a baseline safety control available to any signed-in member, including unlock-pending
+// users — never gated by approval state. The list and unblock action run through /api/account/blocks.
+export default async function AccountBlocksPage() {
+  const decision = await evaluatePluginAccess({
+    requireUsername: false,
+    minUnlockTier: 'any_authenticated',
+  });
+
+  if (!decision.allowed) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-12 space-y-4">
+        <h1 className="text-2xl font-semibold tracking-tight">Sign in to manage blocked members</h1>
+        <p className="text-sm text-muted-foreground">
+          You need to be signed in to see and change who you have blocked.
+        </p>
+        <p className="text-sm">
+          <Link className="underline underline-offset-4" href="/">Return to home</Link>
+        </p>
+      </main>
+    );
+  }
+
+  return <BlockedMembersShell />;
+}

--- a/ctf/packages/web/app/api/account/blocks/[blockedUserId]/route.ts
+++ b/ctf/packages/web/app/api/account/blocks/[blockedUserId]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { requireAccountAccess, ensureMutationCsrf } from '../../_lib';
+import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
+import { unblockUser } from 'lib/blocks/repository';
+import { reportError } from 'lib/observability/report';
+
+// Remove a block (unblock). Same baseline auth as the rest of the blocks API — any signed-in member,
+// never unlock-gated. CSRF-protected and idempotent: unblocking someone who is not blocked still
+// returns ok, so the manage-list never errors on a double-unblock or a stale row.
+//
+// DELETE /api/account/blocks/:blockedUserId
+export async function DELETE(request: Request, context: { params: Promise<{ blockedUserId: string }> }) {
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const { blockedUserId } = await context.params;
+  const target = blockedUserId.trim();
+  if (target.length === 0) {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.invalidPayload, message: 'blockedUserId is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await unblockUser(gate.auth.userId, target);
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'account', op: 'blocks_remove' });
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to unblock this member.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/account/blocks/route.ts
+++ b/ctf/packages/web/app/api/account/blocks/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { requireAccountAccess, ensureMutationCsrf } from '../_lib';
+import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
+import { blockUser, listBlocksForUser, SelfBlockError } from 'lib/blocks/repository';
+import { reportError } from 'lib/observability/report';
+
+// Member blocking — the cross-cutting "block / unblock / see who you've blocked" API (issue #809,
+// task 2). Blocking is a baseline safety control available to ANY signed-in member, so these routes
+// use the same `any_authenticated` gate as account deletion (requireAccountAccess) — never the
+// unlock gate. A block is the member's own private boundary; it is never visible to the person
+// blocked and carries no reason.
+//
+// GET  /api/account/blocks            — list the signed-in member's blocks (newest first).
+// POST /api/account/blocks            — create a block; body { blockedUserId }.
+
+// List the signed-in member's blocks for the manage-list UI.
+export async function GET() {
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const blocks = await listBlocksForUser(gate.auth.userId);
+    return NextResponse.json({ ok: true, blocks }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'account', op: 'blocks_list' });
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to load your blocked members.' },
+      { status: 503 },
+    );
+  }
+}
+
+type BlockBody = { blockedUserId?: unknown };
+
+function badRequest(message: string): NextResponse {
+  return NextResponse.json(
+    { ok: false, code: ACCOUNT_ERROR_CODE.invalidPayload, message },
+    { status: 400 },
+  );
+}
+
+// Create a block. CSRF-protected and idempotent (blocking the same person twice is a no-op). A
+// self-block and a missing/blank target both map to a clear 400.
+export async function POST(request: Request) {
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  let body: BlockBody;
+  try {
+    body = (await request.json()) as BlockBody;
+  } catch {
+    return badRequest('Invalid JSON body.');
+  }
+
+  if (typeof body.blockedUserId !== 'string' || body.blockedUserId.trim().length === 0) {
+    return badRequest('blockedUserId is required.');
+  }
+  const blockedUserId = body.blockedUserId.trim();
+
+  try {
+    await blockUser(gate.auth.userId, blockedUserId);
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    if (error instanceof SelfBlockError) {
+      return badRequest('You cannot block yourself.');
+    }
+    reportError(error, { area: 'account', op: 'blocks_create' });
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to block this member.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/components/account/account-hub-shell.tsx
+++ b/ctf/packages/web/components/account/account-hub-shell.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import type { CSSProperties, ReactNode } from 'react';
 import { UserButton } from '@clerk/nextjs';
-import { ChevronRight, Database, Home, ShieldCheck, Sparkles, UserCircle } from 'lucide-react';
+import { ChevronRight, Database, Home, ShieldCheck, ShieldOff, Sparkles, UserCircle } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { getAccountDataTokens } from '@/components/account-data/account-data-shared';
 import { TrustRightRailCard } from '@/components/shared/trust/TrustRightRailCard';
@@ -107,6 +107,13 @@ export function AccountHubShell({ username, trust }: { username: string | null; 
             icon={<Database size={18} />}
             title="Your data &amp; deletion"
             desc="See everything the platform stores about you, and delete it — one service or your whole account."
+            tok={tok}
+          />
+          <AccountLinkRow
+            href="/account/blocks"
+            icon={<ShieldOff size={18} />}
+            title="Blocked members"
+            desc="See who you&apos;ve blocked and unblock them. Blocked people can&apos;t see or contact you, and they&apos;re never told."
             tok={tok}
             last
           />

--- a/ctf/packages/web/components/blocks/block-member-button.tsx
+++ b/ctf/packages/web/components/blocks/block-member-button.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState, type CSSProperties } from 'react';
+import { Ban, Loader2, ShieldX, X } from 'lucide-react';
+import { useTheme } from '@/hooks/useTheme';
+import { getAccountDataTokens } from '@/components/account-data/account-data-shared';
+import { postBlock } from './blocks-shared';
+
+type Status = 'idle' | 'confirming' | 'submitting' | 'done' | 'error';
+
+type BlockMemberButtonProps = {
+  // The user id of the member to block.
+  targetUserId: string;
+  // Optional human label for that member, used in the confirm copy ("Block Jane Doe?"). Falls back
+  // to a neutral "this member" when absent.
+  displayName?: string | null;
+  // Called after a block is created, so a surface can refresh or hide the blocked member.
+  onBlocked?: () => void;
+  // Optional style override for the trigger button, so a surface can match its own layout.
+  style?: CSSProperties;
+};
+
+// Reusable "Block member" action. Any surface that shows another member can drop this in: it owns
+// the confirm dialog, the POST, and the loading / error / done states. The dialog states plainly
+// what a block does, in trauma-informed language — the blocked person is never told. This is the
+// single create-entry-point control wiring for task 4 (enforcing blocks across surfaces) to reuse;
+// it does not itself hide anyone — it only records the block.
+export function BlockMemberButton({ targetUserId, displayName, onBlocked, style }: BlockMemberButtonProps) {
+  const { theme } = useTheme();
+  const tokens = getAccountDataTokens(theme);
+  const { BORDER, TEXT, SUBTLE } = tokens;
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const label = displayName?.trim() ? displayName.trim() : 'this member';
+
+  async function handleConfirm() {
+    setStatus('submitting');
+    setErrorMessage(null);
+    try {
+      await postBlock(targetUserId);
+      setStatus('done');
+      onBlocked?.();
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to block this member. Please try again.');
+    }
+  }
+
+  // Once blocked, the trigger becomes a calm, non-actionable confirmation rather than disappearing,
+  // so the member gets clear feedback that the block took effect.
+  if (status === 'done') {
+    return (
+      <span
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 7, padding: '8px 14px', borderRadius: 10,
+          background: 'rgba(255,255,255,0.03)', border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 13, fontWeight: 600,
+          ...style,
+        }}
+      >
+        <ShieldX size={15} /> Blocked
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => { setStatus('confirming'); setErrorMessage(null); }}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 7, padding: '8px 14px', borderRadius: 10,
+          background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444',
+          fontSize: 13, fontWeight: 600, cursor: 'pointer',
+          ...style,
+        }}
+      >
+        <Ban size={15} /> Block member
+      </button>
+
+      {status !== 'idle' ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Block this member"
+          style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(9,11,15,0.78)', fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16, overflowY: 'auto' }}
+        >
+          <div style={{ width: '100%', maxWidth: 460, borderRadius: 22, background: '#0D0F14', border: '1px solid rgba(239,68,68,0.3)', boxShadow: '0 28px 72px rgba(0,0,0,0.65)', overflow: 'hidden' }}>
+            <div style={{ padding: '22px 24px 16px', display: 'flex', alignItems: 'flex-start', gap: 12, borderBottom: '1px solid rgba(239,68,68,0.12)' }}>
+              <div style={{ width: 44, height: 44, borderRadius: 12, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                <Ban size={20} color="#EF4444" />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 17, fontWeight: 800, color: TEXT }}>Block {label}?</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => { if (status !== 'submitting') setStatus('idle'); }}
+                disabled={status === 'submitting'}
+                aria-label="Cancel"
+                style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: status === 'submitting' ? 'not-allowed' : 'pointer', color: SUBTLE, flexShrink: 0 }}
+              >
+                <X size={14} />
+              </button>
+            </div>
+
+            <div style={{ padding: '20px 24px' }}>
+              <p style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.6, margin: '0 0 18px' }}>
+                They won&apos;t be able to see or contact you, and they won&apos;t be told. You can unblock
+                them later from your blocked members list.
+              </p>
+
+              {status === 'error' && errorMessage ? (
+                <div style={{ padding: '10px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.3)', color: '#F87171', fontSize: 13, marginBottom: 16, lineHeight: 1.5 }}>
+                  {errorMessage}
+                </div>
+              ) : null}
+
+              <div style={{ display: 'flex', gap: 10 }}>
+                <button
+                  type="button"
+                  onClick={handleConfirm}
+                  disabled={status === 'submitting'}
+                  style={{ flex: 1, padding: '12px', borderRadius: 11, background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.45)', color: '#EF4444', fontSize: 14, fontWeight: 700, cursor: status === 'submitting' ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
+                >
+                  {status === 'submitting' ? <><Loader2 size={15} className="blocks-spin" /> Blocking…</> : <><Ban size={15} /> Block member</>}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { if (status !== 'submitting') setStatus('idle'); }}
+                  disabled={status === 'submitting'}
+                  style={{ padding: '12px 20px', borderRadius: 11, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 14, fontWeight: 600, cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+          <style>{'@keyframes blocks-spin{to{transform:rotate(360deg)}}.blocks-spin{animation:blocks-spin 0.8s linear infinite}'}</style>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/ctf/packages/web/components/blocks/blocked-members-shell.tsx
+++ b/ctf/packages/web/components/blocks/blocked-members-shell.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ChevronLeft, Loader2, ShieldOff, UserX } from 'lucide-react';
+import { useTheme } from '@/hooks/useTheme';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import { getAccountDataTokens } from '@/components/account-data/account-data-shared';
+import { deleteBlock, type BlockedMember, type BlocksListResponse } from './blocks-shared';
+
+// Loading and error states are intentionally NOT theme-aware (mirrors the Account & Data shell): the
+// default-dark palette is used so a loading screen never adopts the comic theme.
+const { BG: DEFAULT_BG, TEXT: DEFAULT_TEXT } = getAccountDataTokens('default');
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+// "Blocked members" manage-list (issue #809, task 2). Lists who the signed-in member has blocked,
+// newest first, with the resolved display name and when each block was created, and an Unblock
+// control on each row. Covers loading, error, empty, and populated states, and is mobile-responsive
+// (the same surface reflows at phone width — the rows already stack). Lives under the account area
+// at /account/blocks, reached from the account hub's "Data & privacy" section.
+export function BlockedMembersShell() {
+  const { theme } = useTheme();
+  const isMobile = useIsMobile();
+  const tokens = getAccountDataTokens(theme);
+  const { BG, SURFACE, BORDER, TEXT, SUBTLE, BRAND } = tokens;
+
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [blocks, setBlocks] = useState<BlockedMember[]>([]);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<{ id: string; message: string } | null>(null);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoadState('loading');
+    try {
+      const res = await fetch('/api/account/blocks', { signal });
+      if (signal?.aborted) return;
+      if (!res.ok) {
+        setLoadState('error');
+        return;
+      }
+      const data = (await res.json()) as BlocksListResponse;
+      setBlocks(data.blocks ?? []);
+      setLoadState('ready');
+    } catch {
+      if (!signal?.aborted) setLoadState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  const handleUnblock = useCallback(async (member: BlockedMember) => {
+    setPendingId(member.blockedUserId);
+    setRowError(null);
+    try {
+      await deleteBlock(member.blockedUserId);
+      // Refetch-free optimistic removal: the server is idempotent, so dropping the row locally keeps
+      // the list correct without a round-trip.
+      setBlocks((prev) => prev.filter((b) => b.blockedUserId !== member.blockedUserId));
+    } catch (error) {
+      setRowError({ id: member.blockedUserId, message: error instanceof Error ? error.message : 'Unable to unblock. Please try again.' });
+    } finally {
+      setPendingId(null);
+    }
+  }, []);
+
+  if (loadState === 'loading') {
+    return (
+      <div style={{ display: 'flex', height: '100dvh', background: DEFAULT_BG, color: DEFAULT_TEXT, alignItems: 'center', justifyContent: 'center', fontFamily: "'Inter',system-ui" }}>
+        <Loader2 size={22} className="blocks-spin" />
+        <style>{'@keyframes blocks-spin{to{transform:rotate(360deg)}}.blocks-spin{animation:blocks-spin 0.8s linear infinite}'}</style>
+      </div>
+    );
+  }
+
+  if (loadState === 'error') {
+    return (
+      <div style={{ display: 'flex', height: '100dvh', background: DEFAULT_BG, color: DEFAULT_TEXT, alignItems: 'center', justifyContent: 'center', fontFamily: "'Inter',system-ui", padding: '0 32px' }}>
+        <div style={{ textAlign: 'center', maxWidth: 420 }}>
+          <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 10 }}>We couldn&apos;t load your blocked members</div>
+          <div style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.6 }}>Please refresh the page to try again.</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ minHeight: '100dvh', background: BG, color: TEXT, fontFamily: "'Inter', system-ui, -apple-system, sans-serif" }}>
+      <style>{'@keyframes blocks-spin{to{transform:rotate(360deg)}}.blocks-spin{animation:blocks-spin 0.8s linear infinite}'}</style>
+
+      <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', padding: '0 16px', gap: 12, position: 'sticky', top: 0, background: BG, zIndex: 1 }}>
+        <Link href="/account" aria-label="Back to your account" title="Back to your account" style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}14`, border: `1px solid ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: BRAND, textDecoration: 'none', flexShrink: 0 }}>
+          <ChevronLeft size={20} />
+        </Link>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <ShieldOff size={17} color={BRAND} />
+          <div style={{ fontSize: 15, fontWeight: 700 }}>Blocked members</div>
+        </div>
+      </header>
+
+      <div style={{ maxWidth: 640, margin: '0 auto', padding: isMobile ? '20px 16px 64px' : '32px 24px 64px' }}>
+        <p style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.6, margin: '0 0 24px' }}>
+          People you&apos;ve blocked can&apos;t see or contact you, and they&apos;re never told. Unblock
+          someone here to let them see and reach you again.
+        </p>
+
+        {blocks.length === 0 ? (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '48px 24px' }}>
+            <div style={{ width: 60, height: 60, borderRadius: 18, background: `${BRAND}08`, border: `1px dashed ${BRAND}30`, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 18 }}>
+              <UserX size={26} color={`${BRAND}80`} />
+            </div>
+            <div style={{ fontSize: 18, fontWeight: 800, marginBottom: 8 }}>You haven&apos;t blocked anyone.</div>
+            <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.6, maxWidth: 420 }}>
+              When you block a member, they appear here so you can unblock them at any time.
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {blocks.map((member) => {
+              const isPending = pendingId === member.blockedUserId;
+              const error = rowError?.id === member.blockedUserId ? rowError.message : null;
+              return (
+                <div
+                  key={member.blockedUserId}
+                  style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '14px 16px', borderRadius: 12, background: SURFACE, border: `1px solid ${error ? 'rgba(239,68,68,0.35)' : BORDER}`, opacity: isPending ? 0.7 : 1, flexWrap: 'wrap' }}
+                >
+                  <div style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}10`, border: `1px solid ${BRAND}20`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: BRAND, flexShrink: 0 }}>
+                    <UserX size={17} />
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{member.displayName}</div>
+                    <div style={{ fontSize: 12, color: error ? '#F87171' : SUBTLE, lineHeight: 1.4 }}>
+                      {error ?? `Blocked ${formatBlockedDate(member.createdAtIso)}`}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleUnblock(member)}
+                    disabled={isPending}
+                    style={{ flexShrink: 0, display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 13px', borderRadius: 9, background: `${BRAND}12`, border: `1px solid ${BRAND}35`, color: BRAND, fontSize: 13, fontWeight: 600, cursor: isPending ? 'not-allowed' : 'pointer' }}
+                  >
+                    {isPending ? <><Loader2 size={13} className="blocks-spin" /> Unblocking…</> : 'Unblock'}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// A calm, human date for a block ("on Jun 24, 2026"). Falls back to nothing recognizable rather than
+// throwing on an unexpected value.
+function formatBlockedDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'recently';
+  return `on ${date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}`;
+}

--- a/ctf/packages/web/components/blocks/blocks-shared.ts
+++ b/ctf/packages/web/components/blocks/blocks-shared.ts
@@ -1,0 +1,54 @@
+// Shared types and a thin API client for the member-blocking surfaces (issue #809, task 2).
+//
+// Blocking is cross-cutting, not a plugin, so these helpers live in their own components/blocks
+// module that any surface can import: the reusable BlockMemberButton, and the "Blocked members"
+// manage-list. Visual tokens reuse getAccountDataTokens (the shipped account-area palette) so the
+// blocking surfaces match the rest of the account/settings area without inventing new colors.
+
+// One row in the signed-in member's block list, as returned by GET /api/account/blocks. Mirrors the
+// repository's MemberBlockListItem so the client and server agree on the shape.
+export type BlockedMember = {
+  blockedUserId: string;
+  displayName: string;
+  createdAtIso: string;
+};
+
+export type BlocksListResponse = {
+  ok: boolean;
+  blocks: BlockedMember[];
+};
+
+// Create a block. Resolves on success; rejects with a member-facing message on failure (a self-block
+// or missing target is a 400 with a clear message, anything else a generic failure).
+export async function postBlock(blockedUserId: string): Promise<void> {
+  const res = await fetch('/api/account/blocks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+    body: JSON.stringify({ blockedUserId }),
+  });
+  if (!res.ok) {
+    throw new Error(await readError(res, 'Unable to block this member. Please try again.'));
+  }
+}
+
+// Remove a block (unblock). Idempotent on the server, so this resolves even if the row was already
+// gone. Rejects with a member-facing message only on a real failure.
+export async function deleteBlock(blockedUserId: string): Promise<void> {
+  const res = await fetch(`/api/account/blocks/${encodeURIComponent(blockedUserId)}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+  });
+  if (!res.ok) {
+    throw new Error(await readError(res, 'Unable to unblock this member. Please try again.'));
+  }
+}
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { message?: string };
+    if (body.message) return body.message;
+  } catch {
+    // keep the fallback message
+  }
+  return fallback;
+}

--- a/ctf/packages/web/components/directory/directory-profile-detail.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-detail.tsx
@@ -10,6 +10,7 @@ import { useExternalLink } from "@/components/hooks/useExternalLink";
 import { getDirectoryTokens, initials, type Member } from "./shared";
 import { DirectoryProfileEdit } from "./directory-profile-edit";
 import { TrustWidgetCard } from "@/components/trust/TrustWidgetCard";
+import { BlockMemberButton } from "@/components/blocks/block-member-button";
 import type { TrustUserExtension } from "@/lib/trust/types";
 
 // One cross-plugin presence entry returned by GET /api/presence/user/[userId].
@@ -268,6 +269,16 @@ export function DirectoryProfileDetail({
               to find someone else who can.
             </div>
           </section>
+
+          {/* Block — only when viewing another member's claimed profile (never your own, never an
+              unclaimed profile). Blocking is a baseline safety control: the button records a one-way
+              block and is invisible to the person blocked. Enforcement across surfaces is wired
+              separately (issue #809 task 4); this is the create-entry-point so the flow is reachable. */}
+          {claimedUserId && !isOwnProfile && (
+            <section style={{ marginTop: 24, display: "flex", justifyContent: "flex-start" }}>
+              <BlockMemberButton targetUserId={claimedUserId} displayName={p.name} />
+            </section>
+          )}
 
           {/* Also active in + Trust — only for a claimed profile. Presence shows where else this
               member is active across plugins; the trust card sits beside it as peer social proof.

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -254,6 +254,23 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     ],
   },
   {
+    slug: 'member-blocks',
+    name: 'Blocked members',
+    dataSummary: 'The members you have blocked (your own private list — never shared with anyone).',
+    // Cross-cutting member safety control (issue #809). A block is the member's own boundary, so the
+    // member may clear their blocks on their own, and they are also removed on full-account deletion.
+    // Only the rows this user *created* (blocker_user_id) are their data; rows where someone else
+    // blocked this user (blocked_user_id) are that other member's private boundary and are NOT cleared
+    // here — when that other member deletes their account, their own blocker rows are removed by this
+    // same entry. A leftover reverse-direction row pointing at a deleted user is harmless (the user is
+    // gone); cleaning those up is a noted follow-up, not done here, so service-scope deletion never
+    // touches another member's blocks.
+    serviceScopeSupported: true,
+    tables: [
+      del('member_blocks', 'blocker_user_id', 'The blocks you created.'),
+    ],
+  },
+  {
     slug: 'workforce',
     name: 'Workforce',
     dataSummary: 'Your workforce extension record, plus any leftover rows from the legacy workforce profile/recruitment tables (now unused — the workforce view is read-only over your Directory profile).',

--- a/ctf/packages/web/lib/blocks/repository.ts
+++ b/ctf/packages/web/lib/blocks/repository.ts
@@ -36,3 +36,85 @@ export async function isBlockedBetween(userA: string, userB: string): Promise<bo
 
   return result.rows[0]?.blocked ?? false;
 }
+
+// --- Member block management (issue #809, task 2) ---------------------------------------------
+//
+// These three functions back the block / unblock / manage-list flow. A block is created one-way by
+// the blocker against the blocked person, is invisible to the blocked person, and carries no reason
+// (ordinary blocks are private — the admin never reads them). The enforcement check above is what
+// makes a block take effect across surfaces; these functions only own the create/remove/list of a
+// member's own boundary. Every query is parameterized — ids are never interpolated into SQL.
+
+// Thrown by blockUser when the blocker and target are the same person. The database also enforces
+// this with the member_blocks_no_self_block CHECK, but we reject it here first so the route can map
+// it to a clear 400 without relying on a database round-trip and constraint error.
+export class SelfBlockError extends Error {
+  constructor() {
+    super('A member cannot block themselves.');
+    this.name = 'SelfBlockError';
+  }
+}
+
+// One row in the signed-in member's block list, shaped for the manage-list UI: who they blocked, a
+// resolved human display label for that person, and when the block was created.
+export interface MemberBlockListItem {
+  blockedUserId: string;
+  displayName: string;
+  createdAtIso: string;
+}
+
+// Create a block: blockerUserId hides/silences blockedUserId. Idempotent — blocking the same person
+// twice is a no-op (ON CONFLICT DO NOTHING on the (blocker, blocked) unique constraint), so the
+// route can always return ok. Rejects a self-block defensively before touching the database.
+export async function blockUser(blockerUserId: string, blockedUserId: string): Promise<void> {
+  if (blockerUserId === blockedUserId) {
+    throw new SelfBlockError();
+  }
+
+  await queryDb(
+    `INSERT INTO member_blocks (blocker_user_id, blocked_user_id)
+     VALUES ($1, $2)
+     ON CONFLICT (blocker_user_id, blocked_user_id) DO NOTHING`,
+    [blockerUserId, blockedUserId],
+  );
+}
+
+// Remove a block (unblock). Idempotent — deleting a block that does not exist succeeds with no rows
+// affected, so the route can always return ok and the manage-list never errors on a double-unblock.
+export async function unblockUser(blockerUserId: string, blockedUserId: string): Promise<void> {
+  await queryDb(
+    `DELETE FROM member_blocks
+     WHERE blocker_user_id = $1 AND blocked_user_id = $2`,
+    [blockerUserId, blockedUserId],
+  );
+}
+
+// List the blocks this member created, newest first, each with the blocked person's resolved display
+// label. The label is the blocked member's claimed Directory profile name (first + last); when there
+// is no claimed profile we fall back to a neutral "Member" so the row still names someone the viewer
+// can recognize and unblock. LEFT JOIN so a missing profile never drops the block from the list.
+export async function listBlocksForUser(blockerUserId: string): Promise<MemberBlockListItem[]> {
+  const result = await queryDb<{
+    blocked_user_id: string;
+    display_name: string | null;
+    created_at: Date;
+  }>(
+    `SELECT
+       mb.blocked_user_id,
+       NULLIF(TRIM(COALESCE(dp.first_name, '') || ' ' || COALESCE(dp.last_name, '')), '') AS display_name,
+       mb.created_at
+     FROM member_blocks mb
+     LEFT JOIN directory_profiles dp
+       ON dp.claimed_by_user_id = mb.blocked_user_id
+      AND dp.deleted_at IS NULL
+     WHERE mb.blocker_user_id = $1
+     ORDER BY mb.created_at DESC`,
+    [blockerUserId],
+  );
+
+  return result.rows.map((row) => ({
+    blockedUserId: row.blocked_user_id,
+    displayName: row.display_name?.trim() ? row.display_name.trim() : 'Member',
+    createdAtIso: new Date(row.created_at).toISOString(),
+  }));
+}


### PR DESCRIPTION
Second task of #809 (product-wide member blocking), built on the core that merged in #831. This makes blocking **usable**: a member can block someone, see who they've blocked, and unblock. Built to the owner-signed model.

**Out of scope (later tasks):** this does **not** enforce blocks across surfaces yet — `isBlockedBetween` is not wired into search/feeds/chat (task 4); the optional "report as suspected predator/trafficker" admin escalation is task 3; the admin global ban is task 5.

## What it adds
- **API** (`/api/account/blocks`) — `GET` (list your blocks), `POST` (create; body `{ blockedUserId }`), `DELETE /:blockedUserId` (unblock). Same baseline auth as account deletion (`requireAccountAccess` — any signed-in member, **not** unlock-gated, because blocking is a safety control), CSRF-protected on both writes, both idempotent. Self-block and missing target map to clear 400s.
- **Repository** (extends `lib/blocks/repository.ts`) — `blockUser` (insert `ON CONFLICT DO NOTHING`, throws on self-block), `unblockUser` (idempotent delete), `listBlocksForUser` (your blocks newest-first, each with a display name resolved via a LEFT JOIN to `directory_profiles`, neutral "Member" fallback). Parameterized queries only; no `reason` stored (ordinary blocks stay private, per the model).
- **Manage-list UI** — `/account/blocks` ("Blocked members"), linked from the account hub's Data & privacy section. Renders loading / error / empty ("You haven't blocked anyone.") / populated (name + blocked-on date + Unblock) states, mobile-responsive, using the shipped account-area tokens (no new visual language).
- **Create entry point** — a reusable `BlockMemberButton` (confirm copy: "They won't be able to see or contact you, and they won't be told."), placed on the **Directory profile detail** of another member (never your own, never an unclaimed profile). Broad per-surface placement is task 4.
- **Account deletion** — `member_blocks` added to the deletion registry: a member's own blocks (`blocker_user_id = them`) are cleared when they delete their account; also available via per-service delete. Validated by the deletion-registry/engine check scripts.

## Decisions / notes for review
- **Reverse-direction rows** (where someone else blocked the deleting member) are intentionally **not** cleared by that member's deletion — that's another member's private boundary, and the deletion engine binds one column. They're removed when the other member deletes their account; a row pointing at a deleted user is harmless. Documented as a minor orphan-cleanup follow-up.
- **Contract home:** cross-cutting member actions have no plugin inventory, and account deletion carries no command-contract YAML, so I added minimal `member.block.*` command/access/deletion contracts under `docs/contracts/` using the existing plugin-contract template (the only contract format the repo has). No fake plugin inventory was created. The `*_PLUGIN_*` filename follows the template's naming; the feature is cross-cutting, not a plugin.

## Why owner-review
New API surface + new stateful write logic + a deletion-registry change. No money movement; no auth/CSRF model change (reuses the account-area gate + shared CSRF helper).

## Verification
`tsc --noEmit` (web) + repo-wide typecheck clean; eslint clean; EOF clean; deletion-registry and deletion-engine checks pass; no `any`; CSRF on writes; parameterized SQL.

Parity Ticket: #809

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_