### PR TITLE
fix: drop double hash on channel label and add desktop contribute gift

### DIFF
--- a/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { UserButton } from '@clerk/nextjs';
-import { Users, Zap, Shield, SlidersHorizontal } from 'lucide-react';
+import { Users, Zap, Shield, SlidersHorizontal, Gift } from 'lucide-react';
 import type { ShellSection } from './shell-types';
 import { HelpControl } from '../bug-reports/help-control';
 import styles from './community-shell.module.css';
@@ -43,6 +43,21 @@ export function ShellIconRail({ section, onSectionChange, initial = 'S', isAuthe
       </button>
 
       <div className={styles.iconRailSpacer} aria-hidden="true" />
+
+      {/* Contribute shortcut: the phone top bar carries a gift trigger, but the desktop rail had no
+          equivalent, so on desktop there was no gift/contribute affordance at all. This restores
+          parity — a persistent entry to the Contributions plugin for signed-in members. Uses the
+          lucide Gift icon to match the rail's other icons (the phone bar keeps its 🎁 emoji). */}
+      {isAuthenticated ? (
+        <Link
+          href="/apps/contributions"
+          className={styles.iconRailBtn}
+          aria-label="Contribute"
+          title="Contribute — support the platform"
+        >
+          <Gift size={18} />
+        </Link>
+      ) : null}
 
       {/* Admin entry: only rendered for users whose Clerk role is "admin". This is the one
           in-app way to reach the admin directory at /admin; the route itself is still

--- a/ctf/packages/web/components/community-shell/shell-sidebar.tsx
+++ b/ctf/packages/web/components/community-shell/shell-sidebar.tsx
@@ -22,7 +22,9 @@ type ShellSidebarProps = {
 // Title-cased version of the slug ("general-announcements" → "General Announcements") so the rail
 // never shows a raw database slug.
 function channelLabel(channel: HubChannelInfo): string {
-  const name = channel.displayName?.trim();
+  // Strip any leading "#" the stored display name may carry (e.g. "#general") — the sidebar row
+  // already renders its own "#" prefix, so keeping it here produced a double hash ("# #general").
+  const name = channel.displayName?.trim().replace(/^#+\s*/, '');
   if (name) return name;
   return channel.slug
     .split('-')


### PR DESCRIPTION
## Two community-shell polish fixes

### 1. Double hash on the channel label ("# #general")
The desktop channel rail renders its own `#` prefix and then the channel's display name. The stored display name already carries a `#` ("#general"), so the row showed **"# #general"**. Strip any leading `#` from the label in `channelLabel()` so the row's own prefix is the single source of the hash. The phone channel pills use the raw slug (`#{ch.slug}`), so they were already correct and are unaffected.

### 2. Missing gift/contribute affordance on desktop
The phone top bar has a gift/contribute trigger, but the desktop icon rail had no equivalent — so on desktop there was no way to reach Contributions from the shell chrome. Add a persistent `Gift` rail button for signed-in members, linking to `/apps/contributions`. It uses the lucide `Gift` icon to match the rail's other icons (the phone bar keeps its 🎁 emoji, which suits that surface).

Files:
- `components/community-shell/shell-sidebar.tsx` — strip leading `#` from the channel label.
- `components/community-shell/shell-icon-rail.tsx` — add the desktop contribute rail button.

No behavior change beyond the above; typecheck, lint, and web build pass locally.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105 — this is the responsive web shell; the native app is Chyme-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJa4M8Wg4mT5je63WBtghw)_