### PR TITLE
chore: add Stream credential validator script (check:stream-env)

### DIFF
--- a/ctf/docs/quota-impact/2026-07-16-stream-credential-validator.md
+++ b/ctf/docs/quota-impact/2026-07-16-stream-credential-validator.md
@@ -1,0 +1,40 @@
+# Stream Quota Impact Note — Stream credential validator script
+
+## Summary
+
+- Feature/Change: New operator diagnostic `ctf/packages/web/scripts/check-stream-env.mjs` (npm script `check:stream-env`). It validates that the Stream (GetStream) API key/secret pairs — the production pair and the demo/staging pair — actually authenticate, by making one lightweight authenticated server call per pair (`upsertUser` on a throwaway probe user, best-effort hard-deleted afterward). It never prints the key or secret. Run manually via Infisical; it is NOT in the request path and NOT wired into CI.
+- PR: chargingthefuture/chargingthefuture#TBD
+- Owner: chargingthefuture
+- Date: 2026-07-16
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: **Chat (auth only).** The script uses the server-side chat client to make an `upsertUser` (and a best-effort `deleteUser`) purely to confirm the credentials authenticate. No channel, message, feed, video, or moderation surface is exercised.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: **Negligible.** One throwaway probe user is upserted and then hard-deleted per manual run of the script. It is run by an operator on demand (typically when debugging a demo/staging Stream failure), not on any schedule, per request, or in CI. Expected runs per month: a handful.
+- Activity Feed API calls estimate: None.
+- Video participant-minutes estimate: None.
+- AI Moderation credits estimate: None.
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): **Green** — unchanged. A manual diagnostic with a single upsert/delete per run does not move any budget threshold.
+- Peak scenario estimate: Even run repeatedly during a debugging session, the load is a few upsert/delete calls — far below any monitored threshold.
+
+## Fallback and Degradation Plan
+
+- What degrades first: Nothing in the product. This is a standalone script; it does not change any user-facing Stream behavior.
+- User-visible messaging behavior: None — the script only prints PASS/FAIL to the operator's terminal.
+- Kill switch / feature flag: Not applicable. If a credential pair is unset the script reports it as a warning and exits 0; if a pair is set but Stream rejects it, the script exits non-zero.
+
+## Observability
+
+- Metrics and alerts added/updated: None. The script's whole purpose is observability — it surfaces whether the configured Stream credentials authenticate, complementing the runtime `reportError` logging added for the Foundation quote path.
+- Dashboard link (if available): Existing Stream usage dashboard; no new panel.
+
+## Validation
+
+- Tests added for degraded mode: Ran the script with dummy credentials to confirm it constructs the client, makes the authenticated call, catches the rejection, reports FAIL without leaking the secret, and exits non-zero; and with an unset pair to confirm it reports "not set" and does not fail. ESLint passes.
+- Rollback strategy: Delete the script and its `check:stream-env` package entry. It is standalone tooling with no product dependency, so removal has no runtime effect.

--- a/ctf/packages/web/package.json
+++ b/ctf/packages/web/package.json
@@ -14,7 +14,8 @@
     "test": "vitest run",
     "check:auth-env": "node ./scripts/check-auth-env.mjs",
     "check:clerk-env": "node ./scripts/check-auth-env.mjs",
