### PR TITLE
fix: address shared code-review findings (aria-invalid, copy fallback, Stream connection)

### DIFF
--- a/ctf/docs/quota-impact/2026-07-10-stream-chat-panel-connection-ref-count.md
+++ b/ctf/docs/quota-impact/2026-07-10-stream-chat-panel-connection-ref-count.md
@@ -1,0 +1,40 @@
+# Stream Quota Impact Note — StreamChatPanel connection ref-count
+
+## Summary
+
+- Feature/Change: Ref-count the shared Stream Chat client connection in `StreamChatPanel` (code-review fix #1414). `StreamChat.getInstance(apiKey)` returns one shared client per API key; previously each panel called `connectUser` on mount and `disconnectUser` on unmount, so with two panels on screen the first to unmount dropped the shared connection for the others, and a quick re-mount could `connectUser` twice. Now the connection is acquired/released with a reference count: connect once for the first panel, disconnect only when the last panel unmounts, and skip `connectUser` when the client is already connected as that user.
+- PR: #1421
+- Owner: farahbrunache
+- Date: 2026-07-10
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: **Chat only.** Client-side WebSocket connection lifecycle (`connectUser` / `disconnectUser`) for the shared chat client. No Activity Feed, Video, or AI Moderation surface is touched. No new channel, watch, message, or credential-minting call is added.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: **None (neutral to slightly negative — fewer connections).** No new members and no new channels are reached. The change only affects how many times an already-signed-in member's single shared client connects: it removes redundant `connectUser` calls (StrictMode double-invoke, token refresh, and a second concurrent panel), so the number of connection handshakes goes down, not up. Concurrent connection count per member is now at most one shared client per API key instead of one-per-panel racing to connect/disconnect.
+- Activity Feed API calls estimate: 0 (surface not used here).
+- Video participant-minutes estimate: 0 (surface not used here).
+- AI Moderation credits estimate: 0 (surface not used here).
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): **Green.** The change reduces or holds connection volume; it cannot increase MAU, channels watched, or messages sent.
+- Peak scenario estimate: With N `StreamChatPanel`s mounted at once for the same member, connection handshakes drop from up to N (plus StrictMode/token-refresh churn) to 1. Peak is strictly lower than before.
+
+## Fallback and Degradation Plan
+
+- What degrades first: If the shared connection fails to open, the affected panel(s) show the existing "Failed to connect to chat." state (unchanged). Watch/connect errors are caught per panel.
+- User-visible messaging behavior: Unchanged — same loading / error / unavailable states as before.
+- Kill switch / feature flag: None added or changed. When Stream is unconfigured, the upstream credential path already returns unconfigured and the panels are not rendered; this change does not alter that.
+
+## Observability
+
+- Metrics and alerts added/updated: None added. Connection counts are visible in the GetStream dashboard as before; this change can only lower them.
+- Dashboard link (if available): GetStream app dashboard (existing).
+
+## Validation
+
+- Tests added for degraded mode: No automated test added (the connection lifecycle needs the live Stream client). Verified by `pnpm --filter @ctf/web lint` / `typecheck` / `build`. The ref-count worst case is a connection kept alive slightly too long (benign until page unload), never one dropped while a panel is still using it.
+- Rollback strategy: Revert PR #1421. No schema, contract, or data change; nothing to migrate.

