### PR TITLE
fix: renamed plugins (WhatWorks/TrustTransport/SocketRelay/LevelUp) listed twice in Apps — purge orphaned old-slug registry rows

### DIFF
--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -1952,6 +1952,13 @@ ALTER TABLE IF EXISTS ctf_plugin_registry ADD COLUMN IF NOT EXISTS is_visible BO
 ALTER TABLE IF EXISTS ctf_plugin_registry ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS ctf_plugin_registry ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
+-- Remove orphaned pre-rename plugin-registry rows. The hyphenation renames changed these slugs
+-- (whatworks->what-works, trusttransport->trust-transport, socketrelay->socket-relay, levelup->level-up)
+-- and the new-slug rows are seeded below; but the ON CONFLICT (plugin_slug) upsert cannot delete the old
+-- slug, so an existing DB kept BOTH rows and listed the plugin twice in the Apps list. Purge the old rows.
+-- (gentlepulse/clicklog still use their original slug until their rename ships.)
+DELETE FROM ctf_plugin_registry WHERE plugin_slug IN ('whatworks', 'trusttransport', 'socketrelay', 'levelup');
+
 -- Seed plugin registry (upsert so re-running is safe)
 INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availability_state, nav_rank, is_visible) VALUES
   ('chyme',              'Chyme',                'Live social audio rooms. Broadcast, listen, and connect in real time.',                       'implemented_shell', 10,  TRUE),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1954,6 +1954,13 @@ ALTER TABLE IF EXISTS ctf_plugin_registry ADD COLUMN IF NOT EXISTS is_visible BO
 ALTER TABLE IF EXISTS ctf_plugin_registry ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS ctf_plugin_registry ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
+-- Remove orphaned pre-rename plugin-registry rows. The hyphenation renames changed these slugs
+-- (whatworks->what-works, trusttransport->trust-transport, socketrelay->socket-relay, levelup->level-up)
+-- and the new-slug rows are seeded below; but the ON CONFLICT (plugin_slug) upsert cannot delete the old
+-- slug, so an existing DB kept BOTH rows and listed the plugin twice in the Apps list. Purge the old rows.
+-- (gentlepulse/clicklog still use their original slug until their rename ships.)
+DELETE FROM ctf_plugin_registry WHERE plugin_slug IN ('whatworks', 'trusttransport', 'socketrelay', 'levelup');
+
 -- Seed plugin registry (upsert so re-running is safe)
 INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availability_state, nav_rank, is_visible) VALUES
   ('chyme',              'Chyme',                'Live social audio rooms. Broadcast, listen, and connect in real time.',                       'implemented_shell', 10,  TRUE),


### PR DESCRIPTION
**Fixes the duplicate plugin cards** you saw (WhatWorks, TrustTransport, LevelUp, and SocketRelay each listed twice in the Apps launcher).

## Root cause
The Apps list reads the `ctf_plugin_registry` **DB table** (`listPluginRegistry` → `SELECT … FROM ctf_plugin_registry`). The hyphenation renames updated the seed to the new slug (`what-works`, `trust-transport`, …), but the seed upserts with `ON CONFLICT (plugin_slug) DO UPDATE` — and since the new slug is a *different* primary key, the upsert **inserts a new row and leaves the old `whatworks`/`trusttransport`/… row in place**. So an existing/production DB ends up with both the old and new row, and the launcher shows the plugin twice. (Fresh DBs were fine — the seed only has the new slugs.)

## Fix
Add a `DELETE FROM ctf_plugin_registry WHERE plugin_slug IN ('whatworks','trusttransport','socketrelay','levelup')` immediately **before** the seed `INSERT`, in `schema.sql` and `schema.demo.sql`. On the next schema apply it purges the orphaned old-slug rows; the new-slug rows are then (re)seeded as usual. Idempotent — on a fresh DB the DELETE is a no-op. `gentlepulse`/`clicklog` keep their original slug (not renamed yet); their rename PRs will add them to this list.

## Why the renames missed it
The rename pattern updated the `ctf_plugin_registry` seed *value* to the new slug but didn't account for the upsert being unable to remove the old slug on an existing DB. I've added "also purge the old `ctf_plugin_registry` row" to the remaining rename steps so `gentle-pulse`/`click-log` won't repeat it.

Schema-only change (no app code). Note: this corrects production on the next deploy/schema-apply; it can't retroactively touch the live DB from here.

Owner-review (schema + row deletion). Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_