### PR TITLE
fix: require contribution links and fix Commons safety copy

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -44,14 +44,16 @@ flow is one-way, like gas-station reward points.
 
 - Submit a contribution claim of one of three kinds:
   - **Gift card** (`amazon`, `apple`, or `dennys`): the member states the amount (over 0, at most
-    500 USD) and their own Signal contact (URL or phone number — reduces fraud). The gift-card
-    **code is never collected or stored anywhere** — the member sends the code to the owner over
-    Signal, outside the app. After submitting, the member sees the owner-authored Signal
-    instructions (codes go to the owner on Signal; everything else belongs in the public Hub
-    support channel).
-  - **Quora comment**: the post URL is optional, because much of the user base struggles with
-    URLs; the owner finds the comment via notifications and pastes the URL in during review.
-  - **GitHub star**: profile URL likewise optional, same reason.
+    500 USD) and their own Signal contact (URL or phone number — reduces fraud). It can be a physical
+    or a digital gift card. The gift-card **code is never collected or stored anywhere** — the member
+    sends the code to the owner over Signal, outside the app. The member is warned, on both the form
+    and the post-submit confirmation, to **never post the code in the Commons** (the single public
+    group chat): doing so means no ServiceCredits and the owner never receives the gift. Questions and
+    anything other than the code belong in the Commons.
+  - **Quora comment**: the member pastes the link to their comment — **required**, because the owner
+    needs it to find and confirm the contribution. If the member cannot find the link, the form points
+    them to the Commons (the group chat) to ask for help rather than submitting an untrackable claim.
+  - **GitHub star**: the member pastes their GitHub profile link — **required**, same reason.
 - See their own claim history and statuses (pending / confirmed / rejected).
 - See the current fundraiser cycle and collective progress (USD raised, comments, stars,
   contributor count) toward the owner-set goals.
@@ -286,6 +288,17 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-07-01: Trackability + Commons safety pass (owner feedback). (1) The Quora comment link and the
+  GitHub profile link are now **required** on submit (web + Android) — without them the owner cannot
+  find and confirm the contribution. Each field shows a help line: if you cannot find the link, ask in
+  the Commons (the group chat). (2) Corrected copy that pointed members to a non-existent "#support
+  channel in the Hub": there is one channel, the Commons. The post-submit confirmation now points
+  questions to the Commons and carries a prominent warning to **never post a gift card code in the
+  Commons** (it is a public group chat — doing so means no ServiceCredits and the owner never receives
+  the gift; codes go only to the owner on Signal). The gift-card form carries the same warning. (3) On
+  desktop, removed the "My contributions" left-nav item — the member's contributions already show
+  permanently in the right rail, so the item only scrolled to something already on screen. The mobile
+  "My history" tab is unchanged. Presentation/copy only — no route, schema, or contract change.
 - 2026-07-01: Contribute-flow copy and cleanup pass (owner feedback). (1) Fixed "50SC" running
   together in the credits disclaimer — the inline JSX interpolation dropped the space where the card
   template literals did not, so both amounts are now built as template literals (`{`${creditsPerUsd} SC`}` /

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -286,6 +286,15 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-07-01: Contribute-flow copy and cleanup pass (owner feedback). (1) Fixed "50SC" running
+  together in the credits disclaimer — the inline JSX interpolation dropped the space where the card
+  template literals did not, so both amounts are now built as template literals (`{`${creditsPerUsd} SC`}` /
+  `{`${creditsPerAction} SC`}`) and render "10 SC" / "50 SC". (2) Added a line to the gift-card form
+  (web + Android) stating the card can be physical or digital and that the card details go to the owner
+  in the Signal chat, never in the form. (3) Removed the "Choose one of the three ways above…"
+  placeholder box under the cards — it read as confusing; the form now simply opens when a card is
+  chosen (the cards' own "Choose this" cue is the prompt). Presentation/copy only — no route, schema,
+  or contract change.
 - 2026-07-01: Made the contribute action discoverable. The three path cards ("How would you like to
   help?") were click-to-expand `role="button"` divs with no visual cue that they open anything, and on
   web the chosen path's form rendered at the very bottom of the section — below the credits

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md` |
-| **Generated** | 2026-07-01 (contribute copy pass: gift-card physical/digital + Signal, credits spacing, no placeholder; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-07-01 (required contribution links + Commons safety copy + desktop nav trim; regenerate via CI to stamp the commit) |
 
 ## How to run this
 
@@ -61,19 +61,25 @@ Voluntary fundraiser drives; thank-you credits, never money. Member role unless 
 2. Pick a method (Amazon / Apple / Denny's), enter an amount (over 0, at most 500 USD), and your own
    Signal contact (URL or phone number).
 3. Submit.
-**Expected:** The claim is accepted and lands `pending`. No gift-card code field exists. After
+**Expected:** The claim is accepted and lands `pending`. No gift-card code field exists. The form
+states the card can be physical or digital and warns to never post the code in the Commons. After
 submitting, the owner-authored Signal instructions show (codes go to the owner on Signal; the owner's
-Signal contact appears inline when set). An amount of 0 or over 500, or a missing Signal contact, is
-rejected.
+Signal contact appears inline when set), plus a prominent warning that posting the code in the Commons
+(the public group chat) means no ServiceCredits and the owner never receives the gift, and a "questions
+→ ask in the Commons" line. There is **no** reference to a "#support channel". An amount of 0 or over
+500, or a missing Signal contact, is rejected.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
-### CON-2 · Submit a Quora comment and a GitHub star
+### CON-2 · Submit a Quora comment and a GitHub star (link required)
 **Role:** member · **Surfaces:** all
 **Steps:**
-1. Submit a Quora comment claim — leave the post URL blank (it is optional).
-2. Submit a GitHub star claim — leave the profile URL blank (it is optional).
-**Expected:** Both accept with the URL omitted (much of the user base struggles with URLs; the owner
-fills it in during review). Both land `pending`.
+1. Choose the Quora comment path. Try to submit with the link field blank.
+2. Paste a link and submit.
+3. Repeat for the GitHub star path (profile link).
+**Expected:** The link field is **required** (marked with a `*`). Submitting blank does nothing except
+show "Please paste the link so we can find and confirm your contribution." Each form shows a help line:
+if you cannot find the link, ask in the Commons (the group chat). With a link pasted, both submit and
+land `pending`.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ### CON-3 · GitHub star is creditable at most once

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md` |
-| **Generated** | 2026-07-01 (discoverable contribute cards + form placement; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-07-01 (contribute copy pass: gift-card physical/digital + Signal, credits spacing, no placeholder; regenerate via CI to stamp the commit) |
 
 ## How to run this
 
@@ -37,9 +37,11 @@ Voluntary fundraiser drives; thank-you credits, never money. Member role unless 
    stuck, no error. → web ☐ mobile ☐ android ☐
 2. **Contributing is obvious.** Under "How would you like to help?" each of the three cards (gift
    card, Quora comment, GitHub star) shows a clear "Choose this" cue, and a one-line instruction says
-   a form opens underneath. Click a card: its form opens **directly below the cards** (not at the
-   bottom of the page), the card reads "Selected", and there is a working Submit. Before any card is
-   chosen a short placeholder prompt sits where the form will appear. → web ☐ mobile ☐ android ☐
+   a form opens underneath. Before any card is chosen, nothing shows under the cards (no placeholder
+   box). Click a card: its form opens **directly below the cards** (not at the bottom of the page),
+   the card reads "Selected", and there is a working Submit. The gift-card form states the card can be
+   physical or digital and that the card details go to the owner in the Signal chat (never in the
+   form). Credit amounts read "10 SC" / "50 SC" with a space. → web ☐ mobile ☐ android ☐
 3. **No gift-card code is ever asked for.** Start a gift-card claim. There is **no** field for the
    gift-card code anywhere; the screen instead points the member to send the code to the owner over
    Signal, outside the app. → web ☐ mobile ☐ android ☐

--- a/ctf/packages/mobile/src/features/contributions/Contributions.tsx
+++ b/ctf/packages/mobile/src/features/contributions/Contributions.tsx
@@ -101,6 +101,7 @@ function GiftCardForm({ submitting, error, onSubmit, onCancel }: { submitting: b
   const [signal, setSignal] = useState('');
   return (
     <View style={st.formCard}>
+      <Text style={[st.hint, { marginBottom: 12 }]}>Your gift card can be physical or digital. Don't enter the card number or code here — after you submit, share the card details with the platform owner in your Signal chat.</Text>
       <Text style={st.fieldLabel}>Card type</Text>
       <View style={st.chipRow}>
         {CARD_TYPES.map((c) => (

--- a/ctf/packages/mobile/src/features/contributions/Contributions.tsx
+++ b/ctf/packages/mobile/src/features/contributions/Contributions.tsx
@@ -101,7 +101,8 @@ function GiftCardForm({ submitting, error, onSubmit, onCancel }: { submitting: b
   const [signal, setSignal] = useState('');
   return (
     <View style={st.formCard}>
-      <Text style={[st.hint, { marginBottom: 12 }]}>Your gift card can be physical or digital. Don't enter the card number or code here — after you submit, share the card details with the platform owner in your Signal chat.</Text>
+      <Text style={[st.hint, { marginBottom: 6 }]}>Your gift card can be physical or digital. Don't enter the card number or code here — after you submit, send the card details privately to the platform owner on Signal (you'll get the link).</Text>
+      <Text style={[st.warnText, { marginBottom: 12 }]}>Never post your gift card code in the Commons — it's a public group chat, so if you do you won't receive ServiceCredits and the owner won't receive the gift.</Text>
       <Text style={st.fieldLabel}>Card type</Text>
       <View style={st.chipRow}>
         {CARD_TYPES.map((c) => (
@@ -130,16 +131,42 @@ function GiftCardForm({ submitting, error, onSubmit, onCancel }: { submitting: b
   );
 }
 
-function UrlForm({ blurb, label, placeholder, submitting, error, onSubmit, onCancel }: { blurb: string; label: string; placeholder: string; submitting: boolean; error: string | null; onSubmit: (_url: string | undefined) => void; onCancel: () => void }) {
+function UrlForm({ blurb, label, placeholder, helpText, submitting, error, onSubmit, onCancel }: { blurb: string; label: string; placeholder: string; helpText: string; submitting: boolean; error: string | null; onSubmit: (_url: string) => void; onCancel: () => void }) {
   const [url, setUrl] = useState('');
+  const [missing, setMissing] = useState(false);
+  // The link is required: without it the owner cannot find and confirm the contribution.
+  function handleSubmit() {
+    const trimmed = url.trim();
+    if (!trimmed) {
+      setMissing(true);
+      return;
+    }
+    onSubmit(trimmed);
+  }
   return (
     <View style={st.formCard}>
       <Text style={st.formBlurb}>{blurb}</Text>
-      <Text style={st.fieldLabel}>{label}</Text>
-      <TextInput value={url} onChangeText={setUrl} placeholder={placeholder} placeholderTextColor={SUBTLE} autoCapitalize="none" style={st.input} />
+      <Text style={st.fieldLabel}>
+        {label} <Text style={{ color: '#EF4444' }}>*</Text>
+      </Text>
+      <TextInput
+        value={url}
+        onChangeText={(v) => {
+          setUrl(v);
+          if (missing) {
+            setMissing(false);
+          }
+        }}
+        placeholder={placeholder}
+        placeholderTextColor={SUBTLE}
+        autoCapitalize="none"
+        style={st.input}
+      />
+      <Text style={st.hint}>{helpText}</Text>
+      {missing ? <Text style={st.errorText}>Please paste the link so we can find and confirm your contribution.</Text> : null}
       {error ? <Text style={st.errorText}>{error}</Text> : null}
       <View style={st.formActions}>
-        <TouchableOpacity disabled={submitting} onPress={() => onSubmit(url.trim() ? url.trim() : undefined)} style={[st.primaryBtn, { flex: 1 }]}>
+        <TouchableOpacity disabled={submitting} onPress={handleSubmit} style={[st.primaryBtn, { flex: 1 }]}>
           <Text style={st.primaryBtnText}>{submitting ? 'Submitting…' : 'Submit'}</Text>
         </TouchableOpacity>
         <TouchableOpacity onPress={onCancel} style={st.secondaryBtn}>
@@ -179,9 +206,13 @@ function Confirmation({ data, onViewHistory }: { data: FundraiserResponse; onVie
         ) : (
           <Text style={st.bodyText}>{instructions}</Text>
         )}
+        <View style={st.warnBox}>
+          <Text style={st.warnLabel}>Send the code only on Signal — never in the Commons</Text>
+          <Text style={st.warnText}>The Commons is a public group chat. If you post your gift card code or details there, you will not receive ServiceCredits and the owner will not receive the gift. The code goes only to the owner on Signal, using the link above.</Text>
+        </View>
         <View style={st.supportBox}>
-          <Text style={st.supportLabel}>Questions or anything else?</Text>
-          <Text style={st.supportLink}>Post in the #support channel in the Hub — that's the right place for anything other than sending the code.</Text>
+          <Text style={st.supportLabel}>Questions or need help?</Text>
+          <Text style={st.supportLink}>Ask in the Commons — the group chat. It's the place for anything other than sending the code.</Text>
         </View>
       </View>
 
@@ -357,23 +388,25 @@ export const Contributions: React.FC = () => {
                   )}
                   {active && p.key === 'quora_comment' && (
                     <UrlForm
-                      blurb="Leave a comment on a Quora post. Paste the URL if you have it — if not, that's fine, we'll find it."
-                      label="Quora post URL (optional)"
+                      blurb="Leave a comment on a Quora post, then paste the link to your comment so we can find and confirm it."
+                      label="Link to your Quora comment"
                       placeholder="https://www.quora.com/…"
+                      helpText="Need help finding the link? Ask in the Commons — the group chat — and we'll help you find it."
                       submitting={submitting}
                       error={submitError}
-                      onSubmit={(url) => void submit({ kind: 'quora_comment', ...(url ? { quoraPostUrl: url } : {}) }, false)}
+                      onSubmit={(url) => void submit({ kind: 'quora_comment', quoraPostUrl: url }, false)}
                       onCancel={() => setActivePath(null)}
                     />
                   )}
                   {active && p.key === 'github_star' && !disabled && (
                     <UrlForm
-                      blurb="Star our GitHub repository. If you'd like to share your profile so we can confirm, paste it — no obligation."
-                      label="GitHub profile URL (optional)"
+                      blurb="Star our GitHub repository, then paste your GitHub profile link so we can confirm it."
+                      label="Your GitHub profile URL"
                       placeholder="https://github.com/your-username"
+                      helpText="Need help finding the link? Ask in the Commons — the group chat — and we'll help you find it."
                       submitting={submitting}
                       error={submitError}
-                      onSubmit={(url) => void submit({ kind: 'github_star', ...(url ? { githubProfileUrl: url } : {}) }, false)}
+                      onSubmit={(url) => void submit({ kind: 'github_star', githubProfileUrl: url }, false)}
                       onCancel={() => setActivePath(null)}
                     />
                   )}
@@ -483,6 +516,9 @@ const st = StyleSheet.create({
   supportBox: { padding: 12, backgroundColor: BG, borderRadius: 8, borderWidth: 1, borderColor: BORDER, marginTop: 10 },
   supportLabel: { fontSize: 11, color: SUBTLE, marginBottom: 4 },
   supportLink: { fontSize: 12, color: SIGNAL_BLUE, lineHeight: 18 },
+  warnBox: { padding: 12, backgroundColor: '#EF44440F', borderRadius: 8, borderWidth: 1, borderColor: '#EF444440', marginTop: 10 },
+  warnLabel: { fontSize: 11, color: '#EF4444', fontWeight: '600' as const, marginBottom: 4 },
+  warnText: { fontSize: 12, color: SUBTLE, lineHeight: 18 },
   pendingCard: { padding: 14, backgroundColor: `${COLOR}08`, borderRadius: 10, borderWidth: 1, borderColor: `${COLOR}20`, marginBottom: 20 },
   pendingTitle: { fontSize: 13, fontWeight: '600', color: TEXT_COLOR, marginBottom: 2 },
 });

--- a/ctf/packages/web/components/contributions/contributions-confirmation.tsx
+++ b/ctf/packages/web/components/contributions/contributions-confirmation.tsx
@@ -14,7 +14,8 @@ export type ConfirmationProps = {
 };
 
 // Render the owner's Signal URL inline as a tappable link, or fall back to the editable
-// instructions text. The surrounding copy and the #support-channel line are always shown.
+// instructions text. The surrounding copy — the never-in-the-Commons warning and the "ask in the
+// Commons" line — is always shown.
 function SignalLine({ ownerSignalUrl, signalInstructions, t }: { ownerSignalUrl: string | null; signalInstructions: string; t: ContributionsTokens }) {
   if (ownerSignalUrl) {
     return (
@@ -44,9 +45,17 @@ function SignalBox({ ownerSignalUrl, signalInstructions, t, compact }: { ownerSi
         <span style={{ fontSize: 13, fontWeight: 600, color: t.TITLE }}>Send the code on Signal</span>
       </div>
       <SignalLine ownerSignalUrl={ownerSignalUrl} signalInstructions={signalInstructions} t={t} />
+      <div style={{ padding: '10px 14px', background: '#EF44440F', borderRadius: 8, border: '1px solid #EF444440', marginBottom: 10 }}>
+        <div style={{ fontSize: 12, color: '#EF4444', fontWeight: 600, marginBottom: 4 }}>Send the code only on Signal — never in the Commons</div>
+        <div style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6 }}>
+          The Commons is a public group chat. If you post your gift card code or details there, you will not receive
+          ServiceCredits and the owner will not receive the gift. The code goes only to the owner on Signal, using the
+          link above.
+        </div>
+      </div>
       <div style={{ padding: '10px 14px', background: t.BG, borderRadius: 8, border: `1px solid ${t.BORDER_SOLID}` }}>
-        <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 4 }}>Questions or anything else?</div>
-        <div style={{ fontSize: 12, color: SIGNAL_BLUE }}>Post in the #support channel in the Hub — that&apos;s the right place for anything other than sending the code.</div>
+        <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 4 }}>Questions or need help?</div>
+        <div style={{ fontSize: 12, color: SIGNAL_BLUE }}>Ask in the Commons — the group chat. It&apos;s the place for anything other than sending the code.</div>
       </div>
     </div>
   );

--- a/ctf/packages/web/components/contributions/contributions-paths.tsx
+++ b/ctf/packages/web/components/contributions/contributions-paths.tsx
@@ -91,7 +91,11 @@ function GiftCardForm({ t, submitting, error, onSubmit, onCancel }: { t: Contrib
 
   return (
     <div style={{ background: t.SURFACE, borderRadius: 12, padding: 20, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-      <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 16 }}>Gift card details</div>
+      <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 8 }}>Gift card details</div>
+      <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, margin: '0 0 16px' }}>
+        Your gift card can be physical or digital. Don&apos;t enter the card number or code here — after you
+        submit, share the card details with the platform owner in your Signal chat.
+      </p>
       <div style={{ marginBottom: 14 }}>
         <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 8 }}>Card type</div>
         <div style={{ display: 'flex', gap: 8 }}>
@@ -242,17 +246,8 @@ export function ContributionPaths({
         })}
       </div>
 
-      {/* The chosen path's form opens here, directly under the cards, so it is obviously connected
-          to the card just selected. Until a card is chosen, a short prompt stands in its place so
-          the screen never looks like a dead end. */}
-      {activePath === null && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '14px 16px', background: t.SURFACE, borderRadius: 10, border: `1px dashed ${t.BORDER_SOLID}`, marginBottom: 20 }}>
-          <ChevronDown size={14} color={t.MUTED} style={{ flexShrink: 0 }} />
-          <span style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6 }}>
-            Choose one of the three ways above and its form will open here.
-          </span>
-        </div>
-      )}
+      {/* The chosen path's form opens here, directly under the cards. Nothing shows until a card is
+          selected — the cards' own "Choose this" cue is the prompt. */}
       {activePath === 'gift_card' && (
         <GiftCardForm t={t} submitting={submitting} error={error} onSubmit={onSubmitGiftCard} onCancel={() => setActivePath(null)} />
       )}
@@ -286,7 +281,7 @@ export function ContributionPaths({
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '10px 14px', background: `${t.ACCENT}08`, borderRadius: 8, border: `1px solid ${t.ACCENT}20`, marginTop: 4 }}>
         <AlertCircle size={13} color={t.ACCENT} style={{ flexShrink: 0, marginTop: 1 }} />
         <span style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6 }}>
-          Confirmed contributions earn ServiceCredits as a thank-you — {creditsPerUsd} SC per dollar for gift cards, and {creditsPerAction} SC for a comment or star. Credits are a thank-you; they can&apos;t be turned back into cash.
+          Confirmed contributions earn ServiceCredits as a thank-you — {`${creditsPerUsd} SC`} per dollar for gift cards, and {`${creditsPerAction} SC`} for a comment or star. Credits are a thank-you; they can&apos;t be turned back into cash.
         </span>
       </div>
     </div>

--- a/ctf/packages/web/components/contributions/contributions-paths.tsx
+++ b/ctf/packages/web/components/contributions/contributions-paths.tsx
@@ -92,9 +92,13 @@ function GiftCardForm({ t, submitting, error, onSubmit, onCancel }: { t: Contrib
   return (
     <div style={{ background: t.SURFACE, borderRadius: 12, padding: 20, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
       <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 8 }}>Gift card details</div>
-      <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, margin: '0 0 16px' }}>
+      <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, margin: '0 0 10px' }}>
         Your gift card can be physical or digital. Don&apos;t enter the card number or code here — after you
-        submit, share the card details with the platform owner in your Signal chat.
+        submit, send the card details privately to the platform owner on Signal (you&apos;ll get the link).
+      </p>
+      <p style={{ fontSize: 12, color: '#EF4444', lineHeight: 1.6, margin: '0 0 16px' }}>
+        Never post your gift card code or details in the Commons. It&apos;s a public group chat, so if you share the
+        code there you won&apos;t receive ServiceCredits and the owner won&apos;t receive the gift.
       </p>
       <div style={{ marginBottom: 14 }}>
         <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 8 }}>Card type</div>
@@ -134,6 +138,7 @@ function UrlForm({
   blurb,
   fieldLabel,
   placeholder,
+  helpText,
   submitting,
   error,
   onSubmit,
@@ -144,22 +149,49 @@ function UrlForm({
   blurb: string;
   fieldLabel: string;
   placeholder: string;
+  helpText: string;
   submitting: boolean;
   error: string | null;
-  onSubmit: (url: string | undefined) => void;
+  onSubmit: (url: string) => void;
   onCancel: () => void;
 }) {
   const [url, setUrl] = useState('');
+  const [missing, setMissing] = useState(false);
+  // The link is required: without it the owner cannot find and confirm the contribution. If the
+  // member cannot find it, the help text points them to the Commons rather than letting them submit
+  // an untrackable claim.
+  function handleSubmit() {
+    const trimmed = url.trim();
+    if (!trimmed) {
+      setMissing(true);
+      return;
+    }
+    onSubmit(trimmed);
+  }
   return (
     <div style={{ background: t.SURFACE, borderRadius: 12, padding: 20, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
       <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 8 }}>{title}</div>
       <p style={{ fontSize: 13, color: t.MUTED, margin: '0 0 14px', lineHeight: 1.6 }}>{blurb}</p>
-      <div style={{ marginBottom: 18 }}>
-        <label style={labelStyle(t)}>{fieldLabel}</label>
-        <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder={placeholder} style={inputStyle(t)} />
+      <div style={{ marginBottom: 8 }}>
+        <label style={labelStyle(t)}>
+          {fieldLabel} <span style={{ color: '#EF4444' }}>*</span>
+        </label>
+        <input
+          value={url}
+          onChange={(e) => {
+            setUrl(e.target.value);
+            if (missing) {
+              setMissing(false);
+            }
+          }}
+          placeholder={placeholder}
+          style={inputStyle(t)}
+        />
       </div>
+      <p style={{ fontSize: 11, color: t.MUTED, margin: '0 0 14px', lineHeight: 1.6 }}>{helpText}</p>
+      {missing && <div style={{ fontSize: 12, color: '#EF4444', marginBottom: 10 }}>Please paste the link so we can find and confirm your contribution.</div>}
       <ErrorLine error={error} />
-      <FormActions t={t} submitting={submitting} onSubmit={() => onSubmit(url.trim() ? url.trim() : undefined)} onCancel={onCancel} />
+      <FormActions t={t} submitting={submitting} onSubmit={handleSubmit} onCancel={onCancel} />
     </div>
   );
 }
@@ -255,9 +287,10 @@ export function ContributionPaths({
         <UrlForm
           t={t}
           title="Quora comment"
-          blurb="Leave a comment on a Quora post in our space. If you have the link, paste it here — if not, that's fine, we'll find it."
-          fieldLabel="Quora post URL (optional)"
+          blurb="Leave a comment on a Quora post in our space, then paste the link to your comment so we can find and confirm it."
+          fieldLabel="Link to your Quora comment"
           placeholder="https://www.quora.com/…"
+          helpText="Need help finding the link? Ask in the Commons — the group chat — and we'll help you find it."
           submitting={submitting}
           error={error}
           onSubmit={onSubmitQuora}
@@ -268,9 +301,10 @@ export function ContributionPaths({
         <UrlForm
           t={t}
           title="GitHub star"
-          blurb="Star our repository on GitHub. If you'd like to share your GitHub profile so we can confirm, paste it here — no obligation."
-          fieldLabel="GitHub profile URL (optional)"
+          blurb="Star our repository on GitHub, then paste your GitHub profile link so we can confirm it."
+          fieldLabel="Your GitHub profile URL"
           placeholder="https://github.com/your-username"
+          helpText="Need help finding the link? Ask in the Commons — the group chat — and we'll help you find it."
           submitting={submitting}
           error={error}
           onSubmit={onSubmitGithub}

--- a/ctf/packages/web/components/contributions/contributions-shell.tsx
+++ b/ctf/packages/web/components/contributions/contributions-shell.tsx
@@ -311,10 +311,12 @@ function ContributionsSidebar({
   active: 'drive' | 'contribute' | 'history';
   onNavigate?: (key: 'drive' | 'contribute' | 'history') => void;
 }) {
+  // Desktop shows the member's contributions permanently in the right rail ("My Contributions"), so a
+  // "My contributions" nav item would only scroll to something already on screen — omit it here. The
+  // mobile layout keeps a real "My history" tab (its history is a separate tab, not a rail).
   const items: { key: 'drive' | 'contribute' | 'history'; label: string }[] = [
     { key: 'drive', label: 'Drive progress' },
     { key: 'contribute', label: 'Contribute' },
-    { key: 'history', label: 'My contributions' },
   ];
   return (
     <div style={{ width: 200, background: t.SURFACE, borderRight: `1px solid ${t.BORDER_SOLID}`, display: 'flex', flexDirection: 'column', flexShrink: 0 }}>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Owner feedback from a live review of the Contributions flow. Copy/UX only — no route, schema, or contract change.

> Note: stacked on #1281 (contribute-flow copy). Until #1281 merges, this PR's diff includes that commit; it drops off automatically once #1281 lands on main.

## 1. Contribution links are now required

The Quora comment link and the GitHub profile link were optional — but without them the owner can't find and confirm the contribution (untrackable). Both are now **required** on submit (web + Android): empty submit is blocked with *"Please paste the link so we can find and confirm your contribution."* Each form shows a help line: **if you can't find the link, ask in the Commons (the group chat).**

## 2. Fixed the "#support channel" copy → the Commons

The post-submit confirmation told members to *"Post in the #support channel in the Hub"* — that channel doesn't exist; there's one channel, **the Commons**. Now:
- Questions → **ask in the Commons**.
- A prominent warning: **never post a gift card code in the Commons.** It's a public group chat, so doing so means no ServiceCredits and the owner never receives the gift — codes go **only** to the owner on Signal. The same warning is on the gift-card form.

## 3. Desktop: removed the "My contributions" nav item

On desktop the member's contributions are always shown in the right rail, so that left-nav item only scrolled to something already on screen. Removed on desktop; the mobile "My history" tab is unchanged.

## Docs

Inventory (Target User Features + change log) and the manual test script (CON-1, CON-2) updated. Drift/inventory/EOF gates pass locally.

## Known follow-up (separate PR)

The member UI shows "50 SC" for a comment/star while the admin config says 10 — the member screen reads a hardcoded default instead of the live config. That's a contract change (the fundraiser API must expose the value) and will come as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jkhgv617YLn5LCj1f7hSD)_