### PR TITLE
feat: robots.txt and per-IP rate limits on public endpoints

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -162,7 +162,7 @@ User routes:
 
 Public (unauthenticated) routes:
 
-- `GET /api/feed/public/community` — read-only Commons for signed-out visitors. Returns `{ isPublic, posts }` where `posts` are community (peer) posts only — no announcements, AI answers, replies, per-user state, or author user ids. Returns `isPublic: false` (empty) unless `feed_render_config.is_public` is on and the community channel is enabled. Backs the signed-out home panel (community posts are public the way Quora posts are; visitors read but cannot post without signing in).
+- `GET /api/feed/public/community` — read-only Commons for signed-out visitors. Returns `{ isPublic, posts }` where `posts` are community (peer) posts only — no announcements, AI answers, replies, per-user state, or author user ids. Returns `isPublic: false` (empty) unless `feed_render_config.is_public` is on and the community channel is enabled. Backs the signed-out home panel (community posts are public the way Quora posts are; visitors read but cannot post without signing in). Rate-limited per IP (2026-07-16): 30 requests/minute via the shared in-memory limiter `lib/security/rate-limit.ts`; over-limit callers get `429` with a `Retry-After` header.
 
 Admin routes:
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -210,6 +210,20 @@ Backend-only endpoints with no UI, each guarded by a dedicated bearer secret and
 
 ## 5) Change Log
 