--- a/ctf/packages/web/components/shared/form-field.tsx
+++ b/ctf/packages/web/components/shared/form-field.tsx
@@ -26,7 +26,10 @@ import { useId, type CSSProperties, type ReactNode } from "react";
 type FieldChildProps = {
   id: string;
   "aria-describedby"?: string;
-  "aria-invalid"?: true;
+  // Always present (true/false) rather than true/undefined: when an error clears, the control goes to
+  // an explicit aria-invalid="false" instead of the attribute vanishing, which some assistive tech
+  // reads more reliably. The HTML/React spec allows the full boolean here.
+  "aria-invalid"?: boolean;
 };
 
 type FormFieldProps = {
@@ -61,7 +64,7 @@ export function FormField({ label, optional, hint, error, children, className, s
           {hint}
         </div>
       ) : null}
-      {children({ id, "aria-describedby": describedBy, "aria-invalid": error ? true : undefined })}
+      {children({ id, "aria-describedby": describedBy, "aria-invalid": error ? true : false })}
       {error ? (
         <div id={errorId} role="alert" style={{ fontSize: 12, color: "#EF4444", marginTop: 6 }}>
           {error}

--- a/ctf/packages/web/components/shared/share-link.tsx
+++ b/ctf/packages/web/components/shared/share-link.tsx
@@ -31,6 +31,12 @@ async function writeToClipboard(text: string): Promise<boolean> {
     // fall through to the legacy path (older mobile browsers / insecure contexts)
   }
   try {
+    // Legacy best-effort fallback for old / insecure-context browsers that lack the async Clipboard
+    // API. Note (iOS Safari): programmatic el.select() + execCommand('copy') can report success while
+    // copying nothing without a direct user gesture on the element, and execCommand is deprecated. The
+    // popover always shows the selectable URL field, so a member can copy by hand; the caller also
+    // surfaces a "Copy failed" state when this returns false so a silent no-op is not mistaken for a
+    // successful copy.
     const el = document.createElement("textarea");
     el.value = text;
     el.setAttribute("readonly", "");
@@ -71,6 +77,9 @@ export function ShareLink({
 }) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  // True briefly when a copy attempt returned false (old browser / iOS gesture limit), so the member
+  // is told to copy the shown URL by hand instead of assuming it worked.
+  const [copyFailed, setCopyFailed] = useState(false);
   // The popup opens above the trigger by default, but flips below when the trigger sits near the top
   // of the viewport — otherwise the popup is clipped behind the header (the "modal doesn't fit" bug).
   const [placement, setPlacement] = useState<"top" | "bottom">("top");
@@ -124,7 +133,11 @@ export function ShareLink({
   async function onCopy() {
     const ok = await writeToClipboard(absolute);
     setCopied(ok);
-    window.setTimeout(() => setCopied(false), 2000);
+    setCopyFailed(!ok);
+    window.setTimeout(() => {
+      setCopied(false);
+      setCopyFailed(false);
+    }, 2000);
   }
 
   function onOpenNewTab() {
@@ -212,7 +225,7 @@ export function ShareLink({
           />
           <button type="button" onClick={() => void onCopy()} style={itemStyle}>
             {copied ? <Check size={15} /> : <Copy size={15} />}
-            <span aria-live="polite">{copied ? "Copied!" : "Copy link"}</span>
+            <span aria-live="polite">{copied ? "Copied!" : copyFailed ? "Copy failed — copy the link above" : "Copy link"}</span>
           </button>
           <button type="button" onClick={onOpenNewTab} style={itemStyle}>
             <ExternalLink size={15} />

--- a/ctf/packages/web/components/shared/stream-chat-panel.tsx
+++ b/ctf/packages/web/components/shared/stream-chat-panel.tsx
@@ -18,6 +18,44 @@ import './stream-chat-panel.css';
 // How far ahead the "Remind me about this" action schedules its nudge (30 minutes).
 const REMINDER_DELAY_MS = 30 * 60 * 1000;
 
+// Shared Stream connection registry, keyed by API key. `StreamChat.getInstance(apiKey)` returns one
+// singleton client per key, so several StreamChatPanels on screen at once (e.g. a Beacon viewer plus a
+// plugin chat) share the SAME client. Previously each panel called connectUser on mount and
+// disconnectUser on unmount, so the first panel to unmount tore the connection out from under every
+// other live panel, and a quick re-mount (React StrictMode, a token refresh) could connect twice.
+// Ref-count the connection instead: connect once for the first panel, and only disconnect when the
+// LAST panel using that client unmounts. Worst case is a connection kept alive slightly too long (a
+// benign leak until page unload), never one dropped while still in use.
+const streamConnections = new Map<string, { userId: string; count: number; ready: Promise<StreamChat> }>();
+
+function acquireStreamConnection(apiKey: string, userId: string, token: string): Promise<StreamChat> {
+  const client = StreamChat.getInstance(apiKey);
+  const existing = streamConnections.get(apiKey);
+  if (existing && existing.userId === userId) {
+    existing.count += 1;
+    return existing.ready;
+  }
+  // No live connection for this key, or it is connected as a different user: (re)connect. Guard
+  // connectUser so we never call it when the client is already connected as this user.
+  const ready = Promise.resolve()
+    .then(() => (client.userID && client.userID !== userId ? client.disconnectUser() : undefined))
+    .then(() => (client.userID === userId ? undefined : client.connectUser({ id: userId }, token)))
+    .then(() => client);
+  streamConnections.set(apiKey, { userId, count: 1, ready });
+  return ready;
+}
+
+function releaseStreamConnection(apiKey: string): void {
+  const entry = streamConnections.get(apiKey);
+  if (!entry) return;
+  entry.count -= 1;
+  if (entry.count <= 0) {
+    streamConnections.delete(apiKey);
+    // Best-effort teardown once nothing is using the shared client anymore.
+    StreamChat.getInstance(apiKey).disconnectUser().catch(() => {});
+  }
+}
+
 // The logged-in author's own messages are always gray; everyone else's use the plugin accent.
 const OWN_BUBBLE_BG = 'rgba(255, 255, 255, 0.07)';
 
@@ -374,11 +412,11 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const chatClient = StreamChat.getInstance(streamApiKey);
     let isMounted = true;
-    chatClient
-      .connectUser({ id: streamUserId }, streamToken)
-      .then(() => {
+    // Ref-counted shared connection (see streamConnections above) — connect once across all panels on
+    // this API key, disconnect only when the last one unmounts.
+    acquireStreamConnection(streamApiKey, streamUserId, streamToken)
+      .then((chatClient) => {
         const ch = chatClient.channel(channelType, streamChannelId);
         // Watch with presence so the channel state carries its member list. The default '@' mention
         // trigger in MessageInput reads the channel members to suggest people, so members must be
@@ -397,7 +435,7 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
       });
     return () => {
       isMounted = false;
-      chatClient.disconnectUser();
+      releaseStreamConnection(streamApiKey);
     };
   }, [streamApiKey, streamToken, streamUserId, streamChannelId, channelType]);
 

--- a/ctf/packages/web/components/socket-relay/sr-post.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-post.tsx
@@ -23,7 +23,7 @@ export type PostDraft = {
   requiresAmount: boolean;
 };
 
-type FieldA11y = { id: string; "aria-describedby"?: string; "aria-invalid"?: true };
+type FieldA11y = { id: string; "aria-describedby"?: string; "aria-invalid"?: boolean };
 
 function TagEditor({
   tags,


### PR DESCRIPTION
Resolves three `code-review` sweep findings in shared components.

## #1415 — aria-invalid typed too narrowly (low)
`FormField` (and the parallel `FieldA11y` type in `sr-post.tsx`) typed `aria-invalid` as `true | undefined` and passed `error ? true : undefined`. Now typed `boolean` and passed `error ? true : false`, so clearing an error sets `aria-invalid="false"` explicitly instead of the attribute vanishing — read more reliably by some assistive tech.

## #1416 — clipboard fallback silent failure (low)
The legacy `execCommand('copy')` fallback can report success while copying nothing on iOS Safari (no direct gesture) and is deprecated. Documented the limitation inline, and the caller now shows a **"Copy failed — copy the link above"** state when the copy returns false, so a silent no-op isn't mistaken for success (the popover already shows the selectable URL).

## #1414 — StreamChatPanel disconnected the shared client (medium)
`StreamChat.getInstance(apiKey)` returns one shared client per key, so with two `StreamChatPanel`s on screen (e.g. a Beacon viewer + a plugin chat) the first to unmount ran `disconnectUser()` and killed the connection for the others; a quick re-mount (StrictMode / token refresh) could also connect twice. Now the connection is **ref-counted**: connect once for the first panel, disconnect only when the last unmounts, and `connectUser` is skipped when the client is already connected as that user. Worst case is a connection kept alive slightly too long (benign until page unload), never one dropped while still in use.

## Dismissed (closed as not planned — false positives)
- **#1413** `useIsMobile` "hydration mismatch": it uses `useSyncExternalStore` with a server snapshot — the React-sanctioned pattern that suppresses the hydration warning by design. No mismatch.
- **#1412** toast "outside the conversation wrapper": `{toast}` is already inside `.ctf-chat-conversation` (it's `<Thread />` that's the outside sibling). The code already matches the suggested fix.
- **#1410** transfer idempotency "partial completion": the INSERT and the balance debit/credit + ledger writes all run inside one `withDbTransaction`, so a mid-transaction crash rolls back the INSERT too — the ON-CONFLICT idempotent replay is only reachable after a fully-committed transfer. Partial completion cannot occur.

## Testing
- `pnpm --filter @ctf/web lint` / `typecheck` / `build` — pass; `check-eof-format.sh` — pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_