### PR TITLE
feat: TrustTransport earnings + payouts surface (web)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -158,6 +158,7 @@ User routes:
 - `POST /api/trust-transport/trips/:tripId/chat` — Mint Stream chat credentials for the trip thread: chat channel (`channelId`/`streamChannelId`) and participant token. Text chat only — no video.
 - `POST /api/trust-transport/trips/:tripId/emergency-stop` — Safety emergency-stop control.
 - `POST /api/trust-transport/orders/:orderId/cancel` — Cancel an order.
+- `GET /api/trust-transport/earnings` — The caller's own available earnings balance (a currency-blind ledger sum; see issue #1233) that a payout can be requested against.
 - `GET /api/trust-transport/payouts` — Payout history.
 - `POST /api/trust-transport/payouts/requests` — Request a payout.
 - `POST /api/trust-transport/service-credits` — Cross-user ServiceCredits transfer for trip economics (rejects self-transfer; emits a `trust-transport.service-credits.transfer` audit event).
@@ -253,6 +254,15 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 3. Command contract complexity should be monitored to prevent drift from UI flow logic.
 
 ## Change Log
+
+- 2026-06-30: Earnings + payouts surface (web). New `GET /api/trust-transport/earnings` returns the
+  caller's own available earnings balance (`getMyEarningsBalance`, wrapping the existing ledger sum). A
+  new "Earnings" tab shows the available balance, a "Request a payout" form (posts to the existing
+  `POST /payouts/requests`; blocked when the balance is zero and client-validated to the balance), and
+  the payout history with per-row status (`GET /payouts`). The balance is shown as a plain number and no
+  currency is asserted — the known payout-currency issue (#1233, `USD` hard-coded while the ledger can
+  hold other currencies) is left for the owner as a separate ledger decision. No schema or contract
+  change. Web only; Android parity tracked in #1250.
 
 - 2026-06-30: Proof capture UI for the provider (web). Each active trip card in the "Help out" tab's
   "Trips you're helping with" section gains an "Add pickup/delivery proof" control: pick a type

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -247,11 +247,11 @@ Result: web ☐ android ☐
 **Precondition:** Signed in as a member who has fulfilled trips and has earnings entries. Any member with earnings can request a payout — there is no provider role.
 
 **Steps:**
-1. Navigate to the earnings/payout surface.
-2. View payout history.
-3. Submit a payout request with a positive amount within available balance.
+1. On web, open the **Earnings** tab. Confirm the available balance shows. (On Android this runs via API/seed until the parity pass — issue #1250.)
+2. View the payout history list with per-row status.
+3. Submit a payout request with a positive amount within the available balance.
 
-**Expected:** Payout request is created and appears in payout history with a status. The amount uses the `price_currency` field (a known currency code); no fiat equivalent is shown alongside ServiceCredits amounts.
+**Expected:** The payout request is created and appears in the history with a status (e.g. Requested). The available balance is shown as a plain number (no fiat equivalent is asserted). Requesting more than the balance is refused.
 
 Result: web ☐ android ☐
 
@@ -264,11 +264,11 @@ Result: web ☐ android ☐
 **Precondition:** Signed in as a member with an earnings balance.
 
 **Steps:**
-1. Navigate to the payout request surface.
+1. On web, open the **Earnings** tab.
 2. Enter `0` as the amount and submit.
-3. Repeat with a negative amount.
+3. Repeat with a negative amount, and with an amount above your available balance.
 
-**Expected:** Both attempts are rejected with a clear error. No payout request is created in either case.
+**Expected:** Every attempt is rejected with a clear inline error. No payout request is created in any case.
 
 Result: web ☐ android ☐
 

--- a/ctf/packages/web/app/api/trust-transport/earnings/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/earnings/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
+import { getMyEarningsBalance } from 'lib/trust-transport/repository';
+import { reportError } from 'lib/observability/report';
+
+// The caller's own available earnings balance (what they can request a payout against). Scoped to the
+// caller's user id. The value is a plain balance from the earnings ledger — no currency is asserted.
+export async function GET() {
+  const gate = await requireTrustTransportReadAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const availableBalance = await getMyEarningsBalance(gate.auth.userId);
+    return NextResponse.json({ ok: true, availableBalance }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'trust-transport', op: 'earnings' });
+    return trustTransportErrorResponse(error, 'Earnings balance unavailable.');
+  }
+}

--- a/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
+++ b/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
@@ -13,6 +13,7 @@ import { TrustTransportSidebar } from "./tt-sidebar";
 import { TrustTransportBookTab } from "./tt-book-tab";
 import { TrustTransportTrackingTab } from "./tt-tracking-tab";
 import { TrustTransportHelpTab } from "./tt-help-tab";
+import { TrustTransportEarningsTab } from "./tt-earnings-tab";
 import { TrustTransportChatTab } from "./tt-chat-tab";
 import { TrustTransportRightPanel } from "./tt-right-panel";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
