### PR TITLE
fix: record escrow refund with its own ledger entry_type

### DIFF
--- a/ctf/packages/mobile/src/features/service-credits/api.ts
+++ b/ctf/packages/mobile/src/features/service-credits/api.ts
@@ -77,6 +77,8 @@ export function describeLedgerEntry(
       return { label: 'Held in escrow', direction: 'out' };
     case 'escrow_release':
       return { label: 'Escrow released', direction: 'neutral' };
+    case 'escrow_refund':
+      return { label: 'Escrow refunded', direction: 'in' };
     case 'initial_allocation':
       return { label: 'Welcome allocation', direction: 'in' };
     case 'skills_hunt_award':

--- a/ctf/packages/web/components/service-credits/sc-shared.ts
+++ b/ctf/packages/web/components/service-credits/sc-shared.ts
@@ -55,6 +55,8 @@ export function describeLedgerEntry(
       return { label: "Held in escrow", direction: "out" };
     case "escrow_release":
       return { label: "Escrow released", direction: "neutral" };
+    case "escrow_refund":
+      return { label: "Escrow refunded", direction: "in" };
     case "initial_allocation":
       return { label: "Welcome allocation", direction: "in" };
     case "skills_hunt_award":

--- a/ctf/packages/web/lib/service-credits/repository.ts
+++ b/ctf/packages/web/lib/service-credits/repository.ts
@@ -834,7 +834,7 @@ export async function refundEscrow(input: {
 
     await client.query(
       `INSERT INTO service_credits_ledger_entries (id, user_id, entry_type, amount, reference_type, reference_id, accounting_scope)
-       VALUES ($1, $2, 'escrow_release', $4, 'escrow', $3, 'service_credits_non_gdp')`,
+       VALUES ($1, $2, 'escrow_refund', $4, 'escrow', $3, 'service_credits_non_gdp')`,
       [randomUUID(), sourceUserId, input.escrowId, amount],
     );
 


### PR DESCRIPTION
## What

`refundEscrow()` in `ctf/packages/web/lib/service-credits/repository.ts` wrote its ledger row with `entry_type` `'escrow_release'` — the same value `releaseEscrow()` uses. A refund (credits return to the sender) and a release (credits go to the recipient) are distinct ledger events; sharing one `entry_type` made them indistinguishable in the ledger, breaking reconciliation and dispute evidence.

## Change

- Use `entry_type` `'escrow_refund'` for the refund ledger write. This is the value the Formance ledger flow already uses (`formance-ledger.ts`), so the two sides now agree.
- Add a matching `escrow_refund` case to the ledger display helpers on web (`sc-shared.ts`) and mobile (`api.ts`) so refunds render as "Escrow refunded" instead of falling through to the generic default label.

`entry_type` is a plain `TEXT` column with no check constraint, so no schema or migration change is needed. No route, contract, or delivery-status change.

Closes #1477

Parity Status: web + mobile-responsive + android complete