### PR TITLE
fix: apply Survivor Hub design audit fixes to the community shell

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -399,6 +399,23 @@
   display: block;
 }
 
+/* Per-stat accent colors. These replace the old inline style={{ color }} on the three hero stats,
+   which the comic theme could not reach (inline styles win over a data-theme rule), so the neon
+   purple/cyan leaked onto the warm comic newsprint. As classes the default palette is preserved
+   pixel-for-pixel while the comic override below swaps them to the warm ink palette. */
+.heroStatMembers {
+  color: #a78bfa;
+}
+
+.heroStatGdp {
+  /* --ctf-gold is #38bdf8 in the default theme — identical to the old inline value. */
+  color: var(--ctf-gold);
+}
+
+.heroStatOpport {
+  color: #34d399;
+}
+
 .heroStatLabel {
   font-size: 11px;
   color: var(--ctf-text-subtle);
@@ -626,7 +643,14 @@
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   padding-bottom: 4px;
-  scrollbar-width: thin;
+  /* Hide the scrollbar (matches .chatChipRow) so it doesn't reserve a gutter on desktop where the
+     chips fit without scrolling; the row still scrolls horizontally on a phone when they overflow. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.conciergeChipRail::-webkit-scrollbar {
+  display: none;
 }
 
 .conciergeChip {
@@ -653,7 +677,9 @@
 
 .chatTime {
   font-size: 11px;
-  color: #374151;
+  /* Token, not the old hardcoded #374151 (~2.8:1 on the panel — below the 4.5:1 AA minimum, so
+     timestamps were effectively invisible). --ctf-text-subtle (#6b7280) clears AA on this bg. */
+  color: var(--ctf-text-subtle);
 }
 
 /* Signed-out Commons: Discord-style message rows. Each post is a full-width row — avatar on the
@@ -1123,7 +1149,8 @@
   margin: 0 0 14px;
   text-align: center;
   font-size: 11px;
-  color: #374151;
+  /* Same fix as .chatTime: the footnote was hardcoded to the sub-AA #374151 and could not be read. */
+  color: var(--ctf-text-subtle);
   flex-shrink: 0;
 }
 
@@ -1183,7 +1210,16 @@
   color: #F3F4F6;
   font-size: 12px;
   font-weight: 600;
-  padding: 7px 10px;
+  /* Extra right padding leaves room for the custom chevron drawn below. */
+  padding: 7px 28px 7px 10px;
+  /* Drop the OS chevron (which flashes light-mode chrome on some systems) and draw our own so the
+     closed control matches the dark custom UI. The dropdown list itself is still OS-native. */
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  cursor: pointer;
 }
 
 .appsSortSelect:focus {
@@ -1224,6 +1260,13 @@
   transition: border-color 0.15s, background 0.15s;
 }
 
+/* The card is a div[role="button"]; without this it had only the browser default focus outline,
+   which the dark card swallows. A visible ring makes keyboard selection legible. */
+.appCard:focus-visible {
+  outline: 2px solid rgba(124, 58, 237, 0.7);
+  outline-offset: 2px;
+}
+
 .appCardTop {
   display: flex;
   align-items: flex-start;
@@ -1255,9 +1298,16 @@
   color: var(--ctf-text-muted);
 }
 
