### PR TITLE
feat: add optional safety-report escalation on member block + admin review queue (#809 task 3)

### DIFF
--- a/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -75,3 +75,81 @@ policies:
       requiresAdditionalAudit: false
     denyConditions:
       - actor_not_authenticated
+
+  # --- Optional safety escalation (issue #809, task 3) ---
+  - pluginId: member-blocks
+    command: member.safety-report.create
+    version: 1.0.0
+    requiredRoles:
+      - member
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      selfReportForbidden: enforced
+      unlockGated: false
+    consentRequirements:
+      scopes:
+        - member_safety_escalation
+      fallbackLawfulBasis: legitimate_interest_safety_support
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - actor_not_authenticated
+      - self_block
+      - missing_csrf_confirmation
+      - cross_origin_request
+
+  - pluginId: member-blocks
+    command: admin.safety-report.list
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      adminOnly: enforced
+      unlockGated: false
+    consentRequirements:
+      scopes:
+        - member_safety_escalation
+      fallbackLawfulBasis: legitimate_interest_safety_support
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - actor_not_authenticated
+      - actor_not_admin
+
+  - pluginId: member-blocks
+    command: admin.safety-report.review
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      adminOnly: enforced
+      unlockGated: false
+    consentRequirements:
+      scopes:
+        - member_safety_escalation
+      fallbackLawfulBasis: legitimate_interest_safety_support
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - actor_not_authenticated
+      - actor_not_admin
+      - missing_csrf_confirmation
+      - cross_origin_request

--- a/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/MEMBER_BLOCKS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -47,3 +47,71 @@ contracts:
     purpose: member_safety_boundary
     retentionClass: derived_short_lived
     idempotency: true
+
+  # --- Optional safety escalation on the block flow (issue #809, task 3) ---
+  # An ordinary block (member.block.create above) is private and never reaches the admin. When the
+  # blocking member flags the block as a safety concern, member.block.create ALSO records a safety
+  # report (this command) in the same transaction. This is the only path by which a member block
+  # reaches the admin.
+  - pluginId: member-blocks
+    command: member.safety-report.create
+    version: 1.0.0
+    description: Record an admin-visible safety report that a member raised while blocking someone they believe to be a suspected predator or human trafficker. Created atomically with the block; an ordinary block writes nothing here.
+    inputSchema:
+      blockedUserId:
+        type: string
+        required: true
+      safetyConcern:
+        type: boolean
+        required: true
+      safetyDetail:
+        type: string
+        required: false
+    outputSchema:
+      ok:
+        type: boolean
+      safetyReported:
+        type: boolean
+    dataAccess:
+      - member_blocks
+      - member_safety_reports
+    purpose: member_safety_escalation
+    retentionClass: transactional_long_lived
+    idempotency: false
+
+  - pluginId: member-blocks
+    command: admin.safety-report.list
+    version: 1.0.0
+    description: Admin-only queue of member safety reports, open reports first then newest, each with resolved reporter and reported display labels and a count of open reports about the same reported member.
+    inputSchema: {}
+    outputSchema:
+      reports:
+        type: array
+    dataAccess:
+      - member_safety_reports
+      - directory_profiles
+    purpose: member_safety_escalation
+    retentionClass: derived_short_lived
+    idempotency: true
+
+  - pluginId: member-blocks
+    command: admin.safety-report.review
+    version: 1.0.0
+    description: Admin-only triage of a member safety report. Marks an open report reviewed or dismissed, stamping who acted and when. Triage only; the global ban is a separate admin action (task 5).
+    inputSchema:
+      reportId:
+        type: string
+        required: true
+      action:
+        type: string
+        required: true
+    outputSchema:
+      ok:
+        type: boolean
+      status:
+        type: string
+    dataAccess:
+      - member_safety_reports
+    purpose: member_safety_escalation
+    retentionClass: transactional_long_lived
+    idempotency: true

--- a/ctf/docs/contracts/MEMBER_BLOCKS_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/MEMBER_BLOCKS_PROFILE_AND_DELETION_CONTRACT.md
@@ -5,8 +5,8 @@
 - Feature Name: Member Blocking (cross-cutting safety control, not a plugin)
 - Service Key (lowercase, stable): `member-blocks`
 - Issue: #809 (owner-signed model, 2026-06-24)
-- Rollout Stage: API + manage-list UI (task 2). Enforcement across surfaces (task 4) and the optional
-  safety escalation (task 3) are separate, later tasks.
+- Rollout Stage: API + manage-list UI (task 2) and the optional safety escalation (task 3) are built.
+  Enforcement across surfaces (task 4) and the admin global ban (task 5) are separate, later tasks.
 
 ## 2) What this stores
 
@@ -17,9 +17,22 @@
   - `created_at` (timestamptz) — when the block was created.
   - Unique on `(blocker_user_id, blocked_user_id)`; CHECK forbids a self-block.
 - No `reason` column. Ordinary blocks are private; the admin never reads them. A member may block
-  anyone for any reason and none is recorded. The optional "report as suspected predator/trafficker"
-  escalation is a separate mechanism (a member safety report kept apart from this table), built in a
-  later task, so ordinary blocks stay out of the admin's view.
+  anyone for any reason and none is recorded.
+- Table: `member_safety_reports` (issue #809, task 3) — the optional safety escalation, kept
+  DELIBERATELY SEPARATE from `member_blocks` so ordinary blocks stay out of the admin's view. A row
+  is written here only when the blocking member flags the block as a safety concern (suspected
+  predator / human trafficker); it is then admin-visible.
+  - `id` (uuid, primary key)
+  - `reporter_user_id` (text) — the member who raised the concern (the blocker).
+  - `reported_user_id` (text) — the member the concern is about (the blocked person).
+  - `detail` (text, nullable) — optional free-text context the reporter added.
+  - `status` (text, default `open`) — `open` | `reviewed` | `dismissed`; CHECK keeps it in-range.
+  - `created_at` (timestamptz), `reviewed_at` (timestamptz, nullable), `reviewed_by_user_id` (text,
+    nullable) — stamped when an admin moves a report out of `open`.
+  - Indexed on `(status, created_at DESC)` for the admin queue read and on `reported_user_id` for the
+    per-member repeat count. CHECK forbids a self-report.
+  - The block and the safety report are written in ONE transaction, so a report can never exist
+    without its block and a report-insert failure rolls the block back.
 
 ## 3) Resolving the blocked member's display label
 
@@ -34,6 +47,12 @@ On full-account deletion, the member's own blocks are removed. This is wired int
 deletion registry (`ctf/packages/web/lib/account/deletion-registry.ts`) as the `member-blocks` entry:
 
 - `member_blocks` — `delete` where `blocker_user_id = <user>` (the blocks the member created).
+- `member_safety_reports` — `delete` where `reporter_user_id = <user>` (the safety reports the member
+  filed about others). Reports ABOUT the member (`reported_user_id = <user>`) are the admin's safety
+  evidence raised by someone else and are **NOT** deleted: retained like an audit/accountability
+  record, because erasing them would destroy the owner's record of a predator/trafficker concern and
+  would let a flagged member delete-and-rejoin to clear reports against them. A retained report that
+  points at a now-deleted account is harmless evidence (the account is gone).
 
 Scope notes:
 

--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -614,3 +614,25 @@ known-open item — sign-in via Clerk (auth) — is owned by the owner's separat
   Android parity deferred (Parity Ticket #809). Still to come: task 3 (optional safety-report
   escalation), task 4 (wiring `isBlockedBetween` into each surface), task 5 (admin global ban).
   Owner-review lane.
+- 2026-06-24: **Member blocking — optional safety escalation to the admin landed (issue #809, task 3
+  of 5).** Built on the task-1/task-2 core. No existing reporting mechanism fit (bug-reports are app
+  bugs, skills-hunt reports are about submissions, trusttransport incidents are ride incidents,
+  lighthouse blocks are plugin-local), so added the minimal `member_safety_reports` table the model
+  prescribes — deliberately SEPARATE from `member_blocks` so ordinary blocks stay private and only a
+  flagged block reaches the admin. The block-create flow (`POST /api/account/blocks`) now takes an
+  optional `{ safetyConcern, safetyDetail }`; when set, the block and a safety report are written in
+  one transaction (atomic — a report cannot exist without its block, and a report-insert failure
+  rolls the block back so the member can retry). An ordinary block is unchanged and writes nothing
+  here. `BlockMemberButton` gained an optional, clearly-secondary "report as suspected predator /
+  human trafficker" checkbox plus an optional note, default off, with plain copy that an ordinary
+  block notifies no one. Added an admin-only queue at `/admin/safety` (open reports first, resolved
+  reporter + reported display names via a `directory_profiles` LEFT JOIN with a neutral fallback, a
+  per-reported-member open-report count so a repeat offender stands out, mark reviewed / dismissed)
+  backed by admin-gated `GET /api/safety/admin/reports` and `POST /api/safety/admin/reports/[id]/review`
+  (CSRF on write), and a card on the admin landing. This surface is read + triage only; the global
+  ban is task 5. Deletion: a member's filed reports (`reporter_user_id`) are removed on account
+  deletion; reports ABOUT a member (`reported_user_id`) are retained as the admin's safety evidence.
+  Trust recorded not-applicable (rule 132 — safety participation is never public). Added the
+  `member.safety-report.create` / `admin.safety-report.list` / `admin.safety-report.review` command
+  and access-policy contracts and updated the profile/deletion contract. Android parity deferred
+  (Parity Ticket #809). Owner-review lane.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -85,6 +85,11 @@ as public trust evidence — **ClickLog** (safety incidents), **Mood** (mental-h
 what a member is going through; their activity is still reflected by the universal login signal. Plugins
 with no per-member participation (Workforce, Weekly Performance, Feed/Announcements, Skills Taxonomy, GDP)
 and Comic (fuzzy completion) are not applicable. **Foundation** surfaces the provider side only (seeker-side help-seeking is excluded for privacy).
+**Member blocking and safety reports** (cross-cutting safety control, issue #809; `member_blocks`,
+`member_safety_reports`) are **not applicable** and are **never** surfaced as Trust evidence — a block is a
+private boundary the blocked person is never told about, and a safety report (suspected predator / human
+trafficker) is sensitive safety/verification participation that must never become public evidence (rule
+132). No numeric score, no count, no categorical signal is derived from either table.
 
 Only coarse COUNTs are read (never amounts, balances, or sensitive per-row detail), so no money figure or
 private detail crosses into Trust. Real-data-only rule: any signal whose backing rows are absent (count of

--- a/ctf/packages/web/app/admin/page.tsx
+++ b/ctf/packages/web/app/admin/page.tsx
@@ -30,6 +30,7 @@ const ADMIN_AREAS: { href: string; name: string; description: string }[] = [
   { href: '/admin/feed-announcements', name: 'Feed Announcements', description: 'Post and manage announcements in the community feed.' },
   { href: '/admin/beacon', name: 'Beacon', description: 'Go live and run broadcast events; manage recordings.' },
   { href: '/admin/bug-reports', name: 'Bug Reports', description: 'Review reports flagged for a human and track ones sent to triage.' },
+  { href: '/admin/safety', name: 'Safety Reports', description: 'Review members flagged as a safety concern when blocked.' },
 ];
 
 export default async function AdminPage() {

--- a/ctf/packages/web/app/admin/safety/page.tsx
+++ b/ctf/packages/web/app/admin/safety/page.tsx
@@ -1,0 +1,44 @@
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import Link from 'next/link';
+import { SafetyAdminShell } from '../../../components/safety/safety-admin-shell';
+
+export const dynamic = 'force-dynamic';
+
+// Admin review of member safety reports (issue #809, task 3). Admin-gated server-side; the client
+// shell lists reports (open first) and marks them reviewed or dismissed via the admin
+// /api/safety/admin routes. A report exists only when a member blocked someone AND flagged them as a
+// suspected predator / human trafficker — ordinary blocks never reach here. The global ban is a
+// separate, later admin action (task 5); this surface is read + triage only.
+export default async function SafetyAdminPage() {
+  const decision = await evaluatePluginAccess({ requiredRoles: ['admin'] });
+
+  if (!decision.allowed) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-12 space-y-4">
+        <h1 className="text-2xl font-semibold tracking-tight">Admin access denied</h1>
+        <p className="text-sm text-muted-foreground">
+          The safety report review area is restricted to admins. Request blocked by server-side role policy.
+        </p>
+        <dl className="rounded-lg border bg-card p-4 text-sm">
+          <div className="flex justify-between gap-4">
+            <dt className="font-medium">HTTP status</dt>
+            <dd>{decision.status}</dd>
+          </div>
+          <div className="mt-2 flex justify-between gap-4">
+            <dt className="font-medium">Deny code</dt>
+            <dd>{decision.code}</dd>
+          </div>
+          <div className="mt-2 flex justify-between gap-4">
+            <dt className="font-medium">Reason</dt>
+            <dd>{decision.reason}</dd>
+          </div>
+        </dl>
+        <p className="text-sm">
+          <Link className="underline underline-offset-4" href="/admin">Back to admin</Link>
+        </p>
+      </main>
+    );
+  }
+
+  return <SafetyAdminShell />;
+}

--- a/ctf/packages/web/app/api/account/blocks/route.ts
+++ b/ctf/packages/web/app/api/account/blocks/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireAccountAccess, ensureMutationCsrf } from '../_lib';
 import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
-import { blockUser, listBlocksForUser, SelfBlockError } from 'lib/blocks/repository';
+import { blockUser, blockUserTx, listBlocksForUser, SelfBlockError } from 'lib/blocks/repository';
+import { insertSafetyReportTx } from 'lib/safety/repository';
+import { SAFETY_REPORT_DETAIL_MAX_LENGTH } from 'lib/safety/constants';
+import { withDbTransaction } from 'lib/db/postgres';
 import { reportError } from 'lib/observability/report';
 
 // Member blocking — the cross-cutting "block / unblock / see who you've blocked" API (issue #809,
@@ -32,7 +35,7 @@ export async function GET() {
   }
 }
 
-type BlockBody = { blockedUserId?: unknown };
+type BlockBody = { blockedUserId?: unknown; safetyConcern?: unknown; safetyDetail?: unknown };
 
 function badRequest(message: string): NextResponse {
   return NextResponse.json(
@@ -43,6 +46,14 @@ function badRequest(message: string): NextResponse {
 
 // Create a block. CSRF-protected and idempotent (blocking the same person twice is a no-op). A
 // self-block and a missing/blank target both map to a clear 400.
+//
+// The body MAY carry an optional safety escalation (issue #809, task 3): `safetyConcern: true` with
+// an optional short `safetyDetail`. An ordinary block (no flag) behaves exactly as before and writes
+// nothing to the reports table — it stays the member's own private boundary that the admin never
+// sees. When the flag is set, the block AND a member_safety_reports row are written in ONE
+// transaction, so they succeed or fail together: a report can never exist without its block, and a
+// failure to record the report rolls the block back so the member can retry rather than silently
+// losing their safety report. This is the only path by which a member block reaches the admin.
 export async function POST(request: Request) {
   const gate = await requireAccountAccess();
   if (!gate.allowed) {
@@ -66,16 +77,46 @@ export async function POST(request: Request) {
   }
   const blockedUserId = body.blockedUserId.trim();
 
+  // A safety escalation is opt-in. Anything other than a literal `true` is treated as an ordinary
+  // block, so a missing/odd value never accidentally raises an admin alert.
+  const safetyConcern = body.safetyConcern === true;
+
+  // The free-text context is optional even when escalating. Reject only a value that is present but
+  // not a string (a clear client bug); trim and cap an actual string, and store null when blank.
+  let safetyDetail: string | null = null;
+  if (safetyConcern && body.safetyDetail !== undefined && body.safetyDetail !== null) {
+    if (typeof body.safetyDetail !== 'string') {
+      return badRequest('safetyDetail must be a string.');
+    }
+    const trimmed = body.safetyDetail.trim();
+    if (trimmed.length > SAFETY_REPORT_DETAIL_MAX_LENGTH) {
+      return badRequest(`safetyDetail must be ${SAFETY_REPORT_DETAIL_MAX_LENGTH} characters or fewer.`);
+    }
+    safetyDetail = trimmed.length > 0 ? trimmed : null;
+  }
+
   try {
+    if (safetyConcern) {
+      // Block + safety report, atomic.
+      await withDbTransaction(async (client) => {
+        await blockUserTx(client, gate.auth.userId, blockedUserId);
+        await insertSafetyReportTx(client, gate.auth.userId, blockedUserId, safetyDetail);
+      });
+      return NextResponse.json({ ok: true, safetyReported: true }, { status: 200 });
+    }
+
     await blockUser(gate.auth.userId, blockedUserId);
-    return NextResponse.json({ ok: true }, { status: 200 });
+    return NextResponse.json({ ok: true, safetyReported: false }, { status: 200 });
   } catch (error) {
     if (error instanceof SelfBlockError) {
       return badRequest('You cannot block yourself.');
     }
-    reportError(error, { area: 'account', op: 'blocks_create' });
+    reportError(error, { area: 'account', op: safetyConcern ? 'blocks_create_with_safety_report' : 'blocks_create' });
+    const message = safetyConcern
+      ? 'We could not record your safety report, so this person was not blocked. Please try again.'
+      : 'Unable to block this member.';
     return NextResponse.json(
-      { ok: false, code: ACCOUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to block this member.' },
+      { ok: false, code: ACCOUNT_ERROR_CODE.persistenceUnavailable, message },
       { status: 503 },
     );
   }

--- a/ctf/packages/web/app/api/safety/admin/_lib.ts
+++ b/ctf/packages/web/app/api/safety/admin/_lib.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
+import { checkMutationOrigin } from 'lib/auth/csrf';
+import { SAFETY_ERROR_CODE } from 'lib/safety/constants';
+
+// Shared helpers for the admin-only safety-report routes under `/api/safety/admin/**` (issue #809,
+// task 3). The safety-report queue is the only path by which a member block reaches the admin, so
+// these routes are admin-gated server-side regardless of what any nav shows (rule 131).
+
+export type SafetyAdminGate =
+  | { allowed: true; auth: AllowDecision }
+  | { allowed: false; response: NextResponse };
+
+export async function requireSafetyAdminAccess(): Promise<SafetyAdminGate> {
+  const decision = await evaluatePluginAccess({ requiredRoles: ['admin'] });
+  if (!decision.allowed) {
+    return {
+      allowed: false,
+      response: NextResponse.json(decision, { status: decision.status }),
+    };
+  }
+
+  return { allowed: true, auth: decision };
+}
+
+// Same-origin CSRF guard for state-changing requests, mirroring the account/bug-report helpers.
+// Requires the `x-ctf-csrf: 1` header and, when origin metadata is present, a matching host.
+export function ensureMutationCsrf(request: Request): NextResponse | null {
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return null;
+  }
+
+  if (request.headers.get('x-ctf-csrf') !== '1') {
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.csrfDenied, message: 'Missing CSRF confirmation header.' },
+      { status: 403 },
+    );
+  }
+
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck === 'invalid_origin') {
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.csrfDenied, message: 'Invalid request origin metadata.' },
+      { status: 403 },
+    );
+  }
+  if (originCheck === 'cross_origin') {
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.csrfDenied, message: 'Cross-origin mutation denied by CSRF policy.' },
+      { status: 403 },
+    );
+  }
+
+  return null;
+}

