### PR TITLE
fix: add uniform desktop back button to rail-less admin screens

### DIFF
--- a/ctf/packages/web/components/shared/mobile-screen-header.tsx
+++ b/ctf/packages/web/components/shared/mobile-screen-header.tsx
@@ -6,36 +6,85 @@ import { ChevronLeft } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { MobileTopActions } from './mobile-top-actions';
 
-// A uniform on-brand mobile top bar for screens that do not build their own — chiefly the admin
-// shells, which on desktop relied on the left icon rail (hidden at phone width) and so had no back
-// button or account/bug controls on mobile at all. It mirrors the look the member shells already use
-// (an accent-tinted back chevron + a brand icon + the screen title), and adds the shared
-// MobileTopActions cluster (report a bug, account & settings, account menu) on the right.
+// A uniform on-brand top bar for screens that do not build their own — chiefly the admin shells,
+// which have no left icon rail. It mirrors the look the member shells already use (an accent-tinted
+// back chevron + a brand icon + the screen title), and adds the shared MobileTopActions cluster
+// (report a bug, account & settings, account menu) on the right at phone width.
 //
-// Self-gating: renders only at phone width, so a caller can drop it in unconditionally and desktop is
-// untouched. `accent` is the plugin's brand hex (the back chevron and icon tint to it); omit it for a
-// neutral chrome.
+// At phone width it renders the full mobile bar. On desktop these rail-less shells otherwise had no
+// back control at all, so it renders a slim top bar with the same "Back to all apps" affordance —
+// keeping the way back uniform across every screen and breakpoint. Shells that build their own
+// desktop back (e.g. a desktop sidebar) pass `desktopBack={false}` to opt out and avoid duplicating.
+//
+// Self-gating: a caller drops it in unconditionally; it picks the right bar for the breakpoint.
+// `accent` is the plugin's brand hex (the back chevron and icon tint to it); omit it for neutral chrome.
 export function MobileScreenHeader({
   title,
   icon,
   accent,
   backHref = '/apps',
+  desktopBack = true,
 }: {
   title: string;
   icon?: ReactNode;
   accent?: string;
   backHref?: string;
+  desktopBack?: boolean;
 }) {
   const isMobile = useIsMobile();
-  if (!isMobile) {
-    return null;
-  }
 
   // Derive translucent tints from the accent hex (#RRGGBB + alpha suffix). Fall back to neutral
   // surface tokens when no accent is supplied.
   const chevronBg = accent ? `${accent}1A` : 'var(--ctf-surface, rgba(255, 255, 255, 0.06))';
   const chevronBorder = accent ? `${accent}4D` : 'var(--ctf-border, rgba(255, 255, 255, 0.12))';
   const chevronColor = accent ?? 'var(--ctf-text, #E5E7EB)';
+
+  // Desktop: a slim sticky bar carrying just the uniform back control. The shell renders its own
+  // title/header below, so we deliberately do not repeat the title/icon here.
+  if (!isMobile) {
+    if (!desktopBack) {
+      return null;
+    }
+    return (
+      <div
+        className="ctf-self-responsive"
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 40,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '10px 16px',
+          background: 'var(--ctf-bg, rgba(8, 8, 10, 0.96))',
+          borderBottom: '1px solid var(--ctf-border, rgba(255, 255, 255, 0.08))',
+          backdropFilter: 'blur(8px)',
+          WebkitBackdropFilter: 'blur(8px)',
+        }}
+      >
+        <Link
+          href={backHref}
+          aria-label="Back to all apps"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            height: 36,
+            padding: '0 12px 0 9px',
+            borderRadius: 10,
+            background: chevronBg,
+            border: `1px solid ${chevronBorder}`,
+            color: chevronColor,
+            textDecoration: 'none',
+            fontSize: 13,
+            fontWeight: 600,
+          }}
+        >
+          <ChevronLeft size={18} aria-hidden="true" /> Back to all apps
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/ctf/packages/web/components/weekly-performance/wp-admin-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-admin-shell.tsx
@@ -213,7 +213,9 @@ export function WeeklyPerformanceAdminShell() {
         padding: isMobile ? 16 : 32,
       }}
     >
-      <MobileScreenHeader title="Weekly Performance Admin" accent={BRAND} icon={<BarChart2 size={18} color={BRAND} />} />
+      {/* This shell renders its own desktop header (with a back chevron) above, so the shared header
+          only supplies the mobile bar here — opt out of its desktop back to avoid a duplicate. */}
+      <MobileScreenHeader title="Weekly Performance Admin" accent={BRAND} icon={<BarChart2 size={18} color={BRAND} />} desktopBack={false} />
       <div style={{ maxWidth: 880, margin: "0 auto" }}>
         {header}
         {body}


### PR DESCRIPTION
## What and why

The column-style admin screens (Unlock admin, ServiceCredits admin, and 16 others) have no left icon rail. On desktop they had **no back button at all** — you could open them from the admin directory but had no in-page way back to the apps. The screenshot that prompted this was `/admin/unlock`.

These shells already render the shared `MobileScreenHeader` for their phone layout (which does carry a back button on mobile), but that component returned nothing on desktop. So the desktop gap was uniform across all of them.

## The fix (one shared component, not 18 edits)

`MobileScreenHeader` now also renders a slim sticky desktop bar carrying the same **"Back to all apps"** control, tinted with each screen's accent. Because every affected shell already renders this component, the single change gives all of them a uniform back button in the same spot, at the same destination as the mobile back — so the way back is identical across breakpoints.

- `components/shared/mobile-screen-header.tsx`: render a desktop back bar when not at phone width; new `desktopBack` prop (default `true`) lets a shell opt out. The screen renders its own title/header, so the desktop bar deliberately shows only the back control (no repeated title).
- `components/weekly-performance/wp-admin-shell.tsx`: passes `desktopBack={false}` — it already renders its own desktop header with a back chevron, so this avoids a duplicate.

`contributions-shell` also uses `MobileScreenHeader`, but only inside its mobile-only frame and it has a desktop sidebar with its own "Back to Hub", so it is unaffected and needs no change.

Screens covered (18): beacon, bug-reports, contributions (admin), feed-announcements, foundation (admin), gdp, level-up, lighthouse, peer-programming, safety, service-credits, skills-hunt (admin), socket-relay, trust-transport, unlock, what-works, workforce, plus the beacon member shell.

## Verification

- `pnpm --filter @ctf/web run typecheck` — passes
- `pnpm --filter @ctf/web run lint` — passes
- Pre-push typecheck gate — passes

No routes, schema, contracts, or seed data changed; this is a surgical UI fix to shipped screens.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNARSwefHdEjJzyQ9XjfDg)_