### PR TITLE
fix: correct the Commons username nudge to point at the real account menu

### DIFF
--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -437,7 +437,7 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
 
       {needsUsername ? (
         <section className={styles.usernameAlert} role="status">
-          You&apos;re posting as <strong>{ownHandle}</strong>. Set a username from your account menu (top-right) so members recognize you.
+          You&apos;re posting as <strong>{ownHandle}</strong>. Open your account menu (your profile picture) and set a username so members recognize you.
         </section>
       ) : null}
 


### PR DESCRIPTION
A member reported the Survivor Hub Commons "set a username" banner. It reads *"Set a username from your account menu (top-right)"* — but on the desktop layout the account control (the Clerk avatar that opens "Manage account", where username is edited) sits at the **bottom of the left icon rail**, not the top-right. So a member on desktop finds no icon where the banner points. On the phone-width layout the avatar is in the top bar, so the old "(top-right)" wording only matched mobile.

Fix: reword to a layout-agnostic pointer — "Open your account menu (your profile picture) and set a username so members recognize you." Accurate on both surfaces (the avatar is present in the left rail on desktop and the top bar on mobile).

Copy-only change to a shipped screen (`components/community-shell/shell-chat-panel.tsx`); no layout or behavior change. It was the only occurrence of the "(top-right)" instruction.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_