### PR TITLE
fix: remove the dead GDP sidebar filters

### DIFF
--- a/ctf/packages/web/components/gdp/gdp-shared.ts
+++ b/ctf/packages/web/components/gdp/gdp-shared.ts
@@ -141,9 +141,10 @@ export function pickGdpMetricValue(
   return row ? row.metricValue : null;
 }
 
-// Matches the design's sidebar filter list (no "By Phase" — that term is banned
-// project-wide and is not present in the design mockup).
-export const SIDEBAR_FILTERS = ["Global Overview", "By Sector", "By Country", "Projections"];
+// Only the single Global Overview view exists. The old "By Sector" / "By Country" /
+// "Projections" entries were removed (owner decision, 2026-07-20): they were never wired to
+// any handler, so they looked clickable but did nothing.
+export const SIDEBAR_FILTERS = ["Global Overview"];
 
 // One registered recognition source's contribution to the live Community Value Index, as returned by
 // GET /api/gdp/report/current. The dashboard renders these as the per-source value breakdown.

--- a/ctf/packages/web/components/gdp/gdp-sidebar.tsx
+++ b/ctf/packages/web/components/gdp/gdp-sidebar.tsx
@@ -46,7 +46,7 @@ export function GdpSidebar({ metrics }: { metrics: GdpMetrics }) {
       <ScrollArea style={{ flex: 1 }}>
         <div style={{ padding: "0 8px 16px" }}>
           {SIDEBAR_FILTERS.map((f, i) => (
-            <div key={f} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: i === 0 ? `${t.ACCENT}18` : "transparent", borderLeft: i === 0 ? `2px solid ${t.ACCENT}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
+            <div key={f} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "default", background: i === 0 ? `${t.ACCENT}18` : "transparent", borderLeft: i === 0 ? `2px solid ${t.ACCENT}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
               <span style={{ fontSize: 13, color: i === 0 ? t.TEXT : t.SUBTLE, flex: 1 }}>{f}</span>
             </div>
           ))}


### PR DESCRIPTION
## What this fixes

The GDP tracker's left sidebar listed four "filters" — **Global Overview**, **By Sector**, **By Country**, **Projections** — rendered with `cursor: pointer` but **no click handler and no state**. Only "Global Overview" was ever (statically) active; clicking the others did nothing. They looked interactive but were dead.

## Change

- `components/gdp/gdp-shared.ts` — reduce `SIDEBAR_FILTERS` to the single real view: `["Global Overview"]`.
- `components/gdp/gdp-sidebar.tsx` — drop the misleading `cursor: pointer` (nothing to click now).

## What is intentionally left alone

The dashboard's own breakdowns are **not** touched: the **Value by Source** panel and the **All Countries — Members by country** panel stay. They are aggregate — they name no individual and attach no value to any specific individual — so they're fine to keep (owner confirmation, 2026-07-20). GDP remains a single global value index; it is not, and should not be, broken down per person.

No behavior change beyond removing the non-functional filters; typecheck, lint, and web build pass locally.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105 — this is the responsive web shell; the native app is Chyme-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJa4M8Wg4mT5je63WBtghw)_