### PR TITLE
ci: select the truly oldest actionable code-review issue

### DIFF
--- a/.github/workflows/bug-reports-build.yml
+++ b/.github/workflows/bug-reports-build.yml
@@ -61,8 +61,12 @@ jobs:
             echo "Selected requested issue #$REQUESTED."
             exit 0
           fi
+          # Pick the genuinely OLDEST open approved issue. `gh issue list` returns newest-first, so
+          # --limit caps the fetch to the N newest BEFORE the jq sort — once more than the cap are open,
+          # the true oldest falls outside the window and the sort picks the wrong one. Use a cap well
+          # above any realistic backlog so the sort sees every open approved issue.
           NUM=$(gh issue list --repo "$TRIAGE_REPO" --label approved-to-build --state open \
-            --json number,createdAt --limit 50 \
+            --json number,createdAt --limit 500 \
             --jq 'sort_by(.createdAt) | .[0].number // empty')
           if [ -z "$NUM" ]; then
             echo "number=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-review-implement.yml
+++ b/.github/workflows/code-review-implement.yml
@@ -98,8 +98,13 @@ jobs:
             echo "Selected requested issue #$REQUESTED."
             exit 0
           fi
+          # Pick the genuinely OLDEST open actionable issue. `gh issue list` returns newest-first,
+          # so --limit caps the fetch to the N newest BEFORE the jq sort runs. With the old --limit 50,
+          # once more than 50 actionable issues were open the true oldest (e.g. #1012) fell outside the
+          # window and the sort picked the oldest-of-the-newest-50 instead. Use a cap comfortably above
+          # any realistic backlog so the sort sees every open actionable issue.
           NUM=$(gh issue list --repo "$REPO" --label "code-review:actionable" --state open \
-            --json number,createdAt --limit 50 \
+            --json number,createdAt --limit 500 \
             --jq 'sort_by(.createdAt) | .[0].number // empty')
           if [ -z "$NUM" ]; then
             echo "number=" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The code-review opener is supposed to build the **oldest** open `code-review:actionable` issue, but it built #1067 while #1012 was open, actionable, and older. Same latent bug in the bug-reports builder's "oldest approved" pick.

## Root cause

The selection runs:

```
gh issue list --label "code-review:actionable" --state open \
  --json number,createdAt --limit 50 \
  --jq 'sort_by(.createdAt) | .[0].number'
```

`gh issue list` returns issues **newest-first**, so `--limit 50` keeps only the **50 newest** *before* the `jq` sort runs. Once more than 50 actionable issues are open, the genuinely-oldest ones fall outside that window and the sort picks the oldest *of the newest 50* — i.e. #1067 instead of #1012.

## Fix

Raise the fetch cap to 500 — comfortably above any realistic open backlog — so the sort sees every open matching issue and picks the true oldest. Applied to both `code-review-implement.yml` (the opener) and `bug-reports-build.yml` (identical "oldest approved" select). No other logic change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_