### PR TITLE
fix: use the bug icon for the desktop report-a-bug control

### DIFF
--- a/ctf/packages/web/components/bug-reports/help-control.tsx
+++ b/ctf/packages/web/components/bug-reports/help-control.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { HelpCircle, AlertCircle } from 'lucide-react';
+import { Bug, AlertCircle } from 'lucide-react';
 import { BugReportModal } from './bug-report-modal';
 import styles from './bug-report-modal.module.css';
 import railStyles from '../community-shell/community-shell.module.css';
 
-// Global "?" Help control for the authenticated shell's icon rail. Clicking it opens
-// a small popover; the popover's one live item, "Report a problem", opens the modal.
+// Global report-a-bug control for the authenticated shell's icon rail (desktop) and phone top bar.
+// It shows a Bug glyph so it matches the mobile plugin header's bug icon (MobileTopActions) — the
+// same feature, identical across breakpoints. Clicking it opens a small popover; the popover's one
+// live item, "Report a problem", opens the modal.
 //
 // The design's popover also showed a "Help center" link, but no help-center URL
 // exists anywhere in the app or config yet, so that item is omitted rather than
@@ -50,11 +52,13 @@ export function HelpControl() {
             : railStyles.iconRailBtn
         }
         onClick={() => setPopoverOpen((open) => !open)}
-        aria-label="Help"
+        aria-label="Report a bug"
         aria-haspopup="menu"
         aria-expanded={popoverOpen}
       >
-        <HelpCircle size={18} />
+        {/* Bug glyph (not a "?"), so this desktop control matches the mobile top bar's bug icon —
+            the two are the same report-a-bug feature and should read identically across breakpoints. */}
+        <Bug size={18} />
       </button>
 
       {popoverOpen && (


### PR DESCRIPTION
## What this fixes

The report-a-bug control shows a **Bug icon on the mobile top bar** (`MobileTopActions`) but a **question mark** on desktop — the shell's `HelpControl` used `HelpCircle`. It's the same feature (its only action is "Report a problem"), so the glyph should match across breakpoints.

## Change

`components/bug-reports/help-control.tsx` — swap `HelpCircle` → `Bug` and relabel the control "Report a bug". This updates the desktop icon rail and the community shell's phone top bar to the bug glyph, matching the mobile plugin header. Behavior is unchanged (it still opens the "Report a problem" action).

Typecheck, lint, and web build pass locally.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105 — this is the responsive web shell; the native app is Chyme-only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJa4M8Wg4mT5je63WBtghw)_