### PR TITLE
fix: run one-off SkillsHunt remediation without the frozen monorepo install

### DIFF
--- a/.github/workflows/oneoff-remediate-duplicate-katie-larkin.yml
+++ b/.github/workflows/oneoff-remediate-duplicate-katie-larkin.yml
@@ -42,13 +42,17 @@ jobs:
         with:
           node-version: 22
 
-      - name: Enable pnpm
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run the remediation
+      # The script only needs `pg`. Install it standalone in a temp dir and run the
+      # script from there, so we avoid a full monorepo `pnpm install` (which fails
+      # here because the committed lockfile is out of date with the app package.json).
+      - name: Install pg and run the remediation
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: node ctf/scripts/oneoffRemediateDuplicateKatieLarkin.mjs
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          cp ctf/scripts/oneoffRemediateDuplicateKatieLarkin.mjs "$workdir/"
+          cd "$workdir"
+          npm init -y >/dev/null 2>&1
+          npm install pg@8 >/dev/null 2>&1
+          node oneoffRemediateDuplicateKatieLarkin.mjs


### PR DESCRIPTION
## What

The one-off remediation workflow failed at `pnpm install --frozen-lockfile` — the committed `pnpm-lock.yaml` is out of date with `ctf/packages/web/package.json` on main, so the frozen install refuses (a pre-existing repo drift, not this change).

The remediation script only needs `pg`, so this installs `pg` standalone in a temp dir and runs the script from there, skipping the whole monorepo install. The script itself is unchanged.

After this merges, re-run the workflow: Actions tab → "One-off — Remediate duplicate SkillsHunt submission" → Run workflow → type `REMEDIATE`.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjgoA8vVHmybUaa5jxcDmf)_