### PR TITLE
fix: harden lighthouse routes and close code-review findings

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
@@ -242,6 +242,13 @@ Android admin present (2026-06-06): `AdminLighthouse.tsx` + `admin-api.ts` added
 
 ## 9) Change Log
 
+- 2026-06-26: **Code-review sweep fixes (issues #1012–#1019).** Security/correctness hardening across the plugin, no schema or contract change:
+  - `POST /api/lighthouse/matches/:matchId/chat` now returns 403 unless the match status is `accepted`, so a pending/rejected/cancelled/completed match can no longer provision a live Stream channel or token (#1012).
+  - `POST /api/lighthouse/service-credits` runs the CSRF gate before the auth/DB lookup, matching every other mutation handler in the plugin (#1014).
+  - `PUT /api/lighthouse/admin/matches/:matchId` rejects an unknown `status` with 400 instead of silently coercing it to `pending` (#1016).
+  - `lighthouse.block.create`, `lighthouse.match.request.create`, and `lighthouse.profile.upsert` now emit a `deny` audit event on policy denials (self-block, blocked-pair, duplicate, ownership, policy), not only on the success path — aligning with the audit contract's `allow_or_deny` status. Self-block is now pre-checked before the DB round-trip (#1013, #1017, #1018).
+  - Mobile `fetchLighthouseStreamCredentials` validates all four Stream credential fields before returning, failing loudly on a missing field instead of passing a null into the chat panel (#1015).
+  - Mobile `LighthouseHostForm` gained `rentCurrency` (default `USD`) and `acceptedCurrencies` (with a ServiceCredits toggle) to match the web host form's `lighthouse.property.create` payload (#1019).
 - 2026-06-25: **Documented the implemented blocks/audit/ServiceCredits routes and two tables** (inventory-debt burn-down). §3.5 replaced its "contract to be finalized" placeholder with the shipped blocks routes (`GET`/`POST /api/lighthouse/blocks`, `DELETE …/blocks/[blockedUserId]`, `GET …/blocks/check`); added `GET /api/lighthouse/admin/audit-events` to §3.4 and a new §3.6 for `POST /api/lighthouse/service-credits`. Added `lighthouse_user_extension` and `lighthouse_admin_audit_trail` to §4. Each verified against the route handlers and `schema.sql`. Removed these two tables and five routes from the inventory-drift allowlist. Documentation only; no code change.
 - 2026-06-20: Multi-currency for property listings (issue #120). The host create/edit form
   (`lighthouse-host.tsx`) no longer assumes USD: it adds a **Rent currency** picker (shared

--- a/ctf/packages/mobile/src/features/lighthouse/LighthouseHostForm.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthouseHostForm.tsx
@@ -7,6 +7,10 @@ const SURFACE = 'rgba(255,255,255,0.02)';
 const BORDER = `${COLOR}20`;
 const MUTED = '#9CA3AF';
 
+// Currency code for ServiceCredits — mirrors SERVICE_CREDITS_CODE in
+// ctf/packages/web/lib/currency/types.ts.
+const SERVICE_CREDITS_CODE = 'SC';
+
 type HostForm = {
   title: string;
   description: string;
@@ -19,6 +23,8 @@ type HostForm = {
   bedrooms: string;
   bathrooms: string;
   monthlyRent: string;
+  rentCurrency: string;
+  acceptedCurrencies: string[];
   availableFromIso: string;
   amenities: string;
   houseRules: string;
@@ -37,6 +43,8 @@ const EMPTY_FORM: HostForm = {
   bedrooms: '',
   bathrooms: '',
   monthlyRent: '',
+  rentCurrency: 'USD',
+  acceptedCurrencies: [],
   availableFromIso: '',
   amenities: '',
   houseRules: '',
@@ -69,6 +77,8 @@ function toInputPayload(form: HostForm): PropertyCreateInput {
     bedrooms: toNumberOrNull(form.bedrooms),
     bathrooms: toNumberOrNull(form.bathrooms),
     monthlyRent: toNumberOrNull(form.monthlyRent),
+    rentCurrency: form.rentCurrency.trim() || 'USD',
+    acceptedCurrencies: form.acceptedCurrencies.length > 0 ? form.acceptedCurrencies : null,
     availableFromIso: form.availableFromIso.trim() || null,
     amenities: toListOrNull(form.amenities),
     houseRules: toListOrNull(form.houseRules),
@@ -110,9 +120,20 @@ interface Props {
 export const LighthouseHostForm: React.FC<Props> = ({ submitting, error, onSubmit }) => {
   const [form, setForm] = useState<HostForm>(EMPTY_FORM);
 
-  const setField = <K extends keyof HostForm>(key: K, value: string) => {
+  const setField = (key: Exclude<keyof HostForm, 'acceptedCurrencies'>, value: string) => {
     setForm((prev) => ({ ...prev, [key]: value }));
   };
+
+  const toggleServiceCredits = () => {
+    setForm((prev) => ({
+      ...prev,
+      acceptedCurrencies: prev.acceptedCurrencies.includes(SERVICE_CREDITS_CODE)
+        ? prev.acceptedCurrencies.filter((code) => code !== SERVICE_CREDITS_CODE)
+        : [...prev.acceptedCurrencies, SERVICE_CREDITS_CODE],
+    }));
+  };
+
+  const acceptsServiceCredits = form.acceptedCurrencies.includes(SERVICE_CREDITS_CODE);
 
   const handleSubmit = () => {
     onSubmit(toInputPayload(form));
@@ -143,6 +164,24 @@ export const LighthouseHostForm: React.FC<Props> = ({ submitting, error, onSubmi
         placeholder="0 for ServiceCredits / free"
         keyboardType="numeric"
       />
+      <Field
+        label="Rent currency"
+        value={form.rentCurrency}
+        onChange={(v) => setField('rentCurrency', v)}
+        placeholder="USD"
+      />
+      <View style={styles.field}>
+        <Text style={styles.label}>Accepted currencies</Text>
+        <TouchableOpacity
+          style={[styles.toggle, acceptsServiceCredits && styles.toggleOn]}
+          onPress={toggleServiceCredits}
+          activeOpacity={0.8}
+        >
+          <Text style={[styles.toggleText, acceptsServiceCredits && styles.toggleTextOn]}>
+            {acceptsServiceCredits ? '✓ ' : ''}Accept ServiceCredits
+          </Text>
+        </TouchableOpacity>
+      </View>
       <Field
         label="Available from"
         value={form.availableFromIso}
@@ -198,6 +237,27 @@ const styles = StyleSheet.create({
   textarea: {
     minHeight: 72,
     textAlignVertical: 'top',
+  },
+  toggle: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    alignSelf: 'flex-start',
+  },
+  toggleOn: {
+    backgroundColor: `${COLOR}14`,
+    borderColor: `${COLOR}40`,
+  },
+  toggleText: {
+    fontSize: 13,
+    color: '#F9FAFB',
+    fontWeight: '600',
+  },
+  toggleTextOn: {
+    color: COLOR,
   },
   errorText: {
     color: '#EF4444',

--- a/ctf/packages/mobile/src/features/lighthouse/fetchLighthouseStreamCredentials.ts
+++ b/ctf/packages/mobile/src/features/lighthouse/fetchLighthouseStreamCredentials.ts
@@ -29,10 +29,21 @@ export async function fetchLighthouseStreamCredentials(): Promise<LighthouseStre
   if (!res.ok || !data.ok) {
     throw new Error(data?.message || 'Unable to load Lighthouse chat credentials');
   }
-  return {
+  // Validate every credential field before returning. A missing field (e.g. a null streamChannelId
+  // from a shape mismatch in the chat route) must fail loudly here rather than silently flow into
+  // StreamChatPanel and surface as an opaque Stream SDK error.
+  const credentials: LighthouseStreamCredentials = {
     streamApiKey: data.streamApiKey,
     streamToken: data.streamToken,
     streamUserId: data.streamUserId,
     streamChannelId: data.streamChannelId,
   };
+  const missing = (Object.keys(credentials) as Array<keyof LighthouseStreamCredentials>).filter(
+    (key) => typeof credentials[key] !== 'string' || credentials[key].length === 0,
+  );
+  if (missing.length > 0) {
+    throw new Error(`Lighthouse chat credentials incomplete: missing ${missing.join(', ')}`);
+  }
+
+  return credentials;
 }

--- a/ctf/packages/mobile/src/features/lighthouse/types.ts
+++ b/ctf/packages/mobile/src/features/lighthouse/types.ts
@@ -71,6 +71,10 @@ export type PropertyCreateInput = {
   bedrooms: number | null;
   bathrooms: number | null;
   monthlyRent: number | null;
+  // Currency the rent is priced in (mirrors the web host form, default 'USD').
+  rentCurrency: string | null;
+  // Currency codes this listing accepts, e.g. 'SC' for ServiceCredits. Independent of rentCurrency.
+  acceptedCurrencies: string[] | null;
   availableFromIso: string | null;
   amenities: string[] | null;
   houseRules: string[] | null;

--- a/ctf/packages/web/app/api/lighthouse/admin/matches/[matchId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/matches/[matchId]/route.ts
@@ -32,10 +32,17 @@ export async function PUT(request: Request, { params }: RouteParams) {
     );
   }
 
+  // Reject an unknown/typo status outright rather than silently resetting the match to 'pending'.
+  const allowedStatuses = ['pending', 'accepted', 'rejected', 'cancelled', 'completed'] as const;
+  if (!allowedStatuses.includes(body.status as (typeof allowedStatuses)[number])) {
+    return NextResponse.json(
+      { ok: false, code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid match status.' },
+      { status: 400 },
+    );
+  }
+
   const input: LighthouseMatchUpdateInput = {
-    status: body.status === 'pending' || body.status === 'accepted' || body.status === 'rejected' || body.status === 'cancelled' || body.status === 'completed'
-      ? body.status
-      : 'pending',
+    status: body.status as (typeof allowedStatuses)[number],
     hostResponse: typeof body.hostResponse === 'string' ? body.hostResponse : null,
   };
 

--- a/ctf/packages/web/app/api/lighthouse/blocks/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/blocks/route.ts
@@ -132,6 +132,24 @@ export async function POST(request: Request) {
     );
   }
 
+  // Self-block check runs before the DB round-trip and emits the contract-required deny audit
+  // event (the audit contract marks lighthouse.block.create as allow_or_deny with a selfBlockCheck).
+  if (blockedUserId === gate.auth.userId) {
+    await insertLighthouseAudit({
+      actorId: gate.auth.userId,
+      command: 'lighthouse.block.create',
+      policyStatus: 'deny',
+      reason: 'self_block',
+      targetType: 'block',
+      targetId: blockedUserId,
+      metadata: { blockedUserId },
+    });
+    return NextResponse.json(
+      { ok: false, code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.' },
+      { status: 403 },
+    );
+  }
+
   try {
     const block = await createBlock(gate.auth.userId, blockedUserId, body.reason);
     await insertLighthouseAudit({
@@ -147,6 +165,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true, block }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'lighthouse', op: 'blocks' });
+    // A policy denial raised by the repository (self_block, policy_denied) must also be audited.
+    const code = error instanceof Error ? error.message : '';
+    if (code === 'self_block' || code === 'policy_denied') {
+      await insertLighthouseAudit({
+        actorId: gate.auth.userId,
+        command: 'lighthouse.block.create',
+        policyStatus: 'deny',
+        reason: code,
+        targetType: 'block',
+        targetId: blockedUserId,
+        metadata: { blockedUserId },
+      });
+    }
     return lighthouseErrorResponse(error, 'Block create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/matches/[matchId]/chat/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/[matchId]/chat/route.ts
@@ -25,6 +25,15 @@ export async function POST(_request: Request, { params }: { params: Promise<{ ma
     return NextResponse.json({ ok: false, message: 'Match not found or access denied' }, { status: 404 });
   }
 
+  // Chat exists only for accepted matches. A pending/rejected/cancelled/completed match must not
+  // be able to provision a live Stream channel or token.
+  if (match.status !== 'accepted') {
+    return NextResponse.json(
+      { ok: false, message: 'Chat is only available for accepted matches.' },
+      { status: 403 },
+    );
+  }
+
   try {
     const streamChannelId = await ensureLighthouseMatchChannel({
       matchId: match.id,

--- a/ctf/packages/web/app/api/lighthouse/matches/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/route.ts
@@ -165,6 +165,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true, ...created }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'lighthouse', op: 'matches' });
+    // The seeker-role check, blocked-pair check, and duplicate check all live in the repository and
+    // raise these codes. The audit contract marks lighthouse.match.request.create as allow_or_deny,
+    // so a policy denial must emit a deny audit event, not only the success path.
+    const code = error instanceof Error ? error.message : '';
+    if (code === 'policy_denied' || code === 'blocked_pair' || code === 'duplicate_match' || code === 'not_owner') {
+      await insertLighthouseAudit({
+        actorId: gate.auth.userId,
+        command: 'lighthouse.match.request.create',
+        policyStatus: 'deny',
+        reason: code,
+        targetType: 'match',
+        targetId: input.propertyId,
+        metadata: { propertyId: input.propertyId },
+      });
+    }
     return lighthouseErrorResponse(error, 'Match create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/profile/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/profile/route.ts
@@ -152,6 +152,21 @@ async function upsertProfileHandler(request: Request) {
     return NextResponse.json({ ok: true, profile }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'lighthouse', op: 'profile' });
+    // The audit contract marks lighthouse.profile.upsert as allow_or_deny (with an ownership and a
+    // profile-type-lock check). A policy denial raised by the repository must emit a deny audit
+    // event, not only the success path.
+    const code = error instanceof Error ? error.message : '';
+    if (code === 'not_owner' || code === 'policy_denied') {
+      await insertLighthouseAudit({
+        actorId: gate.auth.userId,
+        command: 'lighthouse.profile.upsert',
+        policyStatus: 'deny',
+        reason: code,
+        targetType: 'profile',
+        targetId: gate.auth.userId,
+        metadata: { profileType: input.profileType },
+      });
+    }
     return lighthouseErrorResponse(error, 'Profile upsert unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/service-credits/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/service-credits/route.ts
@@ -12,14 +12,16 @@ type LighthouseServiceCreditsSendInput = {
 };
 
 export async function POST(request: Request) {
-  const gate = await requireLighthouseReadAccess();
-  if (!gate.allowed) {
-    return gate.response;
-  }
-
+  // CSRF gate runs first, matching every other mutation handler in this plugin, so a cross-origin
+  // request is rejected before any authenticated DB lookup.
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
     return csrfDeny;
+  }
+
+  const gate = await requireLighthouseReadAccess();
+  if (!gate.allowed) {
+    return gate.response;
   }
 
   let input: LighthouseServiceCreditsSendInput;


### PR DESCRIPTION
Fixes the open Lighthouse code-review sweep findings. Each was checked against the current code; all were valid.

## Changes

- **Chat token only for accepted matches** (#1012, high/security) — `POST /api/lighthouse/matches/:matchId/chat` now returns 403 unless `match.status === 'accepted'`, so a pending/rejected/cancelled/completed match can no longer provision a live Stream channel or token.
- **CSRF before auth** (#1014, security) — `POST /api/lighthouse/service-credits` runs the CSRF gate before the authenticated DB lookup, matching every other mutation handler in the plugin.
- **Reject unknown admin status** (#1016, bug) — `PUT /api/lighthouse/admin/matches/:matchId` returns 400 on an unrecognized `status` instead of silently coercing it to `pending`.
- **Deny audit events** (#1013, #1017, #1018) — `block.create`, `match.request.create`, and `profile.upsert` now emit a `deny` audit event on policy denials (self-block, blocked-pair, duplicate, ownership, policy), not only on success — aligning with the audit contract's `allow_or_deny` status. Self-block is pre-checked before the DB round-trip.
- **Mobile credential validation** (#1015, bug) — `fetchLighthouseStreamCredentials` validates all four Stream fields before returning, failing loudly on a missing field instead of passing a null into the chat panel.
- **Mobile host form currency parity** (#1019, correctness) — `LighthouseHostForm` gained `rentCurrency` (default `USD`) and `acceptedCurrencies` (with a ServiceCredits toggle) to match the web form's `lighthouse.property.create` payload.

Lighthouse feature inventory change log updated. No schema or contract changes.

Verified locally: web + mobile typecheck, web + mobile lint, EOF format, web/android parity, and inventory-drift gate all pass.

Closes #1012
Closes #1013
Closes #1014
Closes #1015
Closes #1016
Closes #1017
Closes #1018
Closes #1019

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_