### PR TITLE
fix: address whatworks code-review findings (audit, teaser stats, mobile public, slug bound, projection)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-whatworks-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-whatworks-feature-inventory.md
@@ -52,7 +52,7 @@ the problem categories and review every suggestion before it joins the shared li
 ## 5. API Surface and Route Map
 
 - `GET /api/whatworks` — Authenticated read of the shared list (problems + approved tools + per-viewer endorsement state + stats + `viewer.isAdmin`).
-- `GET /api/whatworks/public` — Public, identity-free teaser slice of the list + stats.
+- `GET /api/whatworks/public` — Public, identity-free teaser slice of the list + stats. The returned stats describe only the teaser slice (not the full list), so the public payload never advertises counts a signed-out visitor cannot see.
 - `GET /api/whatworks/problems` — Active problems for the suggest form (authenticated).
 - `POST /api/whatworks/products` — Suggest a tool (lands `pending`; suggester auto-recorded as first verifier).
 - `POST /api/whatworks/products/[id]/endorse` — Mark an approved tool helpful.
@@ -108,7 +108,14 @@ Derived metrics (no stored counters): a tool's verified count is `COUNT(*)` of i
   suggestions require an admin (`isAdmin`). Admin page redirects non-admins to `/apps/whatworks`.
 - CSRF: all mutations require `x-ctf-csrf: 1` and same-origin (`ensureMutationCsrf`).
 - Anonymity: `suggested_by` is stored for moderation/abuse control only and is excluded from every
-  reader and admin projection. No survivor identity is rendered anywhere in the plugin.
+  reader and admin projection. No survivor identity is rendered anywhere in the plugin. The
+  `getProductById` lookup selects an explicit column list that omits `suggested_by`/`reviewed_by`, so
+  those identity fields are never present on the returned object (defence in depth).
+- Audit: every command emits one structured audit line via `logWhatWorksAudit`
+  (`lib/whatworks/audit.ts`) on its success path — reads (`whatworks.list.read`,
+  `whatworks.public.read`, `whatworks.problems.list`, the two admin list reads), mutations
+  (suggest/endorse/unendorse), and all admin curation/moderation commands — matching every event
+  declared in the audit contract. The public read records `anonymous` as the actor.
 - Input validation: lengths and `http(s)`-only purchase URLs are enforced server-side.
 - Contracts: see
   [WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml](../../contracts/WHATWORKS_PLUGIN_COMMAND_CONTRACTS.yaml),
@@ -125,7 +132,10 @@ Derived metrics (no stored counters): a tool's verified count is `COUNT(*)` of i
   real (`/api/whatworks*`); no stub arrays in the production shells.
 - Android: complete. Expo feature at `packages/mobile/src/features/whatworks/` (list + Helpful
   toggle + suggest, against the `MobileWhatWorks*` references), registered in
-  `config/plugin-parity-contracts.json`. Pending on-device QA (no device runtime in the build env).
+  `config/plugin-parity-contracts.json`. A signed-out visitor sees `WhatWorksPublic` — the same
+  public teaser the web shows, fetched from `/api/whatworks/public` with no bearer token — instead of
+  an authed list that would 401 (parity with web). Pending on-device QA (no device runtime in the
+  build env).
 - Parity contract: [plugin-parity-contracts.json](../../../config/plugin-parity-contracts.json).
 
 ## 9. Seed Coverage Status
@@ -149,6 +159,20 @@ Derived metrics (no stored counters): a tool's verified count is `COUNT(*)` of i
 
 ## Change Log
 
