### PR TITLE
fix: center Mood "Talk to someone" rail on mobile

### DIFF
--- a/ctf/packages/web/components/mood/mood-crisis-rail.tsx
+++ b/ctf/packages/web/components/mood/mood-crisis-rail.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useTheme } from "@/hooks/useTheme";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { getMoodTokens } from "./mood-shared";
 
 // Owner decision: instead of external crisis-hotline numbers, point a struggling member to the
@@ -23,9 +24,20 @@ const SUPPORT_LINKS = [
 
 export function MoodCrisisRail() {
   const { theme } = useTheme();
+  const isMobile = useIsMobile();
   const t = getMoodTokens(theme);
+  // Desktop: a fixed 280px right rail with a left divider. Mobile: it stacks
+  // below the content, so span the width and center it (capped so it does not
+  // stretch too wide on large phones/tablets) with a top divider instead — the
+  // fixed 280px width otherwise left-aligns the box with dead space on the right.
   return (
-    <aside style={{ width: 280, borderLeft: `1px solid ${t.BORDER}`, background: t.HEADER, padding: "20px 16px", flexShrink: 0 }}>
+    <aside
+      style={
+        isMobile
+          ? { width: "100%", maxWidth: 480, margin: "0 auto", borderTop: `1px solid ${t.BORDER}`, background: t.HEADER, padding: "20px 16px", boxSizing: "border-box" }
+          : { width: 280, borderLeft: `1px solid ${t.BORDER}`, background: t.HEADER, padding: "20px 16px", flexShrink: 0 }
+      }
+    >
       <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: t.MUTED, textTransform: "uppercase", marginBottom: 6 }}>Talk to someone</div>
       <div style={{ fontSize: 12, color: t.SUBTLE, lineHeight: 1.6, marginBottom: 12 }}>If you&apos;re struggling, reach a community member with mental-health expertise.</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>


### PR DESCRIPTION
On phone widths the Mood "Talk to someone" rail (`MoodCrisisRail`) stacked below the content but kept its fixed 280px desktop width, so the box was jammed to the left with dead space on the right (visible on iOS — see report).

Parity Status: web + mobile-responsive + android complete

## Change
`MoodCrisisRail` is now responsive:
- **Mobile:** spans the width and centers (capped at 480px so it doesn't over-stretch on large phones/tablets), with a top divider.
- **Desktop:** unchanged — the fixed 280px right rail with its left divider.

Layout-only change to a shipped screen (no schema, contract, API, or copy change). The React Native Android app has no equivalent rail, so nothing to change there.

## Verification
- web typecheck ✅, web lint ✅, EOF ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jbcGm5T7kbLWPnUQ9kopj)_