### PR TITLE
feat: add cancel-request control to TrustTransport Tracking tab

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -290,6 +290,17 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 
 ## Change Log
 
+- 2026-07-02: Cancel-request UI on both platforms. The `POST /api/trust-transport/orders/:orderId/cancel`
+  route and `cancelOrder()` repository function already existed and were fully authorized (requester or
+  admin only; forward-transition-checked so a completed/cancelled request can't be re-cancelled) but had
+  no caller anywhere in the app — a member had no way to cancel a request they made. Added a "Cancel
+  request" control to the Tracking tab (web `tt-tracking-tab.tsx`) and the Track tab (android
+  `TrustTransport.tsx`, new `cancelOrder()` added to the mobile API client) for any of the member's own
+  non-terminal requests (open, accepted, in progress), each behind an explicit confirmation prompt
+  (`window.confirm` on web, a native `Alert` on android) per the "explicit confirmation for irreversible
+  actions" security control. No schema/route/contract change — the endpoint already existed and was
+  reviewed.
+
 - 2026-07-02: Android earnings + payouts screen (parity with web slice 6, issue #1250). New
   `TrustTransportEarningsTab.tsx` — an "Earnings" tab in the bottom nav with per-currency balance cards
   (`getEarningsBalances`), a payout request form scoped to whichever currency is selected

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -230,11 +230,11 @@ Result: web ☐ android ☐
 **Precondition:** Signed in as a member. A cancellable trip/order exists (seeded).
 
 **Steps:**
-1. Open a cancellable order.
-2. Initiate cancellation.
-3. Confirm the explicit confirmation prompt.
+1. Open the Tracking tab and find a non-terminal request/order you made (open, accepted, or in progress).
+2. Tap/click "Cancel request".
+3. Confirm the explicit confirmation prompt (a `window.confirm` dialog on web, a native `Alert` on android).
 
-**Expected:** The order transitions to a cancelled terminal state. The user sees clear confirmation. The chat tab for this trip now shows read-only mode (no new messages).
+**Expected:** The order transitions to a cancelled terminal state and disappears from the cancellable list (the "Cancel request" control no longer shows). The user sees clear confirmation. The chat tab for this trip now shows read-only mode (no new messages).
 
 Result: web ☐ android ☐
 

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   ScrollView,
   StyleSheet,
   Text,
@@ -15,6 +16,7 @@ import { TrustTransportHelpTab } from './TrustTransportHelpTab';
 import { TrustTransportChatButton } from './TrustTransportChatButton';
 import { TrustTransportEarningsTab } from './TrustTransportEarningsTab';
 import {
+  cancelOrder,
   createRequest,
   listRequests,
   type ListRequestsResponse,
@@ -245,6 +247,47 @@ function statusColor(status: string): string {
   return SUBTLE;
 }
 
+const TERMINAL_REQUEST_STATUSES = new Set(['completed', 'cancelled']);
+
+function CancelRequestButton({ requestId, onCancelled }: { requestId: string; onCancelled: () => void }) {
+  const [cancelling, setCancelling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function doCancel() {
+    setCancelling(true);
+    setError(null);
+    try {
+      await cancelOrder(requestId);
+      onCancelled();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not cancel this request.');
+    } finally {
+      setCancelling(false);
+    }
+  }
+
+  function confirmCancel() {
+    Alert.alert('Cancel this request?', "This can't be undone.", [
+      { text: 'Keep request', style: 'cancel' },
+      { text: 'Cancel request', style: 'destructive', onPress: () => { void doCancel(); } },
+    ]);
+  }
+
+  return (
+    <>
+      {error ? <Text style={styles.cancelErrorText}>{error}</Text> : null}
+      <TouchableOpacity
+        style={[styles.cancelBtn, cancelling && styles.cancelBtnDisabled]}
+        onPress={confirmCancel}
+        disabled={cancelling}
+        accessibilityRole="button"
+      >
+        {cancelling ? <ActivityIndicator size="small" color="#EF4444" /> : <Text style={styles.cancelBtnText}>Cancel request</Text>}
+      </TouchableOpacity>
+    </>
+  );
+}
+
 function TrackTab({
   requests,
   loading,
@@ -299,6 +342,9 @@ function TrackTab({
               <TrustTransportOffersSection requestId={req.id} onAccepted={onRefresh} />
             ) : null}
             {req.tripId ? <TrustTransportChatButton tripId={req.tripId} /> : null}
+            {!TERMINAL_REQUEST_STATUSES.has(req.status) ? (
+              <CancelRequestButton requestId={req.id} onCancelled={onRefresh} />
+            ) : null}
           </View>
         </React.Fragment>
       ))}
@@ -581,6 +627,18 @@ const styles = StyleSheet.create({
   requestLocation: { fontSize: 13, color: SUBTLE, marginBottom: 2 },
   requestSettle: { fontSize: 12, fontWeight: '700', color: '#22C55E', marginTop: 2, marginBottom: 2 },
   settleLabel: { fontSize: 13, color: MUTED, marginTop: 10, marginBottom: 6 },
+  cancelBtn: {
+    marginTop: 8,
+    padding: 10,
+    borderRadius: 9,
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: 'rgba(239,68,68,0.3)',
+    alignItems: 'center',
+  },
+  cancelBtnDisabled: { opacity: 0.6 },
+  cancelBtnText: { fontSize: 13, fontWeight: '600', color: '#EF4444' },
+  cancelErrorText: { fontSize: 12, color: '#EF4444', marginTop: 8 },
   publicContent: { padding: 20 },
   publicHeadRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
   publicTitle: { fontSize: 20, fontWeight: '800', color: TEXT },

--- a/ctf/packages/mobile/src/features/trust-transport/api.ts
+++ b/ctf/packages/mobile/src/features/trust-transport/api.ts
@@ -51,6 +51,15 @@ export async function createRequest(
   return data.item;
 }
 
+// Cancel your own request (any non-terminal status). Confirmed by the caller before invoking.
+export async function cancelOrder(requestId: string): Promise<void> {
+  await authedFetchJson<{ ok: boolean }>(`${BASE}/orders/${requestId}/cancel`, {
+    method: 'POST',
+    headers: MUTATION_HEADERS,
+    body: JSON.stringify({}),
+  });
+}
+
 export async function listOffersForRequest(requestId: string): Promise<TrustTransportOffer[]> {
   const data = await authedFetchJson<{ ok: boolean; items: TrustTransportOffer[] }>(
     `${BASE}/requests/${requestId}/offers`,

--- a/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
+++ b/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
@@ -215,7 +215,7 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
         />
       )}
       {tab === "tracking" && (
-        <TrustTransportTrackingTab requests={requests} onBook={() => setTab("book")} onChat={openChat} onAccepted={() => void fetchRequests()} />
+        <TrustTransportTrackingTab requests={requests} onBook={() => setTab("book")} onChat={openChat} onAccepted={() => void fetchRequests()} onCancelled={() => void fetchRequests()} />
       )}
       {tab === "help" && <TrustTransportHelpTab />}
       {tab === "earnings" && <TrustTransportEarningsTab />}

--- a/ctf/packages/web/components/trust-transport/tt-tracking-tab.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-tracking-tab.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { Car, Navigation, MessageCircle, Check, Loader2 } from "lucide-react";
+import { Car, Navigation, MessageCircle, Check, X, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { COLOR, ttSettlementLabel, type TripRequest, type TtOffer } from "./tt-shared";
+
+const TERMINAL_STATUSES = new Set(["completed", "cancelled"]);
 
 // Offers on the requester's own open request, with Accept. Accepting opens a trip and (per discovery
 // model B) is the point at which the chosen provider gains the pickup/drop-off via the trip.
@@ -113,7 +115,9 @@ function TrackingEmpty({ onBook }: { onBook: () => void }) {
   );
 }
 
-function TrackingCard({ request, onChat, onAccepted }: { request: TripRequest; onChat: (r: TripRequest) => void; onAccepted: () => void }) {
+function TrackingCard({ request, onChat, onAccepted, onCancelled }: { request: TripRequest; onChat: (r: TripRequest) => void; onAccepted: () => void; onCancelled: () => void }) {
+  const [cancelling, setCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
   const pickup = request.pickupCity ?? request.fromLocation ?? null;
   const dropoff = request.dropoffCity ?? request.toLocation ?? null;
   // Show the real pickup → drop-off; fall back to the request title (the API sends pickupCity /
@@ -123,6 +127,27 @@ function TrackingCard({ request, onChat, onAccepted }: { request: TripRequest; o
   // An open/pending request has no driver yet — nothing is being tracked. Only show the live-map
   // placeholder once a driver is on the way; otherwise say plainly that we're waiting for a driver.
   const awaitingDriver = /open|pending|request|search|form|wait/i.test(status);
+  const cancellable = !TERMINAL_STATUSES.has(status.toLowerCase());
+
+  async function handleCancel() {
+    if (!window.confirm("Cancel this request? This can't be undone.")) return;
+    setCancelling(true);
+    setCancelError(null);
+    try {
+      const res = await fetch(`/api/trust-transport/orders/${request.id}/cancel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) throw new Error("Could not cancel this request.");
+      onCancelled();
+    } catch (e: unknown) {
+      setCancelError(e instanceof Error ? e.message : "Could not cancel this request.");
+    } finally {
+      setCancelling(false);
+    }
+  }
+
   return (
     <div style={{ padding: "24px", borderRadius: 16, background: `${COLOR}08`, border: `1px solid ${COLOR}30`, marginBottom: 16 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
@@ -139,9 +164,22 @@ function TrackingCard({ request, onChat, onAccepted }: { request: TripRequest; o
           : "Your driver is on the way. Status updates as they mark progress — message them on the Direct Line for specifics."}
       </div>
       {awaitingDriver && <RequestOffers requestId={request.id} onAccepted={onAccepted} />}
-      <button type="button" onClick={() => onChat(request)} style={{ width: "100%", padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
+      <button type="button" onClick={() => onChat(request)} style={{ width: "100%", padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 6, marginBottom: cancellable ? 10 : 0 }}>
         <MessageCircle size={14} /> {awaitingDriver ? "Direct Line (opens when matched)" : "Direct Line"}
       </button>
+      {cancellable && (
+        <>
+          {cancelError && <div style={{ color: "#EF4444", fontSize: 12, marginBottom: 8 }}>{cancelError}</div>}
+          <button
+            type="button"
+            onClick={() => void handleCancel()}
+            disabled={cancelling}
+            style={{ width: "100%", padding: "12px", borderRadius: 10, background: "transparent", border: "1px solid rgba(239,68,68,0.3)", color: "#EF4444", fontSize: 13, fontWeight: 600, cursor: cancelling ? "default" : "pointer", opacity: cancelling ? 0.6 : 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}
+          >
+            {cancelling ? <Loader2 size={14} className="animate-spin" /> : <X size={14} />} Cancel request
+          </button>
+        </>
+      )}
     </div>
   );
 }
@@ -151,18 +189,20 @@ export function TrustTransportTrackingTab({
   onBook,
   onChat,
   onAccepted,
+  onCancelled,
 }: {
   requests: TripRequest[];
   onBook: () => void;
   onChat: (r: TripRequest) => void;
   onAccepted: () => void;
+  onCancelled: () => void;
 }) {
   return (
     <div style={{ flex: 1, padding: "24px", overflowY: "auto", minHeight: 0 }}>
       <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 20 }}>Tracking</div>
       {requests.length === 0
         ? <TrackingEmpty onBook={onBook} />
-        : requests.map((r) => <TrackingCard key={r.id} request={r} onChat={onChat} onAccepted={onAccepted} />)}
+        : requests.map((r) => <TrackingCard key={r.id} request={r} onChat={onChat} onAccepted={onAccepted} onCancelled={onCancelled} />)}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `POST /api/trust-transport/orders/:orderId/cancel` and its repository function already existed, fully authorized (requester or admin only) and transition-checked (a completed/cancelled request can't be re-cancelled) — but nothing in the app ever called it. A member had no way to cancel a request they made.
- Added a "Cancel request" control to the Tracking tab on web (`tt-tracking-tab.tsx`) and the Track tab on android (`TrustTransport.tsx`, new `cancelOrder()` in the mobile API client), shown for any of the member's own non-terminal requests (open, accepted, in progress).
- Each cancel is behind an explicit confirmation prompt (`window.confirm` on web, a native `Alert` on android) per the plugin's "explicit confirmation for irreversible actions" security control.

No schema, route, or contract changes — the endpoint already existed and was reviewed.

## Test plan
- [x] `pnpm -r run typecheck` passes
- [x] `eslint` passes on all changed files
- [x] EOF formatting check passes
- [x] `check-inventory-drift` passes
- [x] `check-test-script-drift` passes
- [ ] Manual: TT-11 on web and android (cancel a non-terminal request, confirm prompt, request moves to cancelled, chat goes read-only)

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_