### PR TITLE
feat: notify members an @mention in the Commons addresses

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
@@ -96,10 +96,12 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 
 ## 8) Gaps and Known Technical Debt
 
-- @mention notifications are deferred: notifying a mentioned member needs a reliable
-  `@username` → user id lookup, which does not exist centrally (`lib/identity/resolve-usernames`
-  only goes id → name). Reply-to-your-post and announcement-reply notifications ship now; add mention
-  notifications once a username→id index exists.
+- @mention notifications ship now. There is still no central username store, so a handle is resolved
+  at post time (`lib/identity/resolve-mention-user-ids.ts`): a `@username` is looked up against Clerk
+  (the authoritative account store) in one batched call, and the `@user-<token>` pseudonym is reversed
+  against our own community-post authors — accepted only when the short token matches exactly one
+  author, so an ambiguous prefix never pings a bystander. Any handle that cannot be resolved is
+  dropped; resolution is best-effort and never blocks the post.
 - Device push is delivered via Web Push (`lib/notifications/push.ts`, shared with Foundation call
   alerts), gated by the member's per-category opt-in and discreet setting. It requires the VAPID
   server keys (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) in the environment; when they
@@ -113,8 +115,9 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 1. **Backbone (this PR):** schema (`notifications`, `notification_preferences`), repository,
    command + access-policy contracts, deletion-registry entry, the five API routes, and the 🔔 tab
    with the always-on feed + the per-category opt-ins. No dependencies.
-2. **Commons producer (done):** emit on reply-to-your-post and announcement reply. `@mention` is
-   deferred (needs a username→id lookup — see Gaps).
+2. **Commons producer (done):** emit on reply-to-your-post, announcement reply, and `@mention` (each
+   member a new community post addresses; resolved at post time — see Gaps for how a handle maps to a
+   user id).
 3. **Everyday producers (done):** ServiceCredits (credits received on a completed direct transfer),
    LevelUp (milestone credits released to the learner), Recurring Activity (invited / confirmed /
    declined). Emitted from each plugin's route via `notifySafe`, after the underlying write.
@@ -130,6 +133,15 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 
 ## Change Log
 
+- 2026-07-21: @mention notifications. A new Commons community post now notifies each member it
+  @-mentions (`commons.mention`, category `community`), deduped per post via `target_ref` so a member
+  mentioned twice in one post is notified once, never self-notifying, and skipping the parent author
+  on a reply (they already get the reply notification). Handles are pulled from the body by the pure
+  `extractMentionHandles` (an email is not a mention; `@comic` is the AI Assistant, not a member) and
+  resolved by `lib/identity/resolve-mention-user-ids.ts`: `@username` via a batched Clerk lookup, the
+  `@user-<token>` pseudonym reversed against our own community-post authors and accepted only when the
+  token is unambiguous. Best-effort throughout — a handle that will not resolve is dropped and the post
+  is never blocked.
 - 2026-07-20: Device-push delivery. `notifySafe` now sends a Web Push (via the shared
   `sendWebPushToUser`) on a genuinely new notification when the recipient has opted that category in —
   discreet by default (a generic "You have a new update" ping with the in-app path in `data`, no

--- a/ctf/packages/web/lib/feed/author-handle.test.ts
+++ b/ctf/packages/web/lib/feed/author-handle.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { extractMentionHandles } from './author-handle';
+
+// extractMentionHandles is the inverse of the "@ Mentions" filter: it decides who a Commons post
+// addresses so those members can be notified. These cases lock the boundaries that matter — an email
+// is not a mention, @comic is the AI Assistant (not a member), and a member mentioned twice is
+// notified once.
+describe('extractMentionHandles', () => {
+  it('pulls a plain @username mention', () => {
+    expect(extractMentionHandles('welcome @farah, glad you are here')).toEqual(['farah']);
+  });
+
+  it('pulls the @user-<token> pseudonym form', () => {
+    expect(extractMentionHandles('agreed @user-3gysu61f')).toEqual(['user-3gysu61f']);
+  });
+
+  it('captures several handles in one body', () => {
+    expect(extractMentionHandles('@ana and @ben-r should see this @user-90ab12cd')).toEqual([
+      'ana',
+      'ben-r',
+      'user-90ab12cd',
+    ]);
+  });
+
+  it('does not treat an email address as a mention', () => {
+    expect(extractMentionHandles('reach me at name@example.com')).toEqual([]);
+  });
+
+  it('drops @comic (that routes to the AI Assistant, not a member)', () => {
+    expect(extractMentionHandles('@comic what is this @comic')).toEqual([]);
+  });
+
+  it('de-duplicates the same handle case-insensitively, keeping the first spelling', () => {
+    expect(extractMentionHandles('@Farah again @farah and @FARAH')).toEqual(['Farah']);
+  });
+
+  it('returns nothing for a body with no mentions', () => {
+    expect(extractMentionHandles('just a normal post')).toEqual([]);
+    expect(extractMentionHandles('')).toEqual([]);
+  });
+});

--- a/ctf/packages/web/lib/feed/author-handle.ts
+++ b/ctf/packages/web/lib/feed/author-handle.ts
@@ -45,3 +45,31 @@ export function feedMentionTokens(username: string | null, userId: string | null
   }
   return tokens;
 }
