### PR TITLE
feat: Android earnings + payouts screen for TrustTransport

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -237,16 +237,21 @@ at a fiat equivalent.
 
 `web+android complete` (functional). Web surface lives under `/apps/trust-transport`; Android surface lives under `packages/mobile/src/features/trust-transport`. Booking, tracking, completion, safety controls, and deletion behave consistently across platforms. Web pixel pass complete: the shell (`trust-transport-shell.tsx` + `tt-*` sub-components) is aligned to `design/.../survivor-hub/TrustTransport.tsx` and decomposed within rule-116 limits; per the real-data-only rule it binds real `/api/trust-transport/modes` + `requests` + per-trip Stream chat and omits the design's mock driver/stat figures. Android pixel pass complete (2026-05-31): `TrustTransport.tsx` rewritten to align with `design/.../survivor-hub/MobileTrustTransport*.tsx` mockups for all four states (loading, public/unauthenticated, empty, main). Binds real `/api/trust-transport/requests` (list + create) via the existing `api.ts`. Omissions per real-data-only rule: "Nearby Drivers" list (no backend endpoint for available driver discovery), driver ratings/ETAs/vehicle info, and online driver count stat — none of these fields are returned by any `trust-transport` API endpoint. Mock file (`MockTrustTransport.tsx`) retired (content cleared). `AuthProvider` export preserved via `auth-context.tsx` re-export; `TrustTransport` export maintained in `index.ts`.
 
