### PR TITLE
fix: remove the Admin-reviewed verification bullet from the Trust landing

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -139,6 +139,13 @@ Trust has no dedicated seed script, and none is required. Trust is a derived plu
 
 ## Change Log
 
+- 2026-07-19: **"Admin-reviewed verification" removed from the public landing's signal list
+  (owner report: can be misinterpreted).** The bullet read as the platform vetting people, a claim
+  this plugin deliberately never makes. Both the desktop and phone signal lists in
+  `trust-public-shell.tsx` now list four signals (Quora social proof, ServiceCredits activity,
+  Community connections, Cohort completion record). The underlying admin-set status itself is
+  unchanged — only the marketing bullet is gone. Copy only.
+
 - 2026-07-14: **Android pull-to-refresh on the Trust screen (`Trust.tsx`).** Dragging the empty or populated view down re-pulls `GET /api/trust/self` in the background without flashing the branded loading screen (the load function gained a background flag; the retry button reuses it). Mobile-client only — no backend, schema, route, or contract change.
 - 2026-07-14: Fixed odd trust evidence on the demo account. The demo seed (`seedDemo.mjs` `seedTrust`) wrote `trust_evidence` in a non-canonical shape (`{ type, date, source }` — no `summary`, no `createdAt`) and an invalid `trust_status` of `peer_verified`, so the account-hub `TrustWidgetCard` rendered a raw type slug (e.g. "Demo_second_owner") and "Invalid Date". Corrected the seed to write canonical `TrustEvidenceItem` rows (`type`/`summary`/`createdAt`/`createdBy`) with `trust_status: 'verified'` for both demo participants; re-running `seed:demo` overwrites the malformed rows. Hardened the renderers so a malformed or legacy item degrades gracefully: `TrustWidgetCard` now leads with the human `summary` (falling back to a humanized type instead of a raw slug) and only shows the date when `createdAt` parses (never "Invalid Date"); the mobile `Trust.tsx` and `TrustEvidencePanel.tsx` rows apply the same date guard, and `TrustEvidencePanel` drops the raw type-slug line in favour of the summary. No schema, route, or contract change.
 

--- a/ctf/docs/developer/test-scripts/trust-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-test-script.md
@@ -39,6 +39,9 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 4. **Unauthenticated call blocked.** Call `GET /api/trust/user/self` with no auth header. Expect HTTP 401 or 403, never 200.
    web ☐
 
+5. **Public landing lists four signals — no verification claim.** Signed out, open the Trust public landing. The signal list reads exactly: Quora social proof, ServiceCredits activity, Community connections, Cohort completion record. "Admin-reviewed verification" does NOT appear (removed 2026-07-19 — it read as the platform vetting people, a claim this plugin never makes).
+   web ☐
+
 ---
 
 ## Admin walkthrough

--- a/ctf/packages/web/components/trust/trust-public-shell.tsx
+++ b/ctf/packages/web/components/trust/trust-public-shell.tsx
@@ -13,15 +13,15 @@ const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
 // Static description of the voluntary signals Trust aggregates (marketing copy). Every item mirrors a
 // real signal in lib/trust (buildTrustEvidence): social proof and participation — never identity
-// verification (there is none) and never a numeric score (none is ever produced). Mapping:
+// verification (there is none) and never a numeric score (none is ever produced). "Admin-reviewed
+// verification" was removed from this list (owner, 2026-07-19): it read as the platform vetting
+// people, which this plugin deliberately never claims. Mapping:
 //   Quora social proof        → the public Quora profile checked at onboarding
-//   Admin-reviewed verification → the admin-set "Verified by an administrator" status
 //   ServiceCredits activity   → distinct members who completed a ServiceCredits transfer with you
 //   Community connections     → Foundation connections-as-provider + ongoing recurring activities
 //   Cohort completion record  → completed LevelUp / joined PeerProgramming cohorts
 const DESKTOP_SIGNALS = [
   'Quora social proof',
-  'Admin-reviewed verification',
   'ServiceCredits activity',
   'Community connections',
   'Cohort completion record',
@@ -29,7 +29,6 @@ const DESKTOP_SIGNALS = [
 
 const MOBILE_SIGNALS = [
   'Quora social proof',
-  'Admin-reviewed verification',
   'ServiceCredits activity',
   'Community connections',
   'Cohort completion record',


### PR DESCRIPTION
Owner report (screenshot): "Admin-reviewed verification" on the Trust public landing can be misinterpreted — it reads as the platform vetting people, a claim the Trust plugin deliberately never makes (no identity verification exists, and no score is ever produced).

Both the desktop and phone signal lists in `trust-public-shell.tsx` now carry four signals: Quora social proof, ServiceCredits activity, Community connections, Cohort completion record. The underlying admin-set status itself is unchanged — only the marketing bullet is gone. The similar "Admin-reviewed" line on the Android Unlock screen was checked and left alone: it accurately describes the human review of Unlock submissions, a different and true claim.

Trust inventory change-log entry and a new public-landing smoke check added. Copy only; typecheck, eslint, EOF, and test-script drift gates pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_