### PR TITLE
feat: admin manual leaderboard rebuild for SkillsHunt

### DIFF
--- a/ctf/docs/contracts/SKILLS_HUNT_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/SKILLS_HUNT_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -52,6 +52,30 @@ policies:
       - invalid_status_transition
 
   - pluginId: skills-hunt
+    command: skills-hunt.leaderboard.rebuild
+    version: 1.0.0
+    requiredRoles:
+      - admin
+      - operations
+    attributePolicies:
+      tenancy: same_workspace
+      roundExists: required
+    consentRequirements:
+      scopes:
+        - skills_hunt_admin
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - round_not_found
+
+  - pluginId: skills-hunt
     command: skills-hunt.round.list
     version: 1.0.0
     requiredRoles:

--- a/ctf/docs/contracts/SKILLS_HUNT_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/SKILLS_HUNT_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -47,6 +47,28 @@ auditEvents:
     timestamp: rfc3339
     actorId: principal
     pluginId: skills-hunt
+    command: skills-hunt.leaderboard.rebuild
+    commandVersion: 1.0.0
+    purpose: campaign_governance
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - skills_hunt_leaderboard
+      - skills_hunt_submissions
+    targetContext:
+      workspaceId: workspace_identifier
+      roundId: round_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: skills-hunt
     command: skills-hunt.round.list
     commandVersion: 1.0.0
     purpose: campaign_discovery

--- a/ctf/docs/contracts/SKILLS_HUNT_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/SKILLS_HUNT_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -258,6 +258,24 @@ contracts:
     idempotency: true
 
   - pluginId: skills-hunt
+    command: skills-hunt.leaderboard.rebuild
+    version: 1.0.0
+    description: Admin-only manual rebuild of a round's cached leaderboard (individual and team) from its current accepted submissions.
+    inputSchema:
+      roundId:
+        type: string
+        required: true
+    outputSchema:
+      ok:
+        type: boolean
+    dataAccess:
+      - skills_hunt_leaderboard
+      - skills_hunt_submissions
+    purpose: progress_visibility
+    retentionClass: derived_short_lived
+    idempotency: true
+
+  - pluginId: skills-hunt
     command: skills-hunt.achievement.list
     version: 1.0.0
     description: List achievements awarded to the authenticated user.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-feature-inventory.md
@@ -141,6 +141,7 @@ Admin/moderator routes:
 - `POST /api/skills-hunt/admin/rounds`
 - `PUT /api/skills-hunt/admin/rounds/:roundId`
 - `GET /api/skills-hunt/admin/rounds/:roundId/submissions`
+- `POST /api/skills-hunt/admin/rounds/:roundId/leaderboard/rebuild` — admin-gated (`requireSkillsHuntAdminAccess`), CSRF. Recomputes the round's cached `skills_hunt_leaderboard` (individual + team) from current accepted submissions via `rebuildLeaderboard`. Command `skills-hunt.leaderboard.rebuild`. Returns `{ ok: true }`. Exposed as a "Rebuild leaderboard" button per round in the admin Rounds tab.
 - `POST /api/skills-hunt/admin/submissions/:submissionId/review`
 - `PUT /api/skills-hunt/admin/feature-reward-card`
 - `POST /api/skills-hunt/admin/submissions/:submissionId/generate-directory-profile`
@@ -446,6 +447,8 @@ Android admin present (2026-06-06): `AdminSkillsHunt.tsx` + `admin-api.ts` added
 - [ ] Dispute escalation: second-admin sign-off vs flagged queue. Default: flagged queue.
 
 ### Change Log
