### PR TITLE
fix: show both auth paths and drop fabricated country count on public shells

### DIFF
--- a/ctf/packages/web/components/contributions/contributions-public-shell.tsx
+++ b/ctf/packages/web/components/contributions/contributions-public-shell.tsx
@@ -51,33 +51,84 @@ function WayRow({
   );
 }
 
-function SignInButton({ signInUrl, verifyUrl, t, full }: { signInUrl: string; verifyUrl?: string; t: ContributionsTokens; full?: boolean }) {
-  const href = verifyUrl ?? signInUrl;
-  const label = verifyUrl ? 'Finish verifying' : 'Sign in';
+// Call-to-action buttons for the sign-in card. In verify mode (a signed-in but unverified member)
+// the single "Finish verifying" button is the only action. Otherwise both paths are shown so it is
+// clear there is a way in for new and returning members alike: "Join free" (primary sign-up) and
+// "Sign in" (secondary). Both point at the same hosted auth URL, which handles sign-up vs sign-in.
+function AuthCtas({ signInUrl, verifyUrl, t, full }: { signInUrl: string; verifyUrl?: string; t: ContributionsTokens; full?: boolean }) {
+  if (verifyUrl) {
+    return (
+      <a
+        href={verifyUrl}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 5,
+          padding: full ? '11px' : '9px 18px',
+          width: full ? '100%' : undefined,
+          borderRadius: full ? 9 : 8,
+          background: t.ACCENT,
+          border: 'none',
+          color: '#fff',
+          fontSize: full ? 14 : 13,
+          fontWeight: 600,
+          cursor: 'pointer',
+          textDecoration: 'none',
+          flexShrink: 0,
+          boxSizing: 'border-box',
+        }}
+      >
+        Finish verifying <ChevronRight size={full ? 15 : 14} />
+      </a>
+    );
+  }
   return (
-    <a
-      href={href}
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: 5,
-        padding: full ? '11px' : '9px 18px',
-        width: full ? '100%' : undefined,
-        borderRadius: full ? 9 : 8,
-        background: t.ACCENT,
-        border: 'none',
-        color: '#fff',
-        fontSize: full ? 14 : 13,
-        fontWeight: 600,
-        cursor: 'pointer',
-        textDecoration: 'none',
-        flexShrink: 0,
-        boxSizing: 'border-box',
-      }}
-    >
-      {label} <ChevronRight size={full ? 15 : 14} />
-    </a>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: full ? '100%' : undefined, flexShrink: 0 }}>
+      <a
+        href={signInUrl}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 5,
+          padding: full ? '11px' : '9px 18px',
+          flex: full ? 1 : undefined,
+          borderRadius: full ? 9 : 8,
+          background: t.ACCENT,
+          border: 'none',
+          color: '#fff',
+          fontSize: full ? 14 : 13,
+          fontWeight: 600,
+          cursor: 'pointer',
+          textDecoration: 'none',
+          boxSizing: 'border-box',
+        }}
+      >
+        Join free <ChevronRight size={full ? 15 : 14} />
+      </a>
+      <a
+        href={signInUrl}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: full ? '11px' : '9px 18px',
+          flex: full ? 1 : undefined,
+          borderRadius: full ? 9 : 8,
+          background: 'transparent',
+          border: `1px solid ${t.BORDER_SOLID}`,
+          color: t.TITLE,
+          fontSize: full ? 14 : 13,
+          fontWeight: 600,
+          cursor: 'pointer',
+          textDecoration: 'none',
+          boxSizing: 'border-box',
+        }}
+      >
+        Sign in
+      </a>
+    </div>
   );
 }
 
@@ -111,11 +162,11 @@ function DesktopPublic({ signInUrl, verifyUrl, t }: { signInUrl: string; verifyU
           </div>
           <div style={{ flex: 1 }}>
             <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 4 }}>
-              {verifyUrl ? 'Finish verifying to contribute' : 'Sign in to contribute'}
+              {verifyUrl ? 'Finish verifying to contribute' : 'Join or sign in to contribute'}
             </div>
             <div style={{ fontSize: 13, color: t.MUTED }}>Contributions are available to signed-in members.</div>
           </div>
-          <SignInButton signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} />
+          <AuthCtas signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} />
         </div>
       </div>
     </div>
@@ -153,12 +204,12 @@ function MobilePublic({ signInUrl, verifyUrl, t }: { signInUrl: string; verifyUr
             </div>
             <div>
               <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE }}>
