### PR TITLE
fix: announcement draft 503 (missing revision columns) and keep message on failed submit

### DIFF
--- a/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
+++ b/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
@@ -81,8 +81,8 @@ export function FeedAnnouncementsAdminShell({
   const publishedCount = announcements.filter((a) => a.status === 'published').length;
   const draftCount = announcements.filter((a) => a.status === 'draft').length;
 
-  async function act(fn: () => Promise<{ ok: boolean; message?: string }>, okMessage: string) {
-    if (busy) return;
+  async function act(fn: () => Promise<{ ok: boolean; message?: string }>, okMessage: string): Promise<{ ok: boolean; message?: string }> {
+    if (busy) return { ok: false, message: 'Busy.' };
     setBusy(true);
     setError(null);
     setMessage(null);
@@ -94,6 +94,7 @@ export function FeedAnnouncementsAdminShell({
       setError(res.message ?? 'Action failed.');
     }
     setBusy(false);
+    return res;
   }
 
   async function createDraft() {
@@ -101,11 +102,15 @@ export function FeedAnnouncementsAdminShell({
       setError('Title and body are required.');
       return;
     }
-    await act(
+    const res = await act(
       () => adminMutate('/api/feed/admin/announcements', 'POST', { title: draft.title.trim(), body: draft.body.trim(), priority: draft.priority, mandatory: draft.mandatory, scheduleAtIso: null, expiresAtIso: null }),
       'Draft created.',
     );
-    setDraft({ title: '', body: '', priority: 0, mandatory: false });
+    // Only clear the form on success — a failed submit must keep the typed title and message so the
+    // author does not lose their work and can just retry.
+    if (res.ok) {
+      setDraft({ title: '', body: '', priority: 0, mandatory: false });
+    }
   }
 
   return (

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -851,7 +851,26 @@ CREATE TABLE IF NOT EXISTS announcement_revisions (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+-- Backfill every column on legacy databases (per the mandatory CREATE + ALTER-IF-NOT-EXISTS rule).
+-- A database whose announcement_revisions predates these columns keeps the old table on
+-- CREATE TABLE IF NOT EXISTS, so without these ALTERs the app's revision insert (which lists
+-- targeting/status/priority/mandatory/schedule_at/expires_at) fails and the whole "create draft"
+-- transaction rolls back with a 503. Defaults are supplied so the NOT NULL adds succeed on a table
+-- that already has rows.
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS announcement_id UUID;
 ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS revision_number INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS body TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'draft';
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS mandatory BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS schedule_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS targeting JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS created_by_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS updated_by_user_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS announcement_revisions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 CREATE UNIQUE INDEX IF NOT EXISTS idx_announcement_revisions_announcement_revision ON announcement_revisions(announcement_id, revision_number);
 CREATE TABLE IF NOT EXISTS announcement_delivery_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## What this fixes

Creating an announcement draft in **Feed & Announcements Admin** failed with "Unable to create announcement draft." (HTTP 503), and the form erased the typed message.

**Root cause (the 503):** `announcement_revisions` was missing its `ALTER TABLE … ADD COLUMN IF NOT EXISTS` backfills — only `revision_number` had one. On any database where that table was created by an older schema (the **demo** schema, or the **v2-cloned production** DB), `CREATE TABLE IF NOT EXISTS` is a no-op, so the columns the app's revision insert lists — `targeting`, `status`, `priority`, `mandatory`, `schedule_at`, `expires_at` (and `title`/`body`/etc.) — never got added. The second insert in the create-draft transaction then threw `column "targeting" … does not exist`, rolling the whole draft back.

**Fix:** add the missing idempotent ALTERs for every `announcement_revisions` column (per the repo's mandatory CREATE + ALTER-IF-NOT-EXISTS migration rule), with defaults so the NOT NULL adds succeed on a table that already has rows.

**Second fix (lost message):** the admin form reset unconditionally after submit, so a failed post wiped the title and message. It now only clears on success, so a failed submit keeps your work for a retry.

## Testing (local Postgres 16)

- Reproduced: created a legacy-shaped `announcement_revisions` (no `targeting`/`status`/…), applied the current schema statements, and the app's revision insert failed with `column "targeting" … does not exist` — the exact 503.
- After the fix: applied the new backfill ALTERs, and the same insert succeeded.
- `pnpm --filter @ctf/web lint` / `typecheck` — pass; `check-eof-format.sh` — pass.

## Schema Drift

- **Drift class:** DB-Migration Drift (`ctf/schema.sql`) — adds idempotent `ADD COLUMN IF NOT EXISTS` backfills only. No new table/column shape beyond what the `CREATE TABLE` already declared; no column removed.
- **Migration / rollback:** additive and idempotent; safe to re-run. Rollback is reverting the commit.
- **Compatibility:** `compatible`. Fresh DBs already had these columns via `CREATE TABLE`; this only heals legacy tables.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_