### PR TITLE
fix: guard reportError Sentry capture with shouldEnableWebSentry

### DIFF
--- a/ctf/packages/web/lib/observability/report.ts
+++ b/ctf/packages/web/lib/observability/report.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
+import { shouldEnableWebSentry } from './sentry-config';
+
 type ReportContext = {
   // Coarse grouping for the error (e.g. 'chyme', 'directory', 'hub').
   area: string;
@@ -28,6 +30,14 @@ export function reportError(error: unknown, context: ReportContext): void {
     error instanceof Error ? (error.stack ?? error.message) : error,
     context.extra ? JSON.stringify(context.extra) : '',
   );
+
+  // Respect the same enable/disable logic as the rest of this module: when Sentry
+  // is intentionally off (CTF_SKIP_SENTRY_NEXTJS=1, an empty DSN, or the production
+  // build phase), the stdout log above is the only trace and we do not forward to
+  // Sentry.
+  if (!shouldEnableWebSentry()) {
+    return;
+  }
 
   Sentry.captureException(error, {
     tags: { area: context.area, op: context.op },


### PR DESCRIPTION
## What

`reportError` in `ctf/packages/web/lib/observability/report.ts` called `Sentry.captureException` unconditionally, bypassing the enable/disable logic (`shouldEnableWebSentry()`) used everywhere else in the observability module. When Sentry is intentionally off — `CTF_SKIP_SENTRY_NEXTJS=1`, an empty DSN, or the production build phase — errors were still forwarded to Sentry through this path.

## Change

Guard the `captureException` call with `shouldEnableWebSentry()` so this path respects the same switch as the reporter/provider abstraction. The stdout `console.error` log runs first and is unchanged, so caught errors stay visible in the platform runtime logs even when Sentry is off.

Smallest change that resolves the finding; no schema, contract, route, or delivery-status changes.

Parity Status: web + mobile-responsive + android complete

Closes #1710