### PR TITLE
feat: device push delivery for the notifications center

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
@@ -53,6 +53,10 @@ None. Notifications are member self-service; there are no admin governance actio
 - `POST /api/notifications/read-all` — mark all unread read. CSRF-guarded.
 - `GET /api/notifications/preferences` — the member's device-push opt-ins.
 - `PUT /api/notifications/preferences` — update opt-ins (missing field keeps its value). CSRF-guarded.
+- `GET /api/notifications/push/vapid-public-key` — the public VAPID key the browser needs to create a
+  Web Push subscription (not secret; empty string when push is unconfigured).
+- `POST /api/notifications/push/subscribe` — save this device's Web Push subscription. CSRF-guarded.
+- `POST /api/notifications/push/unsubscribe` — remove this device's subscription. CSRF-guarded.
 
 Producers do not use HTTP — each plugin calls `createNotification` in
 `lib/notifications/repository.ts` at its own emit point.
@@ -96,9 +100,11 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
   `@username` → user id lookup, which does not exist centrally (`lib/identity/resolve-usernames`
   only goes id → name). Reply-to-your-post and announcement-reply notifications ship now; add mention
   notifications once a username→id index exists.
-- No device-push delivery yet — preferences are recorded but nothing sends a ping. Web push has
-  platform limits (Android/Chrome and installed iOS web apps only), to be handled in the delivery
-  step.
+- Device push is delivered via Web Push (`lib/notifications/push.ts`, shared with Foundation call
+  alerts), gated by the member's per-category opt-in and discreet setting. It requires the VAPID
+  server keys (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) in the environment; when they
+  are unset every send is a logged no-op, so the in-app feed still works. Platform limits apply:
+  Web Push reaches Android/Chrome and installed iOS web apps, not a plain iOS browser tab.
 - Emergency real-time (an incoming Foundation call ring) is a separate live mechanism from this
   durable feed and is tracked with the Safety producers.
 
@@ -116,12 +122,24 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
    request was claimed), TrustTransport (provider's offer was accepted), Foundation (someone started a
    connection). Foundation's live incoming-call **ring stays its own real-time path** — the feed entry
    is the durable complement, not the ring.
-5. **Device-push delivery:** content-safe/discreet payload, category-gated by preferences, web-push
-   with the PWA/native platform caveats. Blocked by 1; benefits from 2–4 existing so there is
-   something to ping about.
+5. **Device-push delivery (done):** `notifySafe` sends a Web Push on a genuinely new notification when
+   the recipient opted that category in — discreet by default (generic ping, no plugin name or
+   content). Notifications-owned subscribe/unsubscribe/vapid-public-key endpoints, and the 🔔 tab
+   subscribes this device when a member turns a category on. Reuses the shared push sender + the
+   user-global `push_subscriptions` table; no-op until VAPID keys are set.
 
 ## Change Log
 
