### PR TITLE
fix: title the directory detail header "Directory profile"

### DIFF
--- a/ctf/packages/web/components/directory/directory-profile-detail.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-detail.tsx
@@ -159,7 +159,7 @@ export function DirectoryProfileDetail({
         <button onClick={onBack} aria-label="Back to directory" title="Back to directory" style={{ width: 38, height: 38, borderRadius: 10, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}30`, display: "flex", alignItems: "center", justifyContent: "center", color: t.ACCENT, cursor: "pointer", flexShrink: 0 }}>
           <ChevronLeft size={20} />
         </button>
-        <div style={{ fontSize: 15, fontWeight: 700, color: t.TITLE }}>Provider profile</div>
+        <div style={{ fontSize: 15, fontWeight: 700, color: t.TITLE }}>Directory profile</div>
         {/* Share this profile — the one app-wide control (rule 130). The link opens the auth-gated
             deep-link page; a signed-in member lands on this profile, an unauthenticated visitor is
             redirected to the directory landing. */}


### PR DESCRIPTION
The profile detail header in the Directory read "Provider profile". Changed it to "Directory profile" to match the plugin's name.

One-word copy change to the detail header (`directory-profile-detail.tsx`) — no schema, route, or contract change. Covers web desktop and mobile-responsive; the React Native detail screen does not use this label.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_019EDu3sYB3PBN3EWbnkWzd7)_