### PR TITLE
feat: publish a public Accessibility Statement page

### DIFF
--- a/ctf/docs/developer/ACCESSIBILITY_STATEMENT.md
+++ b/ctf/docs/developer/ACCESSIBILITY_STATEMENT.md
@@ -111,5 +111,10 @@ Ordered; later items depend on earlier ones.
    theme palette, and an equivalent React Native accessibility lint for mobile.
 7. Manual assistive-technology passes on the core flows: VoiceOver/NVDA plus keyboard-only on web, and
    TalkBack on Android. Document each pass in a checklist.
-8. Publish this statement as a public, rendered page the landing-page claim can point to, once the
-   audits and gap list above are real.
+8. Publish this statement as a public, rendered page the landing-page claim can point to. Done: the
+   public page is at `/accessibility` (`ctf/packages/web/app/accessibility/page.tsx`), a signed-out
+   static route. It is linked from the web `/terms` footer and from the mobile Account & Data screen
+   (an out-link next to Terms, mirroring how mobile links to `/terms`). Keep the page's "Last reviewed"
+   date and known-limitations list in step with this developer document as the status changes; the page
+   is phrased as an aim ("we aim to meet WCAG 2.2 AA"), not a finished guarantee, until the runtime
+   audits land.

--- a/ctf/packages/mobile/src/features/account-data/AccountData.tsx
+++ b/ctf/packages/mobile/src/features/account-data/AccountData.tsx
@@ -59,6 +59,26 @@ async function openTerms(): Promise<void> {
   }
 }
 
