### PR TITLE
fix: correct the SkillsHunt plugin summary in the Apps directory

### DIFF
--- a/ctf/packages/web/lib/plugins/plugin-catalog.ts
+++ b/ctf/packages/web/lib/plugins/plugin-catalog.ts
@@ -59,7 +59,7 @@ export const pluginCatalog: PluginCatalogItem[] = [
     id: 'skills-hunt',
     name: 'SkillsHunt',
     kind: 'plugin',
-    summary: 'Discover skills across the network.',
+    summary: 'Nominate survivors to build the Directory and grow the economy.',
   },
   {
     id: 'unlock',

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -77,7 +77,7 @@ const fallbackPluginRegistry: PluginRegistryItem[] = [
   {
     slug: 'skills-hunt',
     name: 'SkillsHunt',
-    summary: 'Discover skills across the network.',
+    summary: 'Nominate survivors to build the Directory and grow the economy.',
     availabilityState: 'implemented_shell',
     navRank: 60,
     isVisible: true,

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -2073,7 +2073,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('skills-taxonomy',    'Skills Taxonomy',      'Hierarchy and CRUD for sectors, job titles, and skills with impact preview.',                     'implemented_shell', 20,  TRUE),
   ('directory',          'Directory',            'Browse skills across the survivor community.',                      'implemented_shell', 30,  TRUE),
   ('workforce',          'Workforce',            'Real-time work and skills distribution amongst 5 million survivors globally.',                           'implemented_shell', 50,  TRUE),
-  ('skills-hunt',        'SkillsHunt',          'Discover skills across the network.',                     'implemented_shell', 60,  TRUE),
+  ('skills-hunt',        'SkillsHunt',          'Nominate survivors to build the Directory and grow the economy.', 'implemented_shell', 60,  TRUE),
   ('unlock',             'Unlock',               'Internal verification queue and staged unlock orchestration for Quora URL onboarding.',           'implemented_shell', 65,  FALSE),
   ('foundation',         'Foundation',           'Find talent, tools, repairs, and infrastructure support in real time.',                      'implemented_shell', 70,  TRUE),
   ('lighthouse',         'LightHouse',           'Verified survivor housing listings.',                             'implemented_shell', 80,  TRUE),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2075,7 +2075,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('skills-taxonomy',    'Skills Taxonomy',      'Hierarchy and CRUD for sectors, job titles, and skills with impact preview.',                     'implemented_shell', 20,  TRUE),
   ('directory',          'Directory',            'Browse skills across the survivor community.',                      'implemented_shell', 30,  TRUE),
   ('workforce',          'Workforce',            'Real-time work and skills distribution amongst 5 million survivors globally.',                           'implemented_shell', 50,  TRUE),
-  ('skills-hunt',        'SkillsHunt',          'Discover skills across the network.',                     'implemented_shell', 60,  TRUE),
+  ('skills-hunt',        'SkillsHunt',          'Nominate survivors to build the Directory and grow the economy.', 'implemented_shell', 60,  TRUE),
   ('unlock',             'Unlock',               'Internal verification queue and staged unlock orchestration for Quora URL onboarding.',           'implemented_shell', 65,  FALSE),
   ('foundation',         'Foundation',           'Find talent, tools, repairs, and infrastructure support in real time.',                      'implemented_shell', 70,  TRUE),
   ('lighthouse',         'LightHouse',           'Verified survivor housing listings.',                             'implemented_shell', 80,  TRUE),


### PR DESCRIPTION
## What

The Apps directory showed SkillsHunt's summary as **"Discover skills across the network."** — that describes discovery/search, not what SkillsHunt does (nominate survivors to build the Directory). Corrected to **"Nominate survivors to build the Directory and grow the economy."**, matching the in-app copy.

Fixed in all four sources so they stay consistent:
- `ctf/packages/web/lib/plugins/repository.ts`
- `ctf/packages/web/lib/plugins/plugin-catalog.ts`
- `ctf/schema.sql` (plugins seed)
- `ctf/schema.demo.sql` (demo seed)

The seed upserts `summary = EXCLUDED.summary` on conflict, so an existing database picks up the new text on the next schema run — no separate migration needed.

Parity Status: web + mobile-responsive + android complete


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjgoA8vVHmybUaa5jxcDmf)_