### PR TITLE
fix: three mobile-first "desktop mobile" rendering bugs

### DIFF
--- a/ctf/packages/web/components/bug-reports/bug-report-modal.module.css
+++ b/ctf/packages/web/components/bug-reports/bug-report-modal.module.css
@@ -382,7 +382,13 @@
 
 .modal,
 .modalNarrow {
-  max-width: 100%;
+  /* Bottom sheet, capped to the dialog width (the base .modal/.modalNarrow max-width) and centered,
+     so it does not stretch edge-to-edge on wider viewports — the app is mobile-first and its content
+     sits in a narrow column at every width. On a true phone the cap exceeds the viewport, so it
+     still fills the screen as a full-width sheet. (Formerly max-width:100%, which spanned the whole
+     desktop window.) */
+  margin-left: auto;
+  margin-right: auto;
   border-radius: 20px 20px 0 0;
   border-bottom: none;
   max-height: 85vh;

--- a/ctf/packages/web/components/skills-hunt/sh-notifications.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-notifications.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type CSSProperties } from "react";
 import { type SkillsHuntNotification } from "./sh-shared";
 import { useTheme } from '@/hooks/useTheme';
 import { getSkillsHuntTokens } from './sh-shared';
@@ -8,15 +9,25 @@ export function SkillsHuntNotifications({
   notifications,
   onClose,
   onMarkRead,
+  placement = "desktop",
 }: {
   notifications: SkillsHuntNotification[];
   onClose: () => void;
   onMarkRead: (id: string) => void;
+  // "desktop" anchors the panel absolutely beside the icon rail (left:80, inside the shell's
+  // relative root). "mobile" drops it as a fixed dropdown under the header bell, capped to the
+  // viewport width — the absolute left:80/top:60 coordinates are meaningless without the rail and
+  // left the panel stranded at the bottom-left on the phone / "desktop mobile" layout.
+  placement?: "desktop" | "mobile";
 }) {
   const { theme } = useTheme();
   const t = getSkillsHuntTokens(theme);
+  const positionStyle: CSSProperties =
+    placement === "mobile"
+      ? { position: "fixed", top: 64, right: 12, left: "auto", width: "min(360px, calc(100vw - 24px))", maxHeight: "70vh", zIndex: 60 }
+      : { position: "absolute", left: 80, top: 60, width: 360, maxHeight: 480, zIndex: 50 };
   return (
-    <div style={{ position: "absolute", left: 80, top: 60, width: 360, maxHeight: 480, overflowY: "auto", background: t.HEADER, border: `1px solid ${t.ACCENT}40`, borderRadius: 14, zIndex: 50, boxShadow: "0 12px 32px rgba(0,0,0,0.4)" }}>
+    <div style={{ ...positionStyle, overflowY: "auto", background: t.HEADER, border: `1px solid ${t.ACCENT}40`, borderRadius: 14, boxShadow: "0 12px 32px rgba(0,0,0,0.4)" }}>
       <div style={{ padding: "12px 16px", borderBottom: "1px solid rgba(255,255,255,0.06)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <span style={{ fontSize: 13, fontWeight: 700, color: t.TITLE }}>Status</span>
         <button type="button" aria-label="Close status" onClick={onClose} style={{ background: "none", border: "none", color: t.MUTED, cursor: "pointer", fontSize: 18, lineHeight: 1 }}>×</button>

--- a/ctf/packages/web/components/skills-hunt/sha-moderation.tsx
+++ b/ctf/packages/web/components/skills-hunt/sha-moderation.tsx
@@ -173,22 +173,18 @@ export function SkillsHuntModeration({ rounds, activeRoundId, onRoundChange }: {
       ) : submissions.length === 0 ? (
         <div style={{ color: t.MUTED, fontSize: 13 }}>No submissions matching this filter.</div>
       ) : (
-        <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
-          <div style={{ minWidth: 760 }}>
-            <SkillsHuntAdminTable
-              submissions={submissions}
-              selected={selected}
-              acting={acting}
-              allPendingSelected={allPendingSelected}
-              onToggleAll={toggleAllVisible}
-              onToggle={toggleOne}
-              onAccept={(id) => void reviewAndRefresh(id, "accept", null)}
-              onReject={onReject}
-              onFlag={(id) => void reviewAndRefresh(id, "flag", null)}
-              onRemove={(id) => void onRemove(id)}
-            />
-          </div>
-        </div>
+        <SkillsHuntAdminTable
+          submissions={submissions}
+          selected={selected}
+          acting={acting}
+          allPendingSelected={allPendingSelected}
+          onToggleAll={toggleAllVisible}
+          onToggle={toggleOne}
+          onAccept={(id) => void reviewAndRefresh(id, "accept", null)}
+          onReject={onReject}
+          onFlag={(id) => void reviewAndRefresh(id, "flag", null)}
+          onRemove={(id) => void onRemove(id)}
+        />
       )}
     </>
   );

--- a/ctf/packages/web/components/skills-hunt/sha-table.tsx
+++ b/ctf/packages/web/components/skills-hunt/sha-table.tsx
@@ -22,20 +22,37 @@ function SkillsCell({ submission }: { submission: SkillsHuntSubmission }) {
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
       {submission.skills.map((sk) => (
-        <span key={sk} style={{ padding: "1px 7px", borderRadius: 10, background: `${t.ACCENT}20`, color: t.ACCENT, fontSize: 11 }}>{sk}</span>
+        <span key={sk} style={{ padding: "2px 8px", borderRadius: 10, background: `${t.ACCENT}20`, color: t.ACCENT, fontSize: 11 }}>{sk}</span>
       ))}
       {submission.proposedSkills.map((sk) => (
-        <span key={sk} style={{ padding: "1px 7px", borderRadius: 10, background: "rgba(251,191,36,0.15)", color: t.ACCENT, fontSize: 11 }}>{sk} ✎</span>
+        <span key={sk} style={{ padding: "2px 8px", borderRadius: 10, background: "rgba(251,191,36,0.15)", color: t.ACCENT, fontSize: 11 }}>{sk} ✎</span>
       ))}
     </div>
   );
 }
 
+// One labelled fact (Quora / URL check / Pts / Reward) shown in the card's meta strip.
+function MetaItem({ label, children }: { label: string; children: React.ReactNode }) {
+  const { theme } = useTheme();
+  const t = getSkillsHuntAdminTokens(theme);
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
+      <span style={{ fontSize: 10, textTransform: "uppercase", letterSpacing: "0.06em", color: t.MUTED }}>{label}</span>
+      <span style={{ fontSize: 12 }}>{children}</span>
+    </div>
+  );
+}
+
+// Action buttons sit on their own full-width rows with generous tap targets so a moderator can't
+// accidentally accept/reject on a paid surface (the old inline table crammed four tiny buttons into
+// a scrolling cell). Accept and Reject are the two halves of the primary row; Flag/Remove are a
+// quieter secondary row.
 function RowActions({ submission, acting, onAccept, onReject, onFlag, onRemove }: Omit<RowProps, "selected" | "onToggle">) {
   const { theme } = useTheme();
   const t = getSkillsHuntAdminTokens(theme);
   const btn = (bg: string, border: string, color: string): React.CSSProperties => ({
-    padding: "4px 10px", borderRadius: 6, background: bg, border, color, fontSize: 11, fontWeight: 700, cursor: "pointer", opacity: acting ? 0.5 : 1,
+    flex: "1 1 0", padding: "10px 12px", borderRadius: 8, background: bg, border, color, fontSize: 13, fontWeight: 700,
+    cursor: acting ? "default" : "pointer", opacity: acting ? 0.5 : 1,
   });
   // Remove (soft-delete) is available for any status — it voids a submission
   // (duplicate/spam/mistake) without it counting as a scout rejection.
@@ -47,50 +64,64 @@ function RowActions({ submission, acting, onAccept, onReject, onFlag, onRemove }
   );
   if (submission.status !== "pending") {
     return (
-      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-        <span style={{ fontSize: 11, color: t.MUTED }}>{submission.reviewAction ?? submission.status}</span>
-        {removeBtn}
+      <div style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 12, color: t.MUTED }}>{submission.reviewAction ?? submission.status}</span>
+        <div style={{ display: "flex", maxWidth: 160 }}>{removeBtn}</div>
       </div>
     );
   }
   return (
-    <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-      <button type="button" disabled={acting} onClick={() => onAccept(submission.id)} style={btn("#22C55E", "none", "#fff")}>Accept</button>
-      <button type="button" disabled={acting} onClick={() => onReject(submission.id)} style={btn("#EF4444", "none", "#fff")}>Reject</button>
-      <button type="button" disabled={acting} onClick={() => onFlag(submission.id)} style={btn(`${t.ACCENT}30`, `1px solid ${t.ACCENT}60`, t.ACCENT)}>Flag</button>
-      {removeBtn}
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button type="button" disabled={acting} onClick={() => onAccept(submission.id)} style={btn("#22C55E", "none", "#fff")}>Accept</button>
+        <button type="button" disabled={acting} onClick={() => onReject(submission.id)} style={btn("#EF4444", "none", "#fff")}>Reject</button>
+      </div>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button type="button" disabled={acting} onClick={() => onFlag(submission.id)} style={btn(`${t.ACCENT}30`, `1px solid ${t.ACCENT}60`, t.ACCENT)}>Flag</button>
+        {removeBtn}
+      </div>
     </div>
   );
 }
 