+- 2026-06-26: Code-review batch (issues #931–#938). (1) Audit: added `lib/whatworks/audit.ts` and
+  emit one structured audit line per command on its success path across all `/api/whatworks/*` route
+  handlers, closing the gap where no command was logged against the audit contract (#931). (2) Public
+  read now scopes its returned `stats` to the teaser slice instead of the full list, so the signed-out
+  payload no longer advertises hidden counts (#934). (3) Mobile gains a `WhatWorksPublic` signed-out
+  teaser (fetched from `/api/whatworks/public`) so a signed-out visitor sees the public preview rather
+  than a 401, matching web (#935). (4) `getProductById` selects an explicit column list that omits the
+  `suggested_by`/`reviewed_by` identity fields (#936). (5) `ensureUniqueSlug` is now bounded (max 100
+  attempts, throws a clear error) instead of an unbounded `while (true)` (#937). Reviewed and not
+  changed: #932 (partial-update already preserves an omitted `context`/`emoji` via the
+  `undefined → null → COALESCE` path; sending an explicit empty string to clear is intended), #933
+  (every reader projection and the stats query already filter to `status = 'approved'`, so a
+  suggester's auto-endorsement on a later-rejected product is never counted), #938 (mobile already
+  leaves product state untouched on a failed toggle, so it stays consistent).
 - 2026-06-17: Restyled the `/admin/whatworks` surface (`ww-admin-shell`, `ww-admin-products`, `ww-admin-problems`) to the shared dark admin design system (icon header with `ADMIN` badge, dark panel/surface tokens, status pills, tinted action buttons) per rule 131. Visual only — no change to data, endpoints, or moderation actions. The mockup's invented submitter handles, upvote counts, and per-entry flag have no backing fields, so they were not added; the real four-value status filter and verified counts are kept. Web typecheck + eslint clean.
 - 2026-06-12: The Android What Works API client (`packages/mobile/src/features/whatworks/api.ts`) now uses the shared authenticated fetch helper — every call carries the signed-in member's Clerk bearer token and the server address comes from runtime config (APP_URL) — replacing plain dev-only fetch against a hardcoded development URL with an empty token.
 - 2026-05-31: Initial implementation. Schema (`whatworks_problems`, `whatworks_products`,

--- a/ctf/packages/mobile/src/features/whatworks/WhatWorksPublic.tsx
+++ b/ctf/packages/mobile/src/features/whatworks/WhatWorksPublic.tsx
@@ -1,0 +1,196 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View, Text, ScrollView, Pressable, ActivityIndicator, StyleSheet, Linking, Alert,
+} from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { fetchPublicList, type WhatWorksProblem } from './api';
+import { WW } from './theme';
+
+// Public/unauthenticated state — mirrors the web `WhatWorksPublic` flow. The shared list is
+// readable by anyone, so a signed-out visitor sees the same teaser slice the web shows
+// (from /api/whatworks/public, no bearer token) plus a sign-in/sign-up gate to see the full
+// list and to suggest. Closes the parity gap with web (issue #935).
+
+const TRUST: { icon: keyof typeof Ionicons.glyphMap; title: string; detail: string }[] = [
+  { icon: 'shield-checkmark-outline', title: 'Survivor-verified', detail: 'Used by a real member who said it helped.' },
+  { icon: 'ban-outline', title: 'No ads or affiliates', detail: 'Nothing here is sponsored.' },
+  { icon: 'lock-closed-outline', title: 'Anonymous', detail: 'Suggesting never reveals who you are.' },
+];
+
+async function openLink(url: string): Promise<void> {
+  try {
+    const supported = await Linking.canOpenURL(url);
+    if (!supported) {
+      Alert.alert('Could not open this link.');
+      return;
+    }
+    await Linking.openURL(url);
+  } catch {
+    Alert.alert('Could not open this link.');
+  }
+}
+
+export function WhatWorksPublic({ onSignIn }: { onSignIn?: () => void }) {
+  const [loading, setLoading] = useState(true);
+  const [problems, setProblems] = useState<WhatWorksProblem[]>([]);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchPublicList();
+      setProblems(data.problems ?? []);
+    } catch {
+      // The teaser is best-effort; a fetch failure just leaves the empty/sign-in gate.
+      setProblems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.header}>
+        <Ionicons name="list" size={17} color={WW.brand} />
+        <Text style={styles.headerTitle}>What Works</Text>
+        <View style={styles.verifiedBadge}>
+          <Ionicons name="checkmark-circle-outline" size={11} color={WW.brand} />
+          <Text style={styles.verifiedBadgeText}>Verified</Text>
+        </View>
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <Text style={styles.h1}>The tools that actually work.</Text>
+        <Text style={styles.lede}>
+          Pick a problem you&apos;re facing. Underneath it is a list of specific products a survivor here
+          bought, used, and said helped — each with a direct link to get it. No ads. No affiliates.
+        </Text>
+
+        <Pressable style={styles.joinBtn} onPress={onSignIn}>
+          <Ionicons name="person-add-outline" size={15} color={WW.brandInk} />
+          <Text style={styles.joinText}>Join to suggest items</Text>
+        </Pressable>
+
+        <View style={styles.trustCard}>
+          <Text style={styles.trustHeading}>Why trust this list?</Text>
+          {TRUST.map((item) => (
+            <React.Fragment key={item.title}>
+              <View style={styles.trustRow}>
+                <Ionicons name={item.icon} size={15} color={WW.brand} style={{ marginTop: 1 }} />
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.trustTitle}>{item.title}</Text>
+                  <Text style={styles.trustDetail}>{item.detail}</Text>
+                </View>
+              </View>
+            </React.Fragment>
+          ))}
+        </View>
+
+        <View style={styles.listHead}>
+          <Text style={styles.listHeadTitle}>A look at the list</Text>
+          <Text style={styles.listHeadNote}>publicly readable — no account needed to browse</Text>
+        </View>
+
+        {loading ? (
+          <View style={styles.center}><ActivityIndicator color={WW.brand} /></View>
+        ) : problems.length === 0 ? (
+          <Text style={styles.empty}>The list is just getting started. Be the first to add what worked for you.</Text>
+        ) : (
+          problems.map((problem) => (
+            <React.Fragment key={problem.id}>
+              <View style={{ marginTop: 18 }}>
+                <View style={styles.problemHead}>
+                  <View style={styles.problemEmoji}><Text style={styles.emoji}>{problem.emoji || '🧰'}</Text></View>
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.problemTitle}>{problem.title}</Text>
+                    {problem.context ? <Text style={styles.problemContext}>{problem.context}</Text> : null}
+                  </View>
+                </View>
+                {problem.products.map((product) => (
+                  <React.Fragment key={product.id}>
+                    <View style={styles.card}>
+                      <View style={styles.cardTop}>
+                        <View style={styles.emojiBox}><Text style={styles.emoji}>{product.emoji || '🧰'}</Text></View>
+                        <View style={{ flex: 1, minWidth: 0 }}>
+                          <Text style={styles.productName}>{product.name}</Text>
+                          {product.kind ? <Text style={styles.kind}>{product.kind}</Text> : null}
+                        </View>
+                      </View>
+                      {product.note ? <Text style={styles.note}>{`“${product.note}”`}</Text> : null}
+                      <View style={styles.cardRow}>
+                        <View style={styles.verifiedWrap}>
+                          <Ionicons name="shield-checkmark-outline" size={13} color={WW.brand} />
+                          <Text style={styles.verifiedText}>{product.verifiedCount} verified</Text>
+                        </View>
+                        <Pressable onPress={() => { void openLink(product.purchaseUrl); }} style={styles.viewBtn}>
+                          <Text style={styles.viewText}>View</Text>
+                          <Ionicons name="open-outline" size={12} color={WW.brand} />
+                        </Pressable>
+                      </View>
+                    </View>
+                  </React.Fragment>
+                ))}
+              </View>
+            </React.Fragment>
+          ))
+        )}
+
+        <View style={styles.ctaCard}>
+          <Text style={styles.ctaTitle}>See every problem — and add what worked for you</Text>
+          <Text style={styles.ctaDetail}>Create a free, verified account to view the full list and suggest the tools that helped you.</Text>
+          <Pressable style={styles.ctaBtn} onPress={onSignIn}>
+            <Text style={styles.ctaBtnText}>Get started</Text>
+            <Ionicons name="chevron-forward" size={14} color={WW.brandInk} />
+          </Pressable>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: WW.bg },
+  center: { paddingVertical: 24, alignItems: 'center', justifyContent: 'center' },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 16, paddingVertical: 12, backgroundColor: '#0D0F14', borderBottomWidth: 1, borderBottomColor: WW.border },
+  headerTitle: { fontSize: 16, fontWeight: '700', color: WW.text },
+  verifiedBadge: { marginLeft: 'auto', flexDirection: 'row', alignItems: 'center', gap: 4, paddingHorizontal: 9, paddingVertical: 3, borderRadius: 20, backgroundColor: 'rgba(132,204,22,0.12)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.3)' },
+  verifiedBadgeText: { fontSize: 10.5, fontWeight: '700', color: WW.brand },
+  h1: { fontSize: 21, fontWeight: '800', color: WW.text, marginBottom: 6 },
+  lede: { fontSize: 13, color: '#9CA3AF', lineHeight: 20 },
+  joinBtn: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 12, borderRadius: 10, backgroundColor: WW.brand, marginTop: 14 },
+  joinText: { fontSize: 14, fontWeight: '700', color: WW.brandInk },
+  trustCard: { marginTop: 16, padding: 16, borderRadius: 14, backgroundColor: WW.surface, borderWidth: 1, borderColor: WW.border },
+  trustHeading: { fontSize: 13, fontWeight: '700', color: WW.brand, marginBottom: 12 },
+  trustRow: { flexDirection: 'row', gap: 10, marginBottom: 10 },
+  trustTitle: { fontSize: 12.5, fontWeight: '600', color: WW.text, marginBottom: 2 },
+  trustDetail: { fontSize: 11.5, color: WW.subtle, lineHeight: 17 },
+  listHead: { marginTop: 22, flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 6 },
+  listHeadTitle: { fontSize: 13, fontWeight: '700', color: WW.text },
+  listHeadNote: { fontSize: 11.5, color: WW.subtle },
+  empty: { color: WW.subtle, marginTop: 16, fontSize: 13, lineHeight: 20 },
+  problemHead: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, marginBottom: 11 },
+  problemEmoji: { width: 34, height: 34, borderRadius: 10, backgroundColor: 'rgba(132,204,22,0.12)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.25)', alignItems: 'center', justifyContent: 'center' },
+  problemTitle: { fontSize: 14.5, fontWeight: '700', color: WW.text },
+  problemContext: { fontSize: 11.5, color: WW.subtle, lineHeight: 17, marginTop: 2 },
+  card: { padding: 13, borderRadius: 13, backgroundColor: WW.surface, borderWidth: 1, borderColor: WW.border, marginBottom: 10 },
+  cardTop: { flexDirection: 'row', gap: 11 },
+  emojiBox: { width: 44, height: 44, borderRadius: 10, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: WW.border, alignItems: 'center', justifyContent: 'center' },
+  emoji: { fontSize: 20 },
+  productName: { fontSize: 13.5, fontWeight: '700', color: WW.text },
+  kind: { fontSize: 11, color: WW.subtle },
+  note: { fontSize: 12, color: WW.quote, lineHeight: 18, marginTop: 9, fontStyle: 'italic' },
+  cardRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 11 },
+  verifiedWrap: { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  verifiedText: { fontSize: 11, color: WW.brand, fontWeight: '600' },
+  viewBtn: { flexDirection: 'row', alignItems: 'center', gap: 5, paddingHorizontal: 12, paddingVertical: 7, borderRadius: 8, backgroundColor: 'rgba(132,204,22,0.18)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.4)' },
+  viewText: { fontSize: 11.5, fontWeight: '700', color: WW.brand },
+  ctaCard: { marginTop: 24, padding: 18, borderRadius: 14, backgroundColor: 'rgba(132,204,22,0.06)', borderWidth: 1, borderColor: 'rgba(132,204,22,0.25)' },
+  ctaTitle: { fontSize: 15, fontWeight: '700', color: WW.text, marginBottom: 4 },
+  ctaDetail: { fontSize: 12.5, color: WW.subtle, lineHeight: 18 },
+  ctaBtn: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, paddingVertical: 11, borderRadius: 10, backgroundColor: WW.brand, marginTop: 14 },
+  ctaBtnText: { fontSize: 13.5, fontWeight: '700', color: WW.brandInk },
+});
+
+export default WhatWorksPublic;

