### PR TITLE
docs: correct the Foundation provider-search claim in the guide and inventory

### DIFF
--- a/ctf/docs/USER_GUIDE.md
+++ b/ctf/docs/USER_GUIDE.md
@@ -31,7 +31,7 @@ _Last updated: 2026-07-18_
 
 Find a support provider and connect with them one to one.
 
-Foundation lets you search for providers by service type, location, language, and trauma-informed criteria. Providers are fellow community members, not a formal service.
+Foundation lets you search providers by name, headline, or bio, and filter by the skill they offer. Providers are fellow community members who chose to offer help — not a formal service.
 
 When you want help, request a quote or connect. That opens a private one-to-one chat between you and the provider. Voice and video calls are available once connected, and a call may cost ServiceCredits, shown in credits only.
 
@@ -40,7 +40,7 @@ Private chat exists only inside an active connection or quote — there is no op
 **How to use it**
 
 1. Open Foundation. The provider list loads with each provider's name, headline, and bio.
-2. Search or filter to find a provider that fits.
+2. Search by name or words from a provider's headline or bio, or filter by an offered skill, to find a provider that fits.
 3. Request a quote or connect to open a private chat with them.
 4. Start a voice or video call once connected.
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-foundation-feature-inventory.md
@@ -13,7 +13,10 @@ Foundation provides trauma-informed survivors with deterministic access to vette
 
 ## Target User Features
 
-1. Provider discovery and search by service type, location, language, and trauma-informed criteria.
+1. Provider discovery and search. Shipped: a text search over provider name, headline, and bio,
+   plus an offered-skill filter (`searchProviders` — providers are claimed directory profiles that
+   opted in by offering at least one skill). Location/language/trauma-informed filters from the
+   original target scope were never built and are not claimed anywhere member-facing.
 2. Survivor-provider 1:1 text messaging with delivery/read/seen semantics and file attachment support.
 3. Voice and video session initiation and join for approved 1:1 participants.
 4. Quote request lifecycle (requested → provider_responded → closed) with immutable timeline view. The 1:1 text/voice/video channel is scoped to an active connection/quote between exactly the two parties and opens with it; when the connection/quote reaches a terminal state (closed, declined, or ended) the chat closes — no new messages may be sent, both parties keep read-only access for a limited window, and message/session records are retained server-side for moderation/abuse evidence per the deletion contract. No 1:1 messaging exists outside an active connection/quote (platform rule 100, "Messaging Scope and Lifecycle").
@@ -160,6 +163,14 @@ The instant 1:1 call ring/answer lifecycle (issue #808 task 3) and per-block bil
 10. **Web Push requires the owner to provision VAPID keys.** Until `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` are set (the owner generates them once with `npx web-push generate-vapid-keys` and stores them in Infisical `production`), the ring is delivered in-app only — every push is a graceful no-op. No keys are generated or committed in the repo (open-source secrets policy). See `.claude/rules/123-environment-configuration-rules.mdc`.
 
 ## Change Log
+
+- 2026-07-18: **Corrected the provider-search feature claim (owner report via the user guide).**
+  Target-feature item 1 claimed search "by service type, location, language, and trauma-informed
+  criteria"; the shipped search is a text match over name/headline/bio plus an offered-skill
+  filter, and nothing else. The item now describes the shipped behavior, and the public user guide
+  (`guide-content.json` / `USER_GUIDE.md`) was corrected to match — the guide generator grounds in
+  this inventory, so the aspirational wording had propagated to members as fact. Docs only; no
+  code change.
 
 - 2026-07-17: **History-aware back + admin↔member navigation (app-wide sweep).** The member
   shell's hand-rolled back chevron was replaced by the shared `BackChevronButton` — it returns to

--- a/ctf/docs/developer/test-scripts/foundation-test-script.md
+++ b/ctf/docs/developer/test-scripts/foundation-test-script.md
@@ -52,6 +52,9 @@ checks. Member role unless noted.
 
 ### FND-1 · Provider discovery and search
 **Role:** member · **Surfaces:** all · **Seed:** `seed:foundation`
+**Search scope (matches the shipped `searchProviders`):** a text match over provider name,
+headline, and bio, plus the offered-skill filter — there are no location, language, or
+trauma-informed filters, and no surface (including the public user guide) should claim them.
 **Steps:**
 1. Open Foundation and browse providers; filter by an offered skill chip.
 2. On desktop, set a filter (pick a trade in the sidebar, type a search term, or tap a skill chip),

--- a/ctf/packages/web/app/guide/guide-content.json
+++ b/ctf/packages/web/app/guide/guide-content.json
@@ -29,13 +29,13 @@
       "updated": "2026-07-18",
       "summary": "Find a support provider and connect with them one to one.",
       "body": [
-        "Foundation lets you search for providers by service type, location, language, and trauma-informed criteria. Providers are fellow community members, not a formal service.",
+        "Foundation lets you search providers by name, headline, or bio, and filter by the skill they offer. Providers are fellow community members who chose to offer help — not a formal service.",
         "When you want help, request a quote or connect. That opens a private one-to-one chat between you and the provider. Voice and video calls are available once connected, and a call may cost ServiceCredits, shown in credits only.",
         "Private chat exists only inside an active connection or quote — there is no open inbox to message anyone. When the connection ends, the chat closes."
       ],
       "howTo": [
         "Open Foundation. The provider list loads with each provider's name, headline, and bio.",
-        "Search or filter to find a provider that fits.",
+        "Search by name or words from a provider's headline or bio, or filter by an offered skill, to find a provider that fits.",
         "Request a quote or connect to open a private chat with them.",
         "Start a voice or video call once connected."
       ]


### PR DESCRIPTION
Owner report (screenshot of `/guide`): the Foundation section claimed providers can be searched "by service type, location, language, and trauma-informed criteria." Not true — the shipped search (`searchProviders`) is a text match over provider name, headline, and bio plus an offered-skill filter, nothing else.

Root cause: the Foundation inventory's target-features list still carried the aspirational wording from initial authoring, and the guide generator — which grounds in the inventory by design — copied it to members as fact.

- Inventory: target item 1 now describes the shipped search, with an explicit note that the location/language/trauma-informed filters were never built; dated change-log entry added.
- `guide-content.json` + `USER_GUIDE.md`: the Foundation body and how-to step now describe the real search ("search providers by name, headline, or bio, and filter by the skill they offer").

Docs only; no code change. EOF, inventory-drift, and test-script-drift gates pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_