### PR TITLE
fix: lighthouse listing price, accepted currencies, and property type display

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
@@ -242,6 +242,11 @@ Android admin present (2026-06-06): `AdminLighthouse.tsx` + `admin-api.ts` added
 
 ## 9) Change Log
 
+- 2026-07-05: **Listing price/currency/type display polish (web + mobile-responsive).** No schema, route, or contract change:
+  - Browse card and listing detail render the rent with the amount large and a long currency label (e.g. "ServiceCredits") small, instead of the whole string at the price font size — a ServiceCredits price no longer overflows or breaks mid-word at phone width (`formatRentParts` in `shared.ts`).
+  - The listing detail now shows the full set of accepted currencies (ServiceCredits first), not just a single "Accepts ServiceCredits" badge (`acceptedCurrencyLabels`).
+  - Property **type** is now a defined picker — House, Room in a house, Apartment, Camper (`LIGHTHOUSE_PROPERTY_TYPES`) — in both the web (`lighthouse-host.tsx`) and mobile (`LighthouseHostForm.tsx`) host forms, replacing the free-text field. The type is surfaced as a chip in the web and native listing detail. Legacy free-text values still display and are preserved on edit.
+  - Native (Android) listing card/detail still show a `$`-prefixed price and no accepted-currency list; that display parity is tracked in #1376 (needs a mobile currency catalog).
 - 2026-07-04: **Recurring rent recognition moved to the Recurring Activity plugin (issue #885).** No LightHouse schema, route, or contract change. LightHouse's `monthly_rent`/`rent_currency` stay listing-only (the asking price, never a settled amount), and LightHouse does NOT gain a settlement table. Instead, an ongoing rent relationship is captured in the new `recurring-activity` plugin as a member's self-declared, counterparty-confirmed activity tagged sector `housing` — counted toward GDP by number for fiat (no amount ever stored) and by declared value for ServiceCredits. This closes #885 without LightHouse holding any recurring fiat-payment record.
 - 2026-06-27: **Code-review sweep fixes (issues #1060, #1064, #1071).** No schema or contract change:
   - The member shell's Browse tab now reads `GET /api/lighthouse/properties` (all active public listings) instead of `GET /api/lighthouse/my-properties` (the user's own listings), so a seeker with no listings of their own sees available housing. The Host tab still loads the user's own listings itself (#1071).

--- a/ctf/docs/developer/test-scripts/lighthouse-test-script.md
+++ b/ctf/docs/developer/test-scripts/lighthouse-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:lighthouse` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md` |
-| **Generated** | 2026-06-28 (initial authoring; regenerate via CI to stamp the commit) |
+| **Generated** | 2026-06-28 (initial authoring; hand-updated 2026-07-05 for listing price/currency/type display) |
 
 ## How to run this
 
@@ -38,7 +38,9 @@ Member role unless noted.
    location, rent), not a spinner or error. → web ☐ mobile ☐ android ☐
 3. **Rent and ServiceCredits read correctly.** A fiat rent shows in its own currency; a listing that
    accepts ServiceCredits shows the "Accepts ServiceCredits" badge by its label — never a "$" figure
-   for ServiceCredits, never a credits↔fiat equivalence. → web ☐ mobile ☐ android ☐
+   for ServiceCredits, never a credits↔fiat equivalence. On a narrow (mobile) width the ServiceCredits
+   price stays inside its card — the amount is large, "ServiceCredits" is small, and "/mo" is not
+   clipped or broken mid-word. → web ☐ mobile ☐ android ☐
 4. **Match request is single.** Send a match request on a property, then try again on the same one.
    The second attempt is refused as a duplicate, not silently doubled. → web ☐ mobile ☐ android ☐
 
@@ -53,17 +55,22 @@ Member role unless noted.
 1. Open the browse screen and read the list.
 2. Open one property's detail view.
 **Expected:** The list shows active public listings (not only your own). Detail shows listing fields
