### PR TITLE
fix: Beacon broadcasts are from Farah, not from the team

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -232,6 +232,12 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 
 ## Change Log
 
+- 2026-07-19: **Copy: broadcasts are "from Farah", not "from the team" (owner report).** The
+  platform has a single operator, so "the team" was inaccurate. Updated everywhere the phrase
+  shipped: the plugin-registry summary (schema seed + in-code fallback), the web viewer intro and
+  idle line, and the Android intro and idle line. Copy only; no schema-structure, route, or
+  contract change (the seed row's summary text is upserted on the next database update run).
+
 - 2026-07-18: **Beacon added to the app launcher (owner report: no way to reach the member page).**
   The `ctf_plugin_registry` seed in `ctf/schema.sql` had no `beacon` row, so the launcher — which
   reads the database registry, not the in-code fallback — never showed the tile and members could

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -36,9 +36,10 @@
 One-way admin broadcast; public watch, sign-in to chat. Member role unless noted.
 
 1. **Idle state loads — and Beacon is reachable from the app list.** The Apps launcher shows a
-   Beacon tile (database registry row, nav rank 230) that opens `/apps/beacon`. When nothing is
-   live, a calm "No live event right now" screen renders, with the last replay if one exists. No
-   spinner stuck, no error. → web ☐ mobile ☐ android ☐
+   Beacon tile (database registry row, nav rank 230) that opens `/apps/beacon`. Broadcast copy
+   says "from Farah" (single operator), never "from the team". When nothing is live, a calm "No
+   live event right now" screen renders ("When Farah goes live, it will appear here"), with the
+   last replay if one exists. No spinner stuck, no error. → web ☐ mobile ☐ android ☐
 2. **Anyone can watch, no sign-in.** Sign out and open `/apps/beacon`. The viewer surface still loads
    over the public path (HLS); there is no phone-number or account wall to watch. → web ☐ mobile ☐ android ☐
 3. **Chat is gated to members.** As a signed-out viewer, confirm chat is read-only / shows a "sign in

--- a/ctf/packages/mobile/src/features/beacon/Beacon.tsx
+++ b/ctf/packages/mobile/src/features/beacon/Beacon.tsx
@@ -110,7 +110,7 @@ export const Beacon: React.FC = () => {
     >
       <Text style={[styles.title, { color: tokens.textPrimary }]}>Beacon</Text>
       <Text style={[styles.subtitle, { color: tokens.textSecondary }]}>
-        Live broadcasts from the team. Watch with just the app; sign in to chat and react.
+        Live broadcasts from Farah. Watch with just the app; sign in to chat and react.
       </Text>
 
       {loading ? (

--- a/ctf/packages/mobile/src/features/beacon/BeaconIdleView.tsx
+++ b/ctf/packages/mobile/src/features/beacon/BeaconIdleView.tsx
@@ -26,7 +26,7 @@ export const BeaconIdleView: React.FC<BeaconIdleViewProps> = ({ tokens, replay }
     <View style={styles.idleCard}>
       <Text style={[styles.idleTitle, { color: tokens.textPrimary }]}>No live event right now</Text>
       <Text style={[styles.idleBody, { color: tokens.textSecondary }]}>
-        When the team goes live, it will appear here.
+        When Farah goes live, it will appear here.
       </Text>
       {replay?.recordingUrl ? (
         <View style={styles.replayBlock}>

--- a/ctf/packages/web/components/beacon/beacon-viewer.tsx
+++ b/ctf/packages/web/components/beacon/beacon-viewer.tsx
@@ -161,7 +161,7 @@ export function BeaconViewer({ signInUrl, isMember }: { signInUrl: string; isMem
         <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>Beacon</h1>
       </div>
       <p style={{ color: t.SUBTLE, fontSize: 14, marginTop: 0 }}>
-        Live broadcasts from the team. Watch with just a link; sign in to chat and react.
+        Live broadcasts from Farah. Watch with just a link; sign in to chat and react.
       </p>
 
       {loading ? (
@@ -236,7 +236,7 @@ export function BeaconViewer({ signInUrl, isMember }: { signInUrl: string; isMem
         <div style={{ ...panelStyle(t), textAlign: 'center', padding: '48px 24px' }}>
           <Radio size={40} style={{ color: t.SUBTLE, display: 'block', margin: '0 auto 12px' }} />
           <div style={{ fontSize: 16, fontWeight: 600 }}>No live event right now</div>
-          <p style={{ color: t.SUBTLE, fontSize: 14, marginTop: 6 }}>When the team goes live, it will appear here.</p>
+          <p style={{ color: t.SUBTLE, fontSize: 14, marginTop: 6 }}>When Farah goes live, it will appear here.</p>
           {replay?.recordingUrl ? (
             <div style={{ marginTop: 20, textAlign: 'left' }}>
               <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Last replay</div>

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -221,7 +221,7 @@ const fallbackPluginRegistry: PluginRegistryItem[] = [
   {
     slug: 'beacon',
     name: 'Beacon',
-    summary: 'Live one-way broadcasts from the team. Watch publicly with just a link; sign in to chat and react.',
+    summary: 'Live one-way broadcasts from Farah. Watch publicly with just a link; sign in to chat and react.',
     availabilityState: 'implemented_shell',
     navRank: 230,
     isVisible: true,

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -2128,7 +2128,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('what-works',          'WhatWorks',            'One shared, survivor-verified list of tools — organized by the exact problems survivors face. No ads, no affiliates.','implemented_shell', 200, TRUE),
   ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'implemented_shell', 210, TRUE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE),
-  ('beacon',             'Beacon',               'Live one-way broadcasts from the team. Watch publicly with just a link; sign in to chat and react.','implemented_shell', 230, TRUE),
+  ('beacon',             'Beacon',               'Live one-way broadcasts from Farah. Watch publicly with just a link; sign in to chat and react.','implemented_shell', 230, TRUE),
   ('recurring-activity', 'Recurring Activity',   'Acknowledge an ongoing activity with another member — one tap, no amounts to report. Recognition of your everyday ties, never a bill.','implemented_shell', 240, TRUE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2130,7 +2130,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('what-works',          'WhatWorks',            'One shared, survivor-verified list of tools — organized by the exact problems survivors face. No ads, no affiliates.','implemented_shell', 200, TRUE),
   ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'implemented_shell', 210, TRUE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE),
-  ('beacon',             'Beacon',               'Live one-way broadcasts from the team. Watch publicly with just a link; sign in to chat and react.','implemented_shell', 230, TRUE),
+  ('beacon',             'Beacon',               'Live one-way broadcasts from Farah. Watch publicly with just a link; sign in to chat and react.','implemented_shell', 230, TRUE),
   ('recurring-activity', 'Recurring Activity',   'Acknowledge an ongoing activity with another member — one tap, no amounts to report. Recognition of your everyday ties, never a bill.','implemented_shell', 240, TRUE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,


### PR DESCRIPTION
Owner report: Beacon copy said "Live one-way broadcasts from the team" / "When the team goes live" — but the platform has a single operator. Every shipped occurrence now says Farah:

- Plugin-registry summary — `ctf/schema.sql` seed row + the in-code fallback in `lib/plugins/repository.ts` (`schema.demo.sql` regenerated). The live registry row updates on the next database update run, which I dispatch after merge.
- Web viewer (`beacon-viewer.tsx`): intro line and the idle "When Farah goes live, it will appear here."
- Android (`Beacon.tsx`, `BeaconIdleView.tsx`): same two lines.

Beacon inventory change-log entry and test-script smoke step updated. Copy only; no schema-structure, route, or contract change. All gates pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_