### PR TITLE
feat: peer-to-peer receipts join the ways-to-earn list; Android earn tab corrected

### DIFF
--- a/ctf/docs/developer/test-scripts/service-credits-test-script.md
+++ b/ctf/docs/developer/test-scripts/service-credits-test-script.md
@@ -22,6 +22,11 @@
 - Run **Core smoke** at the start of every test session before anything else.
 - "Web" means the Next.js app in a desktop browser. "Android" means the React Native app on a real Android device or emulator.
 - Run `pnpm --dir ctf seed:demo` once before the session and do not re-seed mid-session unless a case says to.
+- **"Ways to earn" is accurate (2026-07-19):** on web (signed-out landing + member shell) and the
+  Android Earn tab, the list is: Verify your account (+100), Help another member — they send you
+  credits (Per exchange), Take part in SkillsHunt (Per round), Contribute during a fundraiser
+  (Varies). No GentlePulse/LevelUp/referral platform payouts appear anywhere, and peer-to-peer
+  rows say "send credits", never "pay".
 - **Credits are not money** (`ctf/docs/DISCLAIMER.md`, mirrored in the inventory's Intent section):
   while walking any case below, no surface may describe credits as money/cash/currency/a payment,
   show a credits amount at a fiat equivalent, or offer any cash-out/withdrawal path. If one does,

--- a/ctf/packages/mobile/src/features/service-credits/sc-earn-tab.tsx
+++ b/ctf/packages/mobile/src/features/service-credits/sc-earn-tab.tsx
@@ -7,10 +7,15 @@ import { LEDGER } from './sc-styles';
 // Credit amounts shown here are platform documentation, not user-specific data.
 // No user-specific balances or transactions are displayed.
 
+// Mirrors the web list (service-credits.constants.ts, owner-confirmed model): the platform only
+// funds a few rewards; the main ongoing way to earn is peer-to-peer — another member sends you
+// credits for real help. The earlier list here (GentlePulse +5, LevelUp cohort +15, Refer +50)
+// promised platform payouts that do not exist and was removed.
 const EARN_WAYS = [
-  { title: 'Complete a GentlePulse session', credits: '+5 credits', color: '#34D399' },
-  { title: 'Attend a LevelUp cohort', credits: '+15 credits', color: '#22C55E' },
-  { title: 'Refer a survivor', credits: '+50 credits', color: '#22C55E' },
+  { title: 'Verify your account', credits: '+100', color: '#22C55E' },
+  { title: 'Help another member (they send you credits)', credits: 'Per exchange', color: '#38BDF8' },
+  { title: 'Take part in SkillsHunt', credits: 'Per round', color: '#FBBF24' },
+  { title: 'Contribute during a fundraiser', credits: 'Varies', color: '#A855F7' },
 ] as const;
 
 const SPEND_APPS = [

--- a/ctf/packages/web/components/service-credits/service-credits.constants.ts
+++ b/ctf/packages/web/components/service-credits/service-credits.constants.ts
@@ -21,6 +21,16 @@ export const PLATFORM_EARN_METHODS: {
     href: '/plugin/unlock',
   },
   {
+    // Peer-to-peer receipts are the main ongoing way to earn (owner addition, 2026-07-19): every
+    // exchange where another member sends you credits for real help counts.
+    title: 'Help another member',
+    detail: 'Provide a service or good — housing, transport, skills, requests — and the member sends you credits.',
+    credits: 'Per exchange',
+    note: 'ongoing',
+    color: '#38BDF8',
+    href: '/apps/directory',
+  },
+  {
     title: 'Take part in SkillsHunt',
     detail: 'Earn credits by competing in SkillsHunt rounds.',
     credits: 'Per round',
@@ -42,8 +52,9 @@ export const PLATFORM_EARN_METHODS: {
 // buyer — the same transactions, both directions — so this is both how you earn (beyond the platform
 // rewards above) and where you spend.
 export const PEER_TO_PEER_AREAS: { title: string; role: string; icon: string; color: string }[] = [
-  { title: 'Housing — LightHouse', role: 'Host a place / pay a host', icon: '🏠', color: '#60A5FA' },
-  { title: 'Transport — TrustTransport', role: 'Give rides / pay a driver', icon: '📦', color: '#38BDF8' },
-  { title: 'Services — Directory & Foundation', role: 'Offer your skills / hire help', icon: '🪛', color: '#F59E0B' },
+  // "send credits" phrasing, never "pay" — credits are a non-fiat internal unit (ctf/docs/DISCLAIMER.md).
+  { title: 'Housing — LightHouse', role: 'Host a place / send credits to a host', icon: '🏠', color: '#60A5FA' },
+  { title: 'Transport — TrustTransport', role: 'Give rides / send credits to a driver', icon: '📦', color: '#38BDF8' },
+  { title: 'Services — Directory & Foundation', role: 'Offer your skills / exchange credits for help', icon: '🪛', color: '#F59E0B' },
   { title: 'Requests — SocketRelay', role: 'Fulfill requests / ask for help', icon: '🔂', color: '#FB923C' },
 ];


### PR DESCRIPTION
Owner addition (screenshot of the ServiceCredits landing): a way to earn is a peer-to-peer receipt as well.

- **Web** (`service-credits.constants.ts`, feeds the signed-out landing and the member shell): new row right after account verification — **"Help another member"**: provide a service or good — housing, transport, skills, requests — and the member sends you credits. "Per exchange", ongoing, links to the Directory.
- Two accuracy fixes rode along:
  - The peer-to-peer area rows said "pay a host / pay a driver / hire help" — money-framing of credits, which the disclaimer defines as an error. Now "send credits to a host / send credits to a driver / exchange credits for help".
  - **The Android earn tab was stuck on the old overstated list** removed from web on 2026-06-19: GentlePulse +5, LevelUp cohort +15, Refer a survivor +50 — platform payouts that do not exist. It now mirrors the accurate list (Verify +100, Help another member, SkillsHunt per round, fundraiser varies).
- ServiceCredits inventory change-log entry and test-script standing check added (the earn list must match on every surface; "send credits", never "pay").

Copy/content only; no route, schema, or contract change. Web + mobile typecheck and eslint clean.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_