### PR TITLE
feat: TrustTransport trip progression for the provider (web)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -152,6 +152,7 @@ User routes:
 - `GET /api/trust-transport/requests/:requestId/offers` — Offers on a request.
 - `POST /api/trust-transport/requests/:requestId/offers` — Make an offer on an open request (one pending offer per provider per request; re-offering updates it).
 - `POST /api/trust-transport/offers/:offerId/accept` — Accept an offer, opening a trip.
+- `GET /api/trust-transport/trips` — Trips the caller is fulfilling (provider side), with the now-revealed pickup/drop-off, so they can advance the lifecycle.
 - `POST /api/trust-transport/trips/:tripId/status` — Update trip status.
 - `POST /api/trust-transport/trips/:tripId/proof` — Capture pickup/delivery proof.
 - `POST /api/trust-transport/trips/:tripId/chat` — Mint Stream chat credentials for the trip thread: chat channel (`channelId`/`streamChannelId`) and participant token. Text chat only — no video.
@@ -252,6 +253,13 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 3. Command contract complexity should be monitored to prevent drift from UI flow logic.
 
 ## Change Log
+
+- 2026-06-30: Trip progression for the provider (web). New `GET /api/trust-transport/trips` lists the
+  trips the caller is fulfilling (joined to the request for the now-revealed pickup/drop-off — they
+  accepted, so model B allows it) via `listProviderTrips`. The "Help out" tab gains a "Trips you're
+  helping with" section showing each active trip and a one-step-forward control (Start trip → Mark
+  picked up → Mark delivered → Mark complete) that calls the existing `POST /trips/:tripId/status`.
+  No schema or contract change. Web only; Android parity tracked in #1250.
 
 - 2026-06-30: Requester can accept an offer in-app (web). The Tracking tab now loads the offers on each
   of your own open requests (`GET /requests/:requestId/offers`) and shows an Accept button per pending

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -181,10 +181,10 @@ Result: web ☐ android ☐
 **Precondition:** Signed in as the member assigned to fulfil a trip (the driver/courier). Seed has a trip assigned to them that is not yet complete. There is no separate "provider" role — any member can fulfil a trip.
 
 **Steps:**
-1. Open the active trip.
-2. Apply a status update (e.g. advance from accepted to "picked up" or equivalent).
+1. On web, open the **Help out** tab → "Trips you're helping with"; find your active trip. (On Android this runs via API/seed until the parity pass — issue #1250.)
+2. Tap the forward action (Start trip → Mark picked up → Mark delivered → Mark complete) to advance one step.
 
-**Expected:** The trip status changes and the new state is reflected in the tracking view. The previous state is still in the event log (status transitions are append-only — you cannot revert to the previous state by re-selecting it).
+**Expected:** The trip status changes one step forward and the new state shows on the card. Transitions are forward-only and append-only — there is no control to revert to the previous state. An out-of-order transition (via the API) is refused.
 
 Result: web ☐ android ☐
 

--- a/ctf/packages/web/app/api/trust-transport/trips/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/trips/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
+import { listProviderTrips } from 'lib/trust-transport/repository';
+import { reportError } from 'lib/observability/report';
+
+// Trips the caller is fulfilling (they are the provider). Returns the now-revealed pickup/drop-off
+// (acceptance is the model-B reveal point) so the provider can advance the trip through its lifecycle.
+export async function GET() {
+  const gate = await requireTrustTransportReadAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const items = await listProviderTrips(gate.auth.userId);
+    return NextResponse.json({ ok: true, items }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'trust-transport', op: 'trips' });
+    return trustTransportErrorResponse(error, 'Trip listing unavailable.');
+  }
+}