+
+// Pull the @-mention handles out of a Commons post body — the inverse of the
+// filter above, used to work out who a new post addresses so they can be
+// notified. Matches an `@` that starts a handle (at the start of the text or
+// after a non-handle character, so an email like `a@b` is not treated as a
+// mention) followed by a username/pseudonym token. Handles are returned in the
+// case they were typed, de-duplicated case-insensitively (the first spelling
+// wins). `@comic` is dropped — that routes to the AI Assistant, not a member.
+// Pure and dependency-free like the rest of this file; resolving a handle to a
+// user id is a separate server-only step.
+export function extractMentionHandles(body: string): string[] {
+  if (!body) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const handles: string[] = [];
+  const pattern = /(?:^|[^A-Za-z0-9_@/-])@([A-Za-z0-9][A-Za-z0-9_-]{0,63})/g;
+  for (const match of body.matchAll(pattern)) {
+    const handle = match[1];
+    const lower = handle.toLowerCase();
+    if (lower === 'comic' || seen.has(lower)) {
+      continue;
+    }
+    seen.add(lower);
+    handles.push(handle);
+  }
+  return handles;
+}

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -19,11 +19,13 @@ import {
   FEED_REACTION_EMOJIS,
   isAllowedFeedReactionEmoji,
 } from './constants';
-import { feedAuthorHandle, feedMentionTokens } from './author-handle';
+import { extractMentionHandles, feedAuthorHandle, feedMentionTokens } from './author-handle';
 import { generateFeedAssistedAnswer, inferFeedQuestionCategory } from './inference';
 import { emitFeedMembershipEventToStream } from './stream';
 import { getPluginBySlug, getPluginRoute, isAdminOnlyPlugin } from 'lib/plugins/repository';
 import { notifySafe } from 'lib/notifications/repository';
+import { resolveMentionUserIds } from 'lib/identity/resolve-mention-user-ids';
+import { reportError } from 'lib/observability/report';
 
 // Re-exported so existing server callers can keep importing them from the feed
 // repository; the implementations live in the client-safe ./author-handle module.
