### PR TITLE
ci: let pnpm/action-setup use the packageManager pin in the gated setup workflow

### DIFF
--- a/.github/workflows/stream-gated-channel-type-setup.yml
+++ b/.github/workflows/stream-gated-channel-type-setup.yml
@@ -48,8 +48,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
The channel-type setup workflow (#1687) failed at "Set up pnpm": it pinned `version: 9` while the workspace `package.json` pins `pnpm@9.12.0`, and `pnpm/action-setup` refuses conflicting pins. Dropping the workflow-level pin so the `packageManager` field governs, matching how other workflows in this repo set up pnpm.

CI only.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_