### PR TITLE
feat: rebuild Weekly Performance around the locked value-metric table

### DIFF
--- a/.github/workflows/weekly-performance-goal-snapshot.yml
+++ b/.github/workflows/weekly-performance-goal-snapshot.yml
@@ -1,0 +1,57 @@
+name: Weekly Performance — Goal Snapshot Capture
+
+# Records the Weekly Performance goal readings (GDP Community Value Index toward 300B; Workforce
+# recruited toward 2,000,000) into weekly_performance_goal_snapshots by calling the app's internal
+# capture route. Goal metrics are state totals — a past week cannot be recomputed — so each week
+# needs at least one stored reading, and goal history must never depend on someone opening the
+# dashboard that week. Runs daily; each run refreshes the current week's row (last capture of the
+# week wins), so the stored value converges to the week's closing reading. If a run fails, the next
+# day's run covers it — only a whole week of failures loses that week's reading, which is why this
+# is daily rather than weekly.
+#
+# Needs (from Infisical, injected below): APP_URL, INTERNAL_SERVICE_SECRET.
+
+on:
+  schedule:
+    - cron: '35 5 * * *' # daily at 05:35 UTC, offset from the other scheduled jobs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: weekly-performance-goal-snapshot
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Capture the goal snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
+
+      - name: Call the internal capture route
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_URL:-}" ] || [ -z "${INTERNAL_SERVICE_SECRET:-}" ]; then
+            echo "APP_URL or INTERNAL_SERVICE_SECRET missing — cannot capture." >&2
+            exit 1
+          fi
+          HTTP_CODE=$(curl -sS -o /tmp/capture-response.json -w '%{http_code}' \
+            -X POST "${APP_URL%/}/api/internal/weekly-performance/goal-snapshot" \
+            -H "Authorization: Bearer ${INTERNAL_SERVICE_SECRET}")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Capture failed with HTTP ${HTTP_CODE}:" >&2
+            cat /tmp/capture-response.json >&2
+            exit 1
+          fi
+          echo "Goal snapshot captured."

--- a/ctf/config/canonical_metrics.yaml
+++ b/ctf/config/canonical_metrics.yaml
@@ -1533,3 +1533,644 @@ canonical_metrics:
     retention: 120 months
     allowed_thresholds:
       min: 0
