### PR TITLE
feat: move admin to the mobile top bar and hide the phone left rail

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -274,9 +274,9 @@
   flex-shrink: 0;
 }
 
-/* Admins-only link to /admin, shown in the drawer footer. The desktop icon rail
-   carries its own Admin entry, but that rail is hidden on phones, so this is the
-   way admins reach the admin directory on a phone. */
+/* Admins-only link to /admin in the desktop sidebar footer. The desktop icon rail
+   also carries its own Admin entry; on phones this sidebar is hidden and admins
+   reach /admin from the top bar instead. */
 .sidebarAdminLink {
   display: flex;
   align-items: center;
@@ -1313,11 +1313,12 @@
   border: 0;
 }
 
-/* ─── Mobile top bar + nav drawer ────────────────────────────────────────── */
+/* ─── Mobile top bar ─────────────────────────────────────────────────────── */
 /*
- * On phones the icon rail and sidebar are replaced by a top bar (brand, section
- * switch, sign-in/avatar) plus a menu button that slides the sidebar in as a
- * drawer. These pieces stay hidden on desktop and are switched on inside the
+ * On phones the icon rail and sidebar are replaced by a top bar (section switch,
+ * an Admin shortcut for admins, sign-in/avatar). The channel sidebar is hidden
+ * entirely on phones (one "general" channel, no navigation value yet), so there
+ * is no nav drawer. The bar stays hidden on desktop and is switched on inside the
  * max-width: 900px block below, where the multi-column grid also collapses.
  */
 .mobileBar {
@@ -1331,18 +1332,28 @@
   flex-shrink: 0;
 }
 
-.mobileBarMenuBtn {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
+/* Admin shortcut on the phone-width top bar, sitting just right of the section
+   tabs. Admins-only; it replaces the Admin link that used to live in the (now
+   hidden) phone nav drawer, so admins reach /admin without the extra taps. */
+.mobileBarAdminBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
   color: var(--ctf-text-secondary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
   cursor: pointer;
   flex-shrink: 0;
+}
+
+.mobileBarAdminBtn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--ctf-text-shell);
 }
 
 .mobileBarBrand {
@@ -1430,17 +1441,6 @@
   white-space: nowrap;
 }
 
