### PR TITLE
fix: use github.rest.issues in the cleanup-artifacts workflow

### DIFF
--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const issues = await github.issues.listForRepo({
+            const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
@@ -69,13 +69,13 @@ jobs:
             const issueNumbers = process.env.ISSUE_NUMBERS || '';
             if (!issueNumbers) return;
             for (const num of issueNumbers.split(',')) {
-              await github.issues.createComment({
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: Number(num),
                 body: 'Artifacts cleaned up automatically. Closing issue.'
               });
-              await github.issues.update({
+              await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: Number(num),


### PR DESCRIPTION
## What

The **Cleanup — Old Artifacts and Close CI Budget Issues** workflow (one of the 5 in the CI-health tracker #439) failed with:

```
TypeError: Cannot read properties of undefined (reading 'listForRepo')
```

## Cause

The "find/close CI budget monitor issues" steps used `github.issues.listForRepo`, `github.issues.createComment`, and `github.issues.update`. In `actions/github-script` v7 the REST methods live under `github.rest.*` (the bare `github.issues` namespace doesn't exist), so the calls threw. The artifact-cleanup steps in the same file already correctly use `github.rest.actions.*`.

## Fix

Changed the three issues calls to `github.rest.issues.*`. One-line-each change to the workflow.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyNnitKCgdqMM1He9a8vG1)_