+
+  # ─── Weekly Performance Rebuild Metrics ─────────────────────────────────
+  # Live weekly numbers computed by ctf/packages/web/lib/weekly-performance/live-metrics.ts.
+  # Each value.* metric counts one plugin's defining action inside the week window
+  # [:week_start, :week_end). The two wp_goal_* entries register only the weekly snapshot
+  # semantics; the underlying state metrics are already registered as gdp_value_index and
+  # workforce_recruited_current_count.
+
+  - id: wp_value_foundation_calls_answered
+    name: Weekly Foundation Calls Answered
+    description: Count of Foundation 1:1 calls that were answered and charged (at least one block charged) within the week window. Aggregate-only and shown on the admin surface only; the underlying participation is sensitive under rule 132 (wellbeing/payment), so it must never appear on a public surface or as any per-member figure.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: calls
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM foundation_call_sessions
+      WHERE answered_at >= :week_start
+        AND answered_at < :week_end
+        AND blocks_charged > 0;
+    inputs:
+      - name: foundation_call_sessions.answered_at
+        type: datetime
+      - name: foundation_call_sessions.blocks_charged
+        type: integer
+    example_values:
+      - 4
+      - 11
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_socket_relay_requests_fulfilled
+    name: Weekly SocketRelay Requests Fulfilled
+    description: Count of SocketRelay fulfillments the requester closed as successful within the week window. The table has no closed_at column; updated_at is written by the close, so it anchors the week.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: requests
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM socket_relay_fulfillments
+      WHERE updated_at >= :week_start
+        AND updated_at < :week_end
+        AND close_reason = 'successful';
+    inputs:
+      - name: socket_relay_fulfillments.updated_at
+        type: datetime
+      - name: socket_relay_fulfillments.close_reason
+        type: string
+    example_values:
+      - 6
+      - 14
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_trust_transport_trips_completed
+    name: Weekly TrustTransport Trips Completed
+    description: Count of TrustTransport trips completed within the week window where both the requester and the provider confirmed completion.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: trips
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM trust_transport_trips
+      WHERE completed_at >= :week_start
+        AND completed_at < :week_end
+        AND status = 'completed'
+        AND requester_completion_confirmed_at IS NOT NULL
+        AND provider_completion_confirmed_at IS NOT NULL;
+    inputs:
+      - name: trust_transport_trips.completed_at
+        type: datetime
+      - name: trust_transport_trips.status
+        type: string
+      - name: trust_transport_trips.requester_completion_confirmed_at
+        type: datetime|null
+      - name: trust_transport_trips.provider_completion_confirmed_at
+        type: datetime|null
+    example_values:
+      - 9
+      - 21
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_lighthouse_stays_completed
+    name: Weekly Lighthouse Stays Completed
+    description: Count of Lighthouse stays that reached completed status within the week window. The table has no completed_at column, so the window keys on updated_at of rows now in 'completed' — the status flip is the last write in the normal flow.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: stays
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM lighthouse_matches
+      WHERE updated_at >= :week_start
+        AND updated_at < :week_end
+        AND status = 'completed';
+    inputs:
+      - name: lighthouse_matches.updated_at
+        type: datetime
+      - name: lighthouse_matches.status
+        type: string
+    example_values:
+      - 2
+      - 7
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_chyme_tips_sent
+    name: Weekly Chyme Tips Sent
+    description: Count of peer tips sent through Chyme within the week window — completed ServiceCredits transfers originated by the Chyme plugin, never self-to-self.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: tips
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM service_credits_transfers
+      WHERE completed_at >= :week_start
+        AND completed_at < :week_end
+        AND status = 'completed'
+        AND origin_plugin = 'chyme'
+        AND sender_user_id <> recipient_user_id;
+    inputs:
+      - name: service_credits_transfers.completed_at
+        type: datetime
+      - name: service_credits_transfers.status
+        type: string
+      - name: service_credits_transfers.origin_plugin
+        type: string
+      - name: service_credits_transfers.sender_user_id
+        type: uuid
+      - name: service_credits_transfers.recipient_user_id
+        type: uuid
+    example_values:
+      - 33
+      - 58
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_service_credits_peer_sends
+    name: Weekly ServiceCredits Peer Sends
+    description: Count of completed direct peer-to-peer ServiceCredits sends within the week window. Scoping on origin_plugin keeps plugin-mediated transfers (Chyme tips, LevelUp flows) counted once, in their originating plugin.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: sends
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM service_credits_transfers
+      WHERE completed_at >= :week_start
+        AND completed_at < :week_end
+        AND status = 'completed'
+        AND origin_plugin = 'service-credits'
+        AND sender_user_id <> recipient_user_id;
+    inputs:
+      - name: service_credits_transfers.completed_at
+        type: datetime
+      - name: service_credits_transfers.status
+        type: string
+      - name: service_credits_transfers.origin_plugin
+        type: string
+      - name: service_credits_transfers.sender_user_id
+        type: uuid
+      - name: service_credits_transfers.recipient_user_id
+        type: uuid
+    example_values:
+      - 47
+      - 90
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_contributions_confirmed_usd
+    name: Weekly Contributions Confirmed USD
+    description: Sum (not a row count) of confirmed contribution dollars reviewed within the week window. Differs from contributions_fiat_confirmed_total, which is the cumulative all-time gift-card total; this one is windowed on reviewed_at.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: number
+    unit: USD
+    calculation: |
+      SELECT COALESCE(SUM(confirmed_amount_usd), 0) AS v
+      FROM contributions_submissions
+      WHERE status = 'confirmed'
+        AND reviewed_at >= :week_start
+        AND reviewed_at < :week_end;
+    inputs:
+      - name: contributions_submissions.status
+        type: string
+      - name: contributions_submissions.reviewed_at
+        type: datetime
+      - name: contributions_submissions.confirmed_amount_usd
+        type: currency
+    example_values:
+      - 45
+      - 120.5
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_skills_hunt_nominations_accepted
+    name: Weekly SkillsHunt Nominations Accepted
+    description: Count of SkillsHunt nominations a moderator accepted within the week window (an accepted nomination produces a real Directory profile plus a reward).
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: nominations
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM skills_hunt_submissions
+      WHERE reviewed_at >= :week_start
+        AND reviewed_at < :week_end
+        AND status = 'accepted'
+        AND deleted_at IS NULL;
+    inputs:
+      - name: skills_hunt_submissions.reviewed_at
+        type: datetime
+      - name: skills_hunt_submissions.status
+        type: string
+      - name: skills_hunt_submissions.deleted_at
+        type: datetime|null
+    example_values:
+      - 3
+      - 12
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_what_works_tools_approved
+    name: Weekly WhatWorks Tools Approved
+    description: Count of WhatWorks tools that were reviewed and approved within the week window.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: tools
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM what_works_products
+      WHERE reviewed_at >= :week_start
+        AND reviewed_at < :week_end
+        AND status = 'approved';
+    inputs:
+      - name: what_works_products.reviewed_at
+        type: datetime
+      - name: what_works_products.status
+        type: string
+    example_values:
+      - 2
+      - 5
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_what_works_endorsements_given
+    name: Weekly WhatWorks Endorsements Given
+    description: Count of WhatWorks endorsements created within the week window.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: endorsements
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM what_works_endorsements
+      WHERE created_at >= :week_start
+        AND created_at < :week_end;
+    inputs:
+      - name: what_works_endorsements.created_at
+        type: datetime
+    example_values:
+      - 8
+      - 19
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_level_up_completions
+    name: Weekly LevelUp Completions
+    description: Count of LevelUp enrollments that reached completed status within the week window (delivered value is completion, not the enrollment start). No completed_at column exists; the status flip writes updated_at.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: completions
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM level_up_enrollments
+      WHERE updated_at >= :week_start
+        AND updated_at < :week_end
+        AND status = 'completed';
+    inputs:
+      - name: level_up_enrollments.updated_at
+        type: datetime
+      - name: level_up_enrollments.status
+        type: string
+    example_values:
+      - 5
+      - 16
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_level_up_trainer_payouts
+    name: Weekly LevelUp Trainer Payouts
+    description: Count of LevelUp trainer payout disbursements created within the week window.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: payouts
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM level_up_disbursements
+      WHERE created_at >= :week_start
+        AND created_at < :week_end
+        AND disbursement_type = 'trainer_payout';
+    inputs:
+      - name: level_up_disbursements.created_at
+        type: datetime
+      - name: level_up_disbursements.disbursement_type
+        type: string
+    example_values:
+      - 3
+      - 9
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_recurring_ties_confirmed
+    name: Weekly Recurring Ties Confirmed
+    description: Count of Recurring Activity ties the counterparty confirmed within the week window.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: ties
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM recurring_activities
+      WHERE confirmed_at >= :week_start
+        AND confirmed_at < :week_end;
+    inputs:
+      - name: recurring_activities.confirmed_at
+        type: datetime
+    example_values:
+      - 4
+      - 13
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_peer_programming_active_posters
+    name: Weekly PeerProgramming Active Posters
+    description: Count of distinct members who posted at least one message in their PeerProgramming cohort within the week window. Participation is the plugin's purpose, so distinct posters is the honest dashboard signal.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: members
+    calculation: |
+      SELECT COUNT(DISTINCT author_user_id) AS v
+      FROM peer_programming_messages
+      WHERE created_at >= :week_start
+        AND created_at < :week_end;
+    inputs:
+      - name: peer_programming_messages.author_user_id
+        type: uuid
+      - name: peer_programming_messages.created_at
+        type: datetime
+    example_values:
+      - 11
+      - 26
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_value_beacon_broadcast_engagement
+    name: Weekly Beacon Broadcast Engagement
+    description: Count of distinct (member, broadcast) pairs that engaged with a Beacon broadcast's Commons replay post within the week window, via a reaction or a reply. One member engaging with the same broadcast many times counts once. Live in-event chat and reactions are held only in Stream and expire there, so they are not counted. Broadcast completion itself is not counted either — only the owner can start a session, so it would measure the admin, not members.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: engagements
+    calculation: |
+      SELECT COUNT(*) AS v FROM (
+        SELECT r.user_id AS member_id, b.id AS broadcast_id
+        FROM beacon_events b
+        JOIN feed_community_post_reactions r ON r.post_id = b.commons_recording_post_id
+        WHERE r.created_at >= :week_start AND r.created_at < :week_end
+        UNION
+        SELECT p.author_user_id AS member_id, b.id AS broadcast_id
+        FROM beacon_events b
+        JOIN feed_community_replies p ON p.post_id = b.commons_recording_post_id
+        WHERE p.created_at >= :week_start AND p.created_at < :week_end
+      ) engagement;
+    inputs:
+      - name: beacon_events.commons_recording_post_id
+        type: uuid
+      - name: feed_community_post_reactions.post_id
+        type: uuid
+      - name: feed_community_post_reactions.user_id
+        type: uuid
+      - name: feed_community_post_reactions.created_at
+        type: datetime
+      - name: feed_community_replies.post_id
+        type: uuid
+      - name: feed_community_replies.author_user_id
+        type: uuid
+      - name: feed_community_replies.created_at
+        type: datetime
+    example_values:
+      - 15
+      - 42
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_adoption_directory_findable_members
+    name: Weekly Directory Findable Members
+    description: Cumulative state count — claimed, active, non-deleted Directory profiles holding at least one skill, created by the end of the week window. Claim time is not stored, so the count reflects each profile's CURRENT claimed/active/skilled state, not its state at the time.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: members
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM directory_profiles p
+      WHERE p.claimed_by_user_id IS NOT NULL
+        AND p.is_active = TRUE
+        AND p.deleted_at IS NULL
+        AND p.created_at < :week_end
+        AND EXISTS (SELECT 1 FROM directory_profile_skills s WHERE s.profile_id = p.id);
+    inputs:
+      - name: directory_profiles.claimed_by_user_id
+        type: uuid|null
+      - name: directory_profiles.is_active
+        type: boolean
+      - name: directory_profiles.deleted_at
+        type: datetime|null
+      - name: directory_profiles.created_at
+        type: datetime
+      - name: directory_profile_skills.profile_id
+        type: uuid
+    example_values:
+      - 54
+      - 61
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_adoption_mood_checkins
+    name: Weekly Mood Check-ins
+    description: Count of mood check-ins submitted within the week window. Aggregate only — never an individual reading.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: check-ins
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM mood_submissions
+      WHERE submitted_at >= :week_start
+        AND submitted_at < :week_end;
+    inputs:
+      - name: mood_submissions.submitted_at
+        type: datetime
+    example_values:
+      - 38
+      - 72
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_adoption_mood_average
+    name: Weekly Mood Average
+    description: Average mood value across all check-ins submitted within the week window, rounded to two decimals. Aggregate only — never an individual reading.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: float
+    unit: mood_scale
+    calculation: |
+      SELECT ROUND(AVG(mood_value)::numeric, 2) AS v
+      FROM mood_submissions
+      WHERE submitted_at >= :week_start
+        AND submitted_at < :week_end;
+    inputs:
+      - name: mood_submissions.mood_value
+        type: integer
+      - name: mood_submissions.submitted_at
+        type: datetime
+    example_values:
+      - 3.4
+      - 3.72
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_adoption_click_log_incidents
+    name: Weekly ClickLog Incidents
+    description: Count of ClickLog incidents logged within the week window. ClickLog is a private personal tally, so this is aggregate only — never per-member detail.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: incidents
+    calculation: |
+      SELECT COUNT(*) AS v
+      FROM click_log_incidents
+      WHERE created_at >= :week_start
+        AND created_at < :week_end;
+    inputs:
+      - name: click_log_incidents.created_at
+        type: datetime
+    example_values:
+      - 22
+      - 40
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_adoption_click_log_active_loggers
+    name: Weekly ClickLog Active Loggers
+    description: Count of distinct members who logged at least one ClickLog incident within the week window. Aggregate only — never per-member detail.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: members
+    calculation: |
+      SELECT COUNT(DISTINCT user_id) AS v
+      FROM click_log_incidents
+      WHERE created_at >= :week_start
+        AND created_at < :week_end;
+    inputs:
+      - name: click_log_incidents.user_id
+        type: uuid
+      - name: click_log_incidents.created_at
+        type: datetime
+    example_values:
+      - 9
+      - 17
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_goal_gdp_value_index_weekly_snapshot
+    name: Weekly Goal Snapshot — Community Value Index
+    description: Weekly snapshot of the Community Value Index (the state metric already registered as gdp_value_index) toward the platform goal of 300000000000 index points. The index is a state metric, so week-over-week needs memory — each read of the current week upserts the live value into weekly_performance_goal_snapshots; past weeks report their stored snapshot; a week never read while current reports 0 and renders as not captured.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: index
+    calculation: |
+      -- Current week: compute the live gdp_value_index value, then upsert it as this week's snapshot
+      -- (last read of the week wins — the row converges to the week's closing value):
+      INSERT INTO weekly_performance_goal_snapshots (metric_key, week_start_date, metric_value, captured_at)
+      VALUES ('goal.gdp_value_index', :week_start, :live_value, NOW())
+      ON CONFLICT (metric_key, week_start_date)
+      DO UPDATE SET metric_value = EXCLUDED.metric_value, captured_at = NOW();
+      -- Past week: report the stored snapshot:
+      SELECT metric_value AS v
+      FROM weekly_performance_goal_snapshots
+      WHERE metric_key = 'goal.gdp_value_index'
+        AND week_start_date = :week_start;
+    inputs:
+      - name: weekly_performance_goal_snapshots.metric_key
+        type: string
+      - name: weekly_performance_goal_snapshots.week_start_date
+        type: date
+      - name: weekly_performance_goal_snapshots.metric_value
+        type: number
+      - name: weekly_performance_goal_snapshots.captured_at
+        type: datetime
+    example_values:
+      - 13340
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 120 months
+    allowed_thresholds:
+      min: 0
+
+  - id: wp_goal_workforce_recruited_weekly_snapshot
+    name: Weekly Goal Snapshot — Workforce Recruited
+    description: Weekly snapshot of the workforce recruited count (the state metric already registered as workforce_recruited_current_count — all active, non-deleted Directory profiles) toward the platform goal of 2000000 members. A state metric, so week-over-week needs memory — each read of the current week upserts the live value into weekly_performance_goal_snapshots; past weeks report their stored snapshot; a week never read while current reports 0 and renders as not captured.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: integer
+    unit: members
+    calculation: |
+      -- Live value for the current week (the workforce_recruited_current_count definition):
+      SELECT COUNT(*) AS v
+      FROM directory_profiles
+      WHERE is_active = TRUE
+        AND deleted_at IS NULL;
+      -- Current week: upsert that live value as this week's snapshot (last read of the week wins):
+      INSERT INTO weekly_performance_goal_snapshots (metric_key, week_start_date, metric_value, captured_at)
+      VALUES ('goal.workforce_recruited', :week_start, :live_value, NOW())
+      ON CONFLICT (metric_key, week_start_date)
+      DO UPDATE SET metric_value = EXCLUDED.metric_value, captured_at = NOW();
+      -- Past week: report the stored snapshot:
+      SELECT metric_value AS v
+      FROM weekly_performance_goal_snapshots
+      WHERE metric_key = 'goal.workforce_recruited'
+        AND week_start_date = :week_start;
+    inputs:
+      - name: directory_profiles.is_active
+        type: boolean
+      - name: directory_profiles.deleted_at
+        type: datetime|null
+      - name: weekly_performance_goal_snapshots.metric_key
+        type: string
+      - name: weekly_performance_goal_snapshots.week_start_date
+        type: date
+      - name: weekly_performance_goal_snapshots.metric_value
+        type: number
+      - name: weekly_performance_goal_snapshots.captured_at
+        type: datetime
+    example_values:
+      - 67
+    last_updated: "2026-07-18T00:00:00Z"
+    update_cadence: weekly
+    retention: 120 months
+    allowed_thresholds:
+      min: 0

--- a/ctf/docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -64,6 +64,27 @@ contracts:
     dataAccess:
       - weekly_performance_metrics
       - canonical_metrics_registry
+      - weekly_performance_goal_snapshots
+      - foundation_call_sessions
+      - trust_transport_trips
+      - lighthouse_matches
+      - socket_relay_fulfillments
+      - service_credits_transfers
+      - contributions_submissions
+      - skills_hunt_submissions
+      - what_works_products
+      - what_works_endorsements
+      - level_up_enrollments
+      - level_up_disbursements
+      - recurring_activities
+      - peer_programming_messages
+      - beacon_events
+      - feed_community_post_reactions
+      - feed_community_replies
+      - directory_profiles
+      - directory_profile_skills
+      - mood_submissions
+      - click_log_incidents
     purpose: operational_metrics_review
     retentionClass: derived_short_lived
     idempotency: true
@@ -92,6 +113,27 @@ contracts:
     dataAccess:
       - weekly_performance_metrics
       - canonical_metrics_registry
+      - weekly_performance_goal_snapshots
+      - foundation_call_sessions
+      - trust_transport_trips
+      - lighthouse_matches
+      - socket_relay_fulfillments
+      - service_credits_transfers
+      - contributions_submissions
+      - skills_hunt_submissions
+      - what_works_products
+      - what_works_endorsements
+      - level_up_enrollments
+      - level_up_disbursements
+      - recurring_activities
+      - peer_programming_messages
+      - beacon_events
+      - feed_community_post_reactions
+      - feed_community_replies
+      - directory_profiles
+      - directory_profile_skills
+      - mood_submissions
+      - click_log_incidents
     purpose: operational_metrics_comparison
     retentionClass: derived_short_lived
     idempotency: true
@@ -116,12 +158,43 @@ contracts:
         type: array
     dataAccess:
       - weekly_performance_metrics
+      - canonical_metrics_registry
+      - weekly_performance_goal_snapshots
+      - foundation_call_sessions
+      - trust_transport_trips
+      - lighthouse_matches
+      - socket_relay_fulfillments
+      - service_credits_transfers
+      - contributions_submissions
+      - skills_hunt_submissions
+      - what_works_products
+      - what_works_endorsements
+      - level_up_enrollments
+      - level_up_disbursements
+      - recurring_activities
+      - peer_programming_messages
+      - beacon_events
+      - feed_community_post_reactions
+      - feed_community_replies
+      - directory_profiles
+      - directory_profile_skills
+      - mood_submissions
+      - click_log_incidents
       - weekly_performance_audit_trail
     purpose: operational_metrics_export
     retentionClass: audit_long_lived
     idempotency: false
 
 changelog:
+  - date: 2026-07-18
+    change: >-
+      Metrics rebuild (owner-locked decision record ctf/docs/developer/PLUGIN_VALUE_METRICS.md): the
+      metrics/comparison/export reads now compute each plugin's defining value event live from the
+      upstream plugin tables, plus two goal rows (GDP Community Value Index toward 300B via the GDP
+      plugin's live report - see the GDP contracts for that command's own reads - and Workforce
+      recruited toward 2,000,000) snapshotted weekly in the new weekly_performance_goal_snapshots
+      table so week-over-week works for state metrics. dataAccess lists updated to the real read set;
+      the current-week read also upserts the goal snapshot row.
   - date: 2026-02-25
     change: Initial Weekly Performance command contract skeleton added for week listing, snapshot retrieval, comparison, and export workflows.
   - date: 2026-06-27

--- a/ctf/docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -185,6 +185,33 @@ contracts:
     retentionClass: audit_long_lived
     idempotency: false
 
+  - pluginId: weekly-performance
+    command: weekly-performance.goal-snapshot.capture
+    version: 1.0.0
+    description: >-
+      Internal, schedule-driven capture of the two goal readings (GDP Community Value Index toward
+      300B; Workforce recruited toward 2,000,000) into weekly_performance_goal_snapshots for the
+      current week. Goal metrics are state totals - past weeks cannot be recomputed - so each week
+      needs at least one stored reading; the daily workflow calling this command makes goal history
+      independent of anyone opening the dashboard. Guarded by INTERNAL_SERVICE_SECRET (bearer);
+      never member or browser callable. Computing the current week's metrics performs the snapshot
+      upsert (last capture of the week wins). The GDP reading comes from the GDP plugin's live
+      report - see the GDP contracts for that command's own reads.
+    inputSchema: {}
+    outputSchema:
+      ok:
+        type: boolean
+      weekStartDate:
+        type: string
+      goals:
+        type: array
+    dataAccess:
+      - weekly_performance_goal_snapshots
+      - directory_profiles
+    purpose: operational_metrics_capture
+    retentionClass: derived_long_lived
+    idempotency: true
+
 changelog:
   - date: 2026-07-18
     change: >-

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
@@ -70,6 +70,17 @@ Admin-or-operations routes (`ensureWeeklyPerformanceAdmin` admits `isAdmin` or t
 - `PUT /api/weekly-performance/admin/week-selection` — marks a week active (body `{ weekStartDate }`); requires the `x-ctf-csrf: '1'` header and writes a `weekly-performance.admin.week.select` audit row.
 - `GET /api/weekly-performance/export?weekStartDate=...` — returns the week's metrics snapshot as a synchronous inline JSON download (`{ok, weekStartDate, metrics}`); additionally guarded by the `WEEKLY_PERFORMANCE_EXPORT_ENABLED` environment flag and writes a `weekly-performance.report.export` audit row. There is no asynchronous artifact pipeline (no `exportId`/`artifactUrl`/`weekly_performance_exports` record) — the command contract was reconciled to this shipped behavior (#1128).
 
+Internal (service-to-service, never member/browser callable):
+
+- `POST /api/internal/weekly-performance/goal-snapshot` — records the current week's goal readings
+  (GDP Community Value Index, Workforce recruited) into `weekly_performance_goal_snapshots` by
+  computing the current week's metrics (the compute upserts the snapshot rows). Guarded by
+  `Authorization: Bearer INTERNAL_SERVICE_SECRET` (same posture as `/api/internal/product-update`);
+  501 when the secret is unconfigured, 401 on a bad token. Called daily by the scheduled workflow
+  `.github/workflows/weekly-performance-goal-snapshot.yml` so goal history never depends on someone
+  opening the dashboard that week (last capture of the week wins — the stored value converges to the
+  week's closing reading). Contract: `weekly-performance.goal-snapshot.capture`.
+
 ## 3) Data Dependencies and Contracts
 
 1. Aggregated users-domain metrics (new users, verification/approval totals).
@@ -167,6 +178,14 @@ V2's "verified" and "approved" member counts are intentionally omitted: V3's `us
   Android renders the new keys through its existing generic metric list (labels humanized from the
   key); the goal progress *bar* is web-only for now — tracked as a gap. Schema: one new table
   (`weekly_performance_goal_snapshots`), guarded CREATE/ALTER; `schema.demo.sql` regenerated.
+  **History guarantees (owner requirement):** the fifteen value events and three adoption rows are
+  never stored — any week, however old, recomputes live from the upstream rows, so week 1 vs week 53
+  works forever and past weeks recalculate when data changes. The two goal rows are the exception
+  (state totals), so a new internal route
+  (`POST /api/internal/weekly-performance/goal-snapshot`, bearer `INTERNAL_SERVICE_SECRET`, contract
+  `weekly-performance.goal-snapshot.capture`) is called daily by
+  `.github/workflows/weekly-performance-goal-snapshot.yml` to record the current week's goal
+  readings — goal history never depends on someone opening the dashboard that week.
 - 2026-07-17: **History-aware back + admin↔member navigation (app-wide sweep).** The member
   shell's hand-rolled back chevron was replaced by the shared `BackChevronButton` — it returns to
   the previous in-app page and falls back to All Apps when there is no in-app history. The admin

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
@@ -85,6 +85,12 @@ The aggregates above are persisted in two tables in `ctf/schema.sql`:
 
 - `weekly_performance_metrics` — the per-week aggregate store. One row per metric: `id`, `week_start_date` (DATE), `metric_key`, `metric_value` (NUMERIC), `metric_unit`, `source_plugin`, `created_at`.
 - `weekly_performance_audit_trail` — the admin allow/deny audit log. Columns: `id`, `actor_id`, `command`, `policy_status`, `reason`, `target_type`, `target_id`, `metadata` (jsonb), `created_at` — the audit coverage required by §4.4.
+- `weekly_performance_goal_snapshots` — weekly memory for the dashboard's two goal rows (GDP
+  Community Value Index toward 300B; Workforce recruited toward 2,000,000). Those are state metrics
+  (a current total, not a windowed event), so week-over-week needs a stored reading per week: a read
+  of the current week upserts the live value (last read of the week wins), and past weeks report
+  their stored row. Columns: `metric_key` (TEXT), `week_start_date` (DATE), `metric_value`
+  (NUMERIC), `captured_at` — primary key `(metric_key, week_start_date)`.
 
 ## 4) Security and Compliance Controls
 
@@ -136,6 +142,31 @@ V2's "verified" and "approved" member counts are intentionally omitted: V3's `us
 
 ## 8) Change Log
 
+- 2026-07-18: **Dashboard rebuilt around the owner-locked value-metric table
+  (`ctf/docs/developer/PLUGIN_VALUE_METRICS.md`).** The old near-useless metric set (login counts,
+  feed counts, LevelUp *enrollments started*) is replaced in
+  `ctf/packages/web/lib/weekly-performance/live-metrics.ts` by three sections, in card order:
+  (1) **two goal rows** — GDP Community Value Index week-over-week toward the 300B goal (via the GDP
+  plugin's live report) and Workforce recruited toward 2,000,000 (active Directory profiles), both
+  snapshotted weekly in the new `weekly_performance_goal_snapshots` table (state metrics need memory
+  for week-over-week; the current-week read upserts the live value, past weeks report their stored
+  row); (2) **fifteen per-plugin value events** — each plugin's defining action (answered charged
+  Foundation calls — aggregate only, rule 132; successful SocketRelay closes; mutually-confirmed
+  TrustTransport trips; completed Lighthouse stays; Chyme tips; direct ServiceCredits peer sends;
+  confirmed Contributions dollars; accepted SkillsHunt nominations; approved WhatWorks tools +
+  endorsements; LevelUp completions + trainer payouts — replacing enrollments-started; confirmed
+  Recurring Activity ties; distinct PeerProgramming posters; Beacon engagement per unique broadcast
+  via the Commons replay post's reactions/replies); (3) **adoption rows** for Directory (findable
+  members), Mood (check-ins + average, aggregate only), and ClickLog (aggregate incidents + distinct
+  loggers). GentlePulse and Skills Taxonomy carry no dashboard stats (owner ruling). Web UI groups
+  the cards under Goals / Value delivered / Adoption headings, with goal cards showing compact
+  values and a progress bar toward the target (`wp-metric-cards.tsx`, `wp-shared.ts`, shared goal
+  constants in `lib/weekly-performance/goal-constants.ts`). All 22 metrics are registered in the
+  canonical metric registry (`ctf/config/canonical_metrics.yaml`, `wp_value_*` / `wp_adoption_*` /
+  `wp_goal_*`), and the command contracts' `dataAccess` lists now name the real upstream reads.
+  Android renders the new keys through its existing generic metric list (labels humanized from the
+  key); the goal progress *bar* is web-only for now — tracked as a gap. Schema: one new table
+  (`weekly_performance_goal_snapshots`), guarded CREATE/ALTER; `schema.demo.sql` regenerated.
 - 2026-07-17: **History-aware back + admin↔member navigation (app-wide sweep).** The member
   shell's hand-rolled back chevron was replaced by the shared `BackChevronButton` — it returns to
   the previous in-app page and falls back to All Apps when there is no in-app history. The admin

--- a/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
+++ b/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
@@ -40,10 +40,11 @@ Admin-only analytics plugin — these are the can't-ship-broken checks. Admin / 
    `/apps/weekly-performance` gets a plain 404 — never a public landing/marketing page (the plugin
    has no public visitor shell; the unreachable one was deleted 2026-07-15). → web ☐ mobile ☐ android ☐
 2. **Numbers are always live — no "closed" week.** Open the dashboard. Every week shows live numbers
-   computed from that week's activity (active members, questions, answers, community posts,
-   enrollments) — there is no "metrics appear when the week closes" placeholder and no week status to
-   wait on. The current week is marked **Live**; past weeks are plain historical windows with no
-   "Closed" badge. With no activity yet the cards read zero, which is still a real value. → web ☐ mobile ☐ android ☐
+   computed from that week's activity — there is no "metrics appear when the week closes" placeholder
+   and no week status to wait on. The current week is marked **Live**; past weeks are plain historical
+   windows with no "Closed" badge. With no activity yet the cards read zero, which is still a real
+   value. (Exception: the two Goal rows are state totals snapshotted weekly — a past week that was
+   never opened while current reads 0 there.) → web ☐ mobile ☐ android ☐
 3. **Admin surface is review-only — no "set active week".** Open `/admin/weekly-performance`. There is
    one header (no duplicate), a pick-a-week-to-review picker, the week's live metrics, and Export. There
    is **no** "Active week / Set as active week" control and no open/locked/published status. → web ☐ mobile ☐ android ☐
@@ -80,19 +81,31 @@ and no per-week status. The current week is shown even when the weeks table has 
 ### WP-A3 · Metrics and week-over-week comparison
 **Role:** admin / operations · **Surfaces:** web (desktop), web (mobile-responsive), android
 **Steps:**
-1. Open a week's metric cards. The set mirrors V2 minus revenue (non-financial only): total members,
-   new members, weekly/daily/monthly active members, lapsed members (churn), questions, answers,
-   community posts, enrollments, and aggregate mood (check-ins + average). No revenue/MRR/ARR/CLV.
+1. Open a week's metric cards. The set is the owner-locked value-metric table
+   (`ctf/docs/developer/PLUGIN_VALUE_METRICS.md`), grouped on web under three headings:
+   **Goals** — GDP Community Value Index (progress bar toward the 300B goal) and Workforce recruited
+   (progress bar toward 2,000,000); **Value delivered** — one card per plugin's defining event
+   (Foundation answered calls, SocketRelay successful closes, TrustTransport completed trips,
+   Lighthouse completed stays, Chyme tips, ServiceCredits direct peer sends, Contributions confirmed
+   USD, SkillsHunt accepted nominations, WhatWorks approved tools + endorsements, LevelUp
+   completions + trainer payouts, Recurring Activity confirmed ties, PeerProgramming distinct
+   posters, Beacon engagement per unique broadcast); **Adoption** — Directory findable members, Mood
+   check-ins + average, ClickLog incidents + distinct loggers. There are NO login/engagement cards,
+   NO feed cards, NO LevelUp enrollments-started card, and nothing for GentlePulse or Skills
+   Taxonomy. No revenue/MRR/ARR/CLV.
 2. Supply a compare week so the route returns a comparison
    (`GET /api/weekly-performance/metrics?weekStartDate=...&compareWeekStartDate=...`).
 3. On the current week, leave the dashboard open: it silently re-fetches about every 60s and on tab
    focus, so the numbers refresh without a manual reload. Past weeks are settled and do not poll.
-**Expected:** Metric cards render humanized labels from `metric_key` and real values computed live
-for the selected week window from upstream tables (every week, current or past — there is no stored
-snapshot and no "closed" state). The current week shows a **Live** marker; past weeks show none. The
-comparison shows per-metric deltas (this week vs last week); a declining metric shows a
-downward-trend indicator. Reads audit `weekly-performance.metrics.get` or `…comparison.get` per
-branch. Loading, empty, and error states are all distinct.
+**Expected:** Metric cards render humanized labels from `metric_key` (acronyms read correctly: GDP,
+USD) and real values computed live for the selected week window from upstream tables. The two Goal
+cards show a compact value (e.g. "1.2K"), a progress bar, and "% of the 300B/2M goal"; opening the
+current week also records that week's goal snapshot, so next week's comparison has a prior value.
+The current week shows a **Live** marker; past weeks show none. The comparison shows per-metric
+deltas (this week vs last week); a declining metric shows a downward-trend indicator. Reads audit
+`weekly-performance.metrics.get` or `…comparison.get` per branch. Loading, empty, and error states
+are all distinct. Android renders the same metric list with humanized labels (goal progress bars are
+web-only for now — a tracked gap, not a bug).
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ### WP-A4 · Export gate

--- a/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
+++ b/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
@@ -43,8 +43,11 @@ Admin-only analytics plugin — these are the can't-ship-broken checks. Admin / 
    computed from that week's activity — there is no "metrics appear when the week closes" placeholder
    and no week status to wait on. The current week is marked **Live**; past weeks are plain historical
    windows with no "Closed" badge. With no activity yet the cards read zero, which is still a real
-   value. (Exception: the two Goal rows are state totals snapshotted weekly — a past week that was
-   never opened while current reads 0 there.) → web ☐ mobile ☐ android ☐
+   value. Any two weeks compare (week 1 vs week 53): event and adoption rows recompute live from the
+   upstream tables for any window, so past weeks recalculate when data changes. (Exception: the two
+   Goal rows are state totals snapshotted weekly — captured daily by the scheduled
+   goal-snapshot workflow, so a week has its reading even if nobody opened the dashboard; a week from
+   before the capture workflow existed reads 0.) → web ☐ mobile ☐ android ☐
 3. **Admin surface is review-only — no "set active week".** Open `/admin/weekly-performance`. There is
    one header (no duplicate), a pick-a-week-to-review picker, the week's live metrics, and Export. There
    is **no** "Active week / Set as active week" control and no open/locked/published status. → web ☐ mobile ☐ android ☐

--- a/ctf/packages/web/app/api/internal/weekly-performance/goal-snapshot/route.ts
+++ b/ctf/packages/web/app/api/internal/weekly-performance/goal-snapshot/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GOAL_METRIC_KEYS, computeLiveWeekMetrics, currentWeekStart } from 'lib/weekly-performance/live-metrics';
+import { reportError } from 'lib/observability/report';
+
+// Internal, schedule-driven capture of the Weekly Performance goal snapshots (GDP Community Value
+// Index toward 300B; Workforce recruited toward 2,000,000). Those are STATE metrics — past weeks
+// cannot be recomputed — so each week needs at least one recorded reading. Opening the dashboard
+// during the week records one, but goal history must never depend on someone visiting: the
+// weekly-performance-goal-snapshot workflow calls this route on a schedule, and computing the
+// current week's metrics upserts that week's snapshot rows as a side effect (last capture of the
+// week wins, so the stored value converges to the week's closing reading).
+//
+// Guarded by INTERNAL_SERVICE_SECRET, the same posture as /api/internal/product-update — never
+// callable by browsers or members.
+export async function POST(request: NextRequest) {
+  const secret = process.env.INTERNAL_SERVICE_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'Not configured' }, { status: 501 });
+  }
+
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const weekStartDate = currentWeekStart();
+    const metrics = await computeLiveWeekMetrics(weekStartDate);
+    const goals = metrics
+      .filter((m) => (GOAL_METRIC_KEYS as readonly string[]).includes(m.metricKey))
+      .map((m) => ({ metricKey: m.metricKey, metricValue: m.metricValue }));
+    return NextResponse.json({ ok: true, weekStartDate, goals }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'weekly-performance', op: 'internal_goal_snapshot' });
+    return NextResponse.json({ error: 'Snapshot capture failed' }, { status: 500 });
+  }
+}

