### PR TITLE
feat: public community guidelines page linked across discussion spaces

### DIFF
--- a/ctf/packages/web/app/guidelines/guidelines-content.ts
+++ b/ctf/packages/web/app/guidelines/guidelines-content.ts
@@ -1,0 +1,88 @@
+// Content for the public /guidelines page (community discussion guidelines).
+//
+// Kept as plain data so the page component stays a small renderer, same as /terms.
+// This is the page the operator cites when a discussion crosses a line, so every
+// rule here must match how moderation actually behaves. Public and sign-in-free
+// on purpose: a rule you cannot link to is a rule you cannot enforce fairly.
+
+export const GUIDELINES_EFFECTIVE_DATE = 'July 19, 2026';
+
+export type GuidelineBlock =
+  | { type: 'p'; text: string }
+  | { type: 'ul'; items: string[] };
+
+export interface GuidelineSection {
+  id: string;
+  heading: string;
+  blocks: GuidelineBlock[];
+}
+
+export const GUIDELINE_SECTIONS: GuidelineSection[] = [
+  {
+    id: 'purpose',
+    heading: 'What this platform is for',
+    blocks: [
+      {
+        type: 'p',
+        text:
+          'This platform exists to build a psyop-free economy: survivors exchanging real skills, real help, and real resources with each other. Every discussion space — the Commons, the members-only channel, plugin Direct Lines, and replies anywhere — is for that. The focus is us, not them.',
+      },
+    ],
+  },
+  {
+    id: 'acceptable',
+    heading: 'Discussions that belong here',
+    blocks: [
+      {
+        type: 'ul',
+        items: [
+          'Asking for and offering real help: skills, work, training, housing, transport, tools, resources.',
+          'Questions about using the app, and answers to them.',
+          'Honest conversation and encouragement between survivors, focused on what is being built here.',
+          'Meeting members here and continuing off the platform, when it is about a psyop-free economy or lifestyle.',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'unacceptable',
+    heading: 'Discussions that do not belong here',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Any of these can lead to a message being removed and, for repeated or serious cases, to account restriction:',
+      },
+      {
+        type: 'ul',
+        items: [
+          'Advocating, encouraging, planning, or joking about violence or harm to anyone. No exceptions — including people you believe have harmed you.',
+          'Making the space about perps or operations: naming or accusing individuals, revenge talk, or turning a channel into a forum about "them". Discussion and analysis of perp tactics has its place elsewhere (for example Quora); here the focus stays on what survivors build for each other.',
+          'Harassment, demeaning language, or targeting another member.',
+          'Soliciting money, gift cards, or financial details from members, or any scam or impersonation.',
+          "Sharing another member's personal information, photos, or location without their consent.",
+          'Spam, flooding, or advertising unrelated to the community.',
+          'Presenting yourself as staff or a moderator when you are not.',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'enforcement',
+    heading: 'How this is enforced',
+    blocks: [
+      {
+        type: 'ul',
+        items: [
+          'A good-faith slip usually gets a reminder and a redirect, in the channel, citing this page.',
+          'Messages that cross a line may be removed. In the members-only channel, moderators can read everything (disclosed in the channel) and can remove any post.',
+          'Repeated or serious violations lead to account restriction through the safety tools, and members-only channel access is revoked for reviewed cause.',
+          'You can block any member from their profile, and escalate a safety concern with a safety report — you never have to argue with someone who is targeting you.',
+        ],
+      },
+      {
+        type: 'p',
+        text: 'These guidelines are deliberately short. When something is not covered, the test is simple: does it help survivors build, or does it hand the space to the people this platform exists to get away from?',
+      },
+    ],
+  },
+];

--- a/ctf/packages/web/app/guidelines/page.tsx
+++ b/ctf/packages/web/app/guidelines/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next';
+import styles from '../terms/terms.module.css';
+import { CONTACT_EMAIL, OPERATOR_NAME } from '../terms/policy-content';
+import { GUIDELINE_SECTIONS, GUIDELINES_EFFECTIVE_DATE, type GuidelineSection } from './guidelines-content';
+
+// Public community discussion guidelines at /guidelines. Static, no auth — the operator
+// links this page in-app (Commons footnote, gated channel, /terms footer) so a violation
+// can always be answered with a citation instead of an argument. Reuses the /terms styling
+// so the two policy pages read as one set.
+
+export const metadata: Metadata = {
+  title: 'Community Guidelines — Charging the Future',
+  description: 'What discussions belong on the Charging the Future community platform, what does not, and how the rules are enforced.',
+};
+
+function GuidelineSectionView({ section }: { section: GuidelineSection }) {
+  return (
+    <section id={section.id} className={styles.document}>
+      <h2 className={styles.documentTitle}>{section.heading}</h2>
+      {section.blocks.map((block, index) =>
+        block.type === 'p' ? (
+          <p key={index} className={styles.paragraph}>{block.text}</p>
+        ) : (
+          <ul key={index} className={styles.list}>
+            {block.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        ),
+      )}
+    </section>
+  );
+}
+
+export default function GuidelinesPage() {
+  return (
+    <main className={styles.page}>
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <p className={styles.brand}>Charging the Future</p>
+          <h1 className={styles.title}>Community Guidelines</h1>
+          <p className={styles.updated}>Last updated: {GUIDELINES_EFFECTIVE_DATE}</p>
+        </header>
+
+        {GUIDELINE_SECTIONS.map((section) => (
+          <GuidelineSectionView key={section.id} section={section} />
+        ))}
+
+        <footer className={styles.footer}>
+          {OPERATOR_NAME} · Contact{' '}
+          <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
+            {CONTACT_EMAIL}
+          </a>{' '}
+          ·{' '}
+          <a className={styles.link} href="/terms">
+            Terms &amp; Privacy
+          </a>{' '}
+          ·{' '}
+          <a className={styles.link} href="/guide">
+            How to use it
+          </a>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/ctf/packages/web/app/terms/page.tsx
+++ b/ctf/packages/web/app/terms/page.tsx
@@ -99,6 +99,10 @@ export default function TermsPage() {
           ·{' '}
           <a className={styles.link} href="/guide">
             How to use it
+          </a>{' '}
+          ·{' '}
+          <a className={styles.link} href="/guidelines">
+            Community guidelines
           </a>
         </footer>
       </div>

--- a/ctf/packages/web/components/community-shell/gated-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/gated-chat-panel.tsx
@@ -219,7 +219,10 @@ export function GatedChatPanel({ currentUser, isAdmin = false }: GatedChatPanelP
         </button>
       </div>
 
-      <p className={styles.chatFootnote}>{GATED_CHANNEL_MODERATOR_DISCLOSURE} No images here — text only.</p>
+      <p className={styles.chatFootnote}>
+        {GATED_CHANNEL_MODERATOR_DISCLOSURE} No images here — text only.{' '}
+        <a href="/guidelines" style={{ color: 'inherit', textDecoration: 'underline' }}>Community guidelines</a>
+      </p>
     </div>
   );
 }

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -755,7 +755,8 @@ function AuthenticatedChatPanel({ stats, plugins, currentUser }: AuthenticatedCh
       </div>
 
       <p className={styles.chatFootnote}>
-        {isLive ? 'Human-in-the-loop AI support and community support channel.' : 'Support channel keeps syncing as new messages arrive.'}
+        {isLive ? 'Human-in-the-loop AI support and community support channel.' : 'Support channel keeps syncing as new messages arrive.'}{' '}
+        <a href="/guidelines" style={{ color: 'inherit', textDecoration: 'underline' }}>Community guidelines</a>
       </p>
 
       <ComicConsentModal open={consentModalOpen} onConfirm={() => void confirmConsent()} onDismiss={dismissConsent} />


### PR DESCRIPTION
Owner request (after moderating a Commons thread): a brief, citable policy on acceptable and unacceptable discussions, linked in-app, so a violation can be answered with a link instead of an argument.

## What ships

- **`/guidelines`** — public, sign-in-free, same pattern and styling as `/terms` (content as plain data + a small renderer). Four short sections:
  - *What this platform is for* — building a psyop-free economy; the focus is us, not them; applies to every discussion space (Commons, members-only channel, Direct Lines, replies).
  - *Discussions that belong here* — real help asked and offered, app questions, honest survivor conversation, meeting here and continuing off-platform around a psyop-free life.
  - *Discussions that do not belong here* — advocating/encouraging/joking about violence or harm toward anyone, no exceptions; perp/operation-focused threads (that analysis has its place elsewhere, e.g. Quora); harassment; soliciting money/financial details or scams; sharing someone's personal information; spam; impersonating staff.
  - *How this is enforced* — reminder and redirect first; message removal; account restriction for repeated or serious cases; members-only channel access revoked for reviewed cause; block + safety-report tools.
- **Linked in-app** where discussions happen: the Commons chat footnote, the gated channel footnote (next to the moderator disclosure), and the `/terms` footer (which also gains the back-link from `/guidelines`).

Typecheck, eslint, accessibility lint, and EOF gate all pass. New public copy page + two footnote links; no schema, route-behavior, or contract change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_