### PR TITLE
fix: unify Commons phone top-bar controls into one bordered icon-button chrome

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1806,9 +1806,13 @@
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  /* One unified icon-control chrome across the whole phone top bar: the same
+     surface fill + border + radius that the plugin header's MobileTopActions uses,
+     so admin, gift, help, settings, and the tabs all read as one system (both
+     default and comic themes derive from the theme tokens). */
+  border-radius: 10px;
+  background: var(--ctf-surface);
+  border: 1px solid var(--ctf-border);
   color: var(--ctf-text-secondary);
   font-size: 13px;
   font-weight: 600;
@@ -1862,9 +1866,12 @@
 
 .mobileBarSectionBtn {
   padding: 6px 9px;
-  border-radius: 8px;
-  background: transparent;
-  border: 1px solid transparent;
+  /* Both section tabs carry the same boxed chrome as the other top-bar controls so
+     the pair reads as one segmented control; the active state (below) only changes
+     the tint, not the presence of the box. */
+  border-radius: 10px;
+  background: var(--ctf-surface);
+  border: 1px solid var(--ctf-border);
   color: var(--ctf-text-subtle);
   font-size: 13px;
   font-weight: 600;
@@ -1892,11 +1899,26 @@
   width: 38px;
   height: 38px;
   border-radius: 10px;
+  /* Give the phone-bar help + settings buttons the same visible box as the plugin
+     header controls. The base .iconRailBtn is intentionally borderless on the desktop
+     rail; this scoped override only borders the phone bar's copies. */
+  background: var(--ctf-surface);
+  border-color: var(--ctf-border);
+  color: var(--ctf-text-secondary);
 }
 
 @media (max-width: 600px) {
   .mobileBarAdminLabel {
     display: none;
+  }
+
+  /* Label-less at phone width → collapse the admin control to the same 38px square as
+     the other icon buttons so the whole cluster is uniform. */
+  .mobileBarAdminBtn {
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    justify-content: center;
   }
 }
 

--- a/ctf/packages/web/components/contributions/contributions-banner.tsx
+++ b/ctf/packages/web/components/contributions/contributions-banner.tsx
@@ -222,7 +222,26 @@ export function ContributionsGiftTrigger() {
       onClick={() => router.push('/apps/contributions')}
       aria-label="Contribute to the platform"
       title="Contribute"
-      style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 2, flexShrink: 0 }}
+      // Boxed to match the rest of the phone top bar's icon controls (help, settings,
+      // admin) — the same surface + border + radius the plugin header uses — so the gift
+      // is no longer a bare emoji floating among bordered buttons. Theme tokens carry the
+      // default and comic looks.
+      style={{
+        width: 38,
+        height: 38,
+        borderRadius: 10,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--ctf-surface, rgba(255, 255, 255, 0.06))',
+        border: '1px solid var(--ctf-border, rgba(255, 255, 255, 0.12))',
+        color: 'var(--ctf-text, #E5E7EB)',
+        cursor: 'pointer',
+        fontSize: 16,
+        lineHeight: 1,
+        padding: 0,
+        flexShrink: 0,
+      }}
     >
       🎁
     </button>


### PR DESCRIPTION
## What this fixes

On phones, the community shell ("Commons") top bar had drifted into several visual treatments side by side, while the plugin pages (e.g. Beacon) already use one consistent boxed control. Reported by the owner with two screenshots: the Beacon header is right; the Commons header mixes designs.

Before, the Commons phone bar showed:
- the contributions gift as a **bare emoji** (no button box),
- help and settings as **borderless** icons,
- the admin control as a **different pill**,
- and the section tabs as **one boxed** (Commons) next to **one bare text** (Apps).

## Change

Align every Commons phone-bar control to the same chrome the plugin header uses (`MobileTopActions`): a 38px, radius-10 button with the `--ctf-surface` fill and `--ctf-border` border. This covers the gift, help, settings, admin, and both section tabs, so the row reads as one system.

- Works for **both themes** automatically — the look comes from the theme tokens, so the comic theme gets its cream boxed chrome (`--ctf-border: #d4c49a`) with no extra rules.
- The **Clerk avatar is untouched** (owner instruction).
- The **desktop icon rail keeps its intentional borderless look** — the new borders are scoped to `.mobileBar*` / the phone bar's controls only, not the base `.iconRailBtn`.

Files:
- `components/community-shell/community-shell.module.css` — box the admin button, both section tabs, and the phone-bar help/settings buttons; collapse the admin button to a 38px square at ≤600px.
- `components/contributions/contributions-banner.tsx` — box the gift trigger.

No behavior change; presentation only. Typecheck, lint, and web build all pass locally.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105 — this is the responsive web shell; the native app is Chyme-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJa4M8Wg4mT5je63WBtghw)_