### PR TITLE
fix: stop Commons posts rendering twice right after sending

### DIFF
--- a/ctf/packages/web/components/community-shell/use-home-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-home-chat.ts
@@ -132,6 +132,15 @@ function applyReactionToggle(message: ChatMessage, emoji: string): ChatMessage {
 }
 
 function getMessageDedupKey(message: ChatMessage): string {
+  // A peer post is the same post wherever it arrived from: the POST /api/hub/messages response
+  // carries the post id with its created time, while the GET list carries the timeline item id
+  // with its published time. Keying on the stable community post id keeps those two copies from
+  // rendering as a temporary duplicate whenever their timestamps straddle a minute boundary (the
+  // composite key below folds the formatted time label in, so "9:32 PM" vs "9:33 PM" defeated
+  // it). Non-post lines (AI answers, concierge, announcement rows) keep the composite key.
+  if (message.communityPostId) {
+    return `post|${message.communityPostId}`;
+  }
   return [message.from, message.senderLabel ?? '', message.text.trim().toLowerCase(), message.time].join('|');
 }
 


### PR DESCRIPTION
Owner report (screenshot): a just-published Commons message shows twice, then one copy disappears on the next full reload.

Cause: the same post arrives twice with different shapes — the `POST /api/hub/messages` response carries the community post id with its created time, while the poll/live `GET` list carries the hub timeline item id with its published time. The client's merge dedup key was `sender|label|text|formatted-minute` — so whenever the two timestamps straddled a minute boundary ("9:32 PM" vs "9:33 PM"), the same post passed dedup twice. The duplicate survived until something rebuilt the list from the server alone.

Fix: for peer posts the dedup key is now the stable `communityPostId` (identical in both payloads); non-post lines (AI answers, concierge, announcement rows) keep the composite key. One function in `use-home-chat.ts`; the gated channel hook is unaffected (it replaces the whole list on refresh).

Typecheck, eslint, and the EOF gate pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_