--- a/ctf/packages/mobile/src/features/whatworks/WhatWorksTabs.tsx
+++ b/ctf/packages/mobile/src/features/whatworks/WhatWorksTabs.tsx
@@ -3,6 +3,8 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { WhatWorksList } from './WhatWorksList';
 import { WhatWorksSuggest } from './WhatWorksSuggest';
+import { WhatWorksPublic } from './WhatWorksPublic';
+import { useAuth } from '../../auth/auth-context';
 
 type WhatWorksTabParamList = {
   List: undefined;
@@ -17,6 +19,14 @@ const Tab = createBottomTabNavigator<WhatWorksTabParamList>();
 const TabNavigator = Tab.Navigator as React.ComponentType<any>;
 
 export function WhatWorksTabs() {
+  const { isAuthenticated, signIn } = useAuth();
+
+  // Signed-out visitors see the public teaser (matching web), not an authed list that 401s.
+  // The List/Suggest tabs both need a signed-in survivor, so they only mount once authenticated.
+  if (!isAuthenticated) {
+    return <WhatWorksPublic onSignIn={() => { void signIn(); }} />;
+  }
+
   return (
     <TabNavigator>
       <Tab.Screen

--- a/ctf/packages/mobile/src/features/whatworks/api.ts
+++ b/ctf/packages/mobile/src/features/whatworks/api.ts
@@ -1,6 +1,6 @@
 // All calls go through authedFetch so the Clerk bearer token is attached and the
 // base URL comes from runtime config (APP_URL) — same pattern as socketrelay/currency.
-import { authedFetchJson } from '../../auth/authedFetch';
+import { authedFetchJson, getApiBaseUrl } from '../../auth/authedFetch';
 
 export type WhatWorksProduct = {
   id: string;
@@ -28,6 +28,22 @@ export type WhatWorksProblemOption = { id: string; slug: string; emoji: string; 
 
 export async function fetchList(): Promise<{ problems: WhatWorksProblem[]; stats: WhatWorksStats }> {
   return authedFetchJson<{ problems: WhatWorksProblem[]; stats: WhatWorksStats }>('/api/whatworks');
+}
+
+// Public, sign-in-free teaser slice — mirrors the web public flow. Uses a plain fetch (no
+// bearer token) so a signed-out visitor sees the same readable preview the web shows.
+export async function fetchPublicList(): Promise<{ problems: WhatWorksProblem[]; stats: WhatWorksStats }> {
+  const response = await fetch(`${getApiBaseUrl()}/api/whatworks/public`);
+  const payload = (await response.json().catch(() => null)) as
+    | { problems?: WhatWorksProblem[]; stats?: WhatWorksStats }
+    | null;
+  if (!response.ok || !payload) {
+    throw new Error(`Network request failed: ${response.status}`);
+  }
+  return {
+    problems: payload.problems ?? [],
+    stats: payload.stats ?? { problems: 0, verifiedTools: 0, survivorsHelped: 0 },
+  };
 }
 
 export async function fetchProblems(): Promise<{ problems: WhatWorksProblemOption[] }> {

--- a/ctf/packages/mobile/src/features/whatworks/index.ts
+++ b/ctf/packages/mobile/src/features/whatworks/index.ts
@@ -1,1 +1,2 @@
 export * from './WhatWorksTabs';
+export { WhatWorksPublic } from './WhatWorksPublic';

--- a/ctf/packages/web/app/api/whatworks/admin/problems/[id]/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/problems/[id]/route.ts
@@ -9,6 +9,7 @@ import {
   requireWhatWorksAdminAccess,
   whatworksError,
 } from '../../../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -66,6 +67,16 @@ export async function PATCH(request: Request, context: RouteContext) {
   }
 
   const problem = await updateProblem(id, patch);
+  logWhatWorksAudit({
+    actorId: gate.auth.userId,
+    command: 'whatworks.admin.problem.update',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'problem',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+  });
   return NextResponse.json({ ok: true, problem });
 }
 
@@ -84,5 +95,15 @@ export async function DELETE(request: Request, context: RouteContext) {
     return whatworksError('That problem could not be found.', 'whatworks_problem_not_found', 404);
   }
   await deleteProblem(id);
+  logWhatWorksAudit({
+    actorId: gate.auth.userId,
+    command: 'whatworks.admin.problem.delete',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'problem',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+  });
   return NextResponse.json({ ok: true });
 }

--- a/ctf/packages/web/app/api/whatworks/admin/problems/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/problems/route.ts
@@ -8,6 +8,7 @@ import {
   requireWhatWorksAdminAccess,
   whatworksError,
 } from '../../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 
 export async function GET() {
   const gate = await requireWhatWorksAdminAccess();
@@ -15,6 +16,16 @@ export async function GET() {
     return gate.response;
   }
   const problems = await listAdminProblems();
+  logWhatWorksAudit({
+    actorId: gate.auth.userId,
+    command: 'whatworks.admin.problem.list',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'problem',
+    targetId: 'all',
+    result: 'success',
+    errorCategory: null,
+  });
   return NextResponse.json({ ok: true, problems });
 }
 
@@ -58,6 +69,16 @@ export async function POST(request: Request) {
     context,
     sortOrder,
     createdBy: gate.auth.userId,
+  });
+  logWhatWorksAudit({
+    actorId: gate.auth.userId,
+    command: 'whatworks.admin.problem.create',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'problem',
+    targetId: problem.id,
+    result: 'success',
+    errorCategory: null,
   });
   return NextResponse.json({ ok: true, problem }, { status: 201 });
 }

--- a/ctf/packages/web/app/api/whatworks/admin/products/[id]/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/products/[id]/route.ts
@@ -8,6 +8,7 @@ import {
   requireWhatWorksAdminAccess,
   whatworksError,
 } from '../../../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -45,6 +46,17 @@ export async function PATCH(request: Request, context: RouteContext) {
     reviewerId: gate.auth.userId,
     rejectionReason,
   });
