### PR TITLE
ci: enforce web accessibility with a blocking jsx-a11y gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,9 @@ jobs:
       - name: Run lint gate
         run: pnpm --dir ctf run lint
 
+      - name: Run web accessibility gate
+        run: pnpm --dir ctf run lint:a11y
+
       - name: Run typecheck gate
         run: pnpm --dir ctf run typecheck
 

--- a/ctf/a11y-audit.config.mjs
+++ b/ctf/a11y-audit.config.mjs
@@ -2,20 +2,24 @@ import jsxA11y from 'eslint-plugin-jsx-a11y';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 
-// Report-only static accessibility audit for the web app.
+// Static accessibility gate for the web app.
 //
 // Run it with: pnpm --dir ctf run lint:a11y
 //
 // It applies the jsx-a11y recommended rules over app/ and components/ to
-// surface the statically-detectable WCAG 2.2 AA issues: missing or unbound
+// catch the statically-detectable WCAG 2.2 AA issues: missing or unbound
 // labels, click handlers without keyboard handlers, interactive handlers on
 // non-interactive elements, missing media captions, and missing required
 // ARIA props.
 //
-// It is intentionally NOT wired into the blocking CI lint gate yet: doing so
-// at "max warnings 0" would fail CI on the pre-existing findings this audit
-// records. Enabling the blocking gate is the last step of the web
-// accessibility work in issue #1432, after those findings are fixed.
+// This is now a blocking CI check: the "Run web accessibility gate" step in
+// the quality-gates job of .github/workflows/ci.yml runs `lint:a11y` at
+// max-warnings 0, so a new violation fails the build. The few intentional
+// exceptions that remain (modal backdrop click-to-close, the share-link
+// popover's stopPropagation, and the not-yet-captioned Beacon replay video)
+// carry an inline eslint-disable-next-line with a rationale at the call site;
+// see ctf/docs/developer/ACCESSIBILITY_STATEMENT.md for the list. Do not add a
+// blanket disable to silence a real finding — fix it or justify it per line.
 //
 // Limits: static analysis only. It does not check color contrast, focus
 // order, keyboard traps, or screen-reader announcement behavior — those need

--- a/ctf/docs/developer/ACCESSIBILITY_STATEMENT.md
+++ b/ctf/docs/developer/ACCESSIBILITY_STATEMENT.md
@@ -84,8 +84,9 @@ Accessibility reports are triaged as user-facing defects, not cosmetic requests.
 
 - Owner: accessibility target and this statement are owned by the product owner; a named maintainer is
   assigned when the first audit is scheduled.
-- Every pull request: automated accessibility checks run in CI once the gates below are in place, so
-  regressions cannot ship silently.
+- Every pull request: the static accessibility gate runs in CI (the "Run web accessibility gate" step
+  in the `quality-gates` job), so a new web accessibility violation fails the build and cannot ship
+  silently.
 - Every release (or quarterly, whichever comes first): re-run the manual audit on the core flows and
   update the "last tested" date and "known gaps" here. An accessibility line is part of the manual
   test and release checklist.
@@ -104,11 +105,14 @@ Ordered; later items depend on earlier ones.
    errors).
 5. Fix the Android gaps found in step 3 (accessibility labels/roles/state on interactive elements,
    focus order, contrast, touch-target size, TalkBack announcements).
-6. Add automated gates so regressions cannot ship silently. Started: a report-only static scan exists
-   (`pnpm --dir ctf run lint:a11y`, config `ctf/a11y-audit.config.mjs`). Still to do: wire
-   `eslint-plugin-jsx-a11y` into the blocking CI lint gate at max warnings 0 (only after the web gaps
-   above are fixed), add an axe check in the end-to-end/CI path, a contrast-token check against the
-   theme palette, and an equivalent React Native accessibility lint for mobile.
+6. Add automated gates so regressions cannot ship silently. Done: `eslint-plugin-jsx-a11y` runs as a
+   blocking CI check — the "Run web accessibility gate" step in the `quality-gates` job of
+   `.github/workflows/ci.yml` runs `pnpm --dir ctf run lint:a11y` at max-warnings 0, so a new web
+   accessibility violation fails the build. The remaining intentional exceptions carry an inline
+   `eslint-disable-next-line` with a rationale at the call site (the 5 modal backdrops, the share-link
+   popover, and the not-yet-captioned Beacon replay video listed under "Known gaps"). Still to do: add
+   an axe check in the end-to-end/CI path, a contrast-token check against the theme palette, and an
+   equivalent React Native accessibility lint for mobile.
 7. Manual assistive-technology passes on the core flows: VoiceOver/NVDA plus keyboard-only on web, and
    TalkBack on Android. Document each pass in a checklist.
 8. Publish this statement as a public, rendered page the landing-page claim can point to, once the

--- a/ctf/package.json
+++ b/ctf/package.json
@@ -37,7 +37,7 @@
     "schema:report-live-drift": "bash ./scripts/audit_schema_drift.sh",
     "schema:audit-queries": "node ./scripts/audit-schema-queries.mjs",
     "check:inventory-drift": "node ./scripts/check-inventory-drift.mjs",
-    "lint:a11y": "eslint --no-config-lookup --config ./a11y-audit.config.mjs \"packages/web/app/**/*.tsx\" \"packages/web/components/**/*.tsx\"",
+    "lint:a11y": "eslint --no-config-lookup --config ./a11y-audit.config.mjs --max-warnings=0 \"packages/web/app/**/*.tsx\" \"packages/web/components/**/*.tsx\"",
     "check:taxonomy-ops": "node ./scripts/check-taxonomy-change-ops.mjs",
     "check:test-script-drift": "node ./scripts/check-test-script-drift.mjs",
     "formance:fetch:standalone": "node ./scripts/fetchFormanceStandalone.mjs",

--- a/ctf/packages/web/components/beacon/beacon-viewer.tsx
+++ b/ctf/packages/web/components/beacon/beacon-viewer.tsx
@@ -241,6 +241,7 @@ export function BeaconViewer({ signInUrl, isMember }: { signInUrl: string; isMem
             <div style={{ marginTop: 20, textAlign: 'left' }}>
               <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Last replay</div>
               <div style={{ borderRadius: 12, overflow: 'hidden', background: '#000', border: `1px solid ${t.BORDER_SOLID}`, aspectRatio: '16 / 9' }}>
+                {/* eslint-disable-next-line jsx-a11y/media-has-caption -- known gap (WCAG 1.2.2): recorded broadcasts have no captions track yet; a captions pipeline is tracked in issue #1432. */}
                 <video controls playsInline src={replay.recordingUrl} style={{ width: '100%', height: '100%' }} />
               </div>
               <div style={{ fontSize: 14, fontWeight: 600, marginTop: 8 }}>{replay.title}</div>

--- a/ctf/packages/web/components/bug-reports/bug-report-modal.tsx
+++ b/ctf/packages/web/components/bug-reports/bug-report-modal.tsx
@@ -150,6 +150,7 @@ export function BugReportModal({ open, onClose }: BugReportModalProps) {
   const isResultView = view !== 'form';
 
   return createPortal(
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- backdrop click-to-close is a mouse convenience; keyboard users close via Escape (handler above) or the visible close button.
     <div
       className={styles.overlay}
       role="dialog"

--- a/ctf/packages/web/components/chyme/chyme-tip-dialog.tsx
+++ b/ctf/packages/web/components/chyme/chyme-tip-dialog.tsx
@@ -120,6 +120,7 @@ function ChymeTipDialog({
   };
 
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- backdrop click-to-close is a mouse convenience; keyboard users close via Escape (handler above) or the visible close button.
     <div
       role="dialog"
       aria-modal="true"

--- a/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
+++ b/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
@@ -88,6 +88,7 @@ export function ComicConsentModal({ open, onConfirm, onDismiss }: ComicConsentMo
   }
 
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- backdrop click-to-close is a mouse convenience; keyboard users close via Escape (handler above) or the visible close button.
     <div
       className={styles.comicConsentOverlay}
       role="dialog"

--- a/ctf/packages/web/components/directory/directory-profile-edit.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-edit.tsx
@@ -270,6 +270,7 @@ export function DirectoryProfileEdit({
   }, [onClose]);
 
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- backdrop click-to-close is a mouse convenience; keyboard users close via Escape (handler above) or the visible close button.
     <div
       role="dialog"
       aria-modal="true"

--- a/ctf/packages/web/components/foundation/foundation-connect-now.tsx
+++ b/ctf/packages/web/components/foundation/foundation-connect-now.tsx
@@ -198,6 +198,7 @@ function ConnectNowDialog({
   }, [onClose]);
 
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- backdrop click-to-close is a mouse convenience; keyboard users close via Escape (handler above) or the visible close button.
     <div
       role="dialog"
       aria-modal="true"

--- a/ctf/packages/web/components/shared/share-link.tsx
+++ b/ctf/packages/web/components/shared/share-link.tsx
@@ -190,6 +190,7 @@ export function ShareLink({
       </button>
 
       {open ? (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- stopPropagation only prevents the outside-click-close from firing on the popover's own content; it is event management, not a user action. The popover's controls are focusable buttons.
         <div
           id={dialogId}
           role="dialog"

--- a/ctf/packages/web/eslint.config.mjs
+++ b/ctf/packages/web/eslint.config.mjs
@@ -1,5 +1,6 @@
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 export default [
   {
@@ -22,6 +23,11 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
+      // Registered so inline `eslint-disable-next-line jsx-a11y/...` directives resolve in this base
+      // lint. No jsx-a11y rules are enabled here — accessibility is enforced by the separate
+      // `lint:a11y` gate (ctf/a11y-audit.config.mjs); this only stops "rule not found" errors on the
+      // justified disables in component files.
+      'jsx-a11y': jsxA11y,
     },
     rules: {
       ...(tsPlugin.configs.recommended.rules || {}),


### PR DESCRIPTION
## What

Wire the static accessibility scan into CI as a blocking check, so a new web accessibility violation cannot ship silently (#1432, step 7 — done now that the label-association and keyboard-operability findings are fixed).

## How

- Add a "Run web accessibility gate" step to the required `quality-gates` job in `.github/workflows/ci.yml`, running `pnpm --dir ctf run lint:a11y`.
- Make `lint:a11y` strict with `--max-warnings=0`.
- Suppress the 13 known intentional findings with an inline `eslint-disable-next-line` and a rationale at each call site, so main is clean and only *new* violations fail:
  - 5 modal backdrops (click-to-close) — keyboard path is Escape + a visible close button.
  - 1 share-link popover `stopPropagation` — event management, not a user action.
  - 1 not-yet-captioned Beacon replay video — a known WCAG 1.2.2 gap (needs a captions pipeline).
- Update the audit config header and `ACCESSIBILITY_STATEMENT.md` to record the gate is active.

## Why this is safe

Current main is clean under the gate: `pnpm --dir ctf run lint:a11y` exits 0. The gate only fails a PR that introduces a new violation in `app/` or `components/`. It runs in the existing `quality-gates` job, which already runs lint/typecheck/build and is skipped for docs/config-only PRs.

## Verification

- `pnpm --dir ctf run lint:a11y`: exits 0.
- `pnpm --dir ctf run typecheck` (web + mobile): passes.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYDh93v7iYuHonVqxkG8Wy)_