+
+- 2026-07-08: **Admin manual leaderboard rebuild.** New admin-gated `POST /api/skills-hunt/admin/rounds/:roundId/leaderboard/rebuild` (command `skills-hunt.leaderboard.rebuild`) recomputes the round's cached `skills_hunt_leaderboard` from current accepted submissions via the existing `rebuildLeaderboard`, and a "Rebuild leaderboard" button per round in the admin Rounds tab. Fills a gap: the leaderboard is a cached table that only refreshed as a side effect of a review action, so there was no way to refresh it after an out-of-band change (e.g. a data fix that rejected an already-accepted submission). Added the command/access-policy/audit contract entries. **Android parity deferred** — tracked separately; web + mobile-responsive shipped here.
 
 - 2026-07-08: **One person = one Quora profile URL.** `createSubmission` now blocks a second *active* (not rejected, not deleted) submission for the same normalized Quora URL, across all rounds, under a transaction-scoped advisory lock. Reuses the existing `skills_hunt_duplicate_submission` error, so the API returns the same friendly "already nominated" message. Root cause of an incident where the same person was nominated twice in one round with different skill lists: the per-round url + skills signature hashed them differently, so both were accepted and each minted a Directory profile and a ServiceCredits reward. A follow-up may add a global partial unique index on `quora_profile_url_normalized` (WHERE not rejected/deleted) as a hard DB backstop, once production is confirmed free of other active URL duplicates.
 

--- a/ctf/docs/developer/test-scripts/skills-hunt-test-script.md
+++ b/ctf/docs/developer/test-scripts/skills-hunt-test-script.md
@@ -375,6 +375,22 @@ Result: web ☐
 
 ---
 
