### PR TITLE
fix: give the comic theme's peer chat bubble the comic treatment

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -2716,6 +2716,16 @@
   border: 1.5px solid var(--ctf-border);
 }
 
+/* Peer ("hub") chat bubble in comic. The standard theme's purple *gradient* with no border reads
+   as off-brand against the flat cream/ink comic look (comic has no gradients/glow). Keep the purple
+   hue (owner: purple is fine) but flatten the gradient to a solid fill and add the same cream border
+   the own-bubble comic treatment uses, so the two bubble types read as one comic system — differing
+   only by fill colour, not by design language. */
+:global([data-theme='comic']) .chatBubbleHub {
+  background: #6d28d9;
+  border: 1.5px solid var(--ctf-border);
+}
+
 /* AI Assistant cards use inkDim, not cyan (§9). */
 :global([data-theme='comic']) .comicCard {
   background: var(--ctf-surface);


### PR DESCRIPTION
## What this fixes

In the **comic theme**, other members' chat bubbles ("hub" bubbles) kept the standard theme's saturated **purple gradient with no border**, which reads off-brand against comic's flat cream/ink look (comic uses no gradients or glow, cream borders, hard edges). The own-message bubble already had a comic override (flat ink + cream border), but the peer bubble had none — so the two bubble types looked like they came from different design systems.

Reported by the owner: "It is fine that it's purple. But its design seems off-brand for the comic theme."

## Change

`components/community-shell/community-shell.module.css` — add a comic override for `.chatBubbleHub`:
- **Keep the purple hue** (owner: purple is fine) but flatten the gradient to a solid fill.
- Add the **same cream border** (`--ctf-border`) the own-bubble comic treatment uses.

Now the peer and own bubbles read as one comic system, differing only by fill colour rather than by design language. **The default (dark) theme is unchanged** — this is scoped to `[data-theme='comic']`.

No behavior change; presentation only. Typecheck, lint, and web build pass locally.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105 — this is the responsive web shell; the native app is Chyme-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJa4M8Wg4mT5je63WBtghw)_