### PR TITLE
fix: workforce code-review bugs — dashboard 401/403, report leak, dashboard audit

### DIFF
--- a/ctf/packages/mobile/src/features/workforce/admin-api.ts
+++ b/ctf/packages/mobile/src/features/workforce/admin-api.ts
@@ -43,7 +43,13 @@ export async function fetchAdminOverview(): Promise<WorkforceOverviewResult> {
     authedFetch(`${API_ROOT}/dashboard`, { headers: jsonHeaders() }),
   ]);
 
-  if (configRes.status === 401 || configRes.status === 403) {
+  // Either endpoint returning 401/403 means the viewer is not an admin (or the token expired between the
+  // two parallel calls). Check the dashboard the same way as the config — otherwise a config that loads
+  // while the dashboard is forbidden would silently render the admin panel with a missing snapshot.
+  if (
+    configRes.status === 401 || configRes.status === 403 ||
+    dashboardRes.status === 401 || dashboardRes.status === 403
+  ) {
     return { ok: false, forbidden: true, config: null, dashboard: null, message: 'Admin access is required.' };
   }
   if (!configRes.ok) {
@@ -66,7 +72,9 @@ export async function fetchAdminOverview(): Promise<WorkforceOverviewResult> {
     forbidden: false,
     config: configData.config ?? null,
     dashboard: dashboardData.dashboard ?? null,
-    message: null,
+    // A non-auth dashboard failure (e.g. 500) still loads the config, but say so instead of showing a
+    // silently-empty snapshot.
+    message: dashboardRes.ok ? null : `Could not load the dashboard snapshot (${dashboardRes.status}).`,
   };
 }
 

--- a/ctf/packages/web/app/api/workforce/dashboard/route.ts
+++ b/ctf/packages/web/app/api/workforce/dashboard/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireWorkforceReadAccess } from 'lib/workforce/_lib';
 import { WORKFORCE_ERROR_CODE } from 'lib/workforce/constants';
 import { getDashboard } from 'lib/workforce/repository';
+import { logWorkforceAudit } from 'lib/workforce/audit';
 import { reportError } from 'lib/observability/report';
 
 export async function GET() {
@@ -12,6 +13,19 @@ export async function GET() {
 
   try {
     const dashboard = await getDashboard();
+    // The audit contract requires a workforce.dashboard.fetch event on every read (the dashboard returns
+    // only projected counts). Mirrors the admin config route's audit shape.
+    logWorkforceAudit({
+      actorId: gate.auth.userId,
+      command: 'workforce.dashboard.fetch',
+      status: 'allow',
+      reason: 'read_route_guard',
+      targetType: 'dashboard',
+      targetId: 'workforce',
+      result: 'success',
+      errorCategory: null,
+      metadata: { evidence: { roleCheck: 'pass', projectionOnlyCheck: 'pass' } },
+    });
     return NextResponse.json({ dashboard }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'workforce', op: 'dashboard' });

--- a/ctf/packages/web/app/api/workforce/reports/sector/[sector]/route.ts
+++ b/ctf/packages/web/app/api/workforce/reports/sector/[sector]/route.ts
@@ -17,8 +17,14 @@ export async function GET(_request: Request, { params }: { params: Promise<{ sec
   try {
     const items = await fetchSectorReport();
     const normalizedSector = sector.toLowerCase();
+    // `all` returns the full breakdown (the dashboard uses this); a specific sector returns only its own
+    // bucket, so a single-sector request never leaks the whole cross-sector dataset. Output is `{ items }`
+    // per the workforce.report.sector.fetch contract in both cases.
+    if (normalizedSector === 'all') {
+      return NextResponse.json({ items }, { status: 200 });
+    }
     const bucket = items.find((item) => item.bucket.toLowerCase() === normalizedSector) ?? null;
-    return NextResponse.json({ bucket, items }, { status: 200 });
+    return NextResponse.json({ items: bucket ? [bucket] : [] }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'workforce', op: 'reports_sector_sector' });
     return NextResponse.json(

--- a/ctf/packages/web/app/api/workforce/reports/skill-level/[skillLevel]/route.ts
+++ b/ctf/packages/web/app/api/workforce/reports/skill-level/[skillLevel]/route.ts
@@ -16,8 +16,15 @@ export async function GET(_request: Request, { params }: { params: Promise<{ ski
 
   try {
     const items = await fetchSkillLevelReport();
-    const bucket = items.find((item) => item.bucket === skillLevel.toLowerCase()) ?? null;
-    return NextResponse.json({ bucket, items }, { status: 200 });
+    const normalizedSkillLevel = skillLevel.toLowerCase();
+    // `all` returns the full breakdown (the dashboard uses this); a specific skill level returns only its
+    // own bucket, so a single-level request never leaks the whole cross-level dataset. Output is `{ items }`
+    // per the workforce.report.skillLevel.fetch contract in both cases.
+    if (normalizedSkillLevel === 'all') {
+      return NextResponse.json({ items }, { status: 200 });
+    }
+    const bucket = items.find((item) => item.bucket === normalizedSkillLevel) ?? null;
+    return NextResponse.json({ items: bucket ? [bucket] : [] }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'workforce', op: 'reports_skill_level_skilllevel' });
     return NextResponse.json(


### PR DESCRIPTION
Three validated, low-risk workforce fixes from the code-review sweep.

**Closes #846** — `fetchAdminOverview` (mobile `admin-api.ts`) only checked `configRes` for 401/403; a `dashboardRes` 401/403 (token expiring between the two parallel calls, or a stricter gate) was swallowed to `null` and the admin panel rendered with a silently-missing snapshot. Now the dashboard is checked the same way as the config, and a non-auth dashboard failure reports a message instead of an empty snapshot.

**Closes #826** — the parameterised `reports/sector/[sector]` and `reports/skill-level/[skillLevel]` routes returned `{ bucket, items }`, leaking the full cross-segment breakdown on every single-segment request. They now return `{ items }` per the contract: all buckets for the `all` segment (the dashboard's existing use — it reads only `.items`), and just the matched bucket for a specific segment. No consumer change needed.

**Closes #840** — `GET /api/workforce/dashboard` emitted no audit; added the `workforce.dashboard.fetch` event the audit contract requires, mirroring the admin config route's shape.

Validated: web + mobile typecheck, web + mobile lint, EOF all pass; the pre-push hook ran the full build.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_