+### SH-A2b — Manual leaderboard rebuild button
+
+**Role:** admin · **Surfaces:** web
+
+**Precondition:** A round with at least one accepted submission exists.
+
+**Steps:**
+1. In the admin Rounds tab, find the round and click "Rebuild leaderboard"; confirm the prompt.
+2. Open that round's Leaderboard tab and check the standings.
+
+**Expected:** The button shows "Rebuilding…" then "Rebuilt ✓". The Leaderboard reflects the current accepted submissions (individual and team) — a scout whose accepted submission was removed/rejected out-of-band no longer carries its points. A non-admin cannot reach this action.
+
+Result: web ☐
+
+---
+
 ### SH-A3 — Review a submission: accept, then verify leaderboard rebuild and notification
 
 **Role:** admin/moderator · **Surfaces:** web, android

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/leaderboard/rebuild/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/leaderboard/rebuild/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../../../_lib';
+import { withDbTransaction } from 'lib/db/postgres';
+import { insertSkillsHuntAudit, rebuildLeaderboard } from 'lib/skills-hunt/repository';
+import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
+import { reportError } from 'lib/observability/report';
+
+// Admin-only manual leaderboard rebuild. The leaderboard is a cached table that
+// the app only recomputes as a side effect of reviewing a submission, so there
+// is otherwise no way to refresh it after an out-of-band change (e.g. a data fix
+// that rejected an already-accepted submission). This recomputes both the
+// individual and team boards for the round from the current accepted rows.
+export async function POST(request: Request, { params }: { params: Promise<{ roundId: string }> }) {
+  const gate = await requireSkillsHuntAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const { roundId } = await params;
+
+  try {
+    await withDbTransaction((client) => rebuildLeaderboard(client, roundId));
+
+    await insertSkillsHuntAudit({
+      actorId: gate.auth.userId,
+      command: 'skills-hunt.leaderboard.rebuild',
+      policyStatus: 'allow',
+      reason: 'admin_route_guard',
+      targetType: 'round',
+      targetId: roundId,
+    });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'skills-hunt', op: 'admin_rounds_roundid_leaderboard_rebuild' });
+    return NextResponse.json(
+      { ok: false, code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to rebuild leaderboard.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/leaderboard/rebuild/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/leaderboard/rebuild/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../../../_lib';
+import { ensureMutationCsrf, requireSkillsHuntAdminAccess } from '../../../../../_lib';
 import { withDbTransaction } from 'lib/db/postgres';
 import { insertSkillsHuntAudit, rebuildLeaderboard } from 'lib/skills-hunt/repository';
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';

--- a/ctf/packages/web/components/skills-hunt/sha-round-manager.tsx
+++ b/ctf/packages/web/components/skills-hunt/sha-round-manager.tsx
@@ -176,6 +176,40 @@ function rewardLabel(r: SkillsHuntRound): string {
   return `${r.rewardCreditsPerAccept} ServiceCredits / accept${cap}`;
 }
 
+// Manual leaderboard rebuild for a round. The leaderboard is a cached table that
+// only refreshes as a side effect of a review action, so this is the way to
+// recompute it after an out-of-band change (e.g. a data fix that rejected an
+// already-accepted submission) without waiting for the next review.
+function RebuildLeaderboardButton({ round, t }: { round: SkillsHuntRound; t: SkillsHuntAdminTokens }) {
+  const [state, setState] = useState<"idle" | "working" | "done" | "error">("idle");
+
+  async function rebuild() {
+    if (!window.confirm(`Rebuild the leaderboard for “${round.name}” from its current accepted submissions?`)) return;
+    setState("working");
+    try {
+      const res = await fetch(`/api/skills-hunt/admin/rounds/${round.id}/leaderboard/rebuild`, {
+        method: "POST",
+        headers: { "x-ctf-csrf": "1" },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new Error(body?.message ?? "Unable to rebuild leaderboard.");
+      }
+      setState("done");
+    } catch {
+      setState("error");
+    }
+  }
+
+  const label = state === "working" ? "Rebuilding…" : state === "done" ? "Rebuilt ✓" : state === "error" ? "Failed — retry" : "Rebuild leaderboard";
+  return (
+    <button type="button" onClick={() => void rebuild()} disabled={state === "working"}
+      style={{ padding: "6px 14px", borderRadius: 8, background: "transparent", border: "1px solid rgba(255,255,255,0.16)", color: state === "error" ? "#EF4444" : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: state === "working" ? "not-allowed" : "pointer", opacity: state === "working" ? 0.6 : 1 }}>
+      {label}
+    </button>
+  );
+}
+
 export function SkillsHuntRoundManager({ rounds }: { rounds: SkillsHuntRound[] }) {
   const { theme } = useTheme();
   const t = getSkillsHuntAdminTokens(theme);
@@ -218,10 +252,13 @@ export function SkillsHuntRoundManager({ rounds }: { rounds: SkillsHuntRound[] }
                   <div style={{ fontSize: 12, color: t.SUBTLE, marginTop: 2 }}>{rewardLabel(r)}</div>
                   <div style={{ fontSize: 11, color: t.MUTED, marginTop: 2 }}>{new Date(r.startsAtIso).toLocaleDateString()} → {new Date(r.endsAtIso).toLocaleDateString()}</div>
                 </div>
-                <button type="button" onClick={() => { setEditingId(editingId === r.id ? null : r.id); setCreating(false); }}
-                  style={{ padding: "6px 14px", borderRadius: 8, background: "transparent", border: "1px solid rgba(255,255,255,0.16)", color: t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer" }}>
-                  {editingId === r.id ? "Close" : "Edit"}
-                </button>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  <RebuildLeaderboardButton round={r} t={t} />
+                  <button type="button" onClick={() => { setEditingId(editingId === r.id ? null : r.id); setCreating(false); }}
+                    style={{ padding: "6px 14px", borderRadius: 8, background: "transparent", border: "1px solid rgba(255,255,255,0.16)", color: t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer" }}>
+                    {editingId === r.id ? "Close" : "Edit"}
+                  </button>
+                </div>
               </div>
               {editingId === r.id && (
                 <div style={{ marginTop: 14, paddingTop: 14, borderTop: `1px solid ${t.BORDER}` }}>


### PR DESCRIPTION
## What

Adds a way to manually rebuild a round's leaderboard from the admin UI.

- **Route:** `POST /api/skills-hunt/admin/rounds/:roundId/leaderboard/rebuild` — admin-gated, CSRF, calls the existing `rebuildLeaderboard(client, roundId)` in a transaction and writes a `skills-hunt.leaderboard.rebuild` audit row. Returns `{ ok: true }`.
- **UI:** a per-round "Rebuild leaderboard" button in the admin Rounds tab (confirm → "Rebuilding…" → "Rebuilt ✓").
- Command / access-policy / audit contract entries, feature-inventory route + change-log, and a new SH-A2b manual test case.

## Why

`skills_hunt_leaderboard` is a **cached** table — the app only recomputes it as a side effect of reviewing a submission, and an already-accepted row has no review buttons. So after an out-of-band change (like the recent data fix that rejected a duplicate accept), there was no way to refresh the board; the affected scout's score stayed stale. This button reuses the exact `rebuildLeaderboard` logic, so there's no risk of divergence.

## Note

Reuses the tested `rebuildLeaderboard`; no scoring logic is duplicated. Android parity is deferred (the mobile admin has no round management) and tracked separately.

Parity Ticket: #1437


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjgoA8vVHmybUaa5jxcDmf)_