+  logWhatWorksAudit({
+    actorId: gate.auth.userId,
+    command: 'whatworks.admin.product.review',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'product',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+    metadata: { action, status: product?.status ?? null },
+  });
   return NextResponse.json({ ok: true, status: product?.status ?? null });
 }
 
@@ -63,5 +75,15 @@ export async function DELETE(request: Request, context: RouteContext) {
     return whatworksError('That item could not be found.', 'whatworks_product_not_found', 404);
   }
   await deleteProduct(id);
+  logWhatWorksAudit({
+    actorId: gate.auth.userId,
+    command: 'whatworks.admin.product.delete',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'product',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+  });
   return NextResponse.json({ ok: true });
 }

--- a/ctf/packages/web/app/api/whatworks/admin/products/route.ts
+++ b/ctf/packages/web/app/api/whatworks/admin/products/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { listAdminProducts } from 'lib/whatworks/repository';
 import { isWhatWorksProductStatus } from 'lib/whatworks/constants';
 import { requireWhatWorksAdminAccess } from '../../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 
 // Moderation queue. Defaults to pending suggestions; `?status=` narrows the list.
 // Submitter identity is intentionally never returned — admins moderate content, not people.
@@ -14,5 +15,15 @@ export async function GET(request: Request) {
   const statusParam = url.searchParams.get('status');
   const status = statusParam && isWhatWorksProductStatus(statusParam) ? statusParam : undefined;
   const products = await listAdminProducts(status);
+  logWhatWorksAudit({
+    actorId: gate.auth.userId,
+    command: 'whatworks.admin.product.list',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'product',
+    targetId: status ?? 'all',
+    result: 'success',
+    errorCategory: null,
+  });
   return NextResponse.json({ ok: true, products });
 }

