### PR TITLE
fix: hide the fundraiser banner Not now button on web

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -236,7 +236,9 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
   `components/contributions/admin/` — queue, drive management, settings. The app-wide fundraiser
   banner (`components/contributions/contributions-banner.tsx`) is integrated non-blocking at the top
   of the Hub content area for signed-in members. Desktop and phone-width layouts are both built
-  (rule 105).
+  (rule 105). The banner's "Not now" dismiss button is currently hidden (owner request) behind the
+  `SHOW_DISMISS_BUTTON` flag in that component — the button markup and the server-side snooze
+  (`/api/contributions/banner/dismiss`) are left intact so it can be re-enabled by flipping the flag.
 - Android: **shipped** at `packages/mobile/src/features/contributions/` (`Contributions.tsx`,
   `ContributionsAdmin.tsx`, `ContributionsApi.ts`) mirroring the web behavior one-to-one, including
   the greyed github-star path and the inline Signal URL on confirmation.
@@ -284,6 +286,12 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-07-01: Hid the fundraiser banner's "Not now" dismiss button on web (owner request). Gated both
+  layouts (desktop and phone-width) behind a new `SHOW_DISMISS_BUTTON` flag in
+  `components/contributions/contributions-banner.tsx`, defaulting to hidden. The button markup and the
+  `onDismiss` snooze handler (POST `/api/contributions/banner/dismiss`) are kept in place — nothing was
+  deleted — so the control can be restored by flipping the flag. Presentation only; no route, schema,
+  or contract change. The Android app has no fundraiser banner, so nothing changed there.
 - 2026-07-01: Fixed the Contribute button (fundraiser banner) landing on a 404. The banner sends
   members to `/apps/contributions`, but the dedicated page calls `notFound()` when the registry row
   is not visible, and the DB registry seed in `ctf/schema.sql` (and `ctf/schema.demo.sql`) still

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md` |
-| **Generated** | 2026-07-01 (banner Contribute-button navigation coverage; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-07-01 (banner: Contribute navigation + hidden "Not now" button; regenerate via CI to stamp the commit) |
 
 ## How to run this
 
@@ -88,15 +88,15 @@ out — honest retries still work.
 plain language. An empty history shows the empty state, not an error.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
-### CON-5 · Fundraiser banner — Contribute and dismiss
+### CON-5 · Fundraiser banner — Contribute (dismiss button hidden)
 **Role:** member · **Surfaces:** all
 **Steps:**
 1. With the banner showing in the Hub, press **Contribute**.
-2. Go back to the Hub, then dismiss the banner with **Not now**.
+2. Look for a "Not now" / dismiss control on the banner.
 **Expected:** **Contribute** opens the drive at `/apps/contributions` — the page renders (it is
-**not** a 404; the plugin registry row is visible, `is_visible = TRUE`). Dismiss silently hides the
-banner with no guilt copy and no countdown; it stays snoozed for six months (an internal config knob,
-not shown to the member). Dismissing is not audited.
+**not** a 404; the plugin registry row is visible, `is_visible = TRUE`). There is **no** "Not now"
+button on the banner — it is currently hidden by owner request (the `SHOW_DISMISS_BUTTON` flag is
+off). The server-side snooze endpoint still exists but has no UI entry point for now.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ---

--- a/ctf/packages/web/components/contributions/contributions-banner.tsx
+++ b/ctf/packages/web/components/contributions/contributions-banner.tsx
@@ -15,6 +15,11 @@ import {
 
 const CSRF_HEADERS = { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' } as const;
 
+// The dismiss ("Not now") control is temporarily hidden per owner request. The button markup and the
+// onDismiss snooze handler are kept in place so it can be brought back by flipping this flag to true —
+// nothing was removed.
+const SHOW_DISMISS_BUTTON: boolean = false;
+
 type BannerGoal = { label: string; current: number; target: number; unit: string; Icon: typeof DollarSign; color: string };
 
 function bannerGoals(f: FundraiserResponse['fundraiser']): BannerGoal[] {
@@ -102,9 +107,11 @@ export function ContributionsBanner() {
           <button type="button" onClick={onContribute} style={{ flex: 1, padding: '7px 0', borderRadius: 7, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}>
             Contribute
           </button>
-          <button type="button" onClick={() => void onDismiss()} style={{ flex: 1, padding: '7px 0', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, cursor: 'pointer' }}>
-            Not now
-          </button>
+          {SHOW_DISMISS_BUTTON && (
+            <button type="button" onClick={() => void onDismiss()} style={{ flex: 1, padding: '7px 0', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, cursor: 'pointer' }}>
+              Not now
+            </button>
+          )}
         </div>
       </div>
     );
@@ -143,9 +150,11 @@ export function ContributionsBanner() {
         <button type="button" onClick={onContribute} style={{ padding: '6px 16px', borderRadius: 7, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}>
           Contribute
         </button>
-        <button type="button" onClick={() => void onDismiss()} style={{ padding: '6px 14px', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, cursor: 'pointer' }}>
-          Not now
-        </button>
+        {SHOW_DISMISS_BUTTON && (
+          <button type="button" onClick={() => void onDismiss()} style={{ padding: '6px 14px', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, cursor: 'pointer' }}>
+            Not now
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## What

Hide the fundraiser banner's **"Not now"** dismiss button, per owner request. The button is **not deleted** — just hidden for now.

## How

Added a `SHOW_DISMISS_BUTTON` flag (default `false`) in `components/contributions/contributions-banner.tsx` and gated both banner layouts (desktop and phone-width) behind it. The button markup and the `onDismiss` snooze handler (POST `/api/contributions/banner/dismiss`) are left fully intact, so the control comes back by flipping the flag to `true`.

Only the **Contribute** button remains on the banner.

## Scope / parity

- Web-only change. The fundraiser banner lives only in the web app and is served to both desktop and mobile-responsive (phone-width) browsers — both covered.
- The Android app has no fundraiser banner (its "Not now" buttons are unrelated claim-form cancel controls), so nothing changed there.
- Presentation only — no route, schema, or contract change.

## Docs kept in step

- `ctf-contributions-feature-inventory.md` — delivery-status note + change-log entry.
- `contributions-test-script.md` — CON-5 updated (no "Not now" button on the banner; Test Script Drift Gate passes).

## Note

You mentioned the banner also reads "very muted." I did **not** touch the banner styling — only hid the button, staying surgical per the design guardrails. If you want the muted look adjusted (contrast/accent), say so and I'll do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jkhgv617YLn5LCj1f7hSD)_