### PR TITLE
fix: add x-ctf-csrf header to level-up milestone validate POST

### DIFF
--- a/ctf/packages/web/components/level-up/level-up-shell.tsx
+++ b/ctf/packages/web/components/level-up/level-up-shell.tsx
@@ -236,7 +236,7 @@ export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: b
 
   async function handleValidate(milestoneId: string) {
     try {
-      await fetch(`/api/level-up/milestones/${milestoneId}/validate`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}) });
+      await fetch(`/api/level-up/milestones/${milestoneId}/validate`, { method: "POST", headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" }, body: JSON.stringify({}) });
       setPendingValidations((prev) => prev.filter((v) => v.milestoneId !== milestoneId));
     } catch {
       // optimistic remove already applied on success path only


### PR DESCRIPTION
## What

The `handleValidate` function in `level-up-shell.tsx` sent a POST to `/api/level-up/milestones/${milestoneId}/validate` without the `x-ctf-csrf: '1'` header. That route's CSRF gate (`ensureMutationCsrf`) requires the header, so the request was rejected with a 403 and validation never reached the server.

## Fix

Add `'x-ctf-csrf': '1'` to the fetch headers in `handleValidate`, matching the pattern the other level-up mutation routes expect.

Closes #1067

Parity Status: web + mobile-responsive + android complete