### PR TITLE
docs: set WCAG 2.2 AA as the accessibility target and back the claim

### DIFF
--- a/.claude/rules/100-product-context-and-experience-rules.mdc
+++ b/.claude/rules/100-product-context-and-experience-rules.mdc
@@ -23,10 +23,12 @@ Provide mandatory context so implementation decisions protect users and prevent 
 - Use plain, non-stigmatizing language in UI and error messages.
 
 ## Accessibility Rules
-- Target WCAG AAA wherever feasible, including 7:1 contrast for critical content.
+- Public conformance target: WCAG 2.2 Level AA, for both the web app and the Android app. This is the claim we make and maintain (owner decision, 2026-07-11, issue #1432). Do not claim Level AAA as a blanket, site-wide guarantee: WCAG 2.2 itself advises against requiring AAA across an entire site, and several AAA criteria are not achievable for the live and recorded audio-video features (Beacon, Chyme, GentlePulse).
+- AAA enhancements where feasible: apply individual AAA success criteria only where the product can meet them without constraining the whole experience — for example 7:1 contrast on primary text and a 6th-grade reading level per the brand voice. These are internal stretch goals, not part of the public claim.
 - Require keyboard navigability for all core workflows.
 - Require semantic labels and compatibility with screen readers.
 - Preserve accessibility in all responsive breakpoints.
+- Any public accessibility claim (landing page, marketing, in-app) must be backed by the dated Accessibility Statement (`ctf/docs/developer/ACCESSIBILITY_STATEMENT.md`), which records the target, the last test date, and the known gaps. Until an audit backs it, phrase a claim as an aim ("built to WCAG 2.2 AA"), not a present-tense guarantee.
 
 ## User Safety and Harm Prevention
 - Default to least-exposure experiences for sensitive profile and community data.

--- a/ctf/docs/developer/ACCESSIBILITY_STATEMENT.md
+++ b/ctf/docs/developer/ACCESSIBILITY_STATEMENT.md
@@ -1,0 +1,85 @@
+# Accessibility statement
+
+This is the source of truth for the product's accessibility target and its current, honest status.
+Any public accessibility claim — on the landing page, in marketing, or inside the app — must point
+back to this document. Keep the "last tested" date and the "known gaps" list current; a claim is only
+as honest as the dated status behind it.
+
+## Target
+
+WCAG 2.2 Level AA, for both the web app and the Android app.
+
+Owner decision, 2026-07-11 (issue #1432): AA is the target we make and maintain. It is the achievable,
+auditable, legally-recognized bar — the standard referenced by the ADA effective standard, Section
+508, and EN 301 549. We do not claim Level AAA as a blanket guarantee: WCAG 2.2 advises against
+requiring AAA across an entire site, and several AAA criteria cannot be met for the live and recorded
+audio-video features (for example 1.2.6 Sign Language, 1.2.9 Audio-only (Live), and 1.4.6 Contrast
+7:1 across the whole palette).
+
+Where the product can meet an individual AAA success criterion without constraining the whole
+experience, it does — for example 7:1 contrast on primary text and a 6th-grade reading level per the
+brand voice. These are enhancements on top of the AA target, not part of the public claim.
+
+## What we have today
+
+- Web: broad use of semantic roles and `aria-*` attributes across components, a shared accessible-forms
+  standard (`ctf/docs/developer/ACCESSIBLE_FORMS_STANDARD.md`), and contrast tokens in the theme.
+- Android (React Native): accessibility props (`accessibilityLabel`, `accessibilityRole`,
+  `accessible`) on some, but not all, screens.
+
+## Last tested
+
+Not yet audited. No formal WCAG 2.2 AA audit has been completed for either the web app or the Android
+app as of 2026-07-11. Until an audit is complete, public claims are phrased as an aim ("built to WCAG
+2.2 AA"), not a present-tense guarantee.
+
+Update this line with the date and scope each time an audit runs (for example: "Web audited against
+WCAG 2.2 AA on YYYY-MM-DD; Android audited on YYYY-MM-DD").
+
+## Known gaps
+
+Filled in from audit findings. Until the audits run, the honest statement is that gaps are not yet
+enumerated:
+
+- Web: no completed AA audit; per-criterion pass/fail not yet recorded.
+- Android: no completed AA audit; a meaningful share of screens still lack accessibility props, and
+  no assistive-technology (TalkBack) pass has been documented.
+
+## How to report an accessibility problem
+
+Report an accessibility barrier the same way as any other bug (see
+`.claude/rules/129-bug-reporting-and-triage-rules.mdc`). Include the screen, what you were trying to
+do, the assistive technology in use (screen reader, keyboard only, magnifier), and what went wrong.
+Accessibility reports are triaged as user-facing defects, not cosmetic requests.
+
+## Ownership and re-test cadence
+
+- Owner: accessibility target and this statement are owned by the product owner; a named maintainer is
+  assigned when the first audit is scheduled.
+- Every pull request: automated accessibility checks run in CI once the gates below are in place, so
+  regressions cannot ship silently.
+- Every release (or quarterly, whichever comes first): re-run the manual audit on the core flows and
+  update the "last tested" date and "known gaps" here. An accessibility line is part of the manual
+  test and release checklist.
+
+## Remaining work to make the claim fully honest (issue #1432)
+
+Ordered; later items depend on earlier ones.
+
+1. Reconcile the internal target so rule 100 and the accessible-forms standard both state AA baseline
+   with AAA enhancements where feasible. Done in this change.
+2. Audit the web app against WCAG 2.2 AA: automated (axe) sweep of every route plus manual review;
+   record failures per success criterion.
+3. Audit the Android app against WCAG 2.2 AA via WCAG2ICT mapping (satisfied through React Native
+   accessibility APIs plus TalkBack, not `aria-*`); cover the screens with no accessibility props.
+4. Fix the web gaps found in step 2 (labels, roles, focus order, contrast, keyboard traps, form
+   errors).
+5. Fix the Android gaps found in step 3 (accessibility labels/roles/state on interactive elements,
+   focus order, contrast, touch-target size, TalkBack announcements).
+6. Add automated gates so regressions cannot ship silently: `eslint-plugin-jsx-a11y` for web (CI,
+   max warnings 0), an axe check in the end-to-end/CI path, a contrast-token check against the theme
+   palette, and an equivalent React Native accessibility lint for mobile.
+7. Manual assistive-technology passes on the core flows: VoiceOver/NVDA plus keyboard-only on web, and
+   TalkBack on Android. Document each pass in a checklist.
+8. Publish this statement as a public, rendered page the landing-page claim can point to, once the
+   audits and gap list above are real.

--- a/ctf/docs/developer/ACCESSIBLE_FORMS_STANDARD.md
+++ b/ctf/docs/developer/ACCESSIBLE_FORMS_STANDARD.md
@@ -43,6 +43,10 @@ Every field is built from the shared field component, never hand-rolled, so it a
 
 ## Accessibility baseline (applies app-wide, not just forms)
 
+The product's conformance target is WCAG 2.2 Level AA, with selected AAA enhancements where feasible.
+See `ACCESSIBILITY_STATEMENT.md` for the target, current status, and how it is maintained. The
+checklist below is the working baseline that keeps each screen on track toward AA.
+
 Checklist for every screen as it's touched:
 
 - **Labels on every control**, including icon-only buttons (share, copy, nav rails, close, back) —

--- a/ctf/docs/developer/test-scripts/README.md
+++ b/ctf/docs/developer/test-scripts/README.md
@@ -70,3 +70,22 @@ Each case is tagged by **role** (member / admin) and **surface** (web desktop, w
 at ~390px, android), because not every plugin is tested as a logged-in member: most are member-facing,
 `weekly-performance` is admin-only, and `unlock` / `trust` / `bug-reporting` are internal surfaces
 tested through their admin/internal entry points.
+
+## Accessibility check (every sweep)
+
+The product's accessibility target is WCAG 2.2 Level AA — see
+`../ACCESSIBILITY_STATEMENT.md`. On each sweep, and before every release, run this short check on the
+core flow you are testing and file any failure as a Bug Reporting row:
+
+- Keyboard only (web): tab through the flow. Every control is reachable, the focus ring is always
+  visible, focus order is logical, and focus moves to errors and dialogs when they open. No keyboard
+  trap.
+- Screen reader spot-check: VoiceOver or NVDA on web, TalkBack on android. Every control announces a
+  clear label (including icon-only buttons: share, copy, close, back), and loading/success/error
+  states are announced, not only shown.
+- Contrast and non-color cues: text and meaningful UI are readable against the theme; meaning is never
+  carried by color alone.
+- Touch targets on android and mobile-responsive web are at least 44×44px.
+
+This is a manual AA spot-check, not a full audit. The full per-route audit and the automated
+accessibility gates are tracked in issue #1432 and listed in `../ACCESSIBILITY_STATEMENT.md`.


### PR DESCRIPTION
## What

Reconcile the internal accessibility target to match the public claim now set on the landing page (WCAG 2.2 AA), and add the source-of-truth statement the claim points to.

- Rule 100 (`.claude/rules/100-product-context-and-experience-rules.mdc`): public conformance target is WCAG 2.2 Level AA for web and Android. AAA is reframed as internal stretch enhancements where feasible (7:1 contrast on primary text, 6th-grade reading level), not a blanket claim. Any public claim must point to the dated Accessibility Statement.
- New `ctf/docs/developer/ACCESSIBILITY_STATEMENT.md`: target, current status (not yet audited — claims phrased as an aim until then), known gaps, how to report a barrier, ownership and re-test cadence, and the ordered remaining work.
- `ctf/docs/developer/ACCESSIBLE_FORMS_STANDARD.md`: points to the statement for the target.
- `ctf/docs/developer/test-scripts/README.md`: adds an accessibility spot-check to run on every sweep and before every release.

## Why

Rule 100 said "Target WCAG AAA wherever feasible", which disagreed with the accessible-forms standard (AA) and could not be substantiated or maintained. WCAG 2.2 advises against requiring AAA site-wide, and several AAA criteria are impossible for the live/recorded audio-video features. AA is the achievable, auditable, legally-recognized bar. This encodes the owner decision (2026-07-11) behind issue #1432 and removes the internal/public mismatch.

## Scope of this change

Documentation and rules only — no code, schema, contracts, or routes touched. The audits (web + Android against WCAG 2.2 AA), the code fixes they surface, the automated CI accessibility gates, the assistive-technology passes, and the rendered public statement page are the remaining ordered work, listed in the statement and in #1432. They depend on live audit runs and are not doable in a docs change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYDh93v7iYuHonVqxkG8Wy)_