### PR TITLE
fix: remove fabricated safety claims from mobile TrustTransport

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -255,6 +255,14 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 
 ## Change Log
 
+- 2026-07-01: Removed fabricated safety claims that survived on Android (completes the 2026-06-19 fix,
+  which said "mobile public copy updated to match" but only touched the signed-out `PublicState`). The
+  authenticated Book tab still said "Background-checked drivers"; the Track tab still showed a
+  "🛡️ Background checked / ✅ ID verified" badge row per request card; and the post-booking confirmation
+  said "being matched with nearby drivers" (there is no automated matching — a request goes `open` and
+  members browse it to offer help). All three corrected to honest copy consistent with web. UI copy only
+  — no schema, route, or contract change.
+
 - 2026-06-30: Fiat/crypto earnings on completion + currency-aware payouts; closes issue #1233. (1) Money
   precision migration: `trust_transport_earnings_ledger.amount` and `trust_transport_payout_requests.amount`
   widened `INTEGER → NUMERIC`, and the earnings ledger gains a `trip_id UUID` column (via `ALTER ... IF

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -60,7 +60,7 @@ web ☐ android ☐
 4. Leave settlement type as **Free** (the default).
 5. Submit the request.
 
-**Expected:** The request is created and appears in your request list. The settlement badge shows "Free" (never a raw currency code or a fiat equivalent). No "all drivers background-checked" claim appears anywhere. The booking subtitle refers to drivers as community members, not vetted professionals.
+**Expected:** The request is created and appears in your request list. The settlement badge shows "Free" (never a raw currency code or a fiat equivalent). No "all drivers background-checked" claim appears anywhere, and no per-request "🛡️ Background checked / ✅ ID verified" badge is shown on the Tracking list. The booking subtitle refers to drivers as community members, not vetted professionals. The post-submit confirmation says the request is now visible to community members who can offer to help — not that it is "being matched with nearby drivers" (there is no automated matching).
 
 Result: web ☐ android ☐
 

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
@@ -148,7 +148,7 @@ function BookTab({ mode, onSubmitted }: BookTabProps) {
       <View style={styles.bookedBox}>
         <Text style={styles.bookedTitle}>Request submitted!</Text>
         <Text style={styles.bookedDesc}>
-          Your request is being matched with nearby drivers.
+          Your request is now visible to community members who can offer to help.
         </Text>
         <TouchableOpacity
           style={styles.secondaryBtn}
@@ -163,9 +163,9 @@ function BookTab({ mode, onSubmitted }: BookTabProps) {
   return (
     <View style={styles.bookSection}>
       <View style={styles.sectionBox}>
-        <Text style={styles.sectionTitle}>Book a Safe {modeName}</Text>
+        <Text style={styles.sectionTitle}>Book a {modeName}</Text>
         <Text style={styles.sectionDesc}>
-          Background-checked drivers · Trauma-informed · ServiceCredits OK
+          Fellow community members · Trauma-informed · ServiceCredits OK
         </Text>
       </View>
       <View style={styles.inputGroup}>
@@ -289,10 +289,6 @@ function TrackTab({
               <Text style={styles.requestLocation}>To: {req.dropoffCity}</Text>
             ) : null}
             <Text style={styles.requestSettle}>{ttSettlementLabel(req.priceCurrency, req.priceAmount)}</Text>
-            <View style={styles.safetyRow}>
-              <Text style={styles.safetyItem}>🛡️ Background checked</Text>
-              <Text style={styles.safetyItem}>✅ ID verified</Text>
-            </View>
           </View>
         </React.Fragment>
       ))}
@@ -571,8 +567,6 @@ const styles = StyleSheet.create({
   requestLocation: { fontSize: 13, color: SUBTLE, marginBottom: 2 },
   requestSettle: { fontSize: 12, fontWeight: '700', color: '#22C55E', marginTop: 2, marginBottom: 2 },
   settleLabel: { fontSize: 13, color: MUTED, marginTop: 10, marginBottom: 6 },
-  safetyRow: { flexDirection: 'row', gap: 12, marginTop: 8 },
-  safetyItem: { fontSize: 11, color: MUTED },
   publicContent: { padding: 20 },
   publicHeadRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
   publicTitle: { fontSize: 20, fontWeight: '800', color: TEXT },


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Completes the 2026-06-19 web fix that removed fabricated safety claims. That fix's changelog said "Mobile public copy updated to match," but it only touched the signed-out `PublicState` — the authenticated Book/Track screens still carried the fabricated claims. Found while starting the Android parity work for #1250.

## What was still there
- Book tab subtitle: **"Background-checked drivers · Trauma-informed · ServiceCredits OK"**
- Track tab, per request card: a **"🛡️ Background checked / ✅ ID verified"** badge row
- Post-booking confirmation: **"Your request is being matched with nearby drivers"** — implies automated matching, which doesn't exist (a request goes `open` and members browse it in "Help out" to make an offer)

## Fix
- Subtitle → "Fellow community members · Trauma-informed · ServiceCredits OK" (matches web's public copy)
- Removed the fabricated badge row entirely
- Confirmation copy → "Your request is now visible to community members who can offer to help" (what actually happens)

UI copy only — no schema/route/contract change. Low-risk lane (bug fix / copy correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_