### PR TITLE
fix: make the demo seed's Chyme messages and GentlePulse play event idempotent

### DIFF
--- a/ctf/docs/developer/demo-seed-notes.md
+++ b/ctf/docs/developer/demo-seed-notes.md
@@ -39,6 +39,12 @@ The seed is safe to re-run (every statement upserts on a natural key or a determ
 id). All second-owner records use per-owner ids (`sha256id(...)`) and conflict on natural
 keys, so they never collide with the fixed demo UUIDs used for the first owner.
 
+The two remaining plain inserts were made idempotent: the demo Chyme messages and the
+GentlePulse play event now use deterministic ids with `ON CONFLICT (id) DO NOTHING`
+(both tables have only a uuid primary key, no natural unique key), so re-running no longer
+appends duplicate rows. Verified against a local Postgres: `chyme_messages` stays at 3 and
+`gentle_pulse_play_events` stays at 1 across repeated runs.
+
 The what-works seed was corrected to upsert problems on their `slug` (the table's unique
 key) and endorsements on `(product_id, user_id)`, rather than on `id`. Previously a
 pre-existing row with the same slug but a different id was not caught and aborted the whole

--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -679,9 +679,12 @@ async function seedGentlePulse(c) {
 
   // Owner played and rated the first item
   await c.query(
-    `INSERT INTO gentle_pulse_play_events (user_id, item_id, completed)
-     VALUES ($1, $2::uuid, true)`,
-    [OWNER, ID.gpItem1],
+    // Deterministic id + ON CONFLICT so a re-run does not append another play
+    // event (the table has only a uuid pk, no natural unique key).
+    `INSERT INTO gentle_pulse_play_events (id, user_id, item_id, completed)
+     VALUES ($1::uuid, $2, $3::uuid, true)
+     ON CONFLICT (id) DO NOTHING`,
+    [sha256id('gp-play', OWNER, ID.gpItem1), OWNER, ID.gpItem1],
   );
 
   await c.query(
@@ -772,11 +775,15 @@ async function seedChyme(c) {
     [OWNER, 'Thanks! Just exploring the platform. Looks great.'],
     [PEER_1, 'Let me know if you have any questions about how it works.'],
   ];
-  for (const [uid, text] of messages) {
+  for (const [index, [uid, text]] of messages.entries()) {
+    // Deterministic id + ON CONFLICT so re-running the seed does not append a
+    // duplicate copy of each demo message every time (chyme_messages has only a
+    // uuid pk, no natural unique key).
     await c.query(
-      `INSERT INTO chyme_messages (room_id, user_id, username, text)
-       VALUES ($1::uuid, $2, $3, $4)`,
-      [ID.room, uid, memberUsernames[uid] ?? 'demo_user', text],
+      `INSERT INTO chyme_messages (id, room_id, user_id, username, text)
+       VALUES ($1::uuid, $2::uuid, $3, $4, $5)
+       ON CONFLICT (id) DO NOTHING`,
+      [sha256id('chyme-demo-msg', ID.room, String(index)), ID.room, uid, memberUsernames[uid] ?? 'demo_user', text],
     );
   }
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Follow-up to the demo-seed work: the two remaining plain `INSERT`s in `seedDemo.mjs` — the demo **Chyme messages** and the **GentlePulse play event** — appended duplicate rows on every re-run (3 more Chyme messages and 1 more play event each time). Both tables have only a uuid primary key and no natural unique key, so each row now gets a deterministic `sha256id` and `ON CONFLICT (id) DO NOTHING`.

Now the whole seed is fully idempotent. **Verified on a local Postgres:** after three runs, `demo.chyme_messages` stays at 3 and `demo.gentle_pulse_play_events` stays at 1 (previously 9 and 3).

Documented in `ctf/docs/developer/demo-seed-notes.md` (satisfies the schema-drift gate's versioning-note requirement for a seed-only change). No schema, contract, or route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_