@@ -217,6 +218,7 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
         <TrustTransportTrackingTab requests={requests} onBook={() => setTab("book")} onChat={openChat} onAccepted={() => void fetchRequests()} />
       )}
       {tab === "help" && <TrustTransportHelpTab />}
+      {tab === "earnings" && <TrustTransportEarningsTab />}
       {tab === "chat" && (
         <TrustTransportChatTab
           requests={requests}
@@ -236,6 +238,7 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
       { key: "book", label: "Book" },
       { key: "tracking", label: "Tracking" },
       { key: "help", label: "Help" },
+      { key: "earnings", label: "Earnings" },
       { key: "chat", label: "Direct Line" },
     ];
     return (

--- a/ctf/packages/web/components/trust-transport/tt-earnings-tab.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-earnings-tab.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Wallet, Loader2 } from "lucide-react";
+import { COLOR, type TtPayout } from "./tt-shared";
+
+function payoutStatusLabel(s: string | undefined): string {
+  if (!s) return "—";
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function payoutStatusColor(s: string | undefined): string {
+  if (s === "paid" || s === "approved") return "#22C55E";
+  if (s === "rejected") return "#EF4444";
+  return "#F59E0B"; // requested / pending
+}
+
+export function TrustTransportEarningsTab() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [balance, setBalance] = useState<number>(0);
+  const [payouts, setPayouts] = useState<TtPayout[]>([]);
+  const [amount, setAmount] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [requested, setRequested] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [balRes, payRes] = await Promise.all([
+        fetch("/api/trust-transport/earnings"),
+        fetch("/api/trust-transport/payouts"),
+      ]);
+      if (!balRes.ok || !payRes.ok) throw new Error("Could not load your earnings.");
+      const balData = (await balRes.json()) as { availableBalance?: number };
+      const payData = (await payRes.json()) as { items?: TtPayout[] };
+      setBalance(typeof balData.availableBalance === "number" ? balData.availableBalance : 0);
+      setPayouts(Array.isArray(payData.items) ? payData.items : []);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Could not load your earnings.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  async function requestPayout() {
+    const parsed = Number(amount);
+    if (!(Number.isFinite(parsed) && parsed > 0)) {
+      setFormError("Enter an amount greater than zero.");
+      return;
+    }
+    if (parsed > balance) {
+      setFormError("That's more than your available balance.");
+      return;
+    }
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      const res = await fetch("/api/trust-transport/payouts/requests", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({ amount: Math.round(parsed) }),
+      });
+      if (!res.ok) throw new Error("Could not submit your payout request.");
+      setRequested(true);
+      setAmount("");
+      await load();
+    } catch (e: unknown) {
+      setFormError(e instanceof Error ? e.message : "Could not submit your payout request.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div style={{ flex: 1, padding: "24px", overflowY: "auto", minHeight: 0 }}>
+      <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 6 }}>Earnings</div>
+      <div style={{ fontSize: 13, color: "#9CA3AF", marginBottom: 20, lineHeight: 1.5, maxWidth: 520 }}>
+        What you&apos;ve earned by helping fulfil trips, and your payout requests. Payouts are reviewed by an admin.
+      </div>
+
+      {loading ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, color: "#6B7280", fontSize: 13 }}>
+          <Loader2 size={16} className="animate-spin" /> Loading earnings…
+        </div>
+      ) : error ? (
+        <div style={{ color: "#EF4444", fontSize: 13 }}>{error}</div>
+      ) : (
+        <>
+          <div style={{ padding: "18px 20px", borderRadius: 16, background: `${COLOR}0F`, border: `1px solid ${COLOR}30`, marginBottom: 20 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <Wallet size={18} style={{ color: COLOR }} />
+              <div style={{ fontSize: 13, color: "#9CA3AF" }}>Available balance</div>
+            </div>
+            <div style={{ marginTop: 8, fontSize: 28, fontWeight: 800, color: "#F9FAFB" }}>{balance}</div>
+          </div>
+
+          <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase", color: "#9CA3AF", marginBottom: 12 }}>Request a payout</div>
+          {requested && <div style={{ fontSize: 13, color: COLOR, fontWeight: 600, marginBottom: 10 }}>Payout requested. You&apos;ll see it below with its status.</div>}
+          <div style={{ display: "flex", gap: 8, marginBottom: 8, maxWidth: 420 }}>
+            <input value={amount} onChange={(e) => setAmount(e.target.value)} inputMode="numeric" placeholder="Amount" disabled={balance <= 0} style={{ flex: 1, padding: "10px 12px", borderRadius: 9, background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.10)", color: "#E8EAF0", fontSize: 14 }} />
+            <button type="button" onClick={() => void requestPayout()} disabled={submitting || balance <= 0} style={{ padding: "10px 18px", borderRadius: 9, background: `${COLOR}1F`, border: `1px solid ${COLOR}40`, color: COLOR, fontSize: 14, fontWeight: 600, cursor: submitting || balance <= 0 ? "default" : "pointer", opacity: submitting || balance <= 0 ? 0.6 : 1, display: "flex", alignItems: "center", gap: 6 }}>
+              {submitting && <Loader2 size={14} className="animate-spin" />} Request
+            </button>
+          </div>
+          {balance <= 0 && <div style={{ fontSize: 12, color: "#6B7280", marginBottom: 8 }}>You can request a payout once you have an available balance.</div>}
+          {formError && <div style={{ fontSize: 12, color: "#EF4444", marginBottom: 8 }}>{formError}</div>}
+
+          <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase", color: "#9CA3AF", margin: "24px 0 12px" }}>Payout history</div>
+          {payouts.length === 0 ? (
+            <div style={{ padding: "24px", textAlign: "center", color: "#6B7280", fontSize: 13, border: "1px dashed rgba(255,255,255,0.10)", borderRadius: 14 }}>No payout requests yet.</div>
+          ) : (
+            payouts.map((p) => (
+              <div key={p.id} style={{ padding: "12px 16px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)", marginBottom: 8, display: "flex", alignItems: "center", gap: 10 }}>
+                <div style={{ fontSize: 14, fontWeight: 700, color: "#F9FAFB" }}>{p.amount}</div>
+                <span style={{ marginLeft: "auto", fontSize: 12, fontWeight: 600, color: payoutStatusColor(p.status) }}>{payoutStatusLabel(p.status)}</span>
+              </div>
+            ))
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/trust-transport/tt-icon-rail.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-icon-rail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Car, MapPin, Navigation, MessageCircle, HandHeart } from "lucide-react";
+import { Car, MapPin, Navigation, MessageCircle, HandHeart, Wallet } from "lucide-react";
 import { PluginRailFooter } from "@/components/shared/plugin-rail-footer";
 import { COLOR, type Tab } from "./tt-shared";
 
@@ -9,6 +9,7 @@ const TABS: { icon: React.ElementType; key: Tab; label: string }[] = [
   { icon: MapPin, key: "book", label: "Book a ride" },
   { icon: Navigation, key: "tracking", label: "Tracking" },
   { icon: HandHeart, key: "help", label: "Help out" },
+  { icon: Wallet, key: "earnings", label: "Earnings" },
   { icon: MessageCircle, key: "chat", label: "Direct Line" },
 ];
 

--- a/ctf/packages/web/components/trust-transport/tt-shared.ts
+++ b/ctf/packages/web/components/trust-transport/tt-shared.ts
@@ -77,7 +77,17 @@ export interface ChatCreds {
   message?: string;
 }
 
-export type Tab = "book" | "tracking" | "chat" | "help";
+export type Tab = "book" | "tracking" | "chat" | "help" | "earnings";
+
+// A payout request row shown on the Earnings tab.
+export interface TtPayout {
+  id: string;
+  amount?: number;
+  currency?: string;
+  status?: string;
+  requestedAtIso?: string;
+  decisionReason?: string | null;
+}
 
 // An offer shown to the requester on their own request's Tracking card, so they can accept one.
 export interface TtOffer {

--- a/ctf/packages/web/lib/trust-transport/repository.ts
+++ b/ctf/packages/web/lib/trust-transport/repository.ts
@@ -956,6 +956,13 @@ export async function cancelOrder(orderId: string, actorUserId: string, isAdmin:
   await syncTrustTransportRequestPresence(request.requesterUserId, orderId, 'cancelled');
 }
 
+// Public read of the caller's own available earnings balance (for the Earnings surface). Note: this is
+// a currency-blind sum of the ledger (see issue #1233); it is shown as a plain balance, not asserted as
+// a specific currency.
+export async function getMyEarningsBalance(userId: string): Promise<number> {
+  return getProviderAvailableBalance(userId);
+}
+
 async function getProviderAvailableBalance(providerUserId: string): Promise<number> {
   const result = await queryDb<{ balance: string }>(
     `SELECT COALESCE(SUM(CASE


### PR DESCRIPTION
Parity Ticket: #1250

**Slice 6 (final) of closing the provider/marketplace gaps.** Earnings and payouts had endpoints but no UI — this surfaces them.

## What this adds
- **`GET /api/trust-transport/earnings`** — the caller's own available earnings balance (`getMyEarningsBalance`, wrapping the existing ledger sum). Scoped to the caller's user id.
- New **"Earnings" tab**: available balance, a "Request a payout" form (posts to the existing `POST /payouts/requests`; disabled at zero balance and client-validated to the balance), and payout history with per-row status (`GET /payouts`).

## ⚠️ Money surface — please review
This touches the earnings/payout flow. The payout request reuses the existing, reviewed `POST /payouts/requests` (which validates amount and available balance server-side). The balance is shown as a plain number and **no currency is asserted** — the known issue **#1233** (`USD` hard-coded in payouts while the ledger can hold other currencies) is a currency-aware-ledger decision left to you; I did **not** silently resolve it here.

## Scope
- No schema or contract change (one read endpoint + UI).
- Web + mobile-responsive. **Android** earnings/payouts UI parity tracked in #1250.

## Verification
Monorepo typecheck, lint, EOF, inventory-drift, schema-drift, test-script-drift all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_