### PR TITLE
feat: settle ServiceCredits requester → provider on trip completion

### DIFF
--- a/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -159,3 +159,29 @@ auditEvents:
     result:
       status: success_or_failure
       errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: trust-transport
+    command: trust-transport.trip.settlement
+    commandVersion: 1.0.0
+    purpose: trip_settlement_service_credits
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+      evidence:
+        settlementCurrencyCheck: pass_or_fail
+        amountValidationCheck: pass_or_fail
+    dataClassesAccessed:
+      - service_credit_transfer_metadata
+      - trip_status_metadata
+    targetContext:
+      workspaceId: workspace_identifier
+      tripId: trip_identifier
+      transferId: transfer_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class

--- a/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -105,6 +105,10 @@ contracts:
       - trust_transport_trips
       - trust_transport_status_events
       - trust_transport_proof_artifacts
+      # On completion with ServiceCredits settlement, moves credits requester -> provider.
+      - service_credits_wallets
+      - service_credits_transfers
+      - service_credits_ledger_entries
     purpose: lifecycle_transition
     retentionClass: transactional_long_lived
     idempotency: true

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -255,6 +255,19 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 
 ## Change Log
 
+- 2026-06-30: ServiceCredits settlement on trip completion (owner decision). When a trip transitions to
+  `completed` and the requester chose **ServiceCredits** settlement (`price_currency = 'SC'` with a
+  positive `price_amount`), `updateTripStatus` now moves the credits requester → provider via the
+  service-credits `createTransfer` (rail: balance), keyed idempotently by trip id (`trust-transport-settlement-<tripId>`),
+  and writes a `trust-transport.trip.settlement` audit event. It runs after the completion commits and is
+  best-effort: a failure (e.g. the requester lacks balance) is logged for reconciliation rather than
+  reverting the completed trip, and the trip-id key means a retry cannot double-pay. `trip.status.update`
+  command `dataAccess` now lists the `service_credits_*` tables it touches on completion. No schema change.
+  **Scope:** only ServiceCredits settlement moves value here — the provider is paid to their ServiceCredits
+  wallet (not the TrustTransport earnings ledger). Fiat/crypto earnings crediting + currency-aware payouts
+  (issue #1233) are a follow-up that needs an earnings-ledger migration (`amount INTEGER → NUMERIC`, add a
+  `trip_id` column; the seed already assumes both).
+
 - 2026-06-30: Earnings + payouts surface (web). New `GET /api/trust-transport/earnings` returns the
   caller's own available earnings balance (`getMyEarningsBalance`, wrapping the existing ledger sum). A
   new "Earnings" tab shows the available balance, a "Request a payout" form (posts to the existing

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -184,7 +184,7 @@ Result: web ☐ android ☐
 1. On web, open the **Help out** tab → "Trips you're helping with"; find your active trip. (On Android this runs via API/seed until the parity pass — issue #1250.)
 2. Tap the forward action (Start trip → Mark picked up → Mark delivered → Mark complete) to advance one step.
 
-**Expected:** The trip status changes one step forward and the new state shows on the card. Transitions are forward-only and append-only — there is no control to revert to the previous state. An out-of-order transition (via the API) is refused.
+**Expected:** The trip status changes one step forward and the new state shows on the card. Transitions are forward-only and append-only — there is no control to revert to the previous state. An out-of-order transition (via the API) is refused. When you mark the trip **complete** and the requester chose ServiceCredits settlement, the credits move from the requester to you (verify in your ServiceCredits wallet) and a `trust-transport.trip.settlement` audit event is written; a completed Free/Barter trip moves no credits.
 
 Result: web ☐ android ☐
 

--- a/ctf/packages/web/components/trust-transport/tt-earnings-tab.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-earnings-tab.tsx
@@ -80,7 +80,7 @@ export function TrustTransportEarningsTab() {
     <div style={{ flex: 1, padding: "24px", overflowY: "auto", minHeight: 0 }}>
       <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 6 }}>Earnings</div>
       <div style={{ fontSize: 13, color: "#9CA3AF", marginBottom: 20, lineHeight: 1.5, maxWidth: 520 }}>
-        What you&apos;ve earned by helping fulfil trips, and your payout requests. Payouts are reviewed by an admin.
+        ServiceCredits you earn are paid straight to your ServiceCredits wallet when a trip completes. This tab tracks other-currency earnings and your payout requests, which an admin reviews.
       </div>
 
       {loading ? (

--- a/ctf/packages/web/lib/trust-transport/repository.ts
+++ b/ctf/packages/web/lib/trust-transport/repository.ts
@@ -1,5 +1,7 @@
 import { queryDb, withDbTransaction } from 'lib/db/postgres';
 import { getCurrency } from 'lib/currency/repository';
+import { createTransfer } from 'lib/service-credits/repository';
+import { reportError } from 'lib/observability/report';
 import {
   getAccountRestrictionStatus,
   restrictAccount as setSharedRestriction,
@@ -872,7 +874,62 @@ export async function updateTripStatus(
     result.request.status,
   );
 
+  // Settlement (owner decision): when a trip completes and the requester chose ServiceCredits, move the
+  // credits requester -> provider. Runs after the completion is durably committed.
+  await settleServiceCreditsOnCompletion(result.trip, result.request, nextStatus);
+
   return result;
+}
+
+// Move ServiceCredits from the requester to the provider when a trip completes with SC settlement.
+// Best-effort and idempotent by trip id: the trip is already completed and the work done, so a failure
+// here (e.g. the requester lacks balance) is logged for reconciliation rather than reverting the trip,
+// and the trip-id idempotency key means a retry can never double-pay. Only SC settlement moves value
+// here; fiat/crypto earnings and Free/Barter are out of scope for this path.
+async function settleServiceCreditsOnCompletion(
+  trip: TrustTransportTrip,
+  request: TrustTransportRequest,
+  nextStatus: TrustTransportTripStatus,
+): Promise<void> {
+  if (nextStatus !== 'completed') {
+    return;
+  }
+  if (request.priceCurrency !== 'SC') {
+    return;
+  }
+  const amount = request.priceAmount;
+  if (amount === null || !(amount > 0)) {
+    return;
+  }
+
+  try {
+    const tx = await createTransfer({
+      senderUserId: request.requesterUserId,
+      recipientUserId: trip.providerUserId,
+      amount,
+      idempotencyKey: `trust-transport-settlement-${trip.id}`,
+      originPlugin: 'trust-transport',
+      reasonCode: 'trust-transport.trip.settlement',
+    });
+
+    await insertTrustTransportAudit({
+      actorId: trip.providerUserId,
+      command: 'trust-transport.trip.settlement',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'trip',
+      targetId: trip.id,
+      metadata: {
+        rail: 'service_credits',
+        amount,
+        fromUserId: request.requesterUserId,
+        toUserId: trip.providerUserId,
+        transferId: (tx as { id?: string }).id ?? null,
+      },
+    });
+  } catch (error) {
+    reportError(error, { area: 'trust-transport', op: 'trip_settlement' });
+  }
 }
 
 export async function triggerEmergencyStop(tripId: string, actorUserId: string, isAdmin: boolean, notes: string | null) {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Implements the settlement model you approved. **Until now, completing a trip moved no value and credited no earnings** — the earnings ledger was only ever written by the seed. This is the first real settlement.

## ⚠️ Moves real ServiceCredits — please review
- When a trip transitions to `completed` and the requester chose **ServiceCredits** settlement (`price_currency = 'SC'`, positive amount), `updateTripStatus` moves the credits **requester → provider** via the existing service-credits `createTransfer` (balance rail), and writes a `trust-transport.trip.settlement` audit event.
- **Idempotent** by trip id (`trust-transport-settlement-<tripId>`) — a retry can't double-pay.
- **Best-effort after commit:** the trip is already completed and the work done, so if the transfer fails (e.g. the requester lacks balance) it's logged for reconciliation rather than reverting the trip.
- Only SC settlement moves value here — the provider is paid to their **ServiceCredits wallet** (not the TrustTransport earnings ledger). Free/Barter move nothing.

## Contracts / docs
- `trip.status.update` `dataAccess` now lists the `service_credits_*` tables it touches on completion; added the `trip.settlement` audit event. Earnings-tab copy clarifies SC is paid to the wallet.
- No schema change.

## Deliberately out of scope (your call)
Fiat/crypto earnings crediting + currency-aware payouts (**#1233**) need an earnings-ledger migration first: `amount INTEGER → NUMERIC` and a `trip_id` column (the seed already assumes both, so it's currently broken against the live schema). I did not do that migration in this PR — flagging it for your go-ahead as the next money step.

## Verification
Monorepo typecheck, lint, EOF, inventory-drift, schema-drift, test-script-drift all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_