### PR TITLE
fix: hide Weekly Performance from the member home hub app list

### DIFF
--- a/ctf/packages/web/app/page.tsx
+++ b/ctf/packages/web/app/page.tsx
@@ -6,7 +6,7 @@ import { resolveRequestIdentity } from '../lib/auth/request-identity';
 import { getUnlockAccessTier, isUnlockEarlyCommonsEnabled } from '../lib/unlock/access';
 import { getUnlockStatusForUser } from '../lib/unlock/repository';
 import { getGdpShellStats } from '../lib/gdp/repository';
-import { listPluginRegistry } from '../lib/plugins/repository';
+import { listPluginRegistry, filterPluginsForViewer } from '../lib/plugins/repository';
 import { getTrustUserExtension } from '../lib/trust/repository';
 import { getHostedSignInUrl } from '../lib/auth/provider-env';
 
@@ -46,6 +46,12 @@ export default async function HomePage() {
 
   const userId = identity?.isAuthenticated ? identity.userId : null;
   const isAdmin = identity?.isAdmin ?? false;
+
+  // Operator-only plugins (e.g. Weekly Performance) must not appear in the member hub's app list.
+  // The /apps launcher and /api/plugins already apply this filter; the home hub did not, so an
+  // admin-only tile leaked to members here. Admins still see the full list. The plugin's own route
+  // is separately gated, so this only hides the tile.
+  const visiblePlugins = filterPluginsForViewer(plugins, isAdmin);
 
   // Unlock is the single source of truth for who reaches the Hub. Resolve the tier once and branch:
   //   - not signed in                         -> anonymous shell (sign-in prompt)
@@ -103,7 +109,7 @@ export default async function HomePage() {
 
   return (
     <CommunityShell
-      initialPlugins={plugins}
+      initialPlugins={visiblePlugins}
       shellStats={shellStats}
       currentUser={currentUser}
       trust={trust}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## What was wrong
Weekly Performance is an operator-only plugin (`ADMIN_ONLY_PLUGIN_SLUGS`), and its route is already admin-gated. But the **home hub** (`app/page.tsx`) passed the full plugin registry straight to `CommunityShell` without the admin-only filter, so the Weekly Performance tile still showed up in the member app list on the home page.

## The fix
Apply the existing `filterPluginsForViewer(plugins, isAdmin)` in `app/page.tsx` before passing the list to `CommunityShell` — the same filter the `/apps` launcher and the `/api/plugins` endpoint already use. Admins still see the tile; members no longer do. Because the plugin's own route is separately admin-gated, members never had access — this just removes the stray tile.

The other surfaces were already correct: `/apps` filters directly, the `/apps/[slug]` route redirects/404s non-admins, and the mobile app's launcher reads the already-filtered `/api/plugins`. So no mobile/Android change is needed — this completes the behavior across all surfaces.

No schema, route, or contract change. The weekly-performance inventory already documents the plugin as admin-only in navigation; this brings the home hub in line with that.

## Verification
- `pnpm -r typecheck` passes (web, mobile, shared).
- `eslint` clean on `app/page.tsx`.
- Inventory-drift, test-script-drift, and EOF gates pass.
- Note: the local `next build` can't run in the sandbox (a Turbopack workspace-root / font-install quirk); CI runs `build:ci` with a full install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBWjkYDEKzCHwHfQY6hCo8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBWjkYDEKzCHwHfQY6hCo8)_