### PR TITLE
chore: run the user-guide generator weekly, only for changed sections

### DIFF
--- a/.github/workflows/generate-user-guide.yml
+++ b/.github/workflows/generate-user-guide.yml
@@ -5,25 +5,30 @@ name: User Guide — Regenerate
 # rewritten in the project's plain voice by ctf/scripts/generate-user-guide.mjs. The generator is
 # grounded: it can only describe what those docs already say (see issue #1471 for why that matters).
 #
-# Runs when a plugin's user-facing docs change, and on manual dispatch. It never publishes directly:
-# it opens a pull request so the generated wording is reviewed before it goes live on the public
-# page. A manual run with publish_wiki=true also pushes the markdown copy to the GitHub wiki.
+# Runs on a schedule (weekly) and on manual dispatch — NOT on every doc-touching push, to
+# keep the model-API cost bounded. Each run only regenerates the sections whose source docs changed
+# since they were last generated (the generator skips unchanged sections, so a run with no doc
+# changes makes no API calls and opens no PR). It never publishes directly: it opens a pull request
+# so the generated wording is reviewed before it goes live. A manual run with publish_wiki=true also
+# pushes the markdown copy to the GitHub wiki; force=true regenerates every section from scratch.
 
 on:
   workflow_dispatch:
     inputs:
+      force:
+        description: 'Regenerate every section from scratch (ignore the unchanged-docs skip).'
+        required: false
+        default: false
+        type: boolean
       publish_wiki:
         description: 'Also push the markdown copy to the GitHub wiki page (User-Guide).'
         required: false
         default: false
         type: boolean
-  push:
-    branches: [main]
-    paths:
-      - 'ctf/docs/developer/ctf-plugin-feature-inventories/**'
-      - 'ctf/docs/developer/test-scripts/**'
-      - 'ctf/scripts/generate-user-guide.mjs'
-      - 'ctf/config/manual-test-script-manifest.json'
+  schedule:
+    # Weekly, Mondays at 06:00 UTC — a fresh guide at the start of the week. Change-aware, so a week
+    # with no doc changes makes no API calls and opens no PR.
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: write
@@ -61,6 +66,10 @@ jobs:
           recursive: true
 
       - name: Regenerate the guide
+        # GUIDE_FORCE=1 (manual force run) regenerates every section; otherwise the generator skips
+        # sections whose source docs have not changed since their last generation.
+        env:
+          GUIDE_FORCE: ${{ inputs.force == true && '1' || '0' }}
         run: node ctf/scripts/generate-user-guide.mjs
 
       - name: Open a pull request if the guide changed

--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -13,8 +13,10 @@
  *   - ctf/packages/web/app/guide/guide-content.json  (rendered by /guide)
  *   - ctf/docs/USER_GUIDE.md                          (a plain markdown copy to share / paste to the wiki)
  *
- * Reads: ANTHROPIC_API_KEY (optional — without it, falls back to a deterministic, un-polished but
- * still grounded extraction so the build never hard-depends on the model).
+ * Reads: ANTHROPIC_API_KEY (required — the script refuses to run without it rather than publish
+ * ungrounded fallback text). GUIDE_FORCE=1 regenerates every section; otherwise a section whose
+ * source docs have not changed since its last generation is kept verbatim with no model call, so a
+ * scheduled run with no doc changes costs nothing and opens no PR.
  *
  * Per-section "Last updated" is the last commit date touching that plugin's inventory + test script,
  * so each section honestly reflects how current its source docs are.

--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -212,6 +212,17 @@ for (const [slug, title] of ORDER) {
   const coreSmoke = extractSection(ts, /Core smoke/i);
   const updated = lastUpdated([invPath, tsPath]);
 
+  // Cost control: the guide is regenerated on a schedule (see the workflow), so most runs happen
+  // with no doc changes. Skip the model call for any section whose source docs have not changed
+  // since it was last generated — its `updated` date already equals the source's last-commit date.
+  // A GUIDE_FORCE=1 run (manual "force full rebuild") regenerates everything.
+  const existing = prev.get(slug);
+  if (process.env.GUIDE_FORCE !== '1' && existing && existing.updated === updated) {
+    console.error(`  ${slug}: source docs unchanged since ${updated} — keeping current section (no API call).`);
+    sections.push(existing);
+    continue;
+  }
+
   console.error(`generating ${slug}…`);
   const written = await rewrite(slug, title, features, coreSmoke);
   if (!written || !written.summary || !written.body.length) {


### PR DESCRIPTION
Keeps the model-API cost bounded now that the generator's calls succeed.

**Before:** the workflow ran on every push touching plugin docs (many per day) and regenerated all 20 sections each time.

**After:**
- **Weekly schedule** (Mondays 06:00 UTC) plus manual dispatch — the per-push trigger is removed.
- **Change-aware:** a section whose source docs (its inventory + test script) haven't changed since it was last generated is kept verbatim with **no model call**. So a scheduled run in a week with no doc changes makes zero API calls and opens no PR; a week with changes regenerates only the affected sections.
- **Manual `force=true`** dispatch regenerates every section from scratch (for a full rebuild).
- Corrected the file header to match the hardened behavior (key required; change-aware).

Independent of the JSON-parse fix (#1666); either can merge first.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_