### PR TITLE
fix: add mobile back link to AI Assistant review queue

### DIFF
--- a/ctf/packages/web/components/comic/comic-review-dashboard.module.css
+++ b/ctf/packages/web/components/comic/comic-review-dashboard.module.css
@@ -745,6 +745,25 @@
   cursor: pointer;
 }
 
+/* Mobile-only back link in the queue-list header. Hidden on desktop, where the left
+   icon rail already carries the back-to-apps control; shown at phone width (rail hidden). */
+.mobileRailBack {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  margin-bottom: 12px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid #1E2A3A;
+  color: #9CA3AF;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
 .visuallyHidden {
   position: absolute;
   width: 1px;
@@ -804,6 +823,10 @@
   }
 
   .mobileQueueBack {
+    display: inline-flex;
+  }
+
+  .mobileRailBack {
     display: inline-flex;
   }
 

--- a/ctf/packages/web/components/comic/comic-review-dashboard.tsx
+++ b/ctf/packages/web/components/comic/comic-review-dashboard.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import {
   AlertTriangle, ArrowLeft, Check, FileText, Inbox, Pencil, RotateCcw,
   ShieldCheck, Sparkles, X,
 } from 'lucide-react';
 import { PluginRailFooter } from '@/components/shared/plugin-rail-footer';
+import { resolveBackTarget } from '@/lib/nav/back-target';
 import type { ComicReviewItem, ComicTrainingStats } from '../../lib/comic/types';
 import styles from './comic-review-dashboard.module.css';
 
@@ -91,6 +94,11 @@ const REVIEWER_GUIDANCE = [
 ];
 
 export function ComicReviewDashboard() {
+  // At phone width the left icon rail (which carries "back to all apps") is hidden, so the queue
+  // list has no way out. Reuse the same one-level-up target the rail uses for a mobile-only back
+  // link in the queue header.
+  const pathname = usePathname();
+  const backTarget = resolveBackTarget(pathname);
   const [loadState, setLoadState] = useState<LoadState>('loading');
   const [items, setItems] = useState<ComicReviewItem[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -327,6 +335,11 @@ export function ComicReviewDashboard() {
       {/* Queue sidebar */}
       <aside className={styles.queueSidebar}>
         <div className={styles.queueHeader}>
+          {/* Mobile-only: the icon rail (with its back-to-apps control) is hidden at phone width,
+              so surface the same one-level-up link here. */}
+          <Link href={backTarget.href} className={styles.mobileRailBack}>
+            <ArrowLeft size={14} /> {backTarget.label}
+          </Link>
           <div className={styles.queueKicker}>Review Queue</div>
           <div className={styles.queueSub}>AI Assistant drafts awaiting human review</div>
           {trainingStats ? (


### PR DESCRIPTION
## What this fixes

On the AI Assistant review queue at phone width, there was no way back to the rest of the app — the "Review Queue" header started straight below the status bar with no back control (see report screenshot). The shared back-to-all-apps control lives in the left icon rail, and that rail is hidden at phone width, so the queue-list view had no exit.

## The fix

Add a mobile-only back link at the top of the queue header, shown only at phone width (`max-width: 900px`, where the icon rail is hidden). It reuses `resolveBackTarget(pathname)` so it points to the same one-level-up destination the rail uses (the admin directory for this admin surface), keeping web and rail navigation consistent. The detail pane already had its own "Back to queue" link, so both levels now have a back affordance on mobile: list → back to admin, detail → back to queue.

No desktop change — the new link is `display: none` above the breakpoint, where the rail's control is present.

## Parity

Android already shows a persistent top navigator (pill row) on every screen, so it always had a way back — this was a web mobile-responsive-only gap. No RN change needed.

## Testing

- `bash ctf/scripts/check-eof-format.sh` — passes
- `pnpm --filter @ctf/web lint` — passes
- `pnpm --filter @ctf/web typecheck` — passes

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_