### PR TITLE
docs: proposal for trusted channels + earnable contributor badge

### DIFF
--- a/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
+++ b/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
@@ -18,42 +18,74 @@ discover that space and want to reach it.
 - **No images in v1.** Image upload in a survivor community is a serious safety and legal risk (a
   patient perp or a compromised account can post illegal or targeting images). It is a separate,
   later decision that requires a moderation pipeline — never a free perk bundled into the tier.
-- **No numeric trust score. No points, no tiers, no leaderboard, no ranking.** This stays consistent
-  with the Trust plugin rule: standing is categorical, never a number.
+- **No numeric score. No points, no tiers, no leaderboard, no ranking** on any surface. Standing is
+  categorical: a member is eligible or not-yet.
+- **This is its own gating module — it does NOT touch the Trust plugin.** The eligibility engine
+  described here reads existing signals to make an access decision; it never writes to, changes, or
+  re-uses the Trust plugin's model, status, or rules. Keep the two entirely separate.
 - **No claim of verification or vetting.** The platform verifies no one's identity, background, or
   work. No surface may say "verified," "vetted," or "trusted by the platform."
-- **The "material value first" norm still applies** inside these channels — they are not a
+- **The "material value first" norm still applies** inside the channel — it is not a
   pure-socializing lounge.
 
-## 1. Trust eligibility (private, server-computed)
+## 1. How access is earned (material value, weighted per plugin)
 
-A single categorical decision per member: **eligible** or **not-yet**. It is computed on the server
-and never shown as a number or a rank.
+A single categorical decision per member: **eligible** or **not-yet**, computed on the server and
+never shown as a number or a rank.
 
-**Signals (all from data already stored):**
+### The core property: gaming the gate means helping the community
 
-- **Account tenure** — a minimum account age.
-- **Login consistency** (`auth_login_activity`) — weighted **low**, because it is the easiest signal
-  to script.
-- **Unlock status** — `approved_full`.
-- **Participation breadth** — active in more than one plugin, not just one.
-- **Counterparty diversity** — interacts/transacts with **many distinct** people over a window, not
-  the same one or two. This is the strongest anti-collusion signal (it resists sockpuppet rings far
-  better than raw volume) and is the owner's key idea.
-- **Clean standing** — no active blocks or reports against the member.
+Access is bought **only with real material value delivered to real people**. So the only way to
+"game" it is to actually provide steady aid to the community — which is the outcome the platform
+wants. A perp who grinds for access has to spend genuine effort helping survivors; that is
+self-defeating, which is why this gate needs very little fraud detection. Everything below is just
+calibrating "material value" honestly.
 
-**How the signals combine:** an owner-tunable rule (a threshold over weighted signals, or an explicit
-set of minimums). Keep the exact formula server-side and adjustable **without a redeploy**, the same
-way the single-open-cohort toggle and the trust snapshot already work.
+### What counts as value (not logins, not presence)
 
-**Cadence:** recomputed on a schedule (for example, alongside the trust snapshot), **not instantly**.
-This prevents a "spike the signals then coast" gaming pattern.
+- **Value = each plugin's core value-action**, i.e. its *defining metric of success* — the action
+  that means the plugin is being used as intended. Examples: a TrustTransport delivery completed, a
+  Lighthouse stay hosted, a SocketRelay request filled, a Foundation quote fulfilled, a WhatWorks
+  endorsement others found useful. The reference point is Airbnb's "active user = someone who books,"
+  not "someone who logs in."
+- **Logins are downstream of value, so they carry near-zero admission weight.** Recent activity is
+  used only as a **liveness floor** ("is this member still around"), never as a positive score. A
+  member who adds value logs in as a consequence; rewarding the login directly rewards the wrong thing
+  and is the easiest signal to script.
+- **Delivered to distinct people** (counterparty diversity): the value has to reach **many different**
+  members over a window, so it is real community aid, not self-dealing or a sockpuppet ring.
+- **Clean standing:** no active blocks or reports against the member.
+- **Minimum tenure:** an account-age floor.
 
-**Earn and keep:** eligibility can lapse if the signals decay or a report lands, so behaviour stays
-good inside the channel, not just at the door.
+### Weighting value across plugins
 
