### PR TITLE
fix: move the mobile Contributions refresh into the header actions

### DIFF
--- a/ctf/packages/web/components/contributions/contributions-shell.tsx
+++ b/ctf/packages/web/components/contributions/contributions-shell.tsx
@@ -384,16 +384,19 @@ function MobileFrame({ t, children, tab, onTab, onRefresh, isAdmin }: { t: Contr
         title="Contributions"
         accent={t.ACCENT}
         icon={<Gift size={18} color={t.ACCENT} />}
-        actions={<PluginAdminButton href="/admin/contributions" isAdmin={isAdmin} accent={t.ACCENT} />}
+        actions={
+          <>
+            <PluginAdminButton href="/admin/contributions" isAdmin={isAdmin} accent={t.ACCENT} />
+            {onRefresh ? <RefreshButton onRefresh={onRefresh} title="Refresh" /> : null}
+          </>
+        }
       />
       <div style={{ padding: '12px 16px 10px', background: t.SURFACE, borderBottom: `1px solid ${t.BORDER_SOLID}`, flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
           <div style={{ width: 26, height: 26, borderRadius: 7, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <Gift size={13} color="#fff" />
           </div>
-          {/* Title shrinks and truncates so the refresh control stays on screen */}
-          <span style={{ fontSize: 17, fontWeight: 700, color: t.TITLE, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>Contributions</span>
-          {onRefresh ? <RefreshButton onRefresh={onRefresh} title="Refresh" /> : null}
+          <span style={{ fontSize: 17, fontWeight: 700, color: t.TITLE }}>Contributions</span>
         </div>
         <div style={{ fontSize: 12, color: t.MUTED, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>Community support drive</div>
       </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

The refresh button on the phone-width Contributions screen looked disabled and out of place.

## Cause

It was rendered in the plugin **sub-header** (the "Contributions / Community support drive" row), which is outside the system-chrome context where the `--ctf-*` CSS tokens are defined. So it fell back to faint defaults (faded surface/border/icon → reads as disabled), and it sat awkwardly next to a title that already repeats in the top chrome.

## Fix

Move it into the `MobileScreenHeader` **actions** slot, next to the Admin button and the shared top-actions cluster (bug / settings / account) — the exact placement What Works and the other plugin shells use. There the tokens resolve, so it matches the other header buttons, and it's grouped with the other controls instead of floating in the sub-header.

Desktop refresh is unchanged. UI placement/styling only — no logic, route, schema, or contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Jkhgv617YLn5LCj1f7hSD)_