-                {verifyUrl ? 'Finish verifying to contribute' : 'Sign in to contribute'}
+                {verifyUrl ? 'Finish verifying to contribute' : 'Join or sign in to contribute'}
               </div>
               <div style={{ fontSize: 12, color: t.MUTED, marginTop: 2 }}>Available to signed-in members</div>
             </div>
           </div>
-          <SignInButton signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} full />
+          <AuthCtas signInUrl={signInUrl} verifyUrl={verifyUrl} t={t} full />
         </div>
       </div>
     </div>

--- a/ctf/packages/web/components/mood/mood-public-shell.tsx
+++ b/ctf/packages/web/components/mood/mood-public-shell.tsx
@@ -96,10 +96,14 @@ function MobileMoodPublic({ signInUrl, verifyUrl }: { signInUrl: string; verifyU
   const t = getMoodTokens(theme);
   return (
     <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, display: 'flex', flexDirection: 'column', fontFamily: FONT_FAMILY, color: t.TITLE }}>
-      {/* This mobile layout is a centered hero with no header row, so the back
-          control sits alone at the top-left — it is the only navigation here. */}
-      <div style={{ display: 'flex', alignItems: 'center', padding: '12px 16px' }}>
+      {/* Top row: back control on the left, and a Sign In link on the right so both paths are clear
+          (the main button below is the sign-up / join path). In verify mode the single "Finish
+          verifying" button below is the only action, so no Sign In is shown here. */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px' }}>
         <PublicShellBackLink />
+        {!verifyUrl ? (
+          <a href={signInUrl} style={{ padding: '6px 14px', borderRadius: 8, background: t.BORDER_STRONG, border: '1px solid rgba(255,255,255,0.15)', color: t.TITLE, fontSize: 12, fontWeight: 600, textDecoration: 'none' }}>Sign In</a>
+        ) : null}
       </div>
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '24px 24px 40px', gap: 20, textAlign: 'center' }}>
         <div style={{ width: 64, height: 64, borderRadius: 32, background: t.ACCENT + '20', border: `2px solid ${t.ACCENT}40`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>

--- a/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
@@ -61,7 +61,7 @@ function DesktopPeerProgrammingPublic({ signInUrl, verifyUrl }: { signInUrl: str
           <a href={verifyUrl ?? signInUrl} style={{ padding: '14px 32px', borderRadius: 10, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', display: 'inline-block' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <Globe size={14} color={t.MUTED} />
-            <span style={{ fontSize: 13, color: t.MUTED }}>Active cohorts across 47 countries</span>
+            <span style={{ fontSize: 13, color: t.MUTED }}>Open to members worldwide</span>
           </div>
         </div>
       </div>
@@ -95,10 +95,10 @@ function MobilePeerProgrammingPublic({ signInUrl, verifyUrl }: { signInUrl: stri
           <span style={{ fontSize: 20, fontWeight: 800 }}>PeerProgramming</span>
         </div>
         <span style={{ padding: '3px 12px', borderRadius: 20, background: t.ACCENT + '20', border: `1px solid ${t.ACCENT}40`, fontSize: 11, color: t.ACCENT, fontWeight: 600, width: 'fit-content' }}>Deterministic global cohorts</span>
-        <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>12-person weekly cohorts across 47 countries. You&apos;re always placed — no competitive selection, guaranteed spot.</p>
+        <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>12-person weekly cohorts, open worldwide. You&apos;re always placed — no competitive selection, guaranteed spot.</p>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
           <Globe size={13} color={t.MUTED} />
-          <span style={{ fontSize: 12, color: t.MUTED }}>Active cohorts in 47 countries</span>
+          <span style={{ fontSize: 12, color: t.MUTED }}>Open to members worldwide</span>
         </div>
         <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
       </div>


### PR DESCRIPTION
Makes the signed-out landing pages consistent about how to get in, and removes a made-up figure.

- **Contributions:** the sign-in card showed only a single "Sign in" link, hiding the sign-up path. It now shows both "Join free" (primary) and "Sign in" (secondary) for an anonymous visitor, and keeps the single "Finish verifying" action for a signed-in-but-unverified member.
- **Mood (mobile):** the phone layout had only a "Join" button and no sign-in affordance. Added a "Sign In" link to the top row so both paths are visible, matching the desktop layout. Hidden in verify mode.
- **PeerProgramming:** replaced the fabricated "47 countries" copy (there is no country data source for cohorts) with non-numeric "open worldwide" wording in all three places it appeared.

All three shells continue to show no private or per-user data.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_