### PR TITLE
fix: stop the GDP hero stats overflowing the card on mobile

### DIFF
--- a/ctf/packages/web/components/gdp/gdp-dashboard.tsx
+++ b/ctf/packages/web/components/gdp/gdp-dashboard.tsx
@@ -39,8 +39,8 @@ function GdpHero({ metrics }: { metrics: GdpMetrics }) {
   const isEstimate = metrics.isEstimate === true;
   return (
     <div style={{ marginBottom: 24, padding: "28px 32px", borderRadius: 20, background: `linear-gradient(135deg,${COLOR}20 0%,rgba(6,182,212,0.05) 100%)`, border: `1px solid ${COLOR}25` }}>
-      <div style={{ display: "flex", gap: 32, alignItems: "center" }}>
-        <div style={{ flex: 1 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 24, alignItems: "center" }}>
+        <div style={{ flex: "1 1 260px", minWidth: 0 }}>
           <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.1em", color: COLOR, textTransform: "uppercase", marginBottom: 8 }}>TI Skills Economy — Live</div>
           <div style={{ display: "flex", alignItems: "baseline", marginBottom: 8 }}>
             <div style={{ fontSize: 48, fontWeight: 900, color: "#F9FAFB", lineHeight: 1 }}>{metrics.currentValue || "—"}</div>
@@ -60,9 +60,9 @@ function GdpHero({ metrics }: { metrics: GdpMetrics }) {
           ) : null}
         </div>
         {stats.length > 0 ? (
-          <div style={{ display: "flex", gap: 12 }}>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
             {stats.map(({ v, l, c }) => (
-              <div key={l} style={{ textAlign: "center", background: "rgba(255,255,255,0.03)", borderRadius: 12, padding: "16px 20px", border: "1px solid rgba(255,255,255,0.06)" }}>
+              <div key={l} style={{ flex: "1 1 auto", minWidth: 96, textAlign: "center", background: "rgba(255,255,255,0.03)", borderRadius: 12, padding: "16px 20px", border: "1px solid rgba(255,255,255,0.06)" }}>
                 <div style={{ fontSize: 24, fontWeight: 800, color: c ?? COLOR }}>{v}</div>
                 <div style={{ fontSize: 11, color: "#6B7280" }}>{l}</div>
               </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## Problem

The GDP dashboard hero card laid its description text and the **Members / Active** stat boxes in a single non-wrapping flex row. On a phone the text column collapsed to a sliver (one or two words per line) and the fixed-size stat boxes pushed past the card's right edge (per the iOS screenshot — "Active users box overflows").

## Fix

Let the row wrap:
- the text column gets a flex-basis (`flex: 1 1 260px`), so on a narrow screen the stats drop to their own line **below** the text (and still sit beside it on desktop);
- the stat boxes may shrink/wrap (`flex: 1 1 auto`, `min-width: 96`, `flex-wrap`) instead of overflowing;
- reduced the row gap (32 → 24) to reclaim width.

## Checks

`@ctf/web` lint, typecheck, EOF, pre-push web build all pass. No backend/schema/contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_