### PR TITLE
fix: move the phone gift reminder into the top bar

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -297,6 +297,13 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-07-19: **Phone gift reminder moved into the top bar (owner report: the collapsed strip read
+  as wasted space).** After dismissing the fundraiser banner on phone width, the 🎁 reminder now
+  renders in the top bar between the TSE mark and the section tabs (`ContributionsGiftTrigger` in
+  `contributions-banner.tsx`, mounted by `community-shell.tsx`) instead of keeping a dedicated
+  strip where the banner was. The open banner is unchanged and stays at the top of the content
+  area; desktop dismiss behavior is unchanged (nothing until the snooze lapses). UI-only.
+
 - 2026-07-18: Phone-width fundraiser banner is dismissible again and collapses to a subtle emoji
   (owner request). The "Not now" dismiss control is restored on both layouts. On phone width,
   dismissing no longer removes the reminder — the full banner collapses to a small gift emoji (🎁) in

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -106,13 +106,16 @@ plain language. An empty history shows the empty state, not an error.
 **Steps:**
 1. With the banner showing in the Hub, press **Contribute**.
 2. Press **Not now** to dismiss.
-3. On phone width, look at where the banner was. On desktop, look at where the banner was.
+3. On phone width, look at the top bar (between the TSE mark and the Commons tab). On desktop, look
+   at where the banner was.
 **Expected:** **Contribute** opens the drive at `/apps/contributions` — the page renders (not a 404).
 The banner shows a **Not now** dismiss on both layouts. After dismissing on **phone width**, the full
-banner is replaced by a small gift emoji (🎁) in its place that still opens the plugin when tapped
-(the full banner returns on its own after the snooze lapses). After dismissing on **desktop**, the
-banner is gone until the snooze lapses (no emoji). If the admin turns the banner feature off, neither
-the banner nor the emoji shows. (Android app has no fundraiser banner.)
+banner disappears and a small gift emoji (🎁) appears in the top bar between the TSE mark and the
+section tabs — no leftover strip where the banner was — and it still opens the plugin when tapped
+(the full banner returns on its own after the snooze lapses, in its usual place at the top of the
+content area). After dismissing on **desktop**, the banner is gone until the snooze lapses (no
+emoji). If the admin turns the banner feature off, neither the banner nor the emoji shows. (Android
+app has no fundraiser banner.)
 **Result:** web ☐ mobile ☐ android n/a — notes:
 
 ### CON-6 · Refresh the drive

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -17,7 +17,7 @@ import { ShellChatPanel } from './shell-chat-panel';
 import { GatedChatPanel } from './gated-chat-panel';
 import { ShellAppsPanel } from './shell-apps-panel';
 import { ShellRightRail } from './shell-right-rail';
-import { ContributionsBanner } from '../contributions/contributions-banner';
+import { ContributionsBanner, ContributionsGiftTrigger } from '../contributions/contributions-banner';
 import { UnlockVerifyBanner } from './unlock-verify-banner';
 import { HelpControl } from '../bug-reports/help-control';
 import type { UnlockReviewStatus } from '../../lib/unlock/types';
@@ -280,6 +280,10 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
             margin-left:auto so the tabs + controls cluster on the right. "TSE" matches the site
             title "TI Skills Economy (TSE)" in layout.tsx. */}
         <div className={styles.mobileBarLogo} aria-hidden="true">TSE</div>
+        {/* Fundraiser gift reminder — sits between the TSE mark and the section tabs (owner
+            placement). Renders only on phone widths while a drive is active and the full banner is
+            dismissed or snoozed; the banner itself (when open) stays in the content area below. */}
+        {isAuthenticated ? <ContributionsGiftTrigger /> : null}
         <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
           <button
             type="button"