--- a/ctf/packages/web/app/api/safety/admin/reports/[reportId]/review/route.ts
+++ b/ctf/packages/web/app/api/safety/admin/reports/[reportId]/review/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { requireSafetyAdminAccess, ensureMutationCsrf } from '../../../_lib';
+import { SAFETY_ERROR_CODE } from 'lib/safety/constants';
+import { setSafetyReportStatus } from 'lib/safety/repository';
+import { reportError } from 'lib/observability/report';
+
+type ReviewBody = { action?: unknown };
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Mark a member safety report reviewed or dismissed (issue #809, task 3). This is triage only — the
+// admin's actual global ban is a separate, later task (task 5). `reviewed` records that the admin
+// looked at / acted on the report; `dismissed` records that it was not a real safety concern. Both
+// only move a report that is currently open, so a double action is a harmless no-op. Admin-gated,
+// CSRF on write.
+export async function POST(request: Request, { params }: { params: Promise<{ reportId: string }> }) {
+  const gate = await requireSafetyAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const { reportId } = await params;
+  if (!UUID_REGEX.test(reportId)) {
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.invalidPayload, message: 'Invalid report id.' },
+      { status: 400 },
+    );
+  }
+
+  let body: ReviewBody;
+  try {
+    body = (await request.json()) as ReviewBody;
+  } catch {
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
+      { status: 400 },
+    );
+  }
+
+  if (body.action !== 'reviewed' && body.action !== 'dismissed') {
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.invalidPayload, message: 'action must be "reviewed" or "dismissed".' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const changed = await setSafetyReportStatus(reportId, body.action, gate.auth.userId);
+    if (!changed) {
+      // No row moved: the report was already actioned or does not exist.
+      return NextResponse.json(
+        { ok: false, code: SAFETY_ERROR_CODE.forbidden, message: 'This report is no longer open.' },
+        { status: 409 },
+      );
+    }
+
+    return NextResponse.json({ ok: true, reportId, status: body.action }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'safety', op: 'admin_report_review' });
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update this report.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/safety/admin/reports/route.ts
+++ b/ctf/packages/web/app/api/safety/admin/reports/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { requireSafetyAdminAccess } from '../_lib';
+import { SAFETY_ERROR_CODE } from 'lib/safety/constants';
+import { listSafetyReportsForAdmin } from 'lib/safety/repository';
+import { reportError } from 'lib/observability/report';
+
+// Admin list of member safety reports for the /admin/safety review queue (issue #809, task 3).
+// Open reports first, then newest first. Each row carries the resolved reporter and reported display
+// names and a count of OPEN reports about the same reported member, so a repeat offender stands out.
+// Admin-gated; ordinary blocks never appear here.
+export async function GET() {
+  const gate = await requireSafetyAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const reports = await listSafetyReportsForAdmin();
+    return NextResponse.json({ ok: true, reports }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'safety', op: 'admin_reports_list' });
+    return NextResponse.json(
+      { ok: false, code: SAFETY_ERROR_CODE.persistenceUnavailable, message: 'Unable to load safety reports.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/components/blocks/block-member-button.tsx
+++ b/ctf/packages/web/components/blocks/block-member-button.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState, type CSSProperties } from 'react';
-import { Ban, Loader2, ShieldX, X } from 'lucide-react';
+import { AlertTriangle, Ban, Loader2, ShieldX, X } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { getAccountDataTokens } from '@/components/account-data/account-data-shared';
 import { postBlock } from './blocks-shared';
+import { SAFETY_REPORT_DETAIL_MAX_LENGTH } from 'lib/safety/constants';
 
 type Status = 'idle' | 'confirming' | 'submitting' | 'done' | 'error';
 
@@ -31,14 +32,28 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
   const { BORDER, TEXT, SUBTLE } = tokens;
   const [status, setStatus] = useState<Status>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // The optional safety escalation, default off. An ordinary block leaves these untouched and
+  // reaches no one; only when the checkbox is on does a report go to the admins.
+  const [safetyConcern, setSafetyConcern] = useState(false);
+  const [safetyDetail, setSafetyDetail] = useState('');
+  // Set true once the just-created block also raised a safety report, so the done state can confirm
+  // the report reached the admins.
+  const [reported, setReported] = useState(false);
 
   const label = displayName?.trim() ? displayName.trim() : 'this member';
+
+  function resetForm() {
+    setSafetyConcern(false);
+    setSafetyDetail('');
+    setErrorMessage(null);
+  }
 
   async function handleConfirm() {
     setStatus('submitting');
     setErrorMessage(null);
     try {
-      await postBlock(targetUserId);
+      await postBlock(targetUserId, safetyConcern ? { concern: true, detail: safetyDetail } : undefined);
+      setReported(safetyConcern);
       setStatus('done');
       onBlocked?.();
     } catch (error) {
@@ -48,7 +63,8 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
   }
 
   // Once blocked, the trigger becomes a calm, non-actionable confirmation rather than disappearing,
-  // so the member gets clear feedback that the block took effect.
+  // so the member gets clear feedback that the block took effect. When a safety report also went out,
+  // the label says so, so the member knows the admins were notified.
   if (status === 'done') {
     return (
       <span
@@ -58,7 +74,7 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
           ...style,
         }}
       >
-        <ShieldX size={15} /> Blocked
+        <ShieldX size={15} /> {reported ? 'Blocked and reported' : 'Blocked'}
       </span>
     );
   }
