### PR TITLE
fix: trust-transport rating completed-state guard and repository/stream cleanups

### DIFF
--- a/ctf/packages/web/lib/trust-transport/repository.ts
+++ b/ctf/packages/web/lib/trust-transport/repository.ts
@@ -443,9 +443,16 @@ export async function listRequests(options?: { page?: number; pageSize?: number;
   const total = Number.parseInt(count.rows[0]?.total ?? '0', 10);
 
   const result = await queryDb<RequestRow>(
+    // LATERAL with LIMIT 1 so a request with more than one trip row (data anomaly) cannot duplicate the
+    // request in the page and diverge from the COUNT above — at most one trip id per request.
     `SELECT r.id, r.requester_user_id, r.mode, r.title, r.details, r.pickup_city, r.dropoff_city, r.pickup_geo_redacted, r.dropoff_geo_redacted, r.status, r.price_amount, r.price_currency, r.created_at, r.updated_at, t.id AS trip_id
      FROM trust_transport_requests r
-     LEFT JOIN trust_transport_trips t ON t.request_id = r.id
+     LEFT JOIN LATERAL (
+       SELECT id FROM trust_transport_trips
+       WHERE request_id = r.id
+       ORDER BY created_at
+       LIMIT 1
+     ) t ON TRUE
      WHERE ($1::text IS NULL OR r.requester_user_id = $1)
      ORDER BY r.created_at DESC
      OFFSET $2 LIMIT $3`,
@@ -654,7 +661,9 @@ export async function updateTripStatus(
 
     const nextRequestStatus = mapRequestStatusFromTrip(nextStatus);
 
-    if (!(REQUEST_TRANSITIONS[nextRequestStatus] || REQUEST_TRANSITIONS.open)) {
+    // Guard against an unmapped request status. The previous `|| REQUEST_TRANSITIONS.open` fallback was
+    // always truthy, so the check could never fire; drop it so a missing key is actually caught.
+    if (!REQUEST_TRANSITIONS[nextRequestStatus]) {
       throw new Error('invalid_transition');
     }
 
@@ -817,6 +826,12 @@ export async function submitOrderRating(orderId: string, actorUserId: string, is
   }
 
   const trip = tripResult.rows[0];
+
+  // A rating only makes sense once the trip has finished; reject one on a trip that has not reached its
+  // terminal completed state (maps to 409). This also stops a rating being recorded mid-trip.
+  if (trip.status !== 'completed') {
+    throw new Error('invalid_transition');
+  }
 
   await queryDb(
     `INSERT INTO trust_transport_ratings (trip_id, requester_user_id, provider_user_id, score, feedback)

--- a/ctf/packages/web/lib/trust-transport/stream.ts
+++ b/ctf/packages/web/lib/trust-transport/stream.ts
@@ -27,28 +27,27 @@ export async function ensureTrustTransportTripChannel(input: {
     return null;
   }
 
+  // Server-side client authenticated with the API secret: it never calls connectUser, so there is no
+  // websocket to tear down. disconnectUser() is a client-side teardown method and can throw on a
+  // server instance — let the client go out of scope instead.
   const streamClient = new StreamChat(config.apiKey, config.apiSecret);
+  const requesterStreamUserId = await upsertStreamUser(streamClient, input.requesterUserId);
+  const providerStreamUserId = await upsertStreamUser(streamClient, input.providerUserId);
+
+  const streamChannelId = `trust-transport-trip-${input.tripId}`;
+  const channel = streamClient.channel('messaging', streamChannelId, {
+    created_by_id: requesterStreamUserId,
+    name: 'TrustTransport Trip Thread',
+  });
+
   try {
-    const requesterStreamUserId = await upsertStreamUser(streamClient, input.requesterUserId);
-    const providerStreamUserId = await upsertStreamUser(streamClient, input.providerUserId);
-
-    const streamChannelId = `trust-transport-trip-${input.tripId}`;
-    const channel = streamClient.channel('messaging', streamChannelId, {
-      created_by_id: requesterStreamUserId,
-      name: 'TrustTransport Trip Thread',
-    });
-
-    try {
-      await channel.create();
-    } catch {
-      await channel.watch();
-    }
-
-    await channel.addMembers([requesterStreamUserId, providerStreamUserId]);
-    return streamChannelId;
-  } finally {
-    await streamClient.disconnectUser();
+    await channel.create();
+  } catch {
+    await channel.watch();
   }
+
+  await channel.addMembers([requesterStreamUserId, providerStreamUserId]);
+  return streamChannelId;
 }
 
 export async function createTrustTransportParticipantToken(userId: string): Promise<TrustTransportStreamParticipantCredentials | null> {
@@ -57,16 +56,13 @@ export async function createTrustTransportParticipantToken(userId: string): Prom
     return null;
   }
 
+  // Same as above: server-side secret client, no connectUser, so no disconnectUser teardown needed.
   const streamClient = new StreamChat(config.apiKey, config.apiSecret);
-  try {
-    const streamUserId = await upsertStreamUser(streamClient, userId);
+  const streamUserId = await upsertStreamUser(streamClient, userId);
 
-    return {
-      streamApiKey: config.apiKey,
-      streamUserId,
-      streamToken: streamClient.createToken(streamUserId),
-    };
-  } finally {
-    await streamClient.disconnectUser();
-  }
+  return {
+    streamApiKey: config.apiKey,
+    streamUserId,
+    streamToken: streamClient.createToken(streamUserId),
+  };
 }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Backend-only correctness fixes for four trust-transport code-review findings. No schema, route, or contract changes.

## Changes

- **`submitOrderRating` (#1234):** reject a rating on a trip that has not reached its terminal `completed` state (throws `invalid_transition` → 409). A rating can no longer be recorded mid-trip; editing a rating on an already-completed trip stays allowed.
- **`listRequests` (#1236):** join trips via `LEFT JOIN LATERAL (… LIMIT 1)` so a request with more than one trip row (data anomaly) cannot duplicate the request in the page or diverge from the `COUNT`.
- **`ensureTrustTransportTripChannel` / `createTrustTransportParticipantToken` (#1235):** drop the server-side `disconnectUser()` teardown. These clients authenticate with the API secret and never call `connectUser`, so `disconnectUser` is a client-side no-op that can throw on a server instance — the client is left to go out of scope.
- **`updateTripStatus` (#1238):** drop the dead `|| REQUEST_TRANSITIONS.open` fallback that made the unmapped-status guard always falsy, so a missing key is actually caught.

Closes #1234
Closes #1235
Closes #1236
Closes #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_