--- a/ctf/packages/web/components/weekly-performance/wp-metric-cards.tsx
+++ b/ctf/packages/web/components/weekly-performance/wp-metric-cards.tsx
@@ -1,8 +1,19 @@
 "use client";
 
-import { TrendingDown, TrendingUp } from "lucide-react";
+import { Target, TrendingDown, TrendingUp } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
-import { getWeeklyPerformanceTokens, type WpComparison, type WpMetric, formatDelta, formatMetricValue, humanizeMetricKey } from "./wp-shared";
+import { GOAL_TARGETS } from "@/lib/weekly-performance/goal-constants";
+import {
+  METRIC_GROUP_HEADINGS,
+  type WpComparison,
+  type WpMetric,
+  type WpMetricGroup,
+  formatDelta,
+  formatMetricValue,
+  getWeeklyPerformanceTokens,
+  humanizeMetricKey,
+  metricGroup,
+} from "./wp-shared";
 
 // Data-series palette (one color per metric card) — kept raw like every chart palette.
 const CARD_COLORS = ["#A78BFA", "#22C55E", "#6366F1", "#06B6D4", "#EC4899", "#F97316"];
@@ -16,6 +27,61 @@ function deltaFor(comparison: WpComparison | null, metricKey: string): number | 
   return current.metricValue - prior.metricValue;
 }
 
