### PR TITLE
fix: add a back button to the ClickLog empty state (mobile + desktop)

### DIFF
--- a/ctf/packages/web/components/click-log/click-log-empty-state.tsx
+++ b/ctf/packages/web/components/click-log/click-log-empty-state.tsx
@@ -2,7 +2,8 @@
 
 // STATE: Authenticated, no incidents logged yet. Ported from
 // design/.../survivor-hub/ClickLogEmpty.tsx.
-import { AlertTriangle } from "lucide-react";
+import Link from "next/link";
+import { AlertTriangle, ChevronLeft } from "lucide-react";
 import { BG, BORDER, BRAND, SUBTLE, SURFACE, TEXT } from "./click-log-shared";
 
 const STEPS = [
@@ -14,7 +15,17 @@ const STEPS = [
 export function ClickLogEmptyState({ onLog }: { onLog: () => void }) {
   return (
     <div style={{ width: "100%", minHeight: "100vh", background: BG, fontFamily: "'Inter',system-ui", color: TEXT, display: "flex", flexDirection: "column" }}>
-      <div style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 28px", gap: 12, background: "#0D0F14", flexShrink: 0 }}>
+      <div style={{ height: 56, borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", padding: "0 16px", gap: 12, background: "#0D0F14", flexShrink: 0 }}>
+        {/* Back to /apps — the empty state renders full-screen before the shell's
+            own back chrome, so without this a member with no incidents (common on
+            mobile) has no way back to the launcher. */}
+        <Link
+          href="/apps"
+          aria-label="Back to apps"
+          style={{ width: 38, height: 38, borderRadius: 10, background: `${BRAND}20`, border: `1px solid ${BRAND}40`, display: "flex", alignItems: "center", justifyContent: "center", color: BRAND, textDecoration: "none", flexShrink: 0 }}
+        >
+          <ChevronLeft size={20} />
+        </Link>
         <AlertTriangle size={18} color={BRAND} />
         <div>
           <div style={{ fontSize: 15, fontWeight: 600 }}>ClickLog</div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## The bug (from the iOS/mobile-web screenshot)

The authenticated **ClickLog** screen with no incidents logged had no back-to-/apps button — on mobile-responsive web *and* desktop.

`ClickLogShell` short-circuits to the full-screen `ClickLogEmptyState` **before** its mobile/desktop chrome, and that empty state renders its own header with no back control. The *populated* ClickLog view already has a back button in its mobile header (`ClickLogShell` line 187), but the empty state — which is the default state, and the first thing you hit — bypassed it entirely.

## The fix

Added a back-to-/apps `Link` (chevron, accent square) as the first element of the empty state's header, matching the populated view's button. Because the empty state is used for both breakpoints, this fixes mobile and desktop at once.

## Scope check (is it systemic?)

I audited the other authenticated shells:

- **Workforce** also has an empty state, but it's `flex:1` content rendered *inside* the shell chrome, which already carries a back button — so it's fine.
- Every other shell's early return before its chrome is a transient `*Loading` view (no back needed).
- **Android**: the RN app has a persistent horizontal feature-pill nav at the top (always lets you switch back to Home), so there's no per-screen back gap there.

So ClickLog's empty state was the only real offender.

## Checks

`@ctf/web` lint, typecheck, EOF, and the pre-push web build pass. No backend, schema, or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_