### PR TITLE
feat: Android view offers + accept on Track tab

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -252,8 +252,18 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 1. Status vocabulary design across three modes (ride/package/food) may need refinement based on real operational needs.
 2. Event volume and audit storage growth will require archival/retention policy once deployed at scale.
 3. Command contract complexity should be monitored to prevent drift from UI flow logic.
+4. Android has no chat screen wired up: `TrustTransportStreamTab.tsx` exists in the mobile feature directory but is not imported or registered anywhere in the app, so there is no navigation path to it and a trip cannot be chatted with on Android today. Predates and is separate from the #1250 provider-marketplace parity work; needs its own fix.
 
 ## Change Log
+
+- 2026-07-01: Android view-offers + accept (parity with web slice 3, issue #1250). New
+  `TrustTransportOffersSection.tsx` — shown on each of the caller's own **open** requests in the Track
+  tab; loads pending offers via the mobile `listOffersForRequest` and accepts one via the fixed
+  `acceptOffer(requestId, offerId)`. No schema/route/contract change (both endpoints already existed and
+  are reviewed). Discovered and documented a separate, pre-existing gap while wiring this up: Android has
+  no chat screen registered anywhere in the app (`TrustTransportStreamTab.tsx` is orphaned scaffold) — see
+  "Gaps and Known Technical Debt". Trip progression, proof capture, and earnings/payouts screens for
+  Android remain open follow-ups under #1250.
 
 - 2026-06-30: Fiat/crypto earnings on completion + currency-aware payouts; closes issue #1233. (1) Money
   precision migration: `trust_transport_earnings_ledger.amount` and `trust_transport_payout_requests.amount`

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -111,11 +111,11 @@ Result: web ☐ android ☐
 **Precondition:** Signed in as a member. Seed has at least one request with at least one offer on it.
 
 **Steps:**
-1. Open the Tracking tab. On one of your own open requests, click "View offers".
+1. Open the Tracking tab. On one of your own open requests, click/tap "View offers".
 2. Confirm the offers list shows pending offers (a community member, optional note, optional proposed amount).
-3. Accept one offer. (On web; on Android this still runs via API/seed until the parity pass — issue #1250.)
+3. Accept one offer.
 
-**Expected:** The offer is accepted and a trip is created. The request moves to an accepted state and the Direct Line opens for that trip. Per model B, the pickup/drop-off is now available to the accepted provider through the trip. The trip ID is visible (the sidebar/detail shows it, not "— → —").
+**Expected:** The offer is accepted and a trip is created. The request moves to an accepted state. Per model B, the pickup/drop-off is now available to the accepted provider through the trip. The trip ID is visible (the sidebar/detail shows it, not "— → —"). On web, the Direct Line opens for that trip. Android has no chat screen wired up yet (see Known gaps) — this is a separate, pre-existing gap, not a defect in the accept flow you just tested.
 
 Result: web ☐ android ☐
 
@@ -467,6 +467,7 @@ These cases must produce the same observable outcome on both surfaces. Run both 
 | TT-1 | Ride request created; Free settlement badge shown; no fabricated driver claims |
 | TT-2 | ServiceCredits settlement badge shown; no fiat equivalent |
 | TT-3 | Submit blocked with inline error when priced amount is missing |
+| TT-4 | Offers list shows pending offers; accepting opens a trip and moves the request to accepted |
 | TT-5 | Tracking tab label and copy; no live-GPS claim |
 | TT-6 | Chat gating message before accept; text-only chat after accept; no video |
 | TT-7 | Read-only chat after terminal state |
@@ -490,4 +491,5 @@ The following are documented limitations from the inventory's "Gaps and Known Te
 5. **Driver ratings, ETAs, and vehicle info absent** — none of these fields are returned by any `trust-transport` API endpoint; their absence from the UI is correct behavior.
 6. **No admin trip-approval queue** — the design mockup shows an "approve/reject trip request queue" but no admin trip-approval route exists; the incident queue is what the API exposes and is what the admin surface renders.
 7. **Service delete endpoint not yet live** — `DELETE /api/account/trust-transport-profile` is listed as planned in the deletion contract; its absence is not a bug to file now.
-8. **Make-an-offer UI: web shipped, Android deferred** — the web shell has a "Help out" tab that lists open requests (mode + settlement + age only — never pickup/drop-off, per discovery model B) and lets a member submit an offer (optional note + optional amount). The Android equivalent ships in a follow-up pass (Parity Ticket); on Android, exercise offers via the API/seed until then. The discovery list deliberately shows no location — that is correct behavior, not a bug. A provider learns the pickup/drop-off only after the requester accepts their offer.
+8. **Trip progression, proof capture, and earnings/payouts UI: web shipped, Android deferred** — the web "Help out" tab has "Trips you're helping with" (forward status controls) and proof capture, and the web "Earnings" tab has per-currency balances and payout requests. The Android equivalents ship in follow-up passes (Parity Ticket #1250); on Android, exercise these via the API/seed until then. (Make-an-offer/discovery and view-offers/accept UI shipped on both platforms — see TT-18 and TT-4.)
+9. **Android has no chat screen wired up** — `TrustTransportStreamTab.tsx` exists in the mobile feature directory but is not imported or registered anywhere in the app; there is no navigation path to it. A trip cannot be chatted with on Android today. This predates and is separate from the #1250 provider-marketplace parity work (web's chat tab already existed); do not file it as caused by any of the #1250 changes.

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useAuth } from './auth-context';
 import { TrustTransportLoadingState } from './TrustTransportLoadingState';
+import { TrustTransportOffersSection } from './TrustTransportOffersSection';
 import {
   createRequest,
   listRequests,
@@ -293,6 +294,9 @@ function TrackTab({
               <Text style={styles.safetyItem}>🛡️ Background checked</Text>
               <Text style={styles.safetyItem}>✅ ID verified</Text>
             </View>
+            {req.status === 'open' ? (
+              <TrustTransportOffersSection requestId={req.id} onAccepted={onRefresh} />
+            ) : null}
           </View>
         </React.Fragment>
       ))}

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransportOffersSection.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransportOffersSection.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { listOffersForRequest, acceptOffer } from './api';
+import type { TrustTransportOffer } from './types';
+
+const COLOR = '#38BDF8';
+const TEXT = '#F9FAFB';
+const MUTED = '#6B7280';
+const SUBTLE = '#9CA3AF';
+
+// Offers on one of the caller's own open requests, with Accept. Accepting opens a trip and (per
+// discovery model B) is the point at which the chosen provider gains the pickup/drop-off via the trip.
+export function TrustTransportOffersSection({ requestId, onAccepted }: { requestId: string; onAccepted: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [offers, setOffers] = useState<TrustTransportOffer[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [acceptingId, setAcceptingId] = useState<string | null>(null);
+
+  async function load() {
+    setOpen(true);
+    setLoading(true);
+    setError(null);
+    try {
+      const items = await listOffersForRequest(requestId);
+      setOffers(items);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not load offers.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function accept(offerId: string) {
+    setAcceptingId(offerId);
+    setError(null);
+    try {
+      await acceptOffer(requestId, offerId);
+      onAccepted();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not accept this offer.');
+    } finally {
+      setAcceptingId(null);
+    }
+  }
+
+  if (!open) {
+    return (
+      <TouchableOpacity style={styles.viewBtn} onPress={() => { void load(); }} accessibilityRole="button">
+        <Text style={styles.viewBtnText}>View offers</Text>
+      </TouchableOpacity>
+    );
+  }
+
+  const pending = offers.filter((o) => o.status === 'pending');
+
+  return (
+    <View style={styles.section}>
+      {loading ? (
+        <ActivityIndicator size="small" color={COLOR} />
+      ) : error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : pending.length === 0 ? (
+        <Text style={styles.emptyText}>No offers yet. You&apos;ll see them here as people offer to help.</Text>
+      ) : (
+        pending.map((offer) => (
+          <View key={offer.id} style={styles.offerCard}>
+            <Text style={styles.offerText}>
+              A community member{offer.proposedAmount != null ? ` · proposes ${offer.proposedAmount}` : ''}
+            </Text>
+            {offer.note ? <Text style={styles.offerNote}>{offer.note}</Text> : null}
+            <TouchableOpacity
+              style={[styles.acceptBtn, acceptingId !== null && styles.acceptBtnDisabled]}
+              onPress={() => { void accept(offer.id); }}
+              disabled={acceptingId !== null}
+              accessibilityRole="button"
+            >
+              {acceptingId === offer.id ? <ActivityIndicator size="small" color={COLOR} /> : <Text style={styles.acceptBtnText}>✓ Accept offer</Text>}
+            </TouchableOpacity>
+          </View>
+        ))
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  viewBtn: {
+    marginTop: 10,
+    padding: 8,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+    alignItems: 'center',
+  },
+  viewBtnText: { fontSize: 12, fontWeight: '600', color: SUBTLE },
+  section: { marginTop: 10, gap: 8 },
+  errorText: { fontSize: 12, color: '#EF4444' },
+  emptyText: { fontSize: 12, color: MUTED },
+  offerCard: {
+    padding: 10,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  offerText: { fontSize: 13, color: TEXT, fontWeight: '600' },
+  offerNote: { fontSize: 12, color: SUBTLE, marginTop: 4, lineHeight: 17 },
+  acceptBtn: {
+    marginTop: 8,
+    padding: 8,
+    borderRadius: 8,
+    backgroundColor: `${COLOR}1F`,
+    borderWidth: 1,
+    borderColor: `${COLOR}40`,
+    alignItems: 'center',
+  },
+  acceptBtnDisabled: { opacity: 0.5 },
+  acceptBtnText: { fontSize: 12, fontWeight: '600', color: COLOR },
+});


### PR DESCRIPTION
Parity Ticket: #1250

Android parity with web slice 3. Requesters can now review the offers on their own open requests and accept one, on Android.

## What this adds
- **`TrustTransportOffersSection.tsx`** — shown on each of the caller's own **open** requests in the Track tab. Loads pending offers via the mobile `listOffersForRequest` and accepts one via the fixed `acceptOffer(requestId, offerId)` from the mobile API-client foundation PR (#1292).

## Scope
- No schema/route/contract change — both endpoints already exist and are reviewed (this reuses the same accept path web already exercises).
- Low-risk lane: no money, wraps a reviewed endpoint.

## Side finding (documented, not fixed here)
While wiring this up I found Android has **no chat screen registered anywhere in the app** — `TrustTransportStreamTab.tsx` exists but is never imported. This predates and is unrelated to the #1250 parity work; I've recorded it in the inventory's "Gaps and Known Technical Debt" and the test script's "Known gaps" so it isn't mistaken for a regression from this PR. Not fixed in this PR — flagging for a separate task.

## Verification
Monorepo typecheck (incl. mobile), mobile lint, EOF, inventory-drift, schema-drift, test-script-drift all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_