### PR TITLE
fix: make the ServiceCredits public earn/spend lists accurate

### DIFF
--- a/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
@@ -3,6 +3,7 @@
 import { Zap, Lock } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+import { PLATFORM_EARN_METHODS, PEER_TO_PEER_AREAS } from './service-credits.constants';
 
 // Palette from the ServiceCreditsPublic / MobileServiceCreditsPublic design mockups.
 const BG = '#0F1117';
@@ -12,35 +13,16 @@ const TEXT = '#F9FAFB';
 const SUBTLE = '#9CA3AF';
 const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
-// These earn/spend lists are static marketing copy describing how the Hub economy
-// works (program rules), not per-user balances or fabricated transactions, so they
-// are safe to render in a signed-out public shell.
-const EARN_WAYS = [
-  { action: 'Complete a GentlePulse session', credits: '+5' },
-  { action: 'Attend a LevelUp cohort session', credits: '+15' },
-  { action: 'Refer a verified survivor', credits: '+50' },
-  { action: 'Give peer support in Chyme', credits: '+3' },
-  { action: 'Complete SkillsHunt round', credits: '+100' },
-];
+// The earn/spend lists describe how the Hub economy works (program rules), not per-user balances or
+// fabricated transactions, so they are safe to render in a signed-out public shell. They are derived
+// from the SAME shared constants the signed-in Earn tab (sc-earn-tab.tsx) renders, so the public
+// teaser can never drift from the real earn model: a few platform-funded rewards (verify your
+// account, SkillsHunt, fundraiser contributions) plus peer-to-peer trading across the Hub. No
+// invented amounts — each value comes straight from the shared model, and peer-to-peer spend is
+// member-set, so it shows as "Variable".
+const EARN_WAYS = PLATFORM_EARN_METHODS.map((m) => ({ action: m.title, credits: m.credits }));
 
-const SPEND_WAYS = [
-  { action: 'Pay for housing (LightHouse)', credits: 'Variable' },
-  { action: 'Book a TrustTransport ride', credits: '12–40 ServiceCredits' },
-  { action: 'Hire from Foundation (trades)', credits: 'Variable' },
-  { action: 'Pay a Directory provider', credits: 'Variable' },
-];
-
-const EARN_WAYS_MOBILE = [
-  { action: 'Complete a GentlePulse session', credits: '+5' },
-  { action: 'Attend a LevelUp cohort', credits: '+15' },
-  { action: 'Refer a survivor', credits: '+50' },
-];
-
-const SPEND_WAYS_MOBILE = [
-  { action: 'Housing (LightHouse)', credits: 'Variable' },
-  { action: 'Transport (TrustTransport)', credits: '12–40 cr' },
-  { action: 'Trades (Foundation)', credits: 'Variable' },
-];
+const SPEND_WAYS = PEER_TO_PEER_AREAS.map((a) => ({ action: a.title, credits: 'Variable' }));
 
 function DesktopServiceCreditsPublic({ signInUrl, verifyUrl }: { signInUrl: string; verifyUrl?: string }) {
   return (
@@ -65,7 +47,7 @@ function DesktopServiceCreditsPublic({ signInUrl, verifyUrl }: { signInUrl: stri
           Earn credits. Spend them<br /><span style={{ color: COLOR }}>on real services, for free.</span>
         </h1>
         <p style={{ margin: 0, fontSize: 15, color: SUBTLE, maxWidth: 520 }}>
-          ServiceCredits are earned by participating in the Hub and spent on housing, transport, healthcare, and trades. They are usable across all 18 plugins in the network.
+          ServiceCredits are earned from a few platform rewards and by trading with other members, and spent on housing, transport, services, and trades. They are usable across the plugins in the network.
         </p>
         <a href={verifyUrl ?? signInUrl} style={{ marginTop: 8, padding: '14px 32px', borderRadius: 10, background: COLOR, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', width: 'fit-content', textDecoration: 'none', display: 'inline-block' }}>
           {verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}
@@ -114,11 +96,11 @@ function MobileServiceCreditsPublic({ signInUrl, verifyUrl }: { signInUrl: strin
         <h2 style={{ margin: 0, fontSize: 22, fontWeight: 800, lineHeight: 1.2 }}>
           Earn credits by participating.<br /><span style={{ color: COLOR }}>Spend them on real services.</span>
         </h2>
-        <p style={{ margin: 0, fontSize: 14, color: SUBTLE, lineHeight: 1.5 }}>Earn ServiceCredits through learning, mentoring, and community activities. Use them across housing, transport, trades, and more.</p>
+        <p style={{ margin: 0, fontSize: 14, color: SUBTLE, lineHeight: 1.5 }}>A few rewards come from the platform — the rest you earn by trading with other members. Use credits across housing, transport, services, and more.</p>
 
         <div style={{ borderRadius: 14, border: '1px solid rgba(255,255,255,0.08)', padding: '16px', background: 'rgba(255,255,255,0.02)' }}>
           <div style={{ fontSize: 11, fontWeight: 700, color: EARN_GREEN, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 10 }}>Ways to Earn</div>
-          {EARN_WAYS_MOBILE.map((e) => (
+          {EARN_WAYS.map((e) => (
             <div key={e.action} style={{ display: 'flex', justifyContent: 'space-between', padding: '7px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
               <span style={{ fontSize: 13 }}>{e.action}</span>
               <span style={{ fontSize: 13, fontWeight: 700, color: EARN_GREEN }}>{e.credits}</span>
@@ -128,7 +110,7 @@ function MobileServiceCreditsPublic({ signInUrl, verifyUrl }: { signInUrl: strin
 
         <div style={{ borderRadius: 14, border: '1px solid rgba(255,255,255,0.08)', padding: '16px', background: 'rgba(255,255,255,0.02)' }}>
           <div style={{ fontSize: 11, fontWeight: 700, color: COLOR, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 10 }}>Ways to Spend</div>
-          {SPEND_WAYS_MOBILE.map((s) => (
+          {SPEND_WAYS.map((s) => (
             <div key={s.action} style={{ display: 'flex', justifyContent: 'space-between', padding: '7px 0', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
               <span style={{ fontSize: 13 }}>{s.action}</span>
               <span style={{ fontSize: 13, fontWeight: 700, color: COLOR }}>{s.credits}</span>


### PR DESCRIPTION
## What

The signed-out ServiceCredits landing page listed a hardcoded, fabricated earn model — "Complete a GentlePulse session +5", "Attend a LevelUp cohort +15", "Refer a survivor +50", "Give peer support in Chyme +3" — and an invented spend amount ("12–40 cr"). None of that matches how credits are actually earned.

## Fix

Derive the public earn/spend lists from the **same shared constants the signed-in Earn tab uses** (`PLATFORM_EARN_METHODS`, `PEER_TO_PEER_AREAS` in `service-credits.constants.ts`), so the public teaser states the real model and can't drift again:

- **Ways to Earn** → the real platform rewards: Verify your account (+100), Take part in SkillsHunt (Per round), Contribute during a fundraiser (Varies).
- **Ways to Spend** → the real peer-to-peer areas: Housing (LightHouse), Transport (TrustTransport), Services (Directory & Foundation), Requests (SocketRelay) — amounts are member-set, shown as "Variable" (no invented numbers).

Also corrected the intro copy that implied "learning, mentoring" earns credits (it doesn't), mirroring the signed-in tab's approved wording, and dropped the hardcoded "18 plugins" count.

No fabricated numbers remain; the public page now matches the signed-in page exactly because both read the same source.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_