+// Compact big-number label for goal targets/progress (300B, 2M) — goal scales are far beyond
+// what a plain locale string reads well at.
+function compactNumber(value: number): string {
+  return Intl.NumberFormat(undefined, { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function MetricCard({
+  metric,
+  color,
+  comparison,
+}: {
+  metric: WpMetric;
+  color: string;
+  comparison: WpComparison | null;
+}) {
+  const { theme } = useTheme();
+  const t = getTokens(theme);
+  const delta = deltaFor(comparison, metric.metricKey);
+  const positive = (delta ?? 0) >= 0;
+  const goalTarget = GOAL_TARGETS[metric.metricKey];
+  // Goal rows show progress toward the owner-set target. Progress can be tiny early on; show two
+  // decimals so movement is visible instead of rounding to 0%.
+  const progress = goalTarget ? Math.min(100, (metric.metricValue / goalTarget) * 100) : null;
+  return (
+    <div style={{ padding: "18px 16px", borderRadius: 14, background: t.SURFACE, border: `1px solid ${color}20` }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+        <span style={{ fontSize: 11, color: t.MUTED }}>{humanizeMetricKey(metric.metricKey)}</span>
+        {goalTarget ? <Target size={14} color={color} /> : <TrendingUp size={14} color={color} />}
+      </div>
+      <div style={{ fontSize: 26, fontWeight: 800, color, marginBottom: 4 }}>
+        {goalTarget ? compactNumber(metric.metricValue) : formatMetricValue(metric.metricValue, metric.metricUnit)}
+      </div>
+      {goalTarget && progress !== null ? (
+        <div style={{ marginBottom: 6 }}>
+          <div style={{ height: 6, borderRadius: 3, background: `${color}22`, overflow: "hidden", marginBottom: 5 }}>
+            <div style={{ width: `${Math.max(progress, 0.5)}%`, minWidth: 2, height: "100%", background: color }} />
+          </div>
+          <div style={{ fontSize: 11, color: t.MUTED }}>
+            {progress.toLocaleString(undefined, { maximumFractionDigits: 2 })}% of the {compactNumber(goalTarget)} goal
+          </div>
+        </div>
+      ) : null}
+      {delta !== null ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: positive ? "#22C55E" : "#F87171" }}>
+          {positive ? <TrendingUp size={11} /> : <TrendingDown size={11} />} {formatDelta(delta, metric.metricUnit)}
+        </div>
+      ) : (
+        <div style={{ fontSize: 11, color: t.MUTED }}>No prior-week comparison</div>
+      )}
+    </div>
+  );
+}
+
+const getTokens = getWeeklyPerformanceTokens;
+
 export function WeeklyPerformanceMetricCards({
   metrics,
   comparison,
@@ -24,28 +90,34 @@ export function WeeklyPerformanceMetricCards({
   comparison: WpComparison | null;
 }) {
   const { theme } = useTheme();
-  const t = getWeeklyPerformanceTokens(theme);
+  const t = getTokens(theme);
+  const groups: WpMetricGroup[] = ["goal", "value", "adoption", "other"];
+  let colorIndex = 0;
   return (
-    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 12, marginBottom: 24 }}>
-      {metrics.map((metric, i) => {
-        const color = CARD_COLORS[i % CARD_COLORS.length];
-        const delta = deltaFor(comparison, metric.metricKey);
-        const positive = (delta ?? 0) >= 0;
+    <div style={{ marginBottom: 24 }}>
+      {groups.map((group) => {
+        const groupMetrics = metrics.filter((m) => metricGroup(m.metricKey) === group);
+        if (groupMetrics.length === 0) return null;
         return (
-          <div key={metric.metricKey} style={{ padding: "18px 16px", borderRadius: 14, background: t.SURFACE, border: `1px solid ${color}20` }}>
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
-              <span style={{ fontSize: 11, color: t.MUTED }}>{humanizeMetricKey(metric.metricKey)}</span>
-              <TrendingUp size={14} color={color} />
+          <section key={group} style={{ marginBottom: 20 }}>
+            <h3 style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: t.MUTED, margin: "0 0 10px" }}>
+              {METRIC_GROUP_HEADINGS[group]}
+            </h3>
+            <div
+              style={{
+                display: "grid",
+                // Goal cards are the headline pair — give them room; the rest tile compactly.
+                gridTemplateColumns: group === "goal" ? "repeat(auto-fit, minmax(260px, 1fr))" : "repeat(auto-fit, minmax(200px, 1fr))",
+                gap: 12,
+              }}
+            >
+              {groupMetrics.map((metric) => {
+                const color = CARD_COLORS[colorIndex % CARD_COLORS.length];
+                colorIndex += 1;
+                return <MetricCard key={metric.metricKey} metric={metric} color={color} comparison={comparison} />;
+              })}
             </div>
-            <div style={{ fontSize: 26, fontWeight: 800, color, marginBottom: 4 }}>{formatMetricValue(metric.metricValue, metric.metricUnit)}</div>
-            {delta !== null ? (
-              <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: positive ? "#22C55E" : "#F87171" }}>
-                {positive ? <TrendingUp size={11} /> : <TrendingDown size={11} />} {formatDelta(delta, metric.metricUnit)}
-              </div>
-            ) : (
-              <div style={{ fontSize: 11, color: t.MUTED }}>No prior-week comparison</div>
-            )}
-          </div>
+          </section>
         );
       })}
     </div>

--- a/ctf/packages/web/components/weekly-performance/wp-shared.ts
+++ b/ctf/packages/web/components/weekly-performance/wp-shared.ts
@@ -99,16 +99,40 @@ export function formatWeekRange(week: WpWeek): string {
   return `${startLabel}–${endLabel}, ${end.year}`;
 }
 
-// Turn a dotted/snake/camel metric key into a readable label (no label column exists).
-// The namespace dot is treated as a separator too, so "engagement.active_members" reads as
+// The dashboard's three sections, keyed by metric-key prefix (see live-metrics.ts card order):
+// goals the platform drives toward, each plugin's delivered-value event, and honest adoption rows.
+export type WpMetricGroup = "goal" | "value" | "adoption" | "other";
+
+export function metricGroup(key: string): WpMetricGroup {
+  if (key.startsWith("goal.")) return "goal";
+  if (key.startsWith("value.")) return "value";
+  if (key.startsWith("adoption.")) return "adoption";
+  return "other";
+}
+
+export const METRIC_GROUP_HEADINGS: Record<WpMetricGroup, string> = {
+  goal: "Goals",
+  value: "Value delivered",
+  adoption: "Adoption",
+  other: "Other",
+};
+
+// Acronyms the generic title-caser would mangle ("Gdp" → "GDP").
+const LABEL_ACRONYMS: Record<string, string> = { Gdp: "GDP", Usd: "USD" };
+
+// Turn a dotted/snake/camel metric key into a readable label (no label column exists). The group
+// prefix (goal./value./adoption.) is dropped — the section heading already says it — and any other
+// namespace dot is treated as a separator, so "engagement.active_members" reads as
 // "Engagement Active Members" rather than "Engagement.Active Members".
 export function humanizeMetricKey(key: string): string {
-  return key
+  const withoutGroup = key.replace(/^(goal|value|adoption)\./, "");
+  return withoutGroup
     .replace(/[._-]+/g, " ")
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .replace(/\s+/g, " ")
     .trim()
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\b(Gdp|Usd)\b/g, (word) => LABEL_ACRONYMS[word] ?? word);
 }
 
 export function formatMetricValue(value: number, unit: string): string {

--- a/ctf/packages/web/lib/weekly-performance/goal-constants.ts
+++ b/ctf/packages/web/lib/weekly-performance/goal-constants.ts
@@ -1,0 +1,14 @@
+// The two platform goals the Weekly Performance dashboard tracks progress toward
+// (owner-set, 2026-07-18 — see ctf/docs/developer/PLUGIN_VALUE_METRICS.md). Pure constants with no
+// imports so both the server metric computation and the client dashboard can use them.
+
+// GDP Community Value Index goal — an index-point estimate, never money or a price.
+export const GDP_VALUE_INDEX_GOAL = 300_000_000_000;
+
+// Workforce recruited goal — members with an active Directory presence.
+export const WORKFORCE_RECRUITED_GOAL = 2_000_000;
+
+export const GOAL_TARGETS: Record<string, number> = {
+  'goal.gdp_value_index': GDP_VALUE_INDEX_GOAL,
+  'goal.workforce_recruited': WORKFORCE_RECRUITED_GOAL,
+};

--- a/ctf/packages/web/lib/weekly-performance/live-metrics.ts
+++ b/ctf/packages/web/lib/weekly-performance/live-metrics.ts
@@ -1,19 +1,33 @@
 import { queryDb } from 'lib/db/postgres';
+import { buildLiveGdpReport } from 'lib/gdp/repository';
 
-// Live weekly numbers.
+// Live weekly numbers — rebuilt around the per-plugin value-metric decision record
+// (ctf/docs/developer/PLUGIN_VALUE_METRICS.md, owner-locked 2026-07-18).
 //
-// Weekly numbers are computed on read, scoped to the selected week window, directly from the
-// upstream plugin tables — the same way the V2 dashboard aggregated. There is no "close the week"
-// step and no stored snapshot: the current week keeps moving as members use the platform, and any
-// past week reports the real counts for its window.
+// The dashboard's shape, in card order:
+//   1. Two GOAL rows — the two numbers the whole platform is driving toward:
+//      GDP Community Value Index (goal: $300B) and Workforce recruited (goal: 2,000,000).
+//      Both are STATE metrics (a current total, not a windowed event count), so week-over-week
+//      needs memory: each read of the current week upserts the live value into
+//      weekly_performance_goal_snapshots, and past weeks report their stored snapshot.
+//   2. The per-plugin VALUE EVENTS — each plugin's defining action, the event that means the
+//      plugin was used as intended (a completed trip, a hosted stay, a confirmed contribution…).
+//      These are windowed on the event's own timestamp, so any week reports its real count.
+//   3. Honest ADOPTION rows for the no-value-to-others plugins the owner wants visible:
+//      Directory (findable members), Mood (check-ins + average, aggregate only), ClickLog
+//      (aggregate incidents + distinct loggers — never per-member detail).
 //
-// This set mirrors the metrics V2 captured, minus everything revenue/financial (revenue, MRR, ARR,
-// CLV) — V3 is free to end users, so those have no meaning here. What remains is membership, growth,
-// activity (DAU/WAU/MAU), churn, engagement, and wellbeing — all non-financial. Every query is
-// guarded on table existence (environments built only from schema.sql, or the Clerk-mirrored `users`
-// table, may lack a table) and never throws: a missing table or a transient error contributes 0
-// rather than failing the whole dashboard. All table and column names below are fixed literals — no
-// user input is interpolated into SQL.
+// Dropped from the old set (owner decision): login/engagement counts (logins are downstream of
+// value, not value), feed counts, and LevelUp enrollments-started (intent, not delivered value —
+// replaced by completions). GentlePulse and Skills Taxonomy carry no dashboard stats at all.
+//
+// The Foundation row is an aggregate count on this admin-only surface; per rule 132 the underlying
+// participation is sensitive (wellbeing/payment), so it must never appear on a public surface or as
+// any per-member figure.
+//
+// Every query is guarded on table existence and never throws: a missing table or a transient error
+// contributes 0 rather than failing the whole dashboard. All table and column names below are fixed
+// literals — no user input is interpolated into SQL.
 
 type LiveMetric = {
   metricKey: string;
@@ -22,16 +36,21 @@ type LiveMetric = {
   sourcePlugin: string;
 };
 
+export const GOAL_METRIC_KEYS = ['goal.gdp_value_index', 'goal.workforce_recruited'] as const;
+
 async function tableExists(table: string): Promise<boolean> {
   const reg = await queryDb<{ reg: string | null }>(`SELECT to_regclass($1)::text AS reg`, [`public.${table}`]);
   return !!reg.rows[0]?.reg;
 }
 
-// Run a single scalar query (a COUNT or an AVG aliased as `v`) guarded by table existence.
-// Returns 0 on a missing table, a NULL result, or any read error.
-async function guardedScalar(table: string, sql: string, weekStart: string): Promise<number> {
+// Run a single scalar query (a COUNT / SUM / AVG aliased as `v`) guarded on the existence of every
+// table it touches. Returns 0 on a missing table, a NULL result, or any read error.
+async function guardedScalar(tables: string | string[], sql: string, weekStart: string): Promise<number> {
   try {
-    if (!(await tableExists(table))) return 0;
+    const needed = Array.isArray(tables) ? tables : [tables];
+    for (const table of needed) {
+      if (!(await tableExists(table))) return 0;
+    }
     const result = await queryDb<{ v: string | null }>(sql, [weekStart]);
     const value = result.rows[0]?.v;
     return value == null ? 0 : Number(value);
@@ -40,78 +59,8 @@ async function guardedScalar(table: string, sql: string, weekStart: string): Pro
   }
 }
 
-// The week window is [weekStart, weekStart + 7 days). Counting on each row's creation time anchors
-// every number to the week the activity actually happened in.
-
-// Distinct members seen at all up to the end of this week — a cumulative membership count that
-// grows over time, so the week-over-week delta reads as roughly "members added this week".
-function totalMembers(weekStart: string): Promise<number> {
-  return guardedScalar(
-    'login_events',
-    `SELECT COUNT(DISTINCT user_id)::text AS v FROM login_events
-     WHERE created_at < $1::date + INTERVAL '7 days'`,
-    weekStart,
-  );
-}
-
-// Members whose very first recorded activity falls inside this week (first-seen = MIN(created_at)).
-function newMembers(weekStart: string): Promise<number> {
-  return guardedScalar(
-    'login_events',
-    `SELECT COUNT(*)::text AS v FROM (
-       SELECT user_id, MIN(created_at) AS first_seen FROM login_events GROUP BY user_id
-     ) t
-     WHERE t.first_seen >= $1::date AND t.first_seen < $1::date + INTERVAL '7 days'`,
-    weekStart,
-  );
-}
-
-// Distinct members active at any point during the week (weekly active members / WAU).
-function weeklyActiveMembers(weekStart: string): Promise<number> {
-  return guardedScalar(
-    'login_events',
-    `SELECT COUNT(DISTINCT user_id)::text AS v FROM login_events
-     WHERE created_at >= $1::date AND created_at < $1::date + INTERVAL '7 days'`,
-    weekStart,
-  );
-}
-
-// Average daily active members across the week's seven days. login_events holds one row per member
-// per UTC day, so the row count over the window divided by 7 is the average DAU.
-function dailyActiveAverage(weekStart: string): Promise<number> {
-  return guardedScalar(
-    'login_events',
-    `SELECT ROUND(COUNT(*)::numeric / 7)::text AS v FROM login_events
-     WHERE created_at >= $1::date AND created_at < $1::date + INTERVAL '7 days'`,
-    weekStart,
-  );
-}
-
-// Distinct members active in the 30 days ending at this week's end (monthly active members / MAU).
-function monthlyActiveMembers(weekStart: string): Promise<number> {
-  return guardedScalar(
-    'login_events',
-    `SELECT COUNT(DISTINCT user_id)::text AS v FROM login_events
-     WHERE created_at >= ($1::date + INTERVAL '7 days' - INTERVAL '30 days')
-       AND created_at < $1::date + INTERVAL '7 days'`,
-    weekStart,
-  );
-}
-
-// Churn proxy for a free product: members active in the prior week who did not return this week.
-function lapsedMembers(weekStart: string): Promise<number> {
-  return guardedScalar(
-    'login_events',
-    `SELECT COUNT(DISTINCT p.user_id)::text AS v FROM login_events p
-     WHERE p.created_at >= $1::date - INTERVAL '7 days' AND p.created_at < $1::date
-       AND NOT EXISTS (
-         SELECT 1 FROM login_events c
-         WHERE c.user_id = p.user_id
-           AND c.created_at >= $1::date AND c.created_at < $1::date + INTERVAL '7 days'
-       )`,
-    weekStart,
-  );
-}
+// The week window is [weekStart, weekStart + 7 days). Counting on each row's own event timestamp
+// anchors every number to the week the value was actually delivered in.
 
 // COUNT(*) of a table's rows whose date column falls in the week window, with an optional fixed filter.
 function windowCount(table: string, dateColumn: string, filter = ''): (weekStart: string) => Promise<number> {
@@ -125,14 +74,218 @@ function windowCount(table: string, dateColumn: string, filter = ''): (weekStart
     );
 }
 
-// Average mood (1–5) submitted during the week. Aggregate only — never an individual reading.
-function moodAverage(weekStart: string): Promise<number> {
-  return guardedScalar(
+// ── Value events ───────────────────────────────────────────────────────────────
+
+// Foundation: an answered, charged 1:1 call — the only Foundation signal (messages are too easy to
+// game; quote completion is not tracked as an event). Aggregate count only, admin surface only.
+const foundationCallsAnswered = (weekStart: string) =>
+  guardedScalar(
+    'foundation_call_sessions',
+    `SELECT COUNT(*)::text AS v FROM foundation_call_sessions
+     WHERE answered_at >= $1::date AND answered_at < $1::date + INTERVAL '7 days'
+       AND blocks_charged > 0`,
+    weekStart,
+  );
+
+// TrustTransport: a trip both sides confirmed complete.
+const trustTransportTripsCompleted = windowCount(
+  'trust_transport_trips',
+  'completed_at',
+  `status = 'completed' AND requester_completion_confirmed_at IS NOT NULL AND provider_completion_confirmed_at IS NOT NULL`,
+);
+
+// Lighthouse: a completed stay. The table has no completed_at column, so the window keys on
+// updated_at of rows now in 'completed' — the status flip is the last write in the normal flow.
+const lighthouseStaysCompleted = windowCount('lighthouse_matches', 'updated_at', `status = 'completed'`);
+
+// SocketRelay: a request the requester closed as successful. No closed_at column; updated_at is
+// written by the close, so it anchors the week.
+const socketRelayFulfilled = windowCount(
+  'socket_relay_fulfillments',
+  'updated_at',
+  `close_reason = 'successful'`,
+);
+
+// Chyme: a peer tip (a completed ServiceCredits transfer originated by Chyme, never self-to-self).
+const chymeTips = windowCount(
+  'service_credits_transfers',
+  'completed_at',
+  `status = 'completed' AND origin_plugin = 'chyme' AND sender_user_id <> recipient_user_id`,
+);
+
+// ServiceCredits: a completed DIRECT peer send. origin_plugin scoping keeps plugin-mediated
+// transfers (Chyme tips, LevelUp flows…) counted once, in their originating plugin.
+const serviceCreditsPeerSends = windowCount(
+  'service_credits_transfers',
+  'completed_at',
+  `status = 'completed' AND origin_plugin = 'service-credits' AND sender_user_id <> recipient_user_id`,
+);
+
+// Contributions: confirmed real dollars this week (SUM, not a row count).
+const contributionsConfirmedUsd = (weekStart: string) =>
+  guardedScalar(
+    'contributions_submissions',
+    `SELECT COALESCE(SUM(confirmed_amount_usd), 0)::text AS v FROM contributions_submissions
+     WHERE status = 'confirmed'
+       AND reviewed_at >= $1::date AND reviewed_at < $1::date + INTERVAL '7 days'`,
+    weekStart,
+  );
+
+// SkillsHunt: a nomination a moderator accepted (produces a real Directory profile + reward).
+const skillsHuntAccepted = windowCount(
+  'skills_hunt_submissions',
+  'reviewed_at',
+  `status = 'accepted' AND deleted_at IS NULL`,
+);
+
+// WhatWorks: an approved tool contributed (primary) and an endorsement given (secondary).
+const whatWorksApproved = windowCount('what_works_products', 'reviewed_at', `status = 'approved'`);
+const whatWorksEndorsements = windowCount('what_works_endorsements', 'created_at');
+
+// LevelUp: delivered value is COMPLETION (the old dashboard counted enrollments started — intent).
+// No completed_at column; the status flip writes updated_at.
+const levelUpCompletions = windowCount('level_up_enrollments', 'updated_at', `status = 'completed'`);
+const levelUpTrainerPayouts = windowCount(
+  'level_up_disbursements',
+  'created_at',
+  `disbursement_type = 'trainer_payout'`,
+);
+
+// Recurring Activity: a tie the counterparty confirmed this week.
+const recurringTiesConfirmed = windowCount('recurring_activities', 'confirmed_at');
+
+// PeerProgramming: distinct members who posted in their cohort this week (participation IS the
+// plugin's purpose; weighs low for gating but is the honest dashboard signal).
+const peerProgrammingActivePosters = (weekStart: string) =>
+  guardedScalar(
+    'peer_programming_messages',
+    `SELECT COUNT(DISTINCT author_user_id)::text AS v FROM peer_programming_messages
+     WHERE created_at >= $1::date AND created_at < $1::date + INTERVAL '7 days'`,
+    weekStart,
+  );
+
+// Beacon: member engagement per unique broadcast — distinct (member, broadcast) pairs that reacted
+// to or replied on a broadcast's Commons replay post this week. Broadcast completion itself does NOT
+// count (only the owner can start a session — an admin action measures the admin, not members), and
+// one member engaging with the same broadcast many times counts once. Live in-event chat/reactions
+// are Stream-ephemeral and are not countable here.
+const beaconBroadcastEngagement = (weekStart: string) =>
+  guardedScalar(
+    ['beacon_events', 'feed_community_post_reactions', 'feed_community_replies'],
+    `SELECT COUNT(*)::text AS v FROM (
+       SELECT r.user_id AS member_id, b.id AS broadcast_id
+       FROM beacon_events b
+       JOIN feed_community_post_reactions r ON r.post_id = b.commons_recording_post_id
+       WHERE r.created_at >= $1::date AND r.created_at < $1::date + INTERVAL '7 days'
+       UNION
+       SELECT p.author_user_id AS member_id, b.id AS broadcast_id
+       FROM beacon_events b
+       JOIN feed_community_replies p ON p.post_id = b.commons_recording_post_id
+       WHERE p.created_at >= $1::date AND p.created_at < $1::date + INTERVAL '7 days'
+     ) engagement`,
+    weekStart,
+  );
+
+// ── Adoption rows (honest non-value metrics) ──────────────────────────────────
+
+// Directory: findable members — claimed, active, non-deleted profiles holding at least one skill.
+// Claim time is not stored, so this is the cumulative count of such profiles created by week end
+// (their CURRENT claimed/active state) — the same cumulative pattern the old members.total used.
+const directoryFindableMembers = (weekStart: string) =>
+  guardedScalar(
+    ['directory_profiles', 'directory_profile_skills'],
+    `SELECT COUNT(*)::text AS v FROM directory_profiles p
+     WHERE p.claimed_by_user_id IS NOT NULL AND p.is_active = TRUE AND p.deleted_at IS NULL
+       AND p.created_at < $1::date + INTERVAL '7 days'
+       AND EXISTS (SELECT 1 FROM directory_profile_skills s WHERE s.profile_id = p.id)`,
+    weekStart,
+  );
+
+// Mood: adoption, aggregate only — never an individual reading.
+const moodCheckins = windowCount('mood_submissions', 'submitted_at');
+const moodAverage = (weekStart: string) =>
+  guardedScalar(
     'mood_submissions',
     `SELECT ROUND(AVG(mood_value)::numeric, 2)::text AS v FROM mood_submissions
      WHERE submitted_at >= $1::date AND submitted_at < $1::date + INTERVAL '7 days'`,
     weekStart,
   );
+
+// ClickLog: adoption, aggregate only — a private personal tally, so never per-member detail.
+const clickLogIncidents = windowCount('click_log_incidents', 'created_at');
+const clickLogActiveLoggers = (weekStart: string) =>
+  guardedScalar(
+    'click_log_incidents',
+    `SELECT COUNT(DISTINCT user_id)::text AS v FROM click_log_incidents
+     WHERE created_at >= $1::date AND created_at < $1::date + INTERVAL '7 days'`,
+    weekStart,
+  );
+
+// ── Goal rows (state metrics with weekly snapshots) ───────────────────────────
+
+// Current live values. GDP: the Community Value Index (an estimate, never money/price) from the
+// same builder the GDP plugin serves. Workforce: recruited = the count of all active Directory
+// profiles — the registry definition of workforce_recruited_current_count.
+async function liveGdpValueIndex(): Promise<number> {
+  try {
+    const report = await buildLiveGdpReport();
+    const row = report.metrics.find((m) => m.metricKey === 'gdp_value_index');
+    return row ? row.metricValue : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function liveWorkforceRecruited(weekStart: string): Promise<number> {
+  // The trailing ($1::date IS NOT NULL) is always true — it only consumes the week parameter
+  // guardedScalar binds, since this is a current-state count with no window.
+  return guardedScalar(
+    'directory_profiles',
+    `SELECT COUNT(*)::text AS v FROM directory_profiles
+     WHERE is_active = TRUE AND deleted_at IS NULL AND ($1::date IS NOT NULL)`,
+    weekStart,
+  );
+}
+
+// ISO Monday of the current UTC week — "the current week" for snapshot purposes.
+function currentWeekStart(): string {
+  const now = new Date();
+  const utc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const day = utc.getUTCDay();
+  utc.setUTCDate(utc.getUTCDate() + (day === 0 ? -6 : 1 - day));
+  return utc.toISOString().slice(0, 10);
+}
+
+// Reading the CURRENT week records the live value into that week's snapshot row (last read of the
+// week wins — the row converges to the week's closing value). A past week reports its stored
+// snapshot; a week that was never read while current reports 0 and renders as "not captured".
+async function goalMetricForWeek(metricKey: string, weekStartDate: string, live: () => Promise<number>): Promise<number> {
+  const isCurrentWeek = weekStartDate === currentWeekStart();
+  try {
+    if (!(await tableExists('weekly_performance_goal_snapshots'))) {
+      return isCurrentWeek ? await live() : 0;
+    }
+    if (isCurrentWeek) {
+      const value = await live();
+      await queryDb(
+        `INSERT INTO weekly_performance_goal_snapshots (metric_key, week_start_date, metric_value, captured_at)
+         VALUES ($1, $2::date, $3, NOW())
+         ON CONFLICT (metric_key, week_start_date)
+         DO UPDATE SET metric_value = EXCLUDED.metric_value, captured_at = NOW()`,
+        [metricKey, weekStartDate, value],
+      );
+      return value;
+    }
+    const stored = await queryDb<{ v: string | null }>(
+      `SELECT metric_value::text AS v FROM weekly_performance_goal_snapshots
+       WHERE metric_key = $1 AND week_start_date = $2::date`,
+      [metricKey, weekStartDate],
+    );
+    const value = stored.rows[0]?.v;
+    return value == null ? 0 : Number(value);
+  } catch {
+    return 0;
+  }
 }
 
 type MetricSpec = {
@@ -142,20 +295,41 @@ type MetricSpec = {
   compute: (weekStart: string) => Promise<number>;
 };
 
-// Order here is the card order on the dashboard. All non-financial (no revenue/MRR/ARR/CLV).
+// Order here is the card order on the dashboard: goals, value events, adoption.
 const METRIC_SPECS: MetricSpec[] = [
-  { metricKey: 'members.total', metricUnit: 'members', sourcePlugin: 'engagement', compute: totalMembers },
-  { metricKey: 'members.new', metricUnit: 'members', sourcePlugin: 'engagement', compute: newMembers },
-  { metricKey: 'engagement.active_members', metricUnit: 'members', sourcePlugin: 'engagement', compute: weeklyActiveMembers },
-  { metricKey: 'engagement.daily_active', metricUnit: 'members', sourcePlugin: 'engagement', compute: dailyActiveAverage },
-  { metricKey: 'engagement.monthly_active', metricUnit: 'members', sourcePlugin: 'engagement', compute: monthlyActiveMembers },
-  { metricKey: 'retention.lapsed_members', metricUnit: 'members', sourcePlugin: 'engagement', compute: lapsedMembers },
-  { metricKey: 'engagement.questions_asked', metricUnit: 'questions', sourcePlugin: 'feed', compute: windowCount('feed_questions', 'created_at') },
-  { metricKey: 'engagement.answers_posted', metricUnit: 'answers', sourcePlugin: 'feed', compute: windowCount('feed_answers', 'created_at') },
-  { metricKey: 'community.posts_created', metricUnit: 'posts', sourcePlugin: 'feed', compute: windowCount('feed_community_posts', 'created_at', "moderation_status = 'accepted'") },
-  { metricKey: 'learning.enrollments_started', metricUnit: 'enrollments', sourcePlugin: 'level-up', compute: windowCount('level_up_enrollments', 'created_at') },
-  { metricKey: 'wellbeing.mood_checkins', metricUnit: 'check-ins', sourcePlugin: 'mood', compute: windowCount('mood_submissions', 'submitted_at') },
-  { metricKey: 'wellbeing.mood_average', metricUnit: '', sourcePlugin: 'mood', compute: moodAverage },
+  {
+    metricKey: 'goal.gdp_value_index',
+    metricUnit: 'index',
+    sourcePlugin: 'gdp',
+    compute: (weekStart) => goalMetricForWeek('goal.gdp_value_index', weekStart, liveGdpValueIndex),
+  },
+  {
+    metricKey: 'goal.workforce_recruited',
+    metricUnit: 'members',
+    sourcePlugin: 'workforce',
+    compute: (weekStart) =>
+      goalMetricForWeek('goal.workforce_recruited', weekStart, () => liveWorkforceRecruited(weekStart)),
+  },
+  { metricKey: 'value.foundation_calls_answered', metricUnit: 'calls', sourcePlugin: 'foundation', compute: foundationCallsAnswered },
+  { metricKey: 'value.socket_relay_requests_fulfilled', metricUnit: 'requests', sourcePlugin: 'socket-relay', compute: socketRelayFulfilled },
+  { metricKey: 'value.trust_transport_trips_completed', metricUnit: 'trips', sourcePlugin: 'trust-transport', compute: trustTransportTripsCompleted },
+  { metricKey: 'value.lighthouse_stays_completed', metricUnit: 'stays', sourcePlugin: 'lighthouse', compute: lighthouseStaysCompleted },
+  { metricKey: 'value.chyme_tips_sent', metricUnit: 'tips', sourcePlugin: 'chyme', compute: chymeTips },
+  { metricKey: 'value.service_credits_peer_sends', metricUnit: 'sends', sourcePlugin: 'service-credits', compute: serviceCreditsPeerSends },
+  { metricKey: 'value.contributions_confirmed_usd', metricUnit: 'USD', sourcePlugin: 'contributions', compute: contributionsConfirmedUsd },
+  { metricKey: 'value.skills_hunt_nominations_accepted', metricUnit: 'nominations', sourcePlugin: 'skills-hunt', compute: skillsHuntAccepted },
+  { metricKey: 'value.what_works_tools_approved', metricUnit: 'tools', sourcePlugin: 'what-works', compute: whatWorksApproved },
+  { metricKey: 'value.what_works_endorsements_given', metricUnit: 'endorsements', sourcePlugin: 'what-works', compute: whatWorksEndorsements },
+  { metricKey: 'value.level_up_completions', metricUnit: 'completions', sourcePlugin: 'level-up', compute: levelUpCompletions },
+  { metricKey: 'value.level_up_trainer_payouts', metricUnit: 'payouts', sourcePlugin: 'level-up', compute: levelUpTrainerPayouts },
+  { metricKey: 'value.recurring_ties_confirmed', metricUnit: 'ties', sourcePlugin: 'recurring-activity', compute: recurringTiesConfirmed },
+  { metricKey: 'value.peer_programming_active_posters', metricUnit: 'members', sourcePlugin: 'peer-programming', compute: peerProgrammingActivePosters },
+  { metricKey: 'value.beacon_broadcast_engagement', metricUnit: 'engagements', sourcePlugin: 'beacon', compute: beaconBroadcastEngagement },
+  { metricKey: 'adoption.directory_findable_members', metricUnit: 'members', sourcePlugin: 'directory', compute: directoryFindableMembers },
+  { metricKey: 'adoption.mood_checkins', metricUnit: 'check-ins', sourcePlugin: 'mood', compute: moodCheckins },
+  { metricKey: 'adoption.mood_average', metricUnit: '', sourcePlugin: 'mood', compute: moodAverage },
+  { metricKey: 'adoption.click_log_incidents', metricUnit: 'incidents', sourcePlugin: 'click-log', compute: clickLogIncidents },
+  { metricKey: 'adoption.click_log_active_loggers', metricUnit: 'members', sourcePlugin: 'click-log', compute: clickLogActiveLoggers },
 ];
 
 // Compute the live numbers for a week window from upstream plugin tables. Always returns the full

--- a/ctf/packages/web/lib/weekly-performance/live-metrics.ts
+++ b/ctf/packages/web/lib/weekly-performance/live-metrics.ts
@@ -247,8 +247,10 @@ function liveWorkforceRecruited(weekStart: string): Promise<number> {
   );
 }
 
-// ISO Monday of the current UTC week — "the current week" for snapshot purposes.
-function currentWeekStart(): string {
+// ISO Monday of the current UTC week — "the current week" for snapshot purposes. Exported for the
+// internal goal-snapshot capture route, which records the week's goal readings on a schedule so
+// goal history never depends on someone opening the dashboard that week.
+export function currentWeekStart(): string {
   const now = new Date();
   const utc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
   const day = utc.getUTCDay();

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -235,6 +235,25 @@ ALTER TABLE IF EXISTS weekly_performance_weeks ADD COLUMN IF NOT EXISTS summary 
 ALTER TABLE IF EXISTS weekly_performance_weeks ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS weekly_performance_weeks ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
+-- === weekly_performance_goal_snapshots ===
+-- Weekly memory for the dashboard's two goal rows (GDP Community Value Index toward 300B,
+-- Workforce recruited toward 2,000,000). Those are STATE metrics — a current total, not a windowed
+-- event — so week-over-week needs a stored reading per week: reading the current week upserts the
+-- live value (last read of the week wins), and past weeks report their stored row. See
+-- ctf/packages/web/lib/weekly-performance/live-metrics.ts and
+-- ctf/docs/developer/PLUGIN_VALUE_METRICS.md.
+CREATE TABLE IF NOT EXISTS weekly_performance_goal_snapshots (
+  metric_key TEXT NOT NULL,
+  week_start_date DATE NOT NULL,
+  metric_value NUMERIC NOT NULL DEFAULT 0,
+  captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (metric_key, week_start_date)
+);
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS metric_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS week_start_date DATE NOT NULL DEFAULT CURRENT_DATE;
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS metric_value NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 -- === foundation_connection_threads ===
 CREATE TABLE IF NOT EXISTS foundation_connection_threads (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -220,6 +220,25 @@ ALTER TABLE IF EXISTS weekly_performance_weeks ADD COLUMN IF NOT EXISTS summary 
 ALTER TABLE IF EXISTS weekly_performance_weeks ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS weekly_performance_weeks ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
+-- === weekly_performance_goal_snapshots ===
+-- Weekly memory for the dashboard's two goal rows (GDP Community Value Index toward 300B,
+-- Workforce recruited toward 2,000,000). Those are STATE metrics — a current total, not a windowed
+-- event — so week-over-week needs a stored reading per week: reading the current week upserts the
+-- live value (last read of the week wins), and past weeks report their stored row. See
+-- ctf/packages/web/lib/weekly-performance/live-metrics.ts and
+-- ctf/docs/developer/PLUGIN_VALUE_METRICS.md.
+CREATE TABLE IF NOT EXISTS weekly_performance_goal_snapshots (
+  metric_key TEXT NOT NULL,
+  week_start_date DATE NOT NULL,
+  metric_value NUMERIC NOT NULL DEFAULT 0,
+  captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (metric_key, week_start_date)
+);
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS metric_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS week_start_date DATE NOT NULL DEFAULT CURRENT_DATE;
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS metric_value NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS weekly_performance_goal_snapshots ADD COLUMN IF NOT EXISTS captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 -- === foundation_connection_threads ===
 CREATE TABLE IF NOT EXISTS foundation_connection_threads (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
Implements the owner-locked decision record (`ctf/docs/developer/PLUGIN_VALUE_METRICS.md`) end to end: canonical registry + dashboard rebuild.

## The dashboard now shows (in card order)

**Goals** — the two numbers the platform drives toward, each with a compact value, a progress bar, and "% of goal":
- **GDP Community Value Index → 300B** (from the GDP plugin's live report; still an estimate, never money)
- **Workforce recruited → 2,000,000** (active Directory profiles — the registry definition)

Both are *state* metrics, so week-over-week needs memory: a new `weekly_performance_goal_snapshots` table stores one reading per week (reading the current week upserts the live value — last read of the week wins; past weeks report their stored row).

**Value delivered** — fifteen cards, one per plugin's defining event, windowed on the event's own timestamp: Foundation answered charged calls (aggregate-only on this admin surface, rule 132); SocketRelay successful closes; TrustTransport mutually-confirmed trips; Lighthouse completed stays; Chyme tips; ServiceCredits **direct** peer sends (no double-count with plugin-mediated transfers); Contributions confirmed USD; SkillsHunt accepted nominations; WhatWorks approved tools + endorsements; LevelUp **completions** + trainer payouts (replacing the old enrollments-started, which measured intent); Recurring Activity confirmed ties; PeerProgramming distinct posters; Beacon engagement **per unique broadcast** (reactions/replies on the Commons replay post — broadcast completion is an admin action and does not count).

**Adoption** — Directory findable members; Mood check-ins + average (aggregate only); ClickLog incidents + distinct loggers (aggregate only).

Dropped per owner ruling: all login/engagement cards, feed cards, GentlePulse, Skills Taxonomy.

## Plumbing

- All 22 metrics registered in `ctf/config/canonical_metrics.yaml` (`wp_value_*`, `wp_adoption_*`, `wp_goal_*_weekly_snapshot`) with real SQL, per rule 121; the underlying `gdp_value_index` / `workforce_recruited_current_count` are referenced, not re-registered. YAML validates (77 entries, no duplicate ids).
- Command contracts: `metrics.get` / `comparison.get` / `report.export` `dataAccess` lists now name the real upstream reads + the snapshot table, with a dated changelog entry.
- Schema: one new guarded table; `schema.demo.sql` regenerated.
- Web UI groups cards under Goals / Value delivered / Adoption; labels humanize with GDP/USD acronym fixes. Android renders the same metric list generically (humanized labels); the goal progress *bar* is web-only for now — recorded as a gap in the inventory.
- Every query stays table-existence-guarded and never throws; no user input in SQL.
- Inventory drift gate passes; web typecheck + eslint clean; EOF gate passes; test script updated (WP-A3 now asserts the new grouped set and that nothing dropped remains).

**Owner-review lane** (schema + contract changes) — auto-merge not enabled.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_