### PR TITLE
fix: stop the demo banner covering admin nav on mobile (reserve space)

### DIFF
--- a/ctf/packages/web/components/shared/admin-demo-banner.module.css
+++ b/ctf/packages/web/components/shared/admin-demo-banner.module.css
@@ -1,0 +1,30 @@
+.banner {
+  /* Desktop: the admin shells own a fixed 100dvh internal scroll area (globals.css
+     locks html/body to 100vh + overflow:hidden), so the banner overlays as a fixed
+     element and never shifts that layout. */
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10000;
+  background: #b45309;
+  color: #ffffff;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: 'Inter', system-ui, sans-serif;
+  text-align: center;
+  line-height: 1.35;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.35);
+}
+
+/* Phones: the document scrolls and the admin shells are min-height, so the banner
+   sits in normal flow (sticky) and RESERVES its own height instead of overlaying.
+   A fixed overlay here covered the shell's header and its back button — and an
+   app saved to the Home Screen has no browser back, so there was no way out. */
+@media (max-width: 767px) {
+  .banner {
+    position: sticky;
+  }
+}

--- a/ctf/packages/web/components/shared/admin-demo-banner.tsx
+++ b/ctf/packages/web/components/shared/admin-demo-banner.tsx
@@ -1,33 +1,18 @@
-// Loud, fixed banner shown across every /admin screen when the signed-in operator is a demo
-// participant. Admin tools (approve, retry rewards, mint, burn) run against whichever DB schema the
-// caller's demo flag selects (getActivePool -> isDemoMode), so a demo-mode operator can act on demo
-// data without realising it — e.g. a governance burn that hits an empty demo wallet and fails as
-// "Insufficient balance.". This makes the demo context impossible to miss. Rendered only in demo mode,
-// so the normal production operator view is unchanged. Fixed-position so it never shifts a shell's
-// own 100dvh layout.
+import styles from './admin-demo-banner.module.css';
+
+// Loud banner shown across every /admin screen when the signed-in operator is a demo participant.
+// Admin tools (approve, retry rewards, mint, burn) run against whichever DB schema the caller's demo
+// flag selects (getActivePool -> isDemoMode), so a demo-mode operator can act on demo data without
+// realising it — e.g. a governance burn that hits an empty demo wallet and fails as "Insufficient
+// balance.". This makes the demo context impossible to miss. Rendered only in demo mode, so the normal
+// production operator view is unchanged.
+//
+// Positioning (see the CSS module): fixed/overlay on desktop so it never shifts a shell's fixed 100dvh
+// layout; sticky/in-flow on phones so it reserves its own height instead of covering the shell's header
+// and back button (an installed PWA has no browser back to fall back on).
 export function AdminDemoBanner() {
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        zIndex: 10000,
-        background: '#B45309',
-        color: '#FFFFFF',
-        padding: '7px 16px',
-        fontSize: 13,
-        fontWeight: 700,
-        fontFamily: "'Inter', system-ui, sans-serif",
-        textAlign: 'center',
-        lineHeight: 1.35,
-        boxShadow: '0 2px 10px rgba(0,0,0,0.45)',
-        borderBottom: '1px solid rgba(0,0,0,0.35)',
-      }}
-    >
+    <div role="status" aria-live="polite" className={styles.banner}>
       ⚠ Demo mode — you are acting on demo data, not production. Approvals, reward retries, mints, and
       burns here change the demo schema only. Turn off demo mode to operate production.
     </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## The bug (from the iOS screenshot)

The demo-mode banner was `position: fixed` with no reserved space, so on a phone it overlaid the admin screen's header — including the one-level-up **back button**. An app saved to the Home Screen (standalone PWA) has no browser back, so there was **no way to leave the screen**.

## The fix

Moved the banner's styles to a CSS module and made it **`position: sticky` on phones** (`max-width: 767px`) — where the document scrolls and the admin shells are `min-height`. Sticky reserves its own height in normal flow, so the admin shell (and its back button) now render **below** the banner instead of under it, and the banner still stays pinned while scrolling.

On **desktop** it stays **fixed/overlay**, because the admin shells own a fixed `100dvh` internal scroll area (`globals.css` locks `html/body` to `100vh; overflow: hidden`) and must not be shifted. Text and behavior are otherwise unchanged.

## Checks

`@ctf/web` lint, typecheck, EOF, and the pre-push web build pass. No backend, schema, or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_