### PR TITLE
feat: add signed-out public landing for Recurring Activity

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-recurring-activity-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-recurring-activity-feature-inventory.md
@@ -125,6 +125,11 @@ requires the same-origin CSRF header (`x-ctf-csrf: 1`) and writes an audit row.
 `/apps/recurring-activity`; Android feature at `packages/mobile/src/features/recurring-activity`. Both
 bind to the same API and enforce the no-amount-for-fiat rule.
 
+A signed-out visitor (or a signed-in member not verified yet) now sees the marketing landing shell
+(`recurring-activity-public-shell.tsx`) at `/apps/recurring-activity` instead of being redirected to
+sign-in — matching every other plugin, so the URL is shareable. The shell shows only static preview
+copy (no per-user data, per rule 126) and a sign-in / "Finish verifying" call-to-action.
+
 ## Seed Coverage Status
 
 `ctf/scripts/seedRecurringActivityPhase0.mjs` (`pnpm --dir ctf seed:recurring-activity`) seeds three demo
@@ -163,6 +168,11 @@ flow, the Trust signal, and both GDP recognition branches. RACT's contribution w
   off-platform relationships (LightHouse rent and the rest of the "settles later" bucket) are captured
   here as self-declared, confirmed activities rather than via a per-plugin settlement table, so no
   recurring fiat amount is ever stored.
+- 2026-07-04: Added the signed-out public landing shell (`recurring-activity-public-shell.tsx`) and
+  registered it in `public-visitor-registry.tsx`. The dedicated `/apps/recurring-activity` route now
+  renders it for an unauthenticated visitor (or a not-yet-verified member, with a "Finish verifying"
+  CTA) instead of redirecting to sign-in, so the URL is shareable and consistent with the other
+  plugins' public views. Marketing copy only — no per-user data (rule 126).
 
 ## Build Checklist
 

--- a/ctf/docs/developer/test-scripts/recurring-activity-test-script.md
+++ b/ctf/docs/developer/test-scripts/recurring-activity-test-script.md
@@ -21,6 +21,17 @@
    favor tie.
 2. Sign in as an approved member.
 
+## Signed-out visitor — public landing (web, desktop and mobile-responsive at 390px)
+
+1. **Signed out.** In a private/incognito window (no session), open `/apps/recurring-activity`.
+   Confirm it shows the public marketing landing — the "Recognize the ties you keep" shell with the
+   HeartHandshake mark, the three feature tiles, and **Sign In / Join Free** buttons — and does **not**
+   redirect to sign-in or 404. Confirm no per-user data appears (it is static preview copy only).
+2. **Not-yet-verified member.** Sign in as a member who has not finished Unlock verification and open
+   `/apps/recurring-activity`. Confirm the same landing shows but with a single **Finish verifying**
+   button (pointing at `/plugin/unlock`) instead of the Sign In / Join Free pair.
+3. Repeat step 1 at a 390px-wide viewport; confirm the mobile layout renders and nothing overflows.
+
 ## Member — web (desktop and mobile-responsive at 390px)
 
 1. Open `/apps/recurring-activity`. Confirm the hub loads (loading → populated), and that an empty

--- a/ctf/packages/web/app/apps/recurring-activity/page.tsx
+++ b/ctf/packages/web/app/apps/recurring-activity/page.tsx
@@ -1,13 +1,17 @@
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { getHostedSignInUrl } from 'lib/auth/provider-env';
 import { getPluginBySlug } from 'lib/plugins/repository';
 import { RecurringActivityShell } from '@/components/recurring-activity/recurring-activity-shell';
+import { RecurringActivityPublicShell } from '@/components/recurring-activity/recurring-activity-public-shell';
 
 export const dynamic = 'force-dynamic';
 
