### PR TITLE
feat: require both parties to confirm before a TrustTransport trip completes

### DIFF
--- a/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -101,6 +101,33 @@ policies:
       - invalid_state_transition
       - actor_not_authorized_for_transition
       - region_not_permitted
+      - completion_requires_confirmation
+
+  - pluginId: trust-transport
+    command: trust-transport.trip.completion.confirm
+    version: 1.0.0
+    requiredRoles:
+      - member
+    attributePolicies:
+      tenancy: same_workspace
+      actorMustBeParticipant: true
+      onlyFromDeliveredState: true
+      bothPartiesRequiredToComplete: true
+    consentRequirements:
+      scopes:
+        - trust_transport_lifecycle_updates
+      fallbackLawfulBasis: contract_preparation
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: true
+      requiresAdditionalAudit: true
+    denyConditions:
+      - trip_not_delivered
+      - actor_not_participant
+      - region_not_permitted
 
   - pluginId: trust-transport
     command: trust-transport.payout.request

--- a/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -111,6 +111,31 @@ auditEvents:
     timestamp: rfc3339
     actorId: principal
     pluginId: trust-transport
+    command: trust-transport.trip.completion.confirm
+    commandVersion: 1.0.0
+    purpose: lifecycle_transition
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+      evidence:
+        participantAuthorizationCheck: pass_or_fail
+        deliveredStateCheck: pass_or_fail
+    dataClassesAccessed:
+      - trip_status_metadata
+    targetContext:
+      workspaceId: workspace_identifier
+      tripId: trip_identifier
+      bothConfirmed: boolean_flag
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: trust-transport
     command: trust-transport.payout.request
     commandVersion: 1.0.0
     purpose: provider_payouts

--- a/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_TRANSPORT_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -83,7 +83,12 @@ contracts:
   - pluginId: trust-transport
     command: trust-transport.trip.status.update
     version: 1.0.0
-    description: Apply canonical status transition for active trip or delivery lifecycle.
+    description: >-
+      Apply a canonical forward status transition for an active trip (assigned -> en_route ->
+      picked_up -> delivered) or a terminal state (cancelled/disputed/emergency_frozen). A non-admin
+      may NOT set 'completed' here — completion requires both parties to confirm via
+      trust-transport.trip.completion.confirm. Admins keep a direct override to 'completed' (which
+      settles), e.g. when resolving a dispute.
     inputSchema:
       tripId:
         type: string
@@ -105,8 +110,44 @@ contracts:
       - trust_transport_trips
       - trust_transport_status_events
       - trust_transport_proof_artifacts
-      # On completion: ServiceCredits settlement moves credits requester -> provider; fiat/crypto
-      # settlement credits the provider's earnings ledger in that currency.
+      # On an admin-override completion: ServiceCredits settlement moves credits requester -> provider;
+      # fiat/crypto settlement credits the provider's earnings ledger in that currency. (For the normal
+      # member path, settlement fires on trust-transport.trip.completion.confirm instead.)
+      - service_credits_wallets
+      - service_credits_transfers
+      - service_credits_ledger_entries
+      - trust_transport_earnings_ledger
+    purpose: lifecycle_transition
+    retentionClass: transactional_long_lived
+    idempotency: true
+
+  - pluginId: trust-transport
+    command: trust-transport.trip.completion.confirm
+    version: 1.0.0
+    description: >-
+      Record one participant's confirmation that a delivered trip is complete. Only valid from the
+      'delivered' state and only for the trip's requester or provider. The trip actually transitions to
+      'completed' — and settlement fires (ServiceCredits move requester -> provider, or the provider's
+      earnings ledger is credited for a fiat/crypto exchange settled off-platform) — only once BOTH the
+      requester and the provider have confirmed. This exists because completion moves value: neither
+      party may complete a trip unilaterally.
+    inputSchema:
+      tripId:
+        type: string
+        required: true
+    outputSchema:
+      tripId:
+        type: string
+      status:
+        type: string
+      bothConfirmed:
+        type: boolean
+      updatedAt:
+        type: string
+    dataAccess:
+      - trust_transport_trips
+      - trust_transport_status_events
+      # Only when this confirmation is the second one (bothConfirmed) and settlement fires:
       - service_credits_wallets
       - service_credits_transfers
       - service_credits_ledger_entries

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -133,13 +133,14 @@ Command groups in scope:
 3. `trust-transport.offer.create`
 4. `trust-transport.offer.accept`
 5. `trust-transport.trip.status.update`
-6. `trust-transport.delivery.proof.capture`
-7. `trust-transport.order.cancel`
-8. `trust-transport.chat.message.send`
-9. `trust-transport.payout.request`
-10. `trust-transport.admin.dispute.resolve`
-11. `trust-transport.admin.account.restrict`
-12. `trust-transport.admin.market.config.update`
+6. `trust-transport.trip.completion.confirm`
+7. `trust-transport.delivery.proof.capture`
+8. `trust-transport.order.cancel`
+9. `trust-transport.chat.message.send`
+10. `trust-transport.payout.request`
+11. `trust-transport.admin.dispute.resolve`
+12. `trust-transport.admin.account.restrict`
+13. `trust-transport.admin.market.config.update`
 
 ## HTTP Projection Routes
 
@@ -153,7 +154,8 @@ User routes:
 - `POST /api/trust-transport/requests/:requestId/offers` — Make an offer on an open request (one pending offer per provider per request; re-offering updates it).
 - `POST /api/trust-transport/offers/:offerId/accept` — Accept an offer, opening a trip.
 - `GET /api/trust-transport/trips` — Trips the caller is fulfilling (provider side), with the now-revealed pickup/drop-off, so they can advance the lifecycle.
-- `POST /api/trust-transport/trips/:tripId/status` — Update trip status.
+- `POST /api/trust-transport/trips/:tripId/status` — Advance trip status one forward step (assigned → en_route → picked_up → delivered), or set a terminal state. A non-admin cannot set `completed` here — completion requires mutual confirmation (below). Admins keep a direct override to `completed`.
+- `POST /api/trust-transport/trips/:tripId/complete` — Record the caller's completion confirmation for a `delivered` trip. Only the requester or provider may call it. The trip transitions to `completed` (and settlement fires) only once **both** parties have confirmed — neither can complete a trip alone, because completion moves value (a ServiceCredits transfer, or a recorded off-platform fiat/crypto settlement).
 - `POST /api/trust-transport/trips/:tripId/proof` — Capture pickup/delivery proof.
 - `POST /api/trust-transport/trips/:tripId/chat` — Mint Stream chat credentials for the trip thread: chat channel (`channelId`/`streamChannelId`) and participant token. Text chat only — no video.
 - `POST /api/trust-transport/trips/:tripId/emergency-stop` — Safety emergency-stop control.
@@ -194,7 +196,7 @@ Tables owned by this plugin:
 
 1. `trust_transport_requests` — Request rows across ride/package/food modes.
 2. `trust_transport_offers` — Offers placed by providers on a request.
-3. `trust_transport_trips` — Accepted-offer trips with lifecycle state.
+3. `trust_transport_trips` — Accepted-offer trips with lifecycle state. Includes `requester_completion_confirmed_at` and `provider_completion_confirmed_at` (both nullable timestamps): a trip only transitions to `completed` (and settles) once both are set — mutual completion confirmation.
 4. `trust_transport_status_events` — Append-only event log for status transitions.
 5. `trust_transport_proof_artifacts` — Pickup/delivery proof captures (photo, code, signature references).
 6. `trust_transport_disputes` — Dispute records and adjudication state.
@@ -289,6 +291,24 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
    history only (completed vs. not), never a score, by owner directive.
 
 ## Change Log
+
+- 2026-07-08: Mutual completion confirmation (owner decision). Previously either party's single "Mark
+  complete" tap (in practice the provider's) moved the trip straight to `completed`, which immediately
+  settled it — debiting the requester's ServiceCredits wallet, or crediting the provider's earnings
+  ledger for a fiat/crypto amount the platform never processed. That let one side unilaterally trigger a
+  value movement. Now: a trip can only be advanced to `delivered` by the normal status route; from
+  `delivered`, completion requires **both** the requester and the provider to confirm via the new
+  `POST /api/trust-transport/trips/:tripId/complete` route (command `trust-transport.trip.completion.confirm`).
+  The trip becomes `completed` and settles only on the second confirmation. `updateTripStatus` now rejects
+  a non-admin `completed` transition with `completion_requires_confirmation` (admins keep a direct override,
+  e.g. for dispute resolution). Schema: `trust_transport_trips` gains `requester_completion_confirmed_at`
+  and `provider_completion_confirmed_at`. UI: the provider's Help-tab trip card and the requester's
+  Tracking card both show a "Confirm trip completed" control on a delivered trip, then a "waiting for the
+  other party" state after their own confirmation — web and Android. Contracts updated (command,
+  access-policy, audit). This does not change the settlement mechanics themselves; it changes who must
+  agree before settlement runs. (Open follow-up flagged to the owner: for non-SC settlement the platform
+  has no payment processing — the exchange is peer-to-peer off-platform — so the fiat/crypto "earnings
+  ledger + payout request" flow may be reworked so it no longer implies a platform-issued payout.)
 
 - 2026-07-02: Cancel-request UI on both platforms. The `POST /api/trust-transport/orders/:orderId/cancel`
   route and `cancelOrder()` repository function already existed and were fully authorized (requester or

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -11,7 +11,7 @@
 | **Surfaces** | web (`/apps/trust-transport`, `/admin/trust-transport`) · android (`TrustTransport.tsx`, `AdminTrustTransport.tsx`) |
 | **Seed first** | `pnpm --dir ctf seed:trust-transport` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md` |
-| **Generated** | 2026-06-30 (commit 6f320290; manually updated to remove the rating case — ratings were deleted from the plugin; 2026-07-02: Android trip progression, proof capture, chat, and earnings/payouts shipped — issue #1250 closed; TT-8/TT-9/TT-13/TT-14 added to the parity table, the stale "service delete endpoint not live" gap removed, and the "Android deferred" earnings gap note removed) |
+| **Generated** | 2026-06-30 (commit 6f320290; manually updated to remove the rating case — ratings were deleted from the plugin; 2026-07-02: Android trip progression, proof capture, chat, and earnings/payouts shipped — issue #1250 closed; TT-8/TT-9/TT-13/TT-14 added to the parity table, the stale "service delete endpoint not live" gap removed, and the "Android deferred" earnings gap note removed; 2026-07-08: mutual completion confirmation — TT-8 reworded (no unilateral complete) and TT-8b added) |
 
 ---
 
@@ -182,9 +182,29 @@ Result: web ☐ android ☐
 
 **Steps:**
 1. Open the **Help out** tab → "Trips you're helping with"; find your active trip.
-2. Tap the forward action (Start trip → Mark picked up → Mark delivered → Mark complete) to advance one step.
+2. Tap the forward action (Start trip → Mark picked up → Mark delivered) to advance one step.
 
-**Expected:** The trip status changes one step forward and the new state shows on the card. Transitions are forward-only and append-only — there is no control to revert to the previous state. An out-of-order transition (via the API) is refused. When you mark the trip **complete** and the requester chose ServiceCredits settlement, the credits move from the requester to you (verify in your ServiceCredits wallet) and a `trust-transport.trip.settlement` audit event is written; a completed Free/Barter trip moves no credits.
+**Expected:** The trip status changes one step forward and the new state shows on the card. Transitions are forward-only and append-only — there is no control to revert to the previous state. An out-of-order transition (via the API) is refused. The forward steps stop at **Mark delivered** — there is no unilateral "Mark complete" tap; from delivered, completion is mutual (see TT-8b). Confirm no single button on this card moves the trip straight to `completed`.
+
+Result: web ☐ android ☐
+
+---
+
+### TT-8b — Mutual completion confirmation (both parties confirm before settlement)
+
+**Role:** requester and provider (two members) · **Surfaces:** web, android
+
+**Precondition:** A trip is in the `delivered` state (from TT-8). You can act as the provider on the Help-out tab and as the requester on the Tracking tab.
+
+**Steps:**
+1. As the **provider**, on the Help-out trip card, tap "Confirm trip completed".
+2. Observe the card. Then, as the **requester**, open the Tracking card for the same trip.
+3. As the **requester**, tap "Confirm trip completed".
+
+**Expected:**
+- Step 1: The provider's card shows "You confirmed completion. Waiting for the other party to confirm." The trip is **not** yet `completed` and **no** settlement has happened — if settlement is ServiceCredits, no credits have moved yet; if fiat/crypto, no earnings-ledger credit yet.
+- Step 2: The requester's Tracking card shows a "Confirm trip completed" control (and a note that the other party already confirmed).
+- Step 3: On the requester's confirmation the trip becomes `completed` and settlement fires: ServiceCredits move requester → provider (verify the wallet) with a `trust-transport.trip.settlement` audit event; a fiat/crypto priced trip credits the provider's earnings ledger; a Free/Barter trip moves nothing. A member cannot reach `completed` with only one side's confirmation. (Attempting to `POST .../status` with `nextStatus: completed` as a member is refused with `TRUST_TRANSPORT_COMPLETION_REQUIRES_CONFIRMATION`.)
 
 Result: web ☐ android ☐
 
@@ -491,7 +511,8 @@ These cases must produce the same observable outcome on both surfaces. Run both 
 | TT-11 | Explicit confirmation prompt before cancel |
 | TT-17 | Right panel shows "Good to know" reminders; no fabricated safety claims |
 | TT-18 | Discovery list shows only mode + settlement + age; offer sends and confirms |
-| TT-8 | Forward status control advances the trip one step; ServiceCredits settlement moves credits on completion |
+| TT-8 | Forward status control advances the trip one step; no unilateral "Mark complete" past delivered |
+| TT-8b | Completion needs both parties to confirm; settlement fires only on the second confirmation |
 | TT-9 | Proof capture saves a redacted reference; empty value rejected |
 | TT-13 | Balance card per currency; payout request created with the chosen currency; over-balance refused |
 | TT-14 | Zero/negative/over-balance payout attempts all rejected with inline error |

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransport.tsx
@@ -17,6 +17,7 @@ import { TrustTransportChatButton } from './TrustTransportChatButton';
 import { TrustTransportEarningsTab } from './TrustTransportEarningsTab';
 import {
   cancelOrder,
+  confirmTripCompletion,
   createRequest,
   listRequests,
   type ListRequestsResponse,
@@ -288,6 +289,50 @@ function CancelRequestButton({ requestId, onCancelled }: { requestId: string; on
   );
 }
 
+// Requester side of mutual completion confirmation (owner decision, 2026-07-08): once the trip is
+// 'delivered', the ride isn't complete (and no ServiceCredits move / no off-platform exchange is recorded
+// as settled) until both the requester and the provider confirm on-platform.
+function RequesterCompletionConfirm({ tripId, myConfirmedAtIso, otherConfirmedAtIso, onConfirmed }: { tripId: string; myConfirmedAtIso: string | null; otherConfirmedAtIso: string | null; onConfirmed: () => void }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await confirmTripCompletion(tripId);
+      onConfirmed();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not confirm completion.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (myConfirmedAtIso) {
+    return (
+      <View style={styles.completionWaiting}>
+        <Text style={styles.completionWaitingText}>You confirmed completion. Waiting for the other party to confirm.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.completionConfirm}>
+      {error ? <Text style={styles.cancelErrorText}>{error}</Text> : null}
+      <TouchableOpacity
+        style={[styles.confirmCompletionBtn, submitting && styles.cancelBtnDisabled]}
+        onPress={() => { void confirm(); }}
+        disabled={submitting}
+        accessibilityRole="button"
+      >
+        {submitting ? <ActivityIndicator size="small" color={COLOR} /> : <Text style={styles.confirmCompletionBtnText}>✓ Confirm trip completed</Text>}
+      </TouchableOpacity>
+      {otherConfirmedAtIso ? <Text style={styles.completionHint}>The other party has already confirmed — this finishes it.</Text> : null}
+    </View>
+  );
+}
+
 function TrackTab({
   requests,
   loading,
@@ -340,6 +385,14 @@ function TrackTab({
             <Text style={styles.requestSettle}>{ttSettlementLabel(req.priceCurrency, req.priceAmount)}</Text>
             {req.status === 'open' ? (
               <TrustTransportOffersSection requestId={req.id} onAccepted={onRefresh} />
+            ) : null}
+            {req.tripId && req.tripStatus === 'delivered' ? (
+              <RequesterCompletionConfirm
+                tripId={req.tripId}
+                myConfirmedAtIso={req.requesterCompletionConfirmedAtIso}
+                otherConfirmedAtIso={req.providerCompletionConfirmedAtIso}
+                onConfirmed={onRefresh}
+              />
             ) : null}
             {req.tripId ? <TrustTransportChatButton tripId={req.tripId} /> : null}
             {!TERMINAL_REQUEST_STATUSES.has(req.status) ? (
@@ -639,6 +692,26 @@ const styles = StyleSheet.create({
   cancelBtnDisabled: { opacity: 0.6 },
   cancelBtnText: { fontSize: 13, fontWeight: '600', color: '#EF4444' },
   cancelErrorText: { fontSize: 12, color: '#EF4444', marginTop: 8 },
+  completionConfirm: { marginTop: 8 },
+  confirmCompletionBtn: {
+    padding: 10,
+    borderRadius: 9,
+    backgroundColor: `${COLOR}1F`,
+    borderWidth: 1,
+    borderColor: `${COLOR}40`,
+    alignItems: 'center',
+  },
+  confirmCompletionBtnText: { fontSize: 13, fontWeight: '600', color: COLOR },
+  completionWaiting: {
+    marginTop: 8,
+    padding: 10,
+    borderRadius: 9,
+    backgroundColor: 'rgba(245,158,11,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(245,158,11,0.25)',
+  },
+  completionWaitingText: { fontSize: 12, fontWeight: '600', color: '#F59E0B' },
+  completionHint: { marginTop: 6, fontSize: 11, color: MUTED },
   publicContent: { padding: 20 },
   publicHeadRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 },
   publicTitle: { fontSize: 20, fontWeight: '800', color: TEXT },

--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransportHelpTab.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransportHelpTab.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import { listAvailableRequests, createOffer, listProviderTrips, updateTripStatus, captureProof } from './api';
+import { listAvailableRequests, createOffer, listProviderTrips, updateTripStatus, captureProof, confirmTripCompletion } from './api';
 import { ttSettlementLabel, type TrustTransportAvailableRequest, type TrustTransportProviderTrip } from './types';
 import { TrustTransportChatButton } from './TrustTransportChatButton';
 
@@ -13,12 +13,13 @@ function modeLabel(mode: string): string {
   return mode.charAt(0).toUpperCase() + mode.slice(1);
 }
 
-// The forward step a provider can take from each trip status (the happy path). Terminal states have none.
-const NEXT_STEP: Record<string, { next: 'en_route' | 'picked_up' | 'delivered' | 'completed'; label: string }> = {
+// The forward step a provider can take from each trip status (the happy path). No 'delivered' entry —
+// from there, completion requires mutual confirmation (see CompletionConfirm below), not a single
+// unilateral tap, because completion is what triggers settlement.
+const NEXT_STEP: Record<string, { next: 'en_route' | 'picked_up' | 'delivered'; label: string }> = {
   assigned: { next: 'en_route', label: 'Start trip' },
   en_route: { next: 'picked_up', label: 'Mark picked up' },
   picked_up: { next: 'delivered', label: 'Mark delivered' },
-  delivered: { next: 'completed', label: 'Mark complete' },
 };
 
 function tripStatusLabel(s: string): string {
@@ -99,12 +100,58 @@ function ProofForm({ tripId, onDone }: { tripId: string; onDone: () => void }) {
   );
 }
 
-function ProviderTripCard({ trip, busyId, onAdvance }: { trip: TrustTransportProviderTrip; busyId: string | null; onAdvance: (_tripId: string, _next: 'en_route' | 'picked_up' | 'delivered' | 'completed') => void }) {
+// Once a trip is 'delivered', completing it requires both parties to confirm on-platform (owner
+// decision, 2026-07-08) — completion is what triggers settlement (a ServiceCredits debit, or an
+// earnings-ledger credit for an off-platform fiat/crypto exchange the platform never verified), so
+// neither side can complete it alone.
+function CompletionConfirm({ tripId, myConfirmedAtIso, otherConfirmedAtIso, onConfirmed }: { tripId: string; myConfirmedAtIso: string | null; otherConfirmedAtIso: string | null; onConfirmed: () => void }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await confirmTripCompletion(tripId);
+      onConfirmed();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not confirm completion.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (myConfirmedAtIso) {
+    return (
+      <View style={styles.completionWaiting}>
+        <Text style={styles.completionWaitingText}>You confirmed completion. Waiting for the other party to confirm.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.completionConfirm}>
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+      <TouchableOpacity
+        style={[styles.advanceBtn, submitting && styles.sendBtnDisabled]}
+        onPress={() => { void confirm(); }}
+        disabled={submitting}
+        accessibilityRole="button"
+      >
+        {submitting ? <ActivityIndicator size="small" color={COLOR} /> : <Text style={styles.advanceBtnText}>✓ Confirm trip completed</Text>}
+      </TouchableOpacity>
+      {otherConfirmedAtIso ? <Text style={styles.completionHint}>The other party has already confirmed — this finishes it.</Text> : null}
+    </View>
+  );
+}
+
+function ProviderTripCard({ trip, busyId, onAdvance, onConfirmed }: { trip: TrustTransportProviderTrip; busyId: string | null; onAdvance: (_tripId: string, _next: 'en_route' | 'picked_up' | 'delivered') => void; onConfirmed: () => void }) {
   const [proofOpen, setProofOpen] = useState(false);
   const [proofDone, setProofDone] = useState(false);
   const step = NEXT_STEP[trip.status];
   const route = `${trip.pickupCity ?? '—'} → ${trip.dropoffCity ?? '—'}`;
   const terminal = ['completed', 'cancelled', 'disputed', 'emergency_frozen'].includes(trip.status);
+  const awaitingCompletion = trip.status === 'delivered';
 
   return (
     <View style={styles.tripCard}>
@@ -124,6 +171,8 @@ function ProviderTripCard({ trip, busyId, onAdvance }: { trip: TrustTransportPro
         >
           {busyId === trip.tripId ? <ActivityIndicator size="small" color={COLOR} /> : <Text style={styles.advanceBtnText}>✓ {step.label}</Text>}
         </TouchableOpacity>
+      ) : awaitingCompletion ? (
+        <CompletionConfirm tripId={trip.tripId} myConfirmedAtIso={trip.providerCompletionConfirmedAtIso} otherConfirmedAtIso={trip.requesterCompletionConfirmedAtIso} onConfirmed={onConfirmed} />
       ) : (
         <Text style={styles.noStepText}>No further action — this trip is {tripStatusLabel(trip.status).toLowerCase()}.</Text>
       )}
@@ -166,7 +215,7 @@ function ProviderTripsSection() {
 
   useEffect(() => { void load(); }, []);
 
-  async function advance(tripId: string, nextStatus: 'en_route' | 'picked_up' | 'delivered' | 'completed') {
+  async function advance(tripId: string, nextStatus: 'en_route' | 'picked_up' | 'delivered') {
     setBusyId(tripId);
     setError(null);
     try {
@@ -186,7 +235,7 @@ function ProviderTripsSection() {
       <Text style={styles.tripsSectionTitle}>Trips you&apos;re helping with</Text>
       {error ? <Text style={styles.errorText}>{error}</Text> : null}
       {trips.map((t) => (
-        <ProviderTripCard key={t.tripId} trip={t} busyId={busyId} onAdvance={(id, next) => { void advance(id, next); }} />
+        <ProviderTripCard key={t.tripId} trip={t} busyId={busyId} onAdvance={(id, next) => { void advance(id, next); }} onConfirmed={() => { void load(); }} />
       ))}
     </View>
   );
@@ -441,6 +490,17 @@ const styles = StyleSheet.create({
   },
   advanceBtnText: { fontSize: 13, fontWeight: '600', color: COLOR },
   noStepText: { fontSize: 12, color: MUTED, marginTop: 10 },
+  completionConfirm: { marginTop: 12 },
+  completionWaiting: {
+    marginTop: 12,
+    padding: 10,
+    borderRadius: 9,
+    backgroundColor: 'rgba(245,158,11,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(245,158,11,0.25)',
+  },
+  completionWaitingText: { fontSize: 12, fontWeight: '600', color: '#F59E0B' },
+  completionHint: { marginTop: 6, fontSize: 11, color: MUTED },
   addProofBtn: {
     marginTop: 8,
     padding: 8,

--- a/ctf/packages/mobile/src/features/trust-transport/api.ts
+++ b/ctf/packages/mobile/src/features/trust-transport/api.ts
@@ -121,6 +121,21 @@ export async function updateTripStatus(tripId: string, nextStatus: TrustTranspor
   return data.trip;
 }
 
+// Confirm your side of trip completion (only valid once the trip is 'delivered'). Neither party can
+// complete a trip alone — this only actually completes it (and fires settlement) once both the
+// requester and the provider have confirmed.
+export async function confirmTripCompletion(tripId: string): Promise<{ trip: TrustTransportTrip; bothConfirmed: boolean }> {
+  const data = await authedFetchJson<{ ok: boolean; trip: TrustTransportTrip; bothConfirmed: boolean }>(
+    `${BASE}/trips/${tripId}/complete`,
+    {
+      method: 'POST',
+      headers: MUTATION_HEADERS,
+      body: JSON.stringify({}),
+    },
+  );
+  return { trip: data.trip, bothConfirmed: data.bothConfirmed };
+}
+
 // Capture pickup/delivery proof as a redacted reference (no raw images).
 export async function captureProof(tripId: string, artifactType: 'photo' | 'code' | 'note', artifactRedacted: string): Promise<void> {
   await authedFetchJson<{ ok: boolean }>(`${BASE}/trips/${tripId}/proof`, {

--- a/ctf/packages/mobile/src/features/trust-transport/types.ts
+++ b/ctf/packages/mobile/src/features/trust-transport/types.ts
@@ -51,6 +51,11 @@ export type TrustTransportRequest = {
   // The trip id once an offer has been accepted. Chat is keyed by trip id, not the request id; null
   // until a trip exists.
   tripId: string | null;
+  // The underlying trip's own status. Needed because `status` above already reads 'completed' once the
+  // trip reaches 'delivered' — before mutual completion confirmation and settlement actually happen.
+  tripStatus: TrustTransportTripStatus | null;
+  requesterCompletionConfirmedAtIso: string | null;
+  providerCompletionConfirmedAtIso: string | null;
   createdAtIso: string;
   updatedAtIso: string;
 };
@@ -86,6 +91,10 @@ export type TrustTransportTrip = {
   streamChannelId: string | null;
   cancelledReason: string | null;
   completedAtIso: string | null;
+  // Mutual completion confirmation (owner decision, 2026-07-08): once a trip is 'delivered', neither
+  // party alone can complete it — completion (and settlement) fires only once both have confirmed.
+  requesterCompletionConfirmedAtIso: string | null;
+  providerCompletionConfirmedAtIso: string | null;
   createdAtIso: string;
   updatedAtIso: string;
 };
@@ -115,6 +124,8 @@ export type TrustTransportProviderTrip = {
   priceCurrency: string | null;
   priceAmount: number | null;
   createdAtIso: string;
+  requesterCompletionConfirmedAtIso: string | null;
+  providerCompletionConfirmedAtIso: string | null;
 };
 
 export type TrustTransportPayoutRequest = {

--- a/ctf/packages/web/app/api/trust-transport/_lib.ts
+++ b/ctf/packages/web/app/api/trust-transport/_lib.ts
@@ -102,6 +102,13 @@ export function trustTransportErrorResponse(error: unknown, fallbackMessage: str
     return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.invalidTransition, message: 'Invalid status transition.' }, { status: 409 });
   }
 
+  if (code === 'completion_requires_confirmation') {
+    return NextResponse.json(
+      { ok: false, code: TRUST_TRANSPORT_ERROR_CODE.completionRequiresConfirmation, message: 'Both the requester and the provider must confirm before a trip can be marked complete.' },
+      { status: 409 },
+    );
+  }
+
   if (code === 'policy_denied') {
     return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' }, { status: 403 });
   }

--- a/ctf/packages/web/app/api/trust-transport/trips/[tripId]/complete/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/trips/[tripId]/complete/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
+import { confirmTripCompletion, insertTrustTransportAudit } from 'lib/trust-transport/repository';
+import { reportError } from 'lib/observability/report';
+
+type RouteProps = {
+  params: Promise<{ tripId: string }>;
+};
+
+// Record the caller's completion confirmation. Neither party can complete a trip alone — this only
+// actually completes the trip (and fires settlement) once both the requester and the provider have
+// confirmed. See confirmTripCompletion() for why: completion triggers a ServiceCredits debit or an
+// earnings-ledger credit for an off-platform exchange the platform never verified, so a single unilateral
+// "mark complete" is not enough.
+export async function POST(request: Request, { params }: RouteProps) {
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireTrustTransportReadAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { tripId } = await params;
+
+  try {
+    const result = await confirmTripCompletion(tripId, gate.auth.userId);
+    await insertTrustTransportAudit({
+      actorId: gate.auth.userId,
+      command: 'trust-transport.trip.completion.confirm',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'trip',
+      targetId: tripId,
+      metadata: { bothConfirmed: result.bothConfirmed },
+    });
+    return NextResponse.json({ ok: true, ...result }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'trust-transport', op: 'trips_tripid_complete' });
+    return trustTransportErrorResponse(error, 'Trip completion confirmation unavailable.');
+  }
+}

--- a/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
+++ b/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
@@ -215,7 +215,7 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
         />
       )}
       {tab === "tracking" && (
-        <TrustTransportTrackingTab requests={requests} onBook={() => setTab("book")} onChat={openChat} onAccepted={() => void fetchRequests()} onCancelled={() => void fetchRequests()} />
+        <TrustTransportTrackingTab requests={requests} onBook={() => setTab("book")} onChat={openChat} onAccepted={() => void fetchRequests()} onCancelled={() => void fetchRequests()} onCompletionConfirmed={() => void fetchRequests()} />
       )}
       {tab === "help" && <TrustTransportHelpTab />}
       {tab === "earnings" && <TrustTransportEarningsTab />}

--- a/ctf/packages/web/components/trust-transport/tt-help-tab.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-help-tab.tsx
@@ -10,12 +10,13 @@ function modeLabel(mode: string | undefined): string {
   return mode.charAt(0).toUpperCase() + mode.slice(1);
 }
 
-// The forward step a provider can take from each trip status (the happy path). Terminal states have none.
+// The forward step a provider can take from each trip status (the happy path). "delivered" has no
+// entry here — from there, completion requires mutual confirmation (see CompletionConfirm below), not a
+// single unilateral tap, because completion is what triggers settlement.
 const NEXT_STEP: Record<string, { next: string; label: string }> = {
   assigned: { next: "en_route", label: "Start trip" },
   en_route: { next: "picked_up", label: "Mark picked up" },
   picked_up: { next: "delivered", label: "Mark delivered" },
-  delivered: { next: "completed", label: "Mark complete" },
 };
 
 function tripStatusLabel(s: string | undefined): string {
@@ -134,12 +135,56 @@ function TripChat({ tripId }: { tripId: string }) {
   );
 }
 
-function ProviderTripCard({ trip, busyId, onAdvance }: { trip: ProviderTrip; busyId: string | null; onAdvance: (tripId: string, next: string) => void }) {
+// Once a trip is "delivered", completing it requires both parties to confirm on-platform (owner
+// decision, 2026-07-08) — completion is what triggers settlement (a ServiceCredits debit, or an
+// earnings-ledger credit for an off-platform fiat/crypto exchange the platform never verified), so
+// neither side can complete it alone.
+function CompletionConfirm({ tripId, myConfirmedAtIso, otherConfirmedAtIso, onConfirmed }: { tripId: string; myConfirmedAtIso: string | null; otherConfirmedAtIso: string | null; onConfirmed: () => void }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/trust-transport/trips/${tripId}/complete`, { method: "POST", headers: { "x-ctf-csrf": "1" } });
+      if (!res.ok) throw new Error("Could not confirm completion.");
+      onConfirmed();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Could not confirm completion.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (myConfirmedAtIso) {
+    return (
+      <div style={{ marginTop: 12, padding: "10px 12px", borderRadius: 9, background: "rgba(245,158,11,0.08)", border: "1px solid rgba(245,158,11,0.25)", color: "#F59E0B", fontSize: 12, fontWeight: 600 }}>
+        You confirmed completion. Waiting for the other party to confirm.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: 12 }}>
+      {error && <div style={{ fontSize: 12, color: "#EF4444", marginBottom: 8 }}>{error}</div>}
+      <button type="button" onClick={() => void confirm()} disabled={submitting} style={{ width: "100%", padding: "10px 12px", borderRadius: 9, background: `${COLOR}1F`, border: `1px solid ${COLOR}40`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: submitting ? "default" : "pointer", opacity: submitting ? 0.6 : 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
+        {submitting ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />} Confirm trip completed
+      </button>
+      {otherConfirmedAtIso && (
+        <div style={{ marginTop: 6, fontSize: 11, color: "#6B7280" }}>The other party has already confirmed — this finishes it.</div>
+      )}
+    </div>
+  );
+}
+
+function ProviderTripCard({ trip, busyId, onAdvance, onConfirmed }: { trip: ProviderTrip; busyId: string | null; onAdvance: (tripId: string, next: string) => void; onConfirmed: () => void }) {
   const [proofOpen, setProofOpen] = useState(false);
   const [proofDone, setProofDone] = useState(false);
   const step = NEXT_STEP[trip.status ?? ""];
   const route = `${trip.pickupCity ?? "—"} → ${trip.dropoffCity ?? "—"}`;
   const terminal = ["completed", "cancelled", "disputed", "emergency_frozen"].includes(trip.status ?? "");
+  const awaitingCompletion = trip.status === "delivered";
 
   return (
     <div style={{ padding: "14px 16px", borderRadius: 14, background: `${COLOR}08`, border: `1px solid ${COLOR}25`, marginBottom: 12 }}>
@@ -152,6 +197,8 @@ function ProviderTripCard({ trip, busyId, onAdvance }: { trip: ProviderTrip; bus
         <button type="button" onClick={() => onAdvance(trip.tripId, step.next)} disabled={busyId !== null} style={{ marginTop: 12, width: "100%", padding: "10px 12px", borderRadius: 9, background: `${COLOR}1F`, border: `1px solid ${COLOR}40`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: busyId !== null ? "default" : "pointer", opacity: busyId !== null && busyId !== trip.tripId ? 0.5 : 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
           {busyId === trip.tripId ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />} {step.label}
         </button>
+      ) : awaitingCompletion ? (
+        <CompletionConfirm tripId={trip.tripId} myConfirmedAtIso={trip.providerCompletionConfirmedAtIso ?? null} otherConfirmedAtIso={trip.requesterCompletionConfirmedAtIso ?? null} onConfirmed={onConfirmed} />
       ) : (
         <div style={{ marginTop: 10, fontSize: 12, color: "#6B7280" }}>No further action — this trip is {tripStatusLabel(trip.status).toLowerCase()}.</div>
       )}
@@ -221,7 +268,7 @@ function ProviderTripsSection() {
       <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase", color: "#9CA3AF", marginBottom: 12 }}>Trips you&apos;re helping with</div>
       {error && <div style={{ color: "#EF4444", fontSize: 13, marginBottom: 10 }}>{error}</div>}
       {trips.map((t) => (
-        <ProviderTripCard key={t.tripId} trip={t} busyId={busyId} onAdvance={(id, next) => void advance(id, next)} />
+        <ProviderTripCard key={t.tripId} trip={t} busyId={busyId} onAdvance={(id, next) => void advance(id, next)} onConfirmed={() => void load()} />
       ))}
     </div>
   );

--- a/ctf/packages/web/components/trust-transport/tt-shared.ts
+++ b/ctf/packages/web/components/trust-transport/tt-shared.ts
@@ -57,6 +57,11 @@ export interface TripRequest {
   // The trip id once an offer has been accepted. Chat is keyed by trip id, so opening chat needs this
   // (a request id is not a trip id). Null/absent until a trip exists.
   tripId?: string | null;
+  // The underlying trip's own status. Needed because `status` above already reads "completed" once the
+  // trip reaches "delivered" — before mutual completion confirmation (and settlement) actually happens.
+  tripStatus?: string | null;
+  requesterCompletionConfirmedAtIso?: string | null;
+  providerCompletionConfirmedAtIso?: string | null;
 }
 
 // Plain label for how a ride is settled (issue #420). Honors the ServiceCredits rule (never the bare
@@ -112,6 +117,10 @@ export interface ProviderTrip {
   priceCurrency?: string | null;
   priceAmount?: number | null;
   createdAtIso?: string;
+  // Mutual completion confirmation (owner decision, 2026-07-08): once "delivered", neither party alone
+  // can complete the trip — both must confirm.
+  requesterCompletionConfirmedAtIso?: string | null;
+  providerCompletionConfirmedAtIso?: string | null;
 }
 
 // A request shown on the "Help out" tab (discovery model B): mode + settlement + age only. The pickup

--- a/ctf/packages/web/components/trust-transport/tt-tracking-tab.tsx
+++ b/ctf/packages/web/components/trust-transport/tt-tracking-tab.tsx
@@ -92,6 +92,49 @@ function RequestOffers({ requestId, onAccepted }: { requestId: string; onAccepte
   );
 }
 
+// Once a trip is "delivered", completing it requires both parties to confirm on-platform (owner
+// decision, 2026-07-08) — completion is what triggers settlement (a ServiceCredits debit from the
+// requester, or an earnings-ledger credit for an off-platform fiat/crypto exchange the platform never
+// verified), so neither side can complete it alone.
+function CompletionConfirm({ tripId, myConfirmedAtIso, otherConfirmedAtIso, onConfirmed }: { tripId: string; myConfirmedAtIso: string | null; otherConfirmedAtIso: string | null; onConfirmed: () => void }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/trust-transport/trips/${tripId}/complete`, { method: "POST", headers: { "x-ctf-csrf": "1" } });
+      if (!res.ok) throw new Error("Could not confirm completion.");
+      onConfirmed();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Could not confirm completion.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (myConfirmedAtIso) {
+    return (
+      <div style={{ marginBottom: 10, padding: "10px 12px", borderRadius: 9, background: "rgba(245,158,11,0.08)", border: "1px solid rgba(245,158,11,0.25)", color: "#F59E0B", fontSize: 12, fontWeight: 600 }}>
+        You confirmed completion. Waiting for the other party to confirm.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginBottom: 10 }}>
+      {error && <div style={{ fontSize: 12, color: "#EF4444", marginBottom: 8 }}>{error}</div>}
+      <button type="button" onClick={() => void confirm()} disabled={submitting} style={{ width: "100%", padding: "12px", borderRadius: 10, background: `${COLOR}1F`, border: `1px solid ${COLOR}40`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: submitting ? "default" : "pointer", opacity: submitting ? 0.6 : 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
+        {submitting ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />} Confirm trip completed
+      </button>
+      {otherConfirmedAtIso && (
+        <div style={{ marginTop: 6, fontSize: 11, color: "#6B7280" }}>The other party has already confirmed — this finishes it.</div>
+      )}
+    </div>
+  );
+}
+
 function statusBadgeStyle(status: string) {
   const s = status.toLowerCase();
   if (s.includes("cancel")) return { background: "rgba(239,68,68,0.12)", color: "#EF4444", border: "1px solid rgba(239,68,68,0.3)" };
@@ -115,7 +158,7 @@ function TrackingEmpty({ onBook }: { onBook: () => void }) {
   );
 }
 
-function TrackingCard({ request, onChat, onAccepted, onCancelled }: { request: TripRequest; onChat: (r: TripRequest) => void; onAccepted: () => void; onCancelled: () => void }) {
+function TrackingCard({ request, onChat, onAccepted, onCancelled, onCompletionConfirmed }: { request: TripRequest; onChat: (r: TripRequest) => void; onAccepted: () => void; onCancelled: () => void; onCompletionConfirmed: () => void }) {
   const [cancelling, setCancelling] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
   const pickup = request.pickupCity ?? request.fromLocation ?? null;
@@ -128,6 +171,10 @@ function TrackingCard({ request, onChat, onAccepted, onCancelled }: { request: T
   // placeholder once a driver is on the way; otherwise say plainly that we're waiting for a driver.
   const awaitingDriver = /open|pending|request|search|form|wait/i.test(status);
   const cancellable = !TERMINAL_STATUSES.has(status.toLowerCase());
+  // `request.status` already reads "completed" once the trip hits "delivered" (see
+  // mapRequestStatusFromTrip) — before mutual completion confirmation and settlement actually happen.
+  // Use the trip's own status to know whether a confirmation is still pending.
+  const awaitingCompletionConfirmation = request.tripStatus === "delivered";
 
   async function handleCancel() {
     if (!window.confirm("Cancel this request? This can't be undone.")) return;
@@ -164,6 +211,14 @@ function TrackingCard({ request, onChat, onAccepted, onCancelled }: { request: T
           : "Your driver is on the way. Status updates as they mark progress — message them on the Direct Line for specifics."}
       </div>
       {awaitingDriver && <RequestOffers requestId={request.id} onAccepted={onAccepted} />}
+      {awaitingCompletionConfirmation && (
+        <CompletionConfirm
+          tripId={request.tripId ?? ""}
+          myConfirmedAtIso={request.requesterCompletionConfirmedAtIso ?? null}
+          otherConfirmedAtIso={request.providerCompletionConfirmedAtIso ?? null}
+          onConfirmed={onCompletionConfirmed}
+        />
+      )}
       <button type="button" onClick={() => onChat(request)} style={{ width: "100%", padding: "12px", borderRadius: 10, background: `${COLOR}15`, border: `1px solid ${COLOR}30`, color: COLOR, fontSize: 13, fontWeight: 600, cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", gap: 6, marginBottom: cancellable ? 10 : 0 }}>
         <MessageCircle size={14} /> {awaitingDriver ? "Direct Line (opens when matched)" : "Direct Line"}
       </button>
@@ -190,19 +245,21 @@ export function TrustTransportTrackingTab({
   onChat,
   onAccepted,
   onCancelled,
+  onCompletionConfirmed,
 }: {
   requests: TripRequest[];
   onBook: () => void;
   onChat: (r: TripRequest) => void;
   onAccepted: () => void;
   onCancelled: () => void;
+  onCompletionConfirmed: () => void;
 }) {
   return (
     <div style={{ flex: 1, padding: "24px", overflowY: "auto", minHeight: 0 }}>
       <div style={{ fontSize: 22, fontWeight: 800, color: "#F9FAFB", marginBottom: 20 }}>Tracking</div>
       {requests.length === 0
         ? <TrackingEmpty onBook={onBook} />
-        : requests.map((r) => <TrackingCard key={r.id} request={r} onChat={onChat} onAccepted={onAccepted} onCancelled={onCancelled} />)}
+        : requests.map((r) => <TrackingCard key={r.id} request={r} onChat={onChat} onAccepted={onAccepted} onCancelled={onCancelled} onCompletionConfirmed={onCompletionConfirmed} />)}
     </div>
   );
 }

--- a/ctf/packages/web/lib/trust-transport/constants.ts
+++ b/ctf/packages/web/lib/trust-transport/constants.ts
@@ -23,4 +23,5 @@ export const TRUST_TRANSPORT_ERROR_CODE = {
   insufficientBalance: 'TRUST_TRANSPORT_INSUFFICIENT_BALANCE',
   accountRestricted: 'TRUST_TRANSPORT_ACCOUNT_RESTRICTED',
   mutualBlock: 'TRUST_TRANSPORT_MUTUAL_BLOCK',
+  completionRequiresConfirmation: 'TRUST_TRANSPORT_COMPLETION_REQUIRES_CONFIRMATION',
 } as const;

--- a/ctf/packages/web/lib/trust-transport/repository.ts
+++ b/ctf/packages/web/lib/trust-transport/repository.ts
@@ -103,6 +103,9 @@ type RequestRow = {
   updated_at: Date;
   // Present only when the row is selected with a join to trust_transport_trips (e.g. listRequests).
   trip_id?: string | null;
+  trip_status?: TrustTransportTripStatus | null;
+  requester_completion_confirmed_at?: Date | null;
+  provider_completion_confirmed_at?: Date | null;
 };
 
 type OfferRow = {
@@ -127,6 +130,8 @@ type TripRow = {
   stream_channel_id: string | null;
   cancelled_reason: string | null;
   completed_at: Date | null;
+  requester_completion_confirmed_at: Date | null;
+  provider_completion_confirmed_at: Date | null;
   created_at: Date;
   updated_at: Date;
 };
@@ -228,6 +233,9 @@ function mapRequestRow(row: RequestRow): TrustTransportRequest {
     createdAtIso: toIso(row.created_at),
     updatedAtIso: toIso(row.updated_at),
     tripId: row.trip_id ?? null,
+    tripStatus: row.trip_status ?? null,
+    requesterCompletionConfirmedAtIso: row.requester_completion_confirmed_at ? toIso(row.requester_completion_confirmed_at) : null,
+    providerCompletionConfirmedAtIso: row.provider_completion_confirmed_at ? toIso(row.provider_completion_confirmed_at) : null,
   };
 }
 
@@ -256,6 +264,8 @@ function mapTripRow(row: TripRow): TrustTransportTrip {
     streamChannelId: row.stream_channel_id,
     cancelledReason: row.cancelled_reason,
     completedAtIso: row.completed_at ? toIso(row.completed_at) : null,
+    requesterCompletionConfirmedAtIso: row.requester_completion_confirmed_at ? toIso(row.requester_completion_confirmed_at) : null,
+    providerCompletionConfirmedAtIso: row.provider_completion_confirmed_at ? toIso(row.provider_completion_confirmed_at) : null,
     createdAtIso: toIso(row.created_at),
     updatedAtIso: toIso(row.updated_at),
   };
@@ -440,10 +450,11 @@ export async function listRequests(options?: { page?: number; pageSize?: number;
   const result = await queryDb<RequestRow>(
     // LATERAL with LIMIT 1 so a request with more than one trip row (data anomaly) cannot duplicate the
     // request in the page and diverge from the COUNT above — at most one trip id per request.
-    `SELECT r.id, r.requester_user_id, r.mode, r.title, r.details, r.pickup_city, r.dropoff_city, r.pickup_geo_redacted, r.dropoff_geo_redacted, r.status, r.price_amount, r.price_currency, r.created_at, r.updated_at, t.id AS trip_id
+    `SELECT r.id, r.requester_user_id, r.mode, r.title, r.details, r.pickup_city, r.dropoff_city, r.pickup_geo_redacted, r.dropoff_geo_redacted, r.status, r.price_amount, r.price_currency, r.created_at, r.updated_at,
+            t.id AS trip_id, t.status AS trip_status, t.requester_completion_confirmed_at, t.provider_completion_confirmed_at
      FROM trust_transport_requests r
      LEFT JOIN LATERAL (
-       SELECT id FROM trust_transport_trips
+       SELECT id, status, requester_completion_confirmed_at, provider_completion_confirmed_at FROM trust_transport_trips
        WHERE request_id = r.id
        ORDER BY created_at
        LIMIT 1
@@ -633,7 +644,7 @@ export async function acceptOffer(requestId: string, offerId: string, actorUserI
     const offer = offerResult.rows[0];
 
     const existingTrip = await client.query<TripRow>(
-      `SELECT id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, created_at, updated_at
+      `SELECT id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at
        FROM trust_transport_trips
        WHERE request_id = $1::uuid
        LIMIT 1`,
@@ -666,7 +677,7 @@ export async function acceptOffer(requestId: string, offerId: string, actorUserI
     const tripResult = await client.query<TripRow>(
       `INSERT INTO trust_transport_trips (request_id, offer_id, requester_user_id, provider_user_id, mode, status)
        VALUES ($1::uuid, $2::uuid, $3, $4, $5, 'assigned')
-       RETURNING id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, created_at, updated_at`,
+       RETURNING id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at`,
       [requestId, offerId, request.requesterUserId, offer.provider_user_id, request.mode],
     );
 
@@ -722,10 +733,13 @@ export async function listProviderTrips(providerUserId: string): Promise<TrustTr
     dropoff_city: string | null;
     price_amount: string | number | null;
     price_currency: string | null;
+    requester_completion_confirmed_at: Date | null;
+    provider_completion_confirmed_at: Date | null;
     trip_created_at: Date;
   }>(
     `SELECT t.id AS trip_id, t.request_id, t.status, t.mode,
-            r.pickup_city, r.dropoff_city, r.price_amount, r.price_currency, t.created_at AS trip_created_at
+            r.pickup_city, r.dropoff_city, r.price_amount, r.price_currency,
+            t.requester_completion_confirmed_at, t.provider_completion_confirmed_at, t.created_at AS trip_created_at
      FROM trust_transport_trips t
      JOIN trust_transport_requests r ON r.id = t.request_id
      WHERE t.provider_user_id = $1
@@ -742,13 +756,15 @@ export async function listProviderTrips(providerUserId: string): Promise<TrustTr
     dropoffCity: row.dropoff_city,
     priceCurrency: row.price_currency,
     priceAmount: row.price_amount === null || row.price_amount === undefined ? null : Number(row.price_amount),
+    requesterCompletionConfirmedAtIso: row.requester_completion_confirmed_at ? toIso(row.requester_completion_confirmed_at) : null,
+    providerCompletionConfirmedAtIso: row.provider_completion_confirmed_at ? toIso(row.provider_completion_confirmed_at) : null,
     createdAtIso: toIso(row.trip_created_at),
   }));
 }
 
 export async function getTripById(tripId: string): Promise<TrustTransportTrip | null> {
   const result = await queryDb<TripRow>(
-    `SELECT id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, created_at, updated_at
+    `SELECT id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at
      FROM trust_transport_trips
      WHERE id = $1::uuid
      LIMIT 1`,
@@ -798,7 +814,7 @@ export async function updateTripStatus(
 ): Promise<{ trip: TrustTransportTrip; request: TrustTransportRequest }> {
   const result = await withDbTransaction(async (client) => {
     const tripResult = await client.query<TripRow>(
-      `SELECT id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, created_at, updated_at
+      `SELECT id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at
        FROM trust_transport_trips
        WHERE id = $1::uuid
        LIMIT 1
@@ -814,6 +830,15 @@ export async function updateTripStatus(
     const isParticipant = trip.requester_user_id === actorUserId || trip.provider_user_id === actorUserId;
     if (!isParticipant && !isAdmin) {
       throw new Error('policy_denied');
+    }
+
+    // Neither party can unilaterally complete a trip (owner decision, 2026-07-08): completion is what
+    // triggers settlement (a ServiceCredits debit from the requester, or an earnings-ledger credit for an
+    // off-platform fiat/crypto exchange the platform never verified), so it must go through
+    // confirmTripCompletion() below, which requires both the requester and the provider to confirm.
+    // Admins keep a direct override (e.g. resolving a dispute in the requester's or provider's favor).
+    if (nextStatus === 'completed' && !isAdmin) {
+      throw new Error('completion_requires_confirmation');
     }
 
     assertTripTransition(trip.status, nextStatus);
@@ -833,7 +858,7 @@ export async function updateTripStatus(
            completed_at = CASE WHEN $2 = 'completed' THEN NOW() ELSE completed_at END,
            updated_at = NOW()
        WHERE id = $1::uuid
-       RETURNING id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, created_at, updated_at`,
+       RETURNING id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at`,
       [tripId, nextStatus, normalizeNullableText(note)],
     );
 
@@ -877,6 +902,114 @@ export async function updateTripStatus(
   // Settlement (owner decision): when a trip completes, ServiceCredits move requester -> provider, and
   // fiat/crypto settlement credits the provider's earnings ledger. Runs after the completion is committed.
   await settleTripOnCompletion(result.trip, result.request, nextStatus);
+
+  return result;
+}
+
+// Record one participant's completion confirmation. Only confirmable from "delivered". Idempotent per
+// participant (re-confirming does not move the timestamp). Once both the requester and the provider have
+// confirmed, the trip actually transitions to "completed" and settlement fires — this is the only path to
+// "completed" for a non-admin (see the gate in updateTripStatus above). Returns `bothConfirmed` so the
+// caller can distinguish "recorded your confirmation, still waiting on the other party" from "trip is now
+// fully completed."
+export async function confirmTripCompletion(
+  tripId: string,
+  actorUserId: string,
+): Promise<{ trip: TrustTransportTrip; request: TrustTransportRequest; bothConfirmed: boolean }> {
+  const result = await withDbTransaction(async (client) => {
+    const tripResult = await client.query<TripRow>(
+      `SELECT id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at
+       FROM trust_transport_trips
+       WHERE id = $1::uuid
+       LIMIT 1
+       FOR UPDATE`,
+      [tripId],
+    );
+
+    if ((tripResult.rowCount ?? 0) === 0) {
+      throw new Error('trip_not_found');
+    }
+
+    const trip = tripResult.rows[0];
+    const isRequester = trip.requester_user_id === actorUserId;
+    const isProvider = trip.provider_user_id === actorUserId;
+    if (!isRequester && !isProvider) {
+      throw new Error('policy_denied');
+    }
+
+    if (trip.status !== 'delivered') {
+      throw new Error('invalid_transition');
+    }
+
+    const column = isRequester ? 'requester_completion_confirmed_at' : 'provider_completion_confirmed_at';
+    const confirmedResult = await client.query<TripRow>(
+      `UPDATE trust_transport_trips
+       SET ${column} = COALESCE(${column}, NOW()), updated_at = NOW()
+       WHERE id = $1::uuid
+       RETURNING id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at`,
+      [tripId],
+    );
+
+    await client.query(
+      `INSERT INTO trust_transport_status_events (request_id, trip_id, actor_user_id, event_name, from_status, to_status, metadata)
+       VALUES ($1::uuid, $2::uuid, $3, 'trip_completion_confirmed', 'delivered', 'delivered', jsonb_build_object('role', $4))`,
+      [trip.request_id, trip.id, actorUserId, isRequester ? 'requester' : 'provider'],
+    );
+
+    let confirmedTrip = confirmedResult.rows[0];
+    const bothConfirmed = confirmedTrip.requester_completion_confirmed_at !== null && confirmedTrip.provider_completion_confirmed_at !== null;
+
+    let requestRow: RequestRow;
+    if (bothConfirmed) {
+      const completedTripResult = await client.query<TripRow>(
+        `UPDATE trust_transport_trips
+         SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+         WHERE id = $1::uuid
+         RETURNING id, request_id, offer_id, requester_user_id, provider_user_id, mode, status, stream_channel_id, cancelled_reason, completed_at, requester_completion_confirmed_at, provider_completion_confirmed_at, created_at, updated_at`,
+        [tripId],
+      );
+      confirmedTrip = completedTripResult.rows[0];
+
+      const completedRequestResult = await client.query<RequestRow>(
+        `UPDATE trust_transport_requests
+         SET status = 'completed', updated_at = NOW()
+         WHERE id = $1::uuid
+         RETURNING id, requester_user_id, mode, title, details, pickup_city, dropoff_city, pickup_geo_redacted, dropoff_geo_redacted, status, price_amount, price_currency, created_at, updated_at`,
+        [trip.request_id],
+      );
+      requestRow = completedRequestResult.rows[0];
+
+      await client.query(
+        `INSERT INTO trust_transport_status_events (request_id, trip_id, actor_user_id, event_name, from_status, to_status, metadata)
+         VALUES ($1::uuid, $2::uuid, $3, 'trip_status_updated', 'delivered', 'completed', jsonb_build_object('reason', 'mutual_completion_confirmed'))`,
+        [trip.request_id, trip.id, actorUserId],
+      );
+    } else {
+      const requestResult = await client.query<RequestRow>(
+        `SELECT id, requester_user_id, mode, title, details, pickup_city, dropoff_city, pickup_geo_redacted, dropoff_geo_redacted, status, price_amount, price_currency, created_at, updated_at
+         FROM trust_transport_requests
+         WHERE id = $1::uuid
+         LIMIT 1`,
+        [trip.request_id],
+      );
+      requestRow = requestResult.rows[0];
+    }
+
+    return {
+      trip: mapTripRow(confirmedTrip),
+      request: mapRequestRow(requestRow),
+      bothConfirmed,
+    };
+  });
+
+  if (result.bothConfirmed) {
+    await syncTrustTransportRequestPresence(
+      result.request.requesterUserId,
+      result.request.id,
+      result.request.status,
+    );
+    await settleTripOnCompletion(result.trip, result.request, 'completed');
+  }
 
   return result;
 }

--- a/ctf/packages/web/lib/trust-transport/types.ts
+++ b/ctf/packages/web/lib/trust-transport/types.ts
@@ -57,6 +57,14 @@ export type TrustTransportRequest = {
   // The trip id once an offer has been accepted for this request, otherwise null. Chat is keyed by
   // trip id, so the UI needs this to open the right channel (a request id is not a trip id).
   tripId?: string | null;
+  // The underlying trip's own lifecycle status (assigned/en_route/.../delivered/completed), present
+  // only when a trip exists. Needed because the request's own `status` already reads "completed" once
+  // the trip reaches "delivered" (see mapRequestStatusFromTrip) — before mutual completion confirmation
+  // and settlement have actually happened. The UI uses this to know whether a completion confirmation is
+  // still pending.
+  tripStatus?: TrustTransportTripStatus | null;
+  requesterCompletionConfirmedAtIso?: string | null;
+  providerCompletionConfirmedAtIso?: string | null;
 };
 
 export type TrustTransportOffer = {
@@ -82,6 +90,10 @@ export type TrustTransportProviderTrip = {
   priceCurrency: string | null;
   priceAmount: number | null;
   createdAtIso: string;
+  // Mutual completion confirmation (owner decision): once the trip is "delivered", either party
+  // confirming does not alone complete it — both must confirm before it settles.
+  requesterCompletionConfirmedAtIso: string | null;
+  providerCompletionConfirmedAtIso: string | null;
 };
 
 // What a member browsing open requests to help with is allowed to see (discovery model B). Deliberately
@@ -113,6 +125,10 @@ export type TrustTransportTrip = {
   streamChannelId: string | null;
   cancelledReason: string | null;
   completedAtIso: string | null;
+  // Mutual completion confirmation (owner decision, 2026-07-08): once a trip is "delivered", neither
+  // party alone can complete it — completion (and settlement) fires only once both have confirmed.
+  requesterCompletionConfirmedAtIso: string | null;
+  providerCompletionConfirmedAtIso: string | null;
   createdAtIso: string;
   updatedAtIso: string;
 };

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -1320,6 +1320,8 @@ CREATE TABLE IF NOT EXISTS trust_transport_trips (
   stream_channel_id TEXT,
   cancelled_reason TEXT,
   completed_at TIMESTAMPTZ,
+  requester_completion_confirmed_at TIMESTAMPTZ,
+  provider_completion_confirmed_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -4169,6 +4171,8 @@ ALTER TABLE IF EXISTS trust_transport_risk_signals ADD COLUMN IF NOT EXISTS crea
 
 -- trust_transport_trips (1 — defensive)
 ALTER TABLE IF EXISTS trust_transport_trips ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS trust_transport_trips ADD COLUMN IF NOT EXISTS requester_completion_confirmed_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS trust_transport_trips ADD COLUMN IF NOT EXISTS provider_completion_confirmed_at TIMESTAMPTZ;
 
 -- trust_transport_user_extension (4 missing)
 ALTER TABLE IF EXISTS trust_transport_user_extension ADD COLUMN IF NOT EXISTS account_restricted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1343,6 +1343,8 @@ CREATE TABLE IF NOT EXISTS trust_transport_trips (
   stream_channel_id TEXT,
   cancelled_reason TEXT,
   completed_at TIMESTAMPTZ,
+  requester_completion_confirmed_at TIMESTAMPTZ,
+  provider_completion_confirmed_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -4210,6 +4212,8 @@ ALTER TABLE IF EXISTS trust_transport_risk_signals ADD COLUMN IF NOT EXISTS crea
 
 -- trust_transport_trips (1 — defensive)
 ALTER TABLE IF EXISTS trust_transport_trips ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS trust_transport_trips ADD COLUMN IF NOT EXISTS requester_completion_confirmed_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS trust_transport_trips ADD COLUMN IF NOT EXISTS provider_completion_confirmed_at TIMESTAMPTZ;
 
 -- trust_transport_user_extension (4 missing)
 ALTER TABLE IF EXISTS trust_transport_user_extension ADD COLUMN IF NOT EXISTS account_restricted BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary
Addresses the concern that one party could unilaterally complete a trip, which immediately settled it. Before this change, either party's single "Mark complete" tap (in practice only the provider's UI exposed it) moved the trip straight to `completed`, and completion is what fires settlement — a ServiceCredits debit from the requester, or an earnings-ledger credit to the provider for a fiat/crypto amount the platform never processed.

Now:
- The status route (`POST /trips/:tripId/status`) advances a trip only up to `delivered`. A non-admin can no longer set `completed` there — it's rejected with `TRUST_TRANSPORT_COMPLETION_REQUIRES_CONFIRMATION`. Admins keep a direct override (e.g. dispute resolution).
- From `delivered`, completion goes through a new route `POST /trips/:tripId/complete` (command `trust-transport.trip.completion.confirm`). Each party (requester and provider) confirms; the trip becomes `completed` and settles **only on the second confirmation**. Settlement stays idempotent-by-trip-id.
- Schema: `trust_transport_trips` gains `requester_completion_confirmed_at` and `provider_completion_confirmed_at` (both nullable timestamps; added via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for existing DBs and in the `CREATE TABLE` for fresh ones, in both `schema.sql` and `schema.demo.sql`).
- UI (web + Android): the provider's Help-tab trip card and the requester's Tracking card each show a "Confirm trip completed" control once the trip is `delivered`, then a "waiting for the other party" state after their own confirmation.
- Contracts updated: new command, access-policy, and audit entries; the `trip.status.update` command/policy docs note completion now requires confirmation.

## Owner-review lane
Flagged for owner review (not auto-merge) — it touches settlement/ServiceCredits and adds a new API contract.

## Open follow-up for a separate decision
The Earnings screen for non-SC settlement is still odd: the platform has no payment processing, so a fiat/crypto exchange is peer-to-peer off-platform, yet completion currently credits a fiat/crypto "earnings ledger" that the member can "request a payout" against — implying a platform-issued payout that can't happen. This PR does **not** change that; it only makes completion mutual. I'll follow the owner's decision on whether to rework the fiat/crypto earnings-ledger + payout flow so it no longer implies a platform payout.

## Test plan
- [x] `pnpm -r run typecheck` passes
- [x] `eslint` passes on all changed files
- [x] EOF formatting check passes
- [x] `check-inventory-drift` passes
- [x] `check-schema-drift` passes
- [x] `check-test-script-drift` passes
- [ ] Manual: TT-8 and new TT-8b on web and android (delivered has no unilateral complete; both must confirm; settlement fires only on the second confirmation)

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBitur6b3wP2tqjcYgKYz)_