### PR TITLE
fix: preserve original socket-relay message text on idempotent retry

### DIFF
--- a/ctf/packages/web/lib/socket-relay/repository.ts
+++ b/ctf/packages/web/lib/socket-relay/repository.ts
@@ -837,7 +837,7 @@ export async function sendFulfillmentMessage(
     `INSERT INTO socket_relay_messages (fulfillment_id, sender_user_id, message_text, client_message_id, moderation_status)
      VALUES ($1::uuid, $2, $3, $4, 'accepted')
      ON CONFLICT (fulfillment_id, sender_user_id, client_message_id)
-     DO UPDATE SET message_text = EXCLUDED.message_text
+     DO UPDATE SET message_text = socket_relay_messages.message_text
      RETURNING id, fulfillment_id, sender_user_id, message_text, moderation_status, created_at`,
     [fulfillmentId, actorUserId, normalizeText(messageText), normalizeText(clientMessageId)],
   );


### PR DESCRIPTION
## What

The socket-relay `sendFulfillmentMessage` INSERT … ON CONFLICT clause used `DO UPDATE SET message_text = EXCLUDED.message_text`. On an idempotent retry that carried a different `messageText` (for example, the client edited the body before retrying), that silently overwrote the already-stored message body, corrupting the canonical record.

## Change

Switch the conflict clause to a no-op update, `DO UPDATE SET message_text = socket_relay_messages.message_text`. On a retry the original persisted text is preserved, and `RETURNING` still returns the existing row (unlike `DO NOTHING`, which would return no row). One line in `ctf/packages/web/lib/socket-relay/repository.ts`.

No route, schema, contract, or delivery-status change, so no inventory update is required.

Closes #1364

Parity Status: web + mobile-responsive + android complete
