### PR TITLE
fix: stop mobile header controls clipping in installed iOS PWA

### DIFF
--- a/ctf/packages/web/app/globals.css
+++ b/ctf/packages/web/app/globals.css
@@ -107,6 +107,16 @@ body {
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
   background: var(--ctf-root-bg);
   color: var(--ctf-root-text);
+  /*
+   * Pin text to its authored size. iOS inflates text when the app is launched from the Home
+   * Screen (standalone display mode) but not in a normal Safari tab, so tight single-row layouts
+   * (notably the mobile plugin header) render a few pixels wider as an installed app and their
+   * trailing controls — the account menu, settings — get clipped by the root overflow guard:
+   * "content runs off in the installed app but not the browser." Locking text-size-adjust makes the
+   * installed app match the browser. Both the prefixed and unprefixed forms are set for coverage.
+   */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 /*

--- a/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
@@ -365,7 +365,7 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
               <ChevronLeft size={20} />
             </Link>
             <Share2 size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: t.TEXT, flex: 1 }}>SocketRelay</span>
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TEXT, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>SocketRelay</span>
             <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{openCount} open</Badge>
             <PluginAdminButton href="/admin/socket-relay" isAdmin={isAdmin} accent={t.ACCENT} />
             <MobileTopActions />

--- a/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
+++ b/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
@@ -249,7 +249,7 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
               <ChevronLeft size={20} />
             </Link>
             <Car size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1 }}>TrustTransport</span>
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>TrustTransport</span>
             <PluginAdminButton href="/admin/trust-transport" isAdmin={isAdmin} accent={t.ACCENT} />
             <MobileTopActions />
           </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## What and why

When the web app is added to the iOS Home Screen and launched as an installed app (standalone display mode), the top row of the mobile plugin header runs off the right edge — the trailing controls (account menu, settings, and on some plugins the admin/bug buttons) are clipped. Visiting the same page directly in the browser is fine. Reported on SocketRelay and TrustTransport; it affects every plugin's mobile header.

Cause: iOS applies automatic text-size adjustment to installed (Home Screen) web apps that it does not apply to a normal Safari tab. That inflates the header text a few pixels, so a single-row header that just fits in the browser tips past the viewport width in the installed app, and the root `overflow-x: hidden` guard clips the trailing controls.

## Changes

- **`app/globals.css`** — pin `-webkit-text-size-adjust` / `text-size-adjust` to `100%` on `html, body`, so the installed app renders text at the same size as the browser. This is the app-wide fix; it applies to every plugin header at once.
- **SocketRelay and TrustTransport mobile headers** — give the brand title `min-width: 0` with ellipsis truncation so the flexible title yields space to the fixed trailing controls instead of pushing them past the edge. Belt-and-suspenders on the two headers reported; the trailing control cluster keeps its existing `flex-shrink: 0` so those controls stay put.

## Scope notes

CSS/responsive only — no schema, route, contract, money, or auth changes. The Android app uses native headers and is unaffected, so there is no Android counterpart to port. Verified with web typecheck, lint, and EOF formatting; final confirmation of the standalone behavior is best checked on a real iOS Home Screen install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msnz5NmzqkdpZiH6WfQw6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msnz5NmzqkdpZiH6WfQw6S)_