### PR TITLE
chore: omit the Minutes row from the CI budget monitor when it can't be measured

### DIFF
--- a/ctf/scripts/githubActionsBudgetMonitor.mjs
+++ b/ctf/scripts/githubActionsBudgetMonitor.mjs
@@ -378,9 +378,14 @@ function buildSummaryMarkdown({
   lines.push("");
   lines.push("| Metric | Used | Budget | Percent | Level |");
   lines.push("|---|---:|---:|---:|---|");
-  lines.push(
-    `| Minutes | ${formatUsageValue(usage.minutesUsed, "minutes")} | ${formatUsageValue(usage.minutesBudget, "minutes")} | ${classes.minutes.percentUsed ?? "unknown"}% | ${classes.minutes.level} |`,
-  );
+  // Only show the Minutes row when minutes were actually measured. When the billing/timing APIs are
+  // unavailable (degraded auth) there is no real number to report, so an "unknown / unknown% / unknown"
+  // row is noise — omit it entirely. The "Data Notes" section still records why minutes are absent.
+  if (usage.minutesUsed !== null && usage.minutesUsed !== undefined) {
+    lines.push(
+      `| Minutes | ${formatUsageValue(usage.minutesUsed, "minutes")} | ${formatUsageValue(usage.minutesBudget, "minutes")} | ${classes.minutes.percentUsed ?? "unknown"}% | ${classes.minutes.level} |`,
+    );
+  }
   lines.push(
     `| Artifact storage | ${formatUsageValue(usage.artifactStorageMbUsed, "mb")} | ${formatUsageValue(usage.artifactStorageMbBudget, "mb")} | ${classes.artifacts.percentUsed ?? "unknown"}% | ${classes.artifacts.level} |`,
   );


### PR DESCRIPTION
## What

The GitHub Actions Budget Monitor (#1219) printed a `Minutes | unknown | 2,000 min | unknown% | unknown` row when it couldn't actually measure minutes — the org billing API is unavailable for this account and the repo run-timing fallback returned 401 (Bad credentials), so `minutesUsed` was null.

## Fix

Only emit the Minutes row when minutes were actually measured (`minutesUsed` is not null). When it's unmeasurable, the row is omitted entirely instead of showing "unknown" placeholders. The "Data Notes" section still records why minutes are absent (e.g. "minutes unavailable in repo fallback mode"), so the reason isn't lost. Artifact storage and the rest of the report are unchanged.

Closes #1219

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_