### PR TITLE
fix: keep the share popup inside the viewport on phone widths

### DIFF
--- a/ctf/packages/web/components/shared/share-link.tsx
+++ b/ctf/packages/web/components/shared/share-link.tsx
@@ -67,6 +67,10 @@ export function ShareLink({
   // The popup opens above the trigger by default, but flips below when the trigger sits near the top
   // of the viewport — otherwise the popup is clipped behind the header (the "modal doesn't fit" bug).
   const [placement, setPlacement] = useState<"top" | "bottom">("top");
+  // Same idea horizontally: the popup grows rightward from the trigger's left edge by default, but a
+  // trigger near the right edge of the viewport (the usual header position) would push it off-screen
+  // and force the whole page into horizontal scroll — so it flips to grow leftward instead.
+  const [align, setAlign] = useState<"left" | "right">("left");
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const urlRef = useRef<HTMLInputElement>(null);
@@ -79,8 +83,14 @@ export function ShareLink({
     // Decide which way to open: if there isn't room for the popup above the trigger, open below.
     // ~190px covers the popup (title + URL field + two rows + padding).
     const POPUP_HEIGHT = 190;
-    const triggerTop = triggerRef.current?.getBoundingClientRect().top ?? POPUP_HEIGHT + 1;
+    const POPUP_WIDTH = 280;
+    const rect = triggerRef.current?.getBoundingClientRect();
+    const triggerTop = rect?.top ?? POPUP_HEIGHT + 1;
     setPlacement(triggerTop < POPUP_HEIGHT + 16 ? "bottom" : "top");
+    // And which way to grow: right-align the popup when growing rightward would cross the viewport's
+    // right edge (which forces the page into horizontal scroll on a phone).
+    const triggerLeft = rect?.left ?? 0;
+    setAlign(triggerLeft + POPUP_WIDTH > window.innerWidth - 16 ? "right" : "left");
     // Focus the URL field so a keyboard/AT user lands on the link itself.
     urlRef.current?.focus();
     urlRef.current?.select();
@@ -162,7 +172,7 @@ export function ShareLink({
             ...(placement === "top"
               ? { bottom: "calc(100% + 8px)" }
               : { top: "calc(100% + 8px)" }),
-            left: 0,
+            ...(align === "right" ? { right: 0 } : { left: 0 }),
             zIndex: 50,
             width: 280,
             maxWidth: "80vw",


### PR DESCRIPTION
## What

On a phone, opening the Share control on a profile pushed the whole page into horizontal scroll — the share popup was rendered partly off the right edge of the screen and the left side of the page was cut off.

## Why

The shared `ShareLink` popup (`components/shared/share-link.tsx`) was always anchored to the trigger's **left** edge and grew 280px rightward. The Share button sits at the top-right of the header, so on a ~390px viewport the popup crossed the right edge, widening the page.

## Fix

The component already flips vertically (opens below when the trigger is near the top). This mirrors that horizontally: when growing rightward would cross the viewport's right edge (with a 16px margin), the popup right-aligns to the trigger and grows leftward instead. One state variable, computed from the trigger's position when the popup opens.

Applies everywhere `ShareLink` is used: directory profile detail, foundation provider page, socket-relay feed.

## Verification

Web typecheck (cross-package commit gate), lint, and EOF format all pass locally.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_019EDu3sYB3PBN3EWbnkWzd7)_