### PR TITLE
fix: stop requiring a username to open any plugin route

### DIFF
--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -1,6 +1,6 @@
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { getHostedSignInUrl } from 'lib/auth/provider-env';
-import { canonicalizePluginSlug, getPluginBySlug, isAdminOnlyPlugin, pluginRequiresUsername } from 'lib/plugins/repository';
+import { canonicalizePluginSlug, getPluginBySlug, isAdminOnlyPlugin } from 'lib/plugins/repository';
 import { getPublicVisitorShell } from '@/components/plugins/public-visitor-registry';
 import { BeaconShell } from '@/components/beacon/beacon-shell';
 import { ChymeShell } from '@/components/chyme/chyme-shell';
@@ -141,13 +141,15 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   // Every plugin route requires full Unlock access (the default minUnlockTier
   // 'approved_full'). A not-yet-verified member is denied with `unlock_required` and
   // shown the plugin's public landing page below (not the access-denied view), which
-  // nudges them toward the Unlock flow; the Hub general channel is their support
-  // surface. Most plugins also require a username, but the username-optional plugins
-  // (chyme and beacon are watch-first public surfaces; LightHouse requires no per-plugin
-  // profile) must still open for an approved member who has not set a username yet.
-  const decision = await evaluatePluginAccess({
-    requireUsername: pluginRequiresUsername(selectedPlugin.slug),
-  });
+  // nudges them toward the Unlock flow; the Hub general channel is their support surface.
+  //
+  // No plugin route requires a username. Every plugin API already gates with
+  // `requireUsername: false`, and members can be approved on a temporary handle before they
+  // choose a username in Clerk. Requiring one here blocked those members from opening apps
+  // (a leftover: it produced a 403 `missing_username` page), so the page gate matches the
+  // APIs and does not require a username. Shells that show the handle fall back gracefully
+  // when it is null.
+  const decision = await evaluatePluginAccess({ requireUsername: false });
 
   // Operator-only plugins (e.g. Weekly Performance) are admin-only: a non-admin gets a 404 for the
   // route, not the public landing, since there is no approved user-facing version. Admins fall

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -27,19 +27,6 @@ export function isAdminOnlyPlugin(slug: string): boolean {
   return ADMIN_ONLY_PLUGIN_SLUGS.has(slug);
 }
 
-// Plugins whose /apps/<slug> route does NOT require the member to have set a username. Most plugins
-// require a username at the page gate, but these must still open for an approved member who has not
-// chosen a username yet (e.g. a temporary handle before they set one in Clerk): chyme and beacon are
-// watch-first public surfaces, and LightHouse requires no per-plugin profile at all (owner decision,
-// see rule 114 / the LightHouse inventory) and composes its host identity with a "Your account"
-// fallback when no username is set. Its API routes already gate with requireUsername: false; this
-// keeps the page gate in step.
-export const USERNAME_OPTIONAL_PLUGIN_SLUGS = new Set<string>(['chyme', 'beacon', 'lighthouse']);
-
-export function pluginRequiresUsername(slug: string): boolean {
-  return !USERNAME_OPTIONAL_PLUGIN_SLUGS.has(slug);
-}
-
 // Drop operator-only plugins for non-admin viewers; admins see the full list.
 export function filterPluginsForViewer<T extends { slug: string }>(plugins: T[], isAdmin: boolean): T[] {
   return isAdmin ? plugins : plugins.filter((plugin) => !ADMIN_ONLY_PLUGIN_SLUGS.has(plugin.slug));


### PR DESCRIPTION
Follow-up to #1482. That PR unblocked LightHouse; this makes sure the same block isn't hitting **other** apps.

## The problem is broader than one plugin

The member plugin page gate (`app/apps/[pluginSlug]/page.tsx`) required a username for every plugin except a small exempt set. But **every plugin API already gates with `requireUsername: false`** (all ~30 `app/api/*/_lib.ts` files) — no plugin actually needs a username. So an approved member on a temporary handle (before they choose a username in Clerk) was blocked from opening most apps with a 403 "Plugin access denied / missing_username", even though the underlying APIs would have served them.

## Fix

Drop the page-gate username requirement for **all** plugins so the page matches the APIs:

```ts
const decision = await evaluatePluginAccess({ requireUsername: false });
```

Also removes the now-unused `USERNAME_OPTIONAL_PLUGIN_SLUGS` / `pluginRequiresUsername` helper that #1482 introduced (it's subsumed by this).

Username is not a security control here — Unlock tier and authentication are still enforced unchanged. Shells that display the handle (LightHouse, Chyme, the generic view) already render a fallback when it's null.

No route, schema, or contract change.

Verified locally: web typecheck + lint and EOF format pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_