+- 2026-07-20: Device-push delivery. `notifySafe` now sends a Web Push (via the shared
+  `sendWebPushToUser`) on a genuinely new notification when the recipient has opted that category in —
+  discreet by default (a generic "You have a new update" ping with the in-app path in `data`, no
+  plugin name or content on the lock screen); detailed mode sends the neutral summary. Deduped events
+  never re-ping. Added notifications-owned `push/subscribe`, `push/unsubscribe`, and
+  `push/vapid-public-key` routes (thin wrappers over `lib/notifications/push.ts`, reusing the
+  user-global `push_subscriptions` table shared with Foundation), and the 🔔 tab now registers the
+  service worker and subscribes this device when a member turns a category on (best-effort; a note
+  shows if the browser can't, and the in-app feed is unaffected). Requires the VAPID env keys; a no-op
+  without them.
 - 2026-07-20: Safety producers (category `safety`), each emitted from its route via `notifySafe`,
   deduped on the underlying row id, never self-notifying: LightHouse notifies the host of a new stay
   request (`lighthouse.match.requested`); SocketRelay notifies the requester when their request is

--- a/ctf/packages/web/app/api/notifications/push/subscribe/route.ts
+++ b/ctf/packages/web/app/api/notifications/push/subscribe/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { ensureNotificationsCsrf, requireNotificationsAccess } from '../../_lib';
+import { saveWebPushSubscription } from 'lib/notifications/push';
+import { NOTIFICATION_ERROR_CODE } from 'lib/notifications/types';
+import { reportError } from 'lib/observability/report';
+
+// Save the signed-in member's Web Push subscription for one device, so their opted-in notifications can
+// also ping this device. Scoped to the caller's own subscription; stored in the user-global
+// push_subscriptions table (shared with Foundation call alerts) — a device subscribed once receives
+// any push the member has opted into. Secrets policy: the endpoint/keys are stored, never logged.
+export async function POST(request: Request) {
+  const csrfDeny = ensureNotificationsCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireNotificationsAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  let payload: { endpoint?: unknown; keys?: { p256dh?: unknown; auth?: unknown }; userAgent?: unknown };
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, code: NOTIFICATION_ERROR_CODE.invalidPayload, message: 'A subscription is required.' },
+      { status: 400 },
+    );
+  }
+
+  const endpoint = typeof payload.endpoint === 'string' ? payload.endpoint.trim() : '';
+  const p256dh = typeof payload.keys?.p256dh === 'string' ? payload.keys.p256dh : null;
+  const auth = typeof payload.keys?.auth === 'string' ? payload.keys.auth : null;
+  const userAgent = typeof payload.userAgent === 'string' ? payload.userAgent.slice(0, 256) : null;
+
+  if (!endpoint || !p256dh || !auth) {
+    return NextResponse.json(
+      { ok: false, code: NOTIFICATION_ERROR_CODE.invalidPayload, message: 'A complete push subscription is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await saveWebPushSubscription({ userId: gate.auth.userId, endpoint, p256dh, auth, userAgent });
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (error) {
+    reportError(error, { area: 'notifications', op: 'push_subscribe' });
+    return NextResponse.json(
+      { ok: false, code: NOTIFICATION_ERROR_CODE.persistenceUnavailable, message: 'Could not save your device alerts.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/notifications/push/unsubscribe/route.ts
+++ b/ctf/packages/web/app/api/notifications/push/unsubscribe/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { ensureNotificationsCsrf, requireNotificationsAccess } from '../../_lib';
+import { deletePushSubscriptionByEndpoint } from 'lib/notifications/push';
+import { NOTIFICATION_ERROR_CODE } from 'lib/notifications/types';
+import { reportError } from 'lib/observability/report';
+
+// Remove one device's push subscription (the member turned device alerts off, or the browser revoked
+// it). Scoped to the caller so a member can only delete their own subscription.
+export async function POST(request: Request) {
+  const csrfDeny = ensureNotificationsCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireNotificationsAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  let payload: { endpoint?: unknown };
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, code: NOTIFICATION_ERROR_CODE.invalidPayload, message: 'An endpoint is required.' },
+      { status: 400 },
+    );
+  }
+
+  const endpoint = typeof payload.endpoint === 'string' ? payload.endpoint.trim() : '';
+  if (!endpoint) {
+    return NextResponse.json(
+      { ok: false, code: NOTIFICATION_ERROR_CODE.invalidPayload, message: 'An endpoint is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await deletePushSubscriptionByEndpoint({ userId: gate.auth.userId, endpoint });
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'notifications', op: 'push_unsubscribe' });
+    return NextResponse.json(
+      { ok: false, code: NOTIFICATION_ERROR_CODE.persistenceUnavailable, message: 'Could not update your device alerts.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/notifications/push/vapid-public-key/route.ts
+++ b/ctf/packages/web/app/api/notifications/push/vapid-public-key/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { requireNotificationsAccess } from '../../_lib';
+import { getWebPushPublicKey } from 'lib/notifications/push';
+
+// The public VAPID key the browser needs to create a Web Push subscription. Not secret. Empty string
+// when push is not configured, so the client can show "device alerts unavailable" instead of failing.
+export async function GET() {
+  const gate = await requireNotificationsAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  return NextResponse.json({ ok: true, publicKey: getWebPushPublicKey() }, { status: 200 });
+}

--- a/ctf/packages/web/components/community-shell/notifications-panel.tsx
+++ b/ctf/packages/web/components/community-shell/notifications-panel.tsx
@@ -34,6 +34,77 @@ const PUSH_TOGGLES: Array<{ key: keyof Pick<NotificationPreferences, 'pushSafety
   { key: 'pushCommunity', label: 'Community', detail: 'Commons, PeerProgramming' },
 ];
 
+function pushSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
+// A VAPID public key is base64url; pushManager.subscribe needs it as bytes (a plain ArrayBuffer so it
+// satisfies BufferSource). Mirrors the Foundation call-alerts helper.
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const buffer = new ArrayBuffer(raw.length);
+  const output = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+// Ensure this device has a Web Push subscription so opted-in categories can ping it. Best-effort:
+// returns a short note when it can't (unsupported browser, permission denied, push not configured on
+// the server). The in-app feed works regardless; this only governs the device ping. Reuses the
+// user-global push subscription (shared with Foundation), so a device subscribed once needs no repeat.
+async function ensureDeviceSubscribed(): Promise<string | null> {
+  if (!pushSupported()) {
+    return 'This browser can’t show device alerts — the list above still updates in the app.';
+  }
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    const existing = registration ? await registration.pushManager.getSubscription() : null;
+    if (existing) {
+      return null; // already subscribed on this device
+    }
+    if (Notification.permission === 'denied') {
+      return 'Device alerts are blocked in your browser settings — the list above still updates in the app.';
+    }
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') {
+      return 'Device alerts are off for now — the list above still updates in the app.';
+    }
+    const keyRes = await fetch('/api/notifications/push/vapid-public-key', { cache: 'no-store' });
+    const keyData = (await keyRes.json().catch(() => ({}))) as { ok?: boolean; publicKey?: string };
+    if (!keyRes.ok || !keyData.publicKey) {
+      return 'Device alerts aren’t available yet — the list above still updates in the app.';
+    }
+    const reg = await navigator.serviceWorker.register('/sw.js');
+    await navigator.serviceWorker.ready;
+    const subscription = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(keyData.publicKey),
+    });
+    const json = subscription.toJSON();
+    await fetch('/api/notifications/push/subscribe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-ctf-csrf': '1' },
+      body: JSON.stringify({
+        endpoint: json.endpoint,
+        keys: json.keys,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+      }),
+    });
+    return null;
+  } catch {
+    return 'Couldn’t turn on device alerts on this device — the list above still updates in the app.';
+  }
+}
+
 // The notifications center: the member's own feed of updates across plugins, plus the device-push
 // opt-ins. The in-app feed is always shown; the opt-ins only control the device ping and default off.
 // Opt-in lives here (not buried in account settings) so it sits with the feed it governs.
@@ -44,6 +115,9 @@ export function NotificationsPanel() {
   const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
   const [manageOpen, setManageOpen] = useState(false);
   const [savingPref, setSavingPref] = useState<string | null>(null);
+  // A short note shown when turning on a push category couldn't subscribe this device (unsupported
+  // browser, blocked permission, or push not configured). The opt-in is still saved either way.
+  const [pushNote, setPushNote] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -95,6 +169,14 @@ export function NotificationsPanel() {
       const next = { ...prefs, [key]: !prefs[key] };
       setPrefs(next);
       setSavingPref(key);
+      setPushNote(null);
+      // Turning ON any of the three push categories needs a device subscription for the ping to land;
+      // make sure this device is subscribed (best-effort — the opt-in still saves either way).
+      const turningOnPush =
+        (key === 'pushSafety' || key === 'pushActivity' || key === 'pushCommunity') && next[key] === true;
+      if (turningOnPush) {
+        void ensureDeviceSubscribed().then((note) => setPushNote(note));
+      }
       void requestJson<NotificationPreferencesResponse>('/api/notifications/preferences', {
         method: 'PUT',
         headers: { 'content-type': 'application/json', 'x-ctf-csrf': '1' },
@@ -179,6 +261,9 @@ export function NotificationsPanel() {
                 Everything shows in this list either way. These switches only control whether your
                 device also pings you. All are off unless you turn them on.
               </p>
+              {pushNote ? (
+                <p className={styles.notificationsManageNote} role="status">{pushNote}</p>
+              ) : null}
               {PUSH_TOGGLES.map((toggle) => (
                 <label key={toggle.key} className={styles.notificationsPrefRow} aria-label={toggle.label}>
                   <input

--- a/ctf/packages/web/lib/notifications/repository.ts
+++ b/ctf/packages/web/lib/notifications/repository.ts
@@ -1,9 +1,11 @@
 import { queryDb } from 'lib/db/postgres';
 import { reportError } from 'lib/observability/report';
+import { sendWebPushToUser } from './push';
 import {
   isNotificationCategory,
   NOTIFICATIONS_MAX_PAGE_SIZE,
   type Notification,
+  type NotificationCategory,
   type NotificationInput,
   type NotificationPreferences,
 } from './types';
@@ -70,11 +72,47 @@ export async function createNotification(input: NotificationInput): Promise<stri
 // notification write) break the underlying action that triggered it. Every per-plugin emit point
 // should call this — ideally after its own transaction has committed — and ignore the result.
 export async function notifySafe(input: NotificationInput): Promise<void> {
+  let createdId: string | null = null;
   try {
-    await createNotification(input);
+    createdId = await createNotification(input);
   } catch (error) {
     reportError(error, { area: 'notifications', op: `emit_${input.notificationType}` });
+    return;
   }
+  // Only send a device push on a genuinely new notification — createNotification returns null when the
+  // event deduped, so a re-emit of the same event never re-pings. The in-app feed row is already
+  // written above regardless.
+  if (!createdId) {
+    return;
+  }
+  try {
+    await maybeSendDevicePush(input);
+  } catch (error) {
+    reportError(error, { area: 'notifications', op: `push_${input.notificationType}` });
+  }
+}
+
+// Category → the matching device-push opt-in field.
+function isCategoryPushEnabled(category: NotificationCategory, prefs: NotificationPreferences): boolean {
+  if (category === 'safety') return prefs.pushSafety;
+  if (category === 'activity') return prefs.pushActivity;
+  return prefs.pushCommunity;
+}
+
+// Send a device push for a just-created notification when the recipient opted that category in. The
+// in-app feed is never gated by this; only the ping is. Discreet (the default) sends a generic ping
+// with no plugin name or content — safe on a shared or monitored lock screen; the tappable detail
+// lives behind sign-in in the feed. `sendWebPushToUser` is itself best-effort and a no-op when VAPID
+// is unconfigured, so this never throws in a way that matters.
+async function maybeSendDevicePush(input: NotificationInput): Promise<void> {
+  const prefs = await getNotificationPreferences(input.userId);
+  if (!isCategoryPushEnabled(input.category, prefs)) {
+    return;
+  }
+  const payload = prefs.discreetPush
+    ? { title: 'Charging The Future', body: 'You have a new update.', data: { path: input.linkPath ?? '/' } }
+    : { title: 'Charging The Future', body: input.summary, data: { path: input.linkPath ?? '/' } };
+  await sendWebPushToUser(input.userId, payload);
 }
 
 export async function listNotifications(userId: string, limit: number): Promise<Notification[]> {


### PR DESCRIPTION
Completes the last step of the approved notifications plan: a genuinely new notification can now also ping the member's device, on top of the always-on in-app feed.

## What changed

- `notifySafe` sends a Web Push (via the shared `sendWebPushToUser`) only on a genuinely new notification — deduped re-emits never re-ping. It fires only when the recipient has opted that notification's category in.
- Discreet by default: the ping just says "You have a new update" with the in-app path in `data` — no plugin name or content on the lock screen. A member who turns discreet off gets the neutral summary instead.
- Added three notifications-owned routes — `push/subscribe`, `push/unsubscribe`, and `push/vapid-public-key` — thin wrappers over `lib/notifications/push.ts`, reusing the user-global `push_subscriptions` table (shared with Foundation call alerts).
- The 🔔 tab now registers the service worker and subscribes this device the first time a member turns a push category on. Best-effort: an unsupported browser, a blocked permission, or unconfigured push shows a short note, and the in-app feed is unaffected.
- Requires the VAPID env keys (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`); a logged no-op without them, so nothing breaks when push is off.

No schema change: this reuses the existing `push_subscriptions` table and the vetted push sender. All device pushes default off (the opt-ins ship off) and stay opt-in.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN

---
_Generated by [Claude Code](https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN)_