### PR TITLE
ci: let the unattended PR-builder agents act so code-review opens PRs

### DIFF
--- a/.github/workflows/bug-reports-build.yml
+++ b/.github/workflows/bug-reports-build.yml
@@ -83,6 +83,11 @@ jobs:
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_PAT }}
+          # Run fully unattended: this agent must edit files and run git/gh/pnpm. The action's
+          # `agent` mode applies its own permission mode and ignores the repo
+          # `.claude/settings.json` bypassPermissions default, so without this flag every
+          # Bash/Edit/Write call is denied and no PR is opened.
+          claude_args: "--dangerously-skip-permissions"
           prompt: |
             You are implementing one owner-approved bug fix for the "Charging the Future"
             app. Follow the repository rules in CLAUDE.md and .claude/rules exactly.

--- a/.github/workflows/code-review-implement.yml
+++ b/.github/workflows/code-review-implement.yml
@@ -119,6 +119,12 @@ jobs:
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_PAT }}
+          # Run fully unattended: this agent must edit files and run git/gh/pnpm. The action
+          # runs Claude through the Agent SDK in `agent` mode, which applies its OWN permission
+          # mode and does NOT honour the repo `.claude/settings.json` `bypassPermissions`
+          # default — so without this flag every Bash/Edit/Write call is denied and no PR is
+          # opened (the symptom: a "success" run with a high permission_denials_count and no PR).
+          claude_args: "--dangerously-skip-permissions"
           prompt: |
             You are implementing one code-review finding for the "Charging the Future" app,
             fully unattended. Follow the repository rules in CLAUDE.md and .claude/rules

--- a/.github/workflows/code-review-pr-babysitter.yml
+++ b/.github/workflows/code-review-pr-babysitter.yml
@@ -109,6 +109,11 @@ jobs:
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_PAT }}
+          # Run fully unattended: this agent must run git/gh/pnpm and edit files to resolve the
+          # conflict. The action's `agent` mode applies its own permission mode and ignores the
+          # repo `.claude/settings.json` bypassPermissions default, so without this flag every
+          # Bash/Edit call is denied and the conflict is never resolved.
+          claude_args: "--dangerously-skip-permissions"
           prompt: |
             A code-review auto PR has a merge conflict with main and cannot auto-merge. Resolve
             it, fully unattended. Follow CLAUDE.md, including the no-pleasantries / banned-term


### PR DESCRIPTION
## Problem

The code-review loop files issues (sweep works) but opens **no PRs**. In run [28276179330](https://github.com/chargingthefuture/chargingthefuture/actions/runs/28276179330) the "Implement finding and open PR" step ran 24 turns, reported `success`, but `permission_denials_count: 19` and opened no PR for issue #1059.

## Root cause

The step calls `anthropics/claude-code-action@v1` with an **empty `claude_args`**. The action runs Claude through the Agent SDK in `agent` mode, which applies its **own** permission mode and does **not** honour the repo's `.claude/settings.json` `"defaultMode": "bypassPermissions"`. With nothing allowed, every `gh` / `git` / `pnpm` / `Edit` / `Write` call the prompt asks for is auto-denied — so the agent can't read the issue, edit files, typecheck, push, or open the PR. The run "succeeds" only because the agent gives up after exhausting its options.

## Fix

Pass `claude_args: "--dangerously-skip-permissions"` to the action so the agent can act unattended — matching the owner's already-declared `bypassPermissions` intent in `.claude/settings.json`. Applied to the three workflows with the identical gap:

- `code-review-implement.yml` — builds an actionable finding into a PR (the reported failure).
- `code-review-pr-babysitter.yml` — resolves the auto-PR's merge conflicts (same call, same latent failure).
- `bug-reports-build.yml` — builds owner-approved bug fixes into PRs (same latent failure).

No prompt or logic change; only the missing permission grant. After this merges, the next sweep (or a manual dispatch of the implement workflow) will pick up the oldest `code-review:actionable` issue — #1059 still carries that label — and open a PR.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_