@@ -67,7 +83,7 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
     <>
       <button
         type="button"
-        onClick={() => { setStatus('confirming'); setErrorMessage(null); }}
+        onClick={() => { setStatus('confirming'); resetForm(); }}
         style={{
           display: 'inline-flex', alignItems: 'center', gap: 7, padding: '8px 14px', borderRadius: 10,
           background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444',
@@ -105,10 +121,52 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
             </div>
 
             <div style={{ padding: '20px 24px' }}>
-              <p style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.6, margin: '0 0 18px' }}>
-                They won&apos;t be able to see or contact you, and they won&apos;t be told. You can unblock
-                them later from your blocked members list.
+              <p style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.6, margin: '0 0 16px' }}>
+                They won&apos;t be able to see or contact you, and they won&apos;t be told. This is private
+                — no one is notified. You can unblock them later from your blocked members list.
               </p>
+
+              {/* Optional, clearly-secondary safety escalation. An ordinary block reaches no one; only
+                  checking this box sends a report to the admins so they can act. */}
+              <div style={{ borderRadius: 12, background: 'rgba(245,158,11,0.05)', border: '1px solid rgba(245,158,11,0.22)', padding: '12px 14px', marginBottom: 18 }}>
+                <label style={{ display: 'flex', gap: 10, alignItems: 'flex-start', cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={safetyConcern}
+                    disabled={status === 'submitting'}
+                    onChange={(e) => setSafetyConcern(e.target.checked)}
+                    style={{ marginTop: 2, width: 16, height: 16, accentColor: '#F59E0B', flexShrink: 0, cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}
+                  />
+                  <span style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, fontWeight: 700, color: '#F59E0B' }}>
+                      <AlertTriangle size={14} /> Report this person to the admins as a safety concern
+                    </span>
+                    <span style={{ fontSize: 12.5, color: '#9CA3AF', lineHeight: 1.55 }}>
+                      Only check this if you believe they are a suspected predator or human trafficker.
+                      An ordinary block does not notify anyone — this sends a private report to the admins
+                      so they can review and act.
+                    </span>
+                  </span>
+                </label>
+
+                {safetyConcern ? (
+                  <div style={{ marginTop: 12 }}>
+                    <label htmlFor="safety-detail" style={{ display: 'block', fontSize: 12.5, color: SUBTLE, marginBottom: 6 }}>
+                      Anything the admins should know (optional)
+                    </label>
+                    <textarea
+                      id="safety-detail"
+                      value={safetyDetail}
+                      disabled={status === 'submitting'}
+                      onChange={(e) => setSafetyDetail(e.target.value)}
+                      maxLength={SAFETY_REPORT_DETAIL_MAX_LENGTH}
+                      rows={3}
+                      placeholder="A short note that would help the admins (optional)"
+                      style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical', minHeight: 64, padding: '9px 11px', borderRadius: 9, background: 'rgba(255,255,255,0.03)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontFamily: 'inherit', lineHeight: 1.5 }}
+                    />
+                  </div>
+                ) : null}
+              </div>
 
               {status === 'error' && errorMessage ? (
                 <div style={{ padding: '10px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.3)', color: '#F87171', fontSize: 13, marginBottom: 16, lineHeight: 1.5 }}>
@@ -123,7 +181,9 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
                   disabled={status === 'submitting'}
                   style={{ flex: 1, padding: '12px', borderRadius: 11, background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.45)', color: '#EF4444', fontSize: 14, fontWeight: 700, cursor: status === 'submitting' ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
                 >
-                  {status === 'submitting' ? <><Loader2 size={15} className="blocks-spin" /> Blocking…</> : <><Ban size={15} /> Block member</>}
+                  {status === 'submitting'
+                    ? <><Loader2 size={15} className="blocks-spin" /> {safetyConcern ? 'Blocking and reporting…' : 'Blocking…'}</>
+                    : <><Ban size={15} /> {safetyConcern ? 'Block and report' : 'Block member'}</>}
                 </button>
                 <button
                   type="button"

--- a/ctf/packages/web/components/blocks/blocks-shared.ts
+++ b/ctf/packages/web/components/blocks/blocks-shared.ts
@@ -18,13 +18,34 @@ export type BlocksListResponse = {
   blocks: BlockedMember[];
 };
 
-// Create a block. Resolves on success; rejects with a member-facing message on failure (a self-block
-// or missing target is a 400 with a clear message, anything else a generic failure).
-export async function postBlock(blockedUserId: string): Promise<void> {
+// An optional safety escalation that can ride along with a block (issue #809, task 3). When
+// `concern` is true the server ALSO records an admin safety report; otherwise the block stays the
+// member's own private boundary and nothing reaches the admin. `detail` is the optional free-text
+// context ("anything the admins should know").
+export type SafetyEscalation = {
+  concern: boolean;
+  detail?: string;
+};
+
+// Create a block, optionally with a safety report. Resolves on success; rejects with a member-facing
+// message on failure (a self-block or missing target is a 400 with a clear message, anything else a
+// generic failure). When a safety report is requested and recording it fails, the server rolls the
+// block back and returns an error, so this rejects and the member can retry rather than silently
+// losing their report.
+export async function postBlock(blockedUserId: string, safety?: SafetyEscalation): Promise<void> {
+  const body: { blockedUserId: string; safetyConcern?: boolean; safetyDetail?: string } = { blockedUserId };
+  if (safety?.concern) {
+    body.safetyConcern = true;
+    const detail = safety.detail?.trim();
+    if (detail) {
+      body.safetyDetail = detail;
+    }
+  }
+
   const res = await fetch('/api/account/blocks', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
-    body: JSON.stringify({ blockedUserId }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     throw new Error(await readError(res, 'Unable to block this member. Please try again.'));

--- a/ctf/packages/web/components/safety/safety-admin-shell.tsx
+++ b/ctf/packages/web/components/safety/safety-admin-shell.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, ShieldAlert } from 'lucide-react';
+import type { SafetyReportStatus } from 'lib/safety/constants';
+
+// Admin design tokens (shared admin look, rule 131). Safety reports are cross-cutting platform
+// safety tooling with no plugin accent, so the chrome uses the neutral admin indigo; the open/alert
+// state uses amber to read as "needs attention" without being alarming.
+const COLOR = '#6366F1';
+const BG = '#0F1117';
+const PANEL = '#0D0F14';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#6B7280';
+
+type AdminSafetyReport = {
+  id: string;
+  reporterUserId: string;
+  reporterDisplayName: string;
+  reportedUserId: string;
+  reportedDisplayName: string;
+  detail: string | null;
+  status: SafetyReportStatus;
+  createdAtIso: string;
+  reviewedAtIso: string | null;
+  reviewedByUserId: string | null;
+  openReportsAboutReported: number;
+};
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+const STATUS_LABEL: Record<SafetyReportStatus, string> = {
+  open: 'Open',
+  reviewed: 'Reviewed',
+  dismissed: 'Dismissed',
+};
+
+const STATUS_STYLE: Record<SafetyReportStatus, { bg: string; color: string; border: string }> = {
+  open: { bg: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: 'rgba(245,158,11,0.3)' },
+  reviewed: { bg: 'rgba(34,197,94,0.12)', color: '#22C55E', border: 'rgba(34,197,94,0.3)' },
+  dismissed: { bg: 'rgba(107,114,128,0.14)', color: '#9CA3AF', border: 'rgba(107,114,128,0.3)' },
+};
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, { cache: 'no-store', ...init });
+  const payload = (await response.json().catch(() => null)) as T | { message?: string } | null;
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === 'object' && 'message' in payload ? payload.message : 'Request failed.';
+    throw new Error(typeof message === 'string' ? message : 'Request failed.');
+  }
+  return payload as T;
+}
+
+function formatWhen(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return 'unknown time';
+  return new Date(then).toLocaleString();
+}
+
+function StatusPill({ status }: { status: SafetyReportStatus }) {
+  const s = STATUS_STYLE[status];
+  return (
+    <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: s.bg, color: s.color, border: `1px solid ${s.border}` }}>
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function StatBlock({ label, value, accent }: { label: string; value: number; accent?: string }) {
+  return (
+    <div style={{ flex: 1, minWidth: 120, padding: '10px 12px', borderRadius: 10, background: SURFACE, border: `1px solid ${BORDER}` }}>
+      <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? TEXT }}>{value}</div>
+      <div style={{ fontSize: 11, color: SUBTLE, marginTop: 2 }}>{label}</div>
+    </div>
+  );
+}
+
+// Admin safety-report queue (issue #809, task 3). The only path by which a member block reaches the
+// admin: a member who blocked someone and flagged it as a suspected predator / human trafficker. The
+// owner reviews these so they can ban globally (the global ban itself is task 5 — this surface is
+// read + triage only). Open reports surface first; a per-reported-member open count flags a repeat
+// offender. Covers loading, error, empty, and populated states and is mobile-responsive (rows reflow
+// at phone width). Ordinary blocks never appear here.
+export function SafetyAdminShell() {
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [reports, setReports] = useState<AdminSafetyReport[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const payload = await requestJson<{ reports: AdminSafetyReport[] }>('/api/safety/admin/reports');
+      setReports(payload.reports);
+      setLoadState('ready');
+      setError(null);
+    } catch (loadError) {
+      setLoadState('error');
+      setError(loadError instanceof Error ? loadError.message : 'Unable to load safety reports.');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const openCount = useMemo(() => reports.filter((r) => r.status === 'open').length, [reports]);
+
+  const review = useCallback(
+    async (id: string, action: 'reviewed' | 'dismissed') => {
+      const confirmText =
+        action === 'reviewed'
+          ? 'Mark this safety report reviewed? Use this once you have acted on it. Banning this member globally is a separate admin action.'
+          : 'Dismiss this safety report? Use this if it is not a real safety concern.';
+      if (typeof window !== 'undefined' && !window.confirm(confirmText)) {
+        return;
+      }
+
+      setBusyId(id);
+      setError(null);
+      try {
+        await requestJson(`/api/safety/admin/reports/${id}/review`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'x-ctf-csrf': '1' },
+          body: JSON.stringify({ action }),
+        });
+        await refresh();
+      } catch (reviewError) {
+        setError(reviewError instanceof Error ? reviewError.message : 'Unable to update this report.');
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [refresh],
+  );
+
+  return (
+    <div style={{ minHeight: '100dvh', background: BG, color: TEXT, fontFamily: "'Inter',system-ui,sans-serif" }}>
+      <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: PANEL, border: `1px solid ${BORDER}`, marginBottom: 16 }}>
+          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${COLOR}20`, border: `1px solid ${COLOR}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <ShieldAlert size={18} color={COLOR} />
+          </div>
+          <div>
+            <div style={{ fontSize: 17, fontWeight: 800 }}>Safety reports</div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>Members flagged as a safety concern</div>
+          </div>
+          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
+        </div>
+
+        <p style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6, marginBottom: 16 }}>
+          When a member blocks someone and flags them as a{' '}
+          <span style={{ color: TEXT, fontWeight: 600 }}>suspected predator or human trafficker</span>, the
+          report shows up here. Ordinary blocks are private and never appear. Review a report once you have
+          acted on it, or dismiss it if it is not a real safety concern. Banning a member from the whole
+          product is a separate admin action that arrives in a later change.
+        </p>
+
+        {/* Snapshot */}
+        {loadState === 'ready' ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 16 }}>
+            <StatBlock label="Open reports" value={openCount} accent="#F59E0B" />
+            <StatBlock label="Total reports" value={reports.length} />
+          </div>
+        ) : null}
+
+        {error ? (
+          <div role="status" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>
+            {error}
+          </div>
+        ) : null}
+
+        {loadState === 'loading' ? (
+          <div style={{ padding: '32px 16px', textAlign: 'center', color: SUBTLE, fontSize: 14, borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}` }}>
+            Loading safety reports…
+          </div>
+        ) : null}
+
+        {loadState === 'ready' && reports.length === 0 ? (
+          <div style={{ padding: '32px 16px', textAlign: 'center', color: SUBTLE, fontSize: 14, borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}` }}>
+            No safety reports. When a member flags a block as a safety concern, it shows up here.
+          </div>
+        ) : null}
+
+        {reports.map((report) => {
+          const busy = busyId === report.id;
+          const canAct = report.status === 'open';
+          // A repeat offender: more than one open report about the same reported member.
+          const isRepeat = report.openReportsAboutReported > 1;
+          return (
+            <div key={report.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: SURFACE, border: `1px solid ${isRepeat ? 'rgba(245,158,11,0.4)' : BORDER}` }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                <StatusPill status={report.status} />
+                <span style={{ fontSize: 12, color: SUBTLE }}>{formatWhen(report.createdAtIso)}</span>
+                {isRepeat ? (
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
+                    <AlertTriangle size={12} /> {report.openReportsAboutReported} open reports about this member
+                  </span>
+                ) : null}
+              </div>
+
+              <div style={{ fontSize: 13, color: TEXT, lineHeight: 1.7 }}>
+                <span style={{ color: SUBTLE }}>Reported member: </span>
+                <span style={{ fontWeight: 700 }}>{report.reportedDisplayName}</span>
+                <span style={{ color: SUBTLE }}> ({report.reportedUserId})</span>
+              </div>
+              <div style={{ fontSize: 13, color: TEXT, lineHeight: 1.7 }}>
+                <span style={{ color: SUBTLE }}>Reported by: </span>
+                <span style={{ fontWeight: 600 }}>{report.reporterDisplayName}</span>
+                <span style={{ color: SUBTLE }}> ({report.reporterUserId})</span>
+              </div>
+
+              {report.detail ? (
+                <p style={{ whiteSpace: 'pre-wrap', fontSize: 13, color: TEXT, marginTop: 8, marginBottom: 0 }}>
+                  <span style={{ color: SUBTLE, fontWeight: 600 }}>What the reporter said: </span>
+                  {report.detail}
+                </p>
+              ) : (
+                <p style={{ fontSize: 13, color: SUBTLE, marginTop: 8, marginBottom: 0, fontStyle: 'italic' }}>
+                  No additional detail was provided.
+                </p>
+              )}
+
+              {report.status !== 'open' && report.reviewedAtIso ? (
+                <div style={{ fontSize: 12, color: SUBTLE, marginTop: 10 }}>
+                  {STATUS_LABEL[report.status]} {formatWhen(report.reviewedAtIso)}
+                  {report.reviewedByUserId ? ` by ${report.reviewedByUserId}` : ''}
+                </div>
+              ) : null}
+
+              {canAct ? (
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 12 }}>
+                  <button
+                    type="button"
+                    onClick={() => void review(report.id, 'reviewed')}
+                    disabled={busy}
+                    style={{ padding: '7px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+                  >
+                    Mark reviewed
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void review(report.id, 'dismissed')}
+                    disabled={busy}
+                    style={{ padding: '7px 12px', borderRadius: 8, background: SURFACE, border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+
+        <div style={{ marginTop: 16, paddingTop: 16, borderTop: `1px solid ${BORDER}`, fontSize: 13 }}>
+          <Link href="/admin" style={{ color: COLOR, textDecoration: 'none' }}>
+            ← Back to admin
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -265,8 +265,17 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     // same entry. A leftover reverse-direction row pointing at a deleted user is harmless (the user is
     // gone); cleaning those up is a noted follow-up, not done here, so service-scope deletion never
     // touches another member's blocks.
+    //
+    // Safety reports (issue #809, task 3) follow the same reporter-owns-their-row rule: a report this
+    // member FILED (reporter_user_id) is their own action and is deleted with their account. A report
+    // ABOUT this member (reported_user_id) is the ADMIN'S safety evidence raised by another member —
+    // it is NOT deleted here, the same way audit/accountability records are retained for compliance.
+    // Removing it would erase the owner's record of a predator/trafficker concern and would also let
+    // someone delete-and-rejoin to clear reports against them. Reverse-direction reports about a
+    // now-deleted account simply point at a gone user, which is harmless evidence.
     serviceScopeSupported: true,
     tables: [
+      del('member_safety_reports', 'reporter_user_id', 'Safety reports you filed about another member.'),
       del('member_blocks', 'blocker_user_id', 'The blocks you created.'),
     ],
   },

--- a/ctf/packages/web/lib/blocks/repository.ts
+++ b/ctf/packages/web/lib/blocks/repository.ts
@@ -1,3 +1,4 @@
+import type { PoolClient } from 'pg';
 import { queryDb } from 'lib/db/postgres';
 
 // Product-wide member blocking — the cross-cutting data layer (issue #809, owner-signed model
@@ -72,6 +73,27 @@ export async function blockUser(blockerUserId: string, blockedUserId: string): P
   }
 
   await queryDb(
+    `INSERT INTO member_blocks (blocker_user_id, blocked_user_id)
+     VALUES ($1, $2)
+     ON CONFLICT (blocker_user_id, blocked_user_id) DO NOTHING`,
+    [blockerUserId, blockedUserId],
+  );
+}
+
+// Same create-block insert, but issued on the caller's transaction client. Used by the create-block
+// route when the member also raised a safety report (issue #809, task 3): the block and the report
+// are written in one transaction so they succeed or fail together. Idempotent for the same reason as
+// blockUser. Rejects a self-block defensively before touching the database.
+export async function blockUserTx(
+  client: PoolClient,
+  blockerUserId: string,
+  blockedUserId: string,
+): Promise<void> {
+  if (blockerUserId === blockedUserId) {
+    throw new SelfBlockError();
+  }
+
+  await client.query(
     `INSERT INTO member_blocks (blocker_user_id, blocked_user_id)
      VALUES ($1, $2)
      ON CONFLICT (blocker_user_id, blocked_user_id) DO NOTHING`,

--- a/ctf/packages/web/lib/safety/constants.ts
+++ b/ctf/packages/web/lib/safety/constants.ts
@@ -1,0 +1,25 @@
+// Shared constants for the member safety-report escalation (issue #809, task 3).
+//
+// A safety report is the only path by which a member block reaches the admin. An ordinary block is
+// private and the admin never sees it; a block flagged as a safety concern ("suspected predator /
+// human trafficker") also writes a member_safety_reports row, which the admin reviews and acts on.
+// The global ban the admin performs in response is a separate, later task (task 5).
+
+export const SAFETY_ERROR_CODE = {
+  invalidPayload: 'SAFETY_INVALID_PAYLOAD',
+  csrfDenied: 'SAFETY_CSRF_DENIED',
+  persistenceUnavailable: 'SAFETY_PERSISTENCE_UNAVAILABLE',
+  forbidden: 'SAFETY_FORBIDDEN',
+} as const;
+
+export type SafetyErrorCode = (typeof SAFETY_ERROR_CODE)[keyof typeof SAFETY_ERROR_CODE];
+
+// Lifecycle of a single safety report. New reports are `open`; the admin moves one to `reviewed`
+// (looked at / acted on) or `dismissed` (not a real safety concern). It never auto-advances.
+export const SAFETY_REPORT_STATUS = ['open', 'reviewed', 'dismissed'] as const;
+
+export type SafetyReportStatus = (typeof SAFETY_REPORT_STATUS)[number];
+
+// Cap on the optional free-text context. One paragraph is enough for "anything the admins should
+// know"; a cap keeps a single accidental paste from filling the table.
+export const SAFETY_REPORT_DETAIL_MAX_LENGTH = 2000;

--- a/ctf/packages/web/lib/safety/repository.ts
+++ b/ctf/packages/web/lib/safety/repository.ts
@@ -1,0 +1,126 @@
+import type { PoolClient } from 'pg';
+import { queryDb } from 'lib/db/postgres';
+import type { SafetyReportStatus } from './constants';
+
+// Member safety reports — the data layer for the optional safety escalation on the block flow
+// (issue #809, task 3, owner-signed model 2026-06-24). A report is kept in its own table,
+// SEPARATE from member_blocks: ordinary blocks are private and the admin never reads them, while a
+// safety report (a block the member flagged as a suspected predator / human trafficker) always
+// reaches the admin. Every query here is parameterized — ids are never interpolated into SQL.
+
+// One row in the admin safety-report queue, shaped for the admin surface: who reported, who was
+// reported (both resolved to a human display label), the optional context, status, timestamps, and
+// how many OPEN reports exist about the same reported member so a repeat offender stands out.
+export interface AdminSafetyReport {
+  id: string;
+  reporterUserId: string;
+  reporterDisplayName: string;
+  reportedUserId: string;
+  reportedDisplayName: string;
+  detail: string | null;
+  status: SafetyReportStatus;
+  createdAtIso: string;
+  reviewedAtIso: string | null;
+  reviewedByUserId: string | null;
+  // Count of OPEN reports about reportedUserId (this row included when its own status is open).
+  openReportsAboutReported: number;
+}
+
+// Insert a safety report inside the caller's transaction (so the block + report are atomic — the
+// report cannot exist without its block, and a report-insert failure rolls back the block too).
+// Takes a PoolClient because the create-block route wraps both writes in one withDbTransaction.
+export async function insertSafetyReportTx(
+  client: PoolClient,
+  reporterUserId: string,
+  reportedUserId: string,
+  detail: string | null,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO member_safety_reports (reporter_user_id, reported_user_id, detail, status)
+     VALUES ($1, $2, $3, 'open')`,
+    [reporterUserId, reportedUserId, detail],
+  );
+}
+
+// List safety reports for the admin queue: open reports first, then newest first. Both the reporter
+// and the reported member are resolved to a human label the same way the block manage-list resolves
+// them — a LEFT JOIN to directory_profiles on claimed_by_user_id (active profiles only), with a
+// neutral "Member" fallback so a missing profile never blanks a row. A correlated subquery attaches
+// the count of OPEN reports about each reported member so a repeat offender is obvious at a glance.
+export async function listSafetyReportsForAdmin(): Promise<AdminSafetyReport[]> {
+  const result = await queryDb<{
+    id: string;
+    reporter_user_id: string;
+    reporter_display_name: string | null;
+    reported_user_id: string;
+    reported_display_name: string | null;
+    detail: string | null;
+    status: SafetyReportStatus;
+    created_at: Date;
+    reviewed_at: Date | null;
+    reviewed_by_user_id: string | null;
+    open_reports_about_reported: string | number;
+  }>(
+    `SELECT
+       r.id,
+       r.reporter_user_id,
+       NULLIF(TRIM(COALESCE(rp.first_name, '') || ' ' || COALESCE(rp.last_name, '')), '') AS reporter_display_name,
+       r.reported_user_id,
+       NULLIF(TRIM(COALESCE(tp.first_name, '') || ' ' || COALESCE(tp.last_name, '')), '') AS reported_display_name,
+       r.detail,
+       r.status,
+       r.created_at,
+       r.reviewed_at,
+       r.reviewed_by_user_id,
+       (
+         SELECT COUNT(*)
+         FROM member_safety_reports o
+         WHERE o.reported_user_id = r.reported_user_id
+           AND o.status = 'open'
+       ) AS open_reports_about_reported
+     FROM member_safety_reports r
+     LEFT JOIN directory_profiles rp
+       ON rp.claimed_by_user_id = r.reporter_user_id
+      AND rp.deleted_at IS NULL
+     LEFT JOIN directory_profiles tp
+       ON tp.claimed_by_user_id = r.reported_user_id
+      AND tp.deleted_at IS NULL
+     ORDER BY (r.status = 'open') DESC, r.created_at DESC`,
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    reporterUserId: row.reporter_user_id,
+    reporterDisplayName: row.reporter_display_name?.trim() ? row.reporter_display_name.trim() : 'Member',
+    reportedUserId: row.reported_user_id,
+    reportedDisplayName: row.reported_display_name?.trim() ? row.reported_display_name.trim() : 'Member',
+    detail: row.detail,
+    status: row.status,
+    createdAtIso: new Date(row.created_at).toISOString(),
+    reviewedAtIso: row.reviewed_at ? new Date(row.reviewed_at).toISOString() : null,
+    reviewedByUserId: row.reviewed_by_user_id,
+    openReportsAboutReported: Number(row.open_reports_about_reported),
+  }));
+}
+
+// Mark a report reviewed or dismissed. Only moves a report that is currently `open` (so a double
+// action is a no-op rather than re-stamping reviewed_at), stamping who acted and when. Returns true
+// when a row changed, false when the report was already actioned or does not exist — the route maps
+// false to a clear "not in an actionable state" response.
+export async function setSafetyReportStatus(
+  reportId: string,
+  status: Extract<SafetyReportStatus, 'reviewed' | 'dismissed'>,
+  reviewedByUserId: string,
+): Promise<boolean> {
+  const result = await queryDb(
+    `UPDATE member_safety_reports
+        SET status = $2,
+            reviewed_at = NOW(),
+            reviewed_by_user_id = $3
+      WHERE id = $1
+        AND status = 'open'`,
+    [reportId, status, reviewedByUserId],
+  );
+
+  return (result.rowCount ?? 0) > 0;
+}

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -4637,6 +4637,86 @@ $member_blocks_no_self_block$;
 -- the OR-query is index-served regardless of which user is the blocker.
 CREATE INDEX IF NOT EXISTS member_blocks_blocked_blocker_idx
   ON member_blocks (blocked_user_id, blocker_user_id);
+
+-- member_safety_reports: the optional safety escalation on the member-block flow (issue #809, task 3,
+-- owner-signed model 2026-06-24). This table is DELIBERATELY SEPARATE from member_blocks. An ordinary
+-- block is the member's own private boundary and the admin never sees it; only when the blocking
+-- member flags the block as a safety concern ("suspected predator / human trafficker") is a row
+-- written here, and only those rows ever reach the admin. Keeping the two tables apart is what
+-- guarantees ordinary blocks stay out of the admin's view while a safety report always reaches the
+-- owner so they can ban globally (the global ban itself is task 5, built later).
+--
+-- reporter_user_id  — the member who raised the concern (the blocker).
+-- reported_user_id  — the member the concern is about (the blocked person).
+-- detail            — optional free-text context the reporter chose to add (nullable).
+-- status            — open | reviewed | dismissed. New reports are 'open'; the admin marks them
+--                     reviewed or dismissed from the admin queue. CHECK keeps the value in-range.
+-- reviewed_at / reviewed_by_user_id — stamped when an admin moves a report out of 'open'.
+--
+-- user_id columns are TEXT to line up with member_blocks and the user-id type used elsewhere.
+CREATE TABLE IF NOT EXISTS member_safety_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_user_id TEXT NOT NULL,
+  reported_user_id TEXT NOT NULL,
+  detail TEXT,
+  status TEXT NOT NULL DEFAULT 'open',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reviewed_at TIMESTAMPTZ,
+  reviewed_by_user_id TEXT,
+  CONSTRAINT member_safety_reports_status_check CHECK (status IN ('open', 'reviewed', 'dismissed')),
+  CONSTRAINT member_safety_reports_no_self_report CHECK (reporter_user_id <> reported_user_id)
+);
+
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reporter_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reported_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS detail TEXT;
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'open';
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reviewed_by_user_id TEXT;
+
+-- Converge a legacy table that predates the CHECK constraints. Guarded so a fresh table (which
+-- already has them from CREATE TABLE) does not double-add, and a legacy one gains them.
+DO $member_safety_reports_status_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'member_safety_reports_status_check'
+  ) THEN
+    BEGIN
+      ALTER TABLE member_safety_reports
+        ADD CONSTRAINT member_safety_reports_status_check CHECK (status IN ('open', 'reviewed', 'dismissed'));
+    EXCEPTION WHEN duplicate_object THEN
+      NULL;
+    END;
+  END IF;
+END
+$member_safety_reports_status_check$;
+
+DO $member_safety_reports_no_self_report$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'member_safety_reports_no_self_report'
+  ) THEN
+    BEGIN
+      ALTER TABLE member_safety_reports
+        ADD CONSTRAINT member_safety_reports_no_self_report CHECK (reporter_user_id <> reported_user_id);
+    EXCEPTION WHEN duplicate_object THEN
+      NULL;
+    END;
+  END IF;
+END
+$member_safety_reports_no_self_report$;
+
+-- The admin queue reads open reports first (status filter + newest-first), and counts open reports
+-- per reported member so a repeat offender stands out. Index status for the queue read, and
+-- reported_user_id for the per-member repeat count.
+CREATE INDEX IF NOT EXISTS member_safety_reports_status_idx
+  ON member_safety_reports (status, created_at DESC);
+CREATE INDEX IF NOT EXISTS member_safety_reports_reported_user_idx
+  ON member_safety_reports (reported_user_id);
 COMMIT;
 
 -- ── post migration: 0001_directory_display_name_to_first_last.sql ──

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -4639,4 +4639,84 @@ $member_blocks_no_self_block$;
 -- the OR-query is index-served regardless of which user is the blocker.
 CREATE INDEX IF NOT EXISTS member_blocks_blocked_blocker_idx
   ON member_blocks (blocked_user_id, blocker_user_id);
+
+-- member_safety_reports: the optional safety escalation on the member-block flow (issue #809, task 3,
+-- owner-signed model 2026-06-24). This table is DELIBERATELY SEPARATE from member_blocks. An ordinary
+-- block is the member's own private boundary and the admin never sees it; only when the blocking
+-- member flags the block as a safety concern ("suspected predator / human trafficker") is a row
+-- written here, and only those rows ever reach the admin. Keeping the two tables apart is what
+-- guarantees ordinary blocks stay out of the admin's view while a safety report always reaches the
+-- owner so they can ban globally (the global ban itself is task 5, built later).
+--
+-- reporter_user_id  — the member who raised the concern (the blocker).
+-- reported_user_id  — the member the concern is about (the blocked person).
+-- detail            — optional free-text context the reporter chose to add (nullable).
+-- status            — open | reviewed | dismissed. New reports are 'open'; the admin marks them
+--                     reviewed or dismissed from the admin queue. CHECK keeps the value in-range.
+-- reviewed_at / reviewed_by_user_id — stamped when an admin moves a report out of 'open'.
+--
+-- user_id columns are TEXT to line up with member_blocks and the user-id type used elsewhere.
+CREATE TABLE IF NOT EXISTS member_safety_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_user_id TEXT NOT NULL,
+  reported_user_id TEXT NOT NULL,
+  detail TEXT,
+  status TEXT NOT NULL DEFAULT 'open',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reviewed_at TIMESTAMPTZ,
+  reviewed_by_user_id TEXT,
+  CONSTRAINT member_safety_reports_status_check CHECK (status IN ('open', 'reviewed', 'dismissed')),
+  CONSTRAINT member_safety_reports_no_self_report CHECK (reporter_user_id <> reported_user_id)
+);
+
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reporter_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reported_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS detail TEXT;
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'open';
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS member_safety_reports ADD COLUMN IF NOT EXISTS reviewed_by_user_id TEXT;
+
+-- Converge a legacy table that predates the CHECK constraints. Guarded so a fresh table (which
+-- already has them from CREATE TABLE) does not double-add, and a legacy one gains them.
+DO $member_safety_reports_status_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'member_safety_reports_status_check'
+  ) THEN
+    BEGIN
+      ALTER TABLE member_safety_reports
+        ADD CONSTRAINT member_safety_reports_status_check CHECK (status IN ('open', 'reviewed', 'dismissed'));
+    EXCEPTION WHEN duplicate_object THEN
+      NULL;
+    END;
+  END IF;
+END
+$member_safety_reports_status_check$;
+
+DO $member_safety_reports_no_self_report$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'member_safety_reports_no_self_report'
+  ) THEN
+    BEGIN
+      ALTER TABLE member_safety_reports
+        ADD CONSTRAINT member_safety_reports_no_self_report CHECK (reporter_user_id <> reported_user_id);
+    EXCEPTION WHEN duplicate_object THEN
+      NULL;
+    END;
+  END IF;
+END
+$member_safety_reports_no_self_report$;
+
+-- The admin queue reads open reports first (status filter + newest-first), and counts open reports
+-- per reported member so a repeat offender stands out. Index status for the queue read, and
+-- reported_user_id for the per-member repeat count.
+CREATE INDEX IF NOT EXISTS member_safety_reports_status_idx
+  ON member_safety_reports (status, created_at DESC);
+CREATE INDEX IF NOT EXISTS member_safety_reports_reported_user_idx
+  ON member_safety_reports (reported_user_id);
 COMMIT;


### PR DESCRIPTION
Third task of #809, built on tasks 1 and 2. This is your suspected-perp escalation: an ordinary block stays the member's own private boundary that you never see, but a block the member flags as a safety concern (suspected predator / human trafficker) files a separate report that reaches you so you can act.

**Out of scope (task 5):** the actual global ban. This task gets the reports in front of you and lets you triage them; the admin page says plainly that banning is the separate, later step.

## What it adds
- **`member_safety_reports` table** — deliberately separate from `member_blocks` (that separation is what keeps ordinary blocks out of your view). Columns: reporter, reported, optional `detail`, `status` (open/reviewed/dismissed), timestamps + who reviewed. CHECK constraints (valid status, no self-report), indexes on `(status, created_at)` and `reported_user_id`. Standard migration pattern; demo schema regenerated.
- **Optional escalation on the block flow** — `POST /api/account/blocks` now takes optional `{ safetyConcern, safetyDetail }`. When flagged, the block **and** the report are written in **one transaction** — a report can't exist without its block, and if the report write fails the block rolls back and the member is told "not blocked, please retry" (so a safety report is never silently lost). An ordinary block (no flag) is unchanged and writes nothing here. Strict `=== true` guard so an odd value never raises an alert by accident. The `BlockMemberButton` dialog gains an optional, secondary amber checkbox + note (default off), with copy making clear an ordinary block notifies no one.
- **Admin queue** — `/admin/safety` (mirroring the shipped bug-reports admin), backed by `GET /api/safety/admin/reports` and `POST /api/safety/admin/reports/:id/review`. Both gated server-side by `requiredRoles: ['admin']`, CSRF on the write. Open reports first; reporter and reported resolved to display names; a **repeat count** of open reports about the same member with a highlighted badge so a repeat offender stands out. Triage marks a report reviewed/dismissed (only moves an `open` row, so double-clicks are no-ops). Loading/empty/error/populated states, mobile-responsive.

## Decisions for review
- **Reporting system:** no existing report surface fit (bug reports, contest reports, ride incidents, and the LightHouse plugin-local block are all narrower), so per the model I added the minimal `member_safety_reports` table rather than overloading one of those.
- **Deletion:** a member's **filed** reports are cleared when they delete their account; reports **about** a member are **retained** as your safety evidence — otherwise a flagged member could delete-and-rejoin to wipe the record. Documented in the deletion contract; registry/engine checks pass.
- **Repeat count** is a literal count of open reports about the member (two flags from the same reporter would read as 2; in practice self-report is blocked and the button shows "Blocked" after success, so same-reporter duplicates are unlikely). If you'd prefer distinct-reporter counting, it's a one-line `COUNT(DISTINCT reporter_user_id)` change — tell me and I'll adjust.
- **Trust:** recorded not-applicable (rule 132 — safety participation is never public evidence); no signal added.

## Why owner-review
Schema + new API + a new admin safety surface + new stateful logic on a safety path. No money movement; reuses the existing authz + CSRF helpers.

## Verification
`tsc --noEmit` + repo-wide typecheck clean; eslint clean; EOF clean; schema-drift, deletion-registry, and deletion-engine checks pass; no `any`; parameterized SQL; CSRF on writes; admin routes admin-gated.

Parity Ticket: #809

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_