### PR TITLE
fix: count distinct voters per slot in mutual-time computeWinner

### DIFF
--- a/ctf/packages/web/lib/mutual-time/repository.ts
+++ b/ctf/packages/web/lib/mutual-time/repository.ts
@@ -150,7 +150,7 @@ async function computeWinner(
 ): Promise<{ slotStart: Date; canMakeIt: number } | null> {
   const result = await client.query<{ slot_start_utc: Date; c: number }>(
     `
-      SELECT slot_start_utc, COUNT(*)::int AS c
+      SELECT slot_start_utc, COUNT(DISTINCT voter_user_id)::int AS c
       FROM mutual_time_votes
       WHERE event_id = $1
       GROUP BY slot_start_utc


### PR DESCRIPTION
## What

`computeWinner` in `ctf/packages/web/lib/mutual-time/repository.ts` selected the winning slot with `COUNT(*)`, but the contract defines the winner as the slot with the most **distinct** voters. Under normal operation the delete-and-re-insert path in `saveVote` keeps one row per `(event_id, voter_user_id, slot_start_utc)` triple, so the two counts match. If that uniqueness is ever absent or violated (a direct DB insert or a race), `COUNT(*)` over-counts a voter, and it is a contract mismatch regardless.

## Change

Switch the winner query to `COUNT(DISTINCT voter_user_id)`. One-line query change; no schema, contract, or route change.

Closes #1802

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)