-and host reference info on a full page, with the seeker match-request action available.
+and host reference info on a full page, with the seeker match-request action available. When the
+listing has a property type (House, Room in a house, Apartment, Camper) it shows as a chip on the
+detail (and native detail).
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ### LH-2 · Rent currency vs accepted currencies
 **Role:** member · **Surfaces:** all
 **Steps:**
 1. Find a listing with a fiat rent and one that accepts ServiceCredits.
-2. Read the rent and the accepted-currency badge on each.
-**Expected:** Rent renders in its own currency (0 reads as "Free", blank when unset). "Accepts
-ServiceCredits" is a separate field shown by its label, never derived from the rent currency and
-never shown as a fiat amount.
+2. Read the rent and the accepted-currency badge on each, then open the detail of a listing that
+   accepts more than one currency.
+**Expected:** Rent renders in its own currency (0 reads as "Free", blank when unset). A long currency
+label like "ServiceCredits" renders small next to a large amount and does not overflow the card.
+"Accepts ServiceCredits" is a separate field shown by its label, never derived from the rent currency
+and never shown as a fiat amount. The detail view lists the **full** set of accepted currencies
+(ServiceCredits first), not just a single badge.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ### LH-3 · Send a match request
@@ -79,9 +86,10 @@ request on the same property is refused as a duplicate active/pending request.
 ### LH-4 · List your own place (self-service hosting)
 **Role:** member · **Surfaces:** web, mobile (android host tab where present)
 **Steps:**
-1. Open the "List your place" tab and fill the create-listing form: title, description, type,
-   address fields, bedrooms/bathrooms, monthly rent and rent currency, accepted currencies
-   (toggle ServiceCredits), available-from, amenities, house rules.
+1. Open the "List your place" tab and fill the create-listing form: title, description, type
+   (a picker: House, Room in a house, Apartment, Camper), address fields, bedrooms/bathrooms, monthly
+   rent and rent currency, accepted currencies (toggle ServiceCredits), available-from, amenities,
+   house rules.
 2. Save the listing, then open "Your listings".
 **Expected:** Listing is created with no separate host-profile form and no admin gate. Host identity
 shows your username, your Quora link, and the Trust widget — none re-entered. The new listing appears

--- a/ctf/packages/mobile/src/features/lighthouse/LighthouseHostForm.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthouseHostForm.tsx
@@ -11,6 +11,9 @@ const MUTED = '#9CA3AF';
 // ctf/packages/web/lib/currency/types.ts.
 const SERVICE_CREDITS_CODE = 'SC';
 