--- a/ctf/packages/web/app/api/whatworks/problems/route.ts
+++ b/ctf/packages/web/app/api/whatworks/problems/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { listActiveProblems } from 'lib/whatworks/repository';
 import { requireWhatWorksAccess, whatworksError } from '../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 import { reportError } from 'lib/observability/report';
 
 // Active problems for the suggest form. Members may only attach a tool to an existing
@@ -12,6 +13,16 @@ export async function GET() {
   }
   try {
     const problems = await listActiveProblems();
+    logWhatWorksAudit({
+      actorId: gate.auth.userId,
+      command: 'whatworks.problems.list',
+      status: 'allow',
+      reason: 'access_route_guard',
+      targetType: 'problem',
+      targetId: 'active',
+      result: 'success',
+      errorCategory: null,
+    });
     return NextResponse.json({
       ok: true,
       problems: problems.map((problem) => ({

--- a/ctf/packages/web/app/api/whatworks/products/[id]/endorse/route.ts
+++ b/ctf/packages/web/app/api/whatworks/products/[id]/endorse/route.ts
@@ -12,6 +12,7 @@ import {
   whatworksError,
   type WhatWorksApiGate,
 } from '../../../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -50,6 +51,16 @@ export async function POST(request: Request, context: RouteContext) {
   }
   await addEndorsement(id, auth.gate.auth.userId);
   const state = await getProductEndorsementState(id, auth.gate.auth.userId);
+  logWhatWorksAudit({
+    actorId: auth.gate.auth.userId,
+    command: 'whatworks.product.endorse',
+    status: 'allow',
+    reason: 'access_route_guard',
+    targetType: 'product',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+  });
   return NextResponse.json({ ok: true, ...state });
 }
 
@@ -65,5 +76,15 @@ export async function DELETE(request: Request, context: RouteContext) {
   }
   await removeEndorsement(id, auth.gate.auth.userId);
   const state = await getProductEndorsementState(id, auth.gate.auth.userId);
+  logWhatWorksAudit({
+    actorId: auth.gate.auth.userId,
+    command: 'whatworks.product.unendorse',
+    status: 'allow',
+    reason: 'access_route_guard',
+    targetType: 'product',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+  });
   return NextResponse.json({ ok: true, ...state });
 }

--- a/ctf/packages/web/app/api/whatworks/products/route.ts
+++ b/ctf/packages/web/app/api/whatworks/products/route.ts
@@ -16,6 +16,7 @@ import {
   requireWhatWorksAccess,
   whatworksError,
 } from '../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 import { reportError } from 'lib/observability/report';
 
 // A survivor suggests a tool. It lands as `pending` for admin review before it joins
@@ -84,6 +85,16 @@ export async function POST(request: Request) {
       kind,
       note,
       suggestedBy: gate.auth.userId,
+    });
+    logWhatWorksAudit({
+      actorId: gate.auth.userId,
+      command: 'whatworks.product.suggest',
+      status: 'allow',
+      reason: 'access_route_guard',
+      targetType: 'product',
+      targetId: product.id,
+      result: 'success',
+      errorCategory: null,
     });
     return NextResponse.json({ ok: true, productId: product.id, status: product.status }, { status: 201 });
   } catch (error) {

--- a/ctf/packages/web/app/api/whatworks/public/route.ts
+++ b/ctf/packages/web/app/api/whatworks/public/route.ts
@@ -5,6 +5,7 @@ import {
   PUBLIC_PREVIEW_PRODUCTS_PER_PROBLEM,
 } from 'lib/whatworks/constants';
 import { whatworksError } from '../_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 import { reportError } from 'lib/observability/report';
 
 // Public, sign-in-free projection: the list is readable by anyone, but only a teaser
@@ -16,7 +17,28 @@ export async function GET() {
       ...problem,
       products: problem.products.slice(0, PUBLIC_PREVIEW_PRODUCTS_PER_PROBLEM),
     }));