-.mobileBackdrop {
-  display: none;
-  position: fixed;
-  inset: 0;
-  z-index: 999;
-  background: rgba(8, 9, 13, 0.6);
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 @media (max-width: 1280px) {
   .frame {
@@ -1484,22 +1484,6 @@
     border-right: none;
     flex: 1;
     min-height: 0;
-  }
-
-  /* Sidebar slides in as a drawer when the menu button is pressed. */
-  .leftNav.leftNavMobileOpen {
-    display: flex;
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: min(280px, 85vw);
-    z-index: 1000;
-    box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);
-  }
-
-  .mobileBackdrop {
-    display: block;
   }
 
   .heroBanner {

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { UserButton } from '@clerk/nextjs';
-import { Menu } from 'lucide-react';
+import { SlidersHorizontal } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import type { TrustUserExtension } from '../../lib/trust/types';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
@@ -128,7 +128,6 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
   const [sortMode, setSortMode] = useState<PluginSortMode>('recent');
   const [recentPluginSlugs, setRecentPluginSlugs] = useState<string[]>([]);
   const [pluginUsageCounts, setPluginUsageCounts] = useState<Record<string, number>>({});
-  const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   // Self-heal an out-of-date signed-out render. A back/forward navigation can restore a
   // cached "guest" version of this route (the server resolved the visitor before
@@ -263,15 +262,6 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
   return (
     <div className={`${styles.shell} ctf-self-responsive`}>
       <header className={styles.mobileBar}>
-        <button
-          type="button"
-          className={styles.mobileBarMenuBtn}
-          onClick={() => setMobileNavOpen((open) => !open)}
-          aria-label={mobileNavOpen ? 'Close navigation' : 'Open navigation'}
-          aria-expanded={mobileNavOpen}
-        >
-          <Menu size={18} />
-        </button>
         <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
           <button
             type="button"
@@ -292,6 +282,15 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
             Apps
           </button>
         </div>
+        {/* Admins reach /admin straight from the top bar on phones — the left rail
+            (which used to carry this link) is hidden on phones, so this replaces the
+            extra tap through the drawer. Admins only; hidden for everyone else. */}
+        {isAdmin ? (
+          <Link href="/admin" className={styles.mobileBarAdminBtn}>
+            <SlidersHorizontal size={15} aria-hidden="true" />
+            <span>Admin</span>
+          </Link>
+        ) : null}
         <div className={styles.mobileBarAuth}>
           {/* Help control on the phone-width top bar: the desktop icon rail (which
               hosts it) is hidden below 900px, so signed-in members reach the
@@ -310,22 +309,15 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
       </header>
       <div className={styles.frame}>
         <ShellIconRail section={section} onSectionChange={setSection} initial={currentUser.initial} isAuthenticated={isAuthenticated} isAdmin={isAdmin} />
+        {/* Channel rail — desktop only. It is hidden on phones (single "general"
+            channel, no real navigation value yet), so there is no phone drawer to
+            slide it in; bring one back when there is more than one option to show. */}
         <ShellSidebar
           channels={channels}
           activeChannel={activeChannel}
           onChannelSelect={handleChannelSelect}
-          mobileOpen={mobileNavOpen}
-          onNavigate={() => setMobileNavOpen(false)}
           isAdmin={isAdmin}
         />
-        {mobileNavOpen ? (
-          <button
-            type="button"
-            className={styles.mobileBackdrop}
-            aria-label="Close navigation"
-            onClick={() => setMobileNavOpen(false)}
-          />
-        ) : null}
         <main className={`${styles.panel} ${styles.content}`}>
           {/* App-wide fundraiser banner — non-blocking, top of the content area, signed-in only.
               The banner self-hides unless a drive is active and visible for this member. */}

--- a/ctf/packages/web/components/community-shell/shell-sidebar.tsx
+++ b/ctf/packages/web/components/community-shell/shell-sidebar.tsx
@@ -9,28 +9,23 @@ type ShellSidebarProps = {
   channels: HubChannelInfo[];
   activeChannel: string | null;
   onChannelSelect: (slug: string) => void;
-  // On phones the sidebar is a slide-in drawer; `mobileOpen` controls whether it
-  // is shown and `onNavigate` lets it close itself once a destination is picked.
-  mobileOpen?: boolean;
-  onNavigate?: () => void;
-  // Admins get an Admin link in the drawer footer. The desktop icon rail has its own
-  // Admin entry, but that rail is hidden on phones, so this is how admins reach /admin there.
+  // Admins get an Admin link in the sidebar footer. This rail is desktop-only
+  // (hidden on phones); on phones admins reach /admin from the top bar instead.
   isAdmin?: boolean;
 };
 
 // The sidebar is the chat-channel navigation only. Apps are browsed in the main "Apps"
 // grid (ShellAppsPanel), so the sidebar deliberately does not list them — having the same
-// app list in both the grid and the drawer was redundant.
+// app list in both the grid and the drawer was redundant. Desktop-only: on phones it is
+// hidden entirely (one "general" channel offers no real navigation yet).
 export function ShellSidebar({
   channels,
   activeChannel,
   onChannelSelect,
-  mobileOpen = false,
-  onNavigate,
   isAdmin = false,
 }: ShellSidebarProps) {
   return (
-    <aside className={`${styles.panel} ${styles.leftNav}${mobileOpen ? ` ${styles.leftNavMobileOpen}` : ''}`}>
+    <aside className={`${styles.panel} ${styles.leftNav}`}>
       <div className={styles.sidebarHeader}>
         <p className={styles.sectionTitle}>Channels</p>
       </div>
@@ -44,10 +39,7 @@ export function ShellSidebar({
               type="button"
               className={isActive ? `${styles.sidebarChannel} ${styles.sidebarChannelActive}` : styles.sidebarChannel}
               aria-current={isActive ? 'true' : undefined}
-              onClick={() => {
-                onChannelSelect(ch.slug);
-                onNavigate?.();
-              }}
+              onClick={() => onChannelSelect(ch.slug)}
             >
               <span className={styles.sidebarChannelHash}>#</span>
               <span className={styles.sidebarChannelName}>{ch.slug}</span>
@@ -58,7 +50,7 @@ export function ShellSidebar({
 
       <div className={styles.sidebarFooter}>
         {isAdmin ? (
-          <Link href="/admin" className={styles.sidebarAdminLink} onClick={() => onNavigate?.()}>
+          <Link href="/admin" className={styles.sidebarAdminLink}>
             <SlidersHorizontal size={16} aria-hidden="true" />
             <span>Admin</span>
           </Link>


### PR DESCRIPTION
## What changed

All changes are phone-only; desktop is untouched.

- **Admin moved to the top bar.** On phones an `Admin` button now sits directly to the right of the `Apps` tab and links straight to `/admin`. Shown for admins only. This removes the extra taps that reaching Admin used to need (open the drawer, then tap the footer link).
- **Phone left rail hidden.** The homepage left rail held only the single `general` channel and the Admin link, so it offered no real navigation on a phone. Removed the menu (hamburger) button, the slide-in nav drawer, and its backdrop. The channel sidebar is now desktop-only; a comment notes to bring a drawer back when there is more than one option to show.

## Why

Owner request: reaching Admin on a phone took an unnecessary extra tap, and the phone left rail had no use with a single channel.

## Desktop unchanged

The desktop icon rail and channel sidebar (including its own Admin link) render exactly as before.

## Verification

- Web lint, typecheck (all workspaces, via the pre-commit gate), and the production build all pass.
- EOF format check passes.
- Presentational change only — no route/schema/contract edits, so no plugin feature-inventory update was needed.

Parity Status: web + mobile-responsive + android complete

Note: this change lives in the Next.js web app served at phone width (how iOS and every mobile browser is served, per rule 105). The native Android app has no equivalent left-rail/menu surface, so there is nothing to mirror there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSpFdx2poGrET1auZWPbp5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSpFdx2poGrET1auZWPbp5)_