### PR TITLE
fix: drive theme-toggle active text from a --ctf-brand-text token

### DIFF
--- a/ctf/packages/web/app/globals.css
+++ b/ctf/packages/web/app/globals.css
@@ -36,6 +36,7 @@
 
   /* Accents and state. */
   --ctf-brand: #e91e8c;
+  --ctf-brand-text: #ffffff; /* text/icon color that sits on a --ctf-brand fill */
   --ctf-gold: #38bdf8;
   --ctf-danger: #b91c1c;
   --ctf-success: #22c55e;
@@ -74,6 +75,7 @@
 
   /* Account/data destructive zone is danger-red; warm gold is the economy accent. */
   --ctf-brand: #c8a84b;
+  --ctf-brand-text: #0d0d0d; /* text/icon color that sits on a --ctf-brand fill */
   --ctf-gold: #c8a84b;
   --ctf-danger: #b91c1c;
   --ctf-success: #22c55e;

--- a/ctf/packages/web/components/theme/theme-toggle.tsx
+++ b/ctf/packages/web/components/theme/theme-toggle.tsx
@@ -13,7 +13,6 @@ const OPTIONS: { value: ThemeName; label: string }[] = [
 // Data settings surface.
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
-  const activeText = theme === 'comic' ? '#0d0d0d' : '#ffffff';
 
   return (
     <div
@@ -44,7 +43,7 @@ export function ThemeToggle() {
               border: 'none',
               cursor: 'pointer',
               background: active ? 'var(--ctf-brand)' : 'transparent',
-              color: active ? activeText : 'var(--ctf-text-subtle)',
+              color: active ? 'var(--ctf-brand-text)' : 'var(--ctf-text-subtle)',
             }}
           >
             {option.label}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Resolves both open `code-review` findings on `components/theme/theme-toggle.tsx`.

Closes #1311
Closes #1312

## The findings

- **#1312 (low):** the active button's text color was hard-coded hex (`#0d0d0d` / `#ffffff`), bypassing the CSS-variable token system — it could drift from the design tokens or fail contrast if the brand color changed.
- **#1311 (medium):** that color was computed once from the current theme (`activeText`) and applied to whichever button was active. Only coincidentally correct today; fragile if a third theme were added or during an async theme update.

## The fix

Both are resolved by the same change: add a per-theme **`--ctf-brand-text`** token next to `--ctf-brand` in `globals.css` (white on the pink default brand, near-black on the gold comic brand), and have the active button use `var(--ctf-brand-text)`.

The active button is always filled with `--ctf-brand` of the current theme, so the CSS cascade resolves the correct contrasting text color for free — no hard-coded hex (#1312) and no per-button/outer-theme JS (#1311). A future theme just adds its own `--ctf-brand-text`.

## Checks

`@ctf/web` lint, typecheck, and EOF pass. No backend, schema, or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_