### PR TITLE
feat: admins can edit a What Works tool's details after approval

### DIFF
--- a/ctf/docs/contracts/WHAT_WORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHAT_WORKS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -77,6 +77,12 @@ policies:
     attributePolicies: []
     consentRequirements: []
   - pluginId: what-works
+    command: what-works.admin.product.update
+    version: 1.0.0
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: []
+  - pluginId: what-works
     command: what-works.admin.product.delete
     version: 1.0.0
     requiredRoles: [admin]

--- a/ctf/docs/contracts/WHAT_WORKS_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHAT_WORKS_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -84,6 +84,13 @@ auditEvents:
     policyDecision: allow
     dataClassesAccessed: [community_content]
     targetContext: admin
+  - eventId: what-works.admin.product.update
+    pluginId: what-works
+    command: what-works.admin.product.update
+    version: 1.0.0
+    policyDecision: allow
+    dataClassesAccessed: [community_content]
+    targetContext: admin
   - eventId: what-works.admin.product.delete
     pluginId: what-works
     command: what-works.admin.product.delete

--- a/ctf/docs/contracts/WHAT_WORKS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WHAT_WORKS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -268,6 +268,37 @@ commands:
     purpose: Approve or reject a suggested tool
     retentionClass: community_content
   - pluginId: what-works
+    command: what-works.admin.product.update
+    version: 1.0.0
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        purchaseUrl:
+          type: string
+        emoji:
+          type: string
+        kind:
+          type: string
+        note:
+          type: string
+      required: [id, name, purchaseUrl]
+    outputSchema:
+      type: object
+      properties:
+        status:
+          type:
+            - string
+            - 'null'
+    dataAccess:
+      - what_works_products (select)
+      - what_works_products (update)
+    purpose: Correct a suggested tool's own details (name, link, note, emoji, kind) without changing its status, endorsements, or submitter identity
+    retentionClass: community_content
+  - pluginId: what-works
     command: what-works.admin.product.delete
     version: 1.0.0
     inputSchema:

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-what-works-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-what-works-feature-inventory.md
@@ -42,6 +42,9 @@ the problem categories and review every suggestion before it joins the shared li
 ## 4. Target Admin Features
 
 - Review queue: approve or reject (with an admin-only reason) each suggested tool; delete tools.
