### PR TITLE
fix: do not require a username to open the LightHouse plugin route

### DIFF
--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -1,6 +1,6 @@
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { getHostedSignInUrl } from 'lib/auth/provider-env';
-import { canonicalizePluginSlug, getPluginBySlug, isAdminOnlyPlugin } from 'lib/plugins/repository';
+import { canonicalizePluginSlug, getPluginBySlug, isAdminOnlyPlugin, pluginRequiresUsername } from 'lib/plugins/repository';
 import { getPublicVisitorShell } from '@/components/plugins/public-visitor-registry';
 import { BeaconShell } from '@/components/beacon/beacon-shell';
 import { ChymeShell } from '@/components/chyme/chyme-shell';
@@ -142,11 +142,11 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   // 'approved_full'). A not-yet-verified member is denied with `unlock_required` and
   // shown the plugin's public landing page below (not the access-denied view), which
   // nudges them toward the Unlock flow; the Hub general channel is their support
-  // surface. Chyme does not require a username so its anonymous public shell still works.
-  // Chyme and Beacon are watch-first surfaces that do not require a username to view, so anonymous
-  // and not-yet-named members can still watch the public broadcast.
+  // surface. Most plugins also require a username, but the username-optional plugins
+  // (chyme and beacon are watch-first public surfaces; LightHouse requires no per-plugin
+  // profile) must still open for an approved member who has not set a username yet.
   const decision = await evaluatePluginAccess({
-    requireUsername: selectedPlugin.slug !== 'chyme' && selectedPlugin.slug !== 'beacon',
+    requireUsername: pluginRequiresUsername(selectedPlugin.slug),
   });
 
   // Operator-only plugins (e.g. Weekly Performance) are admin-only: a non-admin gets a 404 for the

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -27,6 +27,19 @@ export function isAdminOnlyPlugin(slug: string): boolean {
   return ADMIN_ONLY_PLUGIN_SLUGS.has(slug);
 }
 
+// Plugins whose /apps/<slug> route does NOT require the member to have set a username. Most plugins
+// require a username at the page gate, but these must still open for an approved member who has not
+// chosen a username yet (e.g. a temporary handle before they set one in Clerk): chyme and beacon are
+// watch-first public surfaces, and LightHouse requires no per-plugin profile at all (owner decision,
+// see rule 114 / the LightHouse inventory) and composes its host identity with a "Your account"
+// fallback when no username is set. Its API routes already gate with requireUsername: false; this
+// keeps the page gate in step.
+export const USERNAME_OPTIONAL_PLUGIN_SLUGS = new Set<string>(['chyme', 'beacon', 'lighthouse']);
+
+export function pluginRequiresUsername(slug: string): boolean {
+  return !USERNAME_OPTIONAL_PLUGIN_SLUGS.has(slug);
+}
+
 // Drop operator-only plugins for non-admin viewers; admins see the full list.
 export function filterPluginsForViewer<T extends { slug: string }>(plugins: T[], isAdmin: boolean): T[] {
   return isAdmin ? plugins : plugins.filter((plugin) => !ADMIN_ONLY_PLUGIN_SLUGS.has(plugin.slug));


### PR DESCRIPTION
## Problem

An approved member with no username set (a temporary handle before they choose one in Clerk) hits **"Plugin access denied — missing_username"** (403) when opening LightHouse. Reported by a real member.

## Cause

The member plugin page gate (`app/apps/[pluginSlug]/page.tsx`) required a username for **every** plugin except `chyme` and `beacon`:

```ts
requireUsername: selectedPlugin.slug !== 'chyme' && selectedPlugin.slug !== 'beacon'
```

But LightHouse requires no per-plugin profile (owner decision, rule 114 / the LightHouse inventory), its **API** routes already gate with `requireUsername: false`, and its host identity falls back to "Your account" when no username is set. So this page-level username requirement was a leftover, out of step with the rest of the plugin.

## Fix

Add a `USERNAME_OPTIONAL_PLUGIN_SLUGS` set (`chyme`, `beacon`, `lighthouse`) with a `pluginRequiresUsername()` helper in the plugin repository — mirroring the existing `ADMIN_ONLY_PLUGIN_SLUGS` pattern — and use it for the page gate. Username is not a security control here; Unlock tier and authentication are still enforced unchanged.

No route, schema, or contract change.

Verified locally: web typecheck + lint and EOF format pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_