### PR TITLE
ci: dispatch-only workflow to set up the ctf-gated Stream channel type

### DIFF
--- a/.github/workflows/stream-gated-channel-type-setup.yml
+++ b/.github/workflows/stream-gated-channel-type-setup.yml
@@ -1,0 +1,77 @@
+name: Stream — Gated Channel Type Setup
+
+# One-time (re-runnable) setup of the 'ctf-gated' Stream channel type used by the gated
+# contributor channel: threads/replies on, reactions on, 4000-char messages, uploads OFF.
+# Manual dispatch only. Run once with target=production and once with target=staging so both
+# Stream apps carry the type (demo mode selects the *_STAGING credentials at runtime).
+# Idempotent — an existing type is updated in place; no secret is ever printed.
+#
+# Needs (from Infisical, injected below): STREAM_API_KEY / STREAM_API_SECRET and their
+# *_STAGING counterparts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which Stream app to configure
+        required: true
+        type: choice
+        options:
+          - production
+          - staging
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stream-gated-channel-type-setup
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    name: Create or update the ctf-gated channel type
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Inject secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: ${{ secrets.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          domain: ${{ secrets.INFISICAL_URL }}
+          secret-path: /
+          recursive: true
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm --dir ctf install --frozen-lockfile
+
+      - name: Run the channel-type setup script
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.target }}" = "staging" ]; then
+            if [ -z "${STREAM_API_KEY_STAGING:-}" ] || [ -z "${STREAM_API_SECRET_STAGING:-}" ]; then
+              echo "Staging Stream credentials missing in Infisical — cannot configure." >&2
+              exit 1
+            fi
+            export STREAM_API_KEY="$STREAM_API_KEY_STAGING"
+            export STREAM_API_SECRET="$STREAM_API_SECRET_STAGING"
+          fi
+          if [ -z "${STREAM_API_KEY:-}" ] || [ -z "${STREAM_API_SECRET:-}" ]; then
+            echo "Stream credentials missing in Infisical — cannot configure." >&2
+            exit 1
+          fi
+          node ctf/scripts/setupGatedChannelType.mjs


### PR DESCRIPTION
Adds `.github/workflows/stream-gated-channel-type-setup.yml`: manual-dispatch-only workflow that runs the existing `ctf/scripts/setupGatedChannelType.mjs` with Infisical-injected Stream credentials. A `target` input picks the production or staging Stream app (staging maps the `*_STAGING` values onto the script's expected env — no key renamed or added). Idempotent; no secret is ever printed.

This replaces the manual owner step recorded in the contributor-access inventory: after merge I dispatch it once per target and the `ctf-gated` channel type (threads on, richer reactions, 4000-char messages, uploads OFF) exists in both Stream apps.

CI/infra only — no app code, schema, or contract change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_