+- Edit a tool's own details (emoji, name, type, note, purchase link) at any status — including after
+  it is approved — to fix a typo or a broken link without unpublishing it. Status, verified count,
+  and submitter identity are left untouched.
 - Status filter across pending / approved / rejected / all.
 - Curate problems: create, rename, re-emoji, reorder, deactivate/reactivate, and delete (cascading
   to that problem's tools and endorsements).
@@ -62,7 +65,7 @@ the problem categories and review every suggestion before it joins the shared li
 - `PATCH /api/what-works/admin/problems/[id]` — Admin: edit/reorder/deactivate a problem.
 - `DELETE /api/what-works/admin/problems/[id]` — Admin: delete a problem (cascade).
 - `GET /api/what-works/admin/products` — Admin: moderation queue (optional `?status=`).
-- `PATCH /api/what-works/admin/products/[id]` — Admin: approve/reject a tool.
+- `PATCH /api/what-works/admin/products/[id]` — Admin: with `action` (`approve`/`reject`), moderate the tool; without `action`, correct its own details (name, purchase link, note, emoji, type). The edit path never changes status, endorsements, or the identity columns.
 - `DELETE /api/what-works/admin/products/[id]` — Admin: delete a tool (cascade).
 
 All mutating routes require the `x-ctf-csrf: 1` confirmation header (same-origin enforced).
@@ -114,7 +117,8 @@ Derived metrics (no stored counters): a tool's verified count is `COUNT(*)` of i
 - Audit: every command emits one structured audit line via `logWhatWorksAudit`
   (`lib/what-works/audit.ts`) on its success path — reads (`what-works.list.read`,
   `what-works.public.read`, `what-works.problems.list`, the two admin list reads), mutations
-  (suggest/endorse/unendorse), and all admin curation/moderation commands — matching every event
+  (suggest/endorse/unendorse), and all admin curation/moderation commands — including
+  `what-works.admin.product.update` (an admin editing a tool's details) — matching every event
   declared in the audit contract. The public read records `anonymous` as the actor.
 - Input validation: lengths and `http(s)`-only purchase URLs are enforced server-side.
 - Contracts: see
@@ -159,6 +163,15 @@ Derived metrics (no stored counters): a tool's verified count is `COUNT(*)` of i
 
 ## Change Log
 
+- 2026-07-01: Admins can now edit a suggested tool's own details after the fact. Added a
+  `what-works.admin.product.update` command (command/access/audit contracts), a repository
+  `updateProduct` (COALESCE update of emoji/name/kind/note/purchase_url; status, endorsements, and
+  identity columns untouched), and a field-edit branch on `PATCH /api/what-works/admin/products/[id]`
+  taken when the body carries no `action` (same server-side length + `http(s)`-link validation as the
+  suggest form). The admin moderation UI (`ww-admin-products`) gains an inline Edit form per tool,
+  wired through `ww-admin-shell`. Closes the gap where an approved entry with a typo or broken link
+  could only be deleted and re-created. Web-only admin surface (no Android admin for this plugin);
+  the shell is mobile-responsive.
 - 2026-06-27: Code-review batch (issues #1127–#1136). (1) `listAdminProblems` now selects an explicit
   column list instead of `SELECT pr.*`, so a future identity column added to `what_works_problems` is
   never auto-included in the admin response; output is unchanged (#1127). (2) The endorse/un-endorse

--- a/ctf/docs/developer/test-scripts/what-works-test-script.md
+++ b/ctf/docs/developer/test-scripts/what-works-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:what-works` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-what-works-feature-inventory.md` |
-| **Generated** | 2026-06-28 (initial authoring; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-07-01 (updated by hand for the admin edit-tool feature; regenerate via CI to stamp the commit) |
 
 ## How to run this
 
@@ -131,6 +131,22 @@ returns when reactivated.
 **Expected:** Deleting a tool removes it and its endorsements. Deleting a problem removes that
 problem and cascades to its tools and their endorsements. Both deletes use an inline two-step
 confirm.
+**Result:** web ☐ mobile ☐ android ☐ — notes:
+
+### WW-A4 · Edit an approved tool's details
+**Role:** admin · **Surfaces:** web (admin surface)
+**Precondition:** at least one `approved` tool with a non-zero verified count (approve a seeded
+suggestion first, and mark it Helpful as a member so its count is > 0).
+**Steps:**
+1. Open `/admin/what-works` and find an approved tool.
+2. Click **Edit**, change the name, the note, and the purchase link, then **Save**.
+3. Reopen the member list `/apps/what-works` and find the same tool.
+4. Back in the admin, click **Edit** again and paste a non-http(s) link (e.g. `ftp://x`), then Save.
+**Expected:** The edit form is seeded with the tool's current values. Saving updates the tool's
+name/note/link **without** unpublishing it — it stays `approved`, keeps its verified count, and the
+change shows on the member list. The tool's problem, status, and verified count are unchanged, and no
+submitter identity appears. The non-http(s) link is rejected server-side with an error, and the tool
+keeps its previous link.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ---

--- a/ctf/packages/web/app/api/what-works/admin/products/[id]/route.ts
+++ b/ctf/packages/web/app/api/what-works/admin/products/[id]/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from 'next/server';
-import { deleteProduct, getProductById, reviewProduct } from 'lib/what-works/repository';
-import { MAX_PRODUCT_NOTE_LENGTH } from 'lib/what-works/constants';
+import { deleteProduct, getProductById, reviewProduct, updateProduct } from 'lib/what-works/repository';
+import {
+  MAX_EMOJI_LENGTH,
+  MAX_PRODUCT_KIND_LENGTH,
+  MAX_PRODUCT_NAME_LENGTH,
+  MAX_PRODUCT_NOTE_LENGTH,
+  MAX_PURCHASE_URL_LENGTH,
+} from 'lib/what-works/constants';
 import {
   ensureMutationCsrf,
+  isValidHttpUrl,
   parseJsonBody,
   readTrimmedString,
   requireWhatWorksAdminAccess,
@@ -12,7 +19,11 @@ import { logWhatWorksAudit } from 'lib/what-works/audit';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
-// Approve or reject a suggested tool.
+// PATCH does one of two things depending on the body:
+//   - `action: approve|reject`  → moderate the tool (change its status).
+//   - no `action`               → correct the tool's own details (name, link, note, emoji, kind).
+// The edit path lets an admin fix a typo or a broken link after the tool is already approved,
+// without unpublishing it. Identity columns and endorsements are never touched by either path.
 export async function PATCH(request: Request, context: RouteContext) {
   const csrf = ensureMutationCsrf(request);
   if (csrf) {
@@ -32,7 +43,54 @@ export async function PATCH(request: Request, context: RouteContext) {
   if (!body) {
     return whatWorksError('Invalid JSON body.', 'what_works_invalid_body', 400);
   }
+
   const action = readTrimmedString(body.action);
+
+  // No action → correct the tool's details.
+  if (action === null) {
+    const name = readTrimmedString(body.name);
+    const purchaseUrl = readTrimmedString(body.purchaseUrl);
+    const emoji = typeof body.emoji === 'string' ? body.emoji.trim() : '';
+    const kind = typeof body.kind === 'string' ? body.kind.trim() : '';
+    const note = typeof body.note === 'string' ? body.note.trim() : '';
+
+    if (!name) {
+      return whatWorksError('Add a product name.', 'what_works_name_required', 400);
+    }
+    if (!purchaseUrl) {
+      return whatWorksError('Add a direct purchase link.', 'what_works_link_required', 400);
+    }
+    if (name.length > MAX_PRODUCT_NAME_LENGTH) {
+      return whatWorksError('Product name is too long.', 'what_works_name_too_long', 400);
+    }
+    if (kind.length > MAX_PRODUCT_KIND_LENGTH) {
+      return whatWorksError('Product type is too long.', 'what_works_kind_too_long', 400);
+    }
+    if (note.length > MAX_PRODUCT_NOTE_LENGTH) {
+      return whatWorksError('Note is too long.', 'what_works_note_too_long', 400);
+    }
+    if (emoji.length > MAX_EMOJI_LENGTH) {
+      return whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400);
+    }
+    if (purchaseUrl.length > MAX_PURCHASE_URL_LENGTH || !isValidHttpUrl(purchaseUrl)) {
+      return whatWorksError('Enter a valid http(s) purchase link.', 'what_works_link_invalid', 400);
+    }
+
+    const product = await updateProduct(id, { emoji, name, kind, note, purchaseUrl });
+    logWhatWorksAudit({
+      actorId: gate.auth.userId,
+      command: 'what-works.admin.product.update',
+      status: 'allow',
+      reason: 'admin_route_guard',
+      targetType: 'product',
+      targetId: id,
+      result: 'success',
+      errorCategory: null,
+    });
+    return NextResponse.json({ ok: true, status: product?.status ?? null });
+  }
+
+  // Otherwise → moderate (approve/reject).
   if (action !== 'approve' && action !== 'reject') {
     return whatWorksError('Action must be approve or reject.', 'what_works_invalid_action', 400);
   }

--- a/ctf/packages/web/components/what-works/ww-admin-products.tsx
+++ b/ctf/packages/web/components/what-works/ww-admin-products.tsx
@@ -3,16 +3,35 @@
 // Moderation queue (functional admin surface, dark admin design system — accent lime).
 // Submitter identity is never shown; admins moderate content.
 import { useState } from 'react';
-import { CheckCircle, XCircle, Trash2 } from 'lucide-react';
+import { Check, CheckCircle, Pencil, XCircle, Trash2, X } from 'lucide-react';
 import type { WhatWorksProductStatus } from 'lib/what-works/types';
-import { MAX_PRODUCT_NOTE_LENGTH } from 'lib/what-works/constants';
+import {
+  MAX_EMOJI_LENGTH,
+  MAX_PRODUCT_KIND_LENGTH,
+  MAX_PRODUCT_NAME_LENGTH,
+  MAX_PRODUCT_NOTE_LENGTH,
+  MAX_PURCHASE_URL_LENGTH,
+} from 'lib/what-works/constants';
 import type { AdminProduct } from './ww-admin-shared';
 
 const COLOR = '#84CC16';
+const PANEL = '#0D0F14';
 const SURFACE = '#161B27';
 const BORDER = '#1E2A3A';
 const TEXT = '#F9FAFB';
 const SUBTLE = '#6B7280';
+
+const editInputStyle: React.CSSProperties = {
+  borderRadius: 8,
+  background: PANEL,
+  border: `1px solid ${BORDER}`,
+  color: TEXT,
+  padding: '9px 12px',
+  fontSize: 13,
+  fontFamily: 'inherit',
+};
+
+export type ProductEditDraft = { emoji: string; name: string; kind: string; note: string; purchaseUrl: string };
 
 type Props = {
   products: AdminProduct[];
@@ -20,6 +39,7 @@ type Props = {
   statusFilter: WhatWorksProductStatus | 'all';
   onChangeFilter: (status: WhatWorksProductStatus | 'all') => void;
   onReview: (id: string, action: 'approve' | 'reject', rejectionReason?: string) => void;
+  onEdit: (id: string, patch: ProductEditDraft) => void;
   onDelete: (id: string) => void;
 };
 
@@ -36,13 +56,17 @@ const STATUS_STYLE: Record<WhatWorksProductStatus, { bg: string; color: string; 
   rejected: { bg: 'rgba(239,68,68,0.12)', color: '#EF4444', border: 'rgba(239,68,68,0.3)' },
 };
 
-export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChangeFilter, onReview, onDelete }: Props) {
+export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChangeFilter, onReview, onEdit, onDelete }: Props) {
   // Which row's inline reject form is open, and the reason text being typed. Replaces the old
   // blocking window.prompt with a themable, testable inline textarea.
   const [rejectingId, setRejectingId] = useState<string | null>(null);
   const [reason, setReason] = useState('');
   // Inline two-step delete confirmation (replaces window.confirm).
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  // Inline edit of an approved (or any) tool's own details. editingId marks the open card; the
+  // draft is seeded from the product and saved through the same route's field-edit PATCH.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<ProductEditDraft>({ emoji: '', name: '', kind: '', note: '', purchaseUrl: '' });
 
   function openReject(id: string): void {
     setRejectingId(id);
@@ -58,6 +82,28 @@ export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChang
     const trimmed = reason.trim();
     onReview(id, 'reject', trimmed.length > 0 ? trimmed : undefined);
     closeReject();
+  }
+
+  function openEdit(product: AdminProduct): void {
+    setEditingId(product.id);
+    setDraft({
+      emoji: product.emoji ?? '',
+      name: product.name,
+      kind: product.kind ?? '',
+      note: product.note ?? '',
+      purchaseUrl: product.purchaseUrl,
+    });
+  }
+
+  function saveEdit(id: string): void {
+    onEdit(id, {
+      emoji: draft.emoji.trim(),
+      name: draft.name.trim(),
+      kind: draft.kind.trim(),
+      note: draft.note.trim(),
+      purchaseUrl: draft.purchaseUrl.trim(),
+    });
+    setEditingId(null);
   }
 
   return (
@@ -119,6 +165,9 @@ export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChang
                     <XCircle size={13} /> {product.status === 'approved' ? 'Unpublish' : 'Reject'}
                   </button>
                 ) : null}
+                <button type="button" disabled={busy} onClick={() => (editingId === product.id ? setEditingId(null) : openEdit(product))} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: SURFACE, border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
+                  <Pencil size={13} /> Edit
+                </button>
                 {confirmingDeleteId === product.id ? (
                   <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                     <span style={{ fontSize: 12, color: SUBTLE }}>Delete permanently?</span>
@@ -159,6 +208,32 @@ export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChang
                     </button>
                   </div>
                 </div>
+              ) : null}
+              {editingId === product.id ? (
+                (() => {
+                  const canSave = Boolean(draft.name.trim()) && Boolean(draft.purchaseUrl.trim()) && !busy;
+                  return (
+                    <div style={{ marginTop: 12, padding: 12, borderRadius: 10, background: `${COLOR}08`, border: `1px solid ${COLOR}35` }}>
+                      <div style={{ fontSize: 12, color: SUBTLE, marginBottom: 10 }}>Correct this tool&apos;s details. Its status and verified count are unchanged.</div>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                        <input value={draft.emoji} onChange={(event) => setDraft((prev) => ({ ...prev, emoji: event.target.value.slice(0, MAX_EMOJI_LENGTH) }))} maxLength={MAX_EMOJI_LENGTH} placeholder="Emoji" aria-label="Edit emoji" style={{ ...editInputStyle, width: 80, flexShrink: 0 }} />
+                        <input value={draft.name} onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value.slice(0, MAX_PRODUCT_NAME_LENGTH) }))} maxLength={MAX_PRODUCT_NAME_LENGTH} placeholder="Product name" aria-label="Edit product name" style={{ ...editInputStyle, flex: 1, minWidth: 180 }} />
+                      </div>
+                      <input value={draft.kind} onChange={(event) => setDraft((prev) => ({ ...prev, kind: event.target.value.slice(0, MAX_PRODUCT_KIND_LENGTH) }))} maxLength={MAX_PRODUCT_KIND_LENGTH} placeholder="Type (e.g. Headphones)" aria-label="Edit product type" style={{ ...editInputStyle, width: '100%', marginTop: 8, boxSizing: 'border-box' }} />
+                      <input value={draft.purchaseUrl} onChange={(event) => setDraft((prev) => ({ ...prev, purchaseUrl: event.target.value.slice(0, MAX_PURCHASE_URL_LENGTH) }))} maxLength={MAX_PURCHASE_URL_LENGTH} placeholder="https://…" aria-label="Edit purchase link" inputMode="url" style={{ ...editInputStyle, width: '100%', marginTop: 8, boxSizing: 'border-box' }} />
+                      <textarea value={draft.note} onChange={(event) => setDraft((prev) => ({ ...prev, note: event.target.value.slice(0, MAX_PRODUCT_NOTE_LENGTH) }))} maxLength={MAX_PRODUCT_NOTE_LENGTH} rows={2} placeholder="Why it works (optional)" aria-label="Edit note" style={{ ...editInputStyle, width: '100%', marginTop: 8, resize: 'vertical', boxSizing: 'border-box' }} />
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
+                        <span style={{ fontSize: 11, color: SUBTLE, marginRight: 'auto' }}>{draft.note.length}/{MAX_PRODUCT_NOTE_LENGTH}</span>
+                        <button type="button" onClick={() => setEditingId(null)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: SURFACE, border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+                          <X size={13} /> Cancel
+                        </button>
+                        <button type="button" disabled={!canSave} onClick={() => saveEdit(product.id)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: `${COLOR}20`, border: `1px solid ${COLOR}35`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: canSave ? 'pointer' : 'not-allowed', opacity: canSave ? 1 : 0.6 }}>
+                          <Check size={13} /> {busy ? 'Saving…' : 'Save'}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })()
               ) : null}
             </div>
           );

--- a/ctf/packages/web/components/what-works/ww-admin-shell.tsx
+++ b/ctf/packages/web/components/what-works/ww-admin-shell.tsx
@@ -106,6 +106,19 @@ export function WhatWorksAdminShell() {
     });
   }
 
