### PR TITLE
fix: tolerate fenced/prefixed JSON in the user-guide generator

### DIFF
--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -141,6 +141,22 @@ const VOICE = `VOICE:
 - No selling ("powerful", "seamless", "game-changer", "matters deeply"), no rhetorical questions, no closing flourish, no guessing at the reader's feelings.
 - Never use any of these words: thanks, sorry, glad, happy, excited, feel free, hope, phase, punch list.`;
 
+// Pull the JSON object out of the model's reply. Haiku often wraps it in a ```json fence or adds a
+// line of preamble, so a strict JSON.parse of the raw text rejects a perfectly good answer (that is
+// what silently preserved the old wording on the first successful run). Strip a fence if present,
+// else slice from the first "{" to the last "}".
+function extractJson(text) {
+  let t = String(text).trim();
+  const fence = t.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) t = fence[1].trim();
+  if (!t.startsWith('{')) {
+    const open = t.indexOf('{');
+    const close = t.lastIndexOf('}');
+    if (open >= 0 && close > open) t = t.slice(open, close + 1);
+  }
+  return t;
+}
+
 async function rewrite(slug, title, features, coreSmoke) {
   if (!process.env.ANTHROPIC_API_KEY) return null;
   const res = await fetch('https://api.anthropic.com/v1/messages', {
@@ -172,7 +188,7 @@ async function rewrite(slug, title, features, coreSmoke) {
   const data = await res.json();
   const text = data?.content?.[0]?.text ?? '';
   try {
-    const parsed = JSON.parse(text.trim());
+    const parsed = JSON.parse(extractJson(text));
     return {
       summary: String(parsed.summary ?? '').trim(),
       body: (Array.isArray(parsed.body) ? parsed.body : []).map((s) => String(s).trim()).filter(Boolean),


### PR DESCRIPTION
Follow-up to the guide generator. With the spend limit raised, the model calls now succeed — but the verification run showed every section logging "could not parse model JSON". Haiku wraps its JSON answer in a ```json code fence (or adds a line of preamble), and the strict `JSON.parse(text.trim())` rejected it, so the generator fell back to preserving the reviewed wording — a run that only bumped the section dates (that's why PR #1665 was a no-op diff).

Added `extractJson()`: strip a code fence if present, otherwise slice from the first `{` to the last `}`, before parsing. Unit-tested against raw JSON, ```json-fenced, plain-fenced-with-preamble, and preamble+bare-JSON shapes.

After this merges, re-running the workflow will produce a real content refresh instead of a date-only diff. Closing the no-op PR #1665.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_