### PR TITLE
ci: add manual workflow to validate Stream credentials

### DIFF
--- a/.github/workflows/check-stream-env.yml
+++ b/.github/workflows/check-stream-env.yml
@@ -1,0 +1,57 @@
+name: Check — Stream Credentials
+
+# Manually-run diagnostic: does each Stream (GetStream) API key/secret pair actually authenticate?
+#
+# Use this when a Stream-backed feature (e.g. Foundation "Request Quote" in a demo account) fails with
+# "Connections are temporarily unavailable" even though the keys look present in Infisical. Presence is
+# not enough — a mismatched key+secret pair (dev vs prod Stream apps), a placeholder, or a suspended
+# app all fail the same way. This runs ctf/packages/web/scripts/check-stream-env.mjs, which makes one
+# lightweight authenticated call per pair and prints PASS/FAIL. It never prints the key or secret.
+#
+# Run it from the browser: Actions tab → "Check — Stream Credentials" → Run workflow. A green run means
+# every configured pair authenticates; a red run means at least one set pair was rejected (read the log
+# to see which — production or demo/staging — and Stream's own error text).
+#
+# Note: this reads the CURRENT Infisical values. The live app only picks up new secret values when it
+# is redeployed/restarted, so a green run here confirms the values are correct, but the running app
+# still needs a redeploy to use them.
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  check:
+    name: Validate Stream credential pairs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: |
+          cd ctf
+          pnpm install
+
+      # Inject the production environment's secrets (env-slug "prod"), which is where the *_STAGING
+      # Stream pair lives too. If Infisical is unreachable this step fails the job, by design.
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
+
+      - name: Validate Stream credentials
+        run: |
+          cd ctf/packages/web
+          node scripts/check-stream-env.mjs


### PR DESCRIPTION
## Why

Follow-up to the `check:stream-env` validator (#1583). You have no local environment to run it, so this lets you validate the Stream credentials **from the browser**.

## What

Adds `.github/workflows/check-stream-env.yml` — a `workflow_dispatch` (manual) job that injects the production Infisical secrets (`env-slug: prod`, where the `*_STAGING` pair lives) and runs `check:stream-env`. It makes one lightweight authenticated call per pair and prints PASS/FAIL for **production** and **demo/staging**. It never prints any key or secret.

## How to use

Actions tab → **Check — Stream Credentials** → **Run workflow**.
- **Green run** = every configured pair authenticates.
- **Red run** = at least one set pair was rejected; the log says which (production or demo/staging) and shows Stream's own error text.

## Important

This reads the **current** Infisical values, so a green run confirms the values are correct — but the **live app only picks up new secret values when it is redeployed/restarted** (Infisical injects at process start). So after this goes green, redeploy the app for demo to actually use the corrected staging keys.

## Files

- `.github/workflows/check-stream-env.yml` — the manual workflow.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8rDoThiNxiVQjVhruFQK6)_