### PR TITLE
fix: stop iOS auto-zoom when focusing a form field on phones

### DIFF
--- a/ctf/packages/web/app/globals.css
+++ b/ctf/packages/web/app/globals.css
@@ -153,6 +153,20 @@ option {
     min-height: 100%;
     overflow-x: hidden;
   }
+
+  /*
+   * Stop iOS/WebKit from auto-zooming the whole page when a text field is focused. Mobile Safari
+   * (and the installed web app) zooms in whenever the focused input's font-size is below 16px, and
+   * the zoom sticks — leaving the page magnified and clipped. Pinning form controls to at least 16px
+   * on phones prevents that jump while keeping pinch-to-zoom intact (so it stays WCAG-friendly,
+   * unlike a viewport maximum-scale lock). `!important` is required because many fields set a
+   * smaller font-size inline.
+   */
+  input,
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
 }
 
 a {


### PR DESCRIPTION
Tapping a text field on iOS (Safari and the installed web app) zoomed the whole page in and left it magnified/clipped (reported on the submissions filter field, but it affects every field).

**Cause:** WebKit auto-zooms whenever a focused input's font-size is under 16px.

**Fix:** a phone-breakpoint rule in `globals.css` pinning `input`/`textarea`/`select` to 16px, so the zoom never triggers. Pinch-to-zoom stays available (WCAG-friendly — unlike a viewport `maximum-scale` lock). `!important` is required because many fields set a smaller font-size inline.

CSS-only, mobile breakpoint only. Desktop is unchanged.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_