### PR TITLE
fix: use the illustrative Home icon in LightHouse instead of the house emoji

### DIFF
--- a/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bath, Bed, Heart, MapPin } from "lucide-react";
+import { Bath, Bed, Heart, Home, MapPin } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { formatRentParts, getLighthouseTokens, listingAcceptsCredits, type CurrencyMap, type Property } from "./shared";
 
@@ -35,7 +35,7 @@ export function LighthouseBrowse({
         ) : (
           properties.map((p) => (
             <div key={p.id} style={{ borderRadius: 16, background: "rgba(255,255,255,0.02)", border: `1px solid ${t.ACCENT}20`, overflow: "hidden", cursor: "pointer" }}>
-              <div role="button" tabIndex={0} aria-label={`View ${p.title || p.id}`} onClick={() => onSelect(p)} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(p); } }} style={{ padding: "32px 0", background: `${t.ACCENT}08`, textAlign: "center", fontSize: 48 }}>{p.img || "🏠"}</div>
+              <div role="button" tabIndex={0} aria-label={`View ${p.title || p.id}`} onClick={() => onSelect(p)} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(p); } }} style={{ padding: "32px 0", background: `${t.ACCENT}08`, display: "flex", alignItems: "center", justifyContent: "center" }}><Home size={40} strokeWidth={1.5} style={{ color: `${t.ACCENT}80` }} /></div>
               <div style={{ padding: 16 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 8 }}>
                   <div style={{ fontSize: 14, fontWeight: 700, color: t.TITLE, flex: 1, marginRight: 8, lineHeight: 1.3 }}>{p.title || p.id}</div>

--- a/ctf/packages/web/components/lighthouse/lighthouse-filter-sidebar.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-filter-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Search } from "lucide-react";
+import { Home, Search } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { getLighthouseTokens, listingAcceptsCredits, type Property } from "./shared";
 
@@ -56,7 +56,7 @@ export function LighthouseFilterSidebar({
   return (
     <aside style={{ width: 240, background: t.HEADER, borderRight: `1px solid ${t.BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
       <div style={{ padding: "20px 16px 12px" }}>
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: t.MUTED, textTransform: "uppercase", marginBottom: 12 }}>🏠 LightHouse</div>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: t.MUTED, textTransform: "uppercase", marginBottom: 12, display: "flex", alignItems: "center", gap: 6 }}><Home size={13} strokeWidth={1.75} style={{ color: t.ACCENT }} /> LightHouse</div>
         <div style={{ position: "relative" }}>
           <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: t.FAINT }} />
           <input

--- a/ctf/packages/web/components/lighthouse/lighthouse-property-detail.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-property-detail.tsx
@@ -34,10 +34,10 @@ export function LighthousePropertyDetail({
     <div style={{ width: "100%", minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex", flexDirection: "column" }}>
       <div style={{ height: 56, borderBottom: `1px solid ${t.ACCENT}25`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER }}>
         <button onClick={onBack} style={{ color: t.ACCENT, background: "none", border: "none", cursor: "pointer", fontSize: 14 }}>← Back</button>
-        <div style={{ flex: 1, fontSize: 16, fontWeight: 700, color: t.TITLE }}>🏠 Listing Detail</div>
+        <div style={{ flex: 1, fontSize: 16, fontWeight: 700, color: t.TITLE, display: "flex", alignItems: "center", gap: 8 }}><Home size={18} strokeWidth={1.75} style={{ color: t.ACCENT }} /> Listing Detail</div>
       </div>
       <div style={{ flex: 1, padding: "32px 40px", overflow: "auto" }}>
-        <div style={{ fontSize: 48, marginBottom: 20, textAlign: "center", padding: "40px 0", background: "rgba(255,255,255,0.02)", borderRadius: 16, border: `1px solid ${t.BORDER}` }}>{l.img || "🏠"}</div>
+        <div style={{ marginBottom: 20, padding: "40px 0", background: "rgba(255,255,255,0.02)", borderRadius: 16, border: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", justifyContent: "center" }}><Home size={56} strokeWidth={1.5} style={{ color: `${t.ACCENT}80` }} /></div>
         <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
           <div style={{ flex: 1, minWidth: 280 }}>
             <div style={{ fontSize: 24, fontWeight: 800, color: t.TITLE, marginBottom: 8 }}>{l.title || l.id}</div>

--- a/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { ChevronLeft, Search } from "lucide-react";
+import { ChevronLeft, Home, Search } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import type { Currency } from "@/lib/currency/types";
@@ -206,7 +206,8 @@ export function LighthouseShell({ userId, username, isAdmin }: { userId: string;
               <ChevronLeft size={20} />
             </Link>
             {/* Title shrinks and truncates so the trailing controls stay on screen */}
-            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>🏠 LightHouse</span>
+            <Home size={16} strokeWidth={1.75} style={{ color: t.ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>LightHouse</span>
             <PluginAdminButton href="/admin/lighthouse" isAdmin={isAdmin} accent={t.ACCENT} />
             <RefreshButton onRefresh={() => fetchAll()} title="Refresh" />
             <MobileTopActions />
@@ -243,7 +244,7 @@ export function LighthouseShell({ userId, username, isAdmin }: { userId: string;
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>🏠 LightHouse — Safe Housing</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT, display: "flex", alignItems: "center", gap: 8 }}><Home size={16} strokeWidth={1.75} style={{ color: t.ACCENT }} /> LightHouse — Safe Housing</div>
             <div style={{ fontSize: 12, color: t.MUTED }}>Verified listings · Privacy-first</div>
           </div>
           <RefreshButton onRefresh={() => fetchAll()} title="Refresh" />


### PR DESCRIPTION
## Problem

LightHouse was the only plugin rendering the `🏠` **emoji** — on the browse card and listing-detail image placeholders, the detail header, the filter sidebar, and the shell header. Every other plugin uses illustrative lucide line icons, so LightHouse looked out of place (screenshot).

## Fix

Replaced each `🏠` with the lucide `Home` icon (accent-tinted, outline weight) — the same icon LightHouse already uses in its icon rail, admin shell, and public shell, and the illustrative style used across the app. The card/detail image placeholders now show a centered `Home` glyph instead of the emoji.

The native (Android) app already uses the Ionicons `home-outline` glyph, so this only brings the web surface in line — no mobile change needed.

Cosmetic/icon-only change to shipped screens. No route, schema, or contract change.

Verified locally: web typecheck, lint, and EOF format pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_