@@ -1745,10 +1747,13 @@ export async function createFeedCommunityPost(
   isPrivileged: boolean = false,
 ): Promise<{ postId: string; createdAtIso: string }> {
   // When this post is a reply, the parent post's author (captured inside the transaction) is notified
-  // after commit — best-effort, and never for a self-reply.
+  // after commit — best-effort, and never for a self-reply. The committed body is captured too so the
+  // @-mentions it addresses can be notified after commit.
   let replyParentAuthorId: string | null = null;
+  let committedBody = '';
   const result = await withDbTransaction(async (client) => {
     const body = normalizeMultilineText(input.body);
+    committedBody = body;
     const category = normalizeCommunityCategory(input.category);
 
     const urlCap = isPrivileged ? FEED_ADMIN_MAX_COMMUNITY_POST_URLS : FEED_MAX_COMMUNITY_POST_URLS;
@@ -1816,7 +1821,47 @@ export async function createFeedCommunityPost(
     });
   }
 
+  // Notify each member this post @-mentions — after commit, best-effort. Resolving a handle to a user
+  // id (Clerk for usernames, our own post authors for the pseudonym) can miss, so it never blocks the
+  // post. Skip the author (no self-mention) and skip the parent author when this is a reply (they
+  // already got the reply notification above, so a reply that also @-mentions them is not doubled).
+  await notifyMentionedMembers(committedBody, actorId, replyParentAuthorId, result.postId);
+
   return result;
+}
+
+// Resolve the @-mentions in a just-posted body and notify each addressed member. Best-effort and
+// self-contained: any failure is swallowed so it can never break the post that triggered it. Deduped
+// per post via target_ref, so a member mentioned twice in one post is notified once.
+async function notifyMentionedMembers(
+  body: string,
+  actorId: string,
+  replyParentAuthorId: string | null,
+  postId: string,
+): Promise<void> {
+  try {
+    const handles = extractMentionHandles(body);
+    if (handles.length === 0) {
+      return;
+    }
+    const mentionedIds = await resolveMentionUserIds(handles);
+    for (const userId of mentionedIds) {
+      if (userId === actorId || userId === replyParentAuthorId) {
+        continue;
+      }
+      await notifySafe({
+        userId,
+        sourcePlugin: 'commons',
+        notificationType: 'commons.mention',
+        category: 'community',
+        summary: 'Someone mentioned you in the Commons.',
+        linkPath: '/',
+        targetRef: postId,
+      });
+    }
+  } catch (error) {
+    reportError(error, { area: 'notifications', op: 'emit_commons.mention' });
+  }
 }
 
 // Delete a member's own community (peer) post from the Commons. Author-only: the caller must own