+// Public Accessibility Statement page, opened the same way as Terms.
+const ACCESSIBILITY_FALLBACK_URL = 'https://app.chargingthefuture.com/accessibility';
+
+function accessibilityUrl(): string {
+  try {
+    return `${getApiBaseUrl()}/accessibility`;
+  } catch {
+    return ACCESSIBILITY_FALLBACK_URL;
+  }
+}
+
+async function openAccessibility(): Promise<void> {
+  const url = accessibilityUrl();
+  try {
+    await Linking.openURL(url);
+  } catch {
+    Alert.alert('Unable to open', 'We could not open the Accessibility page.');
+  }
+}
+
 const SERVICE_GLYPH: Record<string, string> = {
   chyme: '💬', directory: '📇', 'feed-announcements': '📣', foundation: '🪛', mood: '🌿',
   'gentle-pulse': '🎵', 'peer-programming': '👥', lighthouse: '🏠', 'socket-relay': '🔂',
@@ -303,6 +323,14 @@ export function AccountData() {
             accessibilityLabel="Open the Terms and Privacy Policy"
           >
             <Text style={s.legalLinkText}>Terms &amp; Privacy Policy</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={openAccessibility}
+            style={s.legalLink}
+            accessibilityRole="link"
+            accessibilityLabel="Open the Accessibility page"
+          >
+            <Text style={s.legalLinkText}>Accessibility</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>

--- a/ctf/packages/web/app/accessibility/accessibility.module.css
+++ b/ctf/packages/web/app/accessibility/accessibility.module.css
@@ -1,0 +1,118 @@
+/* Public Accessibility Statement page.
+   Uses the shared theme tokens from globals.css so the page follows both the
+   default and comic themes without hardcoding colors. This is a static
+   document, so the page scrolls naturally (it must not depend on the desktop
+   body being overflow:hidden). Mirrors the /terms page styling. */
+
+.page {
+  min-height: 100dvh;
+  background: var(--ctf-root-bg);
+  color: var(--ctf-root-text);
+  padding: 48px 20px 96px;
+  display: flex;
+  justify-content: center;
+}
+
+.container {
+  width: 100%;
+  max-width: 760px;
+}
+
+.header {
+  margin-bottom: 40px;
+}
+
+.brand {
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ctf-text-secondary);
+  font-weight: 600;
+  margin: 0 0 12px;
+}
+
+.title {
+  font-size: 30px;
+  line-height: 1.2;
+  font-weight: 700;
+  color: var(--ctf-text);
+  margin: 0 0 10px;
+}
+
+.updated {
+  font-size: 14px;
+  color: var(--ctf-text-subtle);
+  margin: 0;
+}
+
+.lead {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ctf-text-secondary);
+  margin: 20px 0 0;
+}
+
+.section {
+  margin-top: 40px;
+  scroll-margin-top: 24px;
+}
+
+.sectionHeading {
+  font-size: 20px;
+  font-weight: 650;
+  color: var(--ctf-text);
+  margin: 0 0 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--ctf-border);
+}
+
+.paragraph {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ctf-text-secondary);
+  margin: 0 0 14px;
+}
+
+.list {
+  margin: 0 0 14px;
+  padding-left: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.listItem {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ctf-text-secondary);
+}
+
+.link {
+  color: var(--ctf-gold);
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.footer {
+  margin-top: 64px;
+  padding-top: 20px;
+  border-top: 1px solid var(--ctf-border);
+  font-size: 14px;
+  color: var(--ctf-text-subtle);
+}
+
+@media (max-width: 767px) {
+  .page {
+    padding: 32px 16px 72px;
+  }
+
+  .title {
+    font-size: 26px;
+  }
+
+  .sectionHeading {
+    font-size: 18px;
+  }
+}

--- a/ctf/packages/web/app/accessibility/page.tsx
+++ b/ctf/packages/web/app/accessibility/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from 'next';
+import { OPERATOR_NAME, CONTACT_EMAIL } from '../terms/policy-content';
+import styles from './accessibility.module.css';
+
+// Public Accessibility Statement at /accessibility. Static server component
+// with no auth gate, so it is reachable by signed-out visitors (the
+// middleware only sets identity headers and never protects routes). This is
+// the page any public accessibility claim (landing page, marketing) points to.
+// The developer source of truth it summarizes is
+// ctf/docs/developer/ACCESSIBILITY_STATEMENT.md — keep the two in step:
+// when the status or the "last reviewed" date changes there, change it here.
+
+export const metadata: Metadata = {
+  title: 'Accessibility — Charging the Future',
+  description:
+    'How Charging the Future works toward WCAG 2.2 AA accessibility, where it stands today, and how to report a problem.',
+};
+
+const LAST_REVIEWED = 'July 11, 2026';
+
+export default function AccessibilityPage() {
+  return (
+    <main className={styles.page}>
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <p className={styles.brand}>Charging the Future</p>
+          <h1 className={styles.title}>Accessibility</h1>
+          <p className={styles.updated}>Last reviewed: {LAST_REVIEWED}</p>
+          <p className={styles.lead}>
+            We want everyone in our community to be able to use this product, including people who use
+            a screen reader, a keyboard instead of a mouse, larger text, or other assistive technology.
+            This page explains the standard we build to, where we stand today, and how to tell us about
+            a problem.
+          </p>
+        </header>
+
+        <section className={styles.section} aria-labelledby="goal">
+          <h2 id="goal" className={styles.sectionHeading}>
+            The standard we build to
+          </h2>
+          <p className={styles.paragraph}>
+            We aim to meet WCAG 2.2 Level AA on both the web app and the Android app. WCAG (the Web
+            Content Accessibility Guidelines) is the international standard for making digital products
+            usable by people with disabilities; Level AA is the bar that laws and regulators commonly
+            reference. Where we can go further without making the rest of the experience worse, we do —
+            for example higher color contrast on key text and plain, low-reading-level wording.
+          </p>
+          <p className={styles.paragraph}>
+            We do not claim Level AAA across the whole product. The guidelines themselves advise against
+            requiring AAA for an entire site, and a few AAA rules cannot be met for our live and
+            recorded audio and video features.
+          </p>
+        </section>
+
+        <section className={styles.section} aria-labelledby="today">
+          <h2 id="today" className={styles.sectionHeading}>
+            Where we stand today
+          </h2>
+          <p className={styles.paragraph}>
+            We are working toward WCAG 2.2 AA; we have not finished a full audit yet, so we describe
+            this as an aim rather than a finished guarantee. So far we have run an automated check of
+            the web app&apos;s screens and fixed the large majority of what it found — every form
+            control now has a clear label tied to it, and clickable cards, lists, and filters can be
+            operated with the keyboard, not only the mouse.
+          </p>
+          <p className={styles.paragraph}>
+            Still to come: a full review of every screen with accessibility testing tools, a review of
+            the Android app with its screen reader (TalkBack), and hands-on testing with screen readers
+            and keyboard-only use on the core tasks.
+          </p>
+        </section>
+
+        <section className={styles.section} aria-labelledby="known">
+          <h2 id="known" className={styles.sectionHeading}>
+            Known limitations
+          </h2>
+          <p className={styles.paragraph}>These are the gaps we already know about:</p>
+          <ul className={styles.list}>
+            <li className={styles.listItem}>
+              A few pop-up dialogs can be closed by clicking the dark area behind them. Keyboard users
+              can always close the same dialogs with the Escape key or the visible close button.
+            </li>
+            <li className={styles.listItem}>
+              Some recorded video does not have captions yet. Adding captions to recordings is planned.
+            </li>
+            <li className={styles.listItem}>
+              Color contrast, focus order, and screen-reader announcements have not yet been fully
+              reviewed on every screen. That review is in progress.
+            </li>
+          </ul>
+        </section>
+
+        <section className={styles.section} aria-labelledby="report">
+          <h2 id="report" className={styles.sectionHeading}>
+            Report a problem
+          </h2>
+          <p className={styles.paragraph}>
+            If something is hard or impossible to use, tell us and we will treat it as a real bug, not a
+            nice-to-have. Email{' '}
+            <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
+              {CONTACT_EMAIL}
+            </a>{' '}
+            and, if you can, include the screen you were on, what you were trying to do, the assistive
+            technology you were using (for example a screen reader, keyboard only, or screen
+            magnifier), and what went wrong.
+          </p>
+        </section>
+
+        <section className={styles.section} aria-labelledby="maintain">
+          <h2 id="maintain" className={styles.sectionHeading}>
+            How we keep this current
+          </h2>
+          <p className={styles.paragraph}>
+            An automated accessibility check runs on every change to the app so common problems cannot
+            slip back in. We re-check the core tasks by hand as the product changes and update this
+            page&apos;s date and the list above when the status changes.
+          </p>
+        </section>
+
+        <footer className={styles.footer}>{OPERATOR_NAME}</footer>
+      </div>
+    </main>
+  );
+}

--- a/ctf/packages/web/app/terms/page.tsx
+++ b/ctf/packages/web/app/terms/page.tsx
@@ -91,6 +91,10 @@ export default function TermsPage() {
           {OPERATOR_NAME} · Contact{' '}
           <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
             {CONTACT_EMAIL}
+          </a>{' '}
+          ·{' '}
+          <a className={styles.link} href="/accessibility">
+            Accessibility
           </a>
         </footer>
       </div>


### PR DESCRIPTION
## What

Publish a public, signed-out Accessibility Statement page at `/accessibility` (#1432, step 9). It states the standard the product builds to (WCAG 2.2 AA), where it stands today, known limitations, how to report a barrier, and how the statement is kept current. It is phrased as an aim, not a finished guarantee, until the runtime audits land — so any public accessibility claim now has an honest, dated page to point to.

## How

- New web route `ctf/packages/web/app/accessibility/{page.tsx, accessibility.module.css}`, mirroring the `/terms` server-component + CSS-module pattern and reusing the shared theme tokens (renders in both themes; mobile-responsive at the same 767px breakpoint as Terms).
- Linked from the web `/terms` footer and from the mobile Account & Data screen — an out-link next to Terms, matching how the mobile app already links to `/terms` (`Linking.openURL` to `${apiBase}/accessibility`, with a hosted fallback).
- `ACCESSIBILITY_STATEMENT.md` (developer source of truth) records that the public page is published and must be kept in step.

## Verification

- `pnpm --filter @ctf/web run build`: the route compiles as a static page (`○ /accessibility`).
- `pnpm --dir ctf run typecheck` (web + mobile) and the accessibility scan on the new page (0 findings) pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYDh93v7iYuHonVqxkG8Wy)_