### PR TITLE
fix: keep the space before "for" in the contributions credits disclaimer

### DIFF
--- a/ctf/packages/web/components/contributions/contributions-paths.tsx
+++ b/ctf/packages/web/components/contributions/contributions-paths.tsx
@@ -314,8 +314,11 @@ export function ContributionPaths({
 
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '10px 14px', background: `${t.ACCENT}08`, borderRadius: 8, border: `1px solid ${t.ACCENT}20`, marginTop: 4 }}>
         <AlertCircle size={13} color={t.ACCENT} style={{ flexShrink: 0, marginTop: 1 }} />
+        {/* Built as one template-literal string, not interpolations mixed with JSX text: a bare
+            `{expr} word` boundary drops its space when the formatter wraps the line (that produced
+            "50 SC" but "SCfor"). A single string has no such boundary. */}
         <span style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6 }}>
-          Confirmed contributions earn ServiceCredits as a thank-you — {`${creditsPerUsd} SC`} per dollar for gift cards, and {`${creditsPerAction} SC`} for a comment or star. Credits are a thank-you; they can&apos;t be turned back into cash.
+          {`Confirmed contributions earn ServiceCredits as a thank-you — ${creditsPerUsd} SC per dollar for gift cards, and ${creditsPerAction} SC for a comment or star. Credits are a thank-you; they can't be turned back into cash.`}
         </span>
       </div>
     </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

The credits disclaimer rendered **"10 SCfor a comment or star"** — no space between "SC" and "for".

## Cause

The disclaimer mixed JSX interpolations with text (`{`${x} SC`} for a comment`). When the formatter wraps that long line, the expression lands at the end of a line and "for a comment" starts the next — and JSX collapses the whitespace around a line break to nothing, so the space disappears. (The earlier template-literal change fixed the space *inside* "10 SC" but not this expression→text boundary. "10 SC per dollar" survived only because it stayed on one line.)

## Fix

Rebuilt the whole sentence as a single template-literal string, so there is no expression/text boundary anywhere for the formatter to break. Renders "10 SC per dollar for gift cards, and 10 SC for a comment or star."

Copy render only — no logic, route, schema, or contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jkhgv617YLn5LCj1f7hSD)_