### PR TITLE
fix: self-heal orphaned mood check-ins before enforcing demo foreign key

### DIFF
--- a/ctf/docs/developer/demo-seed-notes.md
+++ b/ctf/docs/developer/demo-seed-notes.md
@@ -86,6 +86,27 @@ run and a repeated public run are idempotent (constraint counts unchanged, no er
 `information_schema.columns` guards that already carried `table_schema = 'public'` are left
 alone — `migrateToDemo` rewrites that literal to the target schema for them.
 
+### Follow-on: mood_submissions FK self-heal on the demo schema
+
+Adding the missing constraints to the existing demo schema surfaced a latent data problem the
+skipped guard had been hiding. The `mood_submissions_pseudonym_fkey` foreign key
+(`mood_submissions.pseudonym → mood_client_identities.pseudonym`) had never been enforced on
+the demo schema, and the demo `mood_submissions` table had accumulated a check-in row whose
+`pseudonym` had no matching mapping row. With the guard now schema-scoped, the `ALTER TABLE …
+ADD CONSTRAINT` finally ran on demo and failed validation against that orphan
+(`insert or update on table "mood_submissions" violates foreign key constraint …`).
+
+The mood backfill deliberately severs the direct `user_id` link and repoints each check-in onto
+a mapping pseudonym, so a row can be stranded if its mapping row is ever missing. The FK-add
+guard now self-heals first: when the constraint is absent it inserts a server-controlled mapping
+for every orphan pseudonym (`user_id` set to the pseudonym text — always unique, never a real
+Clerk id) before adding the FK, so no check-in is lost and `ON DELETE CASCADE` still deletes it
+through the mapping. The heal sits inside the `IF NOT EXISTS (… pg_constraint …)` guard, so on a
+schema that already enforces the FK (steady-state production) the whole block is skipped and no
+mapping rows are invented. Verified locally: reproducing the orphan state (FK dropped, orphan
+row inserted) and re-provisioning heals it — FK added, orphan preserved, cascade-delete works,
+idempotent on re-run.
+
 The what-works seed was corrected to upsert problems on their `slug` (the table's unique
 key) and endorsements on `(product_id, user_id)`, rather than on `id`. Previously a
 pre-existing row with the same slug but a different id was not caught and aborted the whole

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -3463,6 +3463,23 @@ UPDATE mood_submissions SET user_id = '' WHERE pseudonym IS NOT NULL AND user_id
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'mood_submissions_pseudonym_fkey' AND connamespace = current_schema()::regnamespace) THEN
+    -- Self-heal orphaned check-ins before enforcing the FK. The backfill above
+    -- severs the direct user_id link and repoints rows onto a mapping pseudonym,
+    -- so a submission whose pseudonym has no mapping row (an orphan left by
+    -- earlier data churn, or by a schema that never enforced this FK) would make
+    -- the ADD CONSTRAINT below fail on existing data. Give each orphan its own
+    -- server-controlled mapping — user_id is set to the pseudonym text, which is
+    -- always unique and can never be a real Clerk id — so no check-in is lost and
+    -- ON DELETE CASCADE still deletes it through the mapping. This runs only when
+    -- the FK is absent, so on a schema that already enforces it (steady-state
+    -- production) the whole block is skipped and no mapping rows are invented.
+    INSERT INTO mood_client_identities (pseudonym, user_id)
+    SELECT DISTINCT s.pseudonym, s.pseudonym::text
+    FROM mood_submissions s
+    LEFT JOIN mood_client_identities m ON m.pseudonym = s.pseudonym
+    WHERE s.pseudonym IS NOT NULL AND m.pseudonym IS NULL
+    ON CONFLICT DO NOTHING;
+
     ALTER TABLE mood_submissions
       ADD CONSTRAINT mood_submissions_pseudonym_fkey
       FOREIGN KEY (pseudonym) REFERENCES mood_client_identities(pseudonym) ON DELETE CASCADE;


### PR DESCRIPTION
## What failed

The **Demo — Seed Schema** workflow ([run 28717697681](https://github.com/chargingthefuture/chargingthefuture/actions/runs/28717697681/job/85161891394)) failed at the "Bring the demo schema up to date" step:

```
ERROR: insert or update on table "mood_submissions" violates foreign key constraint "mood_submissions_pseudonym_fkey"
DETAIL: Key (pseudonym)=(935192c3-…) is not present in table "mood_client_identities".
CONTEXT: ALTER TABLE mood_submissions ADD CONSTRAINT mood_submissions_pseudonym_fkey …
```

## Why

This is a latent data problem that the previous fix (#1352) **exposed**, not a regression. Before #1352 the `mood_submissions_pseudonym_fkey` foreign key was never actually added to the demo schema (the name-only existence guard matched the identically-named constraint in `public` and skipped it). Now that the guard is schema-scoped, the `ALTER TABLE … ADD CONSTRAINT` finally runs on demo — and the demo `mood_submissions` table had accumulated a check-in row whose `pseudonym` has no matching `mood_client_identities` mapping, so validating the FK against existing data fails.

The mood backfill deliberately severs the direct `user_id` link and repoints each check-in onto a mapping pseudonym, so a row can be stranded if its mapping row is ever missing.

## The fix

Self-heal orphaned check-ins **before** enforcing the FK, inside the existing `IF NOT EXISTS (… pg_constraint …)` guard: when the constraint is absent, insert a server-controlled mapping for every orphan pseudonym (`user_id` set to the pseudonym text — always unique, never a real Clerk id) before the `ALTER TABLE`. No check-in is lost and `ON DELETE CASCADE` still deletes it through the mapping.

Because the heal lives inside the guard, a schema that already enforces the FK (steady-state production) **skips the whole block** and invents no mapping rows — it is a no-op there.

## Testing (local Postgres 16)

Reproduced the exact CI state and verified the fix:
- Provisioned `public` + `demo`, dropped the demo FK, inserted an orphan `mood_submissions` row (pseudonym with no mapping) — the pre-fix state.
- Re-provisioned demo with the patched schema: **healed, no FK failure**. FK added; orphan submission preserved; a synthetic mapping created for the orphan pseudonym.
- Deleting the mapping row cascade-deletes the check-in (`ON DELETE CASCADE` intact).
- Re-provisioned again: idempotent, no errors.

## Schema Drift

- **Drift class:** DB-Migration Drift (edit to `ctf/schema.sql`) — adds a data-reconciliation `INSERT` inside the FK-add guard. No table/column/index/constraint added or removed.
- **Migration / rollback:** The reconciliation only runs when the FK is being added; rollback is reverting the commit. No-op in steady-state production.
- **Compatibility decision:** `compatible`. Production (FK already present) skips the block entirely; only a schema missing the FK is affected.
- **Affected contract versions:** none.
- **Docs updated:** `ctf/docs/developer/demo-seed-notes.md`.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_