### PR TITLE
fix: key Stream Feeds singleton on credentials to prevent cross-user reuse

### DIFF
--- a/ctf/packages/web/lib/shared/stream-feeds.ts
+++ b/ctf/packages/web/lib/shared/stream-feeds.ts
@@ -2,10 +2,23 @@
 import { StreamClient } from 'getstream';
 
 let streamFeedsClient: StreamClient | null = null;
+let streamFeedsApiKey: string | null = null;
+let streamFeedsToken: string | null = null;
+let streamFeedsAppId: string | null = null;
 
 export function getStreamFeedsClient(apiKey: string, token: string, appId: string) {
-  if (!streamFeedsClient) {
+  if (
+    !streamFeedsClient ||
+    streamFeedsApiKey !== apiKey ||
+    streamFeedsToken !== token ||
+    streamFeedsAppId !== appId
+  ) {
+    // Drop the previous client if credentials changed so a new user does not
+    // reuse a client authenticated as the previous user.
     streamFeedsClient = new StreamClient(apiKey, token, appId);
+    streamFeedsApiKey = apiKey;
+    streamFeedsToken = token;
+    streamFeedsAppId = appId;
   }
   return streamFeedsClient;
 }


### PR DESCRIPTION
## What

The Stream Feeds client in `ctf/packages/web/lib/shared/stream-feeds.ts` was cached in a module-level singleton keyed only on "was it created?". A different user, or the same user with a refreshed token, calling `getStreamFeedsClient` with new credentials silently received a client authenticated as the original user.

## Fix

Mirror the pattern already used in `stream-video.ts`: store the `apiKey`, `token`, and `appId` used to build the client and recreate it when any of them change. Same-credential calls still reuse the existing client.

Closes #1411

Parity Status: web + mobile-responsive + android complete