### PR TITLE
docs: add portable agent-instructions template

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,0 +1,142 @@
+# Agent Instructions Template (portable)
+
+Drop-in agent instructions for a **new repository**. This is the project-agnostic core —
+the writing voice, the banned-term dictionary, and a few general process rules — distilled
+from a larger codebase's agent rules with all project-specific rules removed. Copy it into a
+new repo, fill in the one placeholder at the bottom with that repo's own rules, and wire up
+the enforcement hook (see `README.md` in this folder).
+
+> Keep the wording below as-is. The voice and dictionary sections are the whole point of this
+> template; they are also what the enforcement hook checks. If you change a banned term here,
+> change it in `hooks/check-no-pleasantries.mjs` too — the hook is the source of truth.
+
+---
+
+## Voice — no pleasantries, no feelings (Critical — every reply, all agents)
+
+Do not address the user with thanks, apologies, congratulations, well-wishes, encouragement, or
+closing sign-offs. Do not use first-person feeling words (for example: glad, happy, excited,
+delighted, sorry, "hope this helps", "I appreciate"). You have no feelings; do not perform them.
+No jargon, no buzzwords. State the result or the next step in plain words, then stop.
+
+This is enforced by the Stop hook `hooks/check-no-pleasantries.mjs`, which blocks a reply that
+contains a banned term and asks for a plain restatement.
+
+### Banned-term dictionary (every reply, all agents)
+
+The Stop hook `hooks/check-no-pleasantries.mjs` holds the canonical list and is the source of
+truth; if this copy and the hook ever differ, the hook wins. Keep the two in sync — when you
+change one, change the other. The hook scans the whole reply and matches the term even inside
+quotes, so do not reach for a banned word even to talk about it; use the replacement below instead.
+
+**Pleasantries, feelings, and sign-offs — never use any of these (in any reply):**
+
+- thanks / thank you
+- you're welcome / you are welcome
+- no problem
+- my pleasure
+- glad
+- happy to
+- excited
+- delighted
+- sorry
+- apology / apologies / apologize / apologise (any form)
+- cheers
+- congrats / congratulations
+- "I appreciate" / "we appreciate" (only the first-person form is banned; "the rate appreciates" is fine)
+- "hope this / hope that / hope you / hope it …"
+- feel free
+- warm / best / kind / kindest regards
+- looking forward
+
+**Excluded vocabulary — banned word → use instead:**
+
+- flywheel → a plain description of the loop (for example "each answer improves the next")
+- punch list → list
+- (the word for out-of-date) → drop it; if you mean something specific, name it (out-of-date, superseded, no longer current)
+- console → dashboard (the code identifiers `console.log` / `console.error` / `console.info` are exempt)
+
+When the hook blocks a reply, restate the result in plain, factual language — none of the terms
+above, no jargon, no first-person feeling words — then stop.
+
+---
+
+## Plain language — no jargon (Critical — all agents)
+
+Write in plain, everyday language. **Do not use jargon, acronyms, or insider terminology** in
+human-facing output — chat replies, pull-request titles and descriptions, review comments, commit
+messages, issue comments, and documentation. Jargon is a distraction and is confusing; it slows the
+reader down and hides meaning.
+
+- **Default to simple words.** Prefer the plain term over the technical or marketing one (for example
+  "test it before you rely on it" over "validate end-to-end"; "make sure" over "ensure idempotency";
+  "the background service" over "the daemon"). Write so a non-specialist can follow.
+- **If a technical term is genuinely necessary, define it in plain words on first use** — one short
+  parenthetical is enough. Do not assume the reader knows acronyms; spell them out the first time.
+- **Explain, don't just name.** Say what something does and why it matters, not only its label.
+- **Exempt:** real code identifiers, file paths, command names, and established proper nouns (service
+  names, library names) — name those accurately; just don't pile extra jargon around them.
+- Applies to **every agent** and all human-facing communication. When in doubt, choose the wording a
+  newcomer would understand.
+
+---
+
+## Task planning — no "phases" (Critical)
+
+Do **not** organize work into "phases." No "Phase 0 / Phase 1 / Phase 2", no phased-rollout buckets —
+anywhere: plans, checklists, design notes, code comments, pull-request descriptions, or commit
+messages. Phases confuse humans and agents alike.
+
+Instead, when given an objective, break it into discrete tasks and **list them one after another in
+the order they must happen**. Where order matters, state it as an explicit blocking dependency, not a
+phase:
+
+- ✅ "Task B is blocked by Task A — do A first."
+- ✅ A flat, ordered, numbered task list (1, 2, 3 …) where each item may name what it depends on.
+- ❌ "Phase 1: …", "Phase 2: …", "do this in a later phase."
+
+A task with no dependency can be done at any time or in parallel; say so plainly ("no dependencies;
+can run anytime").
+
+---
+
+## Branch naming (all agents)
+
+- Always create a descriptive, task-named branch and develop on it. Use a Conventional-Commit-style
+  prefix plus a short kebab-case summary of the task: for example `feat/user-auth-refresh`,
+  `fix/csv-export-dedup`, `chore/ci-node-version-bump`, `docs/readme-quickstart`.
+- Never develop on, commit to, or open a pull request from an auto-generated session branch (an opaque
+  name like `claude/loving-mendel-wwWF4`). Treat it as a throwaway base: immediately branch off it (or
+  off the default branch) to a descriptive name and push from the descriptive branch.
+- Branch names must describe the task at hand — never an opaque or random string.
+
+---
+
+## Search tooling (optional convenience)
+
+- Prefer `rg` (ripgrep) for recursive text and file discovery.
+- Keep a grep fallback in scripts and prompts where a search command is shown, so they run anywhere:
+  - `if command -v rg >/dev/null 2>&1; then rg -n "pattern" path; else grep -RIn "pattern" path; fi`
+
+---
+
+## What this template deliberately leaves out
+
+Everything below was project-specific in the source codebase and is **not** included here. Add the
+ones your new repo needs under the placeholder section, in your own words:
+
+- Design-pass / mockup gating and any design-system rules.
+- Product, feature, plugin, and domain rules.
+- Repository layout, module-boundary, and file-size rules.
+- Database schema, migration, and data-model rules.
+- Integration/auth/observability/provider rules (the specific services a product uses).
+- Continuous-integration job names, pull-request parity checks, and release conventions.
+- Any rules-index / precedence list that points at project rule files.
+
+---
+
+## <PROJECT-SPECIFIC RULES — fill this in for the new repo>
+
+Add this repository's own rules here (architecture, stack, testing, release, domain constraints).
+Keep them under their own headings below this line. The sections above are intended to stay
+unchanged across repos; this section is where each repo differs.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,38 @@
+# Portable agent-instructions template
+
+A project-agnostic starter so a **new repository** keeps the same writing voice and banned-term
+dictionary without re-deriving them each time. It is distilled from this codebase's agent rules,
+with every project-specific rule removed (design-pass gating, product/plugin rules, schema and
+migration rules, continuous-integration conventions, and the like). What stays is the part that
+should be identical in every repo: the plain-voice rule, the banned-term dictionary, and a few
+general process rules.
+
+## What's in this folder
+
+| File | What it is |
+|---|---|
+| `AGENTS.md` | The instructions themselves. Copy into the new repo (as its `CLAUDE.md` or `AGENTS.md`). Ends with a placeholder for that repo's own rules. |
+| `hooks/check-no-pleasantries.mjs` | The Stop hook that enforces the voice rule and the dictionary. This file is the canonical list. |
+| `settings.example.json` | The `.claude/settings.json` snippet that registers the Stop hook. |
+
+## Use it in a new repo
+
+1. Copy `AGENTS.md` to the new repo's root as `CLAUDE.md` (or `AGENTS.md`).
+2. Copy `hooks/check-no-pleasantries.mjs` to the new repo at `.claude/hooks/check-no-pleasantries.mjs`.
+3. Register the Stop hook: merge `settings.example.json` into the new repo's `.claude/settings.json`
+   (create the file if it does not exist). The command path is `node .claude/hooks/check-no-pleasantries.mjs`.
+4. Fill in the `<PROJECT-SPECIFIC RULES>` section at the bottom of the copied `AGENTS.md` with that
+   repo's own rules. Leave the voice, dictionary, and process sections above it unchanged.
+
+That is enough for the dictionary to apply from the first session: the model reads `CLAUDE.md` at
+startup, and the Stop hook blocks any reply that breaks the voice rule and asks for a plain restatement.
+
+## Keeping the two copies in step
+
+`AGENTS.md` documents the dictionary for humans; `hooks/check-no-pleasantries.mjs` enforces it. If you
+add or remove a term, change both. When they disagree, the hook is the source of truth.
+
+## What was left out on purpose
+
+Project-specific rules are not carried here — see the "What this template deliberately leaves out"
+section in `AGENTS.md` for the list. Add the ones a new repo needs under that file's placeholder.

--- a/agents/hooks/check-no-pleasantries.mjs
+++ b/agents/hooks/check-no-pleasantries.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Stop hook: enforce the plain-voice rule (see AGENTS.md "Voice — no pleasantries, no feelings").
+// If the assistant's last reply contains a pleasantry, sign-off, or first-person feeling word, block
+// the stop and ask for a plain restatement. Defensive by design: any error -> allow (never break a
+// session or hard-fail). Loop-safe: if we are already in a stop-hook continuation, do not re-block.
+//
+// This file is the canonical dictionary. AGENTS.md documents the same lists for humans; if the two
+// ever differ, this file wins. Copy this hook into a new repo's .claude/hooks/ and register it as a
+// Stop hook (see agents/README.md and agents/settings.example.json).
+import { readFileSync } from 'node:fs';
+
+// Tight list — clear pleasantries / sign-offs / feeling words. "appreciate" is matched only in the
+// "I/we appreciate" form so it does not trip on text like "the rate appreciates".
+const BANNED = [
+  /\bthanks\b/i,
+  /\bthank you\b/i,
+  /\byou(?:'|’| a)?re welcome\b/i,
+  /\bno problem\b/i,
+  /\bmy pleasure\b/i,
+  /\bglad\b/i,
+  /\bhappy to\b/i,
+  /\bexcited\b/i,
+  /\bdelighted\b/i,
+  /\bsorry\b/i,
+  /\bapolog(?:y|ies|ize|ise|izing|ising)\b/i,
+  /\bcheers\b/i,
+  /\bcongrat(?:s|ulations)\b/i,
+  /\b(?:i|we) (?:really |truly )?appreciate\b/i,
+  /\bhope (?:this|that|you|it)\b/i,
+  /\bfeel free\b/i,
+  /\b(?:warm|best|kind)(?:est)? regards\b/i,
+  /\blooking forward\b/i,
+];
+
+// Excluded vocabulary — jargon / misused words agents must not use. Each entry pairs the banned
+// term with its plain replacement so the block message can name what to use instead. Edit this list
+// to fit the new repo; keep AGENTS.md's copy in step with it.
+const VOCABULARY = [
+  { re: /\bflywheel\b/i, use: 'a plain description of the loop (e.g. "each answer improves the next")' },
+  { re: /\bpunch list\b/i, use: 'list' },
+  { re: /\bstale\b/i, use: 'drop it — it usually adds no value; if you mean something specific, name it (out-of-date, superseded, no longer current)' },
+  // "console" reads as developer jargon for a screen; say "dashboard". The negative lookahead skips
+  // the code identifiers console.log / console.error / console.info so quoting real code never trips.
+  { re: /\bconsole\b(?!\.\w)/i, use: 'dashboard' },
+];
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function lastAssistantText(transcriptPath) {
+  const raw = readFileSync(transcriptPath, 'utf8');
+  const lines = raw.split('\n').filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    let entry;
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+    if (entry.type !== 'assistant') continue;
+    const content = entry.message && entry.message.content;
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      return content
+        .filter((part) => part && part.type === 'text' && typeof part.text === 'string')
+        .map((part) => part.text)
+        .join('\n');
+    }
+    return '';
+  }
+  return '';
+}
+
+try {
+  const input = JSON.parse(readStdin() || '{}');
+  if (input.stop_hook_active) process.exit(0); // already retrying; do not loop
+  const text = input.transcript_path ? lastAssistantText(input.transcript_path) : '';
+  const pleasantry = BANNED.map((re) => text.match(re)).find(Boolean);
+  const vocab = VOCABULARY.map((entry) => {
+    const m = text.match(entry.re);
+    return m ? { term: m[0], use: entry.use } : null;
+  }).find(Boolean);
+
+  if (pleasantry) {
+    process.stdout.write(
+      JSON.stringify({
+        decision: 'block',
+        reason:
+          `The reply contains a banned pleasantry/feeling/sign-off ("${pleasantry[0]}"). ` +
+          'Restate the result in plain, factual language — no thanks, apologies, well-wishes, ' +
+          'sign-offs, jargon, or first-person feeling words — then stop.',
+      }),
+    );
+  } else if (vocab) {
+    process.stdout.write(
+      JSON.stringify({
+        decision: 'block',
+        reason:
+          `The reply uses a banned word ("${vocab.term}"). Use instead: ${vocab.use}. ` +
+          'Restate in plain language, then stop.',
+      }),
+    );
+  }
+} catch {
+  // Never block on error.
+}
+process.exit(0);