--- a/ctf/packages/web/components/contributions/contributions-banner.tsx
+++ b/ctf/packages/web/components/contributions/contributions-banner.tsx
@@ -30,11 +30,16 @@ function bannerGoals(f: FundraiserResponse['fundraiser']): BannerGoal[] {
  * only renders while a drive is active and the banner feature is on. "Contribute" opens the plugin;
  * "Not now" calls the server-side silent snooze (the duration is never shown).
  *
- * On phone width, dismissing does not remove the reminder entirely — the full banner collapses to a
- * small gift emoji in its place that still opens the plugin, so it stays a subtle nudge without
- * taking up space. The full banner returns on its own when the snooze lapses. On desktop, dismissing
- * hides it until the snooze lapses (no emoji — a slim desktop bar is already unobtrusive).
+ * On phone width, dismissing does not remove the reminder entirely — the reminder becomes the small
+ * gift emoji in the top bar (ContributionsGiftTrigger below, mounted between the TSE mark and the
+ * section tabs), so no strip of vertical space is spent on it. The full banner returns on its own
+ * when the snooze lapses. On desktop, dismissing hides it until the snooze lapses (no emoji — a
+ * slim desktop bar is already unobtrusive).
  */
+
+// Cross-component signal: the banner's "Not now" tells the top-bar trigger to appear without a
+// reload (the two components fetch fundraiser state independently).
+const BANNER_DISMISSED_EVENT = 'ctf:contributions-banner-dismissed';
 export function ContributionsBanner() {
   const isMobile = useIsMobile();
   const { theme } = useTheme();
@@ -68,6 +73,7 @@ export function ContributionsBanner() {
 
   const onDismiss = useCallback(async () => {
     setCollapsed(true);
+    window.dispatchEvent(new Event(BANNER_DISMISSED_EVENT));
     try {
       await fetch('/api/contributions/banner/dismiss', { method: 'POST', headers: CSRF_HEADERS });
     } catch {
@@ -82,24 +88,8 @@ export function ContributionsBanner() {
 
   const showFullBanner = fundraiser.bannerVisible && !collapsed;
 
-  // Phone width, dismissed or snoozed → a subtle gift-emoji reminder in the banner's place.
-  if (isMobile && !showFullBanner) {
-    return (
-      <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', padding: '5px 12px', background: `${t.ACCENT}0A`, borderBottom: `1px solid ${t.ACCENT}20`, fontFamily: FONT_FAMILY }}>
-        <button
-          type="button"
-          onClick={onContribute}
-          aria-label="Contribute to the platform"
-          title="Contribute"
-          style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 20, lineHeight: 1, padding: 4 }}
-        >
-          🎁
-        </button>
-      </div>
-    );
-  }
-
-  // Desktop, dismissed or snoozed → nothing until the snooze lapses.
+  // Dismissed or snoozed → nothing here. On phone width the reminder lives on as the gift emoji
+  // in the top bar (ContributionsGiftTrigger); a dedicated strip here read as wasted space.
   if (!showFullBanner) {
     return null;
   }
@@ -178,5 +168,63 @@ export function ContributionsBanner() {
         </button>
       </div>
     </div>
+  );
+}
+
+/**
+ * The phone-top-bar gift reminder: a small 🎁 between the TSE mark and the section tabs (owner
+ * placement decision, 2026-07-19). It appears only while a drive is active AND the full banner is
+ * not showing (dismissed this session or server-snoozed), so the reminder survives without
+ * spending a strip of vertical space. Opens the Contributions plugin. Phone widths only — on
+ * desktop a dismissed banner shows nothing until the snooze lapses, unchanged.
+ */
+export function ContributionsGiftTrigger() {
+  const isMobile = useIsMobile();
+  const router = useRouter();
+
+  const [fundraiser, setFundraiser] = useState<FundraiserResponse['fundraiser'] | null>(null);
+  const [dismissedThisSession, setDismissedThisSession] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      try {
+        const res = await fetch('/api/contributions/fundraiser', { cache: 'no-store', signal: controller.signal });
+        if (!res.ok) return;
+        const data = (await res.json()) as FundraiserResponse;
+        if (!controller.signal.aborted) setFundraiser(data.fundraiser);
+      } catch {
+        // Non-critical chrome: a failed load just means no reminder.
+      }
+    }
+    void load();
+    return () => controller.abort();
+  }, []);
+
+  // The banner's "Not now" makes this trigger appear immediately, without a reload.
+  useEffect(() => {
+    const onDismissed = () => setDismissedThisSession(true);
+    window.addEventListener(BANNER_DISMISSED_EVENT, onDismissed);
+    return () => window.removeEventListener(BANNER_DISMISSED_EVENT, onDismissed);
+  }, []);
+
+  if (!isMobile || !fundraiser || !fundraiser.cycle || !fundraiser.bannerEnabled) {
+    return null;
+  }
+  // While the full banner is visible (and not just dismissed), the top-bar reminder is redundant.
+  if (fundraiser.bannerVisible && !dismissedThisSession) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.push('/apps/contributions')}
+      aria-label="Contribute to the platform"
+      title="Contribute"
+      style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: '2px 4px', flexShrink: 0 }}
+    >
+      🎁
+    </button>
   );
 }


### PR DESCRIPTION
Owner report (screenshot): after dismissing the fundraiser banner on a phone, the collapsed gift-emoji strip kept a whole row of vertical space — wasted. Owner placement decision: put the gift between the TSE mark and the Commons tab in the top bar; keep the open banner where it is.

- The collapsed-strip branch of `ContributionsBanner` is removed — a dismissed/snoozed banner now renders nothing in the content area.
- New `ContributionsGiftTrigger` (same file) renders the 🎁 in the phone top bar between the TSE mark and the section tabs, only while a drive is active and the full banner is dismissed or snoozed. Tapping it opens `/apps/contributions`. A dismiss event from the banner makes it appear instantly, no reload.
- The open banner is untouched (top of the content area); desktop dismiss behavior unchanged (nothing until the snooze lapses).
- Contributions inventory change-log and test-script case CON-5 updated to the new placement.

Typecheck, eslint, accessibility lint, EOF, and test-script drift gates pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_