### PR TITLE
fix: clear lint errors that block CI on main (unused vars + botched fieldBorder)

### DIFF
--- a/ctf/packages/mobile/src/features/trust-transport/TrustTransportEarningsTab.tsx
+++ b/ctf/packages/mobile/src/features/trust-transport/TrustTransportEarningsTab.tsx
@@ -14,7 +14,7 @@ const SUBTLE = '#9CA3AF';
 export function TrustTransportEarningsTab() {
   const { tokens, theme } = useTheme();
   const accent = getAppAccent('trust-transport', theme);
-  const styles = useMemo(() => makeStyles(tokens, accent), [tokens, accent]);
+  const styles = useMemo(() => makeStyles(tokens), [tokens]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [earnings, setEarnings] = useState<TrustTransportRecordedEarning[]>([]);
@@ -78,7 +78,7 @@ export function TrustTransportEarningsTab() {
   );
 }
 
-function makeStyles(t: ThemeTokens, accent: string) {
+function makeStyles(t: ThemeTokens) {
   return StyleSheet.create({
     centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, minHeight: 300 },
     section: { padding: 16 },

--- a/ctf/packages/web/components/skills-hunt/sh-scout-tab.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-scout-tab.tsx
@@ -92,7 +92,8 @@ function WhyThisWorks() {
 }
 
 function fieldBorder(active: boolean, t: ReturnType<typeof getSkillsHuntTokens>): string {
-  return `1px solid `;
+  // A filled/valid field gets the accent-tinted border; an empty one keeps the faint neutral border.
+  return `1px solid ${active ? `${t.ACCENT}50` : "rgba(255,255,255,0.1)"}`;
 }
 
 function NominationFields({ form }: { form: ScoutFormModel }) {

--- a/ctf/packages/web/components/socket-relay/sr-chat.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-chat.tsx
@@ -28,8 +28,6 @@ function ResolveBar({
   resolving: boolean;
   onResolve: (fulfillmentId: string, outcome: SrResolveOutcome) => void;
 }) {
-  const { theme } = useTheme();
-  const t = getSocketRelayTokens(theme);
   if (selected.status !== "active") {
     return (
       <div style={{ padding: "10px 16px", borderTop: "1px solid rgba(255,255,255,0.06)", fontSize: 12, color: SUBTLE }}>


### PR DESCRIPTION
## Why

`main` is currently **red on the whole-repo lint gate** (Quality Gates runs `eslint` across every package), from leftover unused variables in the recent theme-tokenization merges. That blocks CI on every open PR. These are the exact errors:

- `packages/mobile/.../TrustTransportEarningsTab.tsx:81` — `'accent' is defined but never used`
- `packages/web/components/socket-relay/sr-chat.tsx:32` — `'t' is assigned a value but never used`
- `packages/web/components/skills-hunt/sh-scout-tab.tsx:94` — `'active'` and `'t'` defined but never used

## Fixes

- **mobile `TrustTransportEarningsTab`** — `makeStyles` took an unused `accent` param (the local `accent` is still used for the spinner colour); dropped the param and its argument.
- **web `sr-chat`** — a component computed `const { theme } = useTheme(); const t = getSocketRelayTokens(theme)` but never used `t`; removed both dead lines (it renders with `SUBTLE` / action colours only).
- **web `sh-scout-tab`** — `fieldBorder(active, t)` ignored both params and returned an incomplete `` `1px solid ` `` with **no colour** — a botched tokenization edit. Restored the intended behaviour (accent-tinted border when the field is filled, faint neutral otherwise). This also fixes a **real rendering bug** — the field border was rendering empty — not just the lint.

## Notes

None of these files were touched by me otherwise; this is a pure unblock-CI fix. Verified: `pnpm --filter @ctf/mobile lint` and `pnpm --filter @ctf/web lint` both clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_