### PR TITLE
fix: keep long chat messages inside the frame on mobile

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -441,6 +441,9 @@
 
 .chatBubbleGroup {
   max-width: 70%;
+  /* Let the group shrink below its content's intrinsic width inside the flex row, so a long word or
+     URL wraps instead of pushing the bubble past the screen edge. */
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -451,6 +454,9 @@
   font-size: 14px;
   line-height: 1.6;
   color: var(--ctf-text-shell);
+  /* Break long unbroken strings (e.g. a pasted URL) so a message always fits the bubble/frame. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Chat bubble color convention: your own messages are gray; everyone else's use the hub's color
@@ -1996,6 +2002,16 @@
  * Stack them full-width instead so each button has even padding and room.
  */
 @media (max-width: 767px) {
+  /* On a phone the 70% cap wastes horizontal space and forces more wrapping than needed; give the
+     bubble more of the frame, and trim the message padding so long posts read comfortably. */
+  .chatBubbleGroup {
+    max-width: 85%;
+  }
+
+  .chatMessages {
+    padding: 16px 14px;
+  }
+
   /* Compact the hero on phones so it doesn't dominate the screen and crowd out
      the chat / AI Assistant area below it. */
   .heroBanner {


### PR DESCRIPTION
## What and why

On a phone, a chat message containing a long unbroken string (e.g. a pasted `https://…` URL) pushed the bubble past the screen edge, so the text ran out of the frame and was unreadable (see the reported screenshot — the directory/chyme URLs are cut off on the right).

## Fix (`community-shell.module.css`)

- `.chatBubble` — `overflow-wrap: anywhere` + `word-break: break-word` so a long URL/word breaks and wraps instead of forcing the bubble wider than the screen.
- `.chatBubbleGroup` — `min-width: 0` so the bubble can shrink below its content's intrinsic width inside the flex row (without this, the flex item refuses to shrink and the fix wouldn't take effect).
- Phone-width (`max-width: 767px`) — the bubble may use more of the frame (85% instead of 70%) with slightly tighter message padding, so posts read comfortably now that they wrap.

This applies to the shared chat stream, so it fixes both the signed-in home chat (shown in the report) and the signed-out community view.

## Verification

- Pre-push typecheck gate — passes (CSS-only change; no TS/JS touched).

No routes, schema, contracts, or seed data changed.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNARSwefHdEjJzyQ9XjfDg)_