### PR TITLE
docs: add AI behavior change log and lock time/vocabulary preferences

### DIFF
--- a/.claude/rules/135-ai-behavior-change-log-and-user-preferences.mdc
+++ b/.claude/rules/135-ai-behavior-change-log-and-user-preferences.mdc
@@ -1,0 +1,42 @@
+# AI Behavior Change Log and Standing User Preferences
+
+## Intent
+Give the owner a single place to (1) see the AI's standing behavioral rules that must never be
+changed silently, and (2) track, with timestamps, every time the AI drifted from expected behavior.
+This file is both the rulebook for a small set of locked preferences and the running error log.
+
+All timestamps in this file use **US Eastern Time in 12-hour format** (see the time rule below).
+
+## Standing Preferences (locked — do not change without explicit owner confirmation)
+
+These are owner-directed and override any default AI behavior. An agent must not change any of them on
+its own. If an agent believes a change is needed, it must ask the owner and get an explicit "yes"
+first — for each change, every time.
+
+1. **Time format and zone.** Always display dates and times in **US Eastern Time (America/New_York),
+   12-hour clock with AM/PM** (e.g. `2026-07-11 01:57 PM EDT`). Never switch to a 24-hour clock.
+   Never switch to a different time zone. This applies everywhere the AI shows a time to the owner:
+   chat replies, this log, and any human-facing output.
+
+2. **Vocabulary and wording.** Do not change established vocabulary or terminology the owner is used
+   to. Each time an agent wants to change a word, term, or phrasing convention, it must get **explicit
+   confirmation from the owner first** — every single time, not once. (This is in addition to the
+   existing banned-term/brand-voice rules; those still apply.)
+
+3. **No silent behavioral changes.** More generally, do not silently change a behavior the owner has
+   come to rely on. When in doubt, ask before changing; then log the change below.
+
+## How to use the log
+
+- Every time an agent notices it drifted from expected behavior (or the owner points one out), add a
+  new row to the table below.
+- Fill in the timestamp in US Eastern Time, 12-hour format.
+- Keep entries short and factual: what changed, what it should have been, whether it is corrected.
+- Never delete rows. This is an append-only history so the owner can track the AI over time.
+
+## Behavior Change Log
+
+| Timestamp (US Eastern, 12-hour) | Behavior observed | Expected behavior | Status |
+|---|---|---|---|
+| 2026-07-11 01:57 PM EDT | Across sessions the AI switched from a 12-hour clock to a 24-hour clock without being asked. | Always use US Eastern Time, 12-hour clock (AM/PM). | Corrected — locked as standing preference #1 above. |
+| 2026-07-11 01:57 PM EDT | Owner reported unrequested vocabulary changes across sessions. | Do not change established vocabulary/terminology without explicit owner confirmation each time. | Corrected — locked as standing preference #2 above. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,7 @@ and hides meaning.
 - [132-trust-signal-coverage-rules.mdc](.claude/rules/132-trust-signal-coverage-rules.mdc)
 - [133-manual-test-script-sweep-rules.mdc](.claude/rules/133-manual-test-script-sweep-rules.mdc)
 - [134-navigation-and-back-control-rules.mdc](.claude/rules/134-navigation-and-back-control-rules.mdc)
+- [135-ai-behavior-change-log-and-user-preferences.mdc](.claude/rules/135-ai-behavior-change-log-and-user-preferences.mdc)
 - [200-plugin-command-contract-templates.mdc](.claude/rules/200-plugin-command-contract-templates.mdc)
 - [201-plugin-command-schema-template.mdc](.claude/rules/201-plugin-command-schema-template.mdc)
 - [202-plugin-access-policy-schema-template.mdc](.claude/rules/202-plugin-access-policy-schema-template.mdc)


### PR DESCRIPTION
Adds a file in the Claude rules folder so the owner can track the AI's behavioral drift over time, and locks a small set of standing preferences so agents stop changing them silently.

## What changed
- New file `.claude/rules/135-ai-behavior-change-log-and-user-preferences.mdc`:
  - **Standing preferences (locked):** time is always US Eastern Time, 12-hour clock (AM/PM), never 24-hour or another zone; no vocabulary/terminology changes without explicit owner confirmation each time; no silent behavioral changes in general.
  - **Append-only change log:** a timestamped table (US Eastern, 12-hour) for recording every drift, seeded with the two issues the owner reported (12-hour to 24-hour clock switch, unrequested vocabulary changes), both marked corrected.
- Indexed the new module in `CLAUDE.md` so future agents load it.

Documentation only — no code, schema, contract, or route changes.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRzMKJCMQh3csvLxpzVmpY)_