-    return NextResponse.json({ ok: true, problems, stats: list.stats });
+    // Stats describe only the teaser that is actually returned, not the full list — so the
+    // public payload never advertises counts a signed-out visitor cannot see.
+    const stats = {
+      problems: problems.length,
+      verifiedTools: problems.reduce((total, problem) => total + problem.products.length, 0),
+      survivorsHelped: problems.reduce(
+        (total, problem) =>
+          total + problem.products.reduce((sum, product) => sum + product.verifiedCount, 0),
+        0,
+      ),
+    };
+    logWhatWorksAudit({
+      actorId: null,
+      command: 'whatworks.public.read',
+      status: 'allow',
+      reason: 'public_teaser',
+      targetType: 'list',
+      targetId: 'public_teaser',
+      result: 'success',
+      errorCategory: null,
+    });
+    return NextResponse.json({ ok: true, problems, stats });
   } catch (error) {
     reportError(error, { area: 'whatworks', op: 'public' });
     return whatworksError('What Works preview is unavailable right now.', 'whatworks_public_unavailable', 500);

--- a/ctf/packages/web/app/api/whatworks/route.ts
+++ b/ctf/packages/web/app/api/whatworks/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getReaderList } from 'lib/whatworks/repository';
 import { requireWhatWorksAccess, whatworksError } from './_lib';
