### PR TITLE
fix: pin ClickLog public shell bottom nav to the bottom on phones

### DIFF
--- a/ctf/packages/web/components/click-log/click-log-public-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-public-shell.tsx
@@ -16,7 +16,10 @@ function DesktopClickLogPublic({ signInUrl, verifyUrl }: { signInUrl: string; ve
   const { theme } = useTheme();
   const t = getClickLogTokens(theme);
   return (
-    <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TITLE, display: 'flex', flexDirection: 'column' }}>
+    // ctf-self-responsive opts this flex column out of the global small-screen "un-row" fallback
+    // (.ctf-app-viewport > * → display:block on phones), which would otherwise collapse the column
+    // and stop flex:1 from pushing the bottom nav to the bottom.
+    <div className="ctf-self-responsive" style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TITLE, display: 'flex', flexDirection: 'column' }}>
       {/* Top bar */}
       <div style={{ height: 52, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: 'flex', alignItems: 'center', padding: '0 28px', gap: 10 }}>
         <PublicShellBackLink />
@@ -107,7 +110,10 @@ function MobileClickLogPublic({ signInUrl, verifyUrl }: { signInUrl: string; ver
   const { theme } = useTheme();
   const t = getClickLogTokens(theme);
   return (
-    <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TITLE, display: 'flex', flexDirection: 'column' }}>
+    // ctf-self-responsive: keep this a real flex column on phones so the middle (flex:1) pushes the
+    // locked bottom nav to the bottom edge. Without it the global mobile un-row rule forces
+    // display:block and the nav floats mid-screen with empty space beneath it.
+    <div className="ctf-self-responsive" style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TITLE, display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <div style={{ padding: '12px 16px', background: `${t.ACCENT}10`, borderBottom: `1px solid ${t.ACCENT}25`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>


### PR DESCRIPTION
The signed-out ClickLog shell's locked "Log / History / Export" bottom nav floated mid-screen with empty space beneath it, instead of sitting at the bottom edge.

**Cause:** the global small-screen fallback in `globals.css` —
```css
.ctf-app-viewport > *:not(.ctf-self-responsive) { display: block !important; height: auto !important; }
```
— forces the shell's outer `<div>` from `flex` to `block` on phones. That collapses the flex column, so the middle section's `flex:1` no longer expands to push the nav down: the header/middle/nav stack at their natural heights, and the leftover `min-height:100dvh` space falls *below* the nav.

**Fix:** add the designed opt-out marker class `ctf-self-responsive` to the shell's outer divs — the same pattern `chyme-public-shell.tsx` and `workforce-shell.tsx` already use for self-managed flex-column shells. The flex column then survives on phones and the nav pins to the bottom.

Layout-only change to `components/click-log/click-log-public-shell.tsx`; no copy or behavior change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_