### PR TITLE
docs: state the PeerProgramming non-member limit as fact in the guide

### DIFF
--- a/ctf/docs/USER_GUIDE.md
+++ b/ctf/docs/USER_GUIDE.md
@@ -110,7 +110,7 @@ PeerProgramming places active members into small weekly groups of about five peo
 
 The room is text-first with a topic header and supports threaded replies. The timeline stays and comes back after you reconnect.
 
-Group members can post and reply; others may have a more limited view. You can submit feedback from the room.
+Group members can post and reply; everyone else can open a group read-only to listen in, and can never post in it. You can submit feedback from the room.
 
 **How to use it**
 

--- a/ctf/packages/web/app/guide/guide-content.json
+++ b/ctf/packages/web/app/guide/guide-content.json
@@ -98,7 +98,7 @@
       "body": [
         "PeerProgramming places active members into small weekly groups of about five people. When you are assigned, you get an in-app notice with the group and the week's topic.",
         "The room is text-first with a topic header and supports threaded replies. The timeline stays and comes back after you reconnect.",
-        "Group members can post and reply; others may have a more limited view. You can submit feedback from the room."
+        "Group members can post and reply; everyone else can open a group read-only to listen in, and can never post in it. You can submit feedback from the room."
       ],
       "howTo": [
         "Open PeerProgramming. Your group loads, or you see a \"not in a group yet\" state.",


### PR DESCRIPTION
Owner report (screenshot of `/guide`): the PeerProgramming section said "others may have a more limited view" — hedging a definite rule.

The shipped behavior is definite: any signed-in member can open another group read-only (listener access), and posting is membership-gated server-side, so a non-member can never post. The guide (`guide-content.json` + `USER_GUIDE.md`) now reads: "Group members can post and reply; everyone else can open a group read-only to listen in, and can never post in it."

Docs only.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_