### PR TITLE
feat: add a uniform mobile-responsive back button across all app and admin screens

### DIFF
--- a/ctf/packages/web/app/admin/layout.tsx
+++ b/ctf/packages/web/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { isDemoMode } from 'lib/feature-flags/system';
 import { AdminDemoBanner } from '@/components/shared/admin-demo-banner';
+import { MobileBackButton } from '@/components/shared/mobile-back-button';
 
 // Applies to every /admin/* screen. When the signed-in operator is a demo participant, getActivePool
 // routes their admin actions to the demo schema, which is easy to miss and makes operations like
@@ -19,6 +20,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
   return (
     <>
       {demo ? <AdminDemoBanner /> : null}
+      <MobileBackButton />
       {children}
     </>
   );

--- a/ctf/packages/web/app/apps/layout.tsx
+++ b/ctf/packages/web/app/apps/layout.tsx
@@ -1,11 +1,21 @@
 import type { ReactNode } from 'react';
+import { MobileBackButton } from '@/components/shared/mobile-back-button';
 
 /**
  * Wraps every routed `/apps/*` screen in the shared app viewport. On phones this
  * lets each plugin shell's fixed desktop row fall back to a single scrolling
  * column (see `.ctf-app-viewport` in `globals.css`); on desktop it is an inert
  * full-width wrapper that changes nothing.
+ *
+ * The MobileBackButton supplies the phone-width back affordance (the desktop
+ * icon rail's "back to all apps" arrow is hidden at this breakpoint); it renders
+ * only on mobile and only off the apps grid home.
  */
 export default function AppsLayout({ children }: { children: ReactNode }) {
-  return <div className="ctf-app-viewport">{children}</div>;
+  return (
+    <>
+      <MobileBackButton />
+      <div className="ctf-app-viewport">{children}</div>
+    </>
+  );
 }

--- a/ctf/packages/web/app/plugin/layout.tsx
+++ b/ctf/packages/web/app/plugin/layout.tsx
@@ -1,10 +1,19 @@
 import type { ReactNode } from 'react';
+import { MobileBackButton } from '@/components/shared/mobile-back-button';
 
 /**
  * Wraps every routed `/plugin/*` screen in the shared app viewport so plugin
  * shells reflow to a single scrolling column on phones. On desktop it is an
  * inert full-width wrapper. See `.ctf-app-viewport` in `globals.css`.
+ *
+ * The MobileBackButton supplies the phone-width back affordance (the desktop
+ * icon rail's "back to all apps" arrow is hidden at this breakpoint).
  */
 export default function PluginLayout({ children }: { children: ReactNode }) {
-  return <div className="ctf-app-viewport">{children}</div>;
+  return (
+    <>
+      <MobileBackButton />
+      <div className="ctf-app-viewport">{children}</div>
+    </>
+  );
 }

--- a/ctf/packages/web/components/shared/mobile-back-button.tsx
+++ b/ctf/packages/web/components/shared/mobile-back-button.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useRouter, usePathname } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+
+// On desktop every plugin/admin screen carries a "Back to all apps" arrow in the left icon rail
+// (PluginRailFooter). The rail is hidden at phone width, which left mobile screens — including the
+// admin surfaces — with no in-app way back: a member had to reach for the browser's own back button.
+// This renders the missing control: one uniform back button pinned to the top-left of every screen at
+// phone width, so the affordance is in the same place on every page (apps, plugin, and admin alike).
+//
+// It is mounted once in each of the three shared layouts (/apps, /plugin, /admin); a given route lives
+// under exactly one of them, so it renders exactly once. It is hidden on desktop (the rail already has
+// the control) and on the apps grid itself (that screen is the home — there is nowhere "back" to go).
+// The admin hub (/admin) keeps the button so every admin screen, the hub included, has it.
+const SUPPRESSED_PATHS = new Set(['/apps']);
+
+export function MobileBackButton() {
+  const isMobile = useIsMobile();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  if (!isMobile) {
+    return null;
+  }
+
+  // The grid/home roots are a destination, not a step you go "back" from.
+  if (pathname && SUPPRESSED_PATHS.has(pathname)) {
+    return null;
+  }
+
+  function handleBack() {
+    // Prefer real history-back so the button returns the member to wherever they came from. When the
+    // screen was opened directly (a shared link, a fresh tab) there is no in-app history to pop, so
+    // fall back to the all-apps grid — the same destination the desktop rail's back arrow uses.
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push('/apps');
+  }
+
+  return (
+    <div
+      className="ctf-self-responsive"
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 40,
+        display: 'flex',
+        padding: '8px 12px',
+        background: 'var(--ctf-bg, rgba(8, 8, 10, 0.92))',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={handleBack}
+        aria-label="Go back"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          height: 40,
+          padding: '0 14px 0 10px',
+          borderRadius: 12,
+          color: 'var(--ctf-text, #E5E7EB)',
+          background: 'var(--ctf-surface, rgba(255, 255, 255, 0.06))',
+          border: '1px solid var(--ctf-border, rgba(255, 255, 255, 0.12))',
+          fontSize: 15,
+          fontWeight: 600,
+          cursor: 'pointer',
+        }}
+      >
+        <ArrowLeft size={18} aria-hidden="true" />
+        Back
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The web-responsive (phone-width) layout had no back button. On desktop every plugin and admin screen carries a "Back to all apps" arrow in the left icon rail (`PluginRailFooter`), but that rail is hidden at phone width — so on mobile, including the admin surfaces (e.g. Unlock Admin in the report), a member had no in-app way back and had to use the browser's own back button.

## Change

Added a shared `MobileBackButton` (`components/shared/mobile-back-button.tsx`) and mounted it once in each of the three shared layouts — `/apps`, `/plugin`, and `/admin`. A given route lives under exactly one of these, so it renders exactly once, giving a uniform control in the same place on every screen (app and admin alike).

Behavior:
- Renders **only at phone width** (`useIsMobile`) — on desktop the icon-rail control already exists, so nothing changes there.
- Suppressed on the apps grid home (`/apps`) — that screen is the home, with nowhere "back" to go. Every other screen, the admin hub included, shows it.
- Returns the member through real **history-back**, falling back to the all-apps grid (`/apps`) when the screen was opened directly (a shared link or a fresh tab) — the same destination the desktop rail's arrow uses.
- Pinned top-left and **sticky** so it stays reachable while scrolling long admin pages. Rendered as a sibling above the `.ctf-app-viewport` wrapper so its sticky context is the document (the viewport's `overflow-x: hidden` would otherwise break sticky). Uses existing theme tokens (`--ctf-bg`, `--ctf-surface`, `--ctf-text`, `--ctf-border`) so it follows the active theme.

Additive and surgical: no existing shell markup or copy changed; the only edits are the three one-line layout mounts plus the new component. Typecheck, lint, and EOF format are clean.

Android already provides native back navigation through its React Navigation stack and screen headers, so this brings the web-responsive layout to parity rather than adding anything to the native app.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_