### PR TITLE
feat: Android provider discovery + make-an-offer (Help tab)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -237,6 +237,13 @@ at a fiat equivalent.
 
 `web+android complete` (functional). Web surface lives under `/apps/trust-transport`; Android surface lives under `packages/mobile/src/features/trust-transport`. Booking, tracking, completion, safety controls, and deletion behave consistently across platforms. Web pixel pass complete: the shell (`trust-transport-shell.tsx` + `tt-*` sub-components) is aligned to `design/.../survivor-hub/TrustTransport.tsx` and decomposed within rule-116 limits; per the real-data-only rule it binds real `/api/trust-transport/modes` + `requests` + per-trip Stream chat and omits the design's mock driver/stat figures. Android pixel pass complete (2026-05-31): `TrustTransport.tsx` rewritten to align with `design/.../survivor-hub/MobileTrustTransport*.tsx` mockups for all four states (loading, public/unauthenticated, empty, main). Binds real `/api/trust-transport/requests` (list + create) via the existing `api.ts`. Omissions per real-data-only rule: "Nearby Drivers" list (no backend endpoint for available driver discovery), driver ratings/ETAs/vehicle info, and online driver count stat — none of these fields are returned by any `trust-transport` API endpoint. Mock file (`MockTrustTransport.tsx`) retired (content cleared). `AuthProvider` export preserved via `auth-context.tsx` re-export; `TrustTransport` export maintained in `index.ts`.
 
