### PR TITLE
fix: public pages carry a way back to the app and the website

### DIFF
--- a/ctf/packages/web/app/accessibility/page.tsx
+++ b/ctf/packages/web/app/accessibility/page.tsx
@@ -1,3 +1,4 @@
+import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
 import { OPERATOR_NAME, CONTACT_EMAIL } from '../terms/policy-content';
 import styles from './accessibility.module.css';
@@ -22,6 +23,7 @@ export default function AccessibilityPage() {
   return (
     <main className={styles.page}>
       <div className={styles.container}>
+        <PublicPageNav />
         <header className={styles.header}>
           <p className={styles.brand}>Charging the Future</p>
           <h1 className={styles.title}>Accessibility</h1>

--- a/ctf/packages/web/app/guide/page.tsx
+++ b/ctf/packages/web/app/guide/page.tsx
@@ -1,3 +1,4 @@
+import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
 import guideData from './guide-content.json';
 import type { UserGuide } from './guide-types';
@@ -34,6 +35,7 @@ export default function GuidePage() {
   return (
     <main className={styles.page}>
       <div className={styles.container} id="top">
+        <PublicPageNav />
         <header className={styles.header}>
           <p className={styles.brand}>Charging the Future</p>
           <h1 className={styles.title}>How to use it</h1>

--- a/ctf/packages/web/app/guidelines/page.tsx
+++ b/ctf/packages/web/app/guidelines/page.tsx
@@ -1,3 +1,4 @@
+import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
 import styles from '../terms/terms.module.css';
 import { CONTACT_EMAIL, OPERATOR_NAME } from '../terms/policy-content';
@@ -36,6 +37,7 @@ export default function GuidelinesPage() {
   return (
     <main className={styles.page}>
       <div className={styles.container}>
+        <PublicPageNav />
         <header className={styles.header}>
           <p className={styles.brand}>Charging the Future</p>
           <h1 className={styles.title}>Community Guidelines</h1>

--- a/ctf/packages/web/app/terms/page.tsx
+++ b/ctf/packages/web/app/terms/page.tsx
@@ -1,3 +1,4 @@
+import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
 import {
   POLICY_DOCUMENTS,
@@ -65,6 +66,7 @@ export default function TermsPage() {
   return (
     <main className={styles.page}>
       <div className={styles.container}>
+        <PublicPageNav />
         <header className={styles.header}>
           <p className={styles.brand}>Charging the Future</p>
           <h1 className={styles.title}>Terms &amp; Privacy Policy</h1>

--- a/ctf/packages/web/components/shared/public-page-nav.tsx
+++ b/ctf/packages/web/components/shared/public-page-nav.tsx
@@ -1,0 +1,34 @@
+// Escape hatch for the public standalone pages (/terms, /guidelines, /accessibility, /guide).
+// In the installed web app there is no browser chrome, so a member who follows a footer link onto
+// these pages has no way back (owner report, 2026-07-19) — this row always offers the app and the
+// public website. Server-renderable (no client hooks); inline styles so it sits above any page's
+// own CSS module without coupling.
+const linkStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '7px 14px',
+  borderRadius: 9,
+  background: 'rgba(255, 255, 255, 0.06)',
+  border: '1px solid rgba(255, 255, 255, 0.12)',
+  color: 'inherit',
+  fontSize: 13,
+  fontWeight: 600,
+  textDecoration: 'none',
+};
+
+export function PublicPageNav() {
+  return (
+    <nav
+      aria-label="Leave this page"
+      style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 22 }}
+    >
+      <a href="/" style={linkStyle}>
+        ← Back to the app
+      </a>
+      <a href="https://chargingthefuture.com" style={linkStyle}>
+        ChargingTheFuture.com
+      </a>
+    </nav>
+  );
+}


### PR DESCRIPTION
Owner report (screenshot): from the installed web app, following footer links onto the public standalone pages dead-ends — guidelines → terms → accessibility all have no browser chrome and no way back.

Every public standalone page (`/guidelines`, `/terms`, `/accessibility`, `/guide`) now opens with two links above the header:

- **← Back to the app** → `/` (inside the installed app this returns straight to the Commons on app.chargingthefuture.com)
- **ChargingTheFuture.com** → the public website

One shared server-rendered component (`components/shared/public-page-nav.tsx`), inline-styled so it sits above each page's own CSS module without coupling. Typecheck, eslint, and EOF gate pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_