-// Recurring Activity is open to any signed-in, unlocked member (the API gate is the default
-// authenticated tier). A signed-out visitor is sent to sign in; the registry entry must be visible.
+// Recurring Activity is open to any signed-in, unlocked member. This dedicated route mirrors the
+// dynamic [pluginSlug] route's public-visitor handling: a signed-out visitor (or a signed-in member
+// who is not verified yet) sees the marketing landing shell rather than being bounced to sign-in —
+// so the /apps/recurring-activity URL is shareable and always shows something. The registry entry
+// must be visible.
 export default async function RecurringActivityPage() {
   const plugin = await getPluginBySlug('recurring-activity');
   if (!plugin || !plugin.isVisible) {
@@ -16,7 +20,20 @@ export default async function RecurringActivityPage() {
 
   const decision = await evaluatePluginAccess({ requireUsername: false });
   if (!decision.allowed) {
-    redirect(getHostedSignInUrl() ?? '/sign-in');
+    const signInUrl = getHostedSignInUrl() ?? '/sign-in';
+    // A signed-in-but-not-yet-verified member (denied with `unlock_required`) is already
+    // authenticated, so the shell shows a single "Finish verifying" CTA pointing at the Unlock flow;
+    // an anonymous visitor gets the normal sign-in / join CTAs. Any other deny falls through to the
+    // same public shell, which is a safe, non-leaking fallback.
+    const verifyUrl = decision.reason === 'unlock_required' ? '/plugin/unlock' : undefined;
+    return (
+      <RecurringActivityPublicShell
+        pluginSlug="recurring-activity"
+        pluginName="Recurring Activity"
+        signInUrl={signInUrl}
+        verifyUrl={verifyUrl}
+      />
+    );
   }
 
   return <RecurringActivityShell />;

--- a/ctf/packages/web/components/plugins/public-visitor-registry.tsx
+++ b/ctf/packages/web/components/plugins/public-visitor-registry.tsx
@@ -11,6 +11,7 @@ import { LevelUpPublicShell } from '@/components/level-up/level-up-public-shell'
 import { LighthousePublicShell } from '@/components/lighthouse/lighthouse-public-shell';
 import { MoodPublicShell } from '@/components/mood/mood-public-shell';
 import { PeerProgrammingPublicShell } from '@/components/peer-programming/peer-programming-public-shell';
+import { RecurringActivityPublicShell } from '@/components/recurring-activity/recurring-activity-public-shell';
 import { ServiceCreditsPublicShell } from '@/components/service-credits/service-credits-public-shell';
 import { SkillsHuntPublicShell } from '@/components/skills-hunt/skills-hunt-public-shell';
 import { SkillsTaxonomyPublicShell } from '@/components/skills-taxonomy/skills-taxonomy-public-shell';
@@ -69,6 +70,7 @@ const PUBLIC_VISITOR_SHELLS: Record<string, PublicVisitorShell> = {
   lighthouse: LighthousePublicShell,
   mood: MoodPublicShell,
   'peer-programming': PeerProgrammingPublicShell,
+  'recurring-activity': RecurringActivityPublicShell,
   'service-credits': ServiceCreditsPublicShell,
   'skills-hunt': SkillsHuntPublicShell,
   'skills-taxonomy': SkillsTaxonomyPublicShell,

--- a/ctf/packages/web/components/recurring-activity/recurring-activity-public-shell.tsx
+++ b/ctf/packages/web/components/recurring-activity/recurring-activity-public-shell.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { HeartHandshake, Lock, UserPlus, Repeat, EyeOff, Users } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import { useTheme } from '@/hooks/useTheme';
+import { PublicShellBackLink } from '@/components/plugins/public-shell-back-link';
+import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
+import {
+  COMMUNITY_LINE,
+  FONT_FAMILY,
+  getRecurringActivityTokens,
+  type RecurringActivityTokens,
+} from './recurring-activity-shared';
+
+// Signed-out visitor view for Recurring Activity. Marketing copy only — per rule 126 it shows no
+// private or per-user data (the visitor has no session). The three feature tiles are static; the
+// real activities load only after sign-in. Sign-in affordances point at the hosted sign-in URL; a
+// signed-in-but-not-yet-verified member gets a single "Finish verifying" CTA (verifyUrl) instead.
+
+const INTRO =
+  'Acknowledge an ongoing activity you share with another member — one tap, no amounts to report. It is recognition of your everyday ties, never a bill.';
+
+const FEATURES: Array<{ Icon: typeof Repeat; label: string; desc: string }> = [
+  { Icon: Repeat, label: 'One tap', desc: 'Mark an ongoing tie — no forms, no figures.' },
+  { Icon: EyeOff, label: 'No amounts', desc: 'Recognition of the activity, never a bill.' },
+  { Icon: Users, label: 'Between members', desc: 'Both sides confirm; you decide who can see it.' },
+];
+
+function CtaButtons({
+  signInUrl,
+  verifyUrl,
+  t,
+  size,
+}: {
+  signInUrl: string;
+  verifyUrl?: string;
+  t: RecurringActivityTokens;
+  size: 'sm' | 'lg';
+}) {
+  const pad = size === 'lg' ? '14px 28px' : '7px 16px';
+  const radius = size === 'lg' ? 10 : 8;
+  const fontSize = size === 'lg' ? 15 : 13;
+  if (verifyUrl) {
+    return (
+      <a
+        href={verifyUrl}
+        style={{ padding: pad, borderRadius: radius, background: t.ACCENT, border: 'none', color: '#04211D', fontSize, fontWeight: 700, textDecoration: 'none' }}
+      >
+        Finish verifying
+      </a>
+    );
+  }
+  return (
+    <>
+      <a
+        href={signInUrl}
+        style={{ padding: pad, borderRadius: radius, background: 'rgba(255,255,255,0.06)', border: `1px solid ${t.BORDER}`, color: t.TEXT, fontSize, fontWeight: 600, textDecoration: 'none' }}
+      >
+        Sign In
+      </a>
+      <a
+        href={signInUrl}
+        style={{ padding: pad, borderRadius: radius, background: t.ACCENT, border: 'none', color: '#04211D', fontSize, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 6, textDecoration: 'none' }}
+      >
+        <UserPlus size={fontSize} /> Join Free
+      </a>
+    </>
+  );
+}
+
+function Header({ signInUrl, verifyUrl, t, isMobile }: { signInUrl: string; verifyUrl?: string; t: RecurringActivityTokens; isMobile: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: isMobile ? '12px 16px' : '0 28px',
+        height: isMobile ? undefined : 52,
+        background: isMobile ? `${t.ACCENT}10` : undefined,
+        borderBottom: `1px solid ${isMobile ? `${t.ACCENT}25` : t.BORDER}`,
+        flexShrink: 0,
+      }}
+    >
+      <PublicShellBackLink />
+      <HeartHandshake size={18} color={t.ACCENT} />
+      <span style={{ fontSize: 16, fontWeight: 700, color: t.TITLE }}>Recurring Activity</span>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: isMobile ? 6 : 8 }}>
+        <CtaButtons signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} size="sm" />
+      </div>
+    </div>
+  );
+}
+
+function FeatureTiles({ t }: { t: RecurringActivityTokens }) {
+  return (
+    <div style={{ display: 'flex', gap: 10, width: '100%' }}>
+      {FEATURES.map(({ Icon, label, desc }) => (
+        <div key={label} style={{ flex: 1, padding: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, textAlign: 'center' }}>
+          <Icon size={20} color={t.ACCENT} style={{ marginBottom: 8, opacity: 0.8 }} />
+          <div style={{ fontSize: 12, fontWeight: 700, color: t.TITLE, marginBottom: 4 }}>{label}</div>
+          <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>{desc}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function LockedMark({ t, size }: { t: RecurringActivityTokens; size: number }) {
+  const lock = Math.round(size * 0.33);
+  return (
+    <div style={{ position: 'relative' }}>
+      <div
+        style={{
+          width: size,
+          height: size,
+          borderRadius: '50%',
+          background: `${t.ACCENT}1A`,
+          border: `4px solid ${t.ACCENT}4D`,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 6,
+          filter: 'blur(2px)',
+          opacity: 0.5,
+        }}
+      >
+        <HeartHandshake size={Math.round(size * 0.25)} color={t.ACCENT} />
+        <span style={{ fontSize: 13, fontWeight: 800, color: t.ACCENT }}>Acknowledge</span>
+      </div>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ width: lock, height: lock, borderRadius: '50%', background: `${t.ACCENT}26`, border: `2px solid ${t.ACCENT}50`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <Lock size={Math.round(lock * 0.42)} color={t.ACCENT} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DesktopPublic({ signInUrl, verifyUrl, t }: { signInUrl: string; verifyUrl?: string; t: RecurringActivityTokens }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TEXT, display: 'flex', flexDirection: 'column' }}>
+      <Header signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} isMobile={false} />
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '48px 64px' }}>
+        <div style={{ maxWidth: 600, width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 28, textAlign: 'center' }}>
+          <LockedMark t={t} size={160} />
+          <div>
+            <h1 style={{ margin: '0 0 12px', fontSize: 30, fontWeight: 800, lineHeight: 1.2, color: t.TITLE }}>
+              Recognize the ties you keep.<br />
+              <span style={{ color: t.ACCENT }}>Sign in to start.</span>
+            </h1>
+            <p style={{ margin: 0, fontSize: 15, color: t.MUTED, lineHeight: 1.7, maxWidth: 460 }}>{INTRO}</p>
+          </div>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <CtaButtons signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} size="lg" />
+          </div>
+          <FeatureTiles t={t} />
+          <p style={{ margin: 0, fontSize: 12, color: t.MUTED }}>{COMMUNITY_LINE}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobilePublic({ signInUrl, verifyUrl, t }: { signInUrl: string; verifyUrl?: string; t: RecurringActivityTokens }) {
+  return (
+    <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TEXT, display: 'flex', flexDirection: 'column' }}>
+      <Header signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} isMobile />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '28px 24px', textAlign: 'center', gap: 22 }}>
+        <LockedMark t={t} size={140} />
+        <div>
+          <div style={{ fontSize: 22, fontWeight: 800, color: t.TITLE, marginBottom: 8 }}>Recognize the ties you keep</div>
+          <div style={{ fontSize: 13, color: t.MUTED, lineHeight: 1.6, maxWidth: 300 }}>{INTRO}</div>
+        </div>
+        <a
+          href={verifyUrl ?? signInUrl}
+          style={{ width: '100%', padding: 14, borderRadius: 12, background: t.ACCENT, border: 'none', color: '#04211D', fontSize: 14, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, boxSizing: 'border-box', textDecoration: 'none' }}
+        >
+          {verifyUrl ? 'Finish verifying' : <><UserPlus size={15} /> Create free account</>}
+        </a>
+        <FeatureTiles t={t} />
+        <p style={{ margin: 0, fontSize: 11, color: t.MUTED }}>{COMMUNITY_LINE}</p>
+      </div>
+    </div>
+  );
+}
+
+export function RecurringActivityPublicShell({ signInUrl, verifyUrl }: PublicVisitorShellProps) {
+  const isMobile = useIsMobile();
+  const { theme } = useTheme();
+  const t = getRecurringActivityTokens(theme);
+  return isMobile
+    ? <MobilePublic signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} />
+    : <DesktopPublic signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} />;
+}


