### PR TITLE
fix: demo seed level-up enrollment conflicts on id, not the missing composite unique

### DIFF
--- a/ctf/docs/developer/demo-seed-notes.md
+++ b/ctf/docs/developer/demo-seed-notes.md
@@ -45,6 +45,15 @@ GentlePulse play event now use deterministic ids with `ON CONFLICT (id) DO NOTHI
 appends duplicate rows. Verified against a local Postgres: `chyme_messages` stays at 3 and
 `gentle_pulse_play_events` stays at 1 across repeated runs.
 
+The second-owner Level-Up enrollment conflicts on the primary key (a deterministic
+per-owner id), not on `(cohort_id, user_id)`. That composite unique is missing from the
+live `demo` schema: its backfill in `schema.sql` runs inside a `DO` block that checks
+`pg_indexes` without a `schemaname` filter, so in the demo schema (search_path
+`demo,public`) it sees the `public` schema's index and skips creating the demo one. Using
+the primary key avoids depending on a constraint the demo schema lacks. (Separate follow-up:
+fix that `DO` block to qualify the `pg_indexes` check by `schemaname` so the demo schema
+gets its own composite unique index.)
+
 The what-works seed was corrected to upsert problems on their `slug` (the table's unique
 key) and endorsements on `(product_id, user_id)`, rather than on `id`. Previously a
 pre-existing row with the same slug but a different id was not caught and aborted the whole

--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -317,13 +317,17 @@ async function seedLevelUp(c) {
   );
 
   if (OWNER2) {
-    // Second participant in the same cohort — conflict on the natural key
-    // (cohort_id, user_id), with a per-owner id so it never collides on the pk.
+    // Second participant in the same cohort. Conflict on the primary key with a
+    // deterministic per-owner id (like the owner enrollment above), NOT on
+    // (cohort_id, user_id): that composite unique is absent from the live demo
+    // schema (its backfill DO block checks pg_indexes without a schemaname filter,
+    // so it sees the public-schema index and skips creating the demo one). The
+    // deterministic id keeps this idempotent and needs no extra constraint.
     await c.query(
       `INSERT INTO level_up_enrollments
        (id, cohort_id, user_id, status, credits_deposited, assigned_trainer_id)
        VALUES ($1::uuid, $2::uuid, $3, 'active', 300, $4)
-       ON CONFLICT (cohort_id, user_id) DO UPDATE SET
+       ON CONFLICT (id) DO UPDATE SET
          status = EXCLUDED.status, credits_deposited = EXCLUDED.credits_deposited`,
       [sha256id('lu-enrollment', OWNER2), ID.cohort, OWNER2, TRAINER],
     );


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## The failure

The latest **Demo — Seed Schema** run failed in `seedLevelUp`:

```
seed:demo failed: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

The second-owner Level-Up enrollment (added with the two-sided demo support) upserted on `ON CONFLICT (cohort_id, user_id)`, but that composite unique is **absent from the live `demo` schema**. Its backfill in `schema.sql` runs inside a `DO` block that checks `pg_indexes` **without a `schemaname` filter**, so under `search_path=demo,public` it finds the *public* schema's index and skips creating the demo one. The owner enrollment already conflicts on the primary key, which is why only the second-owner insert failed.

## The fix

Switch the second-owner enrollment to `ON CONFLICT (id)` with its deterministic per-owner id (same shape as the owner enrollment) — idempotent and needs no extra constraint.

**Reproduced the live condition locally** (apply the demo schema, drop the demo composite index, then seed): fails before, passes after, and re-running enrolls the second owner exactly once.

## Follow-up (noted, not in this PR)

The real root cause is the schema `DO` block that detects index existence without qualifying by `schemaname`, so the demo schema never gets several of its backfilled indexes. Worth fixing separately so the demo schema matches prod — but out of scope for unblocking the seed.

No schema/contract/route change; documented in `ctf/docs/developer/demo-seed-notes.md` (satisfies the schema-drift versioning-note gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_