### PR TITLE
fix: return member location from the directory browse and deep-link reads

### DIFF
--- a/ctf/packages/web/lib/directory/repository.ts
+++ b/ctf/packages/web/lib/directory/repository.ts
@@ -697,6 +697,9 @@ export async function getDirectoryProfileForMember(profileId: string): Promise<D
           p.source,
           p.invited_by_username,
           p.unclaimed_handle,
+          p.city,
+          p.state,
+          p.country,
           p.created_at,
           p.updated_at
         FROM directory_profiles p
@@ -791,6 +794,9 @@ export async function listDirectoryForMember(
           p.source,
           p.invited_by_username,
           p.unclaimed_handle,
+          p.city,
+          p.state,
+          p.country,
           p.created_at,
           p.updated_at
         FROM directory_profiles p


### PR DESCRIPTION
## What

PR #1446 added `city`/`state`/`country` to `directory_profiles` and to the profile-detail display, but two read paths still used a projection that omitted those columns:

- `listDirectoryForMember` — the browse list (`GET /api/directory/list`)
- `getDirectoryProfileForMember` — the by-id deep-link read (`GET /api/directory/profiles/[id]`)

So location only showed on the member's **own** profile (which reads `getOwnProfile`); on any browsed or shared-link profile it was silently null. The DIR-2 test case already asserts location shows on a browsed profile — this makes that pass.

## Fix

Add `p.city` / `p.state` / `p.country` to both SELECTs. Read-only projection fix; no schema, route, or contract change.

## Verification

Web + mobile typecheck (cross-package commit gate) pass.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_019EDu3sYB3PBN3EWbnkWzd7)_