-Provider/marketplace parity (2026-07-01 through 2026-07-02, issue #1250): the Android app gained a "Help"
-tab (`TrustTransportHelpTab.tsx`) mirroring the web "Help out" tab's discovery model B — it browses open
-requests via `GET /requests/available` (mode + settlement + age only, never a location), submits an offer
-via `POST /requests/:requestId/offers`, and (2026-07-02) shows "Trips you're helping with" with the same
-forward status controls and proof capture the web Help tab has, using the existing `listProviderTrips`,
-`updateTripStatus`, and `captureProof` API client functions. A "Chat" button on both the requester's Track
-tab (once a request has an accepted trip) and the provider's Help tab trips opens `TrustTransportStreamTab`
-in a full-screen modal (`TrustTransportChatButton.tsx`) — this was previously orphaned scaffold, never
-imported anywhere in the app; it is now wired for both parties. Only earnings/payouts UI on Android remains
-open under #1250; see the Change Log for the full shipped list.
+Provider/marketplace parity (2026-07-01 through 2026-07-02, issue #1250 — complete): the Android app
+gained a "Help" tab (`TrustTransportHelpTab.tsx`) mirroring the web "Help out" tab's discovery model B —
+it browses open requests via `GET /requests/available` (mode + settlement + age only, never a location),
+submits an offer via `POST /requests/:requestId/offers`, and shows "Trips you're helping with" with the
+same forward status controls and proof capture the web Help tab has, using the existing
+`listProviderTrips`, `updateTripStatus`, and `captureProof` API client functions. A "Chat" button on both
+the requester's Track tab (once a request has an accepted trip) and the provider's Help tab trips opens
+`TrustTransportStreamTab` in a full-screen modal (`TrustTransportChatButton.tsx`) — this was previously
+orphaned scaffold, never imported anywhere in the app; it is now wired for both parties. An "Earnings" tab
+(`TrustTransportEarningsTab.tsx`) mirrors the web Earnings tab: per-currency balance cards
+(`getEarningsBalances`), a payout request form scoped to the selected currency
+(`requestPayout(amount, currency)`), and payout history (`listPayouts`). Every endpoint used across all of
+the above already existed (no schema/route/contract change); see the Change Log for the full shipped list.
+Issue #1250 is now closed out — Android has full parity with web across discovery/offer, view-offers/accept,
+trip progression, proof capture, chat, and earnings/payouts.
 
 While wiring Android chat, the same gap was found on web: the "Help out" tab's provider trip cards had no
 chat access either — only the requester's "Direct Line" tab could open a trip's chat. `tt-help-tab.tsx`
@@ -275,18 +280,23 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
    undocumented schema table or API route) and the plugin contract templates (rules 200–203). Full
    field-by-field matching of contract YAML against inventory prose is still a manual review step, not an
    automated gate.
-3. Earnings/payouts UI is web-only; the Android equivalent is the one remaining item under issue #1250
-   (Parity Ticket). Trip progression, proof capture, discovery/offer, and chat are shipped on both
-   platforms as of 2026-07-02.
-4. No admin trip-approval queue: the `design/` mockup shows an "approve/reject trip request queue" but no
+3. No admin trip-approval queue: the `design/` mockup shows an "approve/reject trip request queue" but no
    backend route exists for it. The incident queue is the real, shipped moderation surface; the mockup
    predates the incident-queue design and is stale, not a missing feature.
-5. Nearby Drivers list, driver ratings, ETAs, and vehicle info are intentionally absent from both
+4. Nearby Drivers list, driver ratings, ETAs, and vehicle info are intentionally absent from both
    platforms — no backend endpoint returns any of these fields, per the real-data-only rule. Ratings of
    people specifically are never shown anywhere in this plugin: reputation is transparent completion
    history only (completed vs. not), never a score, by owner directive.
 
 ## Change Log
+
+- 2026-07-02: Android earnings + payouts screen (parity with web slice 6, issue #1250). New
+  `TrustTransportEarningsTab.tsx` — an "Earnings" tab in the bottom nav with per-currency balance cards
+  (`getEarningsBalances`), a payout request form scoped to whichever currency is selected
+  (`requestPayout(amount, currency)`), and payout history (`listPayouts`) — all reusing the existing
+  mobile API client functions from the #1233 currency migration. No schema/route/contract change (every
+  endpoint already existed and was reviewed). This was the last Android gap tracked under #1250; trip
+  progression, proof capture, discovery/offer, view-offers/accept, and chat now all have Android parity.
 
 - 2026-07-02: Android trip progression + proof capture (parity with web slices 4–5, issue #1250), plus
   chat wiring on both platforms. `TrustTransportHelpTab.tsx` gained a "Trips you're helping with" section

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -11,7 +11,7 @@
 | **Surfaces** | web (`/apps/trust-transport`, `/admin/trust-transport`) · android (`TrustTransport.tsx`, `AdminTrustTransport.tsx`) |
 | **Seed first** | `pnpm --dir ctf seed:trust-transport` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md` |
-| **Generated** | 2026-06-30 (commit 6f320290; manually updated to remove the rating case — ratings were deleted from the plugin; 2026-07-02: Android trip progression, proof capture, and chat shipped — TT-8/TT-9 added to the parity table and the stale "service delete endpoint not live" gap removed) |
+| **Generated** | 2026-06-30 (commit 6f320290; manually updated to remove the rating case — ratings were deleted from the plugin; 2026-07-02: Android trip progression, proof capture, chat, and earnings/payouts shipped — issue #1250 closed; TT-8/TT-9/TT-13/TT-14 added to the parity table, the stale "service delete endpoint not live" gap removed, and the "Android deferred" earnings gap note removed) |
 
 ---
 
@@ -247,7 +247,7 @@ Result: web ☐ android ☐
 **Precondition:** Signed in as a member who has fulfilled trips and has earnings entries. Any member with earnings can request a payout — there is no provider role.
 
 **Steps:**
-1. On web, open the **Earnings** tab. Confirm a balance card shows for each currency you have a nonzero balance in. (On Android this runs via API/seed until the parity pass — issue #1250.)
+1. Open the **Earnings** tab. Confirm a balance card shows for each currency you have a nonzero balance in.
 2. View the payout history list with per-row amount + currency + status.
 3. Pick a currency, enter a positive amount within that currency's balance, and submit.
 
@@ -264,7 +264,7 @@ Result: web ☐ android ☐
 **Precondition:** Signed in as a member with an earnings balance.
 
 **Steps:**
-1. On web, open the **Earnings** tab and pick a currency.
+1. Open the **Earnings** tab and pick a currency.
 2. Enter `0` as the amount and submit.
 3. Repeat with a negative amount, and with an amount above that currency's balance.
 
@@ -493,6 +493,8 @@ These cases must produce the same observable outcome on both surfaces. Run both 
 | TT-18 | Discovery list shows only mode + settlement + age; offer sends and confirms |
 | TT-8 | Forward status control advances the trip one step; ServiceCredits settlement moves credits on completion |
 | TT-9 | Proof capture saves a redacted reference; empty value rejected |
+| TT-13 | Balance card per currency; payout request created with the chosen currency; over-balance refused |
+| TT-14 | Zero/negative/over-balance payout attempts all rejected with inline error |
 | TT-A1 | Incident resolved after native/web confirmation prompt |
 | TT-A2 | Market config update persists after reload |
 | TT-A4 | Restrict and restore require confirmation; platform-wide signal written |
@@ -509,4 +511,3 @@ The following are documented limitations from the inventory's "Gaps and Known Te
 3. **Nearby Drivers list absent** — no backend endpoint exists for available driver discovery; this data is intentionally omitted from both web and android per the real-data-only rule. The missing list is not a bug.
 4. **Driver ratings, ETAs, and vehicle info absent** — none of these fields are returned by any `trust-transport` API endpoint; their absence from the UI is correct behavior. Ratings of people are never shown anywhere in this plugin, by design — reputation is completion history only (completed vs. not), never a score.
 5. **No admin trip-approval queue** — the design mockup shows an "approve/reject trip request queue" but no admin trip-approval route exists; the incident queue is what the API exposes and is what the admin surface renders. The mockup is outdated, not a missing feature.
-6. **Earnings/payouts UI: web shipped, Android deferred** — the web "Earnings" tab has per-currency balances and payout requests. The Android equivalent ships in a follow-up pass (Parity Ticket #1250); on Android, exercise this via the API/seed until then. (Make-an-offer/discovery, view-offers/accept, trip progression, proof capture, and chat are shipped on both platforms — see TT-18, TT-4, TT-8, TT-9.)

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
@@ -13,6 +13,7 @@ import { TrustTransportLoadingState } from './TrustTransportLoadingState';
 import { TrustTransportOffersSection } from './TrustTransportOffersSection';
 import { TrustTransportHelpTab } from './TrustTransportHelpTab';
 import { TrustTransportChatButton } from './TrustTransportChatButton';
+import { TrustTransportEarningsTab } from './TrustTransportEarningsTab';
 import {
   createRequest,
   listRequests,
@@ -30,7 +31,7 @@ const TEXT = '#F9FAFB';
 const MUTED = '#6B7280';
 const SUBTLE = '#9CA3AF';
 
-type Tab = 'ride' | 'package' | 'track' | 'help';
+type Tab = 'ride' | 'package' | 'track' | 'help' | 'earnings';
 
 // ---------------------------------------------------------------------------
 // Header
@@ -64,6 +65,7 @@ const NAV_ITEMS: { label: string; key: Tab; emoji: string }[] = [
   { label: 'Package', key: 'package', emoji: '📦' },
   { label: 'Track', key: 'track', emoji: '📍' },
   { label: 'Help', key: 'help', emoji: '🤝' },
+  { label: 'Earnings', key: 'earnings', emoji: '💰' },
 ];
 
 function BottomNav({ active, onPress }: { active: Tab; onPress: (_t: Tab) => void }) {
@@ -395,6 +397,8 @@ export const TrustTransport = () => {
           <TrackTab requests={requests} loading={requestsLoading} onRefresh={() => { void loadRequests(); }} />
         ) : tab === 'help' ? (
           <TrustTransportHelpTab />
+        ) : tab === 'earnings' ? (
+          <TrustTransportEarningsTab />
         ) : (
           <BookTab mode={bookMode} onSubmitted={() => { void loadRequests(); }} />
         )}

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransportEarningsTab.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransportEarningsTab.tsx
@@ -1,0 +1,250 @@
+// Mirrors ctf/packages/web/components/trust-transport/tt-earnings-tab.tsx: per-currency balance
+// cards, a payout request form scoped to the selected currency, and payout history.
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { getEarningsBalances, listPayouts, requestPayout } from './api';
+import type { TrustTransportEarningsBalance, TrustTransportPayoutRequest } from './types';
+
+const COLOR = '#38BDF8';
+const TEXT = '#F9FAFB';
+const MUTED = '#6B7280';
+const SUBTLE = '#9CA3AF';
+
+function payoutStatusLabel(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function payoutStatusColor(s: string): string {
+  if (s === 'paid' || s === 'approved') return '#22C55E';
+  if (s === 'rejected') return '#EF4444';
+  return '#F59E0B'; // requested / pending
+}
+
+export function TrustTransportEarningsTab() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [balances, setBalances] = useState<TrustTransportEarningsBalance[]>([]);
+  const [payouts, setPayouts] = useState<TrustTransportPayoutRequest[]>([]);
+  const [selectedCurrency, setSelectedCurrency] = useState<string | null>(null);
+  const [amount, setAmount] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [requested, setRequested] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextBalances, nextPayouts] = await Promise.all([getEarningsBalances(), listPayouts()]);
+      setBalances(nextBalances);
+      setPayouts(nextPayouts);
+      setSelectedCurrency((prev) => (prev && nextBalances.some((b) => b.currency === prev) ? prev : (nextBalances[0]?.currency ?? null)));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not load your earnings.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  const selectedBalance = balances.find((b) => b.currency === selectedCurrency)?.balance ?? 0;
+
+  async function submitPayout() {
+    if (!selectedCurrency) return;
+    const parsed = Number(amount);
+    if (!(Number.isFinite(parsed) && parsed > 0)) {
+      setFormError('Enter an amount greater than zero.');
+      return;
+    }
+    if (parsed > selectedBalance) {
+      setFormError(`That's more than your available ${selectedCurrency} balance.`);
+      return;
+    }
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      await requestPayout(parsed, selectedCurrency);
+      setRequested(true);
+      setAmount('');
+      await load();
+    } catch (e: unknown) {
+      setFormError(e instanceof Error ? e.message : 'Could not submit your payout request.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={COLOR} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.section}>
+      <Text style={styles.sectionTitle}>Earnings</Text>
+      <Text style={styles.sectionDesc}>
+        ServiceCredits you earn are paid straight to your ServiceCredits wallet when a trip completes.
+        This tab tracks other-currency earnings and your payout requests, which an admin reviews.
+      </Text>
+      {error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : (
+        <>
+          <Text style={styles.subheading}>Available balance</Text>
+          {balances.length === 0 ? (
+            <View style={styles.emptyBox}>
+              <Text style={styles.emptyText}>No withdrawable earnings yet. Fiat/crypto earnings from completed trips show up here.</Text>
+            </View>
+          ) : (
+            <View style={styles.balanceRow}>
+              {balances.map((b) => (
+                <TouchableOpacity
+                  key={b.currency}
+                  style={[styles.balanceCard, selectedCurrency === b.currency && styles.balanceCardActive]}
+                  onPress={() => setSelectedCurrency(b.currency)}
+                  accessibilityRole="button"
+                >
+                  <Text style={styles.balanceCurrency}>{b.currency}</Text>
+                  <Text style={styles.balanceAmount}>{b.balance}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          )}
+
+          <Text style={styles.subheading}>Request a payout</Text>
+          {requested ? <Text style={styles.requestedText}>Payout requested. You&apos;ll see it below with its status.</Text> : null}
+          {balances.length === 0 ? (
+            <Text style={styles.emptyText}>You can request a payout once you have a withdrawable balance.</Text>
+          ) : (
+            <>
+              <View style={styles.currencyPickRow}>
+                {balances.map((b) => (
+                  <TouchableOpacity
+                    key={b.currency}
+                    style={[styles.currencyChip, selectedCurrency === b.currency && styles.currencyChipActive]}
+                    onPress={() => setSelectedCurrency(b.currency)}
+                    accessibilityRole="button"
+                  >
+                    <Text style={[styles.currencyChipText, selectedCurrency === b.currency && styles.currencyChipTextActive]}>{b.currency}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+              <TextInput
+                value={amount}
+                onChangeText={(t) => setAmount(t.replace(/[^0-9.]/g, ''))}
+                placeholder={`Amount (max ${selectedBalance})`}
+                placeholderTextColor={MUTED}
+                keyboardType="decimal-pad"
+                style={styles.amountInput}
+                accessibilityLabel="Payout amount"
+              />
+              {formError ? <Text style={styles.errorText}>{formError}</Text> : null}
+              <TouchableOpacity
+                style={[styles.requestBtn, submitting && styles.requestBtnDisabled]}
+                onPress={() => { void submitPayout(); }}
+                disabled={submitting}
+                accessibilityRole="button"
+              >
+                {submitting ? <ActivityIndicator size="small" color={COLOR} /> : <Text style={styles.requestBtnText}>Request payout</Text>}
+              </TouchableOpacity>
+            </>
+          )}
+
+          <Text style={styles.subheading}>Payout history</Text>
+          {payouts.length === 0 ? (
+            <View style={styles.emptyBox}>
+              <Text style={styles.emptyText}>No payout requests yet.</Text>
+            </View>
+          ) : (
+            payouts.map((p) => (
+              <View key={p.id} style={styles.payoutRow}>
+                <Text style={styles.payoutAmount}>{p.amount}{p.currency ? ` ${p.currency}` : ''}</Text>
+                <Text style={[styles.payoutStatus, { color: payoutStatusColor(p.status) }]}>{payoutStatusLabel(p.status)}</Text>
+              </View>
+            ))
+          )}
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, minHeight: 300 },
+  section: { padding: 16 },
+  sectionTitle: { fontSize: 18, fontWeight: '800', color: TEXT, marginBottom: 6 },
+  sectionDesc: { fontSize: 13, color: SUBTLE, lineHeight: 19, marginBottom: 20 },
+  subheading: { fontSize: 12, fontWeight: '700', letterSpacing: 1, textTransform: 'uppercase', color: SUBTLE, marginBottom: 10, marginTop: 8 },
+  errorText: { fontSize: 12, color: '#EF4444', marginBottom: 8 },
+  emptyBox: {
+    padding: 18,
+    borderRadius: 14,
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.06)',
+    marginBottom: 20,
+  },
+  emptyText: { fontSize: 13, color: MUTED },
+  balanceRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginBottom: 20 },
+  balanceCard: {
+    minWidth: 120,
+    padding: 14,
+    borderRadius: 14,
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  balanceCardActive: { backgroundColor: `${COLOR}14`, borderColor: `${COLOR}40` },
+  balanceCurrency: { fontSize: 12, color: SUBTLE },
+  balanceAmount: { marginTop: 6, fontSize: 22, fontWeight: '800', color: TEXT },
+  requestedText: { fontSize: 13, color: COLOR, fontWeight: '600', marginBottom: 10 },
+  currencyPickRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 8 },
+  currencyChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+  },
+  currencyChipActive: { backgroundColor: `${COLOR}20`, borderColor: `${COLOR}40` },
+  currencyChipText: { fontSize: 12, fontWeight: '600', color: SUBTLE },
+  currencyChipTextActive: { color: COLOR },
+  amountInput: {
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+    borderRadius: 9,
+    fontSize: 14,
+    color: '#E8EAF0',
+    padding: 12,
+    marginBottom: 8,
+  },
+  requestBtn: {
+    padding: 12,
+    borderRadius: 9,
+    backgroundColor: `${COLOR}1F`,
+    borderWidth: 1,
+    borderColor: `${COLOR}40`,
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  requestBtnDisabled: { opacity: 0.6 },
+  requestBtnText: { fontSize: 14, fontWeight: '600', color: COLOR },
+  payoutRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.06)',
+    marginBottom: 8,
+  },
+  payoutAmount: { fontSize: 14, fontWeight: '700', color: TEXT },
+  payoutStatus: { marginLeft: 'auto', fontSize: 12, fontWeight: '600' },
+});


### PR DESCRIPTION
## Summary
- New `TrustTransportEarningsTab.tsx` — an "Earnings" tab in the Android bottom nav, mirroring the shipped web Earnings tab: per-currency balance cards (`getEarningsBalances`), a payout request form scoped to the currency you pick (`requestPayout(amount, currency)`), and payout history (`listPayouts`) — all reusing the existing mobile API client functions from the #1233 currency migration.
- This closes the last Android gap tracked under issue #1250. Android now has full parity with web across discovery/offer, view-offers/accept, trip progression, proof capture, chat, and earnings/payouts.
- No schema, route, or contract changes — every endpoint used already existed and was reviewed (`GET /earnings`, `GET /payouts`, `POST /payouts/requests`).

Flagged as owner-review lane (touches the earnings/payout surface) rather than auto-merge, per the two-lane PR policy — this reads earnings balances and submits payout *requests* (which an admin still reviews/approves before any money moves), it does not move ServiceCredits or complete a transfer itself.

## Test plan
- [x] `pnpm -r run typecheck` passes
- [x] `eslint` passes on all changed files
- [x] EOF formatting check passes
- [x] `check-inventory-drift` passes
- [x] `check-test-script-drift` passes
- [ ] Manual: TT-13, TT-14 on Android (balance cards per currency; payout request created/rejected correctly)

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_