### PR TITLE
fix: let a LightHouse member be both a host and a seeker

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
@@ -40,12 +40,15 @@ longer a precondition for browsing, hosting, or matching.
 5. **Seeker self-service screen (2026-07-14).** A "Your details" tab
    (`lighthouse-seeker-profile.tsx`, reached from the icon rail on desktop and the mobile tab bar)
    lets a member fill and save the seeker preference fields above via `POST /api/lighthouse/profile`
-   (`x-ctf-csrf: '1'`). It is still **not** a gate for browsing or hosting, but an **active seeker
-   profile is required to request a stay** (the match endpoint denies otherwise), so the "Request to
-   stay" action points members here when they have none. A member who has listed a place is a host;
-   the profile type is locked server-side (a host cannot also be a seeker), so for a host this screen
-   explains that hosting and seeking are separate accounts rather than showing a form the endpoint
-   would deny with `policy_denied`.
+   (`x-ctf-csrf: '1'`). It is **not** a gate for browsing or hosting, but requesting a stay needs an
+   **active** profile, so the "Request to stay" action points a member with none here.
+6. **A member can be both a host and a seeker (owner decision, 2026-07-14).** Hosting and requesting
+   stays are NOT mutually exclusive and are not separate accounts. A member who has listed a place can
+   also fill in the "Your details" form and request stays. The profile row is no longer type-locked:
+   saving seeker details on a host account keeps the member's host flag (`has_property` is sticky) and
+   does not relabel their `profile_type`, and the match endpoint only requires an **active** profile
+   (not `profile_type = 'seeker'`). A member still cannot request a stay on their own listing (UI hides
+   the action; the endpoint is the backstop).
 
 ### 1.3 Property Browse and Detail
 
@@ -55,7 +58,7 @@ longer a precondition for browsing, hosting, or matching.
 4. Detail view includes host reference metadata and listing details.
 5. Seeker "Request to stay" action from the detail view is **implemented on web and Android**
    (2026-07-14): it posts `POST /api/lighthouse/matches` with an optional message and preferred
-   move-in date. A member with no active seeker profile is routed to the "Your details" screen first;
+   move-in date. A member with no active profile is routed to the "Your details" screen first;
    duplicate and blocked cases are shown inline. The action is hidden on the member's own listing.
 6. Duplicate active/pending match-request prevention remains required.
 
@@ -263,6 +266,7 @@ Android admin present (2026-06-06): `AdminLighthouse.tsx` + `admin-api.ts` added
 
 ## 9) Change Log
 
+- 2026-07-14: **A member can be both a host and a seeker (owner decision — reverses the same-day host/seeker exclusivity).** No schema, route, or contract change. The 2026-07-14 seeker flow shipped a rule that a host account could not also request stays ("hosting and seeking are separate accounts; ask an admin to switch your role"); the owner did not approve that for v3. Removed it end to end: `upsertProfile` no longer throws `policy_denied` on a profile-type change — for a non-admin it now **keeps** the existing `profile_type` (so saving seeker details on a host account does not relabel it) and makes `has_property` sticky (`has_property = existing OR incoming`) so it is never cleared; `createMatchRequest` now requires only an **active** profile, not `profile_type = 'seeker'`, so a host can request stays; and the "Your details" screen (web `lighthouse-seeker-profile.tsx` + mobile `LighthouseSeekerProfile.tsx`) always shows the editable form instead of the "this account hosts, so it can't also request stays" notice. Added a server-side self-match backstop (a member cannot request a stay on their own listing).
 - 2026-07-14: **Android (React Native) parity for the seeker flow.** No schema, route, or contract change; existing endpoints only. Mirrors the web seeker flow shipped the same day onto `packages/mobile/src/features/lighthouse`: a "Your details" tab (`LighthouseSeekerProfile.tsx`, added to `LighthouseTabs.tsx`) sets the seeker profile, and a "Request to stay" action (`LighthouseRequestToStay.tsx`, rendered by `LighthousePropertyDetail.tsx` for non-owners) creates the match request. `LighthouseScreen.tsx` passes the signed-in `currentUserId` (so the action is hidden on the member's own listing) and switches to the "Your details" tab when the endpoint reports no seeker profile (`policy_denied`). New API client methods `fetchProfile`, `upsertSeekerProfile`, and `createMatchRequest` (`api.ts`) bind `GET/POST /api/lighthouse/profile` and `POST /api/lighthouse/matches` with `x-ctf-csrf: '1'`; a host who tries to save a seeker profile sees the same "hosting and seeking are separate" notice as web. This closes the parity follow-up noted in the web entry below.
 - 2026-07-14: **Wired the member seeker flow — seeker profile screen + "Request to stay" (web + mobile-responsive).** No schema, route, or contract change; existing endpoints only. Two member-facing endpoints had no UI and were unreachable: `GET/POST/PUT/DELETE /api/lighthouse/profile` (the seeker/host preference profile) and `POST /api/lighthouse/matches` (the match request). As a result a member could browse and host but never request a stay — the match endpoint requires an active `seeker` `lighthouse_profiles` row, and nothing let a member create one. Added: (1) a "Your details" tab (`lighthouse-seeker-profile.tsx`, wired into `lighthouse-icon-rail.tsx` and the mobile tab bar; `Tab` in `shared.ts` gains `"profile"`) that GETs the profile to prefill and POSTs the seeker fields with `x-ctf-csrf: '1'` — a member who already hosts sees a "hosting and seeking are separate" notice instead of a form the type-lock would deny; (2) a "Request to stay" action replacing the inert "Apply Now"/"Message Host" placeholders on the listing detail (`lighthouse-property-detail.tsx`), posting `POST /api/lighthouse/matches` with an optional message and preferred move-in date, and routing a member with no active seeker profile to "Your details" (the endpoint returns `policy_denied` in that case). The shell refreshes the Matches tab after a successful request. (Android RN parity landed the same day — see the entry above.)
 - 2026-07-14: **Added refresh controls (app-wide refresh rollout).** Web: shared `RefreshButton` in the desktop and mobile-responsive shell headers (`lighthouse-shell.tsx`); the mount fetch was extracted into a `fetchAll` callback shared by the initial load and the button, so a refresh re-pulls listings, matches, and the currency catalog without the full-screen loading skeleton. Android: native pull-to-refresh via `RefreshControl` on the listings FlatList (`LighthouseScreen.tsx`); the load was extracted into a shared callback with a background-refresh variant. UI-only; no schema, route, or contract change.

--- a/ctf/docs/developer/test-scripts/lighthouse-test-script.md
+++ b/ctf/docs/developer/test-scripts/lighthouse-test-script.md
@@ -15,7 +15,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android |
 | **Seed first** | `pnpm --dir ctf seed:lighthouse` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md` |
-| **Generated** | 2026-06-28 (initial authoring; hand-updated 2026-07-05 for listing price/currency/type display; hand-updated 2026-07-14 for the seeker "Your details" screen and "Request to stay" flow) |
+| **Generated** | 2026-06-28 (initial authoring; hand-updated 2026-07-05 for listing price/currency/type display; hand-updated 2026-07-14 for the seeker "Your details" screen and "Request to stay" flow, and again 2026-07-14 for the "a member can be both host and seeker" reversal) |
 
 ## How to run this
 
@@ -80,7 +80,7 @@ ServiceCredits listing) and the native detail lists the accepted currencies.
 
 ### LH-3 · Set up your seeker details
 **Role:** member (seeker) · **Surfaces:** all
-**Precondition:** a member who has **not** listed a place (so they are not a host).
+**Precondition:** any member — including one who has already listed a place (a host can be a seeker too).
 **Steps:**
 1. Open the **Your details** tab (icon rail on desktop, tab bar on phone/android).
 2. Fill housing needs, country, ideal move-in date, budget range (least/most per month), an optional
@@ -88,7 +88,19 @@ ServiceCredits listing) and the native detail lists the accepted currencies.
 3. Reopen the tab.
 **Expected:** The form saves via the seeker profile endpoint and, on reopen, prefills with what you
 entered. A budget where "most" is less than "least" is refused with a readable message. Saving is
-**not** required to browse or view listings — only to request a stay (LH-4).
+**not** required to browse or view listings — only to request a stay (LH-4). A member who already
+hosts sees the **same editable form** (never a "this account hosts, so it can't also request stays"
+notice) and saving it does not remove their listings or change their host status.
+**Result:** web ☐ mobile ☐ android ☐ — notes:
+
+### LH-3b · A host can also request stays (both roles)
+**Role:** member who has listed a place (a host) · **Surfaces:** all
+**Steps:**
+1. As a member who already has a listing, open the **Your details** tab, fill and save your details.
+2. Open a listing you do **not** own and use **Request to stay**.
+3. Open **Your listings** (the host tab) and confirm your own listing is still there.
+**Expected:** The host is not blocked from the seeker flow: the request is created (status `pending`)
+and their existing listing is unaffected — the same account both hosts and requests stays.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ### LH-4 · Request to stay (and the no-details routing)

--- a/ctf/packages/mobile/src/features/lighthouse/LighthouseSeekerProfile.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthouseSeekerProfile.tsx
@@ -7,10 +7,10 @@ import type { LighthouseProfile } from './types';
 
 // Seeker self-service setup (mobile). Mirrors the web
 // ctf/packages/web/components/lighthouse/lighthouse-seeker-profile.tsx: a member fills in their
-// housing needs here so they can request a stay on a listing. Saving upserts the shared
-// lighthouse_profiles row as a 'seeker'. A member who has listed a place is a host — the profile
-// type is locked server-side, so this screen explains that instead of showing a form the endpoint
-// would deny.
+// housing needs here so they can request a stay on a listing. A member can be both a host and a
+// seeker (owner decision) — a member who has listed a place can also fill in these details and
+// request stays. Saving keeps their host flag intact and does not relabel their account, so this
+// screen always shows the editable form.
 
 const SURFACE = 'rgba(255,255,255,0.02)';
 
@@ -153,11 +153,6 @@ export const LighthouseSeekerProfile: React.FC = () => {
       setSaved(true);
       return;
     }
-    if (result.code === 'policy_denied') {
-      setExistingType('host');
-      setError(null);
-      return;
-    }
     setError(result.message ?? 'Could not save your details. Please try again.');
   };
 
@@ -166,24 +161,6 @@ export const LighthouseSeekerProfile: React.FC = () => {
       <View style={styles.center}>
         <ActivityIndicator size="large" color={accent} />
       </View>
-    );
-  }
-
-  if (existingType === 'host') {
-    return (
-      <ScrollView style={styles.container} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-        <View style={styles.noticeCard}>
-          <View style={styles.noticeHead}>
-            <Ionicons name="alert-circle-outline" size={18} color={accent} />
-            <Text style={styles.noticeTitle}>This account hosts, so it can’t also request stays</Text>
-          </View>
-          <Text style={styles.noticeBody}>
-            You listed a place, so LightHouse set you up as a host. Hosting and requesting stays are
-            kept on separate accounts. If you need to request a stay instead of hosting, ask an admin
-            in the Hub to switch your role.
-          </Text>
-        </View>
-      </ScrollView>
     );
   }
 
@@ -359,30 +336,6 @@ function makeStyles(t: ThemeTokens, accent: string) {
       fontSize: 14,
       fontWeight: '700',
       color: '#0B0B0F',
-    },
-    noticeCard: {
-      backgroundColor: SURFACE,
-      borderRadius: 14,
-      borderWidth: 1,
-      borderColor: `${accent}20`,
-      padding: 16,
-    },
-    noticeHead: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 8,
-      marginBottom: 8,
-    },
-    noticeTitle: {
-      fontSize: 15,
-      fontWeight: '700',
-      color: t.textPrimary,
-      flexShrink: 1,
-    },
-    noticeBody: {
-      fontSize: 13,
-      color: MUTED,
-      lineHeight: 19,
     },
   });
 }

--- a/ctf/packages/web/components/lighthouse/lighthouse-seeker-profile.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-seeker-profile.tsx
@@ -1,19 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { CheckCircle2, ShieldAlert } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { CountrySelect } from "@/components/shared/location-select";
 import { getLighthouseTokens, type Profile } from "./shared";
 
 // Seeker self-service setup. A member fills in their housing needs here so they can request a stay
-// on a listing. Saving upserts the shared lighthouse_profiles row as a 'seeker' via
-// POST /api/lighthouse/profile. The two flows are tied together: the "Request to stay" action on a
-// listing needs a seeker profile, and it points members here when they do not have one yet.
+// on a listing. Saving upserts the shared lighthouse_profiles row via POST /api/lighthouse/profile.
+// The "Request to stay" action on a listing points members here when they have not saved details yet.
 //
-// A member who has already listed a place is a 'host' (their profile row was provisioned when they
-// published a listing). The profile type is locked server-side — a host cannot also be a seeker —
-// so for a host this screen explains that instead of showing an editable form that would be denied.
+// A member can be both a host and a seeker (owner decision): a member who has listed a place can also
+// fill in these details and request stays. Saving keeps their host flag intact and does not relabel
+// their account, so this screen always shows the editable form.
 
 type SeekerForm = {
   housingNeeds: string;
@@ -131,15 +130,9 @@ export function LighthouseSeekerProfile() {
       });
       const data = (await res.json().catch(() => ({}))) as { ok?: boolean; code?: string; message?: string };
       if (!res.ok || !data.ok) {
-        if (data.code === "policy_denied") {
-          setExistingType("host");
-          setError(null);
-          return;
-        }
         setError(data.message ?? "Could not save your details. Please try again.");
         return;
       }
-      setExistingType("seeker");
       setSaved(true);
     } catch {
       setError("Could not save your details. Please try again.");
@@ -168,24 +161,6 @@ export function LighthouseSeekerProfile() {
     return (
       <div style={{ padding: "18px 16px 40px", maxWidth: 860, margin: "0 auto", width: "100%", boxSizing: "border-box", color: t.MUTED, fontSize: 14 }}>
         Loading your details…
-      </div>
-    );
-  }
-
-  if (existingType === "host") {
-    return (
-      <div style={{ padding: "18px 16px 40px", maxWidth: 860, margin: "0 auto", width: "100%", boxSizing: "border-box" }}>
-        <div style={{ background: t.HEADER, border: `1px solid ${t.BORDER}`, borderRadius: 14, padding: 18 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
-            <ShieldAlert size={18} style={{ color: t.ACCENT }} />
-            <span style={{ fontSize: 16, fontWeight: 700, color: t.TITLE }}>This account hosts, so it can’t also request stays</span>
-          </div>
-          <div style={{ fontSize: 13, color: t.MUTED, lineHeight: 1.6 }}>
-            You listed a place, so LightHouse set you up as a host. Hosting and requesting stays are
-            kept on separate accounts. If you need to request a stay instead of hosting, ask an admin
-            in the Hub to switch your role.
-          </div>
-        </div>
       </div>
     );
   }

--- a/ctf/packages/web/lib/lighthouse/repository.ts
+++ b/ctf/packages/web/lib/lighthouse/repository.ts
@@ -405,9 +405,14 @@ export async function upsertProfile(actorUserId: string, input: LighthouseProfil
       [actorUserId],
     );
 
-    if (!isAdmin && existing.rows[0] && existing.rows[0].profile_type !== input.profileType) {
-      throw new Error('policy_denied');
-    }
+    // A member can be both a host and a seeker (owner decision). The profile row is no longer locked
+    // to a single type: for a non-admin with an existing row we KEEP their current profile_type
+    // rather than flipping it (so saving seeker details on a host account does not relabel or
+    // un-host them), while a brand-new profile takes the incoming type. Admins may still set the
+    // type explicitly. `has_property` is sticky-true (below) so filling the seeker form never clears
+    // a member's host flag.
+    const effectiveType =
+      !isAdmin && existing.rows[0] ? existing.rows[0].profile_type : input.profileType;
 
     const upserted = await client.query(
       `
@@ -422,7 +427,7 @@ export async function upsertProfile(actorUserId: string, input: LighthouseProfil
           phone_number = EXCLUDED.phone_number,
           signal_url = EXCLUDED.signal_url,
           is_active = EXCLUDED.is_active,
-          has_property = EXCLUDED.has_property,
+          has_property = lighthouse_profiles.has_property OR EXCLUDED.has_property,
           housing_needs = EXCLUDED.housing_needs,
           desired_move_in_date = EXCLUDED.desired_move_in_date,
           budget_min = EXCLUDED.budget_min,
@@ -448,7 +453,7 @@ export async function upsertProfile(actorUserId: string, input: LighthouseProfil
       `,
       [
         actorUserId,
-        input.profileType,
+        effectiveType,
         normalizeNullableText(input.bio),
         normalizeNullableText(input.phoneNumber),
         normalizeNullableText(input.signalUrl),
@@ -935,19 +940,22 @@ export async function createMatchRequest(input: {
   return withDbTransaction(async (client: PoolClient) => {
     void input.idempotencyKey;
 
-    const seeker = await client.query(
+    // A member can be both a host and a seeker (owner decision). Requesting a stay only needs an
+    // active LightHouse profile — it is NOT gated on profile_type = 'seeker', so a member who has
+    // listed a place (a host) can still request stays. Filling the seeker "Your details" form (which
+    // creates/keeps an active profile) is what points members here.
+    const requester = await client.query(
       `
         SELECT id
         FROM lighthouse_profiles
         WHERE user_id = $1
-          AND profile_type = 'seeker'
           AND is_active = TRUE
         LIMIT 1
       `,
       [input.actorUserId],
     );
 
-    if (seeker.rows.length === 0) {
+    if (requester.rows.length === 0) {
       throw new Error('policy_denied');
     }
 
@@ -967,6 +975,12 @@ export async function createMatchRequest(input: {
     }
 
     const hostUserId = property.rows[0].host_user_id;
+
+    // A member cannot request a stay on their own listing (the UI hides the button on an owned
+    // listing; this is the server-side backstop now that hosts can also request).
+    if (hostUserId === input.actorUserId) {
+      throw new Error('policy_denied');
+    }
 
     const blocked = await client.query(
       `


### PR DESCRIPTION
## Problem

A host account was shown **"This account hosts, so it can't also request stays… ask an admin in the Hub to switch your role"** and could not request stays. That host/seeker exclusivity shipped with the 2026-07-14 seeker flow but was **not approved for v3** — the owner's decision is that a member can be both a host and a seeker.

## Fix — reverses the exclusivity end to end

- **`upsertProfile`** (`lib/lighthouse/repository.ts`): no longer throws `policy_denied` on a profile-type change. For a non-admin it now **keeps** the existing `profile_type` (so saving seeker details on a host account does not relabel it), and makes `has_property` **sticky** (`has_property = existing OR incoming`) so filling the seeker form never clears a member's host flag.
- **`createMatchRequest`**: requires only an **active** profile, not `profile_type = 'seeker'` — so a host can request stays. Adds a server-side **self-match backstop** (a member cannot request a stay on their own listing; the UI already hides the action there).
- **"Your details" screen** (web `lighthouse-seeker-profile.tsx` + mobile `LighthouseSeekerProfile.tsx`): always shows the editable form; removed the "hosting and seeking are separate" block and the `policy_denied → host notice` handling.

A host's existing listings are unaffected — property ownership is independent of `profile_type`, and `has_property` is preserved.

No schema, route, or contract change. LightHouse inventory and manual test script updated (new LH-3b case: a host can also request stays).

Verified locally: web + mobile typecheck, web + mobile lint, EOF, web/android parity, and inventory/test-script drift gates all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_