### PR TITLE
fix: reflect real cross-plugin activity on a member's own profile

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-member-presence-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-member-presence-feature-inventory.md
@@ -65,8 +65,17 @@ the existing trust card rendered next to it so trust reads as peer social proof 
     post's current status. Keyed on `owner_user_id`.
 - A read API (`GET /api/presence/user/[userId]`) returns the active presence list for a member,
   gated to any signed-in member.
+- A self re-derivation (`lib/presence/derive.ts` → `refreshOwnPresence`) rebuilds one member's index
+  straight from the same source tables the live hooks and the original backfill used, then returns the
+  active list. It is best-effort and self-contained: a source whose table is missing or unavailable is
+  skipped (its existing index rows are left untouched, never deactivated), so the recompute can only
+  add back missing rows and retire rows whose source listing is genuinely gone — it can never wipe the
+  index because of a transient read failure. Exposed at `GET /api/presence/user/self`.
 - The Directory profile detail (a client component) fetches presence and trust for the profile's
-  `claimed_by_user_id` and renders the "Also active in" section and the trust card beside it.
+  `claimed_by_user_id` and renders the "Also active in" section and the trust card beside it. For the
+  viewer's own profile it reads the refreshing `self` routes so both panels reflect the member's real
+  current activity instead of a frozen index/snapshot; for another member's profile it reads the
+  read-only by-id routes.
 
 ## Trust-beside-presence Decision
 
@@ -114,11 +123,19 @@ Notes on sources:
 
 - `GET /api/presence/user/[userId]` — returns `{ presence: Array<{ pluginSlug, refType, refId, label,
   deepLink }> }` for the member, active rows only, ordered by plugin then label. Gated to any
-  authenticated member (`requireTrustMemberAccess`). Read-only; no mutation route in this first cut.
+  authenticated member (`requireTrustMemberAccess`). Read-only; reads the shared index as written by
+  the live hooks. Used when a member views **another** member's profile.
+- `GET /api/presence/user/self` — re-derives the **caller's** presence from the live source tables
+  (`lib/presence/derive.refreshOwnPresence`), self-healing any index row a best-effort write dropped
+  or that predates the live hooks, then returns the active list in the same shape. Gated to any
+  authenticated member. This is the presence counterpart of `GET /api/trust/user/self`, which
+  recomputes the caller's trust signal on read. Used when a member views **their own** profile.
 
 The Directory profile read is unchanged at the API level: the detail component already receives the
 profile's `claimedByUserId` from the list payload, so presence and trust are fetched client-side from
-that id rather than embedded in a directory route.
+that id rather than embedded in a directory route. When the viewer owns the profile, the detail reads
+the refreshing `self` routes for both presence and trust; for another member's profile it reads the
+read-only by-id routes.
 
 ## Data Model and Storage Contracts
 
@@ -177,9 +194,13 @@ it current, so presence coverage follows the real data of the source plugins.
   create/remove path is added later, wire `recordMemberPresence` / `clearMemberPresence` on
   `provider_user_id` with the same `offer` ref type and "Offering rides" label the backfill uses.
 - Presence writes are best-effort and not part of the listing's database transaction: a presence write
-  that fails after the listing commits is logged and dropped, leaving the index momentarily stale until
-  the next write or backfill. This is intentional — the listing operation must never fail because of a
-  presence write.
+  that fails after the listing commits is logged and dropped, leaving the index momentarily out of date
+  until the next write. This is intentional — the listing operation must never fail because of a
+  presence write. The backfill that used to recover such gaps was removed, so recovery now comes from
+  `refreshOwnPresence`: a member viewing their own profile re-derives their presence from the source
+  tables, restoring any dropped or pre-hook row. A member who never views their own profile can still
+  have a gap until their next live write; a future pass could re-derive on a broader trigger (e.g. on
+  login) if needed.
 - Foundation presence is one row per offered skill, labeled generically; if a member offers many
   skills this could read as several identical "Provider offering" entries. A future pass could collapse
   Foundation to a single per-member entry.
