### PR TITLE
feat: Commons notifications producer (reply + announcement reply)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
@@ -92,7 +92,10 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 
 ## 8) Gaps and Known Technical Debt
 
-- No producers yet — the feed is empty until each plugin's emit points land (see Build Checklist).
+- @mention notifications are deferred: notifying a mentioned member needs a reliable
+  `@username` → user id lookup, which does not exist centrally (`lib/identity/resolve-usernames`
+  only goes id → name). Reply-to-your-post and announcement-reply notifications ship now; add mention
+  notifications once a username→id index exists.
 - No device-push delivery yet — preferences are recorded but nothing sends a ping. Web push has
   platform limits (Android/Chrome and installed iOS web apps only), to be handled in the delivery
   step.
@@ -104,7 +107,8 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 1. **Backbone (this PR):** schema (`notifications`, `notification_preferences`), repository,
    command + access-policy contracts, deletion-registry entry, the five API routes, and the 🔔 tab
    with the always-on feed + the per-category opt-ins. No dependencies.
-2. **Commons producer:** emit on reply-to-your-post, `@mention`, and announcement reply. Blocked by 1.
+2. **Commons producer (done):** emit on reply-to-your-post and announcement reply. `@mention` is
+   deferred (needs a username→id lookup — see Gaps).
 3. **Everyday producers:** ServiceCredits (credits received), LevelUp, Recurring Activity. Blocked by 1.
 4. **Safety producers:** LightHouse, SocketRelay, TrustTransport, Foundation — with the emergency
    real-time ring called out as its own live path (the feed is the durable record, not the ring).
@@ -115,6 +119,12 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 
 ## Change Log
 
