### PR TITLE
refactor: remove unbuilt verified-provider role from TrustTransport

### DIFF
--- a/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -4,7 +4,6 @@ policies:
     version: 1.0.0
     requiredRoles:
       - member
-      - provider
     attributePolicies:
       tenancy: same_workspace
       modeValidation: required
@@ -32,7 +31,6 @@ policies:
     version: 1.0.0
     requiredRoles:
       - member
-      - provider
     attributePolicies:
       tenancy: same_workspace
       actorMustNotOwnRequest: true
@@ -83,7 +81,6 @@ policies:
     version: 1.0.0
     requiredRoles:
       - member
-      - provider
       - admin
     attributePolicies:
       tenancy: same_workspace
@@ -109,7 +106,7 @@ policies:
     command: trust-transport.payout.request
     version: 1.0.0
     requiredRoles:
-      - provider
+      - member
     attributePolicies:
       tenancy: same_workspace
       actorMustOwnLedger: true
@@ -126,6 +123,6 @@ policies:
       containsPHI: false
       requiresAdditionalAudit: true
     denyConditions:
-      - actor_not_provider
+      - actor_not_authenticated
       - insufficient_available_balance
       - payout_channel_not_verified

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -15,7 +15,7 @@ TrustTransport is a trauma-informed, safety-first logistics marketplace plugin f
 1. request and fulfill rides,
 2. request and fulfill package delivery,
 3. request and fulfill food delivery,
-4. earn income through verified provider participation,
+4. earn income by helping fulfill requests,
 5. build reputation and trust through transparent completion history.
 
 The plugin must provide equivalent core behavior across web and Android.
@@ -183,7 +183,7 @@ Single-profile rule is enforced:
 
 Extension entity:
 
-- `trust_transport_user_extension` — mode preferences, trust/safety settings, payout preference metadata, provider eligibility flags, linked by `user_id`.
+- `trust_transport_user_extension` — mode preferences, trust/safety settings, payout preference metadata, linked by `user_id`.
 
 ### 4.2 Domain Entities
 
@@ -251,6 +251,18 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 3. Command contract complexity should be monitored to prevent drift from UI flow logic.
 
 ## Change Log
+
+- 2026-06-30: Removed the unbuilt "verified provider" role/tier (owner directive). There was never any
+  in-app verification or a way to grant the `provider` role — it was only a role string read from the
+  Clerk identity, gating two payout routes and nothing else. Deleted `ensureTrustTransportProviderRole`,
+  the `requireTrustTransportProviderAccess` gate, and the `TRUST_TRANSPORT_PROVIDER_REQUIRED` error code.
+  The payout routes (`GET /payouts`, `POST /payouts/requests`) now use member read access — payouts are
+  already scoped to the caller's own earnings ledger by user id, so any member who has earned can request
+  one. Dropped `provider` from the `requiredRoles` of the request.create, offer.create, trip.status.update,
+  and payout.request access policies (the payout deny condition `actor_not_provider` → `actor_not_authenticated`),
+  and removed "verified provider participation" / "provider eligibility flags" wording from the inventory.
+  "Provider" remains only as a neutral domain term for whoever fulfils a request (the `provider_user_id`
+  columns, the `provider_region`, the `provider_payouts` purpose) — not a gated, verified status.
 
 - 2026-06-30: Added offer creation — the foundation of the provider/matching flow, which previously had
   no write path (offers existed only from seed data). New `POST /api/trust-transport/requests/:requestId/offers`

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -176,9 +176,9 @@ Result: web ☐ android ☐
 
 ### TT-8 — Trip status update (provider/driver side)
 
-**Role:** member acting as provider · **Surfaces:** web, android
+**Role:** member fulfilling a trip · **Surfaces:** web, android
 
-**Precondition:** Signed in as a member who is a provider. Seed has a trip assigned to this provider that is not yet complete.
+**Precondition:** Signed in as the member assigned to fulfil a trip (the driver/courier). Seed has a trip assigned to them that is not yet complete. There is no separate "provider" role — any member can fulfil a trip.
 
 **Steps:**
 1. Open the active trip.
