### PR TITLE
chore: mobile-first collapse — delete dead desktop layout branches

### DIFF
--- a/ctf/docs/developer/desktop-views-archive.md
+++ b/ctf/docs/developer/desktop-views-archive.md
@@ -1,0 +1,40 @@
+# Desktop views — archive and restore
+
+**Owner decision (2026-07-20 → collapse 2026-07-21): the app is mobile-first.** `useIsMobile()` is
+pinned to `true`, so every shell renders its single phone-width layout at every viewport, inside the
+centered `.ctf-phone-frame` column (see `globals.css`). There is no second (desktop) layout shown to
+anyone.
+
+Because of that pin, the old per-shell **desktop layout branches were already dead code** — the
+`if (isMobile) return (<phone layout>)` guard is always taken, so the desktop `return` after it never
+ran. The mobile-first collapse deletes those dead branches so there is only one layout to maintain
+and the two copies can no longer drift.
+
+## Where the desktop views are preserved
+
+A lot of work went into the desktop layouts, so they are kept — as **restorable code**, which is
+better than a screenshot (you can bring the real layout back, not just look at a picture).
+
+- **Archive commit: `44ae66a`** on `main` (the last commit with every desktop branch intact,
+  immediately before the collapse began). Git keeps this forever.
+
+### View a single desktop view later
+
+```bash
+git show 44ae66a:ctf/packages/web/components/<plugin>/<plugin>-shell.tsx
+```
+
+The desktop layout is the JSX after the shell's `if (isMobile) return (...)` block (or the `: <desktop>`
+side of an `isMobile ? <mobile> : <desktop>` expression).
+
+### Restore desktop rendering for real
+
+1. Change `useIsMobile()` in `ctf/packages/web/hooks/use-is-mobile.ts` back to a viewport check
+   (the pre-pin version is in the same file's history).
+2. Restore the desired shell's desktop branch from the archive commit above.
+
+## Status
+
+The collapse removes the dead desktop branches shell-by-shell across the ~90 shells that branched on
+`isMobile`. Member-facing screens keep their phone layout unchanged; wide admin tables are rebuilt as
+stacked cards (SkillsHunt moderation is the template — see `sha-table.tsx`).

--- a/ctf/packages/web/components/chyme/chyme-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-shell.tsx
@@ -2,10 +2,8 @@
 
 import { Radio } from 'lucide-react';
 import { BackChevronButton } from '@/lib/nav/back-history';
-import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import { ChymeLiveShell } from '@/components/chyme/chyme-live-shell';
-import { PluginRailFooter } from '@/components/shared/plugin-rail-footer';
 import { MobileTopActions } from '@/components/shared/mobile-top-actions';
 import { getChymeTokens } from './chyme-shared';
 
@@ -17,14 +15,12 @@ type ChymeShellProps = {
 };
 
 export function ChymeShell({ currentUser }: ChymeShellProps) {
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getChymeTokens(theme);
 
   // Phones: drop the 72px side rail for a compact sticky top bar (back + brand)
   // and let the live shell fill the width and stack its panes vertically.
-  if (isMobile) {
-    return (
+  return (
       <div style={{ minHeight: '100dvh', background: t.BG }}>
         <div style={{ position: 'sticky', top: 0, zIndex: 20, display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <BackChevronButton accent={t.ACCENT} />
@@ -37,51 +33,4 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
         <ChymeLiveShell currentUser={currentUser} />
       </div>
     );
-  }
-
-  return (
-    <div style={{ display: 'flex', minHeight: '100dvh', background: t.BG }}>
-      {/* Left navigation rail */}
-      <aside
-        style={{
-          width: 72,
-          borderRight: `1px solid ${t.BORDER}`,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          padding: '16px 0',
-          gap: 16,
-          background: t.RAIL,
-          flexShrink: 0,
-        }}
-      >
-        {/* Chyme logo/icon */}
-        <div
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: 10,
-            background: t.ACCENT_TINT_15,
-            border: `1px solid ${t.ACCENT_TINT_40}`,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: t.ACCENT,
-          }}
-          title="Chyme chat"
-        >
-          <Radio size={20} />
-        </div>
-
-        {/* Shared bottom: back to all apps, account and settings, and the account avatar —
-            identical to every other plugin rail. */}
-        <PluginRailFooter />
-      </aside>
-
-      {/* Main Chyme component */}
-      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-        <ChymeLiveShell currentUser={currentUser} />
-      </div>
-    </div>
-  );
 }

--- a/ctf/packages/web/components/click-log/click-log-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-shell.tsx
@@ -3,12 +3,8 @@
 import { useEffect, useState } from "react";
 import { BackChevronButton } from "@/lib/nav/back-history";
 import type { ClickLogIncident } from "../../lib/click-log/types";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { deriveClickLogStats, getClickLogTokens } from "./click-log-shared";
-import { ClickLogIconRail } from "./click-log-icon-rail";
-import { ClickLogSidebar } from "./click-log-sidebar";
-import { ClickLogRightRail } from "./click-log-right-rail";
 import { ClickLogLogPanel } from "./click-log-log-panel";
 import { ClickLogIncidentList } from "./click-log-incident-list";
 import { ClickLogEmptyState } from "./click-log-empty-state";
@@ -31,7 +27,6 @@ export function ClickLogShell() {
   const [geoStatus, setGeoStatus] = useState<"idle" | "locating" | "error">("idle");
   const [geoError, setGeoError] = useState<string | null>(null);
   const [logged, setLogged] = useState(false);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getClickLogTokens(theme);
 
@@ -180,8 +175,7 @@ export function ClickLogShell() {
     </>
   );
 
-  if (isMobile) {
-    return (
+  return (
       <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
@@ -199,29 +193,4 @@ export function ClickLogShell() {
         <div style={{ padding: 16 }}>{content}</div>
       </div>
     );
-  }
-
-  return (
-    <div style={{ display: "flex", height: "100dvh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
-      <ClickLogIconRail />
-      <ClickLogSidebar total={displayTotal} weekdayCounts={stats.weekdayCounts} />
-
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <AlertTriangle size={18} color={t.ACCENT} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>Incident Log</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Personal safety tracking — {displayTotal} incidents total</div>
-          </div>
-          <RefreshButton onRefresh={() => fetchIncidents()} title="Refresh incidents" />
-        </header>
-
-        <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: "32px 48px" }}>
-          {content}
-        </div>
-      </div>
-
-      <ClickLogRightRail stats={stats} loading={busy} onQuickLog={() => void postIncident({})} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/contributions/admin/contributions-admin-shell.tsx
+++ b/ctf/packages/web/components/contributions/admin/contributions-admin-shell.tsx
@@ -196,8 +196,7 @@ export function ContributionsAdminShell() {
     </>
   );
 
-  if (isMobile) {
-    return (
+  return (
       <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TEXT, display: 'flex', flexDirection: 'column' }}>
         <MobileScreenHeader title="Contributions Admin" accent={t.ACCENT} icon={<Gift size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/contributions" accent={t.ACCENT} />} />
         <div style={{ padding: '12px 16px 10px', background: t.SURFACE, borderBottom: `1px solid ${t.BORDER_SOLID}`, flexShrink: 0 }}>
@@ -225,44 +224,4 @@ export function ContributionsAdminShell() {
         {content}
       </div>
     );
-  }
-
-  return (
-    // Desktop locks html/body to 100vh + overflow:hidden (globals.css). Use a fixed viewport height
-    // (not min-height) so this row is bounded and the main column's content (flex:1, overflowY:auto)
-    // scrolls internally instead of being clipped and unreachable.
-    <div style={{ display: 'flex', height: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TEXT, overflow: 'hidden' }}>
-      <div style={{ width: 200, background: t.SURFACE, borderRight: `1px solid ${t.BORDER_SOLID}`, display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
-        <div style={{ padding: '18px 14px 14px', borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-            <div style={{ width: 28, height: 28, borderRadius: 8, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Gift size={14} color="#fff" />
-            </div>
-            <span style={{ fontWeight: 700, fontSize: 14, color: t.TITLE }}>Contributions</span>
-          </div>
-          <div style={{ fontSize: 11, color: t.MUTED }}>Admin dashboard</div>
-        </div>
-        <nav style={{ padding: '10px 8px', flex: 1 }}>
-          {TABS.map(({ key, label }) => {
-            const isActive = tab === key;
-            return (
-              <button
-                key={key}
-                type="button"
-                onClick={() => setTab(key)}
-                style={{ width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 10px', borderRadius: 7, marginBottom: 2, fontSize: 13, cursor: 'pointer', background: isActive ? `${t.ACCENT}18` : 'transparent', color: isActive ? t.ACCENT : t.MUTED, fontWeight: isActive ? 600 : 400, border: 'none', borderLeft: isActive ? `3px solid ${t.ACCENT}` : '3px solid transparent' }}
-              >
-                {label}
-                {key === 'queue' && pendingCount > 0 && <span style={{ background: '#F59E0B', color: '#000', fontSize: 10, fontWeight: 700, padding: '1px 6px', borderRadius: 99 }}>{pendingCount}</span>}
-              </button>
-            );
-          })}
-        </nav>
-      </div>
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
-        {loadError && <div style={{ padding: '10px 24px', fontSize: 12, color: '#EF4444' }}>{loadError}</div>}
-        {content}
-      </div>
-    </div>
-  );
 }

--- a/ctf/packages/web/components/contributions/contributions-banner.tsx
+++ b/ctf/packages/web/components/contributions/contributions-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Gift, DollarSign, MessageSquare, Star } from 'lucide-react';
+import { DollarSign, MessageSquare, Star } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import {
@@ -41,7 +41,6 @@ function bannerGoals(f: FundraiserResponse['fundraiser']): BannerGoal[] {
 // reload (the two components fetch fundraiser state independently).
 const BANNER_DISMISSED_EVENT = 'ctf:contributions-banner-dismissed';
 export function ContributionsBanner() {
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getContributionsTokens(theme);
   const router = useRouter();
@@ -96,8 +95,7 @@ export function ContributionsBanner() {
 
   const goals = bannerGoals(fundraiser);
 
-  if (isMobile) {
-    return (
+  return (
       <div style={{ padding: '10px 14px', background: `${t.ACCENT}0A`, borderBottom: `1px solid ${t.ACCENT}25`, fontFamily: FONT_FAMILY }}>
         <div style={{ display: 'flex', gap: 10, marginBottom: 9 }}>
           {goals.map((g) => {
@@ -128,47 +126,6 @@ export function ContributionsBanner() {
         </div>
       </div>
     );
-  }
-
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '10px 18px', background: t.SURFACE, borderBottom: `1px solid ${t.BORDER_SOLID}`, fontFamily: FONT_FAMILY, flexWrap: 'wrap' }}>
-      <div style={{ width: 28, height: 28, borderRadius: 7, background: t.ACCENT, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-        <Gift size={13} color="#fff" />
-      </div>
-      <div style={{ fontSize: 13, color: t.MUTED, flexShrink: 0, maxWidth: 260 }}>If everyone who&apos;s able gave a little, this drive would be covered.</div>
-      <div style={{ display: 'flex', gap: 14, flex: 1, alignItems: 'center', minWidth: 240 }}>
-        {goals.map((g) => {
-          const pct = progressPct(g.current, g.target);
-          return (
-            <div key={g.label} style={{ display: 'flex', alignItems: 'center', gap: 7, flex: 1 }}>
-              <g.Icon size={12} color={g.color} style={{ flexShrink: 0 }} />
-              <div style={{ flex: 1 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 3 }}>
-                  <span style={{ fontSize: 10, color: t.MUTED }}>{g.label}</span>
-                  <span style={{ fontSize: 10, color: g.color }}>
-                    {g.unit}
-                    {g.current.toLocaleString()} / {g.unit}
-                    {g.target.toLocaleString()}
-                  </span>
-                </div>
-                <div style={{ height: 4, background: t.BORDER_SOLID, borderRadius: 99 }}>
-                  <div style={{ width: `${pct}%`, height: '100%', background: g.color, borderRadius: 99 }} />
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexShrink: 0 }}>
-        <button type="button" onClick={onContribute} style={{ padding: '6px 16px', borderRadius: 7, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}>
-          Contribute
-        </button>
-        <button type="button" onClick={() => void onDismiss()} style={{ padding: '6px 14px', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, cursor: 'pointer' }}>
-          Not now
-        </button>
-      </div>
-    </div>
-  );
 }
 
 /**

--- a/ctf/packages/web/components/contributions/contributions-shell.tsx
+++ b/ctf/packages/web/components/contributions/contributions-shell.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Gift, Clock, ArrowLeft } from 'lucide-react';
+import { Gift, ArrowLeft } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import type { ContributionSubmission } from '@/lib/contributions/types';
@@ -19,7 +19,7 @@ import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import { PluginAdminButton } from '@/components/shared/plugin-admin-button';
 import { RefreshButton } from '@/components/shared/refresh-button';
 import { PluginRailFooter } from '@/components/shared/plugin-rail-footer';
-import { goalsFromFundraiser, GoalCard, GoalRow } from './contributions-drive-progress';
+import { goalsFromFundraiser, GoalRow } from './contributions-drive-progress';
 import { ContributionPaths, type SubmitGiftCardInput } from './contributions-paths';
 import { ContributionsHistoryList, ContributionsEmptyHistory } from './contributions-history';
 import { ContributionsConfirmation } from './contributions-confirmation';
@@ -44,20 +44,6 @@ export function ContributionsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [mobileTab, setMobileTab] = useState<MobileTab>('drive');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-
-  // Desktop shows every section on one scrolling page, so the left nav items scroll to their
-  // section (and light up as the active one) rather than swapping the whole view. This makes
-  // "Contribute" and "My contributions" actually do something when clicked on desktop.
-  const [activeSection, setActiveSection] = useState<MobileTab>('drive');
-  const driveRef = useRef<HTMLDivElement>(null);
-  const contributeRef = useRef<HTMLDivElement>(null);
-  const historyRef = useRef<HTMLDivElement>(null);
-  const scrollToSection = useCallback((key: MobileTab) => {
-    setActiveSection(key);
-    const target =
-      key === 'drive' ? driveRef.current : key === 'contribute' ? contributeRef.current : historyRef.current;
-    target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, []);
 
   const loadData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -152,7 +138,6 @@ export function ContributionsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   }
 
   const goals = goalsFromFundraiser(fundraiser.fundraiser);
-  const driveTitle = fundraiser.fundraiser.cycle ? 'Current drive' : 'No active drive';
   const githubStarAlreadyCredited = fundraiser.fundraiser.githubStarAlreadyCredited;
 
   if (view === 'confirmation') {
@@ -191,7 +176,6 @@ export function ContributionsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
     onSubmitGithub,
   };
 
-  if (isMobile) {
     return (
       <MobileFrame t={t} tab={mobileTab} onTab={setMobileTab} onRefresh={() => loadData()} isAdmin={isAdmin}>
         {mobileTab === 'drive' && (
@@ -220,48 +204,6 @@ export function ContributionsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
         )}
       </MobileFrame>
     );
-  }
-
-  return (
-    <DesktopFrame t={t}>
-      <ContributionsSidebar t={t} active={activeSection} onNavigate={scrollToSection} />
-      <div style={{ flex: 1, overflowY: 'auto', padding: '24px 28px' }}>
-        <div ref={driveRef} style={{ marginBottom: 28, scrollMarginTop: 24 }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, marginBottom: 6 }}>
-            <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700, color: t.TITLE }}>{driveTitle}</h1>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <PluginAdminButton href="/admin/contributions" isAdmin={isAdmin} accent={t.ACCENT} />
-              <RefreshButton onRefresh={() => loadData()} title="Refresh" />
-            </div>
-          </div>
-          <p style={{ margin: '0 0 18px', fontSize: 13, color: t.MUTED, lineHeight: 1.7, maxWidth: 620 }}>
-            If every member who can give a little does, the platform&apos;s costs are covered — and it stays free for everyone.
-          </p>
-          <div style={{ display: 'flex', gap: 14 }}>
-            {goals.map((g) => (
-              <GoalCard key={g.key} goal={g} t={t} />
-            ))}
-          </div>
-        </div>
-        <div ref={contributeRef} style={{ scrollMarginTop: 24 }}>
-          <ContributionPaths {...pathsProps} />
-        </div>
-      </div>
-      <div ref={historyRef} style={{ width: 280, background: t.SURFACE, borderLeft: `1px solid ${t.BORDER_SOLID}`, display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
-        <div style={{ padding: '18px 16px 12px', borderBottom: `1px solid ${t.BORDER_SOLID}`, display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Clock size={14} color={t.ACCENT} />
-          <span style={{ fontSize: 13, fontWeight: 600, color: t.TITLE }}>My Contributions</span>
-        </div>
-        <div style={{ flex: 1, overflowY: 'auto', padding: 14 }}>
-          {submissions.length === 0 ? (
-            <ContributionsEmptyHistory t={t} />
-          ) : (
-            <ContributionsHistoryList submissions={submissions} t={t} />
-          )}
-        </div>
-      </div>
-    </DesktopFrame>
-  );
 }
 
 // --- frames + chrome ---------------------------------------------------------------------------

--- a/ctf/packages/web/components/directory/directory-admin-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-admin-shell.tsx
@@ -23,14 +23,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { PluginUserShellButton } from '@/components/shared/plugin-user-shell-button';
 import {
-  BookOpen,
   Search,
   Shield,
   Bell,
   CheckCircle,
   Edit2,
   Trash2,
-  Users,
   X,
   Save,
   UserCheck,
@@ -39,10 +37,8 @@ import {
   ShieldOff,
   RotateCcw,
 } from "lucide-react";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
-import { PluginRailFooter } from "@/components/shared/plugin-rail-footer";
 import { getDirectoryTokens } from "./shared";
 import { DirectorySkillsPicker } from "./directory-skills-picker";
 import { CountrySelect, StateField } from "@/components/shared/location-select";
@@ -148,7 +144,6 @@ function toForm(p: AdminDirectoryProfile): EditForm {
 }
 
 export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }) {
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const pickerTokens = getDirectoryTokens(theme);
   const [profiles, setProfiles] = useState<AdminDirectoryProfile[]>([]);
@@ -522,7 +517,6 @@ export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }
   }
 
   // ── Mobile layout ──────────────────────────────────────────────────────────
-  if (isMobile) {
     if (editing) {
       const p = editing;
       return (
@@ -634,149 +628,6 @@ export function DirectoryAdminShell({ currentUserId }: { currentUserId: string }
         </div>
       </div>
     );
-  }
-
-  // ── Desktop layout ───────────────────────────────────────────────────────
-  return (
-    <div style={{ display: "flex", height: "100dvh", background: BG, fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, overflow: "hidden" }}>
-      {/* Icon rail */}
-      <aside style={{ width: 72, background: "#090B0F", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-        <Link href="/apps/directory" aria-label="Back to Directory" style={{ width: 40, height: 40, borderRadius: 12, background: `${COLOR}25`, border: `1px solid ${COLOR}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12, color: COLOR }}>
-          <BookOpen size={20} />
-        </Link>
-        <div style={{ width: 44, height: 44, borderRadius: 12, background: `${COLOR}20`, border: `1px solid ${COLOR}40`, display: "flex", alignItems: "center", justifyContent: "center", color: COLOR }}>
-          <Users size={20} />
-        </div>
-        <PluginRailFooter />
-      </aside>
-
-      {/* Left sidebar */}
-      <aside style={{ width: 240, background: "#0D0F14", borderRight: `1px solid ${BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
-        <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: SUBTLE, textTransform: "uppercase", marginBottom: 4 }}>📇 Directory Admin</div>
-          <div style={{ fontSize: 12, color: "#4B5563", lineHeight: 1.5 }}>Claim, edit, and attach provider records</div>
-        </div>
-        <div style={{ padding: "0 12px", flex: 1 }}>
-          {FILTERS.map((f) => (
-            <button key={f} onClick={() => setFilter(f)} style={{ width: "100%", display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, marginBottom: 2, cursor: "pointer", background: filter === f ? `${COLOR}15` : "transparent", borderLeft: filter === f ? `2px solid ${COLOR}` : "2px solid transparent", color: filter === f ? TEXT : SUBTLE, fontSize: 13, border: "none", textAlign: "left" }}>
-              {f}
-              {f === "Unclaimed" && unclaimedCount > 0 && (
-                <span style={{ marginLeft: "auto", fontSize: 10, fontWeight: 700, background: `${COMMUNITY}20`, color: COMMUNITY, border: `1px solid ${COMMUNITY}30`, borderRadius: 4, padding: "1px 5px" }}>{unclaimedCount}</span>
-              )}
-            </button>
-          ))}
-          <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: "#4B5563", textTransform: "uppercase" }}>Stats</div>
-          {[
-            { l: "Total profiles", v: String(profiles.length), c: COLOR },
-            { l: "Unclaimed", v: String(unclaimedCount), c: COMMUNITY },
-            { l: "Claimed", v: String(profiles.length - unclaimedCount), c: "#22C55E" },
-          ].map(({ l, v, c }) => (
-            <div key={l} style={{ padding: "5px 2px", fontSize: 12, color: SUBTLE }}>
-              {l}: <span style={{ color: c, fontWeight: 600 }}>{v}</span>
-            </div>
-          ))}
-        </div>
-      </aside>
-
-      {/* Main */}
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: "#0D0F14", flexShrink: 0 }}>
-          <Shield size={18} color={COLOR} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600 }}>Directory — Admin</div>
-            <div style={{ fontSize: 12, color: SUBTLE }}>Profile management · Showing {filtered.length} of {profiles.length}</div>
-          </div>
-          <div style={{ position: "relative" }}>
-            <Search size={13} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: SUBTLE, pointerEvents: "none" }} />
-            <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search profiles…" style={{ padding: "6px 10px 6px 30px", background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, borderRadius: 8, fontSize: 12, color: TEXT, outline: "none", width: 200 }} />
-          </div>
-          <PluginUserShellButton href="/apps/directory" accent={COLOR} />
-        </header>
-
-        <div style={{ display: "grid", gridTemplateColumns: "2fr 1.2fr 0.9fr 1.2fr 160px", gap: 12, padding: "9px 24px", borderBottom: `1px solid ${BORDER}`, background: "rgba(255,255,255,0.01)", flexShrink: 0 }}>
-          {["Provider", "Source", "Status", "Handle", "Actions"].map((h) => (
-            <div key={h} style={{ fontSize: 10, fontWeight: 700, color: "#4B5563", textTransform: "uppercase", letterSpacing: "0.07em", minWidth: 0, textAlign: h === "Actions" ? "right" : "left" }}>{h}</div>
-          ))}
-        </div>
-
-        <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
-          {loading ? (
-            <div style={{ padding: 48, textAlign: "center", color: SUBTLE, fontSize: 14 }}>Loading profiles…</div>
-          ) : error ? (
-            <div style={{ padding: 48, textAlign: "center", color: "#EF4444", fontSize: 14 }}>{error}</div>
-          ) : filtered.length === 0 ? (
-            <div style={{ padding: 48, textAlign: "center", color: SUBTLE, fontSize: 14 }}>No profiles match this view.</div>
-          ) : (
-            filtered.map((p) => {
-              const b = sourceBadge(p);
-              const isEditing = editId === p.id;
-              return (
-                <div key={p.id} style={{ display: "grid", gridTemplateColumns: "2fr 1.2fr 0.9fr 1.2fr 160px", gap: 12, padding: "13px 24px", borderBottom: `1px solid ${BORDER}`, background: isEditing ? `${COLOR}05` : "transparent", alignItems: "center", borderLeft: isEditing ? `3px solid ${COLOR}` : "3px solid transparent" }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
-                    <div style={{ width: 34, height: 34, borderRadius: 10, background: `${COLOR}20`, border: `1px solid ${COLOR}35`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, color: COLOR, flexShrink: 0 }}>{initials(fullName(p))}</div>
-                    <div style={{ minWidth: 0 }}>
-                      <div style={{ fontSize: 13, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{fullName(p) || "Unnamed"}</div>
-                      <div style={{ fontSize: 11, color: SUBTLE, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{p.headline ?? p.jobTitleName ?? ""}</div>
-                    </div>
-                  </div>
-                  <div style={{ minWidth: 0 }}>
-                    <span style={{ fontSize: 11, fontWeight: 700, padding: "2px 8px", borderRadius: 6, background: `${b.color}18`, color: b.color, border: `1px solid ${b.color}30`, display: "inline-block", maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", boxSizing: "border-box" }}>{b.label}</span>
-                  </div>
-                  <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 12, color: p.claimedByUserId ? "#22C55E" : SUBTLE, minWidth: 0 }}>
-                    <CheckCircle size={13} style={{ flexShrink: 0 }} /> {p.claimedByUserId ? "Claimed" : "Unclaimed"}
-                  </div>
-                  <div style={{ fontSize: 11, fontFamily: "monospace", color: p.unclaimedHandle ? COMMUNITY : SUBTLE, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{handleText(p)}</div>
-                  <div style={{ display: "flex", gap: 6, flexShrink: 0, justifyContent: "flex-end" }}>
-                    <button onClick={() => (isEditing ? closeDrawer() : startEdit(p))} style={{ display: "flex", alignItems: "center", gap: 4, padding: "5px 10px", borderRadius: 7, background: isEditing ? `${COLOR}20` : "rgba(255,255,255,0.04)", border: `1px solid ${isEditing ? COLOR + "50" : BORDER}`, color: isEditing ? COLOR : SUBTLE, fontSize: 12, cursor: "pointer" }}>
-                      {isEditing ? <><X size={11} /> Close</> : <><Edit2 size={11} /> Edit</>}
-                    </button>
-                    {p.claimedByUserId == null && p.source === "community-generated" && (
-                      <button onClick={() => void handleTakedown(p)} disabled={saving} aria-label="Remove at person's request" title="Remove at the person's request (blocks the Quora URL from being re-added)" style={{ width: 28, height: 28, borderRadius: 7, background: "rgba(245,158,11,0.08)", border: "1px solid rgba(245,158,11,0.3)", color: "#F59E0B", cursor: saving ? "not-allowed" : "pointer", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                        <Ban size={12} />
-                      </button>
-                    )}
-                    {p.claimedByUserId == null && (
-                      <button onClick={() => void handleDelete(p)} disabled={saving} aria-label="Delete profile" style={{ width: 28, height: 28, borderRadius: 7, background: "rgba(239,68,68,0.06)", border: "1px solid rgba(239,68,68,0.2)", color: "#EF4444", cursor: saving ? "not-allowed" : "pointer", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                        <Trash2 size={12} />
-                      </button>
-                    )}
-                  </div>
-                </div>
-              );
-            })
-          )}
-          <SuppressionPanel />
-        </div>
-      </div>
-
-      {/* Edit drawer */}
-      {editing && (
-        <aside style={{ width: 340, borderLeft: `1px solid ${BORDER}`, background: "#0D0F14", display: "flex", flexDirection: "column", flexShrink: 0 }}>
-          <div style={{ padding: "14px 18px", borderBottom: `1px solid ${BORDER}`, display: "flex", alignItems: "center", gap: 10 }}>
-            <Edit2 size={14} color={COLOR} />
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 13, fontWeight: 700 }}>Edit Profile</div>
-              <div style={{ fontSize: 11, color: SUBTLE }}>{editing.claimedByUserId == null ? "Unclaimed" : "Claimed"} · {sourceBadge(editing).label}</div>
-            </div>
-            <button onClick={closeDrawer} aria-label="Close" style={{ width: 26, height: 26, borderRadius: 6, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: SUBTLE }}>
-              <X size={12} />
-            </button>
-          </div>
-          <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: "16px 18px", display: "flex", flexDirection: "column", gap: 14 }}>
-            {renderDrawerBody(editing)}
-          </div>
-          <div style={{ padding: "13px 18px", borderTop: `1px solid ${BORDER}`, display: "flex", gap: 8 }}>
-            <button onClick={() => void handleSave()} disabled={saving} style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 6, padding: 10, borderRadius: 9, background: COLOR, border: "none", color: "#fff", fontSize: 13, fontWeight: 700, cursor: saving ? "not-allowed" : "pointer", opacity: saving ? 0.6 : 1 }}>
-              <Save size={13} /> {saving ? "Saving…" : "Save"}
-            </button>
-            <button onClick={closeDrawer} style={{ padding: "10px 14px", borderRadius: 9, background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 13, cursor: "pointer" }}>
-              Discard
-            </button>
-          </div>
-        </aside>
-      )}
-    </div>
-  );
 }
 
 // One row of the Quora-URL suppression list (GET /api/directory/admin/suppressed-urls).

--- a/ctf/packages/web/components/directory/directory-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-shell.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from "react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { BookOpen, Pencil, Search, UserPlus } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
@@ -11,10 +10,8 @@ import { DirectoryProfileDetail } from "./directory-profile-detail";
 import { DirectoryProfileEdit } from "./directory-profile-edit";
 import { DirectoryLoadingSkeleton } from "./directory-loading-skeleton";
 import { DirectoryBrowse } from "./directory-browse";
-import { DirectoryRightPanel } from "./directory-right-panel";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
-import { PluginRailFooter } from "@/components/shared/plugin-rail-footer";
 import { RefreshButton } from "@/components/shared/refresh-button";
 
 const DEFAULT_REWARD_CARD: SkillsHuntRewardCard = {
@@ -316,8 +313,7 @@ export function DirectoryShell({ userId, isAdmin, initialProfileId }: { userId: 
   // Shared button that opens the editor; label depends on whether the member already has a profile.
   const profileButtonLabel = hasOwnProfile ? "Edit my profile" : "Add my profile";
 
-  if (isMobile) {
-    return (
+  return (
       <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px" }}>
@@ -350,87 +346,4 @@ export function DirectoryShell({ userId, isAdmin, initialProfileId }: { userId: 
         {profileEditor}
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      {/* Icon rail — the BookOpen brand mark at the top, then the shared PluginRailFooter at the
-          bottom. The footer carries the same three controls every plugin rail has (back to all apps,
-          account & settings, and the signed-in avatar), so the Directory rail no longer drops the
-          standard bottom options. */}
-      <aside style={{ width: 72, background: t.RAIL, borderRight: `1px solid ${t.BORDER}`, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 16, paddingBottom: 16, gap: 8, flexShrink: 0 }}>
-        <div style={{ width: 40, height: 40, borderRadius: 12, background: `${t.ACCENT}30`, border: `1px solid ${t.ACCENT}50`, display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 12, color: t.ACCENT }}>
-          <BookOpen size={20} />
-        </div>
-        <PluginRailFooter />
-      </aside>
-
-      {/* Sidebar */}
-      <aside style={{ width: 240, background: t.HEADER, borderRight: `1px solid ${t.BORDER}`, display: "flex", flexDirection: "column", flexShrink: 0 }}>
-        <div style={{ padding: "20px 16px 12px" }}>
-          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: t.MUTED, textTransform: "uppercase", marginBottom: 12 }}>📇 Directory</div>
-          <div style={{ position: "relative", marginBottom: 12 }}>
-            <Search size={14} style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)", color: t.FAINT }} />
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search name, skill, or location…"
-              style={{ width: "100%", padding: "7px 10px 7px 30px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }}
-            />
-          </div>
-        </div>
-        <ScrollArea style={{ flex: 1 }}>
-          <div style={{ padding: "0 8px 16px" }}>
-            {showSectorFilters && sectorFilters.map((f) => (
-              <div key={f} role="button" tabIndex={0} onClick={() => setActiveFilter(f)} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveFilter(f); } }} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 8, cursor: "pointer", background: activeFilter === f ? `${t.ACCENT}18` : "transparent", borderLeft: activeFilter === f ? `2px solid ${t.ACCENT}` : "2px solid transparent", marginLeft: 2, marginBottom: 2 }}>
-                <span style={{ fontSize: 13, color: activeFilter === f ? t.TEXT : t.SUBTLE, flex: 1 }}>{f}</span>
-              </div>
-            ))}
-            <div style={{ margin: "16px 0 8px", fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", color: t.FAINT, textTransform: "uppercase", padding: "0 10px" }}>Community Stats</div>
-            {[{ l: "Sectors", v: String(sectors.length) }, { l: "Active Listings", v: String(members.length) }].map(({ l, v }) => (
-              <div key={l} style={{ padding: "6px 10px", fontSize: 12, color: t.MUTED }}>
-                {l}: <span style={{ color: t.ACCENT, fontWeight: 600 }}>{v}</span>
-              </div>
-            ))}
-          </div>
-        </ScrollArea>
-        <div style={{ padding: 12, borderTop: `1px solid ${t.BORDER}` }}>
-          <div style={{ padding: "10px 12px", borderRadius: 10, background: `${t.ACCENT}10`, border: `1px solid ${t.ACCENT}25` }}>
-            <div style={{ fontSize: 12, fontWeight: 600, color: t.ACCENT, marginBottom: 2 }}>Become a Provider</div>
-            <div style={{ fontSize: 11, color: t.MUTED }}>Claim your profile today</div>
-          </div>
-        </div>
-      </aside>
-
-      {/* Main */}
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <BookOpen size={18} style={{ color: t.ACCENT }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>📇 Directory</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Fellow community members · Trauma-informed · Safe</div>
-          </div>
-          <button onClick={() => setShowProfileEditor(true)} style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 14px", borderRadius: 9, background: `${t.ACCENT}14`, border: `1px solid ${t.ACCENT}40`, color: t.ACCENT, fontSize: 13, fontWeight: 700, cursor: "pointer", whiteSpace: "nowrap" }}>
-            {hasOwnProfile ? <Pencil size={14} /> : <UserPlus size={14} />} {profileButtonLabel}
-          </button>
-          <RefreshButton onRefresh={() => setRefreshKey((k) => k + 1)} title="Refresh" />
-          <PluginAdminButton href="/admin/directory" isAdmin={isAdmin} accent={t.ACCENT} />
-        </header>
-
-        {content}
-      </div>
-
-      {/* Right panel */}
-      <DirectoryRightPanel
-        members={members}
-        sectors={sectors}
-        activeFilter={activeFilter}
-        loadingMembers={loadingMembers}
-        onSelect={setSelected}
-        onFilter={setActiveFilter}
-      />
-
-      {profileEditor}
-    </div>
-  );
 }

--- a/ctf/packages/web/components/foundation/foundation-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-shell.tsx
@@ -3,11 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Hammer, Search } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { AppLoading } from "@/components/shared/app-loading";
 import { useTheme } from "@/hooks/useTheme";
 import { FONT, getFoundationTokens, type FoundationTab, type ProviderView, type QuoteView } from "./foundation-ui";
-import { IconRail, FilterSidebar, RightRail } from "./foundation-rails";
 import { BrowsePanel, QuotesPanel } from "./foundation-panels";
 import { OfferSkillsPanel } from "./foundation-offer-skills";
 import { ProviderProfile } from "./foundation-profile";
@@ -66,7 +64,7 @@ export function FoundationShell({ isAdmin, initialProviderId }: { isAdmin?: bool
   const [viewerUserId, setViewerUserId] = useState<string | null>(null);
   const [quotes, setQuotes] = useState<QuoteView[]>([]);
   const [tab, setTab] = useState<FoundationTab>("browse");
-  const [trade, setTrade] = useState("All Trades");
+  const [trade] = useState("All Trades");
   const [query, setQuery] = useState("");
   const [skillId, setSkillId] = useState<string | null>(null);
   const [skillName, setSkillName] = useState<string | null>(null);
@@ -79,7 +77,6 @@ export function FoundationShell({ isAdmin, initialProviderId }: { isAdmin?: bool
   const [activeDirectLine, setActiveDirectLine] = useState<{ credentials: DirectLineCredentials; subtitle: string | null } | null>(null);
   // The Direct Line re-opened from a Quotes row — only the thread id; credentials are fetched fresh.
   const [quoteDirectLine, setQuoteDirectLine] = useState<{ threadId: string; subtitle: string | null } | null>(null);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getFoundationTokens(theme);
   // Bumped by the header refresh button; the load effect re-runs without the full-screen loading
@@ -152,17 +149,6 @@ export function FoundationShell({ isAdmin, initialProviderId }: { isAdmin?: bool
     })();
     return () => controller.abort();
   }, [initialProviderId]);
-
-  // "Browse All Providers" in the right rail: return to the full, unfiltered list. Just switching to
-  // the browse tab was a no-op whenever browse was already open (the default), so also clear the trade,
-  // search text, and skill filters so the button always lands the member on every provider.
-  const browseAllProviders = useCallback(() => {
-    setTab("browse");
-    setTrade("All Trades");
-    setQuery("");
-    setSkillId(null);
-    setSkillName(null);
-  }, []);
 
   // Real quote creation is two steps: open a connection thread, then request a quote on it.
   const requestQuote = useCallback(async (provider: ProviderView) => {
@@ -291,7 +277,6 @@ export function FoundationShell({ isAdmin, initialProviderId }: { isAdmin?: bool
     </>
   );
 
-  if (isMobile) {
     const tabs: { key: FoundationTab; label: string }[] = [
       { key: "browse", label: "Browse" },
       { key: "offer", label: "Offer" },
@@ -326,25 +311,4 @@ export function FoundationShell({ isAdmin, initialProviderId }: { isAdmin?: bool
         {content}
       </div>,
     );
-  }
-
-  return withInstantCall(
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: FONT, color: t.TEXT, display: "flex" }}>
-      <IconRail tab={tab} onTab={setTab} />
-      <FilterSidebar query={query} onQuery={setQuery} trade={trade} onTrade={setTrade} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <Hammer size={18} style={{ color: t.ACCENT }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>Foundation — Trade Services</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Community trade providers · Trauma-informed</div>
-          </div>
-          <RefreshButton onRefresh={() => setRefreshKey((k) => k + 1)} title="Refresh" />
-          <PluginAdminButton href="/admin/foundation" isAdmin={isAdmin} accent={t.ACCENT} />
-        </header>
-        {content}
-      </div>
-      <RightRail providers={providers} quoteCount={quotes.length} onBrowse={browseAllProviders} onSelect={setSelected} />
-    </div>,
-  );
 }

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react";
 import { Globe } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
 import { Badge } from "@/components/ui/badge";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import {
   getGdpTokens,
@@ -19,27 +18,9 @@ import {
   type GdpTokens,
 } from "./gdp-shared";
 import { GdpLoading } from "./gdp-loading";
-import { GdpIconRail } from "./gdp-icon-rail";
-import { GdpSidebar } from "./gdp-sidebar";
 import { GdpDashboard } from "./gdp-dashboard";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
-
-function ShellHeader({ t, metrics, onRefresh }: { t: GdpTokens; metrics: GdpMetrics; onRefresh: () => Promise<void> }) {
-  return (
-    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-      <Globe size={18} style={{ color: t.ACCENT }} />
-      <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>Gross Domestic Product — TI Skills Economy</div>
-        <div style={{ fontSize: 12, color: t.MUTED }}>
-          {metrics.countries ? `${metrics.countries} countries · ` : ""}{metrics.members ? `${metrics.members} survivors` : "Loading…"}
-        </div>
-      </div>
-      <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>↑ Live</Badge>
-      <RefreshButton onRefresh={onRefresh} title="Refresh" />
-    </header>
-  );
-}
 
 function EmptyReport({ t }: { t: GdpTokens }) {
   return (
@@ -94,7 +75,6 @@ export default function GdpShell() {
   const [metricRows, setMetricRows] = useState<GdpMetricRow[]>([]);
   // Real per-country member distribution (location tied to people), fetched from /api/gdp/countries.
   const [countries, setCountries] = useState<GdpCountry[]>([]);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getGdpTokens(theme);
 
@@ -171,7 +151,6 @@ export default function GdpShell() {
     metrics.countries = String(distinctCountryCount);
   }
 
-  if (isMobile) {
     return (
       <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT, display: "flex", flexDirection: "column" }}>
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
@@ -188,16 +167,4 @@ export default function GdpShell() {
         <GdpContent t={t} error={error} report={report} sectors={sectors} countries={countries} metrics={metrics} />
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <GdpIconRail />
-      <GdpSidebar metrics={metrics} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader t={t} metrics={metrics} onRefresh={handleRefresh} />
-        <GdpContent t={t} error={error} report={report} sectors={sectors} countries={countries} metrics={metrics} />
-      </div>
-    </div>
-  );
 }

--- a/ctf/packages/web/components/gentle-pulse/gentle-pulse-shell.tsx
+++ b/ctf/packages/web/components/gentle-pulse/gentle-pulse-shell.tsx
@@ -2,17 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { Badge } from "@/components/ui/badge";
 import { Heart } from "lucide-react";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { getGentlePulseTokens, type Session, type Tab } from "./gp-shared";
 import { GentlePulseLoading } from "./gp-loading";
-import { GentlePulseIconRail } from "./gp-icon-rail";
-import { GentlePulseSidebar } from "./gp-sidebar";
 import { GentlePulseSessions } from "./gp-sessions";
 import { GentlePulsePlayer } from "./gp-player";
-import { GentlePulseRightPanel } from "./gp-right-panel";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
 
@@ -28,7 +23,6 @@ export function GentlePulseShell() {
   const [progress] = useState(40);
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [submitting, setSubmitting] = useState(false);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getGentlePulseTokens(theme);
 
@@ -128,7 +122,6 @@ export function GentlePulseShell() {
     </>
   );
 
-  if (isMobile) {
     return (
       <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
@@ -151,36 +144,4 @@ export function GentlePulseShell() {
         {content}
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <GentlePulseIconRail tab={tab} onTab={setTab} />
-      <GentlePulseSidebar
-        categories={categories}
-        category={category}
-        onCategory={setCategory}
-        sessionCount={sessions.length}
-        favoriteCount={favorites.size}
-      />
-
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <Heart size={18} style={{ color: t.ACCENT }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>💚 GentlePulse — Guided Meditation</div>
-            <div style={{ fontSize: 12, color: t.FAINT }}>Trauma-informed · Expert-designed</div>
-          </div>
-          <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-            ✓ Trauma-Informed
-          </Badge>
-          <RefreshButton onRefresh={() => fetchLibrary()} title="Refresh" />
-        </header>
-
-        {content}
-      </div>
-
-      <GentlePulseRightPanel sessions={sessions} onPlay={(id) => void handlePlay(id)} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/level-up/level-up-shell.tsx
+++ b/ctf/packages/web/components/level-up/level-up-shell.tsx
@@ -4,11 +4,9 @@ import { useCallback, useEffect, useState } from "react";
 import { BackChevronButton } from "@/lib/nav/back-history";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
-import { getLevelUpTokens, type LevelUpTokens, type Cohort, type Enrollment, type PendingValidation, type NavKey, type Wallet, type Trainer, type Achievement, type WalletView, idempotencyKey } from "./lu-shared";
-import { LevelUpSidebar } from "./lu-sidebar";
+import { getLevelUpTokens, type LevelUpTokens, type Cohort, type Enrollment, type NavKey, type Wallet, type Trainer, type Achievement, type WalletView, idempotencyKey } from "./lu-shared";
 import { LevelUpBrowse } from "./lu-browse";
 import { LevelUpProgress } from "./lu-progress";
-import { LevelUpRightPanel } from "./lu-right-panel";
 import { LevelUpLoading } from "./lu-loading";
 import { LevelUpTrainers } from "./lu-trainers";
 import { LevelUpAchievements } from "./lu-achievements";
@@ -138,7 +136,7 @@ function ShellContent({
   return <CenteredNote color={t.TEXT_SUBTLE}>{HEADINGS[nav]} — coming soon</CenteredNote>;
 }
 
-export function LevelUpShell({ isAdmin = false, isTrainer = false }: { userId?: string; isAdmin?: boolean; isTrainer?: boolean; query?: { track?: string; status?: string; startDate?: string; cohortId?: string } }) {
+export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: boolean; isTrainer?: boolean; query?: { track?: string; status?: string; startDate?: string; cohortId?: string } }) {
   const [nav, setNav] = useState<NavKey>("browse");
   // Track filtering is pinned to "All Tracks" — the preset track chips were hidden because they were a
   // hardcoded list that did not reflect real cohorts (deferred to #1197). The track-filter plumbing
@@ -148,11 +146,6 @@ export function LevelUpShell({ isAdmin = false, isTrainer = false }: { userId?: 
   const [cohorts, setCohorts] = useState<Cohort[]>([]);
   const [wallet, setWallet] = useState<Wallet | null>(null);
   const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
-  // NOTE: when a pending-validations feed is wired up here, it MUST be scoped server-side to the
-  // cohorts this trainer is assigned to (mirroring getTrainerDashboardData's
-  // `created_by_user_id = actorId` filter). Passing an unscoped list to the panel would disclose
-  // other trainers' learners. It is a static empty list today, so there is no exposure yet.
-  const [pendingValidations, setPendingValidations] = useState<PendingValidation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [enrollingId, setEnrollingId] = useState<string | null>(null);
@@ -247,25 +240,7 @@ export function LevelUpShell({ isAdmin = false, isTrainer = false }: { userId?: 
     }
   }
 
-  async function handleValidate(validation: PendingValidation) {
-    try {
-      const res = await fetch(`/api/level-up/milestones/${validation.milestoneId}/validate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
-        body: JSON.stringify({
-          enrollmentId: validation.enrollmentId,
-          cohortId: validation.cohortId,
-          idempotencyKey: idempotencyKey(),
-        }),
-      });
-      if (!res.ok) return;
-      setPendingValidations((prev) => prev.filter((v) => v.milestoneId !== validation.milestoneId));
-    } catch {
-      // optimistic remove already applied on success path only
-    }
-  }
-
-  const { filtered, balance, escrow, openCount } = deriveView(cohorts, wallet, track, search);
+  const { filtered, escrow, openCount } = deriveView(cohorts, wallet, track, search);
 
   if (loading && cohorts.length === 0 && !error) return <LevelUpLoading />;
 
@@ -299,7 +274,6 @@ export function LevelUpShell({ isAdmin = false, isTrainer = false }: { userId?: 
     </>
   );
 
-  if (isMobile) {
     const navItems: { key: NavKey; label: string }[] = [
       { key: "browse", label: "Browse" },
       { key: "progress", label: "Progress" },
@@ -327,24 +301,4 @@ export function LevelUpShell({ isAdmin = false, isTrainer = false }: { userId?: 
         <div style={{ padding: 16 }}>{content}</div>
       </div>
     );
-  }
-
-  return (
-    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "Inter, system-ui, sans-serif", color: t.TEXT_BODY, overflow: "hidden" }}>
-      <LevelUpSidebar nav={nav} onNav={setNav} isAdmin={isAdmin} balance={balance} escrow={escrow} />
-      <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
-        <div style={{ flex: 1, overflowY: "auto", padding: "24px 28px" }}>
-          {content}
-        </div>
-        <LevelUpRightPanel
-          enrollments={enrollments}
-          pendingValidations={pendingValidations}
-          isAdmin={isAdmin}
-          isTrainer={isTrainer}
-          onBrowse={() => setNav("browse")}
-          onValidate={(validation) => void handleValidate(validation)}
-        />
-      </div>
-    </div>
-  );
 }

--- a/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-shell.tsx
@@ -3,13 +3,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Home, Search } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import type { Currency } from "@/lib/currency/types";
 import { BG, getLighthouseTokens, listingAcceptsCredits, type ChatCredentials, type CurrencyMap, type Match, type Property, type Tab } from "./shared";
-import { LighthouseIconRail } from "./lighthouse-icon-rail";
-import { LighthouseFilterSidebar, type ListingFilter, filterProperties } from "./lighthouse-filter-sidebar";
-import { LighthouseRightPanel } from "./lighthouse-right-panel";
+import { type ListingFilter, filterProperties } from "./lighthouse-filter-sidebar";
 import { LighthouseBrowse } from "./lighthouse-browse";
 import { LighthouseMatches } from "./lighthouse-matches";
 import { LighthouseChat } from "./lighthouse-chat";
@@ -37,7 +34,6 @@ export function LighthouseShell({ userId, username, isAdmin }: { userId: string;
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const [currencies, setCurrencies] = useState<Currency[]>([]);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getLighthouseTokens(theme);
 
@@ -185,7 +181,6 @@ export function LighthouseShell({ userId, username, isAdmin }: { userId: string;
     </>
   );
 
-  if (isMobile) {
     const tabs: { key: Tab; label: string }[] = [
       { key: "browse", label: "Browse" },
       { key: "matches", label: "Matches" },
@@ -232,29 +227,4 @@ export function LighthouseShell({ userId, username, isAdmin }: { userId: string;
         {content}
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <LighthouseIconRail tab={tab} onTab={setTab} />
-      <LighthouseFilterSidebar properties={properties} search={search} onSearch={setSearch} filter={filter} onFilter={setFilter} />
-
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT, display: "flex", alignItems: "center", gap: 8 }}><Home size={16} strokeWidth={1.75} style={{ color: t.ACCENT }} /> LightHouse</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Trauma-informed hosts · ServiceCredits accepted</div>
-          </div>
-          <RefreshButton onRefresh={() => fetchAll()} title="Refresh" />
-          <PluginAdminButton href="/admin/lighthouse" isAdmin={isAdmin} accent={t.ACCENT} />
-        </header>
-
-        <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflowY: "auto", minHeight: 0 }}>
-          {content}
-        </div>
-      </div>
-
-      <LighthouseRightPanel />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/mood/mood-shell.tsx
+++ b/ctf/packages/web/components/mood/mood-shell.tsx
@@ -4,14 +4,11 @@ import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Smile } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
 import { getMoodClientId, getMoodTokens, type MoodEligibility, type Tab } from "./mood-shared";
 import { MoodLoading } from "./mood-loading";
-import { MoodIconRail } from "./mood-icon-rail";
-import { MoodSidebar } from "./mood-sidebar";
 import { MoodCheckin } from "./mood-checkin";
 import { MoodCommunity } from "./mood-community";
 import { MoodCrisisRail } from "./mood-crisis-rail";
@@ -26,7 +23,6 @@ export default function MoodShell() {
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getMoodTokens(theme);
 
@@ -96,7 +92,6 @@ export default function MoodShell() {
     <MoodCommunity />
   );
 
-  if (isMobile) {
     const tabs: { key: Tab; label: string }[] = [
       { key: "checkin", label: "Check-in" },
       { key: "community", label: "Community" },
@@ -123,28 +118,4 @@ export default function MoodShell() {
         <MoodCrisisRail />
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100%", minHeight: "100dvh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <MoodIconRail tab={tab} onTab={setTab} />
-      <MoodSidebar tab={tab} onTab={setTab} />
-
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <Smile size={18} style={{ color: t.ACCENT }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>😁 Mood — Pseudonymous Check-ins</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Private check-ins · Community wellness</div>
-          </div>
-          <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>🔒 Pseudonymous</Badge>
-          <RefreshButton onRefresh={() => loadEligibility(clientId)} title="Refresh" />
-        </header>
-
-        {content}
-      </div>
-
-      <MoodCrisisRail />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-shell.tsx
@@ -3,16 +3,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Users } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
-import { BG, getPeerProgrammingTokens, type CohortSummary, type Message, type PeerProgrammingTokens, type Room, type RoomAccess, type Tab } from "./pp-shared";
+import { BG, getPeerProgrammingTokens, type CohortSummary, type Message, type Room, type RoomAccess, type Tab } from "./pp-shared";
 import { PeerProgrammingLoading } from "./pp-loading";
-import { PeerProgrammingIconRail } from "./pp-icon-rail";
-import { PeerProgrammingSidebar } from "./pp-sidebar";
 import { PeerProgrammingCohortsTab } from "./pp-cohorts-tab";
 import { PeerProgrammingSessionTab } from "./pp-session-tab";
 import { PeerProgrammingChatTab } from "./pp-chat-tab";
-import { PeerProgrammingRightPanel } from "./pp-right-panel";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
@@ -99,25 +95,6 @@ function initialCohortIdFromUrl(): string | null {
   return new URLSearchParams(window.location.search).get("cohortId");
 }
 
-function ShellHeader({ active, t, isAdmin, onRefresh }: { active: boolean; t: PeerProgrammingTokens; isAdmin?: boolean; onRefresh: () => Promise<void> }) {
-  return (
-    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-      <Users size={18} style={{ color: t.ACCENT }} />
-      <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>PeerProgramming</div>
-        <div style={{ fontSize: 12, color: t.MUTED }}>Weekly global masterminds · up to 12 people per cohort · Always-open</div>
-      </div>
-      {active && (
-        <span style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-          Cohort Active
-        </span>
-      )}
-      <PluginAdminButton href="/admin/peer-programming" isAdmin={isAdmin} accent={t.ACCENT} />
-      <RefreshButton onRefresh={onRefresh} title="Refresh" />
-    </header>
-  );
-}
-
 export function PeerProgrammingShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -136,7 +113,6 @@ export function PeerProgrammingShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [feedbackInput, setFeedbackInput] = useState("");
   const [feedbackSuccess, setFeedbackSuccess] = useState(false);
   const [feedbackError, setFeedbackError] = useState<string | null>(null);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getPeerProgrammingTokens(theme);
 
@@ -331,7 +307,6 @@ export function PeerProgrammingShell({ isAdmin }: { isAdmin?: boolean } = {}) {
     </>
   );
 
-  if (isMobile) {
     const tabs: { key: Tab; label: string }[] = [
       { key: "cohorts", label: "Cohorts" },
       { key: "session", label: "Session" },
@@ -358,17 +333,4 @@ export function PeerProgrammingShell({ isAdmin }: { isAdmin?: boolean } = {}) {
         {content}
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <PeerProgrammingIconRail tab={tab} onTab={setTab} />
-      <PeerProgrammingSidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader active={Boolean(room?.cohortId)} t={t} isAdmin={isAdmin} onRefresh={reloadRoom} />
-        {content}
-      </div>
-      <PeerProgrammingRightPanel room={room} participants={participants} onJoinSession={() => setTab("session")} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/recurring-activity/recurring-activity-shell.tsx
+++ b/ctf/packages/web/components/recurring-activity/recurring-activity-shell.tsx
@@ -199,19 +199,10 @@ export function RecurringActivityShell() {
     </div>
   );
 
-  if (isMobile) {
-    return (
-      <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TEXT, display: 'flex', flexDirection: 'column' }}>
-        <MobileScreenHeader title="Recurring Activity" accent={t.ACCENT} icon={<HeartHandshake size={18} color={t.ACCENT} />} />
-        <div style={{ flex: 1, overflowY: 'auto', padding: '16px 14px 32px' }}>{content}</div>
-      </div>
-    );
-  }
-
   return (
-    <div style={{ display: 'flex', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TEXT }}>
-      <RecurringActivityIconRail t={t} />
-      <div style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: '32px 28px 64px' }}>{content}</div>
+    <div style={{ width: '100%', minHeight: '100dvh', background: t.BG, fontFamily: FONT_FAMILY, color: t.TEXT, display: 'flex', flexDirection: 'column' }}>
+      <MobileScreenHeader title="Recurring Activity" accent={t.ACCENT} icon={<HeartHandshake size={18} color={t.ACCENT} />} />
+      <div style={{ flex: 1, overflowY: 'auto', padding: '16px 14px 32px' }}>{content}</div>
     </div>
   );
 }

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -4,12 +4,9 @@ import { useEffect, useState } from "react";
 import { Coins } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
 import { Badge } from "@/components/ui/badge";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { AppLoading } from "@/components/shared/app-loading";
-import { BG, fmtCredits, getServiceCreditsTokens, type ServiceCreditsTokens, type Tab, type WalletData } from "./sc-shared";
-import { ServiceCreditsIconRail } from "./sc-icon-rail";
-import { ServiceCreditsSidebar } from "./sc-sidebar";
+import { BG, fmtCredits, getServiceCreditsTokens, type Tab, type WalletData } from "./sc-shared";
 import { ServiceCreditsWalletTab } from "./sc-wallet-tab";
 import { ServiceCreditsEarnTab } from "./sc-earn-tab";
 import { ServiceCreditsCirculationTab } from "./sc-circulation-tab";
@@ -26,29 +23,11 @@ function CenteredNote({ color, children }: { color: string; children: React.Reac
   );
 }
 
-function ShellHeader({ balance, t, isAdmin, onRefresh }: { balance: number; t: ServiceCreditsTokens; isAdmin?: boolean; onRefresh: () => Promise<void> }) {
-  return (
-    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-      <Coins size={18} style={{ color: t.ACCENT }} />
-      <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>ServiceCredits — Utility Tokens</div>
-        <div style={{ fontSize: 12, color: t.MUTED }}>Earn · Spend · Trade · Across all apps</div>
-      </div>
-      <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-        {fmtCredits(balance)} credits
-      </Badge>
-      <RefreshButton onRefresh={onRefresh} title="Refresh" />
-      <PluginAdminButton href="/admin/service-credits" isAdmin={isAdmin} accent={t.ACCENT} />
-    </header>
-  );
-}
-
 export function ServiceCreditsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [wallet, setWallet] = useState<WalletData | null>(null);
   const [tab, setTab] = useState<Tab>("wallet");
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getServiceCreditsTokens(theme);
 
@@ -91,7 +70,6 @@ export function ServiceCreditsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
     </>
   );
 
-  if (isMobile) {
     const tabs: { key: Tab; label: string }[] = [
       { key: "wallet", label: "Wallet" },
       { key: "earn", label: "Earn" },
@@ -120,17 +98,4 @@ export function ServiceCreditsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
         <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} isMobile />
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <ServiceCreditsIconRail tab={tab} onTab={setTab} />
-      <ServiceCreditsSidebar tab={tab} onTab={setTab} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader balance={balance} t={t} isAdmin={isAdmin} onRefresh={handleRefresh} />
-        {content}
-      </div>
-      <ServiceCreditsSendPanel wallet={wallet} onSent={refreshWallet} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Bell, Search } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { AppLoading } from "@/components/shared/app-loading";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
@@ -14,14 +13,11 @@ import {
   type SkillsHuntRound, type SkillsHuntLeaderboardItem, type SkillsHuntAchievement,
   type SkillsHuntNotification, type SkillsHuntSubmission, type SkillsHuntMissionWithProgress,
 } from "./sh-shared";
-import { SkillsHuntIconRail } from "./sh-icon-rail";
 import { SkillsHuntNotifications } from "./sh-notifications";
-import { SkillsHuntSidebar } from "./sh-sidebar";
 import { SkillsHuntScoutTab, type ScoutFormModel } from "./sh-scout-tab";
 import { SkillsHuntLeaderboardTab } from "./sh-leaderboard-tab";
 import { SkillsHuntMissionsTab } from "./sh-missions-tab";
 import { SkillsHuntMyFindsTab } from "./sh-my-finds-tab";
-import { SkillsHuntRightPanel } from "./sh-right-panel";
 import { useNominationForm } from "./sh-use-nomination-form";
 
 function CenteredNote({ t, color, children }: { t: SkillsHuntTokens; color: string; children: React.ReactNode }) {
@@ -29,24 +25,6 @@ function CenteredNote({ t, color, children }: { t: SkillsHuntTokens; color: stri
     <div style={{ width: "100%", minHeight: "100vh", background: t.BG, display: "flex", alignItems: "center", justifyContent: "center" }}>
       <div style={{ fontSize: 14, color }}>{children}</div>
     </div>
-  );
-}
-
-function ShellHeader({ t, activeRound, onRefresh }: { t: SkillsHuntTokens; activeRound: SkillsHuntRound | null; onRefresh: () => void }) {
-  return (
-    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-      <Search size={18} style={{ color: t.ACCENT }} />
-      <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>SkillsHunt</div>
-        <div style={{ fontSize: 12, color: t.MUTED }}>
-          {activeRound ? activeRound.name : "Nominate survivors · build the Directory · grow the economy"}
-        </div>
-      </div>
-      {activeRound && (
-        <span style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>Round active</span>
-      )}
-      <RefreshButton onRefresh={onRefresh} title="Refresh" />
-    </header>
   );
 }
 
@@ -112,7 +90,7 @@ export function SkillsHuntShell({
   const [loadingMissions, setLoadingMissions] = useState(false);
   const [notifications, setNotifications] = useState<SkillsHuntNotification[]>([]);
   const [notifOpen, setNotifOpen] = useState(false);
-  const [achievements, setAchievements] = useState<SkillsHuntAchievement[]>([]);
+  const [, setAchievements] = useState<SkillsHuntAchievement[]>([]);
   const [myFinds, setMyFinds] = useState<SkillsHuntSubmission[]>([]);
   const [loadingRounds, setLoadingRounds] = useState(true);
   const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
@@ -121,7 +99,6 @@ export function SkillsHuntShell({
   // Bumped by the header refresh button; the data effects below re-run without the full-screen
   // loading state (only the initial load, refreshKey 0, shows AppLoading).
   const [refreshKey, setRefreshKey] = useState(0);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getSkillsHuntTokens(theme);
 
@@ -248,7 +225,7 @@ export function SkillsHuntShell({
   if (loadingRounds) return <AppLoading />;
   if (globalError) return <CenteredNote t={t} color="#EF4444">{globalError}</CenteredNote>;
 
-  const { currentUserEntry, noActiveRound } = deriveShellState({ leaderboard, serverCurrentUserEntry, userId, rounds });
+  const { noActiveRound } = deriveShellState({ leaderboard, serverCurrentUserEntry, userId, rounds });
   const showModeratorTools = isAdmin || isModerator;
 
   const content = (
@@ -262,7 +239,6 @@ export function SkillsHuntShell({
     />
   );
 
-  if (isMobile) {
     return (
       <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
@@ -290,22 +266,4 @@ export function SkillsHuntShell({
         <div style={{ padding: 16 }}>{content}</div>
       </div>
     );
-  }
-
-  return (
-    <div style={{ position: "relative", width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <SkillsHuntIconRail tab={tab} onTab={setTab} notifOpen={notifOpen} onToggleNotif={() => setNotifOpen((o) => !o)} />
-      {notifOpen && (
-        <SkillsHuntNotifications notifications={notifications} onClose={() => setNotifOpen(false)} onMarkRead={(id) => void markRead(id)} />
-      )}
-      <SkillsHuntSidebar tab={tab} onTab={setTab} achievements={achievements} currentUserEntry={currentUserEntry} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader t={t} activeRound={activeRound} onRefresh={() => setRefreshKey((k) => k + 1)} />
-        <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: "24px" }}>
-          {content}
-        </div>
-      </div>
-      <SkillsHuntRightPanel currentUserEntry={currentUserEntry} achievements={achievements} showModeratorTools={showModeratorTools} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
@@ -3,12 +3,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronLeft } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
 import { getSkillsTaxonomyTokens, type StSector } from "./st-shared";
-import { SkillsTaxonomyIconRail } from "./st-icon-rail";
 import { SkillsTaxonomySectorsColumn } from "./st-sectors-column";
 import { SkillsTaxonomyTitlesColumn } from "./st-titles-column";
 import { SkillsTaxonomySkillsDetail } from "./st-skills-detail";
@@ -22,7 +20,6 @@ export function SkillsTaxonomyBrowser() {
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getSkillsTaxonomyTokens(theme);
   const [mobileView, setMobileView] = useState<"sectors" | "titles" | "skills">("sectors");
@@ -63,7 +60,6 @@ export function SkillsTaxonomyBrowser() {
   // Phones can't fit three columns side by side, so the hierarchy becomes a
   // drill-down: sectors → job titles → skills, one level at a time with a
   // back button. The column components go full-width on small screens.
-  if (isMobile) {
     const backTarget = mobileView === "skills" ? "titles" : "sectors";
     const backLabel = mobileView === "skills" ? "Job titles" : "Sectors";
     return (
@@ -109,32 +105,4 @@ export function SkillsTaxonomyBrowser() {
         )}
       </div>
     );
-  }
-
-  return (
-    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
-      <SkillsTaxonomyIconRail onRefresh={() => load()} />
-      <SkillsTaxonomySectorsColumn
-        sectors={sectors}
-        selectedSectorId={selectedSectorId}
-        onSelect={(id) => { setSelectedSectorId(id); setSelectedJobTitleId(null); setSearch(""); }}
-      />
-      <SkillsTaxonomyTitlesColumn
-        sector={selectedSector}
-        selectedJobTitleId={selectedJobTitleId}
-        onSelect={(id) => { setSelectedJobTitleId(id); setSearch(""); }}
-      />
-      {error ? (
-        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#F87171", fontSize: 14 }}>{error}</div>
-      ) : (
-        <SkillsTaxonomySkillsDetail
-          sector={selectedSector}
-          jobTitle={selectedJobTitle}
-          skills={visibleSkills}
-          search={search}
-          onSearch={setSearch}
-        />
-      )}
-    </div>
-  );
 }

--- a/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Share2 } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import {
   BG,
@@ -23,12 +22,9 @@ import {
   type Tab,
 } from "./sr-shared";
 import { SocketRelayLoading } from "./sr-loading";
-import { SocketRelayIconRail } from "./sr-icon-rail";
-import { SocketRelaySidebar } from "./sr-sidebar";
 import { SocketRelayFeed } from "./sr-feed";
 import { SocketRelayPost, type PostDraft } from "./sr-post";
 import { SocketRelayChat } from "./sr-chat";
-import { SocketRelayRightPanel } from "./sr-right-panel";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
@@ -79,7 +75,7 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
   const [error, setError] = useState<string | null>(null);
   const [requests, setRequests] = useState<SrRequest[]>([]);
   const [myRequests, setMyRequests] = useState<SrRequest[]>([]);
-  const [myRequestCount, setMyRequestCount] = useState(0);
+  const [, setMyRequestCount] = useState(0);
   const [fulfillments, setFulfillments] = useState<SrFulfillment[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [tab, setTab] = useState<Tab>("feed");
@@ -96,7 +92,6 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getSocketRelayTokens(theme);
 
@@ -398,7 +393,6 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
     </>
   );
 
-  if (isMobile) {
     const tabs: { key: Tab; label: string }[] = [
       { key: "feed", label: "Feed" },
       { key: "post", label: "Post" },
@@ -435,46 +429,4 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
         {content}
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <SocketRelayIconRail tab={tab} onTab={setTab} />
-      <SocketRelaySidebar
-        categories={categories}
-        category={category}
-        onCategory={setCategory}
-        search={search}
-        onSearch={setSearch}
-        openCount={openCount}
-        myRequestCount={myRequestCount}
-        fulfillmentCount={fulfillments.length}
-      />
-
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <Share2 size={18} style={{ color: t.ACCENT }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>🔂 SocketRelay — Mutual Aid</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Real-time requests · Privacy-minimized</div>
-          </div>
-          <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-            {openCount} open
-          </Badge>
-          <PluginAdminButton href="/admin/socket-relay" isAdmin={isAdmin} accent={t.ACCENT} />
-          <RefreshButton onRefresh={() => fetchData(false)} title="Refresh" />
-        </header>
-
-        {content}
-      </div>
-
-      <SocketRelayRightPanel
-        openCount={openCount}
-        myRequestCount={myRequestCount}
-        fulfillmentCount={fulfillments.length}
-        totalCount={requests.length}
-        onPost={() => setTab("post")}
-      />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
+++ b/ctf/packages/web/components/trust-transport/trust-transport-shell.tsx
@@ -3,39 +3,17 @@
 import { useEffect, useRef, useState } from "react";
 import { Car } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
-import { Badge } from "@/components/ui/badge";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { AppLoading } from "@/components/shared/app-loading";
 import { useTheme } from "@/hooks/useTheme";
-import { BG, deriveRideTypes, getTrustTransportTokens, type ChatCreds, type Mode, type Tab, type TripRequest, type TrustTransportTokens } from "./tt-shared";
-import { TrustTransportIconRail } from "./tt-icon-rail";
-import { TrustTransportSidebar } from "./tt-sidebar";
+import { BG, deriveRideTypes, getTrustTransportTokens, type ChatCreds, type Mode, type Tab, type TripRequest } from "./tt-shared";
 import { TrustTransportBookTab } from "./tt-book-tab";
 import { TrustTransportTrackingTab } from "./tt-tracking-tab";
 import { TrustTransportHelpTab } from "./tt-help-tab";
 import { TrustTransportEarningsTab } from "./tt-earnings-tab";
 import { TrustTransportChatTab } from "./tt-chat-tab";
-import { TrustTransportRightPanel } from "./tt-right-panel";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
-
-function ShellHeader({ t, isAdmin, onRefresh }: { t: TrustTransportTokens; isAdmin?: boolean; onRefresh: () => Promise<void> }) {
-  return (
-    <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-      <Car size={18} style={{ color: t.ACCENT }} />
-      <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>TrustTransport</div>
-        <div style={{ fontSize: 12, color: t.MUTED }}>Rides · Packages · Food · Community mutual aid</div>
-      </div>
-      <Badge style={{ background: "#22C55E20", color: "#22C55E", border: "1px solid #22C55E35", fontSize: 11, padding: "3px 10px", borderRadius: 20 }}>
-        Community
-      </Badge>
-      <PluginAdminButton href="/admin/trust-transport" isAdmin={isAdmin} accent={t.ACCENT} />
-      <RefreshButton onRefresh={onRefresh} title="Refresh" />
-    </header>
-  );
-}
 
 export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const [loading, setLoading] = useState(true);
@@ -61,7 +39,6 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   // Tracks the most recently requested chat trip so a slower earlier response
   // can't overwrite the credentials for a trip the user has since switched to.
   const activeChatReqRef = useRef<string | null>(null);
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getTrustTransportTokens(theme);
 
@@ -235,7 +212,6 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
     </>
   );
 
-  if (isMobile) {
     const tabs: { key: Tab; label: string }[] = [
       { key: "book", label: "Book" },
       { key: "tracking", label: "Tracking" },
@@ -263,17 +239,4 @@ export function TrustTransportShell({ isAdmin }: { isAdmin?: boolean } = {}) {
         {content}
       </div>
     );
-  }
-
-  return (
-    <div style={{ width: "100%", height: "100dvh", overflow: "hidden", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: "flex" }}>
-      <TrustTransportIconRail tab={tab} onTab={setTab} />
-      <TrustTransportSidebar rideTypes={rideTypes} rideType={rideType} onRideType={setRideType} requests={requests} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, minHeight: 0 }}>
-        <ShellHeader t={t} isAdmin={isAdmin} onRefresh={() => fetchRequests()} />
-        {content}
-      </div>
-      <TrustTransportRightPanel requestCount={requests.length} modeCount={modes.length || rideTypes.length} onBook={() => setTab("book")} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/unlock/unlock-status-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-status-view.tsx
@@ -3,13 +3,9 @@
 import { Unlock as UnlockIcon } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTheme } from "@/hooks/useTheme";
 import { STATUS_CONFIG, getUnlockTokens, type DisplayStatus } from "./unlock-shared";
-import { UnlockIconRail } from "./unlock-icon-rail";
-import { UnlockSidebar } from "./unlock-sidebar";
 import { UnlockStatusCard } from "./unlock-status-card";
-import { UnlockRightRail } from "./unlock-right-rail";
 import { UnlockQuoraHelp } from "./unlock-quora-help";
 
 export function UnlockStatusView({
@@ -31,7 +27,6 @@ export function UnlockStatusView({
 }) {
   const cfg = STATUS_CONFIG[status];
   const Icon = cfg.icon;
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getUnlockTokens(theme);
 
@@ -51,7 +46,6 @@ export function UnlockStatusView({
     </>
   );
 
-  if (isMobile) {
     return (
       <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
@@ -68,32 +62,5 @@ export function UnlockStatusView({
         <div style={{ padding: "16px" }}>{content}</div>
       </div>
     );
-  }
 
-  return (
-    <div style={{ display: "flex", height: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
-      <UnlockIconRail />
-      <UnlockSidebar status={status} />
-
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: "flex", alignItems: "center", padding: "0 24px", gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <UnlockIcon size={18} color={cfg.color} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>Verification Status</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Quora profile · account unlock</div>
-          </div>
-          <PluginAdminButton href="/admin/unlock" isAdmin={isAdmin} accent={cfg.color} />
-          <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "4px 12px", borderRadius: 20, background: cfg.bg, border: `1px solid ${cfg.color}30`, fontSize: 11, fontWeight: 600, color: cfg.color }}>
-            <Icon size={11} /> {cfg.label}
-          </div>
-        </header>
-
-        <div style={{ flex: 1, overflowY: "auto", padding: "40px 64px" }}>
-          {content}
-        </div>
-      </div>
-
-      <UnlockRightRail status={status} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
@@ -17,10 +17,7 @@ import {
   isCurrentWeek,
 } from "./wp-shared";
 import { WeeklyPerformanceLoading } from "./wp-loading";
-import { WeeklyPerformanceIconRail } from "./wp-icon-rail";
-import { WeeklyPerformanceSidebar } from "./wp-sidebar";
 import { WeeklyPerformanceDashboardMain } from "./wp-dashboard-main";
-import { WeeklyPerformanceRightRail } from "./wp-right-rail";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
 
@@ -61,7 +58,7 @@ export function WeeklyPerformanceShell() {
   const [weeks, setWeeks] = useState<WpWeek[]>([]);
   const [selectedWeekStart, setSelectedWeekStart] = useState<string | null>(null);
   const [currentWeekStart, setCurrentWeekStart] = useState<string | null>(null);
-  const [activeUsers, setActiveUsers] = useState<number | null>(null);
+  const [, setActiveUsers] = useState<number | null>(null);
   const [metrics, setMetrics] = useState<WpMetric[]>([]);
   const [comparison, setComparison] = useState<WpComparison | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -155,7 +152,6 @@ export function WeeklyPerformanceShell() {
     />
   );
 
-  if (isMobile) {
     return (
       <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
@@ -177,24 +173,5 @@ export function WeeklyPerformanceShell() {
         {content}
       </div>
     );
-  }
 
-  return (
-    <div style={{ display: "flex", height: "100dvh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: "hidden" }}>
-      <WeeklyPerformanceIconRail />
-      <WeeklyPerformanceSidebar
-        weeks={weeks}
-        selectedWeekStart={selectedWeekStart}
-        currentWeekStart={currentWeekStart}
-        onSelect={setSelectedWeekStart}
-      />
-      {content}
-      <WeeklyPerformanceRightRail
-        week={selectedWeek}
-        metricCount={metrics.length}
-        activeUsersLast7Days={activeUsers}
-        isCurrent={selectedIsCurrent}
-      />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/what-works/what-works-shell.tsx
+++ b/ctf/packages/web/components/what-works/what-works-shell.tsx
@@ -7,7 +7,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ListChecks, Plus, Search } from 'lucide-react';
 import { BackChevronButton } from '@/lib/nav/back-history';
 import { PluginAdminButton } from '@/components/shared/plugin-admin-button';
-import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import {
   BG, BRAND, TEXT, getWhatWorksTokens,
@@ -15,10 +14,7 @@ import {
   type WhatWorksProblemOption, type WhatWorksProduct, type WhatWorksStats,
 } from './ww-shared';
 import { WhatWorksLoading } from './ww-loading';
-import { WhatWorksIconRail } from './ww-icon-rail';
-import { WhatWorksSidebar } from './ww-sidebar';
 import { WhatWorksHero } from './ww-hero';
-import { WhatWorksRightRail } from './ww-right-rail';
 import { WhatWorksProblemSection } from './ww-problem-section';
 import { WhatWorksSuggestPanel } from './ww-suggest-panel';
 import { MobileTopActions } from '@/components/shared/mobile-top-actions';
@@ -56,11 +52,9 @@ export function WhatWorksShell() {
   const [isAdmin, setIsAdmin] = useState(false);
   const [problemOptions, setProblemOptions] = useState<WhatWorksProblemOption[]>([]);
   const [query, setQuery] = useState('');
-  const [activeIndex, setActiveIndex] = useState(0);
   const [showSuggest, setShowSuggest] = useState(false);
   const [busyProductId, setBusyProductId] = useState<string | null>(null);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getWhatWorksTokens(theme);
 
@@ -144,14 +138,6 @@ export function WhatWorksShell() {
     }
   }
 
-  function selectProblem(index: number, list: WhatWorksProblem[]): void {
-    setActiveIndex(index);
-    const target = list[index];
-    if (target) {
-      sectionRefs.current[target.id]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }
-
   const visibleProblems = useMemo(() => filterProblems(problems, query), [problems, query]);
 
   if (loading) {
@@ -212,7 +198,6 @@ export function WhatWorksShell() {
     </>
   );
 
-  if (isMobile) {
     return (
       <div style={{ minHeight: '100dvh', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
         <div style={{ position: 'sticky', top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
@@ -254,47 +239,5 @@ export function WhatWorksShell() {
         </div>
       </div>
     );
-  }
 
-  return (
-    <div style={{ display: 'flex', height: '100dvh', maxHeight: '100%', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE, overflow: 'hidden' }}>
-      <WhatWorksIconRail />
-      <WhatWorksSidebar
-        problems={visibleProblems}
-        activeIndex={activeIndex}
-        onSelectProblem={(index) => selectProblem(index, visibleProblems)}
-        onSuggest={() => setShowSuggest(true)}
-      />
-
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-        <header style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: 'flex', alignItems: 'center', padding: '0 24px', gap: 16, background: t.HEADER, flexShrink: 0 }}>
-          <ListChecks size={18} color={t.ACCENT} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>What Works</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Survivor-verified tools · by problem</div>
-          </div>
-          <PluginAdminButton href="/admin/what-works" isAdmin={isAdmin} accent={t.ACCENT} />
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', borderRadius: 9, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, width: 220 }}>
-            <Search size={14} color={t.MUTED} />
-            <input
-              aria-label="Search tools or problems"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search tools or problems…"
-              style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontSize: 12.5, color: t.TITLE, fontFamily: 'inherit' }}
-            />
-          </div>
-          <RefreshButton onRefresh={refreshAll} title="Refresh" />
-        </header>
-
-        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '28px 40px 48px' }}>
-          <div style={{ maxWidth: 760, margin: '0 auto' }}>
-            {content}
-          </div>
-        </div>
-      </div>
-
-      <WhatWorksRightRail stats={stats} />
-    </div>
-  );
 }

--- a/ctf/packages/web/components/workforce/workforce-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-shell.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { BarChart2, Target } from 'lucide-react';
 import { BackChevronButton } from '@/lib/nav/back-history';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useTheme } from '@/hooks/useTheme';
 import { AppLoading } from '@/components/shared/app-loading';
 import { getWorkforceTokens, type WorkforceTokens } from './workforce-shared';
@@ -14,8 +13,6 @@ import type {
   WorkforceOccupationGapItem,
   WorkforceProfile,
 } from '../../lib/workforce/types';
-import { WorkforceIconRail } from './workforce-icon-rail';
-import { WorkforceSidebar } from './workforce-sidebar';
 import { WorkforceHeroStats } from './workforce-hero-stats';
 import { WorkforceSkillDistribution } from './workforce-skill-distribution';
 import { WorkforceSectorGaps } from './workforce-sector-gaps';
@@ -23,12 +20,10 @@ import { WorkforceTrainingGaps } from './workforce-training-gaps';
 import { WorkforceBucketDrilldown } from './workforce-bucket-drilldown';
 import { WorkforceOccupations } from './workforce-occupations';
 import { WorkforceCommunityPlanning } from './workforce-community-planning';
-import { WorkforceProfilePanel } from './workforce-profile-panel';
 import { PluginAdminButton } from '@/components/shared/plugin-admin-button';
 import { MobileTopActions } from '@/components/shared/mobile-top-actions';
 import { RefreshButton } from '@/components/shared/refresh-button';
 
-type Tab = 'dashboard';
 type SidebarView = 'overview' | 'sector' | 'skill-level' | 'occupations' | 'community-planning';
 
 interface WorkforceData {
@@ -222,7 +217,6 @@ function WorkforceDashboardContent({
 }
 
 export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
-  const [tab] = useState<Tab>('dashboard');
   const [view, setView] = useState<SidebarView>('overview');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -234,7 +228,6 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     occupationItems: [],
     profile: null,
   });
-  const isMobile = useIsMobile();
   const { theme } = useTheme();
   const t = getWorkforceTokens(theme);
 
@@ -319,7 +312,7 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     };
   }, [fetchAll]);
 
-  const { dashboard, sectorItems, skillItems, occupationItems, profile } = data;
+  const { dashboard, sectorItems, skillItems, occupationItems } = data;
 
   if (loading) {
     return <WorkforceLoadingState />;
@@ -361,7 +354,6 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     />
   );
 
-  if (isMobile) {
     const views: { key: SidebarView; label: string }[] = [
       { key: 'overview', label: 'Overview' },
       { key: 'sector', label: 'Sectors' },
@@ -394,61 +386,5 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
         </div>
       </div>
     );
-  }
 
-  return (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        minHeight: '100dvh',
-        background: t.BG,
-        fontFamily: "'Inter', system-ui, sans-serif",
-        color: t.TEXT,
-        display: 'flex',
-      }}
-    >
-      <WorkforceIconRail activeTab={tab} onTabChange={() => undefined} />
-
-      <WorkforceSidebar
-        activeView={view}
-        onViewChange={setView}
-        dashboard={dashboard}
-        sectorItems={sectorItems}
-      />
-
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-        <header
-          style={{
-            height: 56,
-            borderBottom: `1px solid ${t.BORDER}`,
-            display: 'flex',
-            alignItems: 'center',
-            padding: '0 24px',
-            gap: 16,
-            background: t.HEADER,
-            flexShrink: 0,
-          }}
-        >
-          <BarChart2 size={18} style={{ color: t.ACCENT }} />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT }}>
-              Workforce Dashboard
-            </div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>
-              {dashboard
-                ? `${dashboard.totalMembers.toLocaleString()} members · ${dashboard.recruitedTotal.toLocaleString()} recruited`
-                : 'Live workforce tracker'}
-            </div>
-          </div>
-          <RefreshButton onRefresh={() => fetchAll(false)} title="Refresh" />
-          <PluginAdminButton href="/admin/workforce" isAdmin={isAdmin} accent={t.ACCENT} />
-        </header>
-
-        {content}
-      </div>
-
-      <WorkforceProfilePanel profile={profile} loading={loading} />
-    </div>
-  );
 }


### PR DESCRIPTION
Finishes the mobile-first collapse (owner directive). `useIsMobile()` is pinned to `true` (2026-07-20), so every shell's desktop layout branch was already **dead, unreachable code**. This deletes those branches so there is only one layout to maintain and the two copies can no longer drift — the source of the "works in mobile, not desktop" churn.

**Behavior is unchanged** — the removed branches never executed. **1,028 lines deleted.**

### Shells collapsed (24)
directory, chyme, click-log, contributions (+ admin, banner), directory-admin, foundation, gdp, gentle-pulse, level-up, lighthouse, mood, peer-programming, recurring-activity, service-credits, skills-hunt, skills-taxonomy, socket-relay, trust-transport, unlock-status, weekly-performance, what-works, workforce.

Each: removed the always-true `if (isMobile)` guard and the trailing dead desktop `return`, plus the now-unused desktop-only imports, components, state, and helpers.

`chyme-header` is intentionally left as-is — its phone path is `return null`, so collapsing it would strip props its caller still passes.

### Preserving the desktop views
A new doc, `ctf/docs/developer/desktop-views-archive.md`, records the archive commit (`44ae66a` — the last state with every desktop branch intact) and how to view or restore any desktop view later. Git keeps it exactly and restorably — a code "mockup", better than a screenshot.

### Not yet collapsed
~65 files still reference `isMobile` inline (`isMobile ? a : b`) or pass it as a prop rather than a full desktop `return` branch. Those are smaller and will follow; this PR takes the 24 shells that carried a whole dead desktop layout.

### Checks
`typecheck`, `lint`, `lint:a11y`, and `build:ci` all pass.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_