### PR DESCRIPTION
## What this fixes

`/apps/recurring-activity` was the only member plugin whose dedicated route redirected a signed-out visitor straight to sign-in, so the URL showed **no landing page** — every other plugin renders a public marketing shell for anonymous visitors. That made the link unshareable (e.g. for posting publicly).

## The fix

- New `recurring-activity-public-shell.tsx` — a signed-out marketing view matching the sibling public shells: theme-aware brand tokens, `PublicShellBackLink`, static preview content only (no per-user data, per rule 126), `Sign In` / `Join Free` CTAs, and a single "Finish verifying" CTA for a signed-in-but-not-yet-verified member.
- The dedicated route now renders that shell on any access denial (anonymous → sign-in CTAs; `unlock_required` → verify CTA) instead of `redirect()`, mirroring the dynamic `[pluginSlug]` route's public-visitor handling.
- Registered in `public-visitor-registry.tsx` for consistency with the other plugins.
- Inventory updated (`ctf-recurring-activity-feature-inventory.md`).

## Parity

Android already shows a persistent navigator and has no signed-out marketing surface concept — this is a web signed-out-visitor gap only. No RN change.

## Testing

- `pnpm --filter @ctf/web lint` — passes
- `pnpm --filter @ctf/web typecheck` — passes
- `pnpm --filter @ctf/web build` — passes; `/apps/recurring-activity` compiles
- `bash ctf/scripts/check-eof-format.sh` — passes

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_