### PR TITLE
feat: add the account hub link to the apps launcher mobile top bar

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { UserButton } from '@clerk/nextjs';
-import { SlidersHorizontal } from 'lucide-react';
+import { SlidersHorizontal, Settings } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import type { TrustUserExtension } from '../../lib/trust/types';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
@@ -296,6 +296,16 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
               hosts it) is hidden below 900px, so signed-in members reach the
               "Report a problem" modal from here instead. */}
           {isAuthenticated ? <HelpControl /> : null}
+          {/* Account hub link on the phone-width bar: the desktop icon rail's
+              account button (which leads to /account — identity, trust, profile,
+              data, blocked members) is hidden below 900px, so this gear restores
+              the one tap to the full account page. The avatar's own menu only
+              edits Clerk identity, so it is not a substitute for this link. */}
+          {isAuthenticated ? (
+            <Link href="/account" className={styles.iconRailBtn} aria-label="Account and settings" title="Account and settings">
+              <Settings size={18} aria-hidden="true" />
+            </Link>
+          ) : null}
           {isAuthenticated ? (
             // Clerk's account widget on the phone-width bar too: avatar opens
             // Clerk's menu; "Manage account" edits name, username, and email.


### PR DESCRIPTION
## What

The apps launcher (`/apps` home grid) was the one screen still missing the account link on mobile. Its desktop left rail has a dedicated Account button (a gear/Shield → `/account`: identity, trust, profile, data, blocked members), but the phone-width top bar dropped it, leaving only the avatar — and the avatar's Clerk menu only edits identity, so it isn't a substitute for the full account page.

## Change

Adds a gear link to `/account` in the launcher's phone-width auth cluster, between the report-a-bug control and the avatar — the same order and the same `/account` destination as the account control the plugin and admin mobile chrome now carry (#1182, #1187). Styled with the existing `iconRailBtn` class so it matches the report-a-bug button beside it. Only shows for signed-in members; desktop is untouched. One file, additive.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_