### PR TITLE
fix: keep Workforce hero stat figures inside their cards on phone width

### DIFF
--- a/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
+++ b/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
@@ -58,9 +58,28 @@ export function WorkforceHeroStats({ dashboard }: WorkforceHeroStatsProps) {
               borderRadius: 16,
               background: `${color}08`,
               border: `1px solid ${color}20`,
+              // Let the grid track shrink instead of being forced wide by the big number, which was
+              // overflowing the card (and the page) on phone-width 2-column layouts.
+              minWidth: 0,
             }}
           >
-            <div style={{ fontSize: 28, fontWeight: 800, color, marginBottom: 4 }}>{value}</div>
+            <div
+              style={{
+                // Scale the figure down on narrow screens so 7-digit numbers stay inside the card
+                // (caps at 28px on desktop). overflow guards against any residual horizontal bleed.
+                fontSize: 'clamp(16px, 4.8vw, 28px)',
+                fontWeight: 800,
+                color,
+                marginBottom: 4,
+                lineHeight: 1.15,
+                letterSpacing: '-0.01em',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {value}
+            </div>
             <div style={{ fontSize: 13, color: '#F9FAFB', fontWeight: 600, marginBottom: 4 }}>{label}</div>
             <div style={{ fontSize: 12, color: '#6B7280' }}>{delta}</div>
           </div>


### PR DESCRIPTION
The Workforce dashboard hero stat numbers (Population, Workforce Total, Total Headcount Target) ran out of their cards on phone width — the fixed 28px size is too wide for 7-digit figures in the 2-column layout, so "2,000,000" was clipped by the card edge and the page picked up a horizontal scroll.

Parity Status: web + mobile-responsive + android complete

## Fix

- The hero figure now uses a responsive size — `clamp(16px, 4.8vw, 28px)` — so it scales down to fit on narrow screens and still caps at 28px on desktop. Full figures are kept (not abbreviated).
- The card can shrink (`minWidth: 0`) instead of being forced wide by the number, and overflow is clipped as a guard against any residual horizontal bleed.

Display-only, web-only (the Android stat cards already use abbreviated counts and don't overflow). No data, API, schema, or contract change. Verified with web typecheck + lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg3KmPnbyvdcArCUUJHNyC)_