### PR TITLE
fix: validate presence userId format before database query

### DIFF
--- a/ctf/packages/web/app/api/presence/user/[userId]/route.ts
+++ b/ctf/packages/web/app/api/presence/user/[userId]/route.ts
@@ -3,16 +3,27 @@ import { requireTrustMemberAccess } from 'lib/trust/_lib';
 import { getMemberPresence } from 'lib/presence/repository';
 import { reportError } from 'lib/observability/report';
 
+// A member id is either a Clerk id (`user_…`) or a UUID; both fit this safe character set. The bound
+// keeps an arbitrary probe string from reaching the query at all.
+const MEMBER_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
 // GET /api/presence/user/[userId]
 // Returns the cross-plugin presence list for one member: where else they are active, each with a
-// deep link into that plugin. Auth-gated to any signed-in member (nothing is public in this app, so
-// any listing a member has counts as presence; there is no per-entry visibility gate). Read-only.
+// deep link into that plugin. Auth-gated to any signed-in member: this is a deliberate decision —
+// nothing is public in this app, so any listing a member has counts as presence and there is no
+// per-entry visibility gate, so any signed-in member may look up any member. Read-only.
 export async function GET(_req: Request, context: unknown) {
   const { userId: targetUserId } = (context as { params: { userId: string } }).params;
 
   const gate = await requireTrustMemberAccess();
   if (!gate.allowed) {
     return gate.response;
+  }
+
+  // Reject an id that cannot be a real member id before touching the database. Return the same empty
+  // list the query would, so a malformed id gives no signal about the table's existence or contents.
+  if (!MEMBER_ID_PATTERN.test(targetUserId)) {
+    return NextResponse.json({ presence: [] }, { status: 200 });
   }
 
   try {


### PR DESCRIPTION
## What

The `[userId]` path parameter on `GET /api/presence/user/[userId]` was passed straight to `getMemberPresence()` with only a whitespace trim. This adds a format guard so an id that cannot be a real member id (not a Clerk `user_…` id or a UUID) never reaches the query.

- Validate the target id against `^[A-Za-z0-9_-]{1,128}$` in the route before touching the database.
- On a malformed id, return the same empty presence list the query would return, so a probe string gives no signal about whether the table exists or has rows.
- Spell out the deliberate access decision in the route comment: nothing is public in this app, so any signed-in member may look up any member (no per-entry visibility gate).

No change to the route's method, parameters, or response shape, and no schema, contract, or auth-gate change.

## Testing

`pnpm --filter @ctf/web typecheck` passes.

Closes #1509

Parity Status: web + mobile-responsive + android complete