@@ -192,9 +192,9 @@ Result: web ☐ android ☐
 
 ### TT-9 — Proof capture on delivery
 
-**Role:** member acting as provider · **Surfaces:** web, android
+**Role:** member fulfilling a trip · **Surfaces:** web, android
 
-**Precondition:** Signed in as a provider. Seed has a trip in a state that requires proof (package or food delivery pickup/dropoff).
+**Precondition:** Signed in as the member fulfilling the trip. Seed has a trip in a state that requires proof (package or food delivery pickup/dropoff).
 
 **Steps:**
 1. Open the active delivery trip.
@@ -242,9 +242,9 @@ Result: web ☐ android ☐
 
 ### TT-13 — Earnings ledger and payout request
 
-**Role:** member acting as provider · **Surfaces:** web, android
+**Role:** member fulfilling a trip · **Surfaces:** web, android
 
-**Precondition:** Signed in as a provider. Seed has completed tasks with earnings entries.
+**Precondition:** Signed in as a member who has fulfilled trips and has earnings entries. Any member with earnings can request a payout — there is no provider role.
 
 **Steps:**
 1. Navigate to the earnings/payout surface.
@@ -259,9 +259,9 @@ Result: web ☐ android ☐
 
 ### TT-14 — Payout request rejected for zero or negative amount
 
-**Role:** member acting as provider · **Surfaces:** web, android
+**Role:** member fulfilling a trip · **Surfaces:** web, android
 
-**Precondition:** Signed in as a provider with an earnings balance.
+**Precondition:** Signed in as a member with an earnings balance.
 
 **Steps:**
 1. Navigate to the payout request surface.

--- a/ctf/packages/web/app/api/trust-transport/_lib.ts
+++ b/ctf/packages/web/app/api/trust-transport/_lib.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
 import { checkMutationOrigin } from 'lib/auth/csrf';
 import { TRUST_TRANSPORT_ERROR_CODE } from 'lib/trust-transport/constants';
-import { ensureTrustTransportAdmin, ensureTrustTransportProviderRole } from 'lib/trust-transport/policy';
+import { ensureTrustTransportAdmin } from 'lib/trust-transport/policy';
 import { reportError } from 'lib/observability/report';
 
 export type TrustTransportApiGate =
@@ -16,20 +16,6 @@ export async function requireTrustTransportReadAccess(): Promise<TrustTransportA
   }
 
   return { allowed: true, auth: decision };
