### PR TITLE
fix: one shared footer with the full link set on every public page

### DIFF
--- a/ctf/packages/web/app/accessibility/page.tsx
+++ b/ctf/packages/web/app/accessibility/page.tsx
@@ -1,6 +1,7 @@
+import { PublicPageFooter } from '@/components/shared/public-page-footer';
 import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
-import { OPERATOR_NAME, CONTACT_EMAIL } from '../terms/policy-content';
+import { CONTACT_EMAIL } from '../terms/policy-content';
 import styles from './accessibility.module.css';
 
 // Public Accessibility Statement at /accessibility. Static server component
@@ -119,7 +120,7 @@ export default function AccessibilityPage() {
           </p>
         </section>
 
-        <footer className={styles.footer}>{OPERATOR_NAME}</footer>
+        <PublicPageFooter />
       </div>
     </main>
   );

--- a/ctf/packages/web/app/guide/page.tsx
+++ b/ctf/packages/web/app/guide/page.tsx
@@ -1,3 +1,4 @@
+import { PublicPageFooter } from '@/components/shared/public-page-footer';
 import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
 import guideData from './guide-content.json';
@@ -89,16 +90,7 @@ export default function GuidePage() {
           </section>
         ))}
 
-        <footer className={styles.footer}>
-          Charging the Future ·{' '}
-          <a className={styles.link} href="/terms">
-            Terms &amp; Privacy
-          </a>{' '}
-          ·{' '}
-          <a className={styles.link} href="/accessibility">
-            Accessibility
-          </a>
-        </footer>
+        <PublicPageFooter />
       </div>
     </main>
   );

--- a/ctf/packages/web/app/guidelines/page.tsx
+++ b/ctf/packages/web/app/guidelines/page.tsx
@@ -1,7 +1,7 @@
+import { PublicPageFooter } from '@/components/shared/public-page-footer';
 import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
 import styles from '../terms/terms.module.css';
-import { CONTACT_EMAIL, OPERATOR_NAME } from '../terms/policy-content';
 import { GUIDELINE_SECTIONS, GUIDELINES_EFFECTIVE_DATE, type GuidelineSection } from './guidelines-content';
 
 // Public community discussion guidelines at /guidelines. Static, no auth — the operator
@@ -48,20 +48,7 @@ export default function GuidelinesPage() {
           <GuidelineSectionView key={section.id} section={section} />
         ))}
 
-        <footer className={styles.footer}>
-          {OPERATOR_NAME} · Contact{' '}
-          <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
-            {CONTACT_EMAIL}
-          </a>{' '}
-          ·{' '}
-          <a className={styles.link} href="/terms">
-            Terms &amp; Privacy
-          </a>{' '}
-          ·{' '}
-          <a className={styles.link} href="/guide">
-            How to use it
-          </a>
-        </footer>
+        <PublicPageFooter />
       </div>
     </main>
   );

--- a/ctf/packages/web/app/terms/page.tsx
+++ b/ctf/packages/web/app/terms/page.tsx
@@ -1,10 +1,9 @@
+import { PublicPageFooter } from '@/components/shared/public-page-footer';
 import { PublicPageNav } from '@/components/shared/public-page-nav';
 import type { Metadata } from 'next';
 import {
   POLICY_DOCUMENTS,
   EFFECTIVE_DATE,
-  OPERATOR_NAME,
-  CONTACT_EMAIL,
   type PolicyBlock,
   type PolicyDocument,
 } from './policy-content';
@@ -89,24 +88,7 @@ export default function TermsPage() {
           <PolicyDoc key={doc.id} doc={doc} />
         ))}
 
-        <footer className={styles.footer}>
-          {OPERATOR_NAME} · Contact{' '}
-          <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
-            {CONTACT_EMAIL}
-          </a>{' '}
-          ·{' '}
-          <a className={styles.link} href="/accessibility">
-            Accessibility
-          </a>{' '}
-          ·{' '}
-          <a className={styles.link} href="/guide">
-            How to use it
-          </a>{' '}
-          ·{' '}
-          <a className={styles.link} href="/guidelines">
-            Community guidelines
-          </a>
-        </footer>
+        <PublicPageFooter />
       </div>
     </main>
   );

--- a/ctf/packages/web/components/shared/public-page-footer.tsx
+++ b/ctf/packages/web/components/shared/public-page-footer.tsx
@@ -1,0 +1,50 @@
+import { CONTACT_EMAIL, OPERATOR_NAME } from '../../app/terms/policy-content';
+
+// One footer for every public standalone page (/terms, /guidelines, /accessibility, /guide) so
+// each carries the full link set (owner decision, 2026-07-19) — before this, each page linked a
+// different subset and a visitor had to hop pages to find the rest. Server-renderable; inline
+// styles so it sits over any page's own CSS module. Includes the current page's own link — a
+// harmless no-op click that keeps the row identical everywhere.
+const linkStyle: React.CSSProperties = {
+  color: 'inherit',
+  textDecoration: 'underline',
+  textUnderlineOffset: 3,
+};
+
+const LINKS: { href: string; label: string }[] = [
+  { href: '/', label: 'The app' },
+  { href: 'https://chargingthefuture.com', label: 'ChargingTheFuture.com' },
+  { href: '/terms', label: 'Terms & Privacy' },
+  { href: '/guidelines', label: 'Community guidelines' },
+  { href: '/accessibility', label: 'Accessibility' },
+  { href: '/guide', label: 'How to use it' },
+];
+
+export function PublicPageFooter() {
+  return (
+    <footer
+      style={{
+        marginTop: 36,
+        paddingTop: 18,
+        borderTop: '1px solid rgba(255, 255, 255, 0.1)',
+        fontSize: 13,
+        lineHeight: 2,
+        opacity: 0.85,
+      }}
+    >
+      {OPERATOR_NAME} · Contact{' '}
+      <a style={linkStyle} href={`mailto:${CONTACT_EMAIL}`}>
+        {CONTACT_EMAIL}
+      </a>
+      {LINKS.map((link) => (
+        <span key={link.href}>
+          {' '}
+          ·{' '}
+          <a style={linkStyle} href={link.href}>
+            {link.label}
+          </a>
+        </span>
+      ))}
+    </footer>
+  );
+}


### PR DESCRIPTION
Owner request (screenshot): each public standalone page carried a different subset of footer links, so a visitor had to hop pages to find the rest.

All four public pages (`/terms`, `/guidelines`, `/accessibility`, `/guide`) now render the same shared `PublicPageFooter`: operator name + contact email, **The app**, **ChargingTheFuture.com**, **Terms & Privacy**, **Community guidelines**, **Accessibility**, **How to use it**. A page's own link is included so the row is identical everywhere. Unused per-page footer imports removed.

Built on #1718 (the back-links row, just merged), so the diff here is the footer only. Typecheck, eslint, and EOF gate pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_