### PR TITLE
feat: comic-theme Commons nav refinements + contributor channel chip

### DIFF
--- a/ctf/packages/web/app/globals.css
+++ b/ctf/packages/web/app/globals.css
@@ -94,6 +94,26 @@
   --ctf-dot-size: 8px 8px;
 }
 
+/*
+ * Comic theme geometry — uniform sharp edges, app-wide.
+ *
+ * The token layer above sets comic card/control radius to 0 and chip radius to 2, but the app
+ * predates those tokens: nearly every surface hardcodes its own border-radius (~1500 inline
+ * `borderRadius` styles in TSX, ~150 declarations in CSS modules) rather than reading the token.
+ * Left alone, comic renders round in most places while the nav is square — a patchwork look. This
+ * one rule flattens the whole theme so every surface matches the nav and the theme is uniform.
+ *
+ * Scoped to comic only, so the default theme is byte-for-byte unchanged. border-radius is purely
+ * cosmetic (never affects layout or behavior). `!important` is required because most radii are
+ * inline styles, which otherwise win on specificity; a stylesheet `!important` still overrides a
+ * non-important inline style. Pseudo-elements are included so decorative/indicator dots square too.
+ */
+:root[data-theme='comic'] *,
+:root[data-theme='comic'] *::before,
+:root[data-theme='comic'] *::after {
+  border-radius: 0 !important;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -3168,6 +3168,9 @@
   }
 
   .channelSwitchBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     padding: 6px 12px;
     border-radius: 999px;
     border: 1px solid rgba(148, 163, 184, 0.3);
@@ -3175,6 +3178,7 @@
     color: #94A3B8;
     font-size: 12px;
     font-weight: 700;
+    line-height: 1;
     cursor: pointer;
   }
 
@@ -3183,4 +3187,174 @@
     background: rgba(99, 102, 241, 0.18);
     color: #C7D2FE;
   }
+
+  /* Locked contributor chip — visible to everyone, opens the explainer. Slightly dimmer than an
+     active channel and carries the braided badge, so it reads as "earnable", not "yours yet". */
+  .channelSwitchBtnLocked {
+    border-style: dashed;
+    opacity: 0.9;
+  }
+}
+
+/* Comic theme — the channel pills follow the newsprint look (near-square corners, cream border,
+   ink surface, warm-gold active) instead of the default purple/rounded pills. The row itself is
+   still phone-only, so these overrides live outside the media query but only bite at that width
+   because the row is otherwise display:none. */
+:global([data-theme='comic']) .channelSwitchBtn {
+  border-radius: 2px;
+  border-color: var(--ctf-border-dim, #7a6a50);
+  background: var(--ctf-surface, #141414);
+  color: var(--ctf-text-secondary, #7a6a50);
+}
+
+:global([data-theme='comic']) .channelSwitchBtnActive {
+  border-color: var(--ctf-border, #d4c49a);
+  background: var(--ctf-surface-raised, #1c1c1c);
+  color: var(--ctf-brand, #c8a84b);
+  box-shadow: 2px 2px 0 var(--ctf-border, #d4c49a);
+}
+
+:global([data-theme='comic']) .channelSwitchBtnLocked {
+  border-color: var(--ctf-border, #d4c49a);
+  color: var(--ctf-text, #ede3cb);
+}
+
+/* Comic theme — icon rail: sharp corners, ink chips, cream border, warm-gold active, and the
+   hand-drawn offset shadow, replacing the default purple gradient/tint that looked out of place on
+   the warm newsprint surface. Visual only — no geometry/size changes. */
+:global([data-theme='comic']) .iconRailLogo {
+  border-radius: 0;
+  background: var(--ctf-surface-raised, #1c1c1c);
+  border: 1px solid var(--ctf-border, #d4c49a);
+  color: var(--ctf-brand, #c8a84b);
+  box-shadow: 3px 3px 0 var(--ctf-border, #d4c49a);
+}
+
+:global([data-theme='comic']) .iconRailBtn {
+  border-radius: 0;
+}
+
+:global([data-theme='comic']) .iconRailBtnActive {
+  background: var(--ctf-surface-raised, #1c1c1c);
+  border-color: var(--ctf-border, #d4c49a);
+  color: var(--ctf-brand, #c8a84b);
+  box-shadow: 3px 3px 0 var(--ctf-border, #d4c49a);
+}
+
+:global([data-theme='comic']) .iconRailAvatar {
+  border-radius: 0;
+  background: var(--ctf-surface-raised, #1c1c1c);
+  border: 1px solid var(--ctf-border, #d4c49a);
+}
+
+/* Comic theme — phone bottom bar mirrors the rail (sharp corners, ink, cream border, gold active).
+   Visual only: no width/height/gap changes, so the owner's 2026-07-19 clipping fix stays intact. */
+:global([data-theme='comic']) .mobileBarLogo {
+  border-radius: 0;
+  background: var(--ctf-surface-raised, #1c1c1c);
+  border: 1px solid var(--ctf-border, #d4c49a);
+  color: var(--ctf-brand, #c8a84b);
+}
+
+:global([data-theme='comic']) .mobileBarSectionBtn {
+  border-radius: 2px;
+}
+
+:global([data-theme='comic']) .mobileBarSectionBtnActive {
+  background: var(--ctf-surface-raised, #1c1c1c);
+  border-color: var(--ctf-border, #d4c49a);
+  color: var(--ctf-brand, #c8a84b);
+}
+
+:global([data-theme='comic']) .mobileBarAvatar {
+  border-radius: 0;
+  background: var(--ctf-surface-raised, #1c1c1c);
+  border: 1px solid var(--ctf-border, #d4c49a);
+}
+
+/* Contributor-channel explainer dialog — centered modal over a dimmed backdrop, mirroring the
+   Directory's Weavers badge dialog. Themed via CSS variables so it reads correctly in both the
+   default and comic palettes; comic gets sharp corners and the offset shadow. */
+.explainerOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.explainerBackdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  padding: 0;
+  cursor: default;
+}
+
+.explainerCard {
+  position: relative;
+  width: 100%;
+  max-width: 380px;
+  background: var(--ctf-surface-raised, #1e293b);
+  border: 1px solid var(--ctf-border, #1e2a3a);
+  border-radius: 16px;
+  padding: 22px 22px 18px;
+}
+
+:global([data-theme='comic']) .explainerCard {
+  border-radius: 0;
+  border-color: var(--ctf-border, #d4c49a);
+  box-shadow: 4px 4px 0 var(--ctf-border, #d4c49a);
+}
+
+.explainerHead {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.explainerTitle {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--ctf-text, #f9fafb);
+}
+
+.explainerBody {
+  font-size: 13px;
+  color: var(--ctf-text-secondary, #9ca3af);
+  line-height: 1.6;
+  margin-bottom: 14px;
+}
+
+.explainerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.explainerLink {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ctf-brand, #A78BFA);
+  text-decoration: none;
+}
+
+.explainerClose {
+  margin-left: auto;
+  padding: 7px 14px;
+  border-radius: 8px;
+  background: transparent;
+  border: 1px solid var(--ctf-border, #1e2a3a);
+  color: var(--ctf-text-secondary, #9ca3af);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+:global([data-theme='comic']) .explainerClose {
+  border-radius: 0;
 }

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -3196,12 +3196,12 @@
   }
 }
 
-/* Comic theme — the channel pills follow the newsprint look (near-square corners, cream border,
-   ink surface, warm-gold active) instead of the default purple/rounded pills. The row itself is
-   still phone-only, so these overrides live outside the media query but only bite at that width
-   because the row is otherwise display:none. */
+/* Comic theme — the channel pills follow the newsprint look (cream border, ink surface, warm-gold
+   active) instead of the default purple/rounded pills. Corners are squared globally by the comic
+   geometry rule in globals.css, so radius is not repeated here. The row itself is still phone-only,
+   so these overrides live outside the media query but only bite at that width because the row is
+   otherwise display:none. */
 :global([data-theme='comic']) .channelSwitchBtn {
-  border-radius: 2px;
   border-color: var(--ctf-border-dim, #7a6a50);
   background: var(--ctf-surface, #141414);
   color: var(--ctf-text-secondary, #7a6a50);
@@ -3219,19 +3219,15 @@
   color: var(--ctf-text, #ede3cb);
 }
 
-/* Comic theme — icon rail: sharp corners, ink chips, cream border, warm-gold active, and the
-   hand-drawn offset shadow, replacing the default purple gradient/tint that looked out of place on
-   the warm newsprint surface. Visual only — no geometry/size changes. */
+/* Comic theme — icon rail: ink chips, cream border, warm-gold active, and the hand-drawn offset
+   shadow, replacing the default purple gradient/tint that looked out of place on the warm newsprint
+   surface. Corners are squared globally by the comic geometry rule in globals.css. Visual only —
+   no size changes. */
 :global([data-theme='comic']) .iconRailLogo {
-  border-radius: 0;
   background: var(--ctf-surface-raised, #1c1c1c);
   border: 1px solid var(--ctf-border, #d4c49a);
   color: var(--ctf-brand, #c8a84b);
   box-shadow: 3px 3px 0 var(--ctf-border, #d4c49a);
-}
-
-:global([data-theme='comic']) .iconRailBtn {
-  border-radius: 0;
 }
 
 :global([data-theme='comic']) .iconRailBtnActive {
@@ -3242,22 +3238,17 @@
 }
 
 :global([data-theme='comic']) .iconRailAvatar {
-  border-radius: 0;
   background: var(--ctf-surface-raised, #1c1c1c);
   border: 1px solid var(--ctf-border, #d4c49a);
 }
 
-/* Comic theme — phone bottom bar mirrors the rail (sharp corners, ink, cream border, gold active).
-   Visual only: no width/height/gap changes, so the owner's 2026-07-19 clipping fix stays intact. */
+/* Comic theme — phone bottom bar mirrors the rail (ink, cream border, gold active). Corners squared
+   globally by the comic geometry rule. Visual only: no width/height/gap changes, so the owner's
+   2026-07-19 clipping fix stays intact. */
 :global([data-theme='comic']) .mobileBarLogo {
-  border-radius: 0;
   background: var(--ctf-surface-raised, #1c1c1c);
   border: 1px solid var(--ctf-border, #d4c49a);
   color: var(--ctf-brand, #c8a84b);
-}
-
-:global([data-theme='comic']) .mobileBarSectionBtn {
-  border-radius: 2px;
 }
 
 :global([data-theme='comic']) .mobileBarSectionBtnActive {
@@ -3267,7 +3258,6 @@
 }
 
 :global([data-theme='comic']) .mobileBarAvatar {
-  border-radius: 0;
   background: var(--ctf-surface-raised, #1c1c1c);
   border: 1px solid var(--ctf-border, #d4c49a);
 }
@@ -3305,7 +3295,6 @@
 }
 
 :global([data-theme='comic']) .explainerCard {
-  border-radius: 0;
   border-color: var(--ctf-border, #d4c49a);
   box-shadow: 4px 4px 0 var(--ctf-border, #d4c49a);
 }
@@ -3353,8 +3342,4 @@
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-}
-
-:global([data-theme='comic']) .explainerClose {
-  border-radius: 0;
 }

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -11,6 +11,7 @@ import type { PluginRegistryItem } from '../../lib/plugins/repository';
 import type { HubChannelInfo } from '../../lib/hub/types';
 import type { PluginSortMode, ShellCurrentUser, ShellSection, ShellStats } from './shell-types';
 import { GATED_CHANNEL_SLUG } from '../../lib/contributor-access/gated-channel-shared';
+import { WeaversBadge } from '../contributor-access/weavers-badge';
 import { ShellIconRail } from './shell-icon-rail';
 import { ShellSidebar } from './shell-sidebar';
 import { ShellChatPanel } from './shell-chat-panel';
@@ -141,6 +142,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
   const [sortMode, setSortMode] = useState<PluginSortMode>('recent');
   const [recentPluginSlugs, setRecentPluginSlugs] = useState<string[]>([]);
   const [pluginUsageCounts, setPluginUsageCounts] = useState<Record<string, number>>({});
+  const [contributorExplainerOpen, setContributorExplainerOpen] = useState(false);
 
   // Self-heal an out-of-date signed-out render. A back/forward navigation can restore a
   // cached "guest" version of this route (the server resolved the visitor before
@@ -256,6 +258,14 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
     });
   };
 
+  // Escape closes the contributor-channel explainer; listener attached only while open.
+  useEffect(() => {
+    if (!contributorExplainerOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setContributorExplainerOpen(false); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [contributorExplainerOpen]);
+
   // Channels live inside the chat panel of this single-page shell, so selecting
   // one just keeps the user in the chat section and marks it active — it must not
   // navigate to a separate route (there is no per-channel page; doing so 404s).
@@ -366,10 +376,12 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
             <section className={styles.usernameAlert} role="alert">{loadError}</section>
           ) : null}
           {/* Channel switch pills — phone widths only (the desktop channel rail is hidden there).
-              Rendered only when there is genuinely more than one channel to pick from, i.e. when
-              the server-filtered list includes the gated contributor channel for this member.
-              Non-eligible members never receive that entry, so they never see this row change. */}
-          {section === 'chat' && channels.length > 1 ? (
+              The general channel is always shown. The contributor channel is shown to everyone:
+              eligible members get it as a real, selectable chip (the server includes it in their
+              channel list); everyone else gets a locked chip that opens the same "Weavers of the
+              Commons" explainer the Directory braided badge shows — so the space is visible and
+              its bar is public, never a hidden back-room. */}
+          {section === 'chat' && isAuthenticated ? (
             <div className={styles.channelSwitchRow} role="tablist" aria-label="Channels">
               {channels.map((ch) => {
                 const isActive = (activeChannel ?? channels[0]?.slug) === ch.slug;
@@ -386,6 +398,18 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
                   </button>
                 );
               })}
+              {!channels.some((ch) => ch.slug === GATED_CHANNEL_SLUG) ? (
+                <button
+                  type="button"
+                  className={`${styles.channelSwitchBtn} ${styles.channelSwitchBtnLocked}`}
+                  onClick={() => setContributorExplainerOpen(true)}
+                  aria-haspopup="dialog"
+                  title="Weavers of the Commons"
+                >
+                  <WeaversBadge size={13} />
+                  <span>#{GATED_CHANNEL_SLUG}</span>
+                </button>
+              ) : null}
             </div>
           ) : null}
           {section === 'chat' ? (
@@ -413,6 +437,46 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
           signInUrl={signInUrl}
         />
       </div>
+      {/* Contributor-channel explainer — shown when a non-eligible member taps the locked
+          contributor chip. Same honest copy the Directory braided badge shows (proposal
+          section 3: no "verified", no "vetted"). "Anyone can earn this." */}
+      {contributorExplainerOpen ? (
+        <div
+          className={styles.explainerOverlay}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Weavers of the Commons"
+        >
+          <button
+            type="button"
+            aria-label="Close"
+            className={styles.explainerBackdrop}
+            onClick={() => setContributorExplainerOpen(false)}
+          />
+          <div className={styles.explainerCard}>
+            <div className={styles.explainerHead}>
+              <WeaversBadge size={30} />
+              <div className={styles.explainerTitle}>Weavers of the Commons</div>
+            </div>
+            <div className={styles.explainerBody}>
+              The contributor channel is for consistent, broad contributors to the community — real
+              help, delivered over time. Anyone can earn it; when you do, the channel opens here.
+            </div>
+            <div className={styles.explainerActions}>
+              <Link href="/apps/directory/weavers-of-the-commons" className={styles.explainerLink}>
+                How it&rsquo;s earned
+              </Link>
+              <button
+                type="button"
+                className={styles.explainerClose}
+                onClick={() => setContributorExplainerOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Refines the Commons home shell from the Replit `design/handoff` mobile mockups. Two parts, both scoped tightly to what the handoff actually improved.

## Comic theme — nav refinements (comic only)
The comic ("newsprint") theme's home nav was inheriting the default theme's purple gradient/tint, which read as messy on the warm surface. This adds comic-only overrides so the nav follows the newsprint look:

- **Icon rail** — logo, buttons, active state, and avatar: sharp corners, ink chips, cream (`--ctf-border`) border, warm-gold (`--ctf-brand`) active, hand-drawn `3px 3px 0` offset shadow.
- **Phone bottom bar** — logo, section buttons, active state, avatar: same newsprint treatment.
- **Channel pills** — near-square corners, cream border, ink surface, gold active with offset shadow.

All comic overrides are **visual only** — no width/height/gap/radius geometry changes to the phone bottom bar, so the owner's 2026-07-19 clipping fix stays intact. **The default theme is unchanged** except for the channel chips below.

## Contributor channel chip (both themes)
The one thing worth keeping from the default-theme mockup: channel chips at the top of the phone chat view.

- The **general** channel is always shown.
- The **contributor** channel is now shown to **everyone**: eligible members get it as a real, selectable chip (the server already includes it in their channel list); everyone else gets a **locked chip** carrying the braided badge.
- Tapping the locked chip opens the **same "Weavers of the Commons" explainer** the Directory braided badge shows — honest copy, "Anyone can earn it," with a link to `/apps/directory/weavers-of-the-commons`. Escape / backdrop / Close all dismiss it.

This keeps the contributor space visible and its bar public — never a hidden back-room — for members who haven't earned it yet.

## Scope / what this is not
- No schema, route, contract, or mobile (React Native) changes — web home shell only.
- No mockup or Replit-specific files brought into the repo; the `design/handoff` branch was read as intent only.

## Checks
`typecheck`, `lint`, `lint:a11y`, and `build:ci` all pass locally.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_