### PR TITLE
feat: add prod/demo target choice to Delete Account workflow

### DIFF
--- a/.github/workflows/delete-account.yml
+++ b/.github/workflows/delete-account.yml
@@ -10,6 +10,11 @@ name: Delete Account (manual)
 # wrong person), then Run. Set "also_delete_clerk" to false to delete only the database data and keep
 # the Clerk account.
 #
+# target: choose "prod" (default) to delete from the live schema, or "demo" to wipe a demo test
+# account from the demo schema — the deletion runs the exact same registry/orchestrator flow, just
+# pinned to the chosen schema. The Clerk identity is a single shared instance (not per-schema), so
+# also_delete_clerk removes it regardless of target; that is what frees the email for a fresh sign-up.
+#
 # What it needs (Settings → Secrets and variables → Actions):
 #   NEXT_PUBLIC_APP_URL secret — your production base URL (same secret the other workflows use).
 #   ACCOUNT_DELETE_SECRET secret — a NEW secret you generate (e.g. `openssl rand -hex 32`). Set the
@@ -33,6 +38,14 @@ on:
         description: 'Also delete the Clerk identity (set false to delete only the database data).'
         type: boolean
         default: true
+        required: false
+      target:
+        description: 'Which database to delete from: prod (default) or demo. Pick "demo" to fully wipe a demo test account. Clerk identity is shared, so also_delete_clerk removes it regardless.'
+        type: choice
+        options:
+          - prod
+          - demo
+        default: prod
         required: false
 
 permissions:
@@ -65,6 +78,7 @@ jobs:
           ACCOUNT_DELETE_SECRET: ${{ secrets.ACCOUNT_DELETE_SECRET }}
           USER_ID: ${{ github.event.inputs.user_id }}
           DELETE_CLERK: ${{ github.event.inputs.also_delete_clerk }}
+          TARGET: ${{ github.event.inputs.target }}
         run: |
           set -euo pipefail
           if [ -z "${APP_URL:-}" ]; then
@@ -75,11 +89,16 @@ jobs:
             echo "::error::ACCOUNT_DELETE_SECRET is not set in GitHub Actions secrets. Add it here AND match it in the app runtime, then re-run. Nothing was deleted."
             exit 1
           fi
+          # Normalize the target to what the route expects: "demo" wipes the demo schema, anything
+          # else (default) targets production.
+          TARGET_VALUE="prod"
+          if [ "${TARGET:-prod}" = "demo" ]; then TARGET_VALUE="demo"; fi
+          echo "Deleting from: ${TARGET_VALUE} schema"
           code=$(curl -sS -o /tmp/delete.json -w '%{http_code}' -X POST \
             "${APP_URL%/}/api/internal/account/delete" \
             -H "Authorization: Bearer ${ACCOUNT_DELETE_SECRET}" \
             -H 'Content-Type: application/json' \
-            -d "{\"userId\":\"${USER_ID}\",\"deleteClerk\":${DELETE_CLERK}}")
+            -d "{\"userId\":\"${USER_ID}\",\"deleteClerk\":${DELETE_CLERK},\"target\":\"${TARGET_VALUE}\"}")
           echo "HTTP ${code}"
           cat /tmp/delete.json
           echo
@@ -87,4 +106,4 @@ jobs:
             echo "::error::Account delete failed (HTTP ${code}). Read the JSON above: code 'account_delete_not_configured' = ACCOUNT_DELETE_SECRET missing in the app runtime; HTTP 403 = the secret here does not match the app runtime value; code 'account_delete_failed' means the deletion itself threw — its 'step' (reclaim_request | data_deletion) and 'detail' fields say why."
             exit 1
           fi
-          echo "Deleted account ${USER_ID}: $(cat /tmp/delete.json)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Deleted account ${USER_ID} from ${TARGET_VALUE} schema: $(cat /tmp/delete.json)" >> "$GITHUB_STEP_SUMMARY"

--- a/ctf/packages/web/app/api/internal/account/delete/route.ts
+++ b/ctf/packages/web/app/api/internal/account/delete/route.ts
@@ -3,6 +3,7 @@ import { createClerkClient } from '@clerk/backend';
 import { markFullAccountDeletionRequested } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { deleteAllAccountData } from 'lib/account/deletion-orchestrator';
+import { runWithForcedPool } from 'lib/db/postgres';
 import { getClerkSecretKey } from 'lib/auth/clerk-env';
 import { reportError } from 'lib/observability/report';
 
@@ -42,9 +43,9 @@ export async function POST(request: Request) {
     );
   }
 
-  let body: { userId?: unknown; deleteClerk?: unknown };
+  let body: { userId?: unknown; deleteClerk?: unknown; target?: unknown };
   try {
-    body = (await request.json()) as { userId?: unknown; deleteClerk?: unknown };
+    body = (await request.json()) as { userId?: unknown; deleteClerk?: unknown; target?: unknown };
   } catch {
     body = {};
   }
