### PR TITLE
fix: tidy the LevelUp Browse page (dead Create button, duplicate balance, static track chips)

### DIFF
--- a/ctf/packages/mobile/src/features/level-up/LevelUp.tsx
+++ b/ctf/packages/mobile/src/features/level-up/LevelUp.tsx
@@ -43,7 +43,9 @@ const TRACK_COLORS: Record<string, string> = {
   'Life Skills': '#A855F7',
 };
 
-const TRACKS = ['All', 'Tech', 'Finance', 'Wellness', 'Life Skills'];
+// Preset track filter pills were a fixed, hardcoded list that did not reflect the cohorts that
+// actually exist, so they are hidden until they can be driven by real cohort data at scale
+// (deferred — see #1197). TRACK_COLORS above is kept — it colors a cohort card by its real track.
 
 // ---------------------------------------------------------------------------
 // Loading state — aligned to MobileLevelUpLoading.tsx
@@ -174,25 +176,6 @@ export function LevelUp() {
     }
     return (
       <>
-        {/* Track filter pills */}
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.trackPills}
-        >
-          {TRACKS.map((track) => (
-            <TouchableOpacity
-              key={track}
-              style={[styles.trackPill, activeTrack === track && styles.trackPillActive]}
-              onPress={() => setActiveTrack(track)}
-            >
-              <Text style={[styles.trackPillText, activeTrack === track && styles.trackPillTextActive]}>
-                {track}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
-
         {/* Cohort list */}
         {filtered.length === 0 ? (
           <LevelUpEmpty onBrowse={() => setActiveTrack('All')} />
@@ -305,15 +288,6 @@ const styles = StyleSheet.create({
   tabText: { fontSize: 13, fontWeight: '600', color: '#9CA3AF' },
   tabTextActive: { color: GREEN },
 
-  // Track pills
-  trackPills: { paddingHorizontal: 16, paddingVertical: 12, gap: 8 },
-  trackPill: {
-    flexShrink: 0, paddingHorizontal: 12, paddingVertical: 5, borderRadius: 20,
-    backgroundColor: BORDER,
-  },
-  trackPillActive: { backgroundColor: GREEN },
-  trackPillText: { fontSize: 11, fontWeight: '400', color: SUBTLE },
-  trackPillTextActive: { color: '#000', fontWeight: '600' },
 
   // List
   list: { paddingHorizontal: 16, paddingBottom: 80 },

--- a/ctf/packages/web/components/level-up/level-up-shell.tsx
+++ b/ctf/packages/web/components/level-up/level-up-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { ChevronLeft, Plus } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { getLevelUpTokens, type LevelUpTokens, type Cohort, type Enrollment, type PendingValidation, type NavKey, type Wallet, type Trainer, type Achievement, type WalletView, idempotencyKey } from "./lu-shared";
@@ -80,12 +80,6 @@ function ShellHeader({ nav, isAdmin, t, showAdminButton = false }: { nav: NavKey
         </div>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-        {nav === "browse" && (
-          <button type="button" disabled={!isAdmin}
-            style={{ display: "flex", alignItems: "center", gap: 6, background: "rgba(255,255,255,0.05)", color: t.TEXT_SUBTLE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 8, padding: "9px 18px", fontSize: 13, fontWeight: 600, cursor: isAdmin ? "pointer" : "not-allowed", opacity: isAdmin ? 1 : 0.5 }}>
-            <Plus size={14} /> Create Cohort
-          </button>
-        )}
         {showAdminButton && <PluginAdminButton href="/admin/level-up" isAdmin={isAdmin} accent={t.ACCENT} />}
       </div>
     </div>
@@ -145,7 +139,10 @@ function ShellContent({
 
 export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: boolean; query?: { track?: string; status?: string; startDate?: string; cohortId?: string } }) {
   const [nav, setNav] = useState<NavKey>("browse");
-  const [track, setTrack] = useState("All Tracks");
+  // Track filtering is pinned to "All Tracks" — the preset track chips were hidden because they were a
+  // hardcoded list that did not reflect real cohorts (deferred to #1197). The track-filter plumbing
+  // (fetchCohorts/deriveView) is kept so dynamic, data-driven filters can be restored later.
+  const track = "All Tracks";
   const [search, setSearch] = useState("");
   const [cohorts, setCohorts] = useState<Cohort[]>([]);
   const [wallet, setWallet] = useState<Wallet | null>(null);
@@ -270,10 +267,7 @@ export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: b
             cohorts={filtered}
             openCount={openCount}
             enrolledCount={enrollments.length}
-            balance={balance}
             escrow={escrow}
-            track={track}
-            onTrack={setTrack}
             search={search}
             onSearch={setSearch}
             enrollError={enrollError}

--- a/ctf/packages/web/components/level-up/lu-browse.tsx
+++ b/ctf/packages/web/components/level-up/lu-browse.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { BookOpen, CheckCircle, Coins, Search, Users } from "lucide-react";
-import { BORDER, GREEN, MUTED, SUBTLE, SURFACE, TEXT, TRACKS, type Cohort } from "./lu-shared";
+import { BookOpen, CheckCircle, Search, Users } from "lucide-react";
+import { BORDER, GREEN, MUTED, SUBTLE, SURFACE, TEXT, type Cohort } from "./lu-shared";
 import { LevelUpCohortCard } from "./lu-cohort-card";
 
 export function LevelUpBrowse({
   cohorts,
   openCount,
   enrolledCount,
-  balance,
   escrow,
-  track,
-  onTrack,
   search,
   onSearch,
   enrollError,
@@ -22,10 +19,7 @@ export function LevelUpBrowse({
   cohorts: Cohort[];
   openCount: number;
   enrolledCount: number;
-  balance: number;
   escrow: number;
-  track: string;
-  onTrack: (track: string) => void;
   search: string;
   onSearch: (value: string) => void;
   enrollError: string | null;
@@ -36,13 +30,12 @@ export function LevelUpBrowse({
   const stats = [
     { label: "Open Cohorts", value: String(openCount), icon: BookOpen, color: GREEN },
     { label: "Enrolled", value: String(enrolledCount), icon: Users, color: "#3B82F6" },
-    { label: "My Balance", value: `${balance.toLocaleString()} SC`, icon: Coins, color: "#A855F7" },
     { label: "In Escrow", value: `${escrow.toLocaleString()} SC`, icon: CheckCircle, color: "#F59E0B" },
   ];
 
   return (
     <>
-      {/* Auto-fit grid so the four stat cards lay out 4-across on desktop and wrap to 2×2 on a phone,
+      {/* Auto-fit grid so the stat cards lay out across the row on desktop and wrap on a phone,
           instead of a fixed flex row that runs off the side of the screen (the app viewport hides
           horizontal overflow, so an off-screen card would be unreachable). */}
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 12, marginBottom: 24 }}>
@@ -57,14 +50,10 @@ export function LevelUpBrowse({
         ))}
       </div>
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
-        {TRACKS.map((t) => (
-          <button key={t} type="button" onClick={() => onTrack(t)}
-            style={{ padding: "7px 14px", borderRadius: 20, border: "none", cursor: "pointer", fontSize: 12, fontWeight: 500, background: track === t ? GREEN : BORDER, color: track === t ? "#000" : SUBTLE }}>
-            {t}
-          </button>
-        ))}
-        <div style={{ flex: 1 }} />
+      {/* Preset track filter chips were a fixed, hardcoded list (Tech / Finance / Wellness / Life
+          Skills) that did not reflect the cohorts that actually exist, so they are hidden until they
+          can be driven by real cohort data at scale (deferred — see #1197). Search stays. */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap", justifyContent: "flex-end" }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8, background: SURFACE, border: `1px solid ${BORDER}`, borderRadius: 8, padding: "7px 12px" }}>
           <Search size={13} color={MUTED} />
           <input value={search} onChange={(e) => onSearch(e.target.value)} placeholder="Search cohorts…"

--- a/ctf/packages/web/components/level-up/lu-shared.ts
+++ b/ctf/packages/web/components/level-up/lu-shared.ts
@@ -67,6 +67,9 @@ export const STATUS_COLOR: Record<string, string> = {
   draft: MUTED,
 };
 
+// Preset track filter chips. Hidden from the Browse UI for now because this is a fixed, hardcoded list
+// that does not reflect the cohorts that actually exist; kept here to restore as data-driven filters
+// once cohorts are automated at scale (deferred — see #1197).
 export const TRACKS = ["All Tracks", "Tech", "Finance", "Wellness", "Life Skills"];
 
 export type NavKey = "browse" | "progress" | "trainers" | "achievements" | "wallet";

--- a/ctf/packages/web/components/level-up/lu-sidebar.tsx
+++ b/ctf/packages/web/components/level-up/lu-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, CheckCircle, Coins, DollarSign, Plus, Target, Trophy, TrendingUp, Users } from "lucide-react";
+import { BookOpen, CheckCircle, Coins, DollarSign, Target, Trophy, TrendingUp, Users } from "lucide-react";
 import { BORDER, GREEN, MUTED, SUBTLE, SURFACE, TEXT, type NavKey } from "./lu-shared";
 
 const NAV_ITEMS: { icon: React.ElementType; label: string; key: NavKey }[] = [
@@ -12,7 +12,6 @@ const NAV_ITEMS: { icon: React.ElementType; label: string; key: NavKey }[] = [
 ];
 
 const TRAINER_TOOLS = [
-  { icon: Plus, label: "Create Cohort" },
   { icon: CheckCircle, label: "Validate Milestones" },
   { icon: DollarSign, label: "Payout History" },
 ];


### PR DESCRIPTION
Cleans up three misleading or non-functional elements on the LevelUp Browse surface, on web and Android.

Parity Status: web + mobile-responsive + android complete

## Changes

- **Dead "Create Cohort" button removed.** The header button (and the matching sidebar "Create Cohort" label) had no click handler — clicking it did nothing. Removed both. Cohort creation is the `POST /api/level-up/cohorts` API plus the auto-creator; there is no working manual create form, so the button only implied a feature that wasn't there.
- **Duplicate balance card removed from Browse.** The "My Balance" SC stat card duplicated the wallet balance on the Browse page. Removed from Browse only — the Credits Wallet tab still shows it, as do the desktop sidebar balance widget and the Android header badge (persistent chrome, left in place). The "In Escrow" card stays.
- **Static track filter chips hidden.** The preset chips (Tech / Finance / Wellness / Life Skills) were a fixed, hardcoded list that did not reflect the cohorts that actually exist. Hidden on web (`lu-browse.tsx`) and Android (`LevelUp.tsx`); the search box stays. The filter plumbing (`fetchCohorts` `?track=` / `deriveView` on web, `activeTrack` on Android) is kept and `TRACKS` is retained with a comment, so the chips can return as **data-driven** filters once cohorts run at scale. Tracked in #1197.

## Notes

- Web and Android both updated, so the Browse surfaces stay in parity.
- Display-only: no schema, route, contract, or data-model change. No inventory/contract update needed (these specific UI elements were not documented features; the dead button never worked).

## Verification

`pnpm --filter @ctf/web` and `--filter @ctf/mobile` typecheck + lint pass; web build passes; EOF format passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J83UGV6UMumitfDwqTrwNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01J83UGV6UMumitfDwqTrwNm)_