-    "check:formance-env": "node ./scripts/check-formance-env.mjs"
+    "check:formance-env": "node ./scripts/check-formance-env.mjs",
+    "check:stream-env": "node ./scripts/check-stream-env.mjs"
   },
   "dependencies": {
     "@clerk/backend": "^3.4.7",

--- a/ctf/packages/web/scripts/check-stream-env.mjs
+++ b/ctf/packages/web/scripts/check-stream-env.mjs
@@ -1,0 +1,124 @@
+// Stream (GetStream) credential validator — a live auth check, not just a presence check.
+//
+// Why this exists: the Foundation plugin (and the other Stream-backed chats) fail with
+// "Connections are temporarily unavailable" when the Stream API key/secret are *present but do not
+// authenticate* — a mismatched key+secret pair (the two belong to different Stream apps), a
+// placeholder value, or a suspended/deleted Stream app. A plain "is the variable set?" check cannot
+// tell those apart from working credentials, so this script makes one lightweight authenticated
+// server call per credential pair and reports PASS/FAIL.
+//
+// Demo mode routes chat to a SEPARATE Stream app via the *_STAGING pair (see
+// lib/integrations/stream-credentials.ts and rule 110). Both the production and the demo/staging
+// pairs are checked here.
+//
+// Secrets safety: this NEVER prints the key or the secret. It prints only PASS/FAIL and the Stream
+// error message (Stream's error text does not echo the secret). Run it through Infisical so the
+// values come from the production environment, e.g.:
+//
+//   infisical run --token="$INFISICAL_TOKEN" --projectId="$INFISICAL_PROJECT_ID" --env=production -- \
+//     pnpm --dir ctf/packages/web run check:stream-env
+//
+// Exit code: 0 when every credential pair that is set authenticates (a pair that is entirely unset is
+// reported as a warning, not a failure — Stream-backed features degrade by design when unconfigured).
+// Non-zero when a pair is set but fails to authenticate, or is only half-set (key without secret).
+
+const PAIRS = [
+  {
+    label: 'production',
+    keyVar: 'STREAM_API_KEY',
+    secretVar: 'STREAM_API_SECRET',
+    note: 'used for real (non-demo) members',
+  },
+  {
+    label: 'demo / staging',
+    keyVar: 'STREAM_API_KEY_STAGING',
+    secretVar: 'STREAM_API_SECRET_STAGING',
+    note: 'used when demo mode is on — this is the Foundation demo path',
+  },
+];
+
+function readTrimmed(name) {
+  const raw = process.env[name];
+  return typeof raw === 'string' ? raw.trim() : '';
+}
+
+// One lightweight authenticated server call. upsertUser hits the Stream API and requires a valid
+// key+secret pair, so a bad pair rejects here. The throwaway user is hard-deleted best-effort after.
+async function verifyPair(StreamChat, apiKey, apiSecret) {
+  const client = new StreamChat(apiKey, apiSecret);
+  const probeUserId = 'ctf-stream-env-check';
+  try {
+    await client.upsertUser({ id: probeUserId, name: 'CTF Stream env check' });
+    try {
+      await client.deleteUser(probeUserId, { hard_delete: true });
+    } catch {
+      // Cleanup is best-effort — leaving the probe user does not affect the result.
+    }
+    return { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, message };
+  } finally {
+    try {
+      await client.disconnectUser();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function main() {
+  let StreamChat;
+  try {
+    ({ StreamChat } = await import('stream-chat'));
+  } catch {
+    console.error('Could not load the "stream-chat" package. Run this from the @ctf/web workspace.');
+    process.exit(2);
+  }
+
+  let hadFailure = false;
+  let checkedAny = false;
+
+  for (const pair of PAIRS) {
+    const apiKey = readTrimmed(pair.keyVar);
+    const apiSecret = readTrimmed(pair.secretVar);
+
+    if (!apiKey && !apiSecret) {
+      console.log(`• ${pair.label}: not set (${pair.keyVar} / ${pair.secretVar}) — ${pair.note}. Stream-backed features degrade when unconfigured.`);
+      continue;
+    }
+
+    if (!apiKey || !apiSecret) {
+      hadFailure = true;
+      const missing = apiKey ? pair.secretVar : pair.keyVar;
+      console.error(`✗ ${pair.label}: half-configured — ${missing} is empty. Both the key and the secret must be set.`);
+      continue;
+    }
+
+    checkedAny = true;
+    const result = await verifyPair(StreamChat, apiKey, apiSecret);
+    if (result.ok) {
+      console.log(`✓ ${pair.label}: credentials authenticate with Stream (${pair.note}).`);
+    } else {
+      hadFailure = true;
+      console.error(`✗ ${pair.label}: credentials are set but Stream REJECTED them — ${pair.note}.`);
+      console.error(`    Stream said: ${result.message}`);
+      console.error(`    Likely cause: ${pair.keyVar} and ${pair.secretVar} are from different Stream apps, a placeholder, or the app is suspended.`);
+    }
+  }
+
+  if (!checkedAny && !hadFailure) {
+    console.log('No Stream credential pairs were set; nothing to validate.');
+    process.exit(0);
+  }
+
+  if (hadFailure) {
+    console.error('\nStream credential validation FAILED. See the lines marked ✗ above.');
+    process.exit(1);
+  }
+
+  console.log('\nAll configured Stream credential pairs authenticate.');
+  process.exit(0);
+}
+
+await main();


### PR DESCRIPTION
## Why

A demo-account **Request Quote** kept failing with "Connections are temporarily unavailable" even though the demo Stream keys (`STREAM_API_KEY_STAGING` / `STREAM_API_SECRET_STAGING`) are present in Infisical. That failure signature (the Stream call *throwing* on thread creation) means the credentials are **present but do not authenticate** — a mismatched key+secret pair, a placeholder, or a suspended Stream app. The existing `check:*-env` scripts only verify a variable is *set*, which can't catch this.

## What

Adds `ctf/packages/web/scripts/check-stream-env.mjs` (npm script `check:stream-env`): a manual diagnostic that makes **one lightweight authenticated server call per credential pair** (production and demo/staging) and reports PASS/FAIL. It **never prints the key or secret** — only PASS/FAIL and Stream's own error text.

Run it through Infisical so the values come from the production environment (where the `*_STAGING` pair lives by design):

```
infisical run --token="$INFISICAL_TOKEN" --projectId="$INFISICAL_PROJECT_ID" --env=production -- \
  pnpm --dir ctf/packages/web run check:stream-env
```

It exits non-zero if any configured pair is set but Stream rejects it, and reports an unset pair as a warning (Stream-backed features degrade by design when unconfigured).

## Files

- `ctf/packages/web/scripts/check-stream-env.mjs` — the validator.
- `ctf/packages/web/package.json` — `check:stream-env` script.
- `ctf/docs/quota-impact/2026-07-16-stream-credential-validator.md` — quota note (one upsert/delete per manual run; not in the request path or CI).

## Notes

- Diagnostic tooling only — no product/runtime behavior change, no schema/route/contract change, not wired into CI.
- Validated by running with dummy credentials (constructs the client, makes the call, catches the rejection, reports FAIL without leaking the secret, exits non-zero) and with an unset pair.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8rDoThiNxiVQjVhruFQK6)_