### PR TITLE
fix: correct Recurring Activity landing copy that overstated "no amounts"

### DIFF
--- a/ctf/packages/web/components/recurring-activity/recurring-activity-public-shell.tsx
+++ b/ctf/packages/web/components/recurring-activity/recurring-activity-public-shell.tsx
@@ -18,11 +18,11 @@ import {
 // signed-in-but-not-yet-verified member gets a single "Finish verifying" CTA (verifyUrl) instead.
 
 const INTRO =
-  'Acknowledge an ongoing activity you share with another member — one tap, no amounts to report. It is recognition of your everyday ties, never a bill.';
+  'Acknowledge an ongoing activity you share with another member — one tap to recognize an everyday tie. No money changes hands: it is a note to each other, never a bill.';
 
 const FEATURES: Array<{ Icon: typeof Repeat; label: string; desc: string }> = [
-  { Icon: Repeat, label: 'One tap', desc: 'Mark an ongoing tie — no forms, no figures.' },
-  { Icon: EyeOff, label: 'No amounts', desc: 'Recognition of the activity, never a bill.' },
+  { Icon: Repeat, label: 'One tap', desc: 'Mark an ongoing tie — no charge, nothing owed.' },
+  { Icon: EyeOff, label: 'No bill', desc: 'No money moves — it is recognition, not a charge.' },
   { Icon: Users, label: 'Between members', desc: 'Both sides confirm; you decide who can see it.' },
 ];
 


### PR DESCRIPTION
The signed-out Recurring Activity landing claimed "no amounts to report" and "no forms, no figures," but the feature can capture an **optional ServiceCredits value** when the currency is ServiceCredits — so those claims read as contradictory to anyone who then sees the value field.

Reworded to the point that is actually true for a visitor, and holds for both fiat and ServiceCredits ties: **no money changes hands, it is never a bill.**

- Intro: "…one tap, no amounts to report…" → "…one tap to recognize an everyday tie. No money changes hands: it is a note to each other, never a bill."
- Tile 1 ("One tap"): "no forms, no figures" → "no charge, nothing owed"
- Tile 2: "No amounts" / "Recognition of the activity, never a bill." → "No bill" / "No money moves — it is recognition, not a charge."

Copy-only change to the public marketing shell; no behaviour, schema, route, or data-model change.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxi1DeZm8cyAPxgz4TZvKU)_