### PR TITLE
fix: center the mobile loading screen so it fills the viewport

### DIFF
--- a/ctf/packages/mobile/src/components/shared/LoadingScreen.tsx
+++ b/ctf/packages/mobile/src/components/shared/LoadingScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 
 /**
  * Universal app-wide loading screen. Shows the "Exit Their Economy / Exit The
@@ -8,10 +8,16 @@ import { StyleSheet, Text, View } from 'react-native';
  *
  * Guardrail from the design spec: loading screens are NOT theme-toggled. Always
  * render the canonical dark treatment (#0F1117), regardless of any app theme.
+ *
+ * When this screen is returned at the app root (before the flex:1 shell mounts),
+ * its parent chain is context providers with no laid-out height, so a bare `flex:1`
+ * collapses and the text pins to the top. `minHeight` = the window height forces the
+ * screen to fill the viewport so the tagline is centered mid-page in every case.
  */
 export function LoadingScreen() {
+  const { height } = useWindowDimensions();
   return (
-    <View style={styles.screen}>
+    <View style={[styles.screen, { minHeight: height }]}>
       <View style={styles.inner}>
         <Text style={[styles.line, styles.lineLead]}>EXIT THEIR ECONOMY</Text>
         <Text style={styles.line}>EXIT THE PSYOP</Text>

--- a/ctf/packages/mobile/src/features/lighthouse/LighthouseLoadingState.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthouseLoadingState.tsx
@@ -1,34 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { LoadingScreen } from '../../components/shared/LoadingScreen';
 
-export const LighthouseLoadingState: React.FC = () => (
-  <View style={styles.container}>
-    <Text style={styles.line1}>EXIT THEIR ECONOMY</Text>
-    <Text style={styles.line2}>EXIT THE PSYOP</Text>
-  </View>
-);
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#0F1117',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 32,
-  },
-  line1: {
-    fontSize: 10,
-    letterSpacing: 2.5,
-    color: 'rgba(255,255,255,0.22)',
-    textTransform: 'uppercase',
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  line2: {
-    fontSize: 10,
-    letterSpacing: 2.5,
-    color: 'rgba(255,255,255,0.22)',
-    textTransform: 'uppercase',
-    fontWeight: '500',
-  },
-});
+// Delegates to the universal LoadingScreen so the "Exit Their Economy / Exit The
+// Psyop" loading state is identical (and correctly centered) everywhere.
+export const LighthouseLoadingState: React.FC = () => <LoadingScreen />;


### PR DESCRIPTION
## Problem

During the transition between the home hub and a plugin (e.g. LightHouse) — and during the initial unlock-status check — the "Exit Their Economy / Exit The Psyop" loading tagline appears pinned to the **top** of a blank screen instead of centered mid-page.

## Cause

The app-root `LoadingScreen` is returned *outside* the `flex:1` shell (`SafeAreaView`), so its parent chain is just context providers with no laid-out height. A bare `flex:1` has no full-height parent to fill, so it collapses to content height and the tagline sits at the top. (In-shell loaders were fine — `styles.content` is `flex:1`.)

## Fix

Force the loading screen to at least the window height via `useWindowDimensions`, so it fills the viewport and centers in every mount path (root or in-shell). Also repoint `LighthouseLoadingState` at the shared `LoadingScreen` so its loader is identical and centered too — matching how SocketRelay / TrustTransport / Workforce already delegate.

Shared UI-component fix only. No route, schema, contract, or inventory change.

Verified locally: mobile typecheck + lint, web/android parity, and EOF format all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_