--- a/agents/settings.example.json
+++ b/agents/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/check-no-pleasantries.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a project-agnostic `agents/` template so a **new repository** keeps the same writing voice and banned-term dictionary without re-deriving them each time. You can start a new repo, copy these three files in, and prompt from that repo's own Claude Code chat — no need to come back here for the rules.

## What's in `agents/`
- **`AGENTS.md`** — the instructions to copy into a new repo (as its `CLAUDE.md`/`AGENTS.md`): the no-pleasantries voice rule, the full banned-term dictionary, the plain-language/no-jargon rule, the no-"phases" task-planning rule, and branch-naming + search-tooling notes. Ends with a placeholder for that repo's own rules.
- **`hooks/check-no-pleasantries.mjs`** — a generalized copy of this repo's Stop hook (the canonical dictionary), with the project-specific comments removed.
- **`settings.example.json`** — the `.claude/settings.json` snippet that registers the Stop hook.
- **`README.md`** — four-step "use it in a new repo" instructions and a note on keeping the doc copy and the hook in step.

## Deliberately left out (project-specific)
Design-pass gating (the example you named), product/plugin/domain rules, repo-layout and file-size rules, schema/migration rules, integration/auth/observability rules, and CI job/parity conventions. The kept rules are the voice, the dictionary, and general process discipline.

## Notes
- New top-level `agents/` folder, separate from the CTF-specific `ctf/agents/` agent set.
- Nothing here is wired into the app or CI — it's reference files only.
- Validated: hook passes `node --check`, the JSON parses, all files end with a single newline.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_