### PR TITLE
feat: everyday notifications producers (ServiceCredits, LevelUp, Recurring Activity)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
@@ -213,6 +213,11 @@ that exist today.
 
 ## Change Log
 
+- 2026-07-20: **Notifications producer.** The milestone-release route emits a best-effort
+  notification (`notifySafe`, `level-up.milestone.released`) to the learner when their milestone
+  credits are released — deduped on the transfer id, never to the trainer/admin who released. To
+  address the learner, `releaseMilestoneCredits` now returns `recipientUserId` on its response
+  (additive; it was already computed internally). No schema/route/contract-list change.
 - 2026-07-20: **Resolved the level-up code-review sweep findings (#1756–#1763).** No schema, route
   list, or contract change — behaviour and security hardening only:
   - **dispute.open ownership (#1756, security).** `openDispute` now verifies the actor is the

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
@@ -109,7 +109,9 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
    with the always-on feed + the per-category opt-ins. No dependencies.
 2. **Commons producer (done):** emit on reply-to-your-post and announcement reply. `@mention` is
    deferred (needs a username→id lookup — see Gaps).
-3. **Everyday producers:** ServiceCredits (credits received), LevelUp, Recurring Activity. Blocked by 1.
+3. **Everyday producers (done):** ServiceCredits (credits received on a completed direct transfer),
+   LevelUp (milestone credits released to the learner), Recurring Activity (invited / confirmed /
+   declined). Emitted from each plugin's route via `notifySafe`, after the underlying write.
 4. **Safety producers:** LightHouse, SocketRelay, TrustTransport, Foundation — with the emergency
    real-time ring called out as its own live path (the feed is the durable record, not the ring).
    Blocked by 1.
@@ -119,6 +121,15 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 
 ## Change Log
 
+- 2026-07-20: Everyday producers. ServiceCredits notifies the recipient of a completed direct
+  member-to-member transfer (`service-credits.received`, emitted from `/api/service-credits/transfers`,
+  not from the ledger function — plugin-origin transfers like rides/calls will notify via their own
+  domain producers). LevelUp notifies the learner when a milestone's credits are released
+  (`level-up.milestone.released`; `releaseMilestoneCredits` now returns `recipientUserId` so the route
+  can address it). Recurring Activity notifies the counterparty on a new activity
+  (`recurring-activity.invited`) and the owner on confirm/decline
+  (`recurring-activity.confirmed` / `.declined`). All best-effort via `notifySafe`, deduped on the
+  underlying row id, never self-notifying.
 - 2026-07-20: Commons producer — `createFeedCommunityPost` now notifies the parent post's author when
   someone replies (`commons.reply`), and `replyToAnnouncement` notifies the announcement's author
   (`commons.announcement_reply`). Both emit after the transaction commits via `notifySafe` (a new

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-recurring-activity-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-recurring-activity-feature-inventory.md
@@ -159,6 +159,11 @@ flow, the Trust signal, and both GDP recognition branches. RACT's contribution w
 
 ## Change Log
 
+- 2026-07-20: **Notifications producer.** Best-effort notifications (`notifySafe`) now fire from the
+  routes: creating an activity notifies the counterparty to confirm/decline
+  (`recurring-activity.invited`); confirming/declining notifies the owner
+  (`recurring-activity.confirmed` / `.declined`). Deduped on the activity id, never self-notifying.
+  No schema/contract change.
 - 2026-07-14: Added refresh controls (app-wide refresh rollout). Web: the shared `RefreshButton` now
   sits next to the "Recurring Activity" heading (the shell renders one header for both the desktop
   and mobile-responsive layouts), wired to a new background mode of `loadData` so the activities and

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-service-credits-feature-inventory.md
@@ -276,6 +276,11 @@ ServiceCredits seeds wallets, transfers, escrow holds, and dispute fixtures via 
 
 ## 10) Change Log
 
+- 2026-07-20: **Notifications producer.** `POST /api/service-credits/transfers` now emits a
+  best-effort notification (`notifySafe`, `service-credits.received`) to the recipient of a completed
+  direct member-to-member transfer — never to the sender, deduped on the transfer id. Emitted from the
+  route only (the `createTransfer` ledger function is untouched); plugin-origin transfers (rides,
+  calls) will notify via their own domain producers. No schema/contract/ledger change.
 - 2026-07-17: **History-aware back + admin↔member navigation (app-wide sweep).** The member
   shell's hand-rolled back chevron was replaced by the shared `BackChevronButton` — it returns to
   the previous in-app page and falls back to All Apps when there is no in-app history. The admin

--- a/ctf/docs/developer/test-scripts/level-up-test-script.md
+++ b/ctf/docs/developer/test-scripts/level-up-test-script.md
@@ -539,3 +539,10 @@ The following cases must produce the same data and UX outcome on both surfaces. 
 - **Unbacked trainer detail fields absent.** Trainer rating, handle, per-cohort name/status, learners count, milestones validated, SC released, and recent-activity feed are not returned by `GET /api/level-up/trainers`. Their absence from the UI is correct.
 - **Unbacked achievement fields absent.** Achievement emoji, rarity, and an "In Progress" bucket with progress fractions are not backed by the endpoint (earned boolean only). Their absence is correct.
 - **Unbacked wallet fields absent.** "Total Spent", per-row running balance, a "Spent" filter tab, per-cohort escrow breakdown, and an "earn more" suggestion list have no data path (grant-only model). Their absence is correct.
+
+---
+
+## Notifications
+
+**1.** As a trainer or admin, release a milestone's credits for a learner. Sign in as that learner, open the 🔔 notifications tab in the Commons, and confirm a "A LevelUp milestone was approved and your credits were released." item appears (unread) with an "Open" pill to LevelUp.
+web ☐

--- a/ctf/docs/developer/test-scripts/recurring-activity-test-script.md
+++ b/ctf/docs/developer/test-scripts/recurring-activity-test-script.md
@@ -354,3 +354,13 @@ These cases must produce identical behavior on both surfaces. Run them on web an
 4. **No admin collusion-review surface** — the bilateral graph is captured in the audit trail but no admin UI to surface collusion patterns is built yet.
 
 > _Terminology (2026-07-20): the source inventory's user-facing section is now titled **User Features** (was "Target User Features"), and its admin section **Admin Features**. Heading rename only — no test steps changed._
+
+---
+
+## Notifications
+
+**1.** As member A, record a new recurring activity with member B. Sign in as member B, open the 🔔 notifications tab in the Commons, and confirm a "Someone recorded a recurring activity with you — confirm or decline it." item appears (unread).
+web ☐
+
+**2.** As member B, confirm the activity. Sign in as member A, open the 🔔 tab, and confirm a "Your recurring activity was confirmed." item appears. (Repeat with decline to confirm the "…was declined." item.)
+web ☐

--- a/ctf/docs/developer/test-scripts/service-credits-test-script.md
+++ b/ctf/docs/developer/test-scripts/service-credits-test-script.md
@@ -546,3 +546,10 @@ These items are recorded in the inventory's Gaps and Known Technical Debt sectio
 3. **Cross-plugin path attestation is a structured field only.** The `origin_plugin` field on transfers is recorded but has not been promoted to a signed/canonical shared contract. If the field is present and readable but not cryptographically attested, that is expected.
 
 4. **Retention classes for dispute artifacts and treasury evidence follow platform defaults.** A plugin-specific retention contract has not been published. Do not file a bug about retention period values.
+
+---
+
+## Notifications
+
+**1.** As member A, send credits to member B via a direct transfer. Sign in as member B, open the 🔔 notifications tab in the Commons, and confirm a "You received N ServiceCredits." item appears (unread) with an "Open" pill to ServiceCredits. Sending to yourself produces no notification.
+web ☐

--- a/ctf/packages/web/app/api/level-up/milestones/[milestoneId]/release/route.ts
+++ b/ctf/packages/web/app/api/level-up/milestones/[milestoneId]/release/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { insertLevelUpAudit, isTrainerForCohort, releaseMilestoneCredits } from 'lib/level-up/repository';
 import { ensureMutationCsrf, levelUpErrorResponse, requireLevelUpReadAccess } from 'lib/level-up/_lib';
+import { notifySafe } from 'lib/notifications/repository';
 import { reportError } from 'lib/observability/report';
 
 type RouteProps = {
@@ -67,6 +68,20 @@ export async function POST(request: Request, { params }: RouteProps) {
         completionBonusAmount: release.completionBonusAmount,
       },
     });
+
+    // Notify the learner their milestone was approved and credits released — best-effort, deduped on
+    // the transfer id, never when the learner is the one releasing (trainer/admin self-release).
+    if (release.recipientUserId && release.recipientUserId !== gate.auth.userId) {
+      await notifySafe({
+        userId: release.recipientUserId,
+        sourcePlugin: 'level-up',
+        notificationType: 'level-up.milestone.released',
+        category: 'activity',
+        summary: 'A LevelUp milestone was approved and your credits were released.',
+        linkPath: '/apps/level-up',
+        targetRef: release.userTransferId,
+      });
+    }
 
     return NextResponse.json({ ok: true, release }, { status: 201 });
   } catch (error) {

--- a/ctf/packages/web/app/api/recurring-activity/[activityId]/confirm/route.ts
+++ b/ctf/packages/web/app/api/recurring-activity/[activityId]/confirm/route.ts
@@ -9,6 +9,7 @@ import {
 } from 'lib/recurring-activity/_lib';
 import { confirmRecurringActivity } from 'lib/recurring-activity/repository';
 import { logRecurringActivityAuditEvent } from 'lib/recurring-activity/audit';
+import { notifySafe } from 'lib/notifications/repository';
 import { reportError } from 'lib/observability/report';
 
 // POST /api/recurring-activity/[activityId]/confirm — the counterparty confirms a pending activity.
@@ -51,6 +52,20 @@ export async function POST(request: Request, context: unknown) {
       requestId,
       traceId,
     });
+    // Notify the owner (proposer) that the other member confirmed — best-effort, deduped on the
+    // activity id. Only the counterparty can confirm, so the owner is never the actor here.
+    if (result.activity.ownerUserId !== userId) {
+      await notifySafe({
+        userId: result.activity.ownerUserId,
+        sourcePlugin: 'recurring-activity',
+        notificationType: 'recurring-activity.confirmed',
+        category: 'activity',
+        summary: 'Your recurring activity was confirmed.',
+        linkPath: '/apps/recurring-activity',
+        targetRef: result.activity.id,
+      });
+    }
+
     return NextResponse.json(
       {
         ok: true,

--- a/ctf/packages/web/app/api/recurring-activity/[activityId]/decline/route.ts
+++ b/ctf/packages/web/app/api/recurring-activity/[activityId]/decline/route.ts
@@ -9,6 +9,7 @@ import {
 } from 'lib/recurring-activity/_lib';
 import { declineRecurringActivity } from 'lib/recurring-activity/repository';
 import { logRecurringActivityAuditEvent } from 'lib/recurring-activity/audit';
+import { notifySafe } from 'lib/notifications/repository';
 import { reportError } from 'lib/observability/report';
 
 // POST /api/recurring-activity/[activityId]/decline — the counterparty declines a pending activity.
@@ -51,6 +52,20 @@ export async function POST(request: Request, context: unknown) {
       requestId,
       traceId,
     });
+    // Notify the owner (proposer) that the other member declined — best-effort, deduped on the
+    // activity id. Only the counterparty can decline, so the owner is never the actor here.
+    if (result.activity.ownerUserId !== userId) {
+      await notifySafe({
+        userId: result.activity.ownerUserId,
+        sourcePlugin: 'recurring-activity',
+        notificationType: 'recurring-activity.declined',
+        category: 'activity',
+        summary: 'A recurring activity you recorded was declined.',
+        linkPath: '/apps/recurring-activity',
+        targetRef: result.activity.id,
+      });
+    }
+
     return NextResponse.json(
       {
         ok: true,

--- a/ctf/packages/web/app/api/recurring-activity/route.ts
+++ b/ctf/packages/web/app/api/recurring-activity/route.ts
@@ -23,6 +23,7 @@ import {
   type RecurringActivityVisibility,
 } from 'lib/recurring-activity/types';
 import { resolveUsernames } from 'lib/identity/resolve-usernames';
+import { notifySafe } from 'lib/notifications/repository';
 import { reportError } from 'lib/observability/report';
 
 function badRequest(message: string) {
@@ -156,6 +157,18 @@ export async function POST(request: Request) {
         hasScValue: activity.scValue !== null,
       },
     });
+    // Notify the counterparty they were named in a recurring activity to confirm or decline —
+    // best-effort, deduped on the activity id.
+    await notifySafe({
+      userId: activity.counterpartyUserId,
+      sourcePlugin: 'recurring-activity',
+      notificationType: 'recurring-activity.invited',
+      category: 'activity',
+      summary: 'Someone recorded a recurring activity with you — confirm or decline it.',
+      linkPath: '/apps/recurring-activity',
+      targetRef: activity.id,
+    });
+
     // The creator is always the owner; attach the reader-scoped role so the response matches the
     // client's required `role` field (same shape the list and mutation endpoints return).
     return NextResponse.json({ ok: true, activity: { ...activity, role: 'owner' as const } }, { status: 201 });

--- a/ctf/packages/web/app/api/service-credits/transfers/route.ts
+++ b/ctf/packages/web/app/api/service-credits/transfers/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createTransfer, insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { ensureMutationCsrf, requireServiceCreditsReadAccess, serviceCreditsErrorResponse } from 'lib/service-credits/_lib';
 import { isRegisteredPluginSlug } from 'lib/plugins/repository';
+import { notifySafe } from 'lib/notifications/repository';
 import { reportError } from 'lib/observability/report';
 
 // A transfer with no originPlugin is a direct member-to-member send from the ServiceCredits app
@@ -82,6 +83,21 @@ export async function POST(request: Request) {
         escrowHoldId: transfer.escrowHoldId,
       },
     });
+
+    // Notify the recipient that credits landed — best-effort, only for a completed transfer to
+    // someone other than the sender. Deduped on the transfer id, so an idempotent retry never
+    // double-notifies. Neutral summary; ServiceCredits are a non-fiat internal unit, not money.
+    if (transfer.status === 'completed' && transfer.recipientUserId !== gate.auth.userId) {
+      await notifySafe({
+        userId: transfer.recipientUserId,
+        sourcePlugin: 'service-credits',
+        notificationType: 'service-credits.received',
+        category: 'activity',
+        summary: `You received ${transfer.amount} ServiceCredits.`,
+        linkPath: '/apps/service-credits',
+        targetRef: transfer.id,
+      });
+    }
 
     return NextResponse.json({ ok: true, transfer }, { status: 201 });
   } catch (error) {

--- a/ctf/packages/web/lib/level-up/repository.ts
+++ b/ctf/packages/web/lib/level-up/repository.ts
@@ -709,6 +709,8 @@ export async function releaseMilestoneCredits(input: {
   type MilestoneReleaseResponse = {
     enrollmentId: string;
     milestoneId: string;
+    // The learner the released credits go to — surfaced so the route can notify them.
+    recipientUserId: string;
     userTransferId: string;
     trainerPayoutGovernanceId: string | null;
     completionBonusGovernanceId: string | null;
@@ -888,6 +890,7 @@ export async function releaseMilestoneCredits(input: {
     const output = {
       enrollmentId: input.enrollmentId,
       milestoneId: input.milestoneId,
+      recipientUserId: releaseDraft.recipientUserId,
       userTransferId: userRelease.transferId,
       trainerPayoutGovernanceId,
       completionBonusGovernanceId,


### PR DESCRIPTION
## What

Step 3 of the notifications plan — the everyday producers. Each emits from its route via the best-effort `notifySafe`, deduped on the underlying row id, never self-notifying.

- **ServiceCredits:** notify the recipient of a **completed direct member-to-member transfer** (`service-credits.received`). Emitted from `/api/service-credits/transfers`, **not** from the `createTransfer` ledger function — so the ledger path is untouched, and plugin-origin transfers (rides, calls) will notify via their own domain producers in step 4. ServiceCredits are a non-fiat internal unit; the summary says "received", not "paid".
- **LevelUp:** notify the learner when a milestone's credits are **released** (`level-up.milestone.released`). `releaseMilestoneCredits` now returns `recipientUserId` (additive — it was already computed internally) so the route can address the learner.
- **Recurring Activity:** notify the **counterparty** on a new activity (`recurring-activity.invited`) and the **owner** on confirm/decline (`recurring-activity.confirmed` / `.declined`).

## Dependency note

This branch also carries the shared `notifySafe` helper, identical to the open Commons-producer PR (#1785). Whichever merges second, the duplicate is a trivial dedupe on rebase; I'll reconcile.

## Scope

No schema change. LevelUp's release response gains one additive field. Touches the ServiceCredits and LevelUp money-adjacent routes (emit-only, no ledger logic change), so this is left for your review/merge — no auto-merge.

## Test

Web typecheck + lint, a11y audit, the all-package pre-commit typecheck all pass.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN)_