+- 2026-07-20: Commons producer — `createFeedCommunityPost` now notifies the parent post's author when
+  someone replies (`commons.reply`), and `replyToAnnouncement` notifies the announcement's author
+  (`commons.announcement_reply`). Both emit after the transaction commits via `notifySafe` (a new
+  best-effort wrapper that logs but never breaks the underlying post), never for a self-reply, with a
+  neutral summary (no author name or content) and `target_ref` set to the new row for dedupe.
+  `@mention` notifications are deferred (see Gaps).
 - 2026-07-20: Created the notifications center backbone — schema, repository, contracts,
   deletion-registry entry, the `/api/notifications/*` routes, and the 🔔 tab in the Commons (always-on
   in-app feed with calm read/unread, an "Open" deep-link pill per row, "mark all read", and the three

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -328,6 +328,12 @@ The Survivor Hub ⟵ Feed consolidation (2026-05-31) superseded the prior `hub_*
 
 ### Change Log
 
+- 2026-07-20: Commons now feeds the notifications center. `createFeedCommunityPost` notifies the
+  parent post's author when someone replies to their post, and `replyToAnnouncement` notifies the
+  announcement's author when someone replies — both best-effort (`notifySafe`, after commit), never on
+  a self-reply, with a neutral summary and no content. These land in the member's 🔔 notifications
+  feed (see the Notifications inventory). `@mention` notifications are deferred pending a
+  username→user-id lookup.
 - 2026-07-18: An announcement can now link **up to 3 plugins** (owner directive: more than 3 is information overload). `GET /api/hub/messages` resolves each announcement's linked plugins to an ordered `{ slug, name }[]` (batched `resolveAnnouncementLinkedPlugins(ids)`), carried on `HubMessage.linkedPlugins` (replaces the singular `linkedPlugin`; empty otherwise). The web official card (`announcement-card.tsx`) renders one "Open <Plugin>" chip per entry in a wrapping row; the body still carries one plain `Open <Plugin>: <url>` line per link. Threaded through `ChatMessage.linkedPlugins`. The native Android Hub (`features/hub/*`) was removed upstream (Chyme is now the mobile home surface), so this is a web / mobile-responsive change only. Storage/authoring changes are recorded in the Announcements inventory.
 - 2026-07-18: Made the mentions filter chip icon-only ("@" glyph, dropping the "Mentions" word) on web and Android so it matches the 📣 announcements chip — the two stream filters read as a matched pair of small glyph pills. Behavior unchanged.
 - 2026-07-18: Added an announcements filter chip (📣) next to the "@ Mentions" chip in the Commons stream, on web (`shell-chat-panel.tsx`) and Android (`HubHome.tsx`). "Announcements" is too long for a chip, so it shows the megaphone emoji alone. When on, the stream reads `GET /api/hub/messages?channel=announcements`, which returns only official announcements — including ones that scrolled off the recent page — so a member with limited message history can still surface them. The two filters are mutually exclusive; turning one on clears the other, and the AI (`@comic`) cards are hidden while any filter is active.

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -23,6 +23,7 @@ import { feedAuthorHandle, feedMentionTokens } from './author-handle';
 import { generateFeedAssistedAnswer, inferFeedQuestionCategory } from './inference';
 import { emitFeedMembershipEventToStream } from './stream';
 import { getPluginBySlug, getPluginRoute, isAdminOnlyPlugin } from 'lib/plugins/repository';
+import { notifySafe } from 'lib/notifications/repository';
 
 // Re-exported so existing server callers can keep importing them from the feed
 // repository; the implementations live in the client-safe ./author-handle module.
@@ -1743,7 +1744,10 @@ export async function createFeedCommunityPost(
   // blocked as spam. Members keep the low cap. The `<>`-tag block still applies to everyone.
   isPrivileged: boolean = false,
 ): Promise<{ postId: string; createdAtIso: string }> {
-  return withDbTransaction(async (client) => {
+  // When this post is a reply, the parent post's author (captured inside the transaction) is notified
+  // after commit — best-effort, and never for a self-reply.
+  let replyParentAuthorId: string | null = null;
+  const result = await withDbTransaction(async (client) => {
     const body = normalizeMultilineText(input.body);
     const category = normalizeCommunityCategory(input.category);
 
@@ -1760,13 +1764,14 @@ export async function createFeedCommunityPost(
       throw new Error('reply_target_invalid');
     }
     if (replyToPostId !== null) {
-      const target = await client.query<{ id: string }>(
-        'SELECT id FROM feed_community_posts WHERE id = $1::uuid LIMIT 1',
+      const target = await client.query<{ id: string; author_user_id: string }>(
+        'SELECT id, author_user_id FROM feed_community_posts WHERE id = $1::uuid LIMIT 1',
         [replyToPostId],
       );
       if (target.rows.length === 0) {
         throw new Error('reply_target_not_found');
       }
+      replyParentAuthorId = target.rows[0].author_user_id;
     }
 
     const allowed = await evaluateFeedRateLimit(client, {
@@ -1796,6 +1801,22 @@ export async function createFeedCommunityPost(
       createdAtIso: toIso(inserted.rows[0].created_at),
     };
   });
+
+  // Notify the parent post's author that someone replied — after commit, best-effort, never for a
+  // self-reply. Neutral summary (no author name or content) so it is safe wherever it surfaces.
+  if (replyParentAuthorId && replyParentAuthorId !== actorId) {
+    await notifySafe({
+      userId: replyParentAuthorId,
+      sourcePlugin: 'commons',
+      notificationType: 'commons.reply',
+      category: 'community',
+      summary: 'Someone replied to your post in the Commons.',
+      linkPath: '/',
+      targetRef: result.postId,
+    });
+  }
+
+  return result;
 }
 
 // Delete a member's own community (peer) post from the Commons. Author-only: the caller must own
@@ -2024,19 +2045,23 @@ export async function replyToAnnouncement(
     throw new Error('announcement_not_found');
   }
 
-  return withDbTransaction(async (client) => {
+  // The announcement's author (captured inside the transaction) is notified after commit that a reply
+  // landed — best-effort, and never when the author is the one replying.
+  let announcementAuthorId: string | null = null;
+  const result = await withDbTransaction(async (client) => {
     const body = normalizeMultilineText(bodyInput);
     if (!passesFeedModeration(body)) {
       throw new Error('content_policy_violation');
     }
 
-    const announcement = await client.query<{ id: string }>(
-      "SELECT id FROM announcements WHERE id = $1::uuid AND status = 'published' LIMIT 1",
+    const announcement = await client.query<{ id: string; created_by_user_id: string }>(
+      "SELECT id, created_by_user_id FROM announcements WHERE id = $1::uuid AND status = 'published' LIMIT 1",
       [normalizedId],
     );
     if (announcement.rows.length === 0) {
       throw new Error('announcement_not_found');
     }
+    announcementAuthorId = announcement.rows[0].created_by_user_id;
 
     const allowed = await evaluateFeedRateLimit(client, {
       userId: actorId,
@@ -2062,6 +2087,20 @@ export async function replyToAnnouncement(
       createdAtIso: toIso(inserted.rows[0].created_at),
     };
   });
+
+  if (announcementAuthorId && announcementAuthorId !== actorId) {
+    await notifySafe({
+      userId: announcementAuthorId,
+      sourcePlugin: 'commons',
+      notificationType: 'commons.announcement_reply',
+      category: 'community',
+      summary: 'Someone replied to your announcement.',
+      linkPath: '/',
+      targetRef: result.replyId,
+    });
+  }
+
+  return result;
 }
 
 // List the accepted replies on an official announcement, oldest-first (thread order). Returns an

--- a/ctf/packages/web/lib/notifications/repository.ts
+++ b/ctf/packages/web/lib/notifications/repository.ts
@@ -1,4 +1,5 @@
 import { queryDb } from 'lib/db/postgres';
+import { reportError } from 'lib/observability/report';
 import {
   isNotificationCategory,
   NOTIFICATIONS_MAX_PAGE_SIZE,
@@ -63,6 +64,17 @@ export async function createNotification(input: NotificationInput): Promise<stri
     ],
   );
   return result.rows[0]?.id ?? null;
+}
+
+// Best-effort producer entry point: record a notification but never let a failure (or a rolled-back
+// notification write) break the underlying action that triggered it. Every per-plugin emit point
+// should call this — ideally after its own transaction has committed — and ignore the result.
+export async function notifySafe(input: NotificationInput): Promise<void> {
+  try {
+    await createNotification(input);
+  } catch (error) {
+    reportError(error, { area: 'notifications', op: `emit_${input.notificationType}` });
+  }
 }
 
 export async function listNotifications(userId: string, limit: number): Promise<Notification[]> {


### PR DESCRIPTION
## What

Step 2 of the notifications plan — the first producers. Now the 🔔 feed actually fills.

- Replying to a member's Commons post notifies that post's author (`commons.reply`).
- Replying to an announcement notifies the announcement's author (`commons.announcement_reply`).

## How

Both emit **after the transaction commits**, via a new best-effort `notifySafe` wrapper in `lib/notifications/repository.ts` — it logs a failure but never breaks the underlying post. Never fires for a self-reply. The summary is neutral (no author name or content, safe wherever it surfaces), and `target_ref` is the new row id so a re-emit dedupes.

## Deferred

`@mention` notifications: notifying a mentioned member needs a reliable `@username` → user-id lookup, which doesn't exist centrally (`lib/identity/resolve-usernames` only goes id → name). Documented in the notifications inventory Gaps; add once a username→id index exists.

## Scope

No schema, route, or contract change — additive emit only. Inventories updated (notifications + survivor-hub-chat).

## Test

Web typecheck + lint, the all-package pre-commit typecheck, and the pre-push production build all pass.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105; the native Android Hub was removed upstream)

---
_Generated by [Claude Code](https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN)_