+Provider/marketplace parity (2026-07-01, in progress — issue #1250): the Android app gains a "Help" tab
+(`TrustTransportHelpTab.tsx`) mirroring the web "Help out" tab's discovery model B — it browses open
+requests via `GET /requests/available` (mode + settlement + age only, never a location) and submits an
+offer via `POST /requests/:requestId/offers`. Trip progression, proof capture, and earnings/payouts UI on
+Android are tracked as follow-up passes under the same issue; see the Change Log for what has shipped so
+far.
+
 Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (exported from `index.ts`, registered in `App.tsx` as the `trust-transport-admin` feature) now matches the shipped web admin at `/admin/trust-transport`. It is admin-gated server-side (every admin route runs `requireTrustTransportAdminAccess`); a 401/403 surfaces an "available to admins only" notice. It binds the same existing admin endpoints with no new backend: incident queue with resolve, market controls (max concurrent trips, proof-on-delivery, emergency freeze), account restrict/restore, and the admin audit trail. Every state-changing action (resolve, market-config update, restrict, restore) asks for confirmation via a native `Alert` before sending, and mutations carry the `x-ctf-csrf: '1'` header. The web admin page is already mobile-responsive: it is a single-column flow (`max-w-5xl` content with a `grid-cols-1` → `sm:grid-cols-2` → `lg:grid-cols-4` stat grid and full-width stacked cards), so no responsive rework was required.
 
 ---
@@ -254,6 +261,14 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 3. Command contract complexity should be monitored to prevent drift from UI flow logic.
 
 ## Change Log
+
+- 2026-07-01: Android provider discovery + make-an-offer (parity with web slice 2, issue #1250). New
+  `TrustTransportHelpTab.tsx` — a "Help" tab in the bottom nav that lists open requests via the mobile
+  `listAvailableRequests` (mode + settlement + age only, discovery model B — never pickup/drop-off) and
+  submits an offer via `createOffer` (optional note + optional proposed amount), reusing the mobile API
+  client shipped in the earlier foundation PR. No schema/route/contract change (both endpoints already
+  existed and are reviewed). Trip progression, proof capture, and earnings/payouts screens for Android
+  remain open follow-ups under #1250.
 
 - 2026-06-30: Fiat/crypto earnings on completion + currency-aware payouts; closes issue #1233. (1) Money
   precision migration: `trust_transport_earnings_ledger.amount` and `trust_transport_payout_requests.amount`

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -320,6 +320,23 @@ Result: web ☐ android ☐
 
 ---
 
+### TT-18 — Browse open requests and make an offer (discovery model B)
+
+**Role:** member · **Surfaces:** web, android
+
+**Precondition:** Signed in as a member. Seed has at least one open request created by a different member.
+
+**Steps:**
+1. Open the **Help out** tab.
+2. Confirm the open-requests list shows mode, settlement, and a relative age for each — and nothing else.
+3. Tap "Make an offer" on one, optionally add a note and a proposed amount, and send it.
+
+**Expected:** The list never shows a pickup/drop-off location, a title, or the requester's identity — only mode + settlement + age (discovery model B). This is correct behavior, not a missing feature. The offer sends and the card confirms it ("Offer sent..."). Submitting a second offer on the same request updates your existing pending offer rather than creating a duplicate.
+
+Result: web ☐ android ☐
+
+---
+
 ## Admin walkthrough
 
 ### TT-A1 — Incident queue loads and an incident can be resolved
@@ -472,6 +489,7 @@ These cases must produce the same observable outcome on both surfaces. Run both 
 | TT-7 | Read-only chat after terminal state |
 | TT-11 | Explicit confirmation prompt before cancel |
 | TT-17 | Right panel shows "Good to know" reminders; no fabricated safety claims |
+| TT-18 | Discovery list shows only mode + settlement + age; offer sends and confirms |
 | TT-A1 | Incident resolved after native/web confirmation prompt |
 | TT-A2 | Market config update persists after reload |
 | TT-A4 | Restrict and restore require confirmation; platform-wide signal written |
@@ -490,4 +508,4 @@ The following are documented limitations from the inventory's "Gaps and Known Te
 5. **Driver ratings, ETAs, and vehicle info absent** — none of these fields are returned by any `trust-transport` API endpoint; their absence from the UI is correct behavior.
 6. **No admin trip-approval queue** — the design mockup shows an "approve/reject trip request queue" but no admin trip-approval route exists; the incident queue is what the API exposes and is what the admin surface renders.
 7. **Service delete endpoint not yet live** — `DELETE /api/account/trust-transport-profile` is listed as planned in the deletion contract; its absence is not a bug to file now.
-8. **Make-an-offer UI: web shipped, Android deferred** — the web shell has a "Help out" tab that lists open requests (mode + settlement + age only — never pickup/drop-off, per discovery model B) and lets a member submit an offer (optional note + optional amount). The Android equivalent ships in a follow-up pass (Parity Ticket); on Android, exercise offers via the API/seed until then. The discovery list deliberately shows no location — that is correct behavior, not a bug. A provider learns the pickup/drop-off only after the requester accepts their offer.
+8. **Trip progression, proof capture, and earnings/payouts UI: web shipped, Android deferred** — the web "Help out" tab has "Trips you're helping with" (forward status controls) and proof capture, and the web "Earnings" tab has per-currency balances and payout requests. The Android equivalents ship in follow-up passes (Parity Ticket #1250); on Android, exercise these via the API/seed until then. (Make-an-offer/discovery UI shipped on both platforms — see TT-18.)

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useAuth } from './auth-context';
 import { TrustTransportLoadingState } from './TrustTransportLoadingState';
+import { TrustTransportHelpTab } from './TrustTransportHelpTab';
 import {
   createRequest,
   listRequests,
@@ -27,7 +28,7 @@ const TEXT = '#F9FAFB';
 const MUTED = '#6B7280';
 const SUBTLE = '#9CA3AF';
 
-type Tab = 'ride' | 'package' | 'track';
+type Tab = 'ride' | 'package' | 'track' | 'help';
 
 // ---------------------------------------------------------------------------
 // Header
@@ -60,6 +61,7 @@ const NAV_ITEMS: { label: string; key: Tab; emoji: string }[] = [
   { label: 'Ride', key: 'ride', emoji: '🚗' },
   { label: 'Package', key: 'package', emoji: '📦' },
   { label: 'Track', key: 'track', emoji: '📍' },
+  { label: 'Help', key: 'help', emoji: '🤝' },
 ];
 
 function BottomNav({ active, onPress }: { active: Tab; onPress: (_t: Tab) => void }) {
@@ -389,6 +391,8 @@ export const TrustTransport = () => {
       <ScrollView style={styles.scroll}>
         {tab === 'track' ? (
           <TrackTab requests={requests} loading={requestsLoading} onRefresh={() => { void loadRequests(); }} />
+        ) : tab === 'help' ? (
+          <TrustTransportHelpTab />
         ) : (
           <BookTab mode={bookMode} onSubmitted={() => { void loadRequests(); }} />
         )}

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransportHelpTab.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransportHelpTab.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { listAvailableRequests, createOffer } from './api';
+import { ttSettlementLabel, type TrustTransportAvailableRequest } from './types';
+
+const COLOR = '#38BDF8';
+const TEXT = '#F9FAFB';
+const MUTED = '#6B7280';
+const SUBTLE = '#9CA3AF';
+
+function modeLabel(mode: string): string {
+  return mode.charAt(0).toUpperCase() + mode.slice(1);
+}
+
+// Plain relative age ("just now", "5 min ago", "2 h ago", "3 d ago") from an ISO timestamp.
+function postedAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const mins = Math.max(0, Math.floor((Date.now() - then) / 60000));
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} h ago`;
+  return `${Math.floor(hours / 24)} d ago`;
+}
+
+// The offer form for one available request. Note + proposed amount are both optional; sending resets
+// this card to a confirmation state so a member can't double-submit by tapping again.
+function OfferForm({ requestId, onSent }: { requestId: string; onSent: () => void }) {
+  const [note, setNote] = useState('');
+  const [amount, setAmount] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const parsed = Number(amount);
+      const proposedAmount = amount.trim().length > 0 && Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : null;
+      await createOffer(requestId, { note: note.trim() || null, proposedAmount });
+      onSent();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not send your offer.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <View style={styles.offerForm}>
+      <TextInput
+        value={note}
+        onChangeText={setNote}
+        placeholder="Add a short note (optional) — e.g. when you can help"
+        placeholderTextColor={MUTED}
+        style={styles.noteInput}
+        multiline
+        accessibilityLabel="Offer note"
+      />
+      <TextInput
+        value={amount}
+        onChangeText={(t) => setAmount(t.replace(/[^0-9.]/g, ''))}
+        placeholder="Propose an amount (optional)"
+        placeholderTextColor={MUTED}
+        keyboardType="decimal-pad"
+        style={styles.amountInput}
+        accessibilityLabel="Proposed amount"
+      />
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+      <TouchableOpacity
+        style={[styles.sendBtn, submitting && styles.sendBtnDisabled]}
+        onPress={() => { void submit(); }}
+        disabled={submitting}
+        accessibilityRole="button"
+      >
+        {submitting ? <ActivityIndicator size="small" color={COLOR} /> : <Text style={styles.sendBtnText}>Send offer</Text>}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function HelpCard({ request }: { request: TrustTransportAvailableRequest }) {
+  const [open, setOpen] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardRow}>
+        <Text style={styles.cardMode}>{modeLabel(request.mode)}</Text>
+        <View style={styles.settleBadge}>
+          <Text style={styles.settleBadgeText}>{ttSettlementLabel(request.priceCurrency, request.priceAmount)}</Text>
+        </View>
+        <Text style={styles.cardAge}>{postedAgo(request.createdAtIso)}</Text>
+      </View>
+      <Text style={styles.cardNote}>Pickup and drop-off are shared with you only if the requester accepts your offer.</Text>
+      {sent ? (
+        <Text style={styles.sentText}>Offer sent. You&apos;ll get the trip details if they accept.</Text>
+      ) : open ? (
+        <OfferForm requestId={request.id} onSent={() => { setSent(true); setOpen(false); }} />
+      ) : (
+        <TouchableOpacity style={styles.offerBtn} onPress={() => setOpen(true)} accessibilityRole="button">
+          <Text style={styles.offerBtnText}>🤝 Make an offer</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+// Discovery model B: browse open requests from the community — mode + settlement + age only, never a
+// location, until the requester accepts an offer (the trip then carries the full request).
+export function TrustTransportHelpTab() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<TrustTransportAvailableRequest[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await listAvailableRequests(1);
+        if (active) setItems(data);
+      } catch (e: unknown) {
+        if (active) setError(e instanceof Error ? e.message : 'Could not load open requests.');
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    void load();
+    return () => { active = false; };
+  }, []);
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Help out</Text>
+      <Text style={styles.sectionDesc}>
+        Open requests from the community you can offer to help with. To protect people&apos;s safety, you
+        see only what kind of help is needed and how it&apos;s settled.
+      </Text>
+      {loading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={COLOR} />
+        </View>
+      ) : error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : items.length === 0 ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>No open requests right now. Check back later.</Text>
+        </View>
+      ) : (
+        items.map((r) => <HelpCard key={r.id} request={r} />)
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { padding: 16 },
+  sectionTitle: { fontSize: 18, fontWeight: '800', color: TEXT, marginBottom: 6 },
+  sectionDesc: { fontSize: 13, color: SUBTLE, lineHeight: 19, marginBottom: 16 },
+  centered: { alignItems: 'center', justifyContent: 'center', padding: 32 },
+  emptyText: { fontSize: 13, color: MUTED, textAlign: 'center' },
+  card: {
+    padding: 14,
+    borderRadius: 14,
+    backgroundColor: `${COLOR}08`,
+    borderWidth: 1,
+    borderColor: `${COLOR}25`,
+    marginBottom: 12,
+  },
+  cardRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  cardMode: { fontSize: 14, fontWeight: '700', color: TEXT },
+  settleBadge: {
+    backgroundColor: 'rgba(34,197,94,0.10)',
+    borderWidth: 1,
+    borderColor: 'rgba(34,197,94,0.25)',
+    borderRadius: 20,
+    paddingHorizontal: 10,
+    paddingVertical: 2,
+  },
+  settleBadgeText: { fontSize: 11, color: '#22C55E', fontWeight: '600' },
+  cardAge: { marginLeft: 'auto', fontSize: 11, color: MUTED },
+  cardNote: { fontSize: 11, color: SUBTLE, marginTop: 8, lineHeight: 16 },
+  sentText: { fontSize: 13, color: COLOR, fontWeight: '600', marginTop: 10 },
+  offerBtn: {
+    marginTop: 10,
+    padding: 10,
+    borderRadius: 9,
+    backgroundColor: `${COLOR}15`,
+    borderWidth: 1,
+    borderColor: `${COLOR}30`,
+    alignItems: 'center',
+  },
+  offerBtnText: { fontSize: 13, fontWeight: '600', color: COLOR },
+  offerForm: { marginTop: 10, gap: 8 },
+  noteInput: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+    borderRadius: 8,
+    fontSize: 13,
+    color: '#E8EAF0',
+    padding: 10,
+    minHeight: 44,
+    textAlignVertical: 'top',
+  },
+  amountInput: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+    borderRadius: 8,
+    fontSize: 13,
+    color: '#E8EAF0',
+    padding: 10,
+  },
+  errorText: { fontSize: 12, color: '#EF4444' },
+  sendBtn: {
+    padding: 10,
+    borderRadius: 9,
+    backgroundColor: `${COLOR}1F`,
+    borderWidth: 1,
+    borderColor: `${COLOR}40`,
+    alignItems: 'center',
+  },
+  sendBtnDisabled: { opacity: 0.6 },
+  sendBtnText: { fontSize: 13, fontWeight: '600', color: COLOR },
+});


### PR DESCRIPTION
Parity Ticket: #1250

Android parity with web slice 2. Members can now browse open requests and offer to help, on Android, via a new **Help** tab in the bottom nav.

## What this adds
- **`TrustTransportHelpTab.tsx`** — lists open requests via the mobile `listAvailableRequests` (mode + settlement + age only — **discovery model B**, never pickup/drop-off) and submits an offer via `createOffer` (optional note + optional proposed amount). Reuses the mobile API client shipped in the earlier foundation PR (#1292).
- Wired into `TrustTransport.tsx`: new `help` tab + bottom nav entry.

## Scope
- No schema/route/contract change — both endpoints already exist and were reviewed when the web equivalent shipped (this is UI wiring to reviewed endpoints, matching mobile-api-client precedent).
- Trip progression, proof capture, and earnings/payouts screens for Android are tracked as follow-up PRs under #1250.

## Why owner-review (no auto-merge)
The offer form includes a `proposedAmount` field (money-adjacent), matching the risk classification used for the equivalent web PR.

## Verification
Monorepo typecheck (incl. mobile), mobile lint, EOF, inventory-drift, schema-drift, test-script-drift all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_