@@ -59,13 +60,24 @@ export async function POST(request: Request) {
   // `{ "deleteClerk": false }` to delete only the database data and keep the Clerk account.
   const deleteClerk = body.deleteClerk !== false;
 
+  // Which database schema's rows to delete. An internal call has no signed-in user, so demo-mode
+  // targeting never applies here — without this it would always hit production. `target: "demo"`
+  // pins the whole deletion to the demo schema (via runWithForcedPool) so a demo test account can be
+  // fully wiped, using the exact same registry/orchestrator flow as production. Anything other than
+  // "demo" (including the default) targets production. The Clerk identity is global (one instance),
+  // so `deleteClerk` is independent of this.
+  const target = body.target === 'demo' ? 'demo' : 'public';
+  const targetLabel = target === 'demo' ? 'demo' : 'production';
+
   // Track which step is running so a failure response can say whether the ServiceCredits reclaim
   // request or the data deletion threw — the generic 503 alone was undiagnosable from the Actions log.
   let step = 'reclaim_request';
   try {
-    const reclaim = await markFullAccountDeletionRequested(userId);
-    step = 'data_deletion';
-    const deletion = await deleteAllAccountData(userId, reclaim.requestedAtIso);
+    const deletion = await runWithForcedPool(target, async () => {
+      const reclaim = await markFullAccountDeletionRequested(userId);
+      step = 'data_deletion';
+      return deleteAllAccountData(userId, reclaim.requestedAtIso);
+    });
 
     let clerkDeleted = false;
     let clerkError: string | null = null;
@@ -91,7 +103,7 @@ export async function POST(request: Request) {
       actorId: OPERATOR_ACTOR_ID,
       status: 'allow',
       reason: 'operator_account_deletion',
-      target: { scope: 'account', userId, clerkDeleted: String(clerkDeleted) },
+      target: { scope: 'account', userId, schema: targetLabel, clerkDeleted: String(clerkDeleted) },
       result: 'success',
       errorCategory: null,
     });
@@ -100,6 +112,7 @@ export async function POST(request: Request) {
       ok: true,
       userId,
       scope: 'account',
+      schema: targetLabel,
       status: 'completed',
       tablesAffected: deletion.tables.length,
       requestedAtIso: deletion.requestedAtIso,
@@ -115,7 +128,7 @@ export async function POST(request: Request) {
       actorId: OPERATOR_ACTOR_ID,
       status: 'allow',
       reason: 'operator_account_deletion',
-      target: { scope: 'account', userId, step },
+      target: { scope: 'account', userId, schema: targetLabel, step },
       result: 'failure',
       errorCategory: 'persistence_error',
     });

--- a/ctf/packages/web/lib/db/postgres.ts
+++ b/ctf/packages/web/lib/db/postgres.ts
@@ -1,7 +1,25 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { Pool, type PoolClient, type QueryResult, type QueryResultRow } from 'pg';
 
 let publicPool: Pool | null = null;
 let demoPool: Pool | null = null;
+
+// Request-scoped override that pins EVERY query in the wrapped callback to a
+// specific schema, ignoring the usual per-user demo-mode targeting. This is for
+// trusted server-only operations that must act on a chosen schema regardless of
+// (or in the absence of) a signed-in caller — e.g. the operator account-delete
+// route, which runs with a bearer secret and no Clerk session, and must be able
+// to delete a DEMO account's rows even though an internal call would otherwise
+// always resolve to the public pool. AsyncLocalStorage makes this concurrency-safe
+// (each request carries its own store) rather than a shared mutable global.
+type ForcedPoolTarget = 'demo' | 'public';
+const forcedPoolStore = new AsyncLocalStorage<ForcedPoolTarget>();
+
+// Run `fn` with every DB query pinned to the chosen schema's pool. Trusted callers
+// only — this bypasses demo-mode access control by design.
+export function runWithForcedPool<T>(target: ForcedPoolTarget, fn: () => Promise<T>): Promise<T> {
+  return forcedPoolStore.run(target, fn);
+}
 
 function getDatabaseUrl(): string {
   const databaseUrl = process.env.DATABASE_URL;
@@ -61,6 +79,16 @@ function getDemoPool(): Pool {
 // plain-node consumers (seed scripts, migrations) never pull Next-only deps into
 // their import graph; if it can't load or there is no request scope, we use public.
 async function getActivePool(): Promise<Pool> {
+  // An explicit forced target (runWithForcedPool) wins over demo-mode targeting —
+  // it is the authoritative choice made by a trusted operator path.
+  const forced = forcedPoolStore.getStore();
+  if (forced === 'demo') {
+    return getDemoPool();
+  }
+  if (forced === 'public') {
+    return getPublicPool();
+  }
+
   try {
     const { isDemoMode } = await import('../feature-flags/system');
     if (await isDemoMode()) {


### PR DESCRIPTION
## What this changes

The manual **Delete Account (manual)** GitHub Actions workflow could only ever delete from the production schema. An internal call has no signed-in user, and demo-mode targeting only applies to a signed-in participant, so the deletion always resolved to the public pool. That left no way to fully wipe a demo test account — its unlock row, wallet, requests, thread membership, etc. — which is needed to re-create the same email in a demo after a bug interrupts a sign-up walkthrough.

This adds a **`target`** choice to the workflow (`prod` default, or `demo`):

- `.github/workflows/delete-account.yml` — new `target` choice input; the curl body now sends `"target":"prod|demo"`.
- `ctf/packages/web/app/api/internal/account/delete/route.ts` — reads `body.target`; pins the whole deletion (reclaim request + orchestrator data deletion) to the chosen schema via `runWithForcedPool`; reports the schema in the response and both audit records.
- `ctf/packages/web/lib/db/postgres.ts` — new `runWithForcedPool(target, fn)` helper: an `AsyncLocalStorage` request-scoped override that makes every query in the callback use the demo or public pool, ignoring the usual per-user demo-mode targeting. `getActivePool()` honours a forced target before falling back to demo-mode.

The deletion runs the **exact same** registry/orchestrator flow either way — only the schema is pinned. The Clerk identity is a single shared instance (not per-schema), so `also_delete_clerk` removes it regardless of target; that is what frees the email for a fresh sign-up.

## Why owner review (not auto-merge)

This modifies the irreversible account-deletion path, so it is opened for owner review rather than auto-merge.

## Testing

- `bash ctf/scripts/check-eof-format.sh` — passes
- `pnpm --filter @ctf/web lint` — passes
- `pnpm --filter @ctf/web typecheck` — passes
- Pre-push typecheck + build gate — passes

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_