### PR TITLE
fix: stop the back button overlapping the header on public plugin landing pages

### DIFF
--- a/ctf/packages/web/components/plugins/public-shell-frame.tsx
+++ b/ctf/packages/web/components/plugins/public-shell-frame.tsx
@@ -11,23 +11,14 @@ import type { ReactNode } from 'react';
  * back button — so this control only ever appears where one was missing, and
  * never doubles an existing one.
  *
- * The control is anchored to a `position: relative` wrapper, never `position:
- * fixed`. A fixed element is positioned against the viewport only when no
- * ancestor establishes a containing block, but a parent with a transform /
- * filter / backdrop-filter does establish one — which previously threw the
- * button to the middle-right edge of the screen and clipped it. Anchoring to our
- * own wrapper resolves reliably regardless of any ancestor.
- *
- * Two breakpoints, because the landing shells differ:
- *  - Desktop shells lay their content out inside wide (~64px) side margins, so a
- *    top-left corner overlay sits in that margin and overlaps nothing.
- *  - Mobile shells run their own brand/title to the top-left edge, so an overlay
- *    there would sit on top of it. On phones the control is a normal-flow bar
- *    above the shell instead, which never collides.
- *
- * The `.ctf-bp-desktop` / `.ctf-bp-mobile` toggling lives on plain wrapper divs
- * (no inline `display`), because an inline `display` would beat the class rule
- * and defeat the breakpoint switch.
+ * The control is a normal-flow sticky bar ABOVE the shell, on every breakpoint.
+ * An earlier version used a `position: absolute` top-left corner overlay on
+ * desktop, on the assumption that desktop shells kept their content inside a wide
+ * side margin. That assumption was wrong: the landing shells render their own
+ * header bar with the plugin icon/title hard against the top-left (only ~28px of
+ * padding), so the overlay sat directly on top of that title. A normal-flow bar
+ * never overlaps the shell's header — it reserves its own height — so it is the
+ * one layout that is correct for every shell regardless of its header padding.
  */
 const BACK_BUTTON_STYLE = {
   width: 38,
@@ -40,43 +31,29 @@ const BACK_BUTTON_STYLE = {
   justifyContent: 'center',
   color: '#F9FAFB',
   textDecoration: 'none',
-  backdropFilter: 'blur(4px)',
   flexShrink: 0,
 } as const;
 
 export function PublicShellFrame({ children }: { children: ReactNode }) {
   return (
     <div style={{ position: 'relative', minHeight: '100dvh' }}>
-      {/* Desktop: corner overlay inside the shell's side margin (adds no height). */}
-      <div className="ctf-bp-desktop">
-        <Link
-          href="/apps"
-          aria-label="Back to apps"
-          style={{ position: 'absolute', top: 14, left: 14, zIndex: 50, ...BACK_BUTTON_STYLE }}
-        >
+      {/* A normal-flow sticky bar above the shell, so it never overlaps the
+          shell's own top-left brand/title on any breakpoint. */}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 50,
+          display: 'flex',
+          alignItems: 'center',
+          padding: '10px 14px',
+          background: 'var(--ctf-bg, #0B0B0F)',
+          borderBottom: '1px solid rgba(255,255,255,0.1)',
+        }}
+      >
+        <Link href="/apps" aria-label="Back to apps" style={BACK_BUTTON_STYLE}>
           <ChevronLeft size={20} />
         </Link>
-      </div>
-
-      {/* Mobile: a normal-flow bar above the shell, so it never overlaps the
-          shell's own top-left brand. */}
-      <div className="ctf-bp-mobile">
-        <div
-          style={{
-            position: 'sticky',
-            top: 0,
-            zIndex: 50,
-            display: 'flex',
-            alignItems: 'center',
-            padding: '10px 14px',
-            background: 'var(--ctf-bg, #0B0B0F)',
-            borderBottom: '1px solid rgba(255,255,255,0.1)',
-          }}
-        >
-          <Link href="/apps" aria-label="Back to apps" style={BACK_BUTTON_STYLE}>
-            <ChevronLeft size={20} />
-          </Link>
-        </div>
       </div>
 
       {children}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## The bug

On the signed-out / not-yet-verified plugin landing pages (e.g. `/apps/peer-programming`), the back-to-/apps chevron overlapped the shell's own header title.

These pages wrap their shell in `PublicShellFrame`, which on **desktop** placed the back button as an `position: absolute` top-left overlay at `top:14, left:14`. That assumed each landing shell kept its content inside a wide side margin — but every landing shell renders its own header bar with the plugin icon and title hard against the top-left (~28px padding), so the overlay sat directly on top of the title.

## The fix

`PublicShellFrame` wraps **every** public visitor shell uniformly (from `app/apps/[pluginSlug]/page.tsx`), so this is one fix for all of them. The mobile branch already used a non-overlapping normal-flow sticky back bar above the shell; this makes the desktop branch use the same bar. A normal-flow bar reserves its own height above the shell, so it never overlaps the shell's header regardless of the header's padding — the one layout that is correct for every public shell at once.

No change to any shell's own content — only the shared wrapper's back-button placement.

## Scope / parity

These are web-only public marketing/landing shells; there is no React Native (Android) equivalent, so there is nothing to change on Android. The fix covers the desktop and phone-width web layouts.

## Checks

`@ctf/web` lint and typecheck pass; the pre-push gate (typecheck + web build) passed. No backend, schema, or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_