### PR TITLE
docs: make Chyme guide chat-panel wording medium-neutral

### DIFF
--- a/ctf/docs/USER_GUIDE.md
+++ b/ctf/docs/USER_GUIDE.md
@@ -50,7 +50,7 @@ _Last updated: 2026-07-18_
 
 One shared audio room where members can talk and chat.
 
-Chyme is a single shared audio room. Join the call to talk with other members, or type in the chat panel alongside it.
+Chyme is a single shared audio room. Join the call to talk with other members, or type in the chat panel.
 
 You start muted and can mute or unmute your own microphone. You can send a Tip in ServiceCredits to another participant from their tile.
 

--- a/ctf/packages/web/app/guide/guide-content.json
+++ b/ctf/packages/web/app/guide/guide-content.json
@@ -46,7 +46,7 @@
       "updated": "2026-07-18",
       "summary": "One shared audio room where members can talk and chat.",
       "body": [
-        "Chyme is a single shared audio room. Join the call to talk with other members, or type in the chat panel alongside it.",
+        "Chyme is a single shared audio room. Join the call to talk with other members, or type in the chat panel.",
         "You start muted and can mute or unmute your own microphone. You can send a Tip in ServiceCredits to another participant from their tile.",
         "Signed-out visitors get a free listen view and must sign in to speak."
       ],


### PR DESCRIPTION
The Chyme user-guide section said the chat panel sits "alongside" the audio room. That is only true in the desktop side-by-side layout; on mobile the chat panel is underneath. The instruction should read the same on any screen, so the spatial wording is dropped.

Change:
- `…or type in the chat panel alongside it.` → `…or type in the chat panel.`

Applied in both generated guide files:
- `ctf/packages/web/app/guide/guide-content.json` (rendered by `/guide`)
- `ctf/docs/USER_GUIDE.md` (the plain markdown copy)

Both are outputs of `ctf/scripts/generate-user-guide.mjs`. The Chyme source docs (inventory "User Features", test-script "Core smoke") contain no spatial framing — the "alongside" phrasing was added during a past model rewrite — so nothing at the source needs changing. The weekly regeneration skips a section whose source docs are unchanged, and this section's date already matches its source date, so a routine scheduled run keeps this reviewed wording.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAnBKZsGtiqaUSSTPYHWBi)_