### PR TITLE
fix: correct the back button position on unauthenticated plugin landing pages

### DIFF
--- a/ctf/packages/web/components/plugins/public-shell-frame.tsx
+++ b/ctf/packages/web/components/plugins/public-shell-frame.tsx
@@ -11,36 +11,75 @@ import type { ReactNode } from 'react';
  * back button — so this control only ever appears where one was missing, and
  * never doubles an existing one.
  *
- * Fixed to the top-left so it overlays the shell without disturbing its layout;
- * neutral styling reads on every plugin's dark public background.
+ * The control is anchored to a `position: relative` wrapper, never `position:
+ * fixed`. A fixed element is positioned against the viewport only when no
+ * ancestor establishes a containing block, but a parent with a transform /
+ * filter / backdrop-filter does establish one — which previously threw the
+ * button to the middle-right edge of the screen and clipped it. Anchoring to our
+ * own wrapper resolves reliably regardless of any ancestor.
+ *
+ * Two breakpoints, because the landing shells differ:
+ *  - Desktop shells lay their content out inside wide (~64px) side margins, so a
+ *    top-left corner overlay sits in that margin and overlaps nothing.
+ *  - Mobile shells run their own brand/title to the top-left edge, so an overlay
+ *    there would sit on top of it. On phones the control is a normal-flow bar
+ *    above the shell instead, which never collides.
+ *
+ * The `.ctf-bp-desktop` / `.ctf-bp-mobile` toggling lives on plain wrapper divs
+ * (no inline `display`), because an inline `display` would beat the class rule
+ * and defeat the breakpoint switch.
  */
+const BACK_BUTTON_STYLE = {
+  width: 38,
+  height: 38,
+  borderRadius: 10,
+  background: 'rgba(255,255,255,0.06)',
+  border: '1px solid rgba(255,255,255,0.14)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: '#F9FAFB',
+  textDecoration: 'none',
+  backdropFilter: 'blur(4px)',
+  flexShrink: 0,
+} as const;
+
 export function PublicShellFrame({ children }: { children: ReactNode }) {
   return (
-    <>
-      <Link
-        href="/apps"
-        aria-label="Back to apps"
-        style={{
-          position: 'fixed',
-          top: 14,
-          left: 14,
-          zIndex: 50,
-          width: 38,
-          height: 38,
-          borderRadius: 10,
-          background: 'rgba(255,255,255,0.06)',
-          border: '1px solid rgba(255,255,255,0.14)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: '#F9FAFB',
-          textDecoration: 'none',
-          backdropFilter: 'blur(4px)',
-        }}
-      >
-        <ChevronLeft size={20} />
-      </Link>
+    <div style={{ position: 'relative', minHeight: '100dvh' }}>
+      {/* Desktop: corner overlay inside the shell's side margin (adds no height). */}
+      <div className="ctf-bp-desktop">
+        <Link
+          href="/apps"
+          aria-label="Back to apps"
+          style={{ position: 'absolute', top: 14, left: 14, zIndex: 50, ...BACK_BUTTON_STYLE }}
+        >
+          <ChevronLeft size={20} />
+        </Link>
+      </div>
+
+      {/* Mobile: a normal-flow bar above the shell, so it never overlaps the
+          shell's own top-left brand. */}
+      <div className="ctf-bp-mobile">
+        <div
+          style={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 50,
+            display: 'flex',
+            alignItems: 'center',
+            padding: '10px 14px',
+            background: 'var(--ctf-bg, #0B0B0F)',
+            borderBottom: '1px solid rgba(255,255,255,0.1)',
+          }}
+        >
+          <Link href="/apps" aria-label="Back to apps" style={BACK_BUTTON_STYLE}>
+            <ChevronLeft size={20} />
+          </Link>
+        </div>
+      </div>
+
       {children}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## What

On every unauthenticated plugin landing page (e.g. ClickLog, Directory), the back-to-apps chevron rendered as a dark rounded button floating against the **middle-right edge** of the screen, half clipped off.

## Cause

`PublicShellFrame` (the wrapper around every public-visitor shell) positioned the chevron with `position: fixed; top: 14; left: 14`. A `fixed` element only anchors to the viewport when no ancestor establishes a containing block — but any ancestor with a `transform` / `filter` / `backdrop-filter` does, and one in the tree was throwing the button to the mid-right edge instead of the top-left.

## Fix

Anchor the control to a `position: relative` wrapper instead of `fixed`, so it resolves reliably regardless of ancestors. Because the landing shells differ by breakpoint:
- **Desktop** keeps the top-left corner overlay — it sits inside the shells' wide (~64px) side margins and overlaps nothing.
- **Mobile** uses a normal-flow bar above the shell, because the mobile landing shells run their own brand (icon + title) to the top-left edge, where an overlay would cover it.

The `.ctf-bp-desktop` / `.ctf-bp-mobile` toggling is on plain wrapper divs (no inline `display`) so an inline `display` can't beat the class rule and defeat the switch. One file, no behavior change for verified members (they never see these shells).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_