### PR TITLE
chore: bump mobile app version to 0.1.1 for new Android release

### DIFF
--- a/ctf/packages/mobile/app.config.ts
+++ b/ctf/packages/mobile/app.config.ts
@@ -34,7 +34,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     // (ctf://oauth-callback). Must match the redirect URI registered on the
     // Clerk OAuth application.
     scheme: 'ctf',
-    version: '0.1.0',
+    version: '0.1.1',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'automatic',

--- a/ctf/packages/mobile/package.json
+++ b/ctf/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctf/mobile",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What this does

Bumps the mobile app version from `0.1.0` to `0.1.1` in `ctf/packages/mobile/package.json` and `ctf/packages/mobile/app.config.ts`.

## Why

The `mobile-v0.1.0` GitHub Release already exists, and releases are immutable, so producing a new Android APK for testing requires a new version. Bumping the app version means the built APK reports `0.1.1`, matching the `mobile-v0.1.1` release tag. The `runtimeVersion` policy is `appVersion`, so the runtime version advances in step. The APK built from this will include all of the merged branding-parity and icon (E6) work.

No behavior change; version metadata only.

Parity Status: web + mobile-responsive + android complete
Android: version-metadata only (Android keep-list app rebuilt for release per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJa4M8Wg4mT5je63WBtghw)_