### PR TITLE
fix: give comic review dashboard the uniform left rail footer

### DIFF
--- a/ctf/packages/web/components/comic/comic-review-dashboard.module.css
+++ b/ctf/packages/web/components/comic/comic-review-dashboard.module.css
@@ -77,20 +77,6 @@
   color: #0EA5E9;
 }
 
-.iconRailAvatar {
-  margin-top: auto;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: rgba(14, 165, 233, 0.15);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  font-weight: 700;
-  color: #0EA5E9;
-}
-
 /* ─── Queue sidebar ──────────────────────────────────────────────────────── */
 .queueSidebar {
   background: #0D0F14;
@@ -899,8 +885,7 @@
 }
 
 /* Cyan AI accent → ink-dim (§6: AI elements use #7A6A50, no blue). */
-:global([data-theme='comic']) .iconRailLogo,
-:global([data-theme='comic']) .iconRailAvatar {
+:global([data-theme='comic']) .iconRailLogo {
   background: #7a6a5014;
   border: 1px solid #7a6a5050;
   color: var(--ctf-border-dim);

--- a/ctf/packages/web/components/comic/comic-review-dashboard.tsx
+++ b/ctf/packages/web/components/comic/comic-review-dashboard.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
 import {
-  AlertTriangle, ArrowLeft, Check, FileText, Home, Inbox, Pencil, RotateCcw,
+  AlertTriangle, ArrowLeft, Check, FileText, Inbox, Pencil, RotateCcw,
   ShieldCheck, Sparkles, X,
 } from 'lucide-react';
+import { PluginRailFooter } from '@/components/shared/plugin-rail-footer';
 import type { ComicReviewItem, ComicTrainingStats } from '../../lib/comic/types';
 import styles from './comic-review-dashboard.module.css';
 
@@ -356,9 +356,8 @@ export function ComicReviewDashboard() {
         <button type="button" className={`${styles.iconRailBtn} ${styles.iconRailBtnActive}`} aria-label="Review queue" aria-current="page">
           <Inbox size={20} />
         </button>
-        <Link href="/apps" className={styles.iconRailAvatar} aria-label="Back to the Hub" title="Back to the Hub">
-          <Home size={18} />
-        </Link>
+        {/* Shared bottom of every plugin rail: back to all apps, account and settings, account menu. */}
+        <PluginRailFooter />
       </aside>
 
       {/* Queue sidebar */}


### PR DESCRIPTION
## What and why

The `/admin/comic` Review & Correction dashboard (the AI Assistant supervision screen) ended its left icon rail with a one-off "Home" link instead of the shared footer every other plugin rail carries. That made its bottom rail different from the rest of the app.

This swaps the bespoke link for the shared `PluginRailFooter`, so the screen now shows the same three controls in the same spot as every other plugin rail:

- Back to all apps
- Account and settings
- Account menu (manage profile / sign out)

## Changes

- `comic-review-dashboard.tsx`: replaced the custom bottom `Home` link with `<PluginRailFooter />`; removed the now-unused `next/link` and `Home` imports.
- `comic-review-dashboard.module.css`: removed the orphaned `iconRailAvatar` rules (base + the `[data-theme='comic']` override) that the old link used.

No routes, schema, contracts, or seed data changed — this is a surgical, additive UI fix to a shipped screen. On mobile the rail is hidden at phone width, same as the other plugin shells, so behavior there is unchanged.

## Verification

- `pnpm --filter @ctf/web run typecheck` — passes
- `pnpm --filter @ctf/web run lint` — passes
- Pre-push verification gate — passes

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNARSwefHdEjJzyQ9XjfDg)_