### PR TITLE
fix: member credit copy reads live config, not a hardcoded default

### DIFF
--- a/ctf/docs/contracts/CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -87,6 +87,12 @@ contracts:
       ownerSignalUrl:
         type: string
         note: The owner's Signal contact URL/number, read from the server-only CONTRIBUTIONS_OWNER_SIGNAL_URL env var, shown inline on the confirmation screen. Null when the env var is unset/empty; the UI then falls back to signalInstructions. Never logged.
+      creditsPerUsd:
+        type: number
+        note: Live thank-you SC granted per USD (gift cards), from the runtime config, so member copy matches the admin settings screen.
+      creditsPerActionSc:
+        type: number
+        note: Live thank-you SC for one confirmed comment or star, computed as nonMonetaryUnitValueUsd × creditsPerUsd (rounded). Replaces a previously hardcoded member-side default.
     dataAccess:
       - contributions_cycles
       - contributions_submissions

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -90,7 +90,9 @@ flow is one-way, like gas-station reward points.
   the viewer, the member-safe Signal instructions copy, `githubStarAlreadyCredited` (true when the
   viewer already holds a confirmed, credit-earning github_star — the UI greys out that path), and
   `ownerSignalUrl` (the owner's Signal contact from the server-only `CONTRIBUTIONS_OWNER_SIGNAL_URL`
-  env var, or null to fall back to the instructions copy).
+  env var, or null to fall back to the instructions copy), and the live thank-you valuations
+  `creditsPerUsd` (SC per dollar) and `creditsPerActionSc` (SC for one confirmed comment or star,
+  = `nonMonetaryUnitValueUsd × creditsPerUsd`), so member copy always matches the admin settings.
 - `POST /api/contributions/banner/dismiss` — Silent banner snooze (not audited).
 - `GET /api/contributions/admin/submissions` — Admin review queue (`?status=` filter).
 - `POST /api/contributions/admin/submissions/[submissionId]/review` — Confirm/reject (body:
@@ -267,11 +269,10 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## 10. Gaps and Known Technical Debt
 
-- The member surfaces show the credit valuations (10 SC/dollar, 50 SC/action) as copy using the
-  seeded defaults; the member fundraiser route does not expose the live config, so if the owner
-  tunes those knobs the member copy can lag until that route also returns the valuations. The admin
-  settings screen is the source of truth for the live values. (Low priority — the figures are
-  framed as a thank-you, not a contract.)
+- (Resolved 2026-07-01) The member surfaces previously showed hardcoded credit valuations (10 SC per
+  dollar, 50 SC per action) that could drift from the admin config. The fundraiser route now returns
+  the live `creditsPerUsd` and `creditsPerActionSc`, and the member cards/disclaimer render those, so
+  member copy always matches the settings screen.
 - The mobile admin screen mirrors the day-to-day review path (confirm/reject) and shows drive and
   settings as read-only summaries; creating/editing a drive and editing the config knobs is done on
   the web admin dashboard. The GitHub-star brand icon is rendered with lucide's `Star` (the brand
@@ -288,6 +289,12 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-07-01: Member credit valuations now come from the live config (owner-reported bug). The member
+  cards and disclaimer showed a hardcoded "50 SC" per comment/star while the admin "Credits per comment
+  or star" setting was 10. The fundraiser route (`GET /api/contributions/fundraiser`) now returns
+  `creditsPerUsd` and `creditsPerActionSc` (= `nonMonetaryUnitValueUsd × creditsPerUsd`), and the web
+  and Android member surfaces render those instead of hardcoded defaults, so the copy always matches
+  the settings screen. Fundraiser command contract `outputSchema` updated. No schema change.
 - 2026-07-01: Trackability + Commons safety pass (owner feedback). (1) The Quora comment link and the
   GitHub profile link are now **required** on submit (web + Android) — without them the owner cannot
   find and confirm the contribution. Each field shows a help line: if you cannot find the link, ask in

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md` |
-| **Generated** | 2026-07-01 (required contribution links + Commons safety copy + desktop nav trim; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-07-01 (live credit valuations in member copy; regenerate via CI to stamp the commit) |
 
 ## How to run this
 
@@ -163,7 +163,9 @@ cycle is the one whose window contains now. The member drive view reflects the g
 **Expected:** The settings screen shows the resulting credits (the stored USD-equivalent ×
 `credits_per_usd`, with a live helper showing the underlying USD value) and converts back to the
 stored USD-equivalent on save, so the stored model stays the source of truth. Config knobs must save
-positive values.
+positive values. After saving, open the member contribute screen (`/apps/contributions`): the cards
+and the credits disclaimer show the **same** SC-per-comment/star and SC-per-dollar as the settings —
+no hardcoded "50 SC" when the config says otherwise.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ---

--- a/ctf/packages/mobile/src/features/contributions/Contributions.tsx
+++ b/ctf/packages/mobile/src/features/contributions/Contributions.tsx
@@ -24,8 +24,6 @@ const TEXT_COLOR = '#F9FAFB';
 const SUBTLE = '#6B7280';
 const SIGNAL_BLUE = '#38BDF8';
 
-const DEFAULT_CREDITS_PER_USD = 10;
-const DEFAULT_CREDITS_PER_ACTION = 50;
 const ALREADY_CREDITED_NOTE = "You've already received credits for starring the repository — thank you.";
 
 type Tab = 'drive' | 'contribute' | 'history';
@@ -315,9 +313,9 @@ export const Contributions: React.FC = () => {
   const alreadyCredited = f.githubStarAlreadyCredited;
 
   const paths: { key: 'gift_card' | 'quora_comment' | 'github_star'; label: string; sub: string; credits: string }[] = [
-    { key: 'gift_card', label: 'Gift card', sub: "Amazon, Apple, or Denny's", credits: `${DEFAULT_CREDITS_PER_USD} SC per dollar` },
-    { key: 'quora_comment', label: 'Quora comment', sub: 'Comment on a Quora post', credits: `${DEFAULT_CREDITS_PER_ACTION} SC` },
-    { key: 'github_star', label: 'GitHub star', sub: 'Star our repository', credits: `${DEFAULT_CREDITS_PER_ACTION} SC` },
+    { key: 'gift_card', label: 'Gift card', sub: "Amazon, Apple, or Denny's", credits: `${fundraiser.creditsPerUsd} SC per dollar` },
+    { key: 'quora_comment', label: 'Quora comment', sub: 'Comment on a Quora post', credits: `${fundraiser.creditsPerActionSc} SC` },
+    { key: 'github_star', label: 'GitHub star', sub: 'Star our repository', credits: `${fundraiser.creditsPerActionSc} SC` },
   ];
 
   return (

--- a/ctf/packages/mobile/src/features/contributions/ContributionsApi.ts
+++ b/ctf/packages/mobile/src/features/contributions/ContributionsApi.ts
@@ -60,6 +60,9 @@ export type FundraiserResponse = {
   fundraiser: FundraiserSnapshot;
   signalInstructions: string;
   ownerSignalUrl: string | null;
+  // Live thank-you valuations from the admin config, so member copy matches the settings screen.
+  creditsPerUsd: number;
+  creditsPerActionSc: number;
 };
 
 export type ContributionsRuntimeConfig = {

--- a/ctf/packages/web/app/api/contributions/fundraiser/route.ts
+++ b/ctf/packages/web/app/api/contributions/fundraiser/route.ts
@@ -19,11 +19,18 @@ export async function GET() {
     // ownerSignalUrl is read from a server-only env var (CONTRIBUTIONS_OWNER_SIGNAL_URL); it is
     // shown inline on the confirmation screen. When unset it is null and the UI falls back to the
     // editable signalInstructions copy. The value is never logged.
+    // Resulting thank-you SC for one confirmed comment or star = USD-equivalent unit value ×
+    // credits-per-dollar. Exposed so member copy matches the admin settings instead of a hardcoded
+    // default.
+    const creditsPerActionSc = Math.round(config.nonMonetaryUnitValueUsd * config.creditsPerUsd);
+
     return NextResponse.json({
       ok: true,
       fundraiser: snapshot,
       signalInstructions: config.signalInstructions,
       ownerSignalUrl: getOwnerSignalUrl(),
+      creditsPerUsd: config.creditsPerUsd,
+      creditsPerActionSc,
     });
   } catch (error) {
     return contributionsErrorResponse(error, 'Fundraiser status unavailable.', 'fundraiser_get');

--- a/ctf/packages/web/components/contributions/contributions-shared.ts
+++ b/ctf/packages/web/components/contributions/contributions-shared.ts
@@ -62,6 +62,11 @@ export type FundraiserResponse = {
   };
   signalInstructions: string;
   ownerSignalUrl: string | null;
+  // Live thank-you valuations from the admin config, so member copy always matches the settings
+  // screen. creditsPerUsd is SC per dollar (gift cards); creditsPerActionSc is the resulting SC for
+  // one confirmed comment or star (nonMonetaryUnitValueUsd × creditsPerUsd).
+  creditsPerUsd: number;
+  creditsPerActionSc: number;
 };
 
 export type SubmissionsResponse = {

--- a/ctf/packages/web/components/contributions/contributions-shell.tsx
+++ b/ctf/packages/web/components/contributions/contributions-shell.tsx
@@ -22,11 +22,6 @@ import { ContributionPaths, type SubmitGiftCardInput } from './contributions-pat
 import { ContributionsHistoryList, ContributionsEmptyHistory } from './contributions-history';
 import { ContributionsConfirmation } from './contributions-confirmation';
 
-// Default credit valuations shown in copy until the fundraiser response (which the member route
-// does not expose config on) is available. These mirror the seeded defaults; the admin surface is
-// the source of truth for the live values.
-const DEFAULT_CREDITS_PER_USD = 10;
-const DEFAULT_CREDITS_PER_ACTION = 50;
 
 type View = 'main' | 'confirmation';
 type MobileTab = 'drive' | 'contribute' | 'history';
@@ -184,8 +179,8 @@ export function ContributionsShell() {
 
   const pathsProps = {
     t,
-    creditsPerUsd: DEFAULT_CREDITS_PER_USD,
-    creditsPerAction: DEFAULT_CREDITS_PER_ACTION,
+    creditsPerUsd: fundraiser.creditsPerUsd,
+    creditsPerAction: fundraiser.creditsPerActionSc,
     githubStarAlreadyCredited,
     submitting,
     error: submitError,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Fixes the owner-reported bug: the member contribute screen showed **"50 SC"** for a comment/star while the admin **"Credits per comment or star"** setting was **10**.

> Stacked on #1282 (which is stacked on #1281). Until those merge, this PR's diff includes their commits; they drop off automatically as each lands on main.

## Cause

The member surfaces used hardcoded defaults (`10` per dollar, `50` per action) because the fundraiser route never exposed the live config, so member copy couldn't track the admin settings.

## Fix

`GET /api/contributions/fundraiser` now returns:
- `creditsPerUsd` — SC per dollar (gift cards)
- `creditsPerActionSc` — SC for one confirmed comment or star, computed as `nonMonetaryUnitValueUsd × creditsPerUsd` (rounded)

The web and Android member cards + disclaimer render those instead of the hardcoded constants (which are removed). Now the copy always matches the settings screen.

## Contract / docs

- Fundraiser command `outputSchema` gains the two fields (`CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml`).
- Inventory API surface updated; the "member copy can lag" gap is marked resolved; change-log entry added.
- Manual test script CON-A5 now verifies member copy matches the config after a settings change.

No database schema change. Money-adjacent (thank-you valuations), so opened for your review rather than auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jkhgv617YLn5LCj1f7hSD)_