### PR TITLE
fix: honour limit=0 on the first request in a rate-limit window

### DIFF
--- a/ctf/packages/web/lib/security/rate-limit.ts
+++ b/ctf/packages/web/lib/security/rate-limit.ts
@@ -53,7 +53,12 @@ export function checkRateLimit(
   const entry = windows.get(key);
   if (!entry || nowMs - entry.windowStartMs >= windowMs) {
     windows.set(key, { windowStartMs: nowMs, windowMs, count: 1 });
-    return { allowed: true, retryAfterSeconds: 0 };
+    // Honour the limit even for the first call in a window, so limit=0 blocks everything.
+    if (1 <= limit) {
+      return { allowed: true, retryAfterSeconds: 0 };
+    }
+    const retryAfterSeconds = Math.max(1, Math.ceil(windowMs / 1000));
+    return { allowed: false, retryAfterSeconds };
   }
 
   entry.count += 1;


### PR DESCRIPTION
Fixes a subtle contract bug in the shared fixed-window rate limiter.

## What

When a window entry was missing or expired, `checkRateLimit` set `count=1` and returned `allowed=true` before comparing against `limit`. A `limit` of 0 (meaning "block everything") therefore let the first request in each window through. The increment path already checks `count <= limit`; the new-window path did not.

## Fix

After creating the initial entry, check `1 <= limit` before returning `allowed=true`, matching the increment path. When the limit is 0 the first request is now blocked and gets a `retryAfterSeconds` for the full window.

No behaviour change for the current callers (`limit=30`).

Closes #1580

Parity Status: web + mobile-responsive + android complete
