### PR TITLE
fix: remove 404ing Member view pill from Bug Reports admin header

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-bug-reporting-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-bug-reporting-feature-inventory.md
@@ -131,6 +131,11 @@ No seed script. Reports are user-generated at runtime; there is no fixture data 
 
 ## Change Log
 
+- 2026-07-18: **"Member view" pill removed from the admin header (owner report: it 404s).** Bug
+  reporting has no member page — `/apps/bug-reporting` does not exist; members report through the
+  in-app modal — so the pill added in the 2026-07-17 sweep linked to a 404 and is removed. The
+  rule-134 admin↔member pairing does not apply to a plugin with no member shell. UI-only; no
+  schema, route, or contract change.
 - 2026-07-17: **Admin↔member navigation (app-wide sweep).** The admin surface header gained the
   shared "Member view" pill (`PluginUserShellButton`) linking to `/apps/bug-reporting`. UI-only;
   no schema, route, or contract change.

--- a/ctf/docs/developer/test-scripts/bug-reporting-test-script.md
+++ b/ctf/docs/developer/test-scripts/bug-reporting-test-script.md
@@ -62,7 +62,9 @@ same-origin cookies. Page URL and (on `/apps/<slug>`) the plugin slug are attach
 no technical detail is asked of the user. A 201 shows the calm success state; the report row is
 stored privately as `new` (or `held_for_review` if flagged). On phone width the modal renders as a
 bottom sheet; android mirrors the same five states.
-The admin screen header shows a "Member view" pill opening `/apps/bug-reporting`.
+The admin screen header shows no "Member view" pill — bug reporting has no member page
+(`/apps/bug-reporting` does not exist; members report through the in-app modal), so the admin
+header carries only the back chevron and title.
 **Result:** web ☐ mobile ☐ android ☐ — notes:
 
 ### BUG-2 · Required field and the five modal states

--- a/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
+++ b/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
@@ -6,7 +6,6 @@ import { Bug, ExternalLink } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
-import { PluginUserShellButton } from '@/components/shared/plugin-user-shell-button';
 import { getBugReportsTokens } from './bug-reports-shared';
 import type { BugReportStatus, BugReportRiskLevel } from 'lib/bug-reports/constants';
 import type { BugReportRiskFlag } from 'lib/bug-reports/sanitize';
@@ -165,7 +164,7 @@ export function BugReportsAdminShell() {
         fontFamily: "'Inter',system-ui,sans-serif",
       }}
     >
-      <MobileScreenHeader title="Bug Reports Admin" accent={t.ACCENT} icon={<Bug size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/bug-reporting" accent={t.ACCENT} />} />
+      <MobileScreenHeader title="Bug Reports Admin" accent={t.ACCENT} icon={<Bug size={18} color={t.ACCENT} />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>


### PR DESCRIPTION
Bug reporting has no member page — `/apps/bug-reporting` does not exist; members report through the in-app modal. The "Member view" pill added to the Bug Reports admin header in the 2026-07-17 navigation sweep therefore linked to a 404 (owner report with screenshot).

Changes:
- `bug-reports-admin-shell.tsx`: removed the `PluginUserShellButton` from the `MobileScreenHeader` and its now-unused import. The back chevron and title remain.
- `bug-reporting-test-script.md`: the step now asserts the admin header shows no "Member view" pill.
- `ctf-bug-reporting-feature-inventory.md`: correcting change-log entry noting the pill is removed and the rule-134 admin↔member pairing does not apply to a plugin with no member shell.

UI-only; no schema, route, or contract change. Web build, typecheck, lint, and EOF gate pass locally.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_