### PR TITLE
docs: sync LevelUp + Unlock manual test scripts with their inventories

### DIFF
--- a/ctf/docs/developer/test-scripts/level-up-test-script.md
+++ b/ctf/docs/developer/test-scripts/level-up-test-script.md
@@ -160,7 +160,7 @@ adjustment transfer applies. An unrelated trainer is denied with a readable mess
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ### LVL-A4 · Auto-cohort run from Workforce gaps
-**Role:** admin · **Surfaces:** web (`/admin/level-up`)
+**Role:** admin · **Surfaces:** web (`/admin/level-up`), android (admin screen)
 **Precondition:** Skills Taxonomy has at least one sector with a positive `workforce_share` and at
 least one Foundational-level occupation whose gap is at or above the configured minimum.
 **Steps:**
@@ -174,7 +174,8 @@ If no sector carries a workforce share, the run reports it was skipped rather th
 Each created cohort carries the configured economic policy (deposit from `default_required_credits`,
 default 0 = free to join; trainer split `default_trainer_split_percent`, default 25%; completion bonus
 `default_completion_bonus_credits`, default 0) and the standard 3-milestone skeleton (40/30/30) — open
-a created cohort's detail and confirm the milestones are present.
+a created cohort's detail and confirm the milestones are present. On android, the same "Run now" action
+and the `auto` / `needs trainer` badges on the cohort overview must behave the same (#1200).
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ---
@@ -183,8 +184,9 @@ a created cohort's detail and confirm the milestones are present.
 
 For LVL-1, LVL-3, LVL-4, and LVL-5, the android app and the mobile-responsive web layout must behave
 the same: same cohort list, same grant-only wallet, same earned badges, same trainer directory. The
-Android admin screen mirrors the cohort overview and the grant action (it has no KPI cards — see Known
-gaps). Note any drift here rather than filing separate bugs.
+Android admin screen mirrors the cohort overview, the grant action, and (since #1200) the auto-cohort
+**Run now** action plus the `auto` / `needs trainer` badges (it has no KPI cards — see Known gaps).
+Note any drift here rather than filing separate bugs.
 
 **Result:** matches ☐ — drift notes:
 
@@ -202,6 +204,3 @@ of these, it is already tracked, not a new bug:
   by role before render; it relies on the server-side admin gate on the grant action.
 - The track/badge management mockup has no backing endpoints, so that surface is not built (tracks are
   a free-text field and there is no badge-editing model).
-- The auto-cohort **Run now** button and the `auto` / `needs trainer` badges are web-only for now; the
-  Android admin screen does not mirror them yet (tracked in #1200). The daily cron runs regardless of
-  platform, so LVL-A4 is a web-only check until then.

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -45,6 +45,26 @@ Access-gating plugin — these are the can't-ship-broken checks. Admin / reviewe
 
 ---
 
+## Member walkthrough
+
+### UNLOCK-M1 · Early Commons access help link (A/B treatment)
+**Role:** member (not yet verified) · **Surfaces:** web (member Unlock screen), android
+**Precondition:** the `feature-unlock-early-commons-access` Unleash flag is enabled and the test
+member falls in the treatment bucket (so `GET /api/unlock/status` returns `earlyCommonsAccess: true`).
+**Steps:**
+1. As an unverified treatment member, open the Unlock screen (both the submission form and, if a
+   submission exists, the status view).
+2. Confirm the "Trouble finding your Quora URL? Ask in the Commons" link shows.
+3. Tap it.
+4. Repeat as a control member (flag off, or control bucket).
+**Expected:** A treatment member sees the link on both the submission and status screens and tapping
+it reaches the Commons (the Hub home) where they can ask for help. A control member sees **no** link
+(and could not post there anyway). On android the link behaves the same and lands on the Hub home.
+With the flag off everywhere, no member sees the link (default state).
+**Result:** web ☐ android ☐ — notes:
+
+---
+
 ## Admin walkthrough
 
 ### UNLOCK-A1 · Queue loads and filters by status
@@ -114,8 +134,10 @@ admin-gated, CSRF-guarded (`x-ctf-csrf: '1'`), and audited.
 
 ## Parity check (web ↔ android)
 
-Unlock has no member-facing android surface for this internal verification queue — there is no web
-↔ android parity row to check here. (An android admin screen exists for the review queue; the
+The internal verification **queue** is admin-only, so there is no web ↔ android parity row for it.
+But the member-facing Unlock screen does have a parity row: **UNLOCK-M1** (the early-Commons help
+link) must behave the same on web and android — same link for treatment members, none for control,
+both landing on the Commons (Hub home). (An android admin screen exists for the review queue; the
 grant/revoke determination actions are an android follow-up per the inventory's Gaps section.)
 
 ---


### PR DESCRIPTION
Follow-up to #1230. That PR updated the LevelUp and Unlock feature inventories for the Android parity work but auto-merged before its manual test scripts were updated (the Test Script Drift Gate failed on the PR but is not a required check). Main is therefore in a documentation drift — inventories updated, test scripts not — which rule 133 exists to prevent. This brings the two back in step.

## Changes (docs only)
- **level-up test script:** LVL-A4 (auto-cohort "Run now") now lists the android admin surface and the `auto` / `needs trainer` badges; removed the now-resolved "web-only" gap note; the parity section notes the android admin mirror.
- **unlock test script:** added UNLOCK-M1, a member-facing case for the early-Commons help link (treatment vs control, web + android), and added it as a parity row.

No code, schema, or contract change. The Test Script Drift Gate passes locally (every changed inventory now has a matching test-script change; this PR changes only the scripts, so there is no drift).

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDHNmuS6ZrqYb8ZYABRjf8)_