-}
-
-export async function requireTrustTransportProviderAccess(): Promise<TrustTransportApiGate> {
-  const gate = await requireTrustTransportReadAccess();
-  if (!gate.allowed) {
-    return gate;
-  }
-
-  const deny = ensureTrustTransportProviderRole(gate.auth);
-  if (deny) {
-    return { allowed: false, response: NextResponse.json(deny, { status: deny.status }) };
-  }
-
-  return gate;
 }
 
 export async function requireTrustTransportAdminAccess(): Promise<TrustTransportApiGate> {
@@ -126,10 +112,6 @@ export function trustTransportErrorResponse(error: unknown, fallbackMessage: str
 
   if (code === 'account_restricted') {
     return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.accountRestricted, message: 'Account is restricted.' }, { status: 403 });
-  }
-
-  if (code === 'provider_required') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.providerRequired, message: 'Provider role required.' }, { status: 403 });
   }
 
   if (code === 'invalid_payload') {

--- a/ctf/packages/web/app/api/trust-transport/payouts/requests/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/payouts/requests/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { ensureMutationCsrf, requireTrustTransportProviderAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
+import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
 import { TRUST_TRANSPORT_ERROR_CODE } from 'lib/trust-transport/constants';
 import { insertTrustTransportAudit, requestPayout } from 'lib/trust-transport/repository';
 import { reportError } from 'lib/observability/report';
@@ -10,7 +10,9 @@ export async function POST(request: Request) {
     return csrfDeny;
   }
 
-  const gate = await requireTrustTransportProviderAccess();
+  // A payout draws from the caller's own earnings ledger (keyed by user id), so any signed-in member
+  // who has earnings can request one. There is no separate provider role.
+  const gate = await requireTrustTransportReadAccess();
   if (!gate.allowed) {
     return gate.response;
   }

--- a/ctf/packages/web/app/api/trust-transport/payouts/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/payouts/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
-import { requireTrustTransportProviderAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
+import { requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
 import { listMyPayouts } from 'lib/trust-transport/repository';
 import { reportError } from 'lib/observability/report';
 
 export async function GET() {
-  const gate = await requireTrustTransportProviderAccess();
+  // Payouts are scoped to the caller's own earnings by user id, so any signed-in member who has
+  // earned (by fulfilling trips) can see their payout history. There is no separate provider role.
+  const gate = await requireTrustTransportReadAccess();
   if (!gate.allowed) {
     return gate.response;
   }

--- a/ctf/packages/web/lib/trust-transport/constants.ts
+++ b/ctf/packages/web/lib/trust-transport/constants.ts
@@ -23,5 +23,4 @@ export const TRUST_TRANSPORT_ERROR_CODE = {
   insufficientBalance: 'TRUST_TRANSPORT_INSUFFICIENT_BALANCE',
   accountRestricted: 'TRUST_TRANSPORT_ACCOUNT_RESTRICTED',
   mutualBlock: 'TRUST_TRANSPORT_MUTUAL_BLOCK',
-  providerRequired: 'TRUST_TRANSPORT_PROVIDER_REQUIRED',
 } as const;

--- a/ctf/packages/web/lib/trust-transport/policy.ts
+++ b/ctf/packages/web/lib/trust-transport/policy.ts
@@ -8,11 +8,3 @@ export function ensureTrustTransportAdmin(decision: AllowDecision): PluginDenyRe
 
   return pluginAuthDeny.forbiddenRole(['admin', 'operations']);
 }
-
-export function ensureTrustTransportProviderRole(decision: AllowDecision): PluginDenyResponse | null {
-  if (decision.isAdmin || decision.role === 'provider') {
-    return null;
-  }
-
-  return pluginAuthDeny.forbiddenRole(['provider']);
-}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Per owner direction: **there is no verified-provider tier**, and request discovery will use the "hide location until accepted" model — so no provider role is needed. The `provider` role never had any verification behind it or any in-app way to grant it; it was only a role string read from the Clerk identity, gating two payout routes and nothing else.

## What this removes
- `ensureTrustTransportProviderRole`, the `requireTrustTransportProviderAccess` gate, and the `TRUST_TRANSPORT_PROVIDER_REQUIRED` error code + its response mapping.
- `GET /payouts` and `POST /payouts/requests` now use **member** read access. Payouts are already scoped to the caller's own earnings ledger by user id, so any member who has earned can request one; a member with no earnings simply hits `insufficient_balance`.
- Drops `provider` from the `requiredRoles` of `request.create`, `offer.create`, `trip.status.update`, and `payout.request`; the payout deny condition `actor_not_provider` → `actor_not_authenticated`.
- Removes "verified provider participation" / "provider eligibility flags" wording from the inventory and reworps the test-script preconditions.

## What stays
"Provider" remains only as a neutral domain term for whoever fulfils a request — the `provider_user_id` columns, the `provider_region`, and the `provider_payouts` purpose label. No data or schema change.

## Why owner-review (no auto-merge)
Touches authorization gating and access-policy contracts. Net effect broadens payout access from a (non-assignable) `provider` role to any member, but stays bounded by per-user earnings.

This unblocks **slice 2** (provider discovery, model B: providers see mode + settlement + coarse area; pickup/drop-off revealed only after the requester accepts), which I'll build next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_