### PR TITLE
fix: resolve clicklog code-review findings (#972-#979)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-clicklog-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-clicklog-feature-inventory.md
@@ -41,8 +41,10 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 ## 7. Security, Privacy, and Compliance Controls
 
 - Auth required for all actions
-- Users can only view/delete their own incidents
-- Admins (future) can view/delete all
+- Users can only view/delete their own incidents; admins can view/delete any incident
+- Web and mobile mutations send the `x-ctf-csrf: 1` header
+- Every allowed operation emits an audit event (`clicklog.incident.create`/`.list`/`.delete`)
+  via `lib/clicklog/audit.ts`, matching [CLICKLOG_PLUGIN_AUDIT_CONTRACTS.yaml](../../contracts/CLICKLOG_PLUGIN_AUDIT_CONTRACTS.yaml)
 - See [CLICKLOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml](../../contracts/CLICKLOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml)
 
 ## 8. Web and Android Delivery Status
@@ -75,6 +77,7 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-06-26: **Resolved the clicklog code-review sweep findings (#972–#979).** Added `lib/clicklog/audit.ts` and emit an audit event on every allowed `GET`/`POST`/`DELETE` so the audit contract is honoured (#972). `POST /api/clicklog` no longer rejects a missing `metadata` — it defaults to `{}` per the command contract (#973) — and trims `notes` before the length check so trailing whitespace can't slip past `MAX_NOTES_LENGTH` or be stored unnormalised (#978). The web shell now sends `x-ctf-csrf: 1` on its POST and DELETE fetches, matching the mobile client (#974). `deleteIncident` takes an `isAdmin` flag and drops the `user_id` condition for admins, so an admin deleting another member's incident no longer returns a spurious 500 (#975). Fixed import ordering in `lib/clicklog/repository.ts` (imports now precede `getIncidentById`) (#976). The web shell stores the true DB `count` from the GET response and shows it as the headline total instead of the capped-at-50 array length (#977). Removed the unused `refreshing` prop from the mobile `ClicklogMain` (and the now-unused `refreshing` state) (#979). No schema change.
 - 2026-06-23: **Closed an unlock-gating gap (audit finding).** The ClickLog API routes gated only on "is signed in" (`resolveRequestIdentity` + `canCreateIncident`/`canDeleteIncident`), so a signed-in but not-yet-unlocked member could create, read, and delete incidents by calling the API directly — even though the `/apps/clicklog` page was gated. This violated the rule that no plugin works while Unlock is pending. Added `app/api/clicklog/_lib.ts` `requireClicklogAccess()` over the shared `evaluatePluginAccess()` (default `minUnlockTier: 'approved_full'`, admins pass) and routed `GET`/`POST` (`route.ts`) and `DELETE` (`[id]/route.ts`) through it; the `DELETE` ownership check now reads `userId`/`isAdmin` from the gate decision. Matches every other plugin's `_lib` pattern. No schema change.
 - 2026-06-14: Registered ClickLog in the production plugin registry. The plugin was fully built (schema `clicklog_incidents`, API routes, web shell + components, mobile feature, contracts, seed) and the dynamic apps route already renders `<ClicklogShell />` for slug `clicklog`, but the `ctf_plugin_registry` seed in `schema.sql` was missing the `clicklog` row — so production (which reads the DB registry, not the code fallback) never listed or routed to it, leaving the app invisible and the "live plugins" count one short. Added the row (`ClickLog`, `implemented_shell`, nav_rank 180, visible). Run "Update Neon DB" so production gets the row. No code/contract change.
 

--- a/ctf/packages/mobile/src/features/clicklog/ClicklogScreen.tsx
+++ b/ctf/packages/mobile/src/features/clicklog/ClicklogScreen.tsx
@@ -247,7 +247,6 @@ function ClicklogMain({
   totalCount: number;
   onLog: (_notes: string, _includeLocation: boolean) => Promise<void>;
   onDelete: (_id: string) => void;
-  refreshing: boolean;
 }) {
   const [tab, setTab] = useState<TabKey>('log');
   const [logged, setLogged] = useState(false);
@@ -463,11 +462,11 @@ export function ClicklogScreen() {
   const [screenState, setScreenState] = useState<ScreenState>('loading');
   const [incidents, setIncidents] = useState<ClicklogIncident[]>([]);
   const [totalCount, setTotalCount] = useState(0);
-  const [refreshing, setRefreshing] = useState(false);
 
   const load = useCallback(async (isRefresh = false) => {
-    if (isRefresh) setRefreshing(true);
-    else setScreenState('loading');
+    // On a background refresh (after a mutation) keep the current screen rather than
+    // flashing the full loading state; only the initial load shows 'loading'.
+    if (!isRefresh) setScreenState('loading');
     try {
       const data = await fetchIncidents();
       const list: ClicklogIncident[] = data.incidents ?? [];
@@ -483,8 +482,6 @@ export function ClicklogScreen() {
         // Network / server error — show empty so user can still attempt to log
         setScreenState('empty');
       }
-    } finally {
-      setRefreshing(false);
     }
   }, []);
 
@@ -548,7 +545,6 @@ export function ClicklogScreen() {
       totalCount={totalCount}
       onLog={handleLog}
       onDelete={handleDelete}
-      refreshing={refreshing}
     />
   );
 }

--- a/ctf/packages/web/app/api/clicklog/[id]/route.ts
+++ b/ctf/packages/web/app/api/clicklog/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { deleteIncident, getIncidentById } from 'lib/clicklog/repository';
 import { canDeleteIncident } from 'lib/clicklog/policy';
+import { logClicklogAudit } from 'lib/clicklog/audit';
 import { requireClicklogAccess } from '../_lib';
 
 export async function DELETE(request: NextRequest, context: { params: Promise<{ id: string }> }) {
@@ -23,9 +24,15 @@ export async function DELETE(request: NextRequest, context: { params: Promise<{ 
   if (!canDeleteIncident(gate.auth.userId, incident.user_id, gate.auth.isAdmin)) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
   }
-  const deleted = await deleteIncident(id, gate.auth.userId);
+  const deleted = await deleteIncident(id, gate.auth.userId, gate.auth.isAdmin);
   if (!deleted) {
     return NextResponse.json({ error: 'Delete failed' }, { status: 500 });
   }
+  logClicklogAudit({
+    actorId: gate.auth.userId,
+    command: 'clicklog.incident.delete',
+    result: 'success',
+    target: { incidentId: id },
+  });
   return NextResponse.json({ success: true });
 }

--- a/ctf/packages/web/app/api/clicklog/route.ts
+++ b/ctf/packages/web/app/api/clicklog/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createIncident, getIncidentsByUser, getIncidentCount } from 'lib/clicklog/repository';
 import { MAX_NOTES_LENGTH } from 'lib/clicklog/constants';
+import { logClicklogAudit } from 'lib/clicklog/audit';
+import type { IncidentMetadata } from 'lib/clicklog/types';
 import { requireClicklogAccess } from './_lib';
 
 export async function GET() {
@@ -11,6 +13,7 @@ export async function GET() {
   const userId = gate.auth.userId;
   const incidents = await getIncidentsByUser(userId);
   const count = await getIncidentCount(userId);
+  logClicklogAudit({ actorId: userId, command: 'clicklog.incident.list', result: 'success' });
   return NextResponse.json({ incidents, count });
 }
 
@@ -26,23 +29,41 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
-  if (!body.metadata) {
-    return NextResponse.json({ error: 'Missing metadata' }, { status: 400 });
+  // metadata is optional per the command contract; default it to {} so a client that
+  // omits it (or sends an empty body) is not rejected with a spurious 400.
+  const rawMetadata = body.metadata ?? {};
+  if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+    return NextResponse.json({ error: 'Invalid metadata' }, { status: 400 });
   }
-  const metadata = body.metadata;
-  if (metadata.latitude !== undefined) {
-    if (typeof metadata.latitude !== 'number' || !Number.isFinite(metadata.latitude) || metadata.latitude < -90 || metadata.latitude > 90) {
+  if (rawMetadata.latitude !== undefined) {
+    if (typeof rawMetadata.latitude !== 'number' || !Number.isFinite(rawMetadata.latitude) || rawMetadata.latitude < -90 || rawMetadata.latitude > 90) {
       return NextResponse.json({ error: 'Invalid latitude' }, { status: 400 });
     }
   }
-  if (metadata.longitude !== undefined) {
-    if (typeof metadata.longitude !== 'number' || !Number.isFinite(metadata.longitude) || metadata.longitude < -180 || metadata.longitude > 180) {
+  if (rawMetadata.longitude !== undefined) {
+    if (typeof rawMetadata.longitude !== 'number' || !Number.isFinite(rawMetadata.longitude) || rawMetadata.longitude < -180 || rawMetadata.longitude > 180) {
       return NextResponse.json({ error: 'Invalid longitude' }, { status: 400 });
     }
   }
-  if (metadata.notes && metadata.notes.length > MAX_NOTES_LENGTH) {
-    return NextResponse.json({ error: 'Notes too long' }, { status: 400 });
+  // Trim notes before validating and storing so trailing/leading whitespace can't push
+  // a note past the limit (or be stored unnormalised). Drop an empty trimmed note.
+  let notes: string | undefined;
+  if (rawMetadata.notes !== undefined) {
+    if (typeof rawMetadata.notes !== 'string') {
+      return NextResponse.json({ error: 'Invalid notes' }, { status: 400 });
+    }
+    const trimmed = rawMetadata.notes.trim();
+    if (trimmed.length > MAX_NOTES_LENGTH) {
+      return NextResponse.json({ error: 'Notes too long' }, { status: 400 });
+    }
+    notes = trimmed.length > 0 ? trimmed : undefined;
   }
+  const metadata: IncidentMetadata = {
+    ...(rawMetadata.latitude !== undefined ? { latitude: rawMetadata.latitude } : {}),
+    ...(rawMetadata.longitude !== undefined ? { longitude: rawMetadata.longitude } : {}),
+    ...(notes !== undefined ? { notes } : {}),
+  };
   const incident = await createIncident({ userId, metadata });
+  logClicklogAudit({ actorId: userId, command: 'clicklog.incident.create', result: 'success' });
   return NextResponse.json({ incident });
 }

--- a/ctf/packages/web/components/clicklog/clicklog-shell.tsx
+++ b/ctf/packages/web/components/clicklog/clicklog-shell.tsx
@@ -22,6 +22,7 @@ export function ClicklogShell() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [incidents, setIncidents] = useState<ClicklogIncident[]>([]);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [note, setNote] = useState("");
   const [geo, setGeo] = useState<Geo>({});
@@ -40,6 +41,7 @@ export function ClicklogShell() {
       if (!res.ok) throw new Error("Failed to fetch incidents");
       const data = (await res.json()) as { incidents: ClicklogIncident[]; count: number };
       setIncidents(data.incidents);
+      setTotalCount(typeof data.count === "number" ? data.count : null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to fetch incidents");
     } finally {
@@ -96,7 +98,7 @@ export function ClicklogShell() {
     try {
       const res = await fetch("/api/clicklog", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
         body: JSON.stringify({ metadata }),
       });
       if (!res.ok) throw new Error("Failed to log incident");
@@ -119,7 +121,7 @@ export function ClicklogShell() {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch(`/api/clicklog/${id}`, { method: "DELETE" });
+      const res = await fetch(`/api/clicklog/${id}`, { method: "DELETE", headers: { "x-ctf-csrf": "1" } });
       if (!res.ok) throw new Error("Failed to delete incident");
       await fetchIncidents();
     } catch (e) {
@@ -136,6 +138,10 @@ export function ClicklogShell() {
   }
 
   const stats = deriveClicklogStats(incidents);
+  // The GET response is capped at 50 incidents but returns the true DB `count`. Use
+  // that for the headline total so a user with >50 incidents sees the real number;
+  // fall back to the loaded array length if `count` is unavailable.
+  const displayTotal = totalCount ?? stats.total;
 
   const content = (
     <>
@@ -177,7 +183,7 @@ export function ClicklogShell() {
             <AlertTriangle size={18} color={t.ACCENT} style={{ flexShrink: 0 }} />
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 15, fontWeight: 700, color: t.TITLE }}>Incident Log</div>
-              <div style={{ fontSize: 11, color: t.MUTED }}>{stats.total} incidents total</div>
+              <div style={{ fontSize: 11, color: t.MUTED }}>{displayTotal} incidents total</div>
             </div>
           </div>
         </div>
@@ -189,14 +195,14 @@ export function ClicklogShell() {
   return (
     <div style={{ display: "flex", height: "100dvh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
       <ClicklogIconRail />
-      <ClicklogSidebar total={stats.total} weekdayCounts={stats.weekdayCounts} />
+      <ClicklogSidebar total={displayTotal} weekdayCounts={stats.weekdayCounts} />
 
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <AlertTriangle size={18} color={t.ACCENT} />
           <div style={{ flex: 1 }}>
             <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>Incident Log</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Personal safety tracking — {stats.total} incidents total</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Personal safety tracking — {displayTotal} incidents total</div>
           </div>
         </header>
 

--- a/ctf/packages/web/lib/clicklog/audit.ts
+++ b/ctf/packages/web/lib/clicklog/audit.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'crypto';
+
+// Audit logger for the ClickLog plugin. Mirrors the lightweight pattern used by the
+// other plugins (mood/chyme/foundation): one structured line per allowed command,
+// emitted to the application log. The audit contract
+// (CLICKLOG_PLUGIN_AUDIT_CONTRACTS.yaml) requires an audit event on every successful
+// allowed operation — clicklog.incident.create, clicklog.incident.list, and
+// clicklog.incident.delete — so the route handlers call this after each success.
+
+type ClicklogCommand =
+  | 'clicklog.incident.create'
+  | 'clicklog.incident.list'
+  | 'clicklog.incident.delete';
+
+type ClicklogAuditEvent = {
+  actorId: string;
+  command: ClicklogCommand;
+  result: 'success' | 'failure';
+  // Optional context identifiers (e.g. the incident id for delete). Empty/undefined
+  // values are dropped so the log never carries blank keys.
+  target?: Record<string, string | undefined>;
+  errorCategory?: string | null;
+};
+
+function buildTargetContext(target: Record<string, string | undefined>): Record<string, string> {
+  return Object.entries(target).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (typeof value === 'string' && value.length > 0) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+}
+
+export function logClicklogAudit(event: ClicklogAuditEvent): void {
+  const payload = {
+    eventId: randomUUID(),
+    timestamp: new Date().toISOString(),
+    actorId: event.actorId,
+    pluginId: 'clicklog',
+    command: event.command,
+    commandVersion: '1.0.0',
+    policyDecision: { status: 'allow' },
+    dataClassesAccessed: ['user_event'],
+    targetContext: buildTargetContext(event.target ?? {}),
+    result: {
+      status: event.result,
+      errorCategory: event.errorCategory ?? 'none',
+    },
+  };
+
+  console.info('[clicklog.audit]', JSON.stringify(payload));
+}

--- a/ctf/packages/web/lib/clicklog/repository.ts
+++ b/ctf/packages/web/lib/clicklog/repository.ts
@@ -1,3 +1,6 @@
+import { queryDb } from 'lib/db/postgres';
+import { ClicklogIncident, CreateIncidentInput } from './types';
+
 export async function getIncidentById(id: string): Promise<ClicklogIncident | null> {
   const result = await queryDb<ClicklogIncident>(
     `SELECT * FROM clicklog_incidents WHERE id = $1`,
@@ -5,9 +8,6 @@ export async function getIncidentById(id: string): Promise<ClicklogIncident | nu
   );
   return result.rows[0] || null;
 }
-
-import { queryDb } from 'lib/db/postgres';
-import { ClicklogIncident, CreateIncidentInput } from './types';
 
 export async function createIncident(input: CreateIncidentInput): Promise<ClicklogIncident> {
   const { userId, metadata } = input;
@@ -36,10 +36,13 @@ export async function getIncidentCount(userId: string): Promise<number> {
   return parseInt(result.rows[0]?.count ?? '0', 10);
 }
 
-export async function deleteIncident(id: string, userId: string): Promise<boolean> {
-  const result = await queryDb(
-    `DELETE FROM clicklog_incidents WHERE id = $1 AND user_id = $2`,
-    [id, userId]
-  );
+// Deletes an incident. Members may delete only their own (the user_id condition
+// scopes the DELETE); admins may delete any incident, so for them the ownership
+// condition is dropped. The route performs the authorization check (canDeleteIncident)
+// before calling this.
+export async function deleteIncident(id: string, userId: string, isAdmin = false): Promise<boolean> {
+  const result = isAdmin
+    ? await queryDb(`DELETE FROM clicklog_incidents WHERE id = $1`, [id])
+    : await queryDb(`DELETE FROM clicklog_incidents WHERE id = $1 AND user_id = $2`, [id, userId]);
   return (result.rowCount ?? 0) > 0;
 }


### PR DESCRIPTION
Resolves the clicklog code-review sweep issues #972–#979. All eight were valid; each is fixed surgically within the clicklog plugin.

- **#972 (high, security)** — No audit events were emitted. Added `lib/clicklog/audit.ts` (mirrors the mood/chyme pattern) and emit `clicklog.incident.list` / `.create` / `.delete` on every allowed GET/POST/DELETE, honouring `CLICKLOG_PLUGIN_AUDIT_CONTRACTS.yaml`.
- **#973 (medium, correctness)** — `POST /api/clicklog` rejected a missing `metadata` though the contract marks it optional. It now defaults to `{}`.
- **#974 (medium, security)** — The web shell's POST and DELETE now send `x-ctf-csrf: 1`, matching the mobile client.
- **#975 (medium, bug)** — `deleteIncident` now takes an `isAdmin` flag and drops the `user_id` condition for admins, so an admin deleting another member's incident no longer returns a spurious 500 after the authorization check passes.
- **#976 (low, bug)** — Moved the imports above `getIncidentById` in `lib/clicklog/repository.ts`.
- **#977 (low, correctness)** — The web shell stores the true DB `count` from the GET response and shows it as the headline total instead of the capped-at-50 array length.
- **#978 (low, correctness)** — `notes` is trimmed server-side before the length check, so trailing/leading whitespace can't slip past `MAX_NOTES_LENGTH` or be stored unnormalised.
- **#979 (low, quality)** — Removed the unused `refreshing` prop (and the now-unused `refreshing` state) from the mobile `ClicklogMain`.

Inventory file updated (section 7 + change log). No schema change. Web/mobile typecheck, lint, EOF, and inventory-drift checks pass locally.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkr4PSsqbea3w8W9mp4J3X)_