--- a/ctf/packages/web/lib/identity/resolve-mention-user-ids.ts
+++ b/ctf/packages/web/lib/identity/resolve-mention-user-ids.ts
@@ -1,0 +1,117 @@
+import { createClerkClient } from '@clerk/backend';
+import { getClerkSecretKey } from '../auth/clerk-env';
+import { queryDb } from '../db/postgres';
+
+// Resolve the @-mention handles found in a Commons post body to the user ids they address, so those
+// members can be notified. There is no central username store in v3, so the two handle forms are
+// resolved from two authoritative sources:
+//
+//   - `@user-<token>` — the stable pseudonym shown for a member who has not set a username. The token
+//     is the first characters of that member's id (see feedAuthorHandle). It is reversed against our
+//     own community-post authors: a member's pseudonym only appears in the feed because they posted,
+//     so their id is present locally. If a token is ambiguous (more than one author shares that short
+//     prefix) it is skipped rather than risk notifying the wrong person.
+//   - `@<username>` — resolved against Clerk, the authoritative account/username store, in one batched
+//     lookup. Best-effort: an unknown handle, or Clerk being unreachable, simply resolves to nothing.
+//
+// Best-effort by contract: any handle that cannot be resolved is dropped. Returns the set of resolved
+// user ids (deduped). Not exposed over HTTP; called by the post producer after the write commits.
+
+// Strip Clerk's non-distinguishing `user_` prefix, matching feedAuthorHandle so the pseudonym token
+// lines up with what members actually see and type.
+function pseudonymTokenLength(): number {
+  return 8;
+}
+
+export async function resolveMentionUserIds(handles: string[]): Promise<Set<string>> {
+  const resolved = new Set<string>();
+  const cleaned = Array.from(
+    new Set(handles.map((handle) => handle.trim()).filter((handle) => handle.length > 0)),
+  );
+  if (cleaned.length === 0) {
+    return resolved;
+  }
+
+  const pseudonymTokens: string[] = [];
+  const usernameHandles: string[] = [];
+  for (const handle of cleaned) {
+    const lower = handle.toLowerCase();
+    if (lower.startsWith('user-')) {
+      const token = lower.slice('user-'.length).slice(0, pseudonymTokenLength());
+      if (token.length > 0) {
+        pseudonymTokens.push(token);
+      }
+    } else {
+      usernameHandles.push(handle);
+    }
+  }
+
+  await Promise.all([
+    resolvePseudonymTokens(pseudonymTokens, resolved),
+    resolveUsernameHandles(usernameHandles, resolved),
+  ]);
+
+  return resolved;
+}
+
+// Reverse each `@user-<token>` pseudonym to its author id via our own community posts. Only a token
+// that matches exactly one author is accepted — a shared short prefix is ambiguous and skipped so we
+// never ping a bystander who happens to share the prefix.
+async function resolvePseudonymTokens(tokens: string[], into: Set<string>): Promise<void> {
+  const unique = Array.from(new Set(tokens));
+  if (unique.length === 0) {
+    return;
+  }
+  try {
+    const result = await queryDb<{ token: string; author_user_id: string; author_count: string }>(
+      `
+        SELECT token, author_user_id, author_count
+        FROM (
+          SELECT
+            lower(substr(regexp_replace(author_user_id, '^user_', ''), 1, $2)) AS token,
+            author_user_id,
+            COUNT(DISTINCT author_user_id) OVER (
+              PARTITION BY lower(substr(regexp_replace(author_user_id, '^user_', ''), 1, $2))
+            )::text AS author_count
+          FROM feed_community_posts
+        ) AS authors
+        WHERE token = ANY($1::text[])
+      `,
+      [unique, pseudonymTokenLength()],
+    );
+    for (const row of result.rows) {
+      if (row.author_count === '1') {
+        into.add(row.author_user_id);
+      }
+    }
+  } catch {
+    // best-effort: leave pseudonym mentions unresolved
+  }
+}
+
+// Resolve `@username` handles to ids via Clerk in one batched call. Clerk is the authoritative
+// username store; a username no account holds resolves to nothing.
+async function resolveUsernameHandles(handles: string[], into: Set<string>): Promise<void> {
+  const unique = Array.from(new Set(handles));
+  if (unique.length === 0) {
+    return;
+  }
+  const secretKey = getClerkSecretKey();
+  if (!secretKey) {
+    return;
+  }
+  let client: ReturnType<typeof createClerkClient>;
+  try {
+    client = createClerkClient({ secretKey });
+  } catch {
+    return;
+  }
+  try {
+    const response = await client.users.getUserList({ username: unique, limit: unique.length });
+    for (const user of response.data) {
+      into.add(user.id);
+    }
+  } catch {
+    // best-effort: leave username mentions unresolved
+  }
+}


### PR DESCRIPTION
Completes the last deferred part of the notifications plan: a Commons community post now notifies each member it @-mentions.

## What changed

- A new community post is scanned for `@`-mentions after it commits, and each addressed member gets a `commons.mention` notification (community category) via the existing best-effort `notifySafe`.
- Handle extraction is a new pure helper `extractMentionHandles` (in `author-handle.ts`, the inverse of the existing "@ Mentions" filter): an email address is not a mention, and `@comic` is dropped (it routes to the AI Assistant, not a member). A member mentioned twice in one post is counted once.
- Resolving a handle to a user id is a new server module `lib/identity/resolve-mention-user-ids.ts`. There is still no central username store in v3, so:
  - `@username` → looked up against Clerk (the authoritative account store) in one batched call.
  - `@user-<token>` (the pseudonym shown for a member without a username) → reversed against our own community-post authors, accepted only when the short token matches exactly one author, so an ambiguous prefix never pings a bystander.
- Deduped per post (via `target_ref`), never self-notifying, and skips the parent author on a reply so a reply that also @-mentions them is not doubled.
- Best-effort throughout: any handle that will not resolve is dropped, and a resolution failure never blocks the post.

No schema change and no new API route or contract — this is an additive producer on the existing notifications backbone.

Added unit tests for `extractMentionHandles` covering the mention/email/`@comic`/dedupe boundaries.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN

---
_Generated by [Claude Code](https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN)_