### PR TITLE
fix: attribute each signed-out community post to its author

### DIFF
--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -67,6 +67,21 @@ function formatPostTime(iso: string): string {
   return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 }
 
+// Deterministic avatar tint for a signed-out community post, keyed on the author's handle, so
+// distinct members read as distinct people instead of one purple stream. Posts with no handle
+// (anonymized "Community member") share a single neutral slate tint.
+function publicAvatarBackground(authorUsername: string | null): string {
+  if (!authorUsername) {
+    return 'linear-gradient(135deg, #475569 0%, #334155 100%)';
+  }
+  let hash = 0;
+  for (let index = 0; index < authorUsername.length; index += 1) {
+    hash = (hash * 31 + authorUsername.charCodeAt(index)) >>> 0;
+  }
+  const hue = hash % 360;
+  return `linear-gradient(135deg, hsl(${hue}, 62%, 55%) 0%, hsl(${(hue + 38) % 360}, 62%, 45%) 100%)`;
+}
+
 // Signed-out Commons: community (peer) posts are public the way Quora posts are, so a not-signed-in
 // visitor reads them here — read-only and nothing else (no AI assistant, no concierge chips, no
 // composer). Posts come from the public, unauthenticated endpoint, which itself only returns posts
@@ -144,10 +159,19 @@ function PublicCommunityPanel({ stats, plugins, signInUrl }: { stats: ShellStats
             const initial = post.authorUsername ? post.authorUsername.charAt(0).toUpperCase() : 'C';
             return (
               <div key={post.id} className={styles.chatRow}>
-                <div className={styles.chatAvatar} aria-hidden="true">{initial}</div>
+                <div
+                  className={styles.chatAvatar}
+                  style={{ background: publicAvatarBackground(post.authorUsername) }}
+                  aria-hidden="true"
+                >
+                  {initial}
+                </div>
                 <div className={styles.chatBubbleGroup}>
+                  {/* Sender name above the bubble, matching the signed-in stream. Without it every
+                      post read as one speaker; here each message is clearly attributed to its author. */}
+                  <span className={styles.chatSender}>{authorLabel}</span>
                   <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>{post.body}</div>
-                  <span className={styles.chatTime}>{authorLabel} · {formatPostTime(post.createdAtIso)}</span>
+                  <span className={styles.chatTime}>{formatPostTime(post.createdAtIso)}</span>
                 </div>
               </div>
             );

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -67,6 +67,17 @@ function formatPostTime(iso: string): string {
   return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 }
 
+// A stable hue (0–359) derived from an author's handle, so the same member always gets the same
+// color. Both the avatar and the bubble tint read from this, keeping one person's posts in one
+// consistent color family.
+function authorHue(authorUsername: string): number {
+  let hash = 0;
+  for (let index = 0; index < authorUsername.length; index += 1) {
+    hash = (hash * 31 + authorUsername.charCodeAt(index)) >>> 0;
+  }
+  return hash % 360;
+}
+
 // Deterministic avatar tint for a signed-out community post, keyed on the author's handle, so
 // distinct members read as distinct people instead of one purple stream. Posts with no handle
 // (anonymized "Community member") share a single neutral slate tint.
@@ -74,12 +85,20 @@ function publicAvatarBackground(authorUsername: string | null): string {
   if (!authorUsername) {
     return 'linear-gradient(135deg, #475569 0%, #334155 100%)';
   }
-  let hash = 0;
-  for (let index = 0; index < authorUsername.length; index += 1) {
-    hash = (hash * 31 + authorUsername.charCodeAt(index)) >>> 0;
-  }
-  const hue = hash % 360;
+  const hue = authorHue(authorUsername);
   return `linear-gradient(135deg, hsl(${hue}, 62%, 55%) 0%, hsl(${(hue + 38) % 360}, 62%, 45%) 100%)`;
+}
+
+// Deterministic bubble tint for a signed-out community post, in the same hue family as the author's
+// avatar but dark enough that the light bubble text stays readable. This is the real fix for "every
+// message looks like one person": each member's bubbles carry their own color, not a shared purple.
+// Anonymized posts (no handle) get a neutral slate bubble that matches their neutral avatar.
+function publicBubbleBackground(authorUsername: string | null): string {
+  if (!authorUsername) {
+    return 'linear-gradient(135deg, #3a4453 0%, #2b333f 100%)';
+  }
+  const hue = authorHue(authorUsername);
+  return `linear-gradient(135deg, hsl(${hue}, 45%, 34%) 0%, hsl(${hue}, 48%, 26%) 100%)`;
 }
 
 // Signed-out Commons: community (peer) posts are public the way Quora posts are, so a not-signed-in
@@ -170,7 +189,12 @@ function PublicCommunityPanel({ stats, plugins, signInUrl }: { stats: ShellStats
                   {/* Sender name above the bubble, matching the signed-in stream. Without it every
                       post read as one speaker; here each message is clearly attributed to its author. */}
                   <span className={styles.chatSender}>{authorLabel}</span>
-                  <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>{post.body}</div>
+                  <div
+                    className={`${styles.chatBubble} ${styles.chatBubbleHub}`}
+                    style={{ background: publicBubbleBackground(post.authorUsername) }}
+                  >
+                    {post.body}
+                  </div>
                   <span className={styles.chatTime}>{formatPostTime(post.createdAtIso)}</span>
                 </div>
               </div>


### PR DESCRIPTION
## What and why

On the signed-out home Commons, several members' posts read as if one person were talking to themselves. The cause: every post rendered as the same purple bubble on the same side, with the author handle buried in tiny low-contrast text (`chatTime`, `#374151`) *below* the bubble. The signed-in stream doesn't have this problem — it shows a clear sender name *above* each bubble. This brings the signed-out view to the same clarity, and goes further so each member's posts are visually their own.

## Changes (`components/community-shell/shell-chat-panel.tsx`)

- **Sender name above the bubble.** Each signed-out post now shows its author handle (`@name`, or "Community member" when anonymized) above the bubble using the same `chatSender` treatment the signed-in stream uses. The timestamp stays below on its own line.
- **Per-author color, in three coordinated places.** A stable hue is derived from the author's handle and drives both the avatar tint and the **bubble** tint (a dark shade of the same hue, chosen so the light bubble text stays readable). So one member's posts share one color family, and distinct members are clearly distinct — instead of every bubble being the same purple. Anonymized posts (no handle) get a neutral slate avatar + bubble.

Scope is the signed-out `PublicCommunityPanel` only; the signed-in stream and the read/anonymization rules are untouched. System/fallback bubbles (sign-in prompt, "no posts yet") keep the existing hub purple.

## Verification

- `pnpm --filter @ctf/web run typecheck` — passes
- `pnpm --filter @ctf/web run lint` — passes
- Pre-push typecheck gate — passes

No routes, schema, contracts, or seed data changed.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)