@@ -212,6 +233,10 @@ Deferred follow-ups (not yet done):
    LightHouse host, the TrustTransport driver, and the Foundation provider — so presence and trust are
    visible where members actually meet, not only on the Directory profile.
 
+10. Self re-derivation on own-profile view. Added `lib/presence/derive.ts` (`refreshOwnPresence`) and
+    `GET /api/presence/user/self`; the Directory detail reads the `self` route for the viewer's own
+    profile so a dropped or pre-hook index row is restored from the source tables on read. Done.
+
 ## Change Log
 
 - 2026-06-21: First cut. Added `member_plugin_presence`, the presence repository, the backfill script,
@@ -232,3 +257,12 @@ Deferred follow-ups (not yet done):
   hooks keep the index current from here. The four source repositories' comments that pointed at the
   deleted script were reworded to describe the active-state rules inline. No code behavior or schema
   change.
+- 2026-06-25: Own-profile activity now reflects real participation on read. Two surfaces showed empty
+  even for an active member: the "Also active in" list (the index had no row — a best-effort write was
+  dropped or the listing predated the live hooks, with the backfill gone) and the Trust card (the
+  Directory detail read the non-refreshing by-id trust route, so it showed a frozen/empty snapshot).
+  Fix: added `lib/presence/derive.refreshOwnPresence` and `GET /api/presence/user/self` (re-derive the
+  caller's presence from the source tables, self-healing the index without ever wiping it on a
+  transient read failure), and switched the Directory detail to read the refreshing `self` routes for
+  both presence and trust when the viewer owns the profile. Another member's profile still reads the
+  read-only by-id routes. No schema change.

--- a/ctf/packages/web/app/api/presence/user/self/route.ts
+++ b/ctf/packages/web/app/api/presence/user/self/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { requireTrustMemberAccess } from 'lib/trust/_lib';
+import { getMemberPresence } from 'lib/presence/repository';
+import { refreshOwnPresence } from 'lib/presence/derive';
+import { reportError } from 'lib/observability/report';
+
+// GET /api/presence/user/self
+// Re-derive the CALLER's cross-plugin presence from the live source tables, self-healing any index
+// row that a best-effort write dropped or that predates the live write hooks, then return the active
+// list. This is the presence counterpart of GET /api/trust/user/self, which recomputes the caller's
+// trust signal on read. Auth-gated to any signed-in member; read-shaped (the recompute writes only
+// the caller's own presence rows, idempotently).
+export async function GET() {
+  const gate = await requireTrustMemberAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const userId = gate.auth.userId;
+
+  try {
+    const presence = await refreshOwnPresence(userId);
+    return NextResponse.json({ presence }, { status: 200 });
+  } catch (error) {
+    // A failed recompute must never break the member's own read: fall back to the last stored index
+    // so the panel still renders whatever rows already exist.
+    reportError(error, { area: 'presence', op: 'self_refresh' });
+    try {
+      const presence = await getMemberPresence(userId);
+      return NextResponse.json({ presence }, { status: 200 });
+    } catch (readError) {
+      reportError(readError, { area: 'presence', op: 'self_read' });
+      return NextResponse.json({ presence: [] }, { status: 200 });
+    }
+  }
+}

--- a/ctf/packages/web/components/directory/directory-profile-detail.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-detail.tsx
@@ -71,6 +71,12 @@ export function DirectoryProfileDetail({
   // Presence and the trust panel only apply to a claimed profile. Both are client fetches that
   // degrade quietly: a presence failure leaves the list empty (the section hides), and a trust
   // failure hides the trust panel — neither can crash the profile.
+  //
+  // When the viewer owns this profile, both panels read the refreshing "self" routes
+  // (/api/presence/user/self and /api/trust/user/self), which recompute from the member's real
+  // cross-plugin activity on read — so your own profile reflects what you have actually done instead
+  // of a frozen index/snapshot that nothing refreshed. Viewing someone else's profile keeps the
+  // read-only by-id routes (you never trigger a recompute of another member's data).
   useEffect(() => {
     if (!claimedUserId) {
       setPresence([]);
@@ -82,7 +88,10 @@ export function DirectoryProfileDetail({
 
     async function loadPresence(userId: string) {
       try {
-        const res = await fetch(`/api/presence/user/${encodeURIComponent(userId)}`, { signal: controller.signal });
+        const url = isOwnProfile
+          ? `/api/presence/user/self`
+          : `/api/presence/user/${encodeURIComponent(userId)}`;
+        const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) return;
         const data = (await res.json()) as { presence?: PresenceEntry[] };
         if (!controller.signal.aborted) setPresence(data.presence ?? []);
@@ -94,7 +103,10 @@ export function DirectoryProfileDetail({
     async function loadTrust(userId: string) {
       setTrustState({ kind: "loading" });
       try {
-        const res = await fetch(`/api/trust/user/${encodeURIComponent(userId)}`, { signal: controller.signal });
+        const url = isOwnProfile
+          ? `/api/trust/user/self`
+          : `/api/trust/user/${encodeURIComponent(userId)}`;
+        const res = await fetch(url, { signal: controller.signal });
         if (controller.signal.aborted) return;
         if (res.status === 403) {
           // The member limits who can view their trust details — a calm state, not an error.
@@ -116,7 +128,7 @@ export function DirectoryProfileDetail({
     void loadTrust(claimedUserId);
 
     return () => controller.abort();
-  }, [claimedUserId]);
+  }, [claimedUserId, isOwnProfile]);
   const profileUrl = p.profileUrl?.trim() ? p.profileUrl.trim() : null;
   const headline = p.headline?.trim() ? p.headline.trim() : null;
   const bio = p.bio?.trim() ? p.bio.trim() : null;

--- a/ctf/packages/web/lib/presence/derive.ts
+++ b/ctf/packages/web/lib/presence/derive.ts
@@ -1,0 +1,203 @@
+import { queryDb } from 'lib/db/postgres';
+import {
+  deactivateMemberPresence,
+  getMemberPresence,
+  upsertMemberPresence,
+  type MemberPresenceEntry,
+} from './repository';
+
+// Self-heal re-derivation of one member's cross-plugin presence.
+//
+// The shared index (member_plugin_presence) is normally kept current by each source plugin's live
+// write hooks. Those hooks are best-effort: a write that fails after the listing commits is logged
+// and dropped, and any listing made before the hooks shipped was only ever seeded by the one-time
+// backfill, which has been removed. That leaves no recovery path for a missing row.
+//
+// This module rebuilds the index for a SINGLE member straight from the same source tables the live
+// hooks and the original backfill used, so a member's own "Also active in" list always reflects their
+// real current listings even if an index row was dropped or never written. It is the presence
+// equivalent of the trust "self" route, which recomputes the caller's signal on read.
+
+// A presence row that SHOULD be active right now for this member, derived from a source table.
+interface DesiredPresenceRow {
+  pluginSlug: string;
+  refType: string;
+  refId: string;
+  label: string;
+  deepLink: string;
+}
+
+// One source the re-derivation reads. `slug` lets reconciliation deactivate only within sources that
+// were read successfully, so a briefly-missing source table never wipes another plugin's rows.
+interface PresenceSource {
+  slug: string;
+  read: (userId: string) => Promise<DesiredPresenceRow[]>;
+}
+
+// TrustTransport `status` is free text with no schema-level enum, so "active" is everything that is
+// not one of these terminal states — mirroring the original backfill rather than guessing the active
+// set. Kept in sync with the live TrustTransport write hooks.
+const TRUSTTRANSPORT_TERMINAL_STATUSES = [
+  'cancelled',
+  'canceled',
+  'completed',
+  'closed',
+  'withdrawn',
+  'declined',
+  'expired',
+  'rejected',
+];
+
+const PRESENCE_SOURCES: PresenceSource[] = [
+  {
+    slug: 'lighthouse',
+    read: async (userId) => {
+      const result = await queryDb<{ id: string }>(
+        `SELECT id::text AS id FROM lighthouse_properties WHERE host_user_id = $1 AND is_active = TRUE`,
+        [userId],
+      );
+      return result.rows.map((row) => ({
+        pluginSlug: 'lighthouse',
+        refType: 'property',
+        refId: row.id,
+        label: 'Housing listing',
+        deepLink: '/apps/lighthouse',
+      }));
+    },
+  },
+  {
+    slug: 'trusttransport',
+    read: async (userId) => {
+      const [requests, offers] = await Promise.all([
+        queryDb<{ id: string }>(
+          `SELECT id::text AS id FROM trusttransport_requests
+           WHERE requester_user_id = $1 AND LOWER(status) <> ALL($2::text[])`,
+          [userId, TRUSTTRANSPORT_TERMINAL_STATUSES],
+        ),
+        queryDb<{ id: string }>(
+          `SELECT id::text AS id FROM trusttransport_offers
+           WHERE provider_user_id = $1 AND LOWER(status) <> ALL($2::text[])`,
+          [userId, TRUSTTRANSPORT_TERMINAL_STATUSES],
+        ),
+      ]);
+      return [
+        ...requests.rows.map((row) => ({
+          pluginSlug: 'trusttransport',
+          refType: 'request',
+          refId: row.id,
+          label: 'Ride request',
+          deepLink: '/apps/trusttransport',
+        })),
+        ...offers.rows.map((row) => ({
+          pluginSlug: 'trusttransport',
+          refType: 'offer',
+          refId: row.id,
+          label: 'Offering rides',
+          deepLink: '/apps/trusttransport',
+        })),
+      ];
+    },
+  },
+  {
+    slug: 'foundation',
+    read: async (userId) => {
+      const result = await queryDb<{ skill_id: string }>(
+        `SELECT skill_id::text AS skill_id FROM foundation_provider_skills WHERE user_id = $1`,
+        [userId],
+      );
+      return result.rows.map((row) => ({
+        pluginSlug: 'foundation',
+        refType: 'provider-skill',
+        refId: row.skill_id,
+        label: 'Provider offering',
+        deepLink: '/apps/foundation',
+      }));
+    },
+  },
+  {
+    slug: 'socketrelay',
+    read: async (userId) => {
+      const result = await queryDb<{ id: string }>(
+        `SELECT id::text AS id FROM socketrelay_requests WHERE owner_user_id = $1 AND status = 'open'`,
+        [userId],
+      );
+      return result.rows.map((row) => ({
+        pluginSlug: 'socketrelay',
+        refType: 'post',
+        refId: row.id,
+        label: 'Help post',
+        deepLink: '/apps/socketrelay',
+      }));
+    },
+  },
+];
+
+function presenceKey(slug: string, refType: string, refId: string): string {
+  return `${slug}:${refType}:${refId}`;
+}
+
+// Rebuild the member's presence index from the live source tables, then return the current active
+// list. Best-effort and self-contained: a source whose table is missing/unavailable is skipped (its
+// existing index rows are left untouched, never deactivated), so re-derivation can only add back
+// missing rows and retire ones whose source listing is genuinely gone — it can never wipe the index
+// because of a transient read failure. Reconciliation only touches sources that read cleanly.
+export async function refreshOwnPresence(userId: string): Promise<MemberPresenceEntry[]> {
+  const trimmed = userId.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  const desired: DesiredPresenceRow[] = [];
+  const reconciledSlugs = new Set<string>();
+
+  for (const source of PRESENCE_SOURCES) {
+    try {
+      const rows = await source.read(trimmed);
+      desired.push(...rows);
+      // Only a source we read without error is safe to reconcile (deactivate stale rows within).
+      reconciledSlugs.add(source.slug);
+    } catch {
+      // Missing table or transient failure: skip this source so we neither add nor remove its rows.
+    }
+  }
+
+  const desiredKeys = new Set(desired.map((row) => presenceKey(row.pluginSlug, row.refType, row.refId)));
+
+  // Deactivate any currently-active index rows that the source no longer backs — but only for the
+  // plugins whose source read succeeded, so a skipped source never loses its rows.
+  try {
+    const current = await queryDb<{ plugin_slug: string; ref_type: string; ref_id: string }>(
+      `SELECT plugin_slug, ref_type, ref_id FROM member_plugin_presence WHERE user_id = $1 AND is_active = TRUE`,
+      [trimmed],
+    );
+    for (const row of current.rows) {
+      if (!reconciledSlugs.has(row.plugin_slug)) {
+        continue;
+      }
+      if (!desiredKeys.has(presenceKey(row.plugin_slug, row.ref_type, row.ref_id))) {
+        await deactivateMemberPresence({
+          userId: trimmed,
+          pluginSlug: row.plugin_slug,
+          refType: row.ref_type,
+          refId: row.ref_id,
+        });
+      }
+    }
+  } catch {
+    // If the index itself is unavailable, fall through: the upserts below will surface the error and
+    // the caller's read handles an empty result. Nothing was deactivated.
+  }
+
+  for (const row of desired) {
+    await upsertMemberPresence({
+      userId: trimmed,
+      pluginSlug: row.pluginSlug,
+      refType: row.refType,
+      refId: row.refId,
+      label: row.label,
+      deepLink: row.deepLink,
+    });
+  }
+
+  return getMemberPresence(trimmed);
+}


### PR DESCRIPTION
## What and why

A member viewing their **own** Directory provider profile saw "No activity in other plugins yet" and "No trust signals yet" even when they had real activity (offerings in LightHouse, Foundation, and SocketRelay, and a completed profile). Both panels were reading frozen data:

- **"Also active in"** reads the shared presence index (`member_plugin_presence`), which is now written only by live hooks going forward. The one-time backfill was removed, so any listing made before the hooks shipped — or a dropped best-effort write — was permanently missing with no recovery path.
- **Trust card** fetched the non-refreshing by-id trust route (`/api/trust/user/[userId]`) for every profile, so an owner saw only their last stored snapshot, which is empty if it was never refreshed from that path.

## The fix

Mirrors the existing trust "self route" pattern: when the viewer owns the profile, recompute both panels live.

- Add `lib/presence/derive.refreshOwnPresence` — re-derives a member's presence from the same source tables the live hooks and the original backfill used, self-healing the index. Best-effort and self-contained: a source whose table is unavailable is skipped (its rows are never deactivated), so a transient read failure can never wipe the index; it only adds back missing rows and retires rows whose source listing is genuinely gone.
- Add `GET /api/presence/user/self` — the presence counterpart of the existing `GET /api/trust/user/self`.
- Directory profile detail reads the refreshing `self` routes for both presence and trust when the viewer owns the profile; another member's profile still reads the read-only by-id routes (you never trigger a recompute of someone else's data).
- Updated the member-presence feature inventory to match.

## Note on SocketRelay

Presence for SocketRelay counts help posts a member **created** (status open), per the original owner-locked mapping. If "making an offering" means fulfilling someone else's request, that is not counted as presence by design — left unchanged here to avoid expanding an owner-locked decision.

## Verification

- `pnpm --filter @ctf/web typecheck` — pass
- `pnpm --filter @ctf/web lint` — pass
- `pnpm --filter @ctf/web build:ci` — pass (both `/api/presence/user/[userId]` and `/api/presence/user/self` registered)
- `pnpm --dir ctf check:inventory-drift` — pass
- `ctf/scripts/check-eof-format.sh` — pass

Parity Status: web + mobile-responsive + android complete

The change is backend (new read route + re-derivation module) plus a one-line endpoint swap in the already-mobile-responsive Directory detail; there is no new UI. The Android app has no Directory-profile presence surface (deferred at the feature's first cut), so there is no Android work for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5uLtPSq5izLNe7EDgV5RR)_