--- a/ctf/packages/web/components/trust-transport/tt-help-tab.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-help-tab.tsx
@@ -1,12 +1,105 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { HandHeart, Loader2 } from "lucide-react";
-import { COLOR, ttSettlementLabel, type AvailableRequest } from "./tt-shared";
+import { HandHeart, Loader2, Check } from "lucide-react";
+import { COLOR, ttSettlementLabel, type AvailableRequest, type ProviderTrip } from "./tt-shared";
 
 function modeLabel(mode: string | undefined): string {
   if (!mode) return "Request";
   return mode.charAt(0).toUpperCase() + mode.slice(1);
+}
+
+// The forward step a provider can take from each trip status (the happy path). Terminal states have none.
+const NEXT_STEP: Record<string, { next: string; label: string }> = {
+  assigned: { next: "en_route", label: "Start trip" },
+  en_route: { next: "picked_up", label: "Mark picked up" },
+  picked_up: { next: "delivered", label: "Mark delivered" },
+  delivered: { next: "completed", label: "Mark complete" },
+};
+
+function tripStatusLabel(s: string | undefined): string {
+  if (s === "en_route") return "En route";
+  if (s === "picked_up") return "Picked up";
+  if (s === "emergency_frozen") return "Emergency stop";
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : "—";
+}
+
+// Trips the member is fulfilling, with controls to advance the lifecycle one step at a time. Renders
+// nothing until loaded and nothing when the member has no trips, so it stays out of the way otherwise.
+function ProviderTripsSection() {
+  const [loading, setLoading] = useState(true);
+  const [trips, setTrips] = useState<ProviderTrip[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/trust-transport/trips");
+      if (!res.ok) throw new Error("Could not load your trips.");
+      const data = (await res.json()) as { items?: ProviderTrip[] };
+      setTrips(Array.isArray(data.items) ? data.items : []);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Could not load your trips.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  async function advance(tripId: string, nextStatus: string) {
+    setBusyId(tripId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/trust-transport/trips/${tripId}/status`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({ nextStatus }),
+      });
+      if (!res.ok) throw new Error("Could not update the trip.");
+      await load();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Could not update the trip.");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (loading || trips.length === 0) return null;
+
+  return (
+    <div style={{ marginBottom: 28 }}>
+      <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase", color: "#9CA3AF", marginBottom: 12 }}>Trips you&apos;re helping with</div>
+      {error && <div style={{ color: "#EF4444", fontSize: 13, marginBottom: 10 }}>{error}</div>}
+      {trips.map((t) => {
+        const step = NEXT_STEP[t.status ?? ""];
+        const route = `${t.pickupCity ?? "—"} → ${t.dropoffCity ?? "—"}`;
+        return (
+          <div key={t.tripId} style={{ padding: "14px 16px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}25`, marginBottom: 12 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB" }}>{route}</div>
+              <span style={{ marginLeft: "auto", fontSize: 12, color: COLOR, background: `${COLOR}1A`, border: `1px solid ${COLOR}33`, borderRadius: 20, padding: "2px 10px" }}>{tripStatusLabel(t.status)}</span>
+            </div>
+            <div style={{ marginTop: 6, fontSize: 12, color: "#9CA3AF" }}>{modeLabel(t.mode)} · {ttSettlementLabel(t.priceCurrency, t.priceAmount)}</div>
+            {step ? (
+              <button
+                type="button"
+                onClick={() => void advance(t.tripId, step.next)}
+                disabled={busyId !== null}
+                style={{ marginTop: 12, width: "100%", padding: "10px 12px", borderRadius: 9, background: `${COLOR}1F`, border: `1px solid ${COLOR}40`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: busyId !== null ? "default" : "pointer", opacity: busyId !== null && busyId !== t.tripId ? 0.5 : 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}
+              >
+                {busyId === t.tripId ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />} {step.label}
+              </button>
+            ) : (
+              <div style={{ marginTop: 10, fontSize: 12, color: "#6B7280" }}>No further action — this trip is {tripStatusLabel(t.status).toLowerCase()}.</div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 // Plain relative age ("just now", "5 min ago", "2 h ago", "3 d ago") from an ISO timestamp.
@@ -145,6 +238,8 @@ export function TrustTransportHelpTab() {
         see only what kind of help is needed and how it&apos;s settled — the pickup and drop-off are shared
         with you only if the requester accepts your offer.
       </div>
+      <ProviderTripsSection />
+      <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase", color: "#9CA3AF", marginBottom: 12 }}>Open requests</div>
       {loading ? (
         <div style={{ display: "flex", alignItems: "center", gap: 8, color: "#6B7280", fontSize: 13 }}>
           <Loader2 size={16} className="animate-spin" /> Loading open requests…

--- a/ctf/packages/web/components/trust-transport/tt-shared.ts
+++ b/ctf/packages/web/components/trust-transport/tt-shared.ts
@@ -90,6 +90,20 @@ export interface TtOffer {
   createdAtIso?: string;
 }
 
+// A trip the member is fulfilling (provider side), shown on the "Help out" tab so they can advance it.
+// Pickup/drop-off are present because they accepted (model B reveal).
+export interface ProviderTrip {
+  tripId: string;
+  requestId?: string;
+  status?: string;
+  mode?: string;
+  pickupCity?: string | null;
+  dropoffCity?: string | null;
+  priceCurrency?: string | null;
+  priceAmount?: number | null;
+  createdAtIso?: string;
+}
+
 // A request shown on the "Help out" tab (discovery model B): mode + settlement + age only. The pickup
 // and drop-off are deliberately absent — they're shared with a provider only after the requester accepts.
 export interface AvailableRequest {

--- a/ctf/packages/web/lib/trust-transport/repository.ts
+++ b/ctf/packages/web/lib/trust-transport/repository.ts
@@ -23,6 +23,7 @@ import type {
   TrustTransportOffer,
   TrustTransportOfferInput,
   TrustTransportPayoutRequest,
+  TrustTransportProviderTrip,
   TrustTransportRequest,
   TrustTransportRequestInput,
   TrustTransportTrip,
@@ -705,6 +706,42 @@ export async function acceptOffer(requestId: string, offerId: string, actorUserI
   }
 
   return created;
+}
+
+// Trips the caller is fulfilling (provider side), with the now-revealed request location. Powers the
+// provider's "trips you're helping with" surface so they can advance the lifecycle.
+export async function listProviderTrips(providerUserId: string): Promise<TrustTransportProviderTrip[]> {
+  const result = await queryDb<{
+    trip_id: string;
+    request_id: string;
+    status: TrustTransportTrip['status'];
+    mode: TrustTransportMode;
+    pickup_city: string | null;
+    dropoff_city: string | null;
+    price_amount: string | number | null;
+    price_currency: string | null;
+    trip_created_at: Date;
+  }>(
+    `SELECT t.id AS trip_id, t.request_id, t.status, t.mode,
+            r.pickup_city, r.dropoff_city, r.price_amount, r.price_currency, t.created_at AS trip_created_at
+     FROM trust_transport_trips t
+     JOIN trust_transport_requests r ON r.id = t.request_id
+     WHERE t.provider_user_id = $1
+     ORDER BY t.created_at DESC`,
+    [providerUserId],
+  );
+
+  return result.rows.map((row) => ({
+    tripId: row.trip_id,
+    requestId: row.request_id,
+    status: row.status,
+    mode: row.mode,
+    pickupCity: row.pickup_city,
+    dropoffCity: row.dropoff_city,
+    priceCurrency: row.price_currency,
+    priceAmount: row.price_amount === null || row.price_amount === undefined ? null : Number(row.price_amount),
+    createdAtIso: toIso(row.trip_created_at),
+  }));
 }
 
 export async function getTripById(tripId: string): Promise<TrustTransportTrip | null> {

--- a/ctf/packages/web/lib/trust-transport/types.ts
+++ b/ctf/packages/web/lib/trust-transport/types.ts
@@ -70,6 +70,20 @@ export type TrustTransportOffer = {
   updatedAtIso: string;
 };
 
+// A trip the caller is fulfilling (they are the provider). Once they accepted, the request location is
+// theirs to see (model B reveal), so pickup/drop-off are included here.
+export type TrustTransportProviderTrip = {
+  tripId: string;
+  requestId: string;
+  status: TrustTransportTripStatus;
+  mode: TrustTransportMode;
+  pickupCity: string | null;
+  dropoffCity: string | null;
+  priceCurrency: string | null;
+  priceAmount: number | null;
+  createdAtIso: string;
+};
+
 // What a member browsing open requests to help with is allowed to see (discovery model B). Deliberately
 // omits the pickup/drop-off text and the title (which embeds the locations) — those are revealed to a
 // provider only once the requester accepts their offer.


### PR DESCRIPTION
Parity Ticket: #1250

**Slice 4 of closing the provider/marketplace gaps.** A provider could accept and open a trip (slices 1–3) but had no way to *see* the trips they're fulfilling or move them forward. This adds that.

## What this adds
- **`GET /api/trust-transport/trips`** — the trips the caller is fulfilling (provider side), joined to the request for the **now-revealed** pickup/drop-off (they accepted, so model B allows it), via `listProviderTrips`.
- The **"Help out" tab** gains a "Trips you're helping with" section above the open requests. Each active trip shows its route + status and a single forward control: **Start trip → Mark picked up → Mark delivered → Mark complete**, calling the existing `POST /trips/:tripId/status`.
- Forward-only / append-only (the transition matrix in `updateTripStatus` rejects out-of-order moves); terminal trips show no action.

## Scope
- No schema or contract change (`trip.status.update` already existed; this adds one read endpoint + UI).
- Web + mobile-responsive. **Android** trip-progression UI parity tracked in #1250.

## Verification
Monorepo typecheck, lint, EOF, inventory-drift, schema-drift, test-script-drift all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_