### PR TITLE
fix: remove over-promising claims from LightHouse copy

### DIFF
--- a/ctf/packages/mobile/src/features/lighthouse/LighthouseEmptyState.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthouseEmptyState.tsx
@@ -15,12 +15,8 @@ export const LighthouseEmptyState: React.FC = () => {
       </View>
       <Text style={styles.heading}>No listings match</Text>
       <Text style={styles.body}>
-        Check back soon for safe, verified housing near you.
+        Check back soon for new housing listings near you.
       </Text>
-      <View style={styles.privacyBadge}>
-        <Ionicons name="shield-checkmark-outline" size={13} color={accent} />
-        <Text style={styles.privacyText}>Location is never stored</Text>
-      </View>
       <TouchableOpacity style={styles.primaryBtn} activeOpacity={0.8}>
         <Ionicons name="search-outline" size={16} color="#000" />
         <Text style={styles.primaryBtnText}>Adjust Filters</Text>

--- a/ctf/packages/mobile/src/features/lighthouse/LighthouseListHeader.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthouseListHeader.tsx
@@ -21,7 +21,7 @@ export const LighthouseListHeader: React.FC<Props> = ({ total }) => {
         <View>
           <Text style={styles.title}>LightHouse</Text>
           <Text style={styles.subtitle}>
-            {total > 0 ? `${total.toLocaleString()} verified listings` : 'Safe & verified housing'}
+            {total > 0 ? `${total.toLocaleString()} listings` : 'Community housing listings'}
           </Text>
         </View>
       </View>

--- a/ctf/packages/mobile/src/features/lighthouse/LighthousePropertyDetail.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthousePropertyDetail.tsx
@@ -159,13 +159,6 @@ export const LighthousePropertyDetail: React.FC<Props> = ({ property, currencies
               ))}
             </View>
           ) : null}
-          <View style={styles.privacyNote}>
-            <Ionicons name="lock-closed-outline" size={12} color={accent} />
-            <Text style={styles.privacyNoteTitle}>Privacy Protected</Text>
-          </View>
-          <Text style={styles.privacyBody}>
-            Your location is never shown until you confirm.
-          </Text>
         </View>
       </ScrollView>
     </View>

--- a/ctf/packages/mobile/src/features/lighthouse/LighthousePublicState.tsx
+++ b/ctf/packages/mobile/src/features/lighthouse/LighthousePublicState.tsx
@@ -20,10 +20,9 @@ export const LighthousePublicState: React.FC<Props> = ({ onSignIn, onJoin }) => 
         <Text style={styles.title}>LightHouse</Text>
       </View>
       <View style={styles.badge}>
-        <Text style={styles.badgeText}>Privacy-first housing</Text>
+        <Text style={styles.badgeText}>Community housing</Text>
       </View>
       <Text style={styles.description}>
-        Safe, verified housing. Your location is never shared without consent.
         Trauma-informed hosts. ServiceCredits accepted.
       </Text>
       <TouchableOpacity style={styles.joinBtn} activeOpacity={0.8} onPress={onJoin}>
@@ -54,7 +53,7 @@ export const LighthousePublicState: React.FC<Props> = ({ onSignIn, onJoin }) => 
 };
 
 const PREVIEW_LISTINGS = [
-  { title: 'Private Studio — Safe & Verified', price: '$850/mo' },
+  { title: 'Private Studio — Near transit', price: '$850/mo' },
   { title: 'Furnished 1BR — Female-only Floor', price: '$1,100/mo' },
   { title: 'Micro-unit — Month-to-month', price: '$650/mo' },
 ];