+  // Correct an entry's own details (name, link, note, emoji, kind) after it is already approved,
+  // without unpublishing it. Sends no `action`, so the products route takes its field-edit path.
+  function editProduct(id: string, patch: { emoji: string; name: string; kind: string; note: string; purchaseUrl: string }): void {
+    void run(id, async () => {
+      const result = await adminMutate(`/api/what-works/admin/products/${id}`, 'PATCH', patch);
+      if (!result.ok) {
+        setError(result.message ?? 'Could not update the tool.');
+        return;
+      }
+      await Promise.all([loadProducts(statusFilter), loadProblems()]);
+    });
+  }
+
   // Delete confirmation is now an inline step inside the products/problems lists (themable and
   // testable), not a blocking window.confirm.
   function deleteProduct(id: string): void {
@@ -239,6 +252,7 @@ export function WhatWorksAdminShell() {
               statusFilter={statusFilter}
               onChangeFilter={changeFilter}
               onReview={reviewProduct}
+              onEdit={editProduct}
               onDelete={deleteProduct}
             />
             <WhatWorksAdminProblems

--- a/ctf/packages/web/lib/what-works/audit.ts
+++ b/ctf/packages/web/lib/what-works/audit.ts
@@ -19,6 +19,7 @@ const WHAT_WORKS_COMMAND_VERSIONS: Record<string, string> = {
   'what-works.admin.problem.delete': '1.0.0',
   'what-works.admin.product.list': '1.0.0',
   'what-works.admin.product.review': '1.0.0',
+  'what-works.admin.product.update': '1.0.0',
   'what-works.admin.product.delete': '1.0.0',
 };
 
@@ -37,6 +38,7 @@ const WHAT_WORKS_COMMAND_DATA_CLASSES: Record<string, string[]> = {
   'what-works.admin.problem.delete': ['community_content', 'user_event'],
   'what-works.admin.product.list': ['community_content'],
   'what-works.admin.product.review': ['community_content'],
+  'what-works.admin.product.update': ['community_content'],
   'what-works.admin.product.delete': ['community_content', 'user_event'],
 };
 

--- a/ctf/packages/web/lib/what-works/repository.ts
+++ b/ctf/packages/web/lib/what-works/repository.ts
@@ -4,6 +4,7 @@ import type {
   ReviewProductInput,
   SuggestProductInput,
   UpdateProblemInput,
+  UpdateProductInput,
   WhatWorksAdminProblem,
   WhatWorksAdminProduct,
   WhatWorksList,
@@ -395,6 +396,36 @@ export async function reviewProduct(
       WHERE id = $1
       RETURNING *`,
     [id, nextStatus, input.reviewerId, input.action === 'reject' ? input.rejectionReason ?? null : null],
+  );
+  return result.rows[0] ?? null;
+}
+
+// Correct a suggested tool's own details after the fact (admin fixes a typo, a broken link, a
+// wrong note). Status, endorsements, and the identity columns are intentionally left untouched.
+// COALESCE lets an omitted field keep its current value; the route always sends the full set.
+export async function updateProduct(
+  id: string,
+  patch: UpdateProductInput,
+): Promise<WhatWorksProductLookup | null> {
+  const result = await queryDb<WhatWorksProductLookup>(
+    `UPDATE what_works_products
+        SET emoji = COALESCE($2, emoji),
+            name = COALESCE($3, name),
+            kind = COALESCE($4, kind),
+            note = COALESCE($5, note),
+            purchase_url = COALESCE($6, purchase_url),
+            updated_at = NOW()
+      WHERE id = $1
+      RETURNING id, problem_id, emoji, name, kind, note, purchase_url, status,
+                reviewed_at, rejection_reason, created_at, updated_at`,
+    [
+      id,
+      patch.emoji ?? null,
+      patch.name ?? null,
+      patch.kind ?? null,
+      patch.note ?? null,
+      patch.purchaseUrl ?? null,
+    ],
   );
   return result.rows[0] ?? null;
 }

--- a/ctf/packages/web/lib/what-works/types.ts
+++ b/ctf/packages/web/lib/what-works/types.ts
@@ -118,3 +118,13 @@ export type ReviewProductInput = {
   reviewerId: string;
   rejectionReason?: string;
 };
+
+// Admin correction of a suggested tool's own details (name, link, note, etc.). Never touches
+// status, endorsements, or the identity columns — those are governed by review/delete.
+export type UpdateProductInput = {
+  emoji?: string;
+  name?: string;
+  kind?: string;
+  note?: string;
+  purchaseUrl?: string;
+};


### PR DESCRIPTION
## What

The What Works admin surface could approve, reject, unpublish, and delete a suggested tool, but there was no way to **correct** a tool's own details (name, purchase link, note, emoji, type) once it existed. A typo or a broken link on an approved entry could only be fixed by deleting it and re-creating it (losing its verified count). This adds inline editing.

## Changes

- **New command `what-works.admin.product.update`** — added to the command, access-policy (admin-only), and audit contracts.
- **Repository `updateProduct`** — a `COALESCE` update of `emoji` / `name` / `kind` / `note` / `purchase_url`. Status, endorsements, and the identity columns (`suggested_by` / `reviewed_by`) are never touched.
- **`PATCH /api/what-works/admin/products/[id]`** — takes a field-edit path when the body carries **no `action`**; keeps the existing approve/reject path when `action` is present. The edit path applies the same server-side length limits and `http(s)`-only link validation as the suggest form, and emits the new audit event.
- **Admin UI** — an inline **Edit** form per tool in `ww-admin-products`, wired through `ww-admin-shell` (mirrors the existing inline problem-edit). Editing an approved tool does not unpublish it.
- **Inventory** — What Works feature inventory updated (admin features, route map, audit controls, change log).

## Notes

- This adds a new API command/contract. It is admin-only, CSRF-protected, and content-only (no money, auth, schema, or deletion changes) — symmetric to the existing `what-works.admin.problem.update`.
- The What Works admin is a web-only surface; there is no Android admin screen for this plugin, so there is no Android work for this change. The admin shell is mobile-responsive.

## Checks

Web typecheck + lint, all three package typechecks (shared/web/mobile), inventory-drift gate, and EOF format pass locally. (The local pre-push `next build` fails on a Next.js workspace-root resolution quirk in this sandbox, unrelated to the diff; CI runs the authoritative `build:ci` with a clean install.)

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQSBoziaKEYp9f5ce2svP5)_