+/* Status badge ("Coming soon" / "Alpha" / "Beta"). Bumped from 10px to a legible 11px pill; the
+   per-plugin accent color is still applied inline, so only geometry/legibility change here. */
 .appCardLive {
-  font-size: 10px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .appCardName {
@@ -1403,21 +1453,27 @@
   font-size: 10px;
 }
 
+/* Secondary (outline) sign-in on the right rail. The primary gradient CTA is the larger
+   "Sign In to Get Started" in the chat panel; above 1280px both are visible at once, so the rail
+   one is demoted to an outline to remove the competing-primaries read. (Comic theme overrides this
+   to its own flat-ink CTA treatment below, unchanged.) */
 .profileLoginBtn {
   display: inline-block;
   padding: 8px 16px;
   border-radius: 8px;
-  background: linear-gradient(135deg, #7C3AED 0%, #0EA5E9 100%);
-  color: #fff;
+  background: transparent;
+  border: 1px solid rgba(124, 58, 237, 0.45);
+  color: #A78BFA;
   text-decoration: none;
   font-size: 13px;
   font-weight: 600;
   margin-top: 8px;
-  transition: opacity 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .profileLoginBtn:hover {
-  opacity: 0.9;
+  background: rgba(124, 58, 237, 0.12);
+  border-color: rgba(124, 58, 237, 0.7);
 }
 
 .rightRailSectionTitle {
@@ -1960,11 +2016,19 @@
   height: 6px;
   border-radius: 50%;
   background: #38BDF8;
+  /* Staggered pulse so the "Reviewing for safety" card reads as in-progress, not frozen. The old
+     static opacities (0.35/0.6/0.85) held still and looked broken. Staggered by animation-delay. */
+  animation: ctf-dot-pulse 1.4s ease-in-out infinite;
 }
 
-.comicPendingDot:nth-child(1) { opacity: 0.35; }
-.comicPendingDot:nth-child(2) { opacity: 0.6; }
-.comicPendingDot:nth-child(3) { opacity: 0.85; }
+.comicPendingDot:nth-child(1) { animation-delay: 0s; }
+.comicPendingDot:nth-child(2) { animation-delay: 0.2s; }
+.comicPendingDot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes ctf-dot-pulse {
+  0%, 80%, 100% { opacity: 0.25; transform: scale(0.9); }
+  40% { opacity: 1; transform: scale(1); }
+}
 
 .comicPendingText {
   font-size: 13px;
@@ -2408,6 +2472,17 @@
   background: var(--ctf-surface);
   border: 1.5px solid var(--ctf-border);
   box-shadow: var(--ctf-elevation-shadow);
+}
+
+/* Hero stat accents in comic: no purple, no blue (§6). Members/GDP take the warm gold; Opportunity
+   keeps the shared success green. (.heroStatGdp already resolves to --ctf-gold, so it flips on its
+   own; Members and Opportunity are mapped here.) */
+:global([data-theme='comic']) .heroStatMembers {
+  color: var(--ctf-gold);
+}
+
+:global([data-theme='comic']) .heroStatOpport {
+  color: var(--ctf-success);
 }
 
 /* User chat bubble gradient → flat ink panel + cream border. */

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -277,8 +277,9 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
       <header className={styles.mobileBar}>
         {/* Brand mark on the phone bar (styled in CSS, previously unused): it is the first product
             identity a member sees on a phone. It sits on the left; the section tabs keep their
-            margin-left:auto so the tabs + controls cluster on the right. */}
-        <div className={styles.mobileBarLogo} aria-hidden="true">SH</div>
+            margin-left:auto so the tabs + controls cluster on the right. "TSE" matches the site
+            title "TI Skills Economy (TSE)" in layout.tsx. */}
+        <div className={styles.mobileBarLogo} aria-hidden="true">TSE</div>
         <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
           <button
             type="button"

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -275,6 +275,10 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
   return (
     <div className={`${styles.shell} ctf-self-responsive`}>
       <header className={styles.mobileBar}>
+        {/* Brand mark on the phone bar (styled in CSS, previously unused): it is the first product
+            identity a member sees on a phone. It sits on the left; the section tabs keep their
+            margin-left:auto so the tabs + controls cluster on the right. */}
+        <div className={styles.mobileBarLogo} aria-hidden="true">SH</div>
         <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
           <button
             type="button"
@@ -341,6 +345,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
           channels={channels}
           activeChannel={activeChannel}
           onChannelSelect={handleChannelSelect}
+          shellStats={shellStats}
           isAdmin={isAdmin}
         />
         <main className={`${styles.panel} ${styles.content}`}>

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -13,6 +13,7 @@ import { useHomeChat } from './use-home-chat';
 import { ComicAnswerCard, ComicPendingCard } from './comic-cards';
 import { AnnouncementCard } from './announcement-card';
 import { ComicConsentModal } from './comic-consent-modal';
+import { formatScaledValue } from './shell-format';
 import styles from './community-shell.module.css';
 
 const ECONOMY_TARGET_USD = 300_000_000_000;
@@ -24,14 +25,6 @@ function avatarFromSender(label: string): string {
   if (!trimmed || trimmed.toLowerCase() === 'survivor hub') return 'SH';
   const handle = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
   return handle.charAt(0).toUpperCase() || 'SH';
-}
-
-function formatScaledValue(value: number | null, prefix = ''): string {
-  if (!value) return `${prefix}0`;
-  if (value >= 1_000_000_000) return `${prefix}${(value / 1_000_000_000).toFixed(0)}B`;
-  if (value >= 1_000_000) return `${prefix}${(value / 1_000_000).toFixed(1)}M`;
-  if (value >= 1_000) return `${prefix}${(value / 1_000).toFixed(1)}K`;
-  return `${prefix}${value.toLocaleString()}`;
 }
 
 // One unified stream entry: either a peer/hub chat message or an AI Assistant (@comic) Q&A item.
@@ -111,6 +104,7 @@ function publicRowBackground(authorUsername: string | null): string {
 function PublicCommunityPanel({ stats, plugins, signInUrl }: { stats: ShellStats; plugins: PluginRegistryItem[]; signInUrl: string }) {
   const implementedCount = plugins.filter((plugin) => plugin.availabilityState === 'implemented_shell').length;
   const opportunityValue = Math.max(ECONOMY_TARGET_USD - (stats.gdpValueUsd ?? 0), 0);
+  const isMobile = useIsMobile();
 
   const [posts, setPosts] = useState<PublicCommunityPost[]>([]);
   const [isPublic, setIsPublic] = useState(false);
@@ -149,26 +143,31 @@ function PublicCommunityPanel({ stats, plugins, signInUrl }: { stats: ShellStats
           <h1 className={styles.heroBannerTitle}>Welcome to Survivor Hub</h1>
           <p className={styles.heroBannerSub}>Connect with your community. Access {implementedCount} live plugins for housing, work, safety, and support.</p>
         </div>
-        <div className={styles.heroStats}>
-          <div className={styles.heroStatBlock}>
-            <span className={styles.heroStatValue} style={{ color: '#A78BFA' }}>
-              {formatScaledValue(stats.memberCount)}
-            </span>
-            <span className={styles.heroStatLabel}>Members</span>
+        {/* Stats are hidden on phones, where the three blocks filled a quarter of the first screen
+            before any community posts were visible (the authenticated panel already hides its whole
+            hero on mobile). The title + description above stay. */}
+        {!isMobile ? (
+          <div className={styles.heroStats}>
+            <div className={styles.heroStatBlock}>
+              <span className={`${styles.heroStatValue} ${styles.heroStatMembers}`}>
+                {formatScaledValue(stats.memberCount)}
+              </span>
+              <span className={styles.heroStatLabel}>Members</span>
+            </div>
+            <div className={styles.heroStatBlock}>
+              <span className={`${styles.heroStatValue} ${styles.heroStatGdp}`}>
+                {formatScaledValue(stats.gdpValueUsd, '$')}
+              </span>
+              <span className={styles.heroStatLabel}>GDP</span>
+            </div>
+            <div className={styles.heroStatBlock}>
+              <span className={`${styles.heroStatValue} ${styles.heroStatOpport}`}>
+                {formatScaledValue(opportunityValue, '$')}
+              </span>
+              <span className={styles.heroStatLabel}>Opportunity</span>
+            </div>
           </div>
-          <div className={styles.heroStatBlock}>
-            <span className={styles.heroStatValue} style={{ color: '#38BDF8' }}>
-              {formatScaledValue(stats.gdpValueUsd, '$')}
-            </span>
-            <span className={styles.heroStatLabel}>GDP</span>
-          </div>
-          <div className={styles.heroStatBlock}>
-            <span className={styles.heroStatValue} style={{ color: '#34D399' }}>
-              {formatScaledValue(opportunityValue, '$')}
-            </span>
-            <span className={styles.heroStatLabel}>Opportunity</span>
-          </div>
-        </div>
+        ) : null}
       </div>
 
       <div className={styles.chatMessages}>
@@ -435,19 +434,19 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
         </div>
         <div className={styles.heroStats}>
           <div className={styles.heroStatBlock}>
-            <span className={styles.heroStatValue} style={{ color: '#A78BFA' }}>
+            <span className={`${styles.heroStatValue} ${styles.heroStatMembers}`}>
               {formatScaledValue(stats.memberCount)}
             </span>
             <span className={styles.heroStatLabel}>Members</span>
           </div>
           <div className={styles.heroStatBlock}>
-            <span className={styles.heroStatValue} style={{ color: '#38BDF8' }}>
+            <span className={`${styles.heroStatValue} ${styles.heroStatGdp}`}>
               {formatScaledValue(stats.gdpValueUsd, '$')}
             </span>
             <span className={styles.heroStatLabel}>GDP</span>
           </div>
           <div className={styles.heroStatBlock}>
-            <span className={styles.heroStatValue} style={{ color: '#34D399' }}>
+            <span className={`${styles.heroStatValue} ${styles.heroStatOpport}`}>
               {formatScaledValue(opportunityValue, '$')}
             </span>
             <span className={styles.heroStatLabel}>Opportunity</span>

--- a/ctf/packages/web/components/community-shell/shell-format.ts
+++ b/ctf/packages/web/components/community-shell/shell-format.ts
@@ -1,0 +1,11 @@
+// Compact number formatting shared across the community shell (hero stats, sidebar footer count).
+// Renders large counts as "4.9M" / "$300B" so a big member count or economy value stays readable in
+// a small stat block instead of a long digit string. Extracted here so the chat panel and the
+// sidebar format identically from one source.
+export function formatScaledValue(value: number | null, prefix = ''): string {
+  if (!value) return `${prefix}0`;
+  if (value >= 1_000_000_000) return `${prefix}${(value / 1_000_000_000).toFixed(0)}B`;
+  if (value >= 1_000_000) return `${prefix}${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${prefix}${(value / 1_000).toFixed(1)}K`;
+  return `${prefix}${value.toLocaleString()}`;
+}

--- a/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
@@ -18,7 +18,8 @@ type IconRailProps = {
 export function ShellIconRail({ section, onSectionChange, initial = 'S', isAuthenticated = false, isAdmin = false }: IconRailProps) {
   return (
     <aside className={styles.iconRail}>
-      <div className={styles.iconRailLogo} aria-hidden="true">SH</div>
+      {/* Product wordmark — matches the site title "TI Skills Economy (TSE)" in layout.tsx. */}
+      <div className={styles.iconRailLogo} aria-hidden="true">TSE</div>
 
       <button
         type="button"

--- a/ctf/packages/web/components/community-shell/shell-right-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-right-rail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useUser } from '@clerk/nextjs';
 import type { TrustUserExtension } from '../../lib/trust/types';
 import type { ShellCurrentUser } from './shell-types';
 import { TrustRightRailCard } from '../shared/trust/TrustRightRailCard';
@@ -15,12 +16,28 @@ type ShellRightRailProps = {
 
 export function ShellRightRail({ currentUser, trust, isAuthenticated = false, signInUrl = '/sign-in' }: ShellRightRailProps) {
   const initial = currentUser.initial;
+  // Clerk photo when the member has uploaded one, so this card matches the avatar the icon-rail
+  // UserButton shows for the same person (it was a gradient monogram here vs. a photo there).
+  // Rendered as a background image on the existing avatar div (the repo uses no raw <img>), so the
+  // profileAvatar sizing/border-radius/comic-theme border all still apply. Falls back to the initial
+  // monogram when there is no photo or the user is signed out.
+  const { user } = useUser();
+  const photoUrl = user?.imageUrl;
+  const avatar = photoUrl ? (
+    <div
+      className={styles.profileAvatar}
+      style={{ backgroundImage: `url("${photoUrl}")`, backgroundSize: 'cover', backgroundPosition: 'center' }}
+      aria-hidden="true"
+    />
+  ) : (
+    <div className={styles.profileAvatar} aria-hidden="true">{initial}</div>
+  );
 
   if (!isAuthenticated) {
     return (
       <aside className={`${styles.panel} ${styles.rightRail}`}>
         <section className={styles.profileCard}>
-          <div className={styles.profileAvatar} aria-hidden="true">{initial}</div>
+          {avatar}
           <p className={styles.profileName}>Welcome to Survivor Hub</p>
           <p className={styles.profileMeta}>Sign in to access full features and connect with your community</p>
           <Link href={signInUrl} className={styles.profileLoginBtn}>Sign In</Link>
@@ -42,7 +59,7 @@ export function ShellRightRail({ currentUser, trust, isAuthenticated = false, si
   return (
     <aside className={`${styles.panel} ${styles.rightRail}`}>
       <section className={styles.profileCard}>
-        <div className={styles.profileAvatar} aria-hidden="true">{initial}</div>
+        {avatar}
         {/* The greeting deliberately carries no handle: displayName is already "@username", so
             "Welcome, @username" plus the @username meta line below repeated the handle twice. */}
         <p className={styles.profileName}>Welcome back</p>

--- a/ctf/packages/web/components/community-shell/shell-sidebar.tsx
+++ b/ctf/packages/web/components/community-shell/shell-sidebar.tsx
@@ -3,16 +3,32 @@
 import Link from 'next/link';
 import { SlidersHorizontal } from 'lucide-react';
 import type { HubChannelInfo } from '../../lib/hub/types';
+import type { ShellStats } from './shell-types';
+import { formatScaledValue } from './shell-format';
 import styles from './community-shell.module.css';
 
 type ShellSidebarProps = {
   channels: HubChannelInfo[];
   activeChannel: string | null;
   onChannelSelect: (slug: string) => void;
+  // Live shell stats (member count) for the footer, so the count is real instead of hardcoded.
+  shellStats?: ShellStats;
   // Admins get an Admin link in the sidebar footer. This rail is desktop-only
   // (hidden on phones); on phones admins reach /admin from the top bar instead.
   isAdmin?: boolean;
 };
+
+// A readable label for a channel: prefer the server-provided displayName, falling back to a
+// Title-cased version of the slug ("general-announcements" → "General Announcements") so the rail
+// never shows a raw database slug.
+function channelLabel(channel: HubChannelInfo): string {
+  const name = channel.displayName?.trim();
+  if (name) return name;
+  return channel.slug
+    .split('-')
+    .map((word) => (word ? word.charAt(0).toUpperCase() + word.slice(1) : word))
+    .join(' ');
+}
 
 // The sidebar is the chat-channel navigation only. Apps are browsed in the main "Apps"
 // grid (ShellAppsPanel), so the sidebar deliberately does not list them — having the same
@@ -22,8 +38,10 @@ export function ShellSidebar({
   channels,
   activeChannel,
   onChannelSelect,
+  shellStats,
   isAdmin = false,
 }: ShellSidebarProps) {
+  const memberCount = shellStats?.memberCount ?? null;
   return (
     <aside className={`${styles.panel} ${styles.leftNav}`}>
       <div className={styles.sidebarHeader}>
@@ -42,7 +60,7 @@ export function ShellSidebar({
               onClick={() => onChannelSelect(ch.slug)}
             >
               <span className={styles.sidebarChannelHash}>#</span>
-              <span className={styles.sidebarChannelName}>{ch.slug}</span>
+              <span className={styles.sidebarChannelName}>{channelLabel(ch)}</span>
             </button>
           );
         })}
@@ -58,7 +76,9 @@ export function ShellSidebar({
         {/* Per-member verification exists (admin-reviewed); a community-wide "verified" claim does
             not, so the footer states only the membership model. */}
         <p className={styles.sidebarFooterTitle}>Invite Only</p>
-        <p className={styles.sidebarFooterMeta}>4.9M survivors worldwide</p>
+        <p className={styles.sidebarFooterMeta}>
+          {memberCount ? `${formatScaledValue(memberCount)} survivors worldwide` : 'Survivors worldwide'}
+        </p>
       </div>
     </aside>
   );


### PR DESCRIPTION
Applies a UI/UX design audit to the existing web community shell (`ctf/packages/web/components/community-shell/`). All changes reference code that already ships — no new features, routing, or business logic.

Parity Ticket: #1684

## What changed

**Legibility / accessibility**
- Timestamps and the composer footnote were hardcoded to `#374151` (~2.8:1 on the panel background, below the 4.5:1 AA minimum) and were effectively invisible — switched to `--ctf-text-subtle`.
- App cards (`div[role="button"]`) had no visible focus ring beyond the browser default (swallowed by the dark card) — added a `:focus-visible` outline.
- Plugin status badge ("Coming soon" / "Alpha" / "Beta") bumped from 10px to a legible 11px pill.

**Theme correctness**
- The three hero stats used inline `style={{ color }}`, which the comic theme could not override, so neon purple/cyan leaked onto the comic newsprint background. Moved to CSS classes (default palette preserved pixel-for-pixel) with comic-theme overrides.

**Polish**
- The "Reviewing for safety" pending dots were static and read as frozen — added a staggered pulse animation.
- Added the product brand mark to the phone-width top bar (`.mobileBarLogo` was styled but unused).
- Demoted the right-rail sign-in to an outline so it no longer competes with the primary CTA above 1280px.
- Right-rail profile avatar now uses the member's Clerk photo when set, matching the icon-rail `UserButton` for the same person.
- Channel names render from `displayName` (fallback: title-cased slug) instead of the raw database slug.
- Sidebar footer count is driven by live shell stats instead of a hardcoded "4.9M".
- Signed-out hero stat blocks are hidden on phones (matching the signed-in panel), reclaiming ~25% of the first screen.
- Concierge chip-rail scrollbar gutter hidden on desktop (matches `.chatChipRow`).
- App-sort `<select>` given a custom chevron so it stops flashing OS chrome in the dark UI.
- Standardized the icon-rail and phone-bar logo marks on "TSE" to match the site title "TI Skills Economy (TSE)".

## Notes / deviations from the audit
- Hero stat colors: the default-theme colors are kept exactly as shipped; only the comic-theme breakage is fixed (the audit's literal token remap would have changed the default Members color, which the design guardrail forbids without owner approval).
- Clerk photo is rendered as a `background-image` on the avatar div rather than an `<img>` — the web package uses no raw `<img>` and that lint rule isn't registered; this keeps the existing sizing/border and needs no Next image config.
- The "SH" avatars for the "Survivor Hub" sender persona (AI chat + official announcements) are intentionally left as-is; they track the "Survivor Hub" sender name still used in the copy.

## Verification
- `pnpm --filter @ctf/web run lint` — pass
- `pnpm --filter @ctf/web run typecheck` — pass
- Repo-wide `pnpm run typecheck` — pass
- EOF-format CI gate (`ctf/scripts/check-eof-format.sh`) — pass
- Pre-push `verify:web` + `verify:mobile` gate — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHaqTdmKNiak1C9teptV9v)_