### PR TITLE
fix: Android Workforce overview parity — headcount tile dropped, goal subtitle

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
@@ -442,6 +442,10 @@ Profile read + compliance-delete surface: the profile is read-only (owner decisi
 
 ### Change Log
 
+- 2026-07-19: **Android parity for the overview (owner: "parity android now").** The Android
+  Overview tab drops its "Headcount Target" tile (same duplicate-of-Workforce-Total reasoning as
+  web), and the screen subtitle now reads "{recruited} recruited · {min recruitable} goal" instead
+  of measuring against the headcount target — matching the web card's goal framing. UI-only.
 - 2026-07-19: **Dropped the "Total Headcount Target" hero card from the web overview (owner
   decision).** It was Workforce Total re-summed after per-sector rounding (1,999,998 vs 2,000,000)
   — a duplicate at the top level. The overview now shows Population, Workforce Total, and

--- a/ctf/docs/developer/test-scripts/workforce-test-script.md
+++ b/ctf/docs/developer/test-scripts/workforce-test-script.md
@@ -34,8 +34,9 @@ Workforce is a read-only live tracker — these are the can't-ship-broken checks
 
 1. **Dashboard loads with numbers.** Open the Workforce dashboard. Population, Workforce Total,
    and Recruited all render as numbers, not a spinner or error. There is NO "Total Headcount
-   Target" card on web — it duplicated Workforce Total after sector rounding (dropped 2026-07-19);
-   per-sector targets live in the Sectors view. → web ☐ mobile ☐ android ☐
+   Target" card on any surface — it duplicated Workforce Total after sector rounding (dropped
+   2026-07-19, web and android); per-sector targets live in the Sectors view. On android the
+   screen subtitle reads "{recruited} recruited · {goal} goal". → web ☐ mobile ☐ android ☐
 2. **Top-line numbers reconcile.** Recruited equals the count of all active Directory members, and
    the Recruitment Progress shows a percent of target, not a repeated count. → web ☐ mobile ☐ android ☐
 3. **No write controls on the profile.** Open the Workforce profile view. There is no profile editor

--- a/ctf/packages/mobile/src/features/workforce/WorkforceDashboard.tsx
+++ b/ctf/packages/mobile/src/features/workforce/WorkforceDashboard.tsx
@@ -55,9 +55,10 @@ function StatGrid({ dashboard }: { dashboard: WorkforceDashboardData }) {
   const { accent, styles } = useWorkforceStyles();
   // Stat-tile series palette (indigo/red/green data colors) stays raw; only the plugin accent is themed.
   const stats = [
+    // "Headcount Target" was dropped (owner decision, 2026-07-19, parity with web): it is
+    // Workforce Total re-summed after per-sector rounding — a duplicate at the overview level.
     { label: 'Population', value: formatCount(dashboard.population), color: '#6366F1' },
     { label: 'Workforce Total', value: formatCount(dashboard.workforceTotal), color: accent },
-    { label: 'Headcount Target', value: formatCount(dashboard.totalHeadcountTarget), color: '#EF4444' },
     { label: 'Recruited', value: formatCount(dashboard.recruitedTotal), color: '#22C55E' },
   ];
 
@@ -190,7 +191,7 @@ export function WorkforceDashboard() {
     || (dashboard.sectorsTotal === 0 && dashboard.occupationsTotal === 0 && dashboard.totalMembers === 0);
 
   const subtitle = dashboard
-    ? `${formatCount(dashboard.recruitedTotal)} recruited · ${formatCount(dashboard.totalHeadcountTarget)} target`
+    ? `${formatCount(dashboard.recruitedTotal)} recruited · ${formatCount(dashboard.minRecruitable)} goal`
     : 'Live workforce tracker';
 
   const tabs: { key: WorkforceTab; label: string }[] = [


### PR DESCRIPTION
Android half of the Workforce overview cleanup (#1697, merged): owner directive "parity android now".

- The Android Overview tab drops its "Headcount Target" stat tile — the same duplicate-of-Workforce-Total-after-sector-rounding reasoning as the web card.
- The screen subtitle now reads `{recruited} recruited · {goal} goal` against the 2,000,000 recruitment goal (`minRecruitable`, already in the API payload) instead of the headcount target.

Workforce inventory change-log and test-script WF-1/smoke updated to cover all surfaces. Mobile typecheck, EOF, and test-script drift gates pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_