### PR TITLE
fix: add the missing Beacon row to the plugin-registry seed

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -232,6 +232,12 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 
 ## Change Log
 
+- 2026-07-18: **Beacon added to the app launcher (owner report: no way to reach the member page).**
+  The `ctf_plugin_registry` seed in `ctf/schema.sql` had no `beacon` row, so the launcher — which
+  reads the database registry, not the in-code fallback — never showed the tile and members could
+  not reach `/apps/beacon` to see the idle/replay screen. Seed row added (nav rank 230, visible),
+  matching the in-code fallback entry. No route, contract, or behavior change.
+
 - 2026-07-17: **Admin↔member navigation (app-wide sweep).** The admin surface header gained the
   shared "Member view" pill (`PluginUserShellButton`) linking to `/apps/beacon`. The member shell
   header now shows the shared Admin shortcut (`PluginAdminButton`, admins only). UI-only; no

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -35,8 +35,10 @@
 
 One-way admin broadcast; public watch, sign-in to chat. Member role unless noted.
 
-1. **Idle state loads.** Open `/apps/beacon` when nothing is live. A calm "No live event right now"
-   screen renders, with the last replay if one exists. No spinner stuck, no error. → web ☐ mobile ☐ android ☐
+1. **Idle state loads — and Beacon is reachable from the app list.** The Apps launcher shows a
+   Beacon tile (database registry row, nav rank 230) that opens `/apps/beacon`. When nothing is
+   live, a calm "No live event right now" screen renders, with the last replay if one exists. No
+   spinner stuck, no error. → web ☐ mobile ☐ android ☐
 2. **Anyone can watch, no sign-in.** Sign out and open `/apps/beacon`. The viewer surface still loads
    over the public path (HLS); there is no phone-number or account wall to watch. → web ☐ mobile ☐ android ☐
 3. **Chat is gated to members.** As a signed-out viewer, confirm chat is read-only / shows a "sign in

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -2128,6 +2128,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('what-works',          'WhatWorks',            'One shared, survivor-verified list of tools — organized by the exact problems survivors face. No ads, no affiliates.','implemented_shell', 200, TRUE),
   ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'implemented_shell', 210, TRUE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE),
+  ('beacon',             'Beacon',               'Live one-way broadcasts from the team. Watch publicly with just a link; sign in to chat and react.','implemented_shell', 230, TRUE),
   ('recurring-activity', 'Recurring Activity',   'Acknowledge an ongoing activity with another member — one tap, no amounts to report. Recognition of your everyday ties, never a bill.','implemented_shell', 240, TRUE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2130,6 +2130,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('what-works',          'WhatWorks',            'One shared, survivor-verified list of tools — organized by the exact problems survivors face. No ads, no affiliates.','implemented_shell', 200, TRUE),
   ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'implemented_shell', 210, TRUE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE),
+  ('beacon',             'Beacon',               'Live one-way broadcasts from the team. Watch publicly with just a link; sign in to chat and react.','implemented_shell', 230, TRUE),
   ('recurring-activity', 'Recurring Activity',   'Acknowledge an ongoing activity with another member — one tap, no amounts to report. Recognition of your everyday ties, never a bill.','implemented_shell', 240, TRUE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,


### PR DESCRIPTION
Owner report: Beacon is not listed in the app directory, so members have no way to open `/apps/beacon` and see the idle "no live event" / replay screen.

Root cause: the launcher reads the `ctf_plugin_registry` database table; its seed block in `ctf/schema.sql` never included a `beacon` row. The in-code fallback registry has one, but the fallback only applies when the table is empty — so the tile never appeared in production.

- Seed row added: `('beacon', 'Beacon', …, 'implemented_shell', 230, TRUE)`, matching the in-code entry; the upsert applies it on the next database update run (I dispatch it right after merge).
- `schema.demo.sql` regenerated; Beacon inventory change-log entry and test-script smoke step updated (the launcher tile is now part of core smoke).

One seed row only; no route, contract, or behavior change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_