### PR TITLE
fix: reconcile remaining Trust public signals to lib/trust

### DIFF
--- a/ctf/packages/web/components/trust/trust-public-shell.tsx
+++ b/ctf/packages/web/components/trust/trust-public-shell.tsx
@@ -11,23 +11,27 @@ import { getTrustTokens } from './trust-shared';
 // TrustPublic / MobileTrustPublic mockup values, so the default UI is pixel-identical).
 const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
-// Static description of the voluntary signals Trust aggregates (marketing copy). These mirror the
-// real signals in lib/trust: participation and social proof — never identity verification (there is
-// none) and never a numeric score (none is ever produced). "ServiceCredits activity" reads as social
-// proof: how many distinct members chose to transact with you, not your balance.
+// Static description of the voluntary signals Trust aggregates (marketing copy). Every item mirrors a
+// real signal in lib/trust (buildTrustEvidence): social proof and participation — never identity
+// verification (there is none) and never a numeric score (none is ever produced). Mapping:
+//   Quora social proof        → the public Quora profile checked at onboarding
+//   Admin-reviewed verification → the admin-set "Verified by an administrator" status
+//   ServiceCredits activity   → distinct members who completed a ServiceCredits transfer with you
+//   Community connections     → Foundation connections-as-provider + ongoing recurring activities
+//   Cohort completion record  → completed LevelUp / joined PeerProgramming cohorts
 const DESKTOP_SIGNALS = [
   'Quora social proof',
-  'Survivor-status attestation (non-coercive)',
+  'Admin-reviewed verification',
   'ServiceCredits activity',
-  'Community peer vouches',
+  'Community connections',
   'Cohort completion record',
 ];
 
 const MOBILE_SIGNALS = [
   'Quora social proof',
-  'Survivor-status attestation',
+  'Admin-reviewed verification',
   'ServiceCredits activity',
-  'Community peer vouches',
+  'Community connections',
   'Cohort completion record',
 ];
 


### PR DESCRIPTION
Follow-up to #1469. Two signals on the Trust public shell still had no backing in the real trust model (`lib/trust/db.ts` `buildTrustEvidence`):

- **"Survivor-status attestation"** — does not exist anywhere in `lib/trust`; there is no attestation mechanism. Replaced with **"Admin-reviewed verification"**, which maps to the real admin-set `verified` status ("Verified by an administrator").
- **"Community peer vouches"** — there is no vouch mechanism. Replaced with **"Community connections"**, which maps to the real `foundationConnectionsAsProvider` ("Connected with N members as a Foundation provider") and `recurringActivityCounterparties` ("Ongoing activities with N community members") signals.

Every bullet now mirrors a real signal, and the mapping is documented in a comment above the list. Copy-only change to the signed-out shell (`components/trust/trust-public-shell.tsx`); verified by rendering desktop + mobile.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_