--- a/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-browse.tsx
@@ -26,8 +26,8 @@ export function LighthouseBrowse({
   return (
     <div style={{ padding: 24 }}>
       <div style={{ marginBottom: 20, padding: "18px 24px", borderRadius: 16, background: `linear-gradient(135deg,${t.ACCENT}15 0%,rgba(234,179,8,0.05) 100%)`, border: `1px solid ${t.ACCENT}25` }}>
-        <div style={{ fontSize: 20, fontWeight: 800, color: t.TITLE, marginBottom: 4 }}>Find Safe, Verified Housing</div>
-        <div style={{ fontSize: 14, color: t.SUBTLE }}>{totalCount} listings · {creditsCount} accept ServiceCredits · Privacy by design</div>
+        <div style={{ fontSize: 20, fontWeight: 800, color: t.TITLE, marginBottom: 4 }}>Housing listings</div>
+        <div style={{ fontSize: 14, color: t.SUBTLE }}>{totalCount} listings · {creditsCount} accept ServiceCredits</div>
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 14 }}>
         {properties.length === 0 ? (

--- a/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
@@ -72,14 +72,14 @@ function DesktopLightHousePublic({ signInUrl, verifyUrl }: { signInUrl: string; 
 
       <div style={{ padding: '48px 64px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
         <span style={{ padding: '4px 14px', borderRadius: 20, background: t.ACCENT + '20', border: `1px solid ${t.ACCENT}40`, fontSize: 12, color: t.ACCENT, fontWeight: 600, display: 'inline-block', width: 'fit-content' }}>
-          Privacy-first housing
+          Community housing
         </span>
         <h1 style={{ margin: 0, fontSize: 34, fontWeight: 800, lineHeight: 1.1 }}>
-          Safe, verified housing —<br />
-          <span style={{ color: t.ACCENT }}>your location stays private</span>
+          Housing listings<br />
+          <span style={{ color: t.ACCENT }}>for the survivor community</span>
         </h1>
         <p style={{ margin: 0, fontSize: 15, color: t.SUBTLE, maxWidth: 520 }}>
-          All listings are privacy-minimized. Your location is never shared without consent. Trauma-informed hosts. ServiceCredits accepted. Month-to-month options available.
+          Trauma-informed hosts. ServiceCredits accepted.
         </p>
         <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
           {verifyUrl ? (
@@ -109,7 +109,7 @@ function DesktopLightHousePublic({ signInUrl, verifyUrl }: { signInUrl: string; 
           <div style={{ width: 52, height: 52, borderRadius: '50%', border: `2px solid ${t.ACCENT}50`, background: t.ACCENT + '10', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <Lock size={22} color={t.ACCENT} />
           </div>
-          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to view safe housing</div>
+          <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center' }}>Sign in to view listings</div>
           <div style={{ fontSize: 13, color: t.MUTED, textAlign: 'center', maxWidth: 300 }}>
             Filter by price, location, availability, and Service Credit acceptance.
           </div>
@@ -133,8 +133,8 @@ function MobileLightHousePublic({ signInUrl, verifyUrl }: { signInUrl: string; v
           <Home size={20} color={t.ACCENT} />
           <span style={{ fontSize: 20, fontWeight: 800 }}>LightHouse</span>
         </div>
-        <span style={{ padding: '3px 12px', borderRadius: 20, background: t.ACCENT + '20', border: `1px solid ${t.ACCENT}40`, fontSize: 11, color: t.ACCENT, fontWeight: 600, width: 'fit-content' }}>Privacy-first housing</span>
-        <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Safe, verified housing. Your location is never shared without consent. Trauma-informed hosts. ServiceCredits accepted.</p>
+        <span style={{ padding: '3px 12px', borderRadius: 20, background: t.ACCENT + '20', border: `1px solid ${t.ACCENT}40`, fontSize: 11, color: t.ACCENT, fontWeight: 600, width: 'fit-content' }}>Community housing</span>
+        <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Trauma-informed hosts. ServiceCredits accepted.</p>
         <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
       </div>
 

--- a/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
@@ -242,8 +242,8 @@ export function LighthouseShell({ userId, username, isAdmin }: { userId: string;
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
         <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
           <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT, display: "flex", alignItems: "center", gap: 8 }}><Home size={16} strokeWidth={1.75} style={{ color: t.ACCENT }} /> LightHouse — Safe Housing</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Verified listings · Privacy-first</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT, display: "flex", alignItems: "center", gap: 8 }}><Home size={16} strokeWidth={1.75} style={{ color: t.ACCENT }} /> LightHouse</div>
+            <div style={{ fontSize: 12, color: t.MUTED }}>Trauma-informed hosts · ServiceCredits accepted</div>
           </div>
           <RefreshButton onRefresh={() => fetchAll()} title="Refresh" />
           <PluginAdminButton href="/admin/lighthouse" isAdmin={isAdmin} accent={t.ACCENT} />

--- a/ctf/packages/web/lib/plugins/plugin-catalog.ts
+++ b/ctf/packages/web/lib/plugins/plugin-catalog.ts
@@ -77,7 +77,7 @@ export const pluginCatalog: PluginCatalogItem[] = [
     id: 'lighthouse',
     name: 'LightHouse',
     kind: 'plugin',
-    summary: 'Verified survivor housing listings.',
+    summary: 'Community housing listings from trauma-informed hosts; ServiceCredits accepted.',
   },
   {
     id: 'socket-relay',

--- a/ctf/packages/web/lib/plugins/repository.ts
+++ b/ctf/packages/web/lib/plugins/repository.ts
@@ -101,7 +101,7 @@ const fallbackPluginRegistry: PluginRegistryItem[] = [
   {
     slug: 'lighthouse',
     name: 'LightHouse',
-    summary: 'Verified survivor housing listings.',
+    summary: 'Community housing listings from trauma-informed hosts; ServiceCredits accepted.',
     availabilityState: 'implemented_shell',
     navRank: 80,
     isVisible: true,

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -2113,7 +2113,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('skills-hunt',        'SkillsHunt',          'Nominate survivors to build the Directory and grow the economy.', 'implemented_shell', 60,  TRUE),
   ('unlock',             'Unlock',               'Internal verification queue and staged unlock orchestration for Quora URL onboarding.',           'implemented_shell', 65,  FALSE),
   ('foundation',         'Foundation',           'Find talent, tools, repairs, and infrastructure support in real time.',                      'implemented_shell', 70,  TRUE),
-  ('lighthouse',         'LightHouse',           'Verified survivor housing listings.',                             'implemented_shell', 80,  TRUE),
+  ('lighthouse',         'LightHouse',           'Community housing listings from trauma-informed hosts; ServiceCredits accepted.', 'implemented_shell', 80,  TRUE),
   ('socket-relay',         'SocketRelay',          'Real-time resource sharing across the network.',                        'implemented_shell', 90,  TRUE),
   ('trust-transport',    'TrustTransport',       'Vetted transportation for safe travel. Drivers screened by the community, for the community.',                           'implemented_shell', 100, TRUE),
   ('peer-programming',   'PeerProgramming',     'Weekly global mastermind sessions.',                            'implemented_shell', 110, TRUE),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2115,7 +2115,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('skills-hunt',        'SkillsHunt',          'Nominate survivors to build the Directory and grow the economy.', 'implemented_shell', 60,  TRUE),
   ('unlock',             'Unlock',               'Internal verification queue and staged unlock orchestration for Quora URL onboarding.',           'implemented_shell', 65,  FALSE),
   ('foundation',         'Foundation',           'Find talent, tools, repairs, and infrastructure support in real time.',                      'implemented_shell', 70,  TRUE),
-  ('lighthouse',         'LightHouse',           'Verified survivor housing listings.',                             'implemented_shell', 80,  TRUE),
+  ('lighthouse',         'LightHouse',           'Community housing listings from trauma-informed hosts; ServiceCredits accepted.', 'implemented_shell', 80,  TRUE),
   ('socket-relay',         'SocketRelay',          'Real-time resource sharing across the network.',                        'implemented_shell', 90,  TRUE),
   ('trust-transport',    'TrustTransport',       'Vetted transportation for safe travel. Drivers screened by the community, for the community.',                           'implemented_shell', 100, TRUE),
   ('peer-programming',   'PeerProgramming',     'Weekly global mastermind sessions.',                            'implemented_shell', 110, TRUE),


### PR DESCRIPTION
## Problem

The LightHouse copy over-promised. Per the owner, only **"Trauma-informed hosts"** and **"ServiceCredits accepted"** are accurate — claims like "Safe, verified housing", "your location is never shared / never shown / never stored", "Privacy-first", and "Privacy by design" are over-promises the product can't guarantee.

## Fix

Removed the over-promising claims across every LightHouse surface and kept only the two accurate ones:

- **Public shell** (web desktop + mobile) and **native public state**: badge → "Community housing"; headline → "Housing listings for the survivor community"; description → "Trauma-informed hosts. ServiceCredits accepted."
- **Browse header** ("Find Safe, Verified Housing" → "Housing listings"; dropped "· Privacy by design"), **shell header subtitle**, **native list header**, and **native empty state**: dropped the safe/verified/privacy wording.
- Removed the native detail **"Privacy Protected — location never shown"** note and the empty-state **"Location is never stored"** badge; de-claimed a mock preview title.
- **Plugin summary** updated in the code registry, the plugin catalog, and the `ctf_plugin_registry` seed (`schema.sql` + `schema.demo.sql` — the seed upserts `summary` on deploy, so production updates on the next migration).

Copy/data change only — no schema-structure, route, or contract change.

Verified locally: web typecheck + lint, mobile lint, and EOF format pass. (The mobile typecheck can't complete locally because main's `pnpm-lock.yaml` is missing the newly-added `@expo-google-fonts/inter` / `expo-font` entries — unrelated to this change, which touches no fonts; CI installs authoritatively.)

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXK6KNBC7CvP1kGHoznWd8)_