+import { logWhatWorksAudit } from 'lib/whatworks/audit';
 import { reportError } from 'lib/observability/report';
 
 // Full shared list for an authenticated survivor, with per-row endorsement state.
@@ -11,6 +12,16 @@ export async function GET() {
   }
   try {
     const list = await getReaderList(gate.auth.userId);
+    logWhatWorksAudit({
+      actorId: gate.auth.userId,
+      command: 'whatworks.list.read',
+      status: 'allow',
+      reason: 'access_route_guard',
+      targetType: 'list',
+      targetId: 'shared',
+      result: 'success',
+      errorCategory: null,
+    });
     return NextResponse.json({ ok: true, ...list, viewer: { isAdmin: gate.auth.isAdmin } });
   } catch (error) {
     reportError(error, { area: 'whatworks', op: 'index' });

--- a/ctf/packages/web/lib/whatworks/audit.ts
+++ b/ctf/packages/web/lib/whatworks/audit.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'crypto';
+
+// One audit line per WhatWorks command, matching the declared events in
+// docs/contracts/WHATWORKS_PLUGIN_AUDIT_CONTRACTS.yaml. Modelled on the directory/workforce
+// audit helpers: a single structured console line that the platform log pipeline collects.
+
+// Every WhatWorks command sits at contract version 1.0.0 today; kept as a map so a future
+// per-command bump records the version that actually governed the call.
+const WHATWORKS_COMMAND_VERSIONS: Record<string, string> = {
+  'whatworks.list.read': '1.0.0',
+  'whatworks.public.read': '1.0.0',
+  'whatworks.problems.list': '1.0.0',
+  'whatworks.product.suggest': '1.0.0',
+  'whatworks.product.endorse': '1.0.0',
+  'whatworks.product.unendorse': '1.0.0',
+  'whatworks.admin.problem.list': '1.0.0',
+  'whatworks.admin.problem.create': '1.0.0',
+  'whatworks.admin.problem.update': '1.0.0',
+  'whatworks.admin.problem.delete': '1.0.0',
+  'whatworks.admin.product.list': '1.0.0',
+  'whatworks.admin.product.review': '1.0.0',
+  'whatworks.admin.product.delete': '1.0.0',
+};
+
+// The data classes each command touches, mirrored from the audit contract so the recorded
+// line carries the same classification the contract declares.
+const WHATWORKS_COMMAND_DATA_CLASSES: Record<string, string[]> = {
+  'whatworks.list.read': ['community_content'],
+  'whatworks.public.read': ['community_content'],
+  'whatworks.problems.list': ['community_content'],
+  'whatworks.product.suggest': ['community_content', 'user_event'],
+  'whatworks.product.endorse': ['user_event'],
+  'whatworks.product.unendorse': ['user_event'],
+  'whatworks.admin.problem.list': ['community_content'],
+  'whatworks.admin.problem.create': ['community_content'],
+  'whatworks.admin.problem.update': ['community_content'],
+  'whatworks.admin.problem.delete': ['community_content', 'user_event'],
+  'whatworks.admin.product.list': ['community_content'],
+  'whatworks.admin.product.review': ['community_content'],
+  'whatworks.admin.product.delete': ['community_content', 'user_event'],
+};
+
+type WhatWorksAuditEvent = {
+  // The acting member's id, or null for the unauthenticated public read.
+  actorId: string | null;
+  command: string;
+  status: 'allow' | 'deny';
+  reason: string;
+  targetType: string;
+  targetId: string;
+  result: 'success' | 'failure';
+  errorCategory?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export function logWhatWorksAudit(event: WhatWorksAuditEvent): void {
+  const payload = {
+    eventId: randomUUID(),
+    timestamp: new Date().toISOString(),
+    actorId: event.actorId ?? 'anonymous',
+    pluginId: 'whatworks',
+    command: event.command,
+    commandVersion: WHATWORKS_COMMAND_VERSIONS[event.command] ?? '1.0.0',
+    policyDecision: {
+      status: event.status,
+      reason: event.reason,
+    },
+    targetContext: {
+      targetType: event.targetType,
+      targetId: event.targetId,
+    },
+    dataClassesAccessed: WHATWORKS_COMMAND_DATA_CLASSES[event.command] ?? [],
+    result: {
+      status: event.result,
+      errorCategory: event.errorCategory ?? 'none',
+    },
+    metadata: event.metadata ?? {},
+  };
+
+  console.info('[whatworks.audit]', JSON.stringify(payload));
+}

--- a/ctf/packages/web/lib/whatworks/repository.ts
+++ b/ctf/packages/web/lib/whatworks/repository.ts
@@ -23,11 +23,14 @@ function slugifyTitle(title: string): string {
   return base.length > 0 ? base : 'problem';
 }
 
+// Collisions are tiny in practice, but the loop is capped so a degraded DB or a pathological
+// run of identically-named problems fails with a clear error instead of hanging the request.
+const MAX_SLUG_ATTEMPTS = 100;
+
 async function ensureUniqueSlug(base: string): Promise<string> {
   let candidate = base;
   let suffix = 2;
-  // Loop is bounded by the number of existing collisions, which is tiny in practice.
-  while (true) {
+  for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt += 1) {
     const existing = await queryDb<{ id: string }>(
       'SELECT id FROM whatworks_problems WHERE slug = $1 LIMIT 1',
       [candidate],
@@ -38,6 +41,7 @@ async function ensureUniqueSlug(base: string): Promise<string> {
     candidate = `${base}-${suffix}`;
     suffix += 1;
   }
+  throw new Error(`whatworks: could not find a unique slug for "${base}" after ${MAX_SLUG_ATTEMPTS} attempts`);
 }
 
 type ProductProjectionRow = {
@@ -164,9 +168,19 @@ export async function getProblemById(id: string): Promise<WhatWorksProblem | nul
   return result.rows[0] ?? null;
 }
 
-export async function getProductById(id: string): Promise<WhatWorksProduct | null> {
-  const result = await queryDb<WhatWorksProduct>(
-    'SELECT * FROM whatworks_products WHERE id = $1 LIMIT 1',
+// Identity columns (`suggested_by`, `reviewed_by`) are deliberately omitted: the anonymity
+// contract excludes them from every reader and admin projection, and no caller of this lookup
+// needs them. Selecting an explicit column list keeps those fields out of the returned object
+// entirely, so a future route cannot accidentally serialise or forward them.
+export type WhatWorksProductLookup = Omit<WhatWorksProduct, 'suggested_by' | 'reviewed_by'>;
+
+export async function getProductById(id: string): Promise<WhatWorksProductLookup | null> {
+  const result = await queryDb<WhatWorksProductLookup>(
+    `SELECT id, problem_id, emoji, name, kind, note, purchase_url, status,
+            reviewed_at, rejection_reason, created_at, updated_at
+       FROM whatworks_products
+      WHERE id = $1
+      LIMIT 1`,
     [id],
   );
   return result.rows[0] ?? null;


### PR DESCRIPTION
Reviews the whatworks code-review sweep findings (issues #931–#938), keeps the valid ones, and fixes them.

## Fixed

- **#931 (audit events):** added `ctf/packages/web/lib/whatworks/audit.ts` and emit one structured audit line per command on the success path of every `/api/whatworks/*` route handler — reads, mutations, and all admin curation/moderation commands — matching every event declared in the audit contract. The public read records `anonymous` as the actor.
- **#934 (public stats):** the public endpoint now scopes its returned `stats` to the teaser slice it actually returns, instead of reporting the full-list counts. A signed-out payload no longer advertises counts a visitor cannot see.
- **#935 (mobile public path):** mobile gains a `WhatWorksPublic` signed-out teaser that fetches `/api/whatworks/public` with no bearer token, matching the web public flow, instead of showing a 401 to signed-out visitors. `WhatWorksTabs` renders it when the viewer is not authenticated.
- **#936 (identity leak via SELECT *):** `getProductById` now selects an explicit column list that omits `suggested_by`/`reviewed_by`, so those identity fields are never present on the returned object (defence in depth; no caller needs them).
- **#937 (unbounded slug loop):** `ensureUniqueSlug` is bounded to 100 attempts and throws a clear error instead of an unbounded `while (true)`.

## Reviewed and not changed (not valid)

- **#932:** partial-update already preserves an omitted `context`/`emoji` — the route leaves the field unset, which `updateProblem` passes as `null`, so `COALESCE($n, column)` keeps the existing value. Sending an explicit empty string to clear the field is intended behaviour.
- **#933:** every reader projection and the stats query already filter to `status = 'approved'`, so a suggester's auto-endorsement on a later-rejected product is never counted in any user-visible total.
- **#938:** mobile already updates product state only on a successful toggle, so a failed toggle leaves state untouched and consistent.

## Checks

Web typecheck + lint, mobile typecheck + lint, inventory-drift gate, and EOF format all pass locally; the pre-push hook ran the full workspace typecheck. The whatworks plugin feature inventory is updated (API surface, security/audit controls, Android delivery, change log).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQSBoziaKEYp9f5ce2svP5)_