### PR TITLE
docs: document announcements membership-events route

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-announcements-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-announcements-feature-inventory.md
@@ -106,6 +106,7 @@ Admin routes:
 - `POST /api/announcements/admin/:announcementId/publish`
 - `POST /api/announcements/admin/:announcementId/archive`
 - `POST /api/announcements/admin/targeting/validate`
+- `POST /api/announcements/membership/events` — records a member join/leave membership event so announcement audience eligibility can be recalculated; admin-gated (`requireFeedAdminAccess`) + CSRF (`x-ctf-csrf: '1'`). Body `{ userId, pluginId, eventType: 'join' | 'leave', requestId?, traceId? }` (`eventType` defaults to `join`; `userId` and `pluginId` required, else 400). Shares the feed membership-events handler (`emitMembershipEvent`, contracts unified under `feed.*`) and returns `{ ok, streamEmitted }` — the announcements-namespaced twin of `POST /api/feed/membership/events`.
 
 ---
 
@@ -199,6 +200,7 @@ references them, so they are removed here to match the real data model.
 
 ## 11) Change Log
 
+- 2026-06-25: **Documented the membership-events route** (inventory-debt burn-down — documentation catch-up, no code change). Added `POST /api/announcements/membership/events` (admin-gated join/leave membership event for audience recalculation; the announcements-namespaced twin of the feed membership-events handler) to §3.2 Admin routes. Verified against the route handler. Removed it from `ctf/scripts/inventory-drift-allowlist.json`.
 - 2026-05-18: Replaced "Web and Android Delivery Plan (Approved)" with canonical "Web and Android Delivery Status" (`web+android complete`); removed web-first/Android-follow-up language. Renamed "Gaps, Ambiguities, and Known Technical Debt (Current)" to canonical "Gaps and Known Technical Debt" and condensed deprecation note. Updated seed coverage to reference shipping seed script.
 - 2026-04-05: Deprecated standalone announcements namespace — all contracts unified under `feed.*`.
 - 2026-02-25: Added Rule 120 gaps section.

--- a/ctf/scripts/inventory-drift-allowlist.json
+++ b/ctf/scripts/inventory-drift-allowlist.json
@@ -2,7 +2,6 @@
   "_README": "Existing-inventory-drift baseline for check-inventory-drift.mjs. Tables/routes here are documented in NO feature inventory as of this gate. This is a BURN-DOWN list: it must only shrink — document the item in the right inventory and delete it from here. Never add a NEW table/route to silence the gate; document it instead. Some routes are non-plugin/infra (health, internal, admin) that belong in ctf-non-plugin-feature-inventory.md.",
   "tables": [],
   "routes": [
-    "/api/announcements/membership/events",
     "/api/chyme/service-credits",
     "/api/socketrelay/service-credits"
   ]


### PR DESCRIPTION
## What

Inventory-debt burn-down — documentation catch-up, no code change. Documents the one undocumented announcements route in `ctf-announcements-feature-inventory.md`.

- **§3.2 Admin routes** — `POST /api/announcements/membership/events`: records a member join/leave membership event so announcement audience eligibility can be recalculated; admin-gated (`requireFeedAdminAccess`) + CSRF. Body `{ userId, pluginId, eventType: 'join' | 'leave', requestId?, traceId? }`. Shares the feed membership-events handler (`emitMembershipEvent`) — the announcements-namespaced twin of `POST /api/feed/membership/events`.

## Verification

Checked against the route handler (`app/api/announcements/membership/events/route.ts`). The drift-gate allowlist drops from 0 tables / 3 routes to **0 tables / 2 routes** (chyme + socketrelay service-credits routes remain). Locally:

- `node ctf/scripts/check-inventory-drift.mjs` → no drift
- `bash ctf/scripts/check-eof-format.sh` → passed

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFWfrWHRmPsCfMhBJpwMfM)_