### PR TITLE
feat: tell scouts when the SkillsHunt weekly nomination limit resets

### DIFF
--- a/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/submissions/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/submissions/route.ts
@@ -9,6 +9,22 @@ import { reportError } from 'lib/observability/report';
 
 type SubmissionBody = Partial<Omit<SkillsHuntSubmissionInput, 'roundId'>>;
 
+// Turn the rate-limit reset timestamp into an approximate, timezone-safe hint for
+// the scout ("in about 3 days"). Empty string when there is no usable reset time.
+function formatRetryApprox(resetAtIso: string | null): string {
+  if (!resetAtIso) return '';
+  const resetMs = new Date(resetAtIso).getTime();
+  if (Number.isNaN(resetMs)) return '';
+  const diffMs = resetMs - Date.now();
+  if (diffMs <= 0) return ' You can submit again now — refresh and retry.';
+  const minutes = Math.round(diffMs / 60000);
+  if (minutes < 60) return ` You can submit again in about ${minutes} minute${minutes === 1 ? '' : 's'}.`;
+  const hours = Math.round(diffMs / 3600000);
+  if (hours < 24) return ` You can submit again in about ${hours} hour${hours === 1 ? '' : 's'}.`;
+  const days = Math.round(diffMs / 86400000);
+  return ` You can submit again in about ${days} day${days === 1 ? '' : 's'}.`;
+}
+
 function toSubmissionInput(roundId: string, body: SubmissionBody): SkillsHuntSubmissionInput {
   return {
     roundId,
@@ -125,10 +141,12 @@ export async function POST(request: Request, { params }: { params: Promise<{ rou
       status = 409;
       code = SKILLS_HUNT_ERROR_CODE.roundNotActive;
       responseMessage = 'Round is not currently active.';
-    } else if (message === 'skills_hunt_submission_limit_exceeded') {
+    } else if (message.startsWith('skills_hunt_submission_limit_exceeded')) {
       status = 429;
       code = SKILLS_HUNT_ERROR_CODE.submissionLimitExceeded;
-      responseMessage = 'Submission rate limit exceeded.';
+      const sep = message.indexOf(':');
+      const resetAtIso = sep >= 0 ? message.slice(sep + 1) : null;
+      responseMessage = `You've reached the weekly nomination limit.${formatRetryApprox(resetAtIso)}`;
     } else if (message === 'skills_hunt_pre_approval_required') {
       status = 403;
       code = SKILLS_HUNT_ERROR_CODE.preApprovalRequired;

--- a/ctf/packages/web/lib/skills-hunt/repository.ts
+++ b/ctf/packages/web/lib/skills-hunt/repository.ts
@@ -658,7 +658,24 @@ async function ensureSubmissionRateLimits(client: PoolClient, userId: string): P
   }
 
   if (profile.rolling7dCount >= profile.rolling7dLimit) {
-    throw new Error('skills_hunt_submission_limit_exceeded');
+    // The cap is a rolling 7-day window, so a slot frees when an in-window
+    // submission ages past 7 days. To drop back under the cap we need
+    // (count - limit + 1) of the oldest in-window submissions to age out; the
+    // last of those to expire (created_at + 7 days) is when the scout can submit
+    // again. Encode that time in the error so the API can tell the scout when.
+    const offset = Math.max(0, profile.rolling7dCount - profile.rolling7dLimit);
+    const oldestResult = await client.query<{ created_at: Date }>(
+      `SELECT created_at FROM skills_hunt_submissions
+        WHERE submitter_user_id = $1
+          AND created_at >= NOW() - INTERVAL '7 days'
+          AND deleted_at IS NULL
+        ORDER BY created_at ASC
+        OFFSET $2 LIMIT 1`,
+      [userId, offset],
+    );
+    const oldest = oldestResult.rows[0]?.created_at;
+    const resetAtIso = oldest ? new Date(oldest.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString() : null;
+    throw new Error(resetAtIso ? `skills_hunt_submission_limit_exceeded:${resetAtIso}` : 'skills_hunt_submission_limit_exceeded');
   }
 
   // Belt-and-braces: keep the legacy rejection-rate guard on the most recent
@@ -1785,7 +1802,9 @@ export async function createSubmission(
       throw new Error('skills_hunt_round_not_found');
     }
     if (message.includes('skills_hunt_submission_limit_exceeded')) {
-      throw new Error('skills_hunt_submission_limit_exceeded');
+      // Preserve the whole message — it may carry a `:<reset ISO>` suffix the
+      // route uses to tell the scout when they can submit again.
+      throw new Error(message);
     }
     if (message.includes('skills_hunt_pre_approval_required')) {
       throw new Error('skills_hunt_pre_approval_required');


### PR DESCRIPTION
## What

When a scout hits the submission rate limit, the error now says approximately when they can submit again, instead of the bare "Submission rate limit exceeded."

- **Before:** `Submission rate limit exceeded.`
- **After:** `You've reached the weekly nomination limit. You can submit again in about 3 days.` (days / hours / minutes as appropriate)

## How

The cap is a rolling 7-day window, so a slot frees when an in-window submission ages past 7 days. `ensureSubmissionRateLimits` computes the reset time — the `(count - limit + 1)`-th oldest in-window submission's `created_at + 7 days` (so it's correct even if the count sits above the cap after a tier change) — and encodes it in the thrown error. The submissions route parses it and formats an approximate, timezone-safe hint (`formatRetryApprox`).

No route/schema/contract change — it's a message refinement on the existing rate-limit path. Admins remain exempt (from the prior change), so they never see it.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjgoA8vVHmybUaa5jxcDmf)_