### PR TITLE
fix: correct trust-transport sidebar trip locations and type mobile chat client

### DIFF
--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransportStreamTab.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransportStreamTab.tsx
@@ -13,14 +13,17 @@ interface TrustTransportStreamTabProps {
 export const TrustTransportStreamTab: React.FC<TrustTransportStreamTabProps> = ({ tripId }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // `stream-chat` and `stream-chat-react-native` bundle divergent StreamChat type definitions:
+  // StreamChat.getInstance() returns StreamChat<DefaultGenerics>, but the <Chat>/<Channel> props want the
+  // RN package's generic-less StreamChat, so neither single type satisfies both ends (TS2740). Hold the
+  // client loosely and let the JSX below consume it; the runtime object is the same StreamChat instance.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [chatClient, setChatClient] = useState<any>(null);
   const [channelId, setChannelId] = useState<string | null>(null);
 
   useEffect(() => {
     let isMounted = true;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let chat: any = null;
+    let chat: StreamChat | null = null;
 
     fetchTrustTransportStreamCredentials(tripId)
       .then(async (creds) => {

--- a/ctf/packages/web/components/trust-transport/tt-sidebar.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-sidebar.tsx
@@ -40,7 +40,9 @@ export function TrustTransportSidebar({
             requests.slice(0, 3).map((r) => (
               <div key={r.id} style={{ padding: "10px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.05)", marginBottom: 6 }}>
                 <div style={{ fontSize: 12, color: "#E8EAF0", fontWeight: 600, marginBottom: 2 }}>
-                  {r.fromLocation ?? "—"} → {r.toLocation ?? "—"}
+                  {/* The API returns pickupCity/dropoffCity (and a title), never fromLocation/toLocation,
+                      so read those first — matching the tracking and chat tabs — to avoid always showing "— → —". */}
+                  {r.pickupCity ?? r.fromLocation ?? "—"} → {r.dropoffCity ?? r.toLocation ?? "—"}
                 </div>
                 <div style={{ fontSize: 11, color: "#4B5563" }}>{r.status ?? "Pending"}</div>
               </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Two low-risk trust-transport code-review findings.

## Changes

- **`tt-sidebar` (#1113):** the "My Trips" cards read `fromLocation`/`toLocation`, which the API never returns, so every card rendered "— → —". Now reads `pickupCity`/`dropoffCity` first (with the legacy names as fallback), matching the tracking and chat tabs. (The original #1113 chat-id bug was already fixed earlier; the live sweep finding on that issue is this sidebar display bug.)
- **`TrustTransportStreamTab` (#1207):** type the effect-local chat client as `StreamChat` instead of `any`. The component-level client stays loosely typed at the JSX boundary because `stream-chat` and `stream-chat-react-native` ship divergent `StreamChat` type definitions (TS2740); the bare `eslint-disable` is replaced with a comment that explains the version skew, which is what the finding asked for.

Closes #1113
Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_