### PR TITLE
fix: make contributions plugin visible so Contribute button resolves

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -284,6 +284,14 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-07-01: Fixed the Contribute button (fundraiser banner) landing on a 404. The banner sends
+  members to `/apps/contributions`, but the dedicated page calls `notFound()` when the registry row
+  is not visible, and the DB registry seed in `ctf/schema.sql` (and `ctf/schema.demo.sql`) still
+  carried the pre-UI values `availability_state = 'alpha'`, `is_visible = FALSE`. Because the seed
+  upserts with `ON CONFLICT DO UPDATE`, every deploy forced the production row back to hidden even
+  though `repository.ts` and this inventory both declare it visible. Aligned both schema seeds to
+  `'implemented_shell'`, `TRUE`, matching the code registry so the page resolves. Seed/data only —
+  no route, contract, or component change.
 - 2026-06-18: Fixed the admin Drive form overflowing on mobile (`contributions-admin-drive.tsx`). Each goal row was a fixed `display:flex` with a non-shrinking 180px label plus a fixed-width input, so the fields ran off the screen on a phone. The goal rows now stack the label over a full-width input on mobile (`isMobile`); desktop keeps the inline row. Presentation only — no route, schema, or contract change.
 - 2026-06-18: Changed the Contributions plugin icon from `Heart` to `Gift` across the shell, public shell, banner, and admin shell (`components/contributions/**`). The heart duplicated the app brand logo (also a heart); `Gift` is distinct and fits the fundraiser/gift-drive purpose. Icon swap only — no copy, route, schema, or contract change.
 - 2026-06-12: Android API client (`ContributionsApi.ts`) now calls the backend through the shared authenticated fetch wrapper (`authedFetch`): the signed-in member's Clerk bearer token is attached and the base URL comes from runtime config, replacing the plain dev-only fetch against hardcoded emulator/localhost URLs. No backend, schema, or contract change.

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md` |
-| **Generated** | 2026-06-28 (initial authoring; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-07-01 (banner Contribute-button navigation coverage; regenerate via CI to stamp the commit) |
 
 ## How to run this
 
@@ -88,12 +88,15 @@ out — honest retries still work.
 plain language. An empty history shows the empty state, not an error.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
-### CON-5 · Dismiss the fundraiser banner
+### CON-5 · Fundraiser banner — Contribute and dismiss
 **Role:** member · **Surfaces:** all
 **Steps:**
-1. With the banner showing in the Hub, dismiss it.
-**Expected:** The banner silently goes away with no guilt copy and no countdown. It stays snoozed for
-six months (an internal config knob, not shown to the member). Dismissing is not audited.
+1. With the banner showing in the Hub, press **Contribute**.
+2. Go back to the Hub, then dismiss the banner with **Not now**.
+**Expected:** **Contribute** opens the drive at `/apps/contributions` — the page renders (it is
+**not** a 404; the plugin registry row is visible, `is_visible = TRUE`). Dismiss silently hides the
+banner with no guilt copy and no countdown; it stays snoozed for six months (an internal config knob,
+not shown to the member). Dismissing is not audited.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ---

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -1994,7 +1994,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('level-up',           'LevelUp',              'Paid skills-training cohorts — learn a skill with a trainer and earn stipends as you reach each milestone.','implemented_shell', 170, TRUE),
   ('click-log',          'ClickLog',             'Safety check-in and incident logging — location optional. Log what happened, check in when you''re safe.','implemented_shell', 180, TRUE),
   ('what-works',          'WhatWorks',            'One shared, survivor-verified list of tools — organized by the exact problems survivors face. No ads, no affiliates.','implemented_shell', 200, TRUE),
-  ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'alpha',             210, FALSE),
+  ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'implemented_shell', 210, TRUE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1996,7 +1996,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('level-up',           'LevelUp',              'Paid skills-training cohorts — learn a skill with a trainer and earn stipends as you reach each milestone.','implemented_shell', 170, TRUE),
   ('click-log',          'ClickLog',             'Safety check-in and incident logging — location optional. Log what happened, check in when you''re safe.','implemented_shell', 180, TRUE),
   ('what-works',          'WhatWorks',            'One shared, survivor-verified list of tools — organized by the exact problems survivors face. No ads, no affiliates.','implemented_shell', 200, TRUE),
-  ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'alpha',             210, FALSE),
+  ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'implemented_shell', 210, TRUE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## What was broken

The fundraiser banner's **Contribute** button (`components/contributions/contributions-banner.tsx`) sends members to `/apps/contributions`. In production that page returns a 404.

## Why

`app/apps/contributions/page.tsx` calls `notFound()` when the plugin's registry row is not visible. The DB registry seed in `ctf/schema.sql` (and `ctf/schema.demo.sql`) still carried the pre-UI values `availability_state = 'alpha'`, `is_visible = FALSE`. Because the seed upserts with `ON CONFLICT (plugin_slug) DO UPDATE`, every deploy forced the production row back to hidden — even though the code registry (`lib/plugins/repository.ts`) and the plugin inventory both already declare it `implemented_shell` / visible.

Net effect: the banner is live and drives members to a page that 404s.

## Fix

Align both schema seeds to `'implemented_shell'`, `TRUE`, matching the code registry. On the next deploy the row upserts to visible and `/apps/contributions` resolves. Seed/data only — no route, contract, or component change.

## Files

- `ctf/schema.sql` — contributions registry seed row → `implemented_shell` / `TRUE`
- `ctf/schema.demo.sql` — same
- `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md` — change-log entry

## Notes for review

- This makes the Contributions plugin visible wherever gating reads the registry (its dedicated page, and any nav that lists visible plugins). That matches what the live banner already assumes.
- If the intent is instead to keep the plugin hidden, the opposite fix would be to suppress the banner rather than expose the page — flag it and I'll switch.
- Inventory-drift gate passes locally (`node scripts/check-inventory-drift.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jkhgv617YLn5LCj1f7hSD)_