-**Storage:** a computed eligibility flag plus a non-exposed reason snapshot. Reuse the Trust snapshot
-infrastructure rather than building a second scoring system.
+- **Each plugin's value-action is weighted, normalized by its base rate / effort.** A frequent, small
+  action (a TrustTransport delivery) and a rare, large one (hosting a Lighthouse stay) must not count
+  equally: one Lighthouse action is worth many TrustTransport actions. The weights reflect *value
+  contributed*, not raw event count, and are **owner-tunable without a redeploy** (the model the
+  single-open-cohort toggle already uses).
+- **Reuse each plugin's defining metric — do not reinvent it.** "Material value per plugin" is exactly
+  what the **canonical metric registry (rule 121)** and the **Weekly Performance** plugin are meant to
+  define (each plugin's success metric, tied to whether it is used in its intended form). The gating
+  module should *consume* those per-plugin metrics. This is a real dependency: the cleanest version of
+  this waits on the per-plugin success metrics being settled (part of the tabled Weekly Performance
+  work). Build the admission engine on top of that layer, not beside it.
+- **Note on plugin archetypes:** most plugins mirror a known app, so their value-action is borrowed
+  from that archetype (Lighthouse ≈ a stay, TrustTransport ≈ a delivery/ride, Foundation ≈ a fulfilled
+  service). A few — PeerProgramming, Workforce, LevelUp — are bespoke, so their value-action has to be
+  defined from their own intended use rather than copied.
+
+### Output, cadence, and storage
+
+- **Output:** a categorical eligibility flag per member (internal). Any internal score used to reach
+  it stays server-side and is never surfaced.
+- **Cadence:** recomputed on a schedule (not instantly), so nobody spikes the signals then coasts.
+- **Earn and keep:** eligibility can lapse if value dries up or a report lands, so good behaviour
+  continues inside the channel, not just at the door.
+- **High churn is expected and fine.** With typical messaging-app churn, most members never qualify;
+  the badge is for the persistent value-adding minority, by design.
+- **Storage:** a computed eligibility flag plus a non-exposed reason snapshot, owned by this module —
+  separate from the Trust plugin's storage.
 
 ## 2. The gated channel (one, not many)
 
@@ -109,8 +141,13 @@ members something to aim for — and "you can earn it too" keeps it from reading
 
 ## Open decisions for the owner
 
-- The exact eligibility weights/thresholds and the minimum account age.
-- The recompute cadence (weekly? alongside the trust snapshot?).
+- **The per-plugin value-action weights** and the base-rate normalization (how much one Lighthouse
+  action is worth vs one TrustTransport action, and so on), plus the overall threshold and the minimum
+  account age.
+- **The dependency on per-plugin success metrics:** whether to settle each plugin's defining metric
+  (canonical metric registry / Weekly Performance) first and have the gating module consume it, or to
+  ship an interim weighting and reconcile later.
+- The recompute cadence (weekly?).
 - The badge's name and click-through wording (brand-voice pass).
 - The minimum number of eligible members required before the single gated channel opens.
 - When (if ever) the single gated channel is noisy enough to justify splitting — the same
@@ -120,9 +157,14 @@ members something to aim for — and "you can earn it too" keeps it from reading
 
 ## Build sequence (only when approved)
 
-1. Eligibility computation (reuse the trust snapshot) producing the categorical flag.
+0. **(Dependency)** Settle each plugin's defining value-metric via the canonical metric registry /
+   Weekly Performance, so the gating module has a real per-plugin definition of material value to
+   consume rather than a guessed one.
+1. Eligibility computation in this new gating module (reads the per-plugin value-actions + counterparty
+   diversity + liveness floor + clean standing; owner-tunable weights), producing the categorical flag.
+   It does not touch the Trust plugin.
 2. The Directory badge + click-through + a short "how it's earned" page.
 3. One gated Stream channel (richer reactions, threads, **no images**), membership synced from the
-   flag, moderators read-in and disclosed.
+   flag, moderators read-in and disclosed. Open it only once enough members qualify.
 4. Observe how it behaves. Only then consider images, and only with a full report → fast-removal →
    retention pipeline (the Foundation retention model is the reference).

--- a/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
+++ b/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
@@ -148,9 +148,15 @@ of splitting members into tiny rooms. So the gated space is differentiated by **
 A hidden perk that nobody can find is not a perk. One earnable badge solves discovery and gives
 members something to aim for — and "you can earn it too" keeps it from reading as a clique.
 
-- **One categorical badge** on the Directory profile, fitting the existing badge pattern (for example
-  the "Community generated" badge). Binary: a member has it or does not. **No tiers, no points, no
-  leaderboard, no visible ranking.**
+- **It is a designed award emblem, not a UI chip.** A commissioned-quality vector seal
+  (challenge-coin / die-cut sticker feel — something a member would print and put on a laptop),
+  because it is an award, not a plain interface distinction. A first concept exists (a navy-and-gold
+  seal, working name "Keeper of the Commons": a beacon-flame woven from many contributor nodes on a
+  "Commons" baseline, ringed "Charging the Future · Keeper of the Commons · Earned"). Motif, palette,
+  and name are still open.
+- **One categorical badge** on the Directory profile, fitting the existing badge slot (alongside, for
+  example, the "Community generated" badge). Binary: a member has it or does not. **No tiers, no
+  points, no leaderboard, no visible ranking.**
 - **Same concept as channel access.** The eligibility that grants channel access is the same thing
   that grants the badge — one system, two surfaces.
 - **Honest click-through copy** (needs a brand-voice pass): say what is true, e.g. *"This member is a

--- a/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
+++ b/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
@@ -1,0 +1,115 @@
+# Proposal: Trusted Channels + Contributor Badge
+
+> **Status: proposal — NOT built.** Owner-directed exploration, 2026-07-18. Nothing here ships until
+> the owner approves it. A future agent reading this must not treat any of it as an existing feature.
+> The open decisions at the bottom are still open.
+
+## Why this exists
+
+Commons is deliberately one channel with no direct messages: it makes spam easy to spot, blocks perps
+from trolling people one-on-one, and its "provide material value before storytelling" norm filters
+out most bad actors fast. This proposal keeps all of that and adds an **earned**, higher-feature space
+for members who have shown, over time, that they are here to help — plus a way for members to
+discover that space and want to reach it.
+
+## Hard guardrails (do not violate)
+
+- **No direct messages. Ever.** These channels are group spaces, never 1:1 inboxes.
+- **No images in v1.** Image upload in a survivor community is a serious safety and legal risk (a
+  patient perp or a compromised account can post illegal or targeting images). It is a separate,
+  later decision that requires a moderation pipeline — never a free perk bundled into the tier.
+- **No numeric trust score. No points, no tiers, no leaderboard, no ranking.** This stays consistent
+  with the Trust plugin rule: standing is categorical, never a number.
+- **No claim of verification or vetting.** The platform verifies no one's identity, background, or
+  work. No surface may say "verified," "vetted," or "trusted by the platform."
+- **The "material value first" norm still applies** inside these channels — they are not a
+  pure-socializing lounge.
+
+## 1. Trust eligibility (private, server-computed)
+
+A single categorical decision per member: **eligible** or **not-yet**. It is computed on the server
+and never shown as a number or a rank.
+
+**Signals (all from data already stored):**
+
+- **Account tenure** — a minimum account age.
+- **Login consistency** (`auth_login_activity`) — weighted **low**, because it is the easiest signal
+  to script.
+- **Unlock status** — `approved_full`.
+- **Participation breadth** — active in more than one plugin, not just one.
+- **Counterparty diversity** — interacts/transacts with **many distinct** people over a window, not
+  the same one or two. This is the strongest anti-collusion signal (it resists sockpuppet rings far
+  better than raw volume) and is the owner's key idea.
+- **Clean standing** — no active blocks or reports against the member.
+
+**How the signals combine:** an owner-tunable rule (a threshold over weighted signals, or an explicit
+set of minimums). Keep the exact formula server-side and adjustable **without a redeploy**, the same
+way the single-open-cohort toggle and the trust snapshot already work.
+
+**Cadence:** recomputed on a schedule (for example, alongside the trust snapshot), **not instantly**.
+This prevents a "spike the signals then coast" gaming pattern.
+
+**Earn and keep:** eligibility can lapse if the signals decay or a report lands, so behaviour stays
+good inside the channel, not just at the door.
+
+**Storage:** a computed eligibility flag plus a non-exposed reason snapshot. Reuse the Trust snapshot
+infrastructure rather than building a second scoring system.
+
+## 2. Gated channels
+
+- **Channel model:** admin-created, or auto-formed the way PeerProgramming cohorts are — **topical**
+  channels with a purpose. **Not** user-created private rooms (a private room for a few friends is a
+  group DM by another name, and it moves trolling into an unwatched back-room). Keep the number
+  **small**.
+- **Access:** channel membership is synced from the eligibility flag. Lose eligibility, lose access.
+- **Features (v1):** a richer reaction set / more emoji, threads, and longer messages. **No image
+  upload.**
+- **Moderation:** moderators keep **read access** to these channels, and members are told so in-channel
+  ("moderators can read this channel"). That is what keeps a "non-public" channel from becoming an
+  unmoderated back-room where the same trolling simply relocates.
+- **Detection:** keep the channel count small, logged, and moderated, so the spam-detection advantage
+  of few channels is not diluted.
+- **Implementation:** a distinct GetStream channel-type with the richer feature config; Commons stays
+  its own, more limited channel-type. Stream already powers Chyme/Hub, so per-channel-type feature
+  configuration (uploads off, reaction set, threads) is a native setting, not custom plumbing.
+
+## 3. Contributor badge (discovery + motivation)
+
+A hidden perk that nobody can find is not a perk. One earnable badge solves discovery and gives
+members something to aim for — and "you can earn it too" keeps it from reading as a clique.
+
+- **One categorical badge** on the Directory profile, fitting the existing badge pattern (for example
+  the "Community generated" badge). Binary: a member has it or does not. **No tiers, no points, no
+  leaderboard, no visible ranking.**
+- **Same concept as channel access.** The eligibility that grants channel access is the same thing
+  that grants the badge — one system, two surfaces.
+- **Honest click-through copy** (needs a brand-voice pass): say what is true, e.g. *"This member is a
+  consistent, broad contributor to the community. Access is earned through steady participation over
+  time — anyone can earn it,"* with a short "how it's earned" link. It must **not** say "verified,"
+  "vetted," or "trusted by the platform." Prefer "contribution / participation" over "value" so it
+  does not read as "big spender" or a judgement of a person's worth.
+- **Only ever the positive.** Show the badge to members who have it; never surface an absence or a
+  "does not have it" state on anyone else. No shaming.
+- **Real members only.** The badge attaches to claimed profiles that earned it — not to
+  community-generated (unclaimed) profiles.
+- **Health note:** gamification in a trauma community can nudge performative activity or status
+  anxiety. A single binary badge with transparent, earnable criteria (not a points race) is what
+  keeps it healthy.
+
+## Open decisions for the owner
+
+- The exact eligibility weights/thresholds and the minimum account age.
+- The recompute cadence (weekly? alongside the trust snapshot?).
+- The badge's name and click-through wording (brand-voice pass).
+- How many gated channels, their topics, and admin-created vs auto-formed.
+- Whether a member can opt out of showing the badge.
+- Whether eligibility loss on a report is immediate or applies at the next recompute.
+
+## Build sequence (only when approved)
+
+1. Eligibility computation (reuse the trust snapshot) producing the categorical flag.
+2. The Directory badge + click-through + a short "how it's earned" page.
+3. One gated Stream channel (richer reactions, threads, **no images**), membership synced from the
+   flag, moderators read-in and disclosed.
+4. Observe how it behaves. Only then consider images, and only with a full report → fast-removal →
+   retention pipeline (the Foundation retention model is the reference).

--- a/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
+++ b/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
@@ -74,6 +74,15 @@ calibrating "material value" honestly.
   from that archetype (Lighthouse ≈ a stay, TrustTransport ≈ a delivery/ride, Foundation ≈ a fulfilled
   service). A few — PeerProgramming, Workforce, LevelUp — are bespoke, so their value-action has to be
   defined from their own intended use rather than copied.
+- **The bar is intentionally high (owner directive).** Access is meant to be genuinely hard to earn —
+  sustained, broad, real contribution — not an easy unlock. The exact threshold and weights are
+  **deferred until the per-plugin value metrics are settled** (that work defines what "contribution"
+  even means per plugin), then set high on purpose.
+- **Count each value event once, in its originating plugin (no double-counting).** A Chyme tip is a
+  ServiceCredits transfer; a TrustTransport trip writes a credit line. If several metrics counted the
+  same underlying event the total would inflate. Define each plugin's value event to be mutually
+  exclusive — the GDP recognition model (fixed contribution weights, distinct recognition sources)
+  already does this and is the reference.
 
 ### Output, cadence, and storage
 

--- a/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
+++ b/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
@@ -80,10 +80,37 @@ calibrating "material value" honestly.
 - **Output:** a categorical eligibility flag per member (internal). Any internal score used to reach
   it stays server-side and is never surfaced.
 - **Cadence:** recomputed on a schedule (not instantly), so nobody spikes the signals then coasts.
-- **Earn and keep:** eligibility can lapse if value dries up or a report lands, so good behaviour
-  continues inside the channel, not just at the door.
+  The recompute is **additive only** — it admits newly-qualified members and never revokes on signal
+  decay (see the next two points).
+- **The badge is permanent once earned.** It is recognition of real past contribution, so it is
+  **never** removed for going quiet, a dip in activity, or a hard stretch. Stripping a real survivor
+  for struggling or stepping away is not trauma-informed. No decay, no "use it or lose it."
+- **Channel access is revoked only for substantiated cause** — a *reviewed* harm or abuse action
+  inside the space, handled by moderation. **Not** for inactivity, and **not** on an unreviewed report
+  alone (an auto-revoke-on-report rule would be weaponized against real victims via report-brigading).
+  A quiet survivor keeps everything; only someone who actually causes harm loses access.
 - **High churn is expected and fine.** With typical messaging-app churn, most members never qualify;
   the badge is for the persistent value-adding minority, by design.
+
+### Threat model: the long-game perp
+
+A patient perp could earn access, then try to cause harm later. Perfect prevention is not the bar (no
+community achieves it); **bounded, observable, recoverable** harm is — and the design already reaches
+it:
+
+- **Entry cost is real aid.** Getting in requires sustained material value delivered to many real
+  survivors first. That is slow and expensive, and the survivors were genuinely helped along the way —
+  the net is not zero even if the perp is later removed.
+- **The blast radius is small and watched.** Inside there are no DMs, no images (v1), it is group-only,
+  and moderators read it (disclosed). A perp cannot do 1:1 targeting or post images; harm is bounded
+  and observable, which is what makes it actionable.
+- **Removal is for-cause and immediate.** The moment they cause harm, moderation revokes access — you
+  do not need to have caught them earlier, you catch them when they act, in a space built to make
+  acting visible.
+- **Account deletion resets the barrier.** A perp who deletes and returns loses the earned history and
+  must re-grind real aid from scratch, so deletion is self-defeating, not a loophole. The broader
+  "same person, new identity" problem is platform-level (Unlock's Quora social proof, suppression /
+  takedown tools); this gate only adds cost on top.
 - **Storage:** a computed eligibility flag plus a non-exposed reason snapshot, owned by this module —
   separate from the Trust plugin's storage.
 
@@ -153,7 +180,12 @@ members something to aim for — and "you can earn it too" keeps it from reading
 - When (if ever) the single gated channel is noisy enough to justify splitting — the same
   low-population trigger PeerProgramming uses for cohorts.
 - Whether a member can opt out of showing the badge.
-- Whether eligibility loss on a report is immediate or applies at the next recompute.
+- **Does stopping contributing cost channel access?** Recommended: **no** — access is for-cause-only
+  (removed only for a reviewed harm/abuse action), so a member who goes quiet keeps their seat. This is
+  the trauma-informed default and inactivity is not a safety threat in a no-DM, no-image, moderated
+  group; an inactivity-decay rule would mostly punish struggling survivors and would not stop a
+  determined lurker anyway. The trade-off is channel vibrancy vs. trauma-informed retention — the owner
+  can choose active-contributors-only instead, at that cost.
 
 ## Build sequence (only when approved)
 

--- a/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
+++ b/ctf/docs/developer/TRUSTED_CHANNELS_AND_CONTRIBUTOR_BADGE_PROPOSAL.md
@@ -55,20 +55,31 @@ good inside the channel, not just at the door.
 **Storage:** a computed eligibility flag plus a non-exposed reason snapshot. Reuse the Trust snapshot
 infrastructure rather than building a second scoring system.
 
-## 2. Gated channels
+## 2. The gated channel (one, not many)
 
-- **Channel model:** admin-created, or auto-formed the way PeerProgramming cohorts are — **topical**
-  channels with a purpose. **Not** user-created private rooms (a private room for a few friends is a
-  group DM by another name, and it moves trolling into an unwatched back-room). Keep the number
-  **small**.
+**One gated channel, not topic channels.** This is a correction from real evidence: the owner ran
+several topic-based Signal groups, nobody adhered to the topics, they were folded into one group, and
+a member said they preferred the single group. That result is not an anomaly — at low population there
+is not enough traffic to keep several rooms alive, so topic-splitting produces dead channels while a
+single general room is what actually gets used. The app already learned this twice: **Commons folded
+to one channel**, and **PeerProgramming runs a single standing cohort** in low-population mode instead
+of splitting members into tiny rooms. So the gated space is differentiated by **who is in it**
+(trusted members) and **what features it has**, **not** by topic.
+
+- **Channel model:** a single admin-owned channel — "Commons for trusted members." **Not** multiple
+  topic rooms, and **not** user-created private rooms (a private room for a few friends is a group DM
+  by another name, and it moves trolling into an unwatched back-room). Split into more than one channel
+  only if and when the single channel becomes genuinely too noisy to follow — the same low-population
+  reasoning PeerProgramming uses to decide whether to split cohorts.
+- **Launch gate:** do not open the channel until enough members qualify to make it feel alive. A cold,
+  near-empty "trusted" room reads worse than not having one, so gate the launch on a minimum number of
+  eligible members and let it open populated.
 - **Access:** channel membership is synced from the eligibility flag. Lose eligibility, lose access.
 - **Features (v1):** a richer reaction set / more emoji, threads, and longer messages. **No image
   upload.**
-- **Moderation:** moderators keep **read access** to these channels, and members are told so in-channel
+- **Moderation:** moderators keep **read access** to the channel, and members are told so in-channel
   ("moderators can read this channel"). That is what keeps a "non-public" channel from becoming an
   unmoderated back-room where the same trolling simply relocates.
-- **Detection:** keep the channel count small, logged, and moderated, so the spam-detection advantage
-  of few channels is not diluted.
 - **Implementation:** a distinct GetStream channel-type with the richer feature config; Commons stays
   its own, more limited channel-type. Stream already powers Chyme/Hub, so per-channel-type feature
   configuration (uploads off, reaction set, threads) is a native setting, not custom plumbing.
@@ -101,7 +112,9 @@ members something to aim for — and "you can earn it too" keeps it from reading
 - The exact eligibility weights/thresholds and the minimum account age.
 - The recompute cadence (weekly? alongside the trust snapshot?).
 - The badge's name and click-through wording (brand-voice pass).
-- How many gated channels, their topics, and admin-created vs auto-formed.
+- The minimum number of eligible members required before the single gated channel opens.
+- When (if ever) the single gated channel is noisy enough to justify splitting — the same
+  low-population trigger PeerProgramming uses for cohorts.
 - Whether a member can opt out of showing the badge.
 - Whether eligibility loss on a report is immediate or applies at the next recompute.
 


### PR DESCRIPTION
A written design spec (**not built** — clearly marked as a proposal) capturing the trusted-channels + contributor-badge idea so it's ready to build when you decide.

Covers:
- **Hard guardrails:** no DMs, no images in v1, no numeric score/leaderboard, no verification claims, "material value first" still applies.
- **Trust eligibility:** a private, categorical eligible/not-yet decision from signals you already store — tenure, login consistency (weighted low), Unlock `approved_full`, participation breadth, **counterparty diversity** (the anti-collusion signal you named), and clean standing. Owner-tunable, recomputed on a schedule, earn-and-keep.
- **Gated channels:** admin-created/auto-formed topical channels (not user private rooms), richer reactions/threads and **no images** in v1, moderators read-in and disclosed, implemented as a distinct Stream channel-type.
- **Contributor badge:** one earnable, categorical Directory badge for discovery — no tiers/points, honest non-vetting click-through copy, only ever the positive state, real claimed members only.
- **Open decisions** and a **build sequence** for when approved.

This is a doc for your review — edit on the branch or tell me changes. Not auto-merging.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_