### PR TITLE
fix: remove inaccurate Designed By section from GentlePulse right panel

### DIFF
--- a/ctf/packages/web/components/gentle-pulse/gp-right-panel.tsx
+++ b/ctf/packages/web/components/gentle-pulse/gp-right-panel.tsx
@@ -3,8 +3,6 @@
 import { Play } from "lucide-react";
 import { COLOR, FAINT, TEXT, type Session } from "./gp-shared";
 
-const DESIGNERS = ["Certified Trauma Therapists", "EMDR Specialists", "Somatic Coaches"];
-
 export function GentlePulseRightPanel({ sessions, onPlay }: { sessions: Session[]; onPlay: (id: string) => void }) {
   return (
     <aside style={{ width: 280, borderLeft: "1px solid rgba(20,184,166,0.08)", background: "#080D0C", padding: "20px 16px", flexShrink: 0 }}>
@@ -25,12 +23,6 @@ export function GentlePulseRightPanel({ sessions, onPlay }: { sessions: Session[
       <div style={{ marginTop: 16, padding: "16px", borderRadius: 12, background: `${COLOR}08`, border: `1px solid ${COLOR}18` }}>
         <div style={{ fontSize: 12, fontWeight: 700, color: COLOR, marginBottom: 8 }}>Today&apos;s Affirmation</div>
         <div style={{ fontSize: 13, color: "#9CA3AF", lineHeight: 1.7, fontStyle: "italic" }}>&quot;You did not choose what happened to you. You DO choose what happens next.&quot;</div>
-      </div>
-      <div style={{ marginTop: 12, padding: "14px 16px", borderRadius: 12, background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.04)" }}>
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: FAINT, textTransform: "uppercase", marginBottom: 8 }}>Designed By</div>
-        {DESIGNERS.map((p) => (
-          <div key={p} style={{ fontSize: 12, color: "#6B7280", marginBottom: 4 }}>• {p}</div>
-        ))}
       </div>
     </aside>
   );


### PR DESCRIPTION
## What changed

Removed the "Designed By" section from the GentlePulse app's right panel. It listed "Certified Trauma Therapists", "EMDR Specialists", and "Somatic Coaches" as designers, which is not true. The unused `DESIGNERS` constant was removed with it.

File: `ctf/packages/web/components/gentle-pulse/gp-right-panel.tsx`

## Why

The claim was inaccurate and should not be shown to members.

## Checks

- Typecheck: passes (no new errors on the edited file)
- EOF format check: passes

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BR1JFrsUvCj7QkDfM2D4HW)_