+// Kinds of place a member can list — mirrors LIGHTHOUSE_PROPERTY_TYPES on the web.
+const PROPERTY_TYPES = ['House', 'Room in a house', 'Apartment', 'Camper'] as const;
+
 type HostForm = {
   title: string;
   description: string;
@@ -142,7 +145,24 @@ export const LighthouseHostForm: React.FC<Props> = ({ submitting, error, onSubmi
   return (
     <View style={styles.card}>
       <Field label="Title *" value={form.title} onChange={(v) => setField('title', v)} placeholder="Quiet 1-bed near transit" />
-      <Field label="Type" value={form.propertyType} onChange={(v) => setField('propertyType', v)} placeholder="Apartment, room, house…" />
+      <View style={styles.field}>
+        <Text style={styles.label}>Type</Text>
+        <View style={styles.chipRow}>
+          {PROPERTY_TYPES.map((type) => {
+            const selected = form.propertyType === type;
+            return (
+              <TouchableOpacity
+                key={type}
+                style={[styles.chip, selected && styles.chipOn]}
+                onPress={() => setField('propertyType', selected ? '' : type)}
+                activeOpacity={0.8}
+              >
+                <Text style={[styles.chipText, selected && styles.chipTextOn]}>{type}</Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
       <Field
         label="Description *"
         value={form.description}
@@ -237,6 +257,31 @@ const styles = StyleSheet.create({
   textarea: {
     minHeight: 72,
     textAlignVertical: 'top',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  chipOn: {
+    backgroundColor: `${COLOR}14`,
+    borderColor: `${COLOR}40`,
+  },
+  chipText: {
+    fontSize: 13,
+    color: '#F9FAFB',
+    fontWeight: '600',
+  },
+  chipTextOn: {
+    color: COLOR,
   },
   toggle: {
     backgroundColor: 'rgba(255,255,255,0.04)',

--- a/ctf/packages/mobile/src/features/lighthouse/LighthousePropertyDetail.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthousePropertyDetail.tsx
@@ -76,6 +76,12 @@ export const LighthousePropertyDetail: React.FC<Props> = ({ property, onBack }) 
               <Text style={styles.locationText}>{location}</Text>
             </View>
           ) : null}
+          {property.propertyType && property.propertyType.trim().length > 0 ? (
+            <View style={styles.typeChip}>
+              <Ionicons name="home-outline" size={11} color={COLOR} />
+              <Text style={styles.typeChipText}>{property.propertyType}</Text>
+            </View>
+          ) : null}
           <View style={styles.metaRow}>
             <Text style={styles.metaText}>{beds}</Text>
             {baths ? <Text style={styles.metaDivider}>·</Text> : null}
@@ -190,6 +196,25 @@ const styles = StyleSheet.create({
   locationText: {
     fontSize: 12,
     color: '#9CA3AF',
+    marginLeft: 2,
+  },
+  typeChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    alignSelf: 'flex-start',
+    backgroundColor: `${COLOR}12`,
+    borderWidth: 1,
+    borderColor: `${COLOR}30`,
+    borderRadius: 8,
+    paddingVertical: 3,
+    paddingHorizontal: 10,
+    marginBottom: 12,
+  },
+  typeChipText: {
+    fontSize: 12,
+    color: COLOR,
+    fontWeight: '600',
     marginLeft: 2,
   },
   metaRow: {

--- a/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Bath, Bed, Heart, MapPin } from "lucide-react";
-import { COLOR, formatRent, listingAcceptsCredits, type CurrencyMap, type Property } from "./shared";
+import { COLOR, formatRentParts, listingAcceptsCredits, type CurrencyMap, type Property } from "./shared";
 
 export function LighthouseBrowse({
   properties,
@@ -56,12 +56,17 @@ export function LighthouseBrowse({
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", gap: 8 }}>
                   <div style={{ minWidth: 0, flex: 1 }}>
                     {(() => {
-                      const rent = formatRent(p, currencies);
+                      const rent = formatRentParts(p, currencies);
                       if (rent === null) return null;
-                      if (rent === "Free") return <div style={{ fontSize: 18, fontWeight: 800, color: COLOR }}>Free</div>;
-                      // overflowWrap lets a long currency label (e.g. "ServiceCredits") wrap inside the
-                      // card instead of pushing "/mo" and the View button past the clipped card edge.
-                      return <div style={{ fontSize: 18, fontWeight: 800, color: COLOR, lineHeight: 1.2, overflowWrap: "anywhere" }}>{rent}<span style={{ fontSize: 11, color: "#6B7280", fontWeight: 400 }}>/mo</span></div>;
+                      // Number stays large; a long unit like "ServiceCredits" renders small so it fits
+                      // and wraps cleanly instead of breaking mid-word or spilling past the card edge.
+                      return (
+                        <div style={{ color: COLOR, lineHeight: 1.15, overflowWrap: "anywhere" }}>
+                          <span style={{ fontSize: 18, fontWeight: 800 }}>{rent.primary}</span>
+                          {rent.unit ? <span style={{ fontSize: 11, fontWeight: 600, marginLeft: 3 }}>{rent.unit}</span> : null}
+                          {rent.perMonth ? <span style={{ fontSize: 11, color: "#6B7280", fontWeight: 400 }}>/mo</span> : null}
+                        </div>
+                      );
                     })()}
                     {listingAcceptsCredits(p) && <div style={{ fontSize: 10, color: "#F59E0B", marginTop: 2 }}>Credits ✓</div>}
                   </div>

--- a/ctf/packages/web/components/lighthouse/lighthouse-host.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-host.tsx
@@ -9,7 +9,7 @@ import { CurrencySelect } from "@/components/shared/currency-select";
 import type { Currency } from "@/lib/currency/types";
 import { SERVICE_CREDITS_LABEL } from "@/lib/currency/types";
 import { sortPreferred } from "@/lib/currency/format";
-import { formatRent, getLighthouseTokens, type CurrencyMap, type Property } from "./shared";
+import { formatRent, getLighthouseTokens, LIGHTHOUSE_PROPERTY_TYPES, type CurrencyMap, type Property } from "./shared";
 
 // Member self-service hosting. A member lists their own place here; there is NO separate "host
 // profile" form — the host identity shown on a listing is composed from data we already have
@@ -321,7 +321,23 @@ export function LighthouseHost({
           <div style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 12 }}>{editingId ? "Edit listing" : "List your place"}</div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
             {field("title", "Title *", { placeholder: "Quiet 1-bed near transit" })}
-            {field("propertyType", "Type", { placeholder: "Apartment, room, house…" })}
+            <div style={{ flex: "1 1 160px", minWidth: 140 }}>
+              <label style={labelStyle}>Type</label>
+              <select
+                value={form.propertyType}
+                onChange={(e) => setField("propertyType", e.target.value)}
+                style={inputStyle}
+                aria-label="Property type"
+              >
+                <option value="">Select type…</option>
+                {LIGHTHOUSE_PROPERTY_TYPES.map((type) => (
+                  <option key={type} value={type}>{type}</option>
+                ))}
+                {form.propertyType && !LIGHTHOUSE_PROPERTY_TYPES.includes(form.propertyType as (typeof LIGHTHOUSE_PROPERTY_TYPES)[number]) ? (
+                  <option value={form.propertyType}>{form.propertyType}</option>
+                ) : null}
+              </select>
+            </div>
             <div style={{ flex: "1 1 100%" }}>{field("description", "Description *", { textarea: true, placeholder: "Describe the place, the neighborhood, who it suits…" })}</div>
             {field("addressLine", "Address")}
             {field("city", "City")}

--- a/ctf/packages/web/components/lighthouse/lighthouse-property-detail.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-property-detail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Bath, Bed, Calendar, MapPin, MessageSquare, Pencil } from "lucide-react";
-import { BG, COLOR, formatRent, listingAcceptsCredits, type CurrencyMap, type Property } from "./shared";
+import { Bath, Bed, Calendar, Home, MapPin, MessageSquare, Pencil } from "lucide-react";
+import { acceptedCurrencyLabels, BG, COLOR, formatRentParts, listingAcceptsCredits, type CurrencyMap, type Property } from "./shared";
 
 export function LighthousePropertyDetail({
   property,
@@ -30,6 +30,9 @@ export function LighthousePropertyDetail({
           <div style={{ flex: 1, minWidth: 280 }}>
             <div style={{ fontSize: 24, fontWeight: 800, color: "#F9FAFB", marginBottom: 8 }}>{l.title || l.id}</div>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginBottom: 16 }}>
+              {l.propertyType && String(l.propertyType).trim().length > 0 ? (
+                <span style={{ background: `${COLOR}12`, color: COLOR, border: `1px solid ${COLOR}30`, fontSize: 12, borderRadius: 8, padding: "3px 10px", display: "inline-flex", alignItems: "center", gap: 4 }}><Home size={11} />{l.propertyType}</span>
+              ) : null}
               {([l.city, l.state].filter((s) => s && String(s).trim().length > 0).join(", ")) ? (
                 <span style={{ background: "rgba(255,255,255,0.05)", color: "#9CA3AF", border: "1px solid rgba(255,255,255,0.08)", fontSize: 12, borderRadius: 8, padding: "3px 10px", display: "inline-flex", alignItems: "center", gap: 4 }}><MapPin size={11} />{[l.city, l.state].filter((s) => s && String(s).trim().length > 0).join(", ")}</span>
               ) : null}
@@ -56,12 +59,36 @@ export function LighthousePropertyDetail({
           <div style={{ width: 280, flexShrink: 0 }}>
             <div style={{ padding: "24px", borderRadius: 16, background: "rgba(255,255,255,0.03)", border: `1px solid ${COLOR}25` }}>
               {(() => {
-                const rent = formatRent(l, currencies);
+                const rent = formatRentParts(l, currencies);
                 if (rent === null) return null;
-                if (rent === "Free") return <div style={{ fontSize: 32, fontWeight: 800, color: COLOR, marginBottom: 4 }}>Free</div>;
-                return <div style={{ fontSize: 32, fontWeight: 800, color: COLOR, marginBottom: 4 }}>{rent}<span style={{ fontSize: 14, color: "#6B7280", fontWeight: 400 }}>/mo</span></div>;
+                // Number large; a long unit like "ServiceCredits" stays small so it fits the 280px card.
+                return (
+                  <div style={{ color: COLOR, marginBottom: 4, lineHeight: 1.15, overflowWrap: "anywhere" }}>
+                    <span style={{ fontSize: 32, fontWeight: 800 }}>{rent.primary}</span>
+                    {rent.unit ? <span style={{ fontSize: 15, fontWeight: 700, marginLeft: 4 }}>{rent.unit}</span> : null}
+                    {rent.perMonth ? <span style={{ fontSize: 14, color: "#6B7280", fontWeight: 400 }}>/mo</span> : null}
+                  </div>
+                );
               })()}
-              {listingAcceptsCredits(l) && <div style={{ fontSize: 12, color: "#F59E0B", marginBottom: 16 }}>✓ Accepts ServiceCredits</div>}
+              {(() => {
+                const accepted = acceptedCurrencyLabels(l, currencies);
+                if (accepted.length === 0) {
+                  return listingAcceptsCredits(l) ? <div style={{ fontSize: 12, color: "#F59E0B", marginBottom: 16 }}>✓ Accepts ServiceCredits</div> : null;
+                }
+                return (
+                  <div style={{ marginBottom: 16 }}>
+                    <div style={{ fontSize: 11, color: "#9CA3AF", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 6 }}>Accepts</div>
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                      {accepted.map((label) => {
+                        const isCredits = label === "ServiceCredits";
+                        return (
+                          <span key={label} style={{ fontSize: 12, borderRadius: 8, padding: "3px 10px", background: isCredits ? "#F59E0B15" : "rgba(255,255,255,0.05)", color: isCredits ? "#F59E0B" : "#D1D5DB", border: `1px solid ${isCredits ? "#F59E0B30" : "rgba(255,255,255,0.08)"}` }}>{isCredits ? "✓ " : ""}{label}</span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })()}
               {isOwn ? (
                 <>
                   <div style={{ fontSize: 12, color: "#9CA3AF", marginBottom: 12, lineHeight: 1.6 }}>This is your listing.</div>

--- a/ctf/packages/web/components/lighthouse/shared.ts
+++ b/ctf/packages/web/components/lighthouse/shared.ts
@@ -4,7 +4,12 @@
 import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
 import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 import type { Currency } from "@/lib/currency/types";
-import { formatPrice } from "@/lib/currency/format";
+import { SERVICE_CREDITS_LABEL } from "@/lib/currency/types";
+import { formatPrice, sortPreferred } from "@/lib/currency/format";
+
+// The kinds of place a member can list on LightHouse (owner: houses, rooms in a house, apartments,
+// and campers). Stored verbatim on `property_type`; also the option set for the host form picker.
+export const LIGHTHOUSE_PROPERTY_TYPES = ["House", "Room in a house", "Apartment", "Camper"] as const;
 
 export const COLOR = "#60A5FA";
 // App surface background as rendered by the mockup (the mockup's `BG`
@@ -43,6 +48,8 @@ export interface Property {
   hostUserId: string;
   img?: string;
   title: string;
+  // What kind of place this is (e.g. "House", "Apartment", "Camper"). Free-form on older rows.
+  propertyType?: string | null;
   city: string;
   state: string;
   bedrooms: number;
@@ -82,6 +89,47 @@ export function formatRent(property: Property, currencies: CurrencyMap): string 
   const currency = currencies[code];
   if (currency) return formatPrice(amount, currency);
   return `$${amount}`;
+}
+
+/**
+ * A rent split into a large primary part and a small unit label, so a long currency name like
+ * "ServiceCredits" renders small next to the number instead of at the giant price font size (which
+ * overflowed the card). `perMonth` is false for "Free" and amount-less currencies (no "/mo").
+ *   fiat        → { primary: "$1,200", unit: null,             perMonth: true  }
+ *   credits     → { primary: "20",     unit: "ServiceCredits", perMonth: true  }
+ *   free / zero → { primary: "Free",   unit: null,             perMonth: false }
+ */
+export interface RentParts {
+  primary: string;
+  unit: string | null;
+  perMonth: boolean;
+}
+
+export function formatRentParts(property: Property, currencies: CurrencyMap): RentParts | null {
+  const amount = property.monthlyRent;
+  if (!Number.isFinite(amount)) return null;
+  if (amount === 0) return { primary: "Free", unit: null, perMonth: false };
+  const code = property.rentCurrency ?? "USD";
+  const currency = currencies[code];
+  if (!currency) return { primary: `$${amount}`, unit: null, perMonth: true };
+  if (currency.kind === "barter" || !currency.requiresAmount) {
+    return { primary: currency.isServiceCredits ? SERVICE_CREDITS_LABEL : currency.label, unit: null, perMonth: false };
+  }
+  const formatted = amount.toLocaleString("en-US", {
+    minimumFractionDigits: currency.decimalPlaces,
+    maximumFractionDigits: currency.decimalPlaces,
+  });
+  if (currency.isServiceCredits) return { primary: formatted, unit: SERVICE_CREDITS_LABEL, perMonth: true };
+  if (currency.symbol) return { primary: `${currency.symbol}${formatted}`, unit: null, perMonth: true };
+  return { primary: formatted, unit: currency.code, perMonth: true };
+}
+
+/** Accepted-currency labels for a listing, ServiceCredits first, resolved via the currency catalog. */
+export function acceptedCurrencyLabels(property: Property, currencies: CurrencyMap): string[] {
+  const resolved = (property.acceptedCurrencies ?? [])
+    .map((code) => currencies[code])
+    .filter((c): c is Currency => Boolean(c));
+  return sortPreferred(resolved).map((c) => (c.isServiceCredits ? SERVICE_CREDITS_LABEL : c.label));
 }
 
 export interface Match {


### PR DESCRIPTION
Addresses three things reported on the LightHouse listing surfaces (screenshots were the phone-width web view).

## 1. ServiceCredits price no longer overflows / breaks mid-word

A ServiceCredits listing's rent is a long label ("20 ServiceCredits") rather than a short "$20". The browse card and the listing detail were rendering the whole string at the big price font (18px / 32px), so it spilled past the card edge — clipping "/mo" — and my earlier wrap fix only made it break mid-word ("Servic eCredi ts").

New `formatRentParts` helper splits the rent into a large amount and a small unit label: the number stays big, and "ServiceCredits" renders small next to it (never a `$`). Fits cleanly at phone width in both the browse card and the detail card.

## 2. Accepted currencies now shown in the expanded (detail) view

The listing detail only showed a single "Accepts ServiceCredits" badge. It now lists the full set of accepted currencies (ServiceCredits first), resolved from the currency catalog via the new `acceptedCurrencyLabels` helper. The data was already reaching the component; it just wasn't rendered.

## 3. Property type is a defined picker

Per the product ("houses, rooms in houses, apartments and campers"), the free-text Type field is now a picker with **House, Room in a house, Apartment, Camper** (`LIGHTHOUSE_PROPERTY_TYPES`) in both the web and mobile host forms. The type is surfaced as a chip in the web and native listing detail. Legacy free-text values still display and are preserved when editing.

## Scope / parity

Web (desktop) + mobile-responsive: fully done. Mobile host form: type picker added. Native (Android) listing card/detail still show a `$`-prefixed price and no accepted-currency list — that display needs a mobile currency catalog and is tracked separately.

No route, schema, or contract change. LightHouse feature inventory change log updated.

Verified locally: web + mobile typecheck, web + mobile lint, EOF format, and web/android parity all pass.

Parity Ticket: #1376

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_