+- 2026-07-16: **Crawler policy and public-endpoint rate limiting (owner approved).** New
+  `ctf/packages/web/app/robots.ts` serves `/robots.txt`: allow `/` (the public marketing shells are
+  meant to be crawled), disallow `/api/`, `/admin/`, `/account`, `/plugin/`; no sitemap reference (the
+  app has no sitemap route). New shared limiter `ctf/packages/web/lib/security/rate-limit.ts` — an
+  in-memory fixed-window per-process brake (`checkRateLimit`, plus `enforcePublicReadRateLimit` which
+  keys per IP from the first `x-forwarded-for` value, falling back to `unknown`) — applied at
+  30 requests/minute per IP to the unauthenticated public read endpoints only:
+  `GET /api/feed/public/community`, `GET /api/chyme/public/room`, `GET /api/what-works/public`,
+  `GET /api/socket-relay/public`, `GET /api/socket-relay/public/[id]`,
+  `GET /api/workforce/public-snapshot`, `GET /api/skills-taxonomy/summary`, `GET /api/beacon/current`.
+  Over-limit callers get `429` with a `Retry-After` header and a plain JSON `{ error }`.
+  `GET /api/health` is deliberately not limited (uptime probes). Limits are per server process
+  (reset on deploy, per-instance) — a first bulk-abuse brake, not a distributed quota; authenticated
+  plugin routes are untouched. No schema or contract change.
 - 2026-07-15: **Plugin registry/catalog code-review fixes (findings #1533, #1534, #1536, #1537).**
   `GET /api/plugins` now double-gates the non-admin list: on top of the admin-only-slug filter
   (`filterPluginsForViewer`), non-admin responses explicitly drop rows with `isVisible === false`

--- a/ctf/packages/web/app/api/beacon/current/route.ts
+++ b/ctf/packages/web/app/api/beacon/current/route.ts
@@ -2,12 +2,19 @@ import { NextResponse } from 'next/server';
 import { getBeaconHlsPlaybackUrl } from 'lib/beacon/stream';
 import { getLatestReplayBeaconEvent, getLiveBeaconEvent } from 'lib/beacon/repository';
 import { reportError } from 'lib/observability/report';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 export const dynamic = 'force-dynamic';
 
 // Public: the currently-live event (or null) plus the public HLS playback URL, and the last replay
 // for the idle state. No sign-in required — this is what lets anyone watch with just a link.
-export async function GET() {
+export async function GET(request: Request) {
+  // Per-IP brake against bulk scraping of the anonymous read (see lib/security/rate-limit.ts).
+  const limited = enforcePublicReadRateLimit(request, 'beacon-current');
+  if (limited) {
+    return limited;
+  }
+
   try {
     const liveEvent = await getLiveBeaconEvent();
     const replayEvent = await getLatestReplayBeaconEvent();

--- a/ctf/packages/web/app/api/chyme/public/room/route.ts
+++ b/ctf/packages/web/app/api/chyme/public/room/route.ts
@@ -3,6 +3,7 @@ import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
 import { getPublicRoomLiveState } from 'lib/chyme/repository';
 import { createChymeGuestListenCredentials } from 'lib/chyme/stream';
 import { reportError } from 'lib/observability/report';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 // Public, unauthenticated view of the one default Chyme room so a signed-out visitor can listen in.
 // Chyme's promise is "free to listen, sign in to speak", so this route returns whether the room is
@@ -12,10 +13,15 @@ import { reportError } from 'lib/observability/report';
 // Abuse surface: this mints a billable Stream guest identity for anonymous callers, so it could be
 // hammered to burn participant-minutes. It is bounded today by (1) only minting when the room is
 // actually live and (2) a short-lived (1h) guest token (see createChymeGuestListenCredentials). A
-// shared-store rate limit / IP throttle is the next step if guest minutes become material — tracked
-// as a documented limitation in ctf/docs/quota-impact/2026-06-19-chyme-guest-listen.md. Not added
-// here to avoid standing up throttling infra in this change.
-export async function GET() {
+// per-process per-IP rate limit below (lib/security/rate-limit.ts) — a shared-store limit remains
+// the next step if guest minutes become material; see also the documented limitation in
+// ctf/docs/quota-impact/2026-06-19-chyme-guest-listen.md.
+export async function GET(request: Request) {
+  const limited = enforcePublicReadRateLimit(request, 'chyme-public-room');
+  if (limited) {
+    return limited;
+  }
+
   try {
     const state = await getPublicRoomLiveState();
 

--- a/ctf/packages/web/app/api/feed/public/community/route.ts
+++ b/ctf/packages/web/app/api/feed/public/community/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import type { PublicCommunityPost } from 'lib/feed/types';
 import { listPublicCommunityPosts } from 'lib/feed/repository';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 // Public, unauthenticated read of the Commons (peer community posts), so signed-out visitors can
 // read what members have posted — public the way Quora posts are. This route has no auth gate on
@@ -15,7 +16,13 @@ type PublicCommunityResponse = {
   posts: PublicCommunityPost[];
 };
 
-export async function GET() {
+export async function GET(request: Request) {
+  // Per-IP brake against bulk scraping of the anonymous read (see lib/security/rate-limit.ts).
+  const limited = enforcePublicReadRateLimit(request, 'feed-public-community');
+  if (limited) {
+    return limited;
+  }
+
   try {
     const { isPublic, posts } = await listPublicCommunityPosts();
 

--- a/ctf/packages/web/app/api/skills-taxonomy/summary/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/summary/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { SKILLS_TAXONOMY_ERROR_CODE } from 'lib/skills-taxonomy/constants';
 import { getTaxonomySummary } from 'lib/skills-taxonomy/repository';
 import { reportError } from 'lib/observability/report';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 // Public, UNAUTHENTICATED aggregate counts for the signed-out splash teaser (sectors / job titles /
 // skills). Intentionally has no access gate — unlike /hierarchy, which is auth-gated and returns the
@@ -10,7 +11,13 @@ import { reportError } from 'lib/observability/report';
 // job title, or skill shows up on the next load.
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(request: Request) {
+  // Per-IP brake against bulk scraping of the anonymous read (see lib/security/rate-limit.ts).
+  const limited = enforcePublicReadRateLimit(request, 'skills-taxonomy-summary');
+  if (limited) {
+    return limited;
+  }
+
   try {
     const summary = await getTaxonomySummary();
     return NextResponse.json(summary, { status: 200 });

--- a/ctf/packages/web/app/api/socket-relay/public/[id]/route.ts
+++ b/ctf/packages/web/app/api/socket-relay/public/[id]/route.ts
@@ -3,12 +3,19 @@ import { socketRelayErrorResponse } from 'lib/socket-relay/_lib';
 import { SOCKET_RELAY_ERROR_CODE } from 'lib/socket-relay/constants';
 import { getPublicRequestById } from 'lib/socket-relay/repository';
 import { reportError } from 'lib/observability/report';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 type RouteProps = {
   params: Promise<{ id: string }>;
 };
 
-export async function GET(_: Request, { params }: RouteProps) {
+export async function GET(request: Request, { params }: RouteProps) {
+  // Per-IP brake against bulk scraping of the anonymous read (see lib/security/rate-limit.ts).
+  const limited = enforcePublicReadRateLimit(request, 'socket-relay-public-id');
+  if (limited) {
+    return limited;
+  }
+
   const { id } = await params;
 
   try {

--- a/ctf/packages/web/app/api/socket-relay/public/route.ts
+++ b/ctf/packages/web/app/api/socket-relay/public/route.ts
@@ -3,8 +3,15 @@ import { parsePositiveInteger, socketRelayErrorResponse } from 'lib/socket-relay
 import { SOCKET_RELAY_DEFAULT_PAGE, SOCKET_RELAY_DEFAULT_PAGE_SIZE } from 'lib/socket-relay/constants';
 import { listPublicRequests } from 'lib/socket-relay/repository';
 import { reportError } from 'lib/observability/report';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 export async function GET(request: Request) {
+  // Per-IP brake against bulk scraping of the anonymous read (see lib/security/rate-limit.ts).
+  const limited = enforcePublicReadRateLimit(request, 'socket-relay-public');
+  if (limited) {
+    return limited;
+  }
+
   try {
     const url = new URL(request.url);
     const page = parsePositiveInteger(url.searchParams.get('page'), SOCKET_RELAY_DEFAULT_PAGE);

--- a/ctf/packages/web/app/api/what-works/public/route.ts
+++ b/ctf/packages/web/app/api/what-works/public/route.ts
@@ -7,10 +7,17 @@ import {
 import { whatWorksError } from '../_lib';
 import { logWhatWorksAudit } from 'lib/what-works/audit';
 import { reportError } from 'lib/observability/report';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 // Public, sign-in-free projection: the list is readable by anyone, but only a teaser
 // slice is returned and submitter identity is never exposed. Full browse is sign-in gated.
-export async function GET() {
+export async function GET(request: Request) {
+  // Per-IP brake against bulk scraping of the anonymous read (see lib/security/rate-limit.ts).
+  const limited = enforcePublicReadRateLimit(request, 'what-works-public');
+  if (limited) {
+    return limited;
+  }
+
   try {
     const list = await getReaderList(null);
     const problems = list.problems.slice(0, PUBLIC_PREVIEW_PROBLEM_LIMIT).map((problem) => ({

--- a/ctf/packages/web/app/api/workforce/public-snapshot/route.ts
+++ b/ctf/packages/web/app/api/workforce/public-snapshot/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getWorkforcePublicSnapshot } from 'lib/workforce/repository';
 import { reportError } from 'lib/observability/report';
+import { enforcePublicReadRateLimit } from 'lib/security/rate-limit';
 
 // Public, unauthenticated snapshot for the signed-out Workforce landing page. It returns two coarse
 // aggregate counts (Recruited / Sector Gaps) from the same projection model the signed-in dashboard
@@ -9,7 +10,13 @@ import { reportError } from 'lib/observability/report';
 // force-dynamic keeps it from being statically cached so the landing snapshot reflects current data.
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(request: Request) {
+  // Per-IP brake against bulk scraping of the anonymous read (see lib/security/rate-limit.ts).
+  const limited = enforcePublicReadRateLimit(request, 'workforce-public-snapshot');
+  if (limited) {
+    return limited;
+  }
+
   try {
     const snapshot = await getWorkforcePublicSnapshot();
     return NextResponse.json(snapshot, { status: 200 });

--- a/ctf/packages/web/app/robots.ts
+++ b/ctf/packages/web/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next';
+
+// Crawler policy for the web app. The public marketing shells (the signed-out home and the
+// per-plugin landing pages) are meant to be crawled, so the root stays open. Everything a
+// crawler has no business fetching is disallowed: the API surface, the admin surface, the
+// signed-in account area, and the plugin runtime pages. Served by Next.js at /robots.txt.
+// No sitemap reference — the app has no sitemap route today.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/admin/', '/account', '/plugin/'],
+      },
+    ],
+  };
+}

--- a/ctf/packages/web/lib/security/rate-limit.ts
+++ b/ctf/packages/web/lib/security/rate-limit.ts
@@ -1,0 +1,97 @@
+// Shared fixed-window rate limiter for public (unauthenticated) read endpoints.
+//
+// Honest limits of this design — read before reusing it elsewhere:
+// - PER-PROCESS MEMORY ONLY. Counters live in a Map inside one Node server process. They
+//   reset on every deploy/restart, and if the app ever runs on more than one instance each
+//   instance counts independently (so the effective limit is limit × instances).
+// - FIXED WINDOW. A caller can burst up to 2× the limit across a window boundary.
+// - This is adequate as a first brake against bulk scraping and accidental floods of the
+//   public endpoints. It is NOT a distributed quota, not billing-grade metering, and not a
+//   substitute for a shared-store (e.g. Redis/Postgres) limiter if abuse becomes material.
+//
+// Existing per-feature limits (bug-reports, comic, level-up) count rows in Postgres per
+// user; they gate authenticated writes and are unrelated to this per-IP read brake.
+
+import { NextResponse } from 'next/server';
+
+type WindowEntry = {
+  windowStartMs: number;
+  windowMs: number;
+  count: number;
+};
+
+const windows = new Map<string, WindowEntry>();
+
+// Prune at most once per this interval so a hot endpoint does not scan the Map on every
+// request, while abandoned keys still get dropped and memory stays bounded.
+const PRUNE_INTERVAL_MS = 60_000;
+let lastPruneMs = 0;
+
+function pruneExpired(nowMs: number): void {
+  if (nowMs - lastPruneMs < PRUNE_INTERVAL_MS) {
+    return;
+  }
+  lastPruneMs = nowMs;
+  for (const [key, entry] of windows) {
+    // An entry is dead weight once its own window has fully passed.
+    if (nowMs - entry.windowStartMs >= entry.windowMs) {
+      windows.delete(key);
+    }
+  }
+}
+
+// Fixed-window check: at most `limit` calls per `windowMs` for this key. Returns whether
+// this call is allowed and, when it is not, how many whole seconds until the window resets.
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+): { allowed: boolean; retryAfterSeconds: number } {
+  const nowMs = Date.now();
+  pruneExpired(nowMs);
+
+  const entry = windows.get(key);
+  if (!entry || nowMs - entry.windowStartMs >= windowMs) {
+    windows.set(key, { windowStartMs: nowMs, windowMs, count: 1 });
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  entry.count += 1;
+  if (entry.count <= limit) {
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  const retryAfterSeconds = Math.max(1, Math.ceil((entry.windowStartMs + windowMs - nowMs) / 1000));
+  return { allowed: false, retryAfterSeconds };
+}
+
+// Shared policy for the public read endpoints: per IP, per route.
+export const PUBLIC_READ_RATE_LIMIT = 30;
+export const PUBLIC_READ_RATE_WINDOW_MS = 60_000;
+
+// Client IP for rate-limit keying: first value of x-forwarded-for (set by the platform's
+// proxy), 'unknown' when absent. 'unknown' callers share one bucket — acceptable for a
+// brake whose goal is to bound total anonymous load, not to meter individuals precisely.
+export function getClientIp(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  const first = forwarded?.split(',')[0]?.trim();
+  return first || 'unknown';
+}
+
+// Convenience gate for a public read route. Returns null when the call may proceed, or a
+// ready-to-return 429 JSON response (with Retry-After) when the caller is over the limit.
+export function enforcePublicReadRateLimit(request: Request, routeKey: string): NextResponse | null {
+  const ip = getClientIp(request);
+  const result = checkRateLimit(
+    `public:${routeKey}:${ip}`,
+    PUBLIC_READ_RATE_LIMIT,
+    PUBLIC_READ_RATE_WINDOW_MS,
+  );
+  if (result.allowed) {
+    return null;
+  }
+  return NextResponse.json(
+    { error: 'Too many requests. Wait a moment and try again.' },
+    { status: 429, headers: { 'Retry-After': String(result.retryAfterSeconds) } },
+  );
+}


### PR DESCRIPTION
Owner-approved follow-up to the crawler/bulk-abuse question: authentication was the main protection; public endpoints had no request-rate cap and there was no robots.txt.

**robots.txt** (`app/robots.ts`): allows `/` (the public marketing shells are meant to be crawled); disallows `/api/`, `/admin/`, `/account`, `/plugin/`. No sitemap exists, so none referenced.

**Rate limiting** (`lib/security/rate-limit.ts`, new shared helper): fixed-window in-memory limiter, honestly documented as a per-process first brake (resets on deploy, per-instance) rather than a distributed quota. Applied to the eight unauthenticated public GET reads at **30 requests/minute per IP** (keyed per route, first `x-forwarded-for` value), returning **429 + Retry-After**:

feed public community · chyme public room · what-works public · socket-relay public list + detail · workforce public snapshot · skills-taxonomy summary · beacon current

`GET /api/health` is deliberately unlimited (uptime probes). No authenticated route touched — those keep auth + their existing per-feature limits. Non-plugin and feed inventories updated. Lint, typecheck, EOF pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_