### PR TITLE
fix: contribute-flow copy — gift card physical/digital, credits spacing, drop placeholder

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -286,6 +286,15 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-07-01: Contribute-flow copy and cleanup pass (owner feedback). (1) Fixed "50SC" running
+  together in the credits disclaimer — the inline JSX interpolation dropped the space where the card
+  template literals did not, so both amounts are now built as template literals (`{`${creditsPerUsd} SC`}` /
+  `{`${creditsPerAction} SC`}`) and render "10 SC" / "50 SC". (2) Added a line to the gift-card form
+  (web + Android) stating the card can be physical or digital and that the card details go to the owner
+  in the Signal chat, never in the form. (3) Removed the "Choose one of the three ways above…"
+  placeholder box under the cards — it read as confusing; the form now simply opens when a card is
+  chosen (the cards' own "Choose this" cue is the prompt). Presentation/copy only — no route, schema,
+  or contract change.
 - 2026-07-01: Made the contribute action discoverable. The three path cards ("How would you like to
   help?") were click-to-expand `role="button"` divs with no visual cue that they open anything, and on
   web the chosen path's form rendered at the very bottom of the section — below the credits

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md` |
-| **Generated** | 2026-07-01 (discoverable contribute cards + form placement; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-07-01 (contribute copy pass: gift-card physical/digital + Signal, credits spacing, no placeholder; regenerate via CI to stamp the commit) |
 
 ## How to run this
 
@@ -37,9 +37,11 @@ Voluntary fundraiser drives; thank-you credits, never money. Member role unless 
    stuck, no error. → web ☐ mobile ☐ android ☐
 2. **Contributing is obvious.** Under "How would you like to help?" each of the three cards (gift
    card, Quora comment, GitHub star) shows a clear "Choose this" cue, and a one-line instruction says
-   a form opens underneath. Click a card: its form opens **directly below the cards** (not at the
-   bottom of the page), the card reads "Selected", and there is a working Submit. Before any card is
-   chosen a short placeholder prompt sits where the form will appear. → web ☐ mobile ☐ android ☐
+   a form opens underneath. Before any card is chosen, nothing shows under the cards (no placeholder
+   box). Click a card: its form opens **directly below the cards** (not at the bottom of the page),
+   the card reads "Selected", and there is a working Submit. The gift-card form states the card can be
+   physical or digital and that the card details go to the owner in the Signal chat (never in the
+   form). Credit amounts read "10 SC" / "50 SC" with a space. → web ☐ mobile ☐ android ☐
 3. **No gift-card code is ever asked for.** Start a gift-card claim. There is **no** field for the
    gift-card code anywhere; the screen instead points the member to send the code to the owner over
    Signal, outside the app. → web ☐ mobile ☐ android ☐

--- a/ctf/packages/mobile/src/features/contributions/Contributions.tsx
+++ b/ctf/packages/mobile/src/features/contributions/Contributions.tsx
@@ -101,6 +101,7 @@ function GiftCardForm({ submitting, error, onSubmit, onCancel }: { submitting: b
   const [signal, setSignal] = useState('');
   return (
     <View style={st.formCard}>
+      <Text style={[st.hint, { marginBottom: 12 }]}>Your gift card can be physical or digital. Don't enter the card number or code here — after you submit, share the card details with the platform owner in your Signal chat.</Text>
       <Text style={st.fieldLabel}>Card type</Text>
       <View style={st.chipRow}>
         {CARD_TYPES.map((c) => (

--- a/ctf/packages/web/components/contributions/contributions-paths.tsx
+++ b/ctf/packages/web/components/contributions/contributions-paths.tsx
@@ -91,7 +91,11 @@ function GiftCardForm({ t, submitting, error, onSubmit, onCancel }: { t: Contrib
 
   return (
     <div style={{ background: t.SURFACE, borderRadius: 12, padding: 20, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-      <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 16 }}>Gift card details</div>
+      <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 8 }}>Gift card details</div>
+      <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, margin: '0 0 16px' }}>
+        Your gift card can be physical or digital. Don&apos;t enter the card number or code here — after you
+        submit, share the card details with the platform owner in your Signal chat.
+      </p>
       <div style={{ marginBottom: 14 }}>
         <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 8 }}>Card type</div>
         <div style={{ display: 'flex', gap: 8 }}>
@@ -242,17 +246,8 @@ export function ContributionPaths({
         })}
       </div>
 
-      {/* The chosen path's form opens here, directly under the cards, so it is obviously connected
-          to the card just selected. Until a card is chosen, a short prompt stands in its place so
-          the screen never looks like a dead end. */}
-      {activePath === null && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '14px 16px', background: t.SURFACE, borderRadius: 10, border: `1px dashed ${t.BORDER_SOLID}`, marginBottom: 20 }}>
-          <ChevronDown size={14} color={t.MUTED} style={{ flexShrink: 0 }} />
-          <span style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6 }}>
-            Choose one of the three ways above and its form will open here.
-          </span>
-        </div>
-      )}
+      {/* The chosen path's form opens here, directly under the cards. Nothing shows until a card is
+          selected — the cards' own "Choose this" cue is the prompt. */}
       {activePath === 'gift_card' && (
         <GiftCardForm t={t} submitting={submitting} error={error} onSubmit={onSubmitGiftCard} onCancel={() => setActivePath(null)} />
       )}
@@ -286,7 +281,7 @@ export function ContributionPaths({
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '10px 14px', background: `${t.ACCENT}08`, borderRadius: 8, border: `1px solid ${t.ACCENT}20`, marginTop: 4 }}>
         <AlertCircle size={13} color={t.ACCENT} style={{ flexShrink: 0, marginTop: 1 }} />
         <span style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6 }}>
-          Confirmed contributions earn ServiceCredits as a thank-you — {creditsPerUsd} SC per dollar for gift cards, and {creditsPerAction} SC for a comment or star. Credits are a thank-you; they can&apos;t be turned back into cash.
+          Confirmed contributions earn ServiceCredits as a thank-you — {`${creditsPerUsd} SC`} per dollar for gift cards, and {`${creditsPerAction} SC`} for a comment or star. Credits are a thank-you; they can&apos;t be turned back into cash.
         </span>
       </div>
     </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Three owner-requested fixes on the member Contributions screen:

## 1. "50SC" → "50 SC" (missing space)

The credits disclaimer rendered "50SC" while the path cards rendered "50 SC". The cards build the amount with a JS template literal (`` `${creditsPerAction} SC` ``) — space preserved — but the disclaimer used a bare JSX interpolation (`{creditsPerAction} SC`), which dropped the space in the built output. Switched both amounts in the disclaimer to template literals so they match the cards and render "10 SC" / "50 SC".

## 2. Gift-card form: say physical or digital, and share details in Signal

Added a line under "Gift card details" (web + Android): *"Your gift card can be physical or digital. Don't enter the card number or code here — after you submit, share the card details with the platform owner in your Signal chat."* This reinforces the existing model (the code is never collected in-app; it goes to the owner over Signal).

## 3. Remove the confusing placeholder box

The "Choose one of the three ways above and its form will open here." box under the cards read as confusing. Removed it — the form now simply opens when a card is chosen, and the cards' own "Choose this ⌄" cue is the prompt.

## Scope

Presentation/copy only — no route, schema, or contract change; submit flow and server logic untouched. Docs (inventory change log + manual test script) updated; drift/inventory/EOF gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jkhgv617YLn5LCj1f7hSD)_