-function SubmissionRow(props: RowProps) {
+// One submission as a self-contained card: a header (select + submitter + name), the skills as
+// wrapping chips, a labelled meta strip, then the action rows. No horizontal scroll, no tiny
+// adjacent buttons — the whole thing stacks inside the app's single mobile-first column.
+function SubmissionCard(props: RowProps) {
   const { theme } = useTheme();
   const t = getSkillsHuntAdminTokens(theme);
   const { submission: s, selected, onToggle } = props;
   const urlColor = s.urlValidationResult === "dead" ? "#EF4444" : s.urlValidationResult === "valid" ? "#22C55E" : t.MUTED;
   return (
-    <tr style={{ borderTop: `1px solid ${t.BORDER}` }}>
-      <td style={{ padding: "10px 6px" }}>
-        <input type="checkbox" checked={selected} onChange={() => onToggle(s.id)} disabled={s.status !== "pending"} aria-label={`Select ${s.fullName}`} />
-      </td>
-      <td style={{ padding: "10px 6px" }}>
-        <div style={{ fontWeight: 600, color: t.TITLE }}>{feedAuthorHandle(s.submitterUsername, s.submitterUserId)}</div>
-        <div style={{ fontSize: 11, color: t.FAINT }}>{new Date(s.createdAtIso).toLocaleString()}</div>
-      </td>
-      <td style={{ padding: "10px 6px" }}>{s.fullName}</td>
-      <td style={{ padding: "10px 6px", maxWidth: 280 }}><SkillsCell submission={s} /></td>
-      <td style={{ padding: "10px 6px" }}>
-        {s.quoraProfileUrl
-          ? <a href={s.quoraProfileUrl} target="_blank" rel="noopener noreferrer" style={{ color: "#3B82F6", fontSize: 11 }}>open ↗</a>
-          : <span style={{ color: t.FAINT }}>—</span>}
-      </td>
-      <td style={{ padding: "10px 6px", fontSize: 11, color: urlColor }}>{s.urlValidationResult ?? "—"}</td>
-      <td style={{ padding: "10px 6px", color: t.ACCENT, fontWeight: 700 }}>{s.pointsAwarded}</td>
-      <td style={{ padding: "10px 6px", fontSize: 12, color: s.creditGranted ? "#22C55E" : t.FAINT, fontWeight: s.creditGranted ? 700 : 400 }} title={s.creditGranted ? "ServiceCredits paid to this scout" : "No ServiceCredits paid"}>
-        {s.creditGranted ? `+${s.creditAmount}` : "—"}
-      </td>
-      <td style={{ padding: "10px 6px" }}><RowActions {...props} /></td>
-    </tr>
+    <div style={{ border: `1px solid ${t.BORDER}`, borderRadius: 12, padding: 14, display: "flex", flexDirection: "column", gap: 12, background: t.HEADER }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+        <input type="checkbox" checked={selected} onChange={() => onToggle(s.id)} disabled={s.status !== "pending"} aria-label={`Select ${s.fullName}`} style={{ marginTop: 3, width: 18, height: 18, flexShrink: 0 }} />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 15, fontWeight: 700, color: t.TITLE }}>{s.fullName}</div>
+          <div style={{ fontSize: 12, color: t.SUBTLE }}>{feedAuthorHandle(s.submitterUsername, s.submitterUserId)}</div>
+          <div style={{ fontSize: 11, color: t.FAINT }}>{new Date(s.createdAtIso).toLocaleString()}</div>
+        </div>
+      </div>
+
+      <SkillsCell submission={s} />
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "10px 20px" }}>
+        <MetaItem label="Quora">
+          {s.quoraProfileUrl
+            ? <a href={s.quoraProfileUrl} target="_blank" rel="noopener noreferrer" style={{ color: "#3B82F6" }}>open ↗</a>
+            : <span style={{ color: t.FAINT }}>—</span>}
+        </MetaItem>
+        <MetaItem label="URL check"><span style={{ color: urlColor }}>{s.urlValidationResult ?? "—"}</span></MetaItem>
+        <MetaItem label="Pts"><span style={{ color: t.ACCENT, fontWeight: 700 }}>{s.pointsAwarded}</span></MetaItem>
+        <MetaItem label="Reward">
+          <span style={{ color: s.creditGranted ? "#22C55E" : t.FAINT, fontWeight: s.creditGranted ? 700 : 400 }} title={s.creditGranted ? "ServiceCredits paid to this scout" : "No ServiceCredits paid"}>
+            {s.creditGranted ? `+${s.creditAmount}` : "—"}
+          </span>
+        </MetaItem>
+      </div>
+
+      <RowActions {...props} />
+    </div>
   );
 }
 
@@ -119,39 +150,25 @@ export function SkillsHuntAdminTable({
 }) {
   const { theme } = useTheme();
   const t = getSkillsHuntAdminTokens(theme);
-  const headCell: React.CSSProperties = { padding: "8px 6px" };
   return (
-    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
-      <thead>
-        <tr style={{ textAlign: "left", color: t.MUTED, fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em" }}>
-          <th style={{ ...headCell, width: 32 }}>
-            <input type="checkbox" checked={allPendingSelected} onChange={onToggleAll} aria-label="Select all pending" />
-          </th>
-          <th style={headCell}>Submitter</th>
-          <th style={headCell}>Full Name</th>
-          <th style={headCell}>Skills</th>
-          <th style={headCell}>Quora</th>
-          <th style={headCell}>URL check</th>
-          <th style={headCell}>Pts</th>
-          <th style={headCell}>Reward</th>
-          <th style={{ ...headCell, width: 220 }}>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {submissions.map((s) => (
-          <SubmissionRow
-            key={s.id}
-            submission={s}
-            selected={selected.has(s.id)}
-            acting={acting === s.id}
-            onToggle={onToggle}
-            onAccept={onAccept}
-            onReject={onReject}
-            onFlag={onFlag}
-            onRemove={onRemove}
-          />
-        ))}
-      </tbody>
-    </table>
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: t.MUTED, cursor: "pointer" }}>
+        <input type="checkbox" checked={allPendingSelected} onChange={onToggleAll} aria-label="Select all pending" style={{ width: 18, height: 18 }} />
+        Select all pending
+      </label>
+      {submissions.map((s) => (
+        <SubmissionCard
+          key={s.id}
+          submission={s}
+          selected={selected.has(s.id)}
+          acting={acting === s.id}
+          onToggle={onToggle}
+          onAccept={onAccept}
+          onReject={onReject}
+          onFlag={onFlag}
+          onRemove={onRemove}
+        />
+      ))}
+    </div>
   );
 }

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -285,7 +285,7 @@ export function SkillsHuntShell({
           </div>
         </div>
         {notifOpen && (
-          <SkillsHuntNotifications notifications={notifications} onClose={() => setNotifOpen(false)} onMarkRead={(id) => void markRead(id)} />
+          <SkillsHuntNotifications placement="mobile" notifications={notifications} onClose={() => setNotifOpen(false)} onMarkRead={(id) => void markRead(id)} />
         )}
         <div style={{ padding: 16 }}>{content}</div>
       </div>

--- a/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
+++ b/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
@@ -61,21 +61,24 @@ export function WorkforceHeroStats({ dashboard }: WorkforceHeroStatsProps) {
               // Let the grid track shrink instead of being forced wide by the big number, which was
               // overflowing the card (and the page) on phone-width 2-column layouts.
               minWidth: 0,
+              // Size the figure below relative to THIS card, not the viewport. The app renders in a
+              // narrow centered column on desktop, so a viewport-relative (vw) figure hit its cap and
+              // overflowed the narrow card, truncating the number to "5,000…". A container makes the
+              // figure track the card width, so it fits at every width.
+              containerType: 'inline-size',
             }}
           >
             <div
               style={{
-                // Scale the figure down on narrow screens so 7-digit numbers stay inside the card
-                // (caps at 28px on desktop). overflow guards against any residual horizontal bleed.
-                fontSize: 'clamp(16px, 4.8vw, 28px)',
+                // Figure scales with the card (cqi = 1% of the container's inline size), capped at
+                // 28px, so the full number always shows — never truncated, never overflowing.
+                fontSize: 'clamp(15px, 11cqi, 28px)',
                 fontWeight: 800,
                 color,
                 marginBottom: 4,
                 lineHeight: 1.15,
                 letterSpacing: '-0.01em',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
+                overflowWrap: 'anywhere',
               }}
             >
               {value}


### PR DESCRIPTION
Fixes four surfaces that broke when the mobile layout renders on a wide desktop window (the mobile-first conversion removed their breakpoints, so mobile styles now apply at every width).

- **Workforce stat cards** — big numbers were sized with a viewport unit (`4.8vw`) but truncated inside a card whose width comes from the narrow content column, so `5,000,000` showed as `5,000…` on desktop while fine on a phone. Now sized by the card itself (container query) and no longer truncated — the full number shows at every width.
- **Report-a-problem modal** — the bottom sheet used `max-width: 100%`, spanning the whole desktop window instead of the content column. Capped to the dialog width and centered; on a real phone it still fills the screen as a full sheet.
- **SkillsHunt "Status" panel** — absolutely positioned at `left:80/top:60` (coordinates for the desktop icon rail); without the rail it stranded at the viewport's bottom-left. Added a `placement="mobile"` variant that drops it under the header bell as a fixed, viewport-capped dropdown.
- **SkillsHunt moderation table** — a 9-column table forced to `minWidth: 760px` inside the single column, so it side-scrolled and crammed four tiny adjacent action buttons into a scrolling cell (easy to mis-tap Accept/Reject on a surface that pays ServiceCredits). Rebuilt as one card per submission: header (select + name + submitter + date), skills as wrapping chips, a labelled meta strip (Quora / URL check / Pts / Reward), and actions on their own full-width rows with large tap targets. Same props — the moderation shell is unchanged.

All four are consistent with the mobile-first direction (single layout at every width). `typecheck`, `lint`, `lint:a11y`, and `build:ci` pass.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)