### PR TITLE
fix: register Mutual Time in the schema.sql plugin-registry seed

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
@@ -145,6 +145,14 @@ idempotent. Fixed candidate window (`2026-07-21`, 7 days) keeps the seed determi
   four contracts, seed, this inventory, and the test script. No credits; Trust N/A; web +
   mobile-responsive only. Built from the Replit design mockups as intent, recreated with the app's
   existing plugin-shell tokens per the production-era design policy.
+- 2026-07-21: **Fix — plugin missing from the launcher.** The initial build registered Mutual Time in
+  the code fallback registry (`lib/plugins/repository.ts`) but not in the inline `ctf_plugin_registry`
+  seed in `schema.sql`. Because the launcher list (`listPluginRegistry`) reads the DB registry and only
+  falls back when the DB is empty, Mutual Time was absent from the app launcher on any DB that already
+  had the other plugins seeded — the `/apps/mutual-time` page worked by direct URL (via `getPluginBySlug`
+  fallback), but there was no link to it, so admins could not reach the create/manage dashboard ("not
+  linked anywhere; cannot create a poll"). Added the `mutual-time` row (nav_rank 250, visible) to the
+  `schema.sql` registry seed. Takes effect when `schema.sql` is applied to the database on deploy.
 
 ## Build Checklist
 

--- a/ctf/docs/developer/test-scripts/mutual-time-test-script.md
+++ b/ctf/docs/developer/test-scripts/mutual-time-test-script.md
@@ -28,13 +28,15 @@
 
 Run the seed first: `pnpm --dir ctf seed:mutual-time`
 
-1. **Admin dashboard loads.** Sign in as an admin, navigate to `/apps/mutual-time`. The page renders without error and shows at least two events — "Weekly check-in" (open) and "Q3 onboarding" (closed). web ☐ mobile ☐
+1. **Plugin is listed in the launcher.** Sign in, open the Commons apps launcher, and confirm a **Mutual Time** tile appears (it must be reachable from the launcher, not only by typing the URL — this is the regression fixed 2026-07-21, where the plugin was missing from the `ctf_plugin_registry` seed). Tapping the tile opens `/apps/mutual-time`. web ☐ mobile ☐
 
-2. **Public event link loads unauthenticated.** Sign out entirely. Open the shareable link for the seeded open event (copy it from the dashboard or use the known fixed slug). The page renders the event title, a set of time slots, and a sign-in prompt — no error, no blank screen. web ☐ mobile ☐
+2. **Admin dashboard loads.** Sign in as an admin, navigate to `/apps/mutual-time`. The page renders without error and shows at least two events — "Weekly check-in" (open) and "Q3 onboarding" (closed). web ☐ mobile ☐
 
-3. **Closed event shows a result.** Open the shareable link for "Q3 onboarding" (seeded closed event) while signed out. The page shows the winning time and how many members can make it — no vote controls visible. web ☐ mobile ☐
+3. **Public event link loads unauthenticated.** Sign out entirely. Open the shareable link for the seeded open event (copy it from the dashboard or use the known fixed slug). The page renders the event title, a set of time slots, and a sign-in prompt — no error, no blank screen. web ☐ mobile ☐
 
-4. **Approved member can reach the vote surface.** Sign in as an approved member, open the shareable link for the open event. Slot chips are visible and at least one is selectable. web ☐ mobile ☐
+4. **Closed event shows a result.** Open the shareable link for "Q3 onboarding" (seeded closed event) while signed out. The page shows the winning time and how many members can make it — no vote controls visible. web ☐ mobile ☐
+
+5. **Approved member can reach the vote surface.** Sign in as an approved member, open the shareable link for the open event. Slot chips are visible and at least one is selectable. web ☐ mobile ☐
 
 ---
 

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2231,7 +2231,8 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('contributions',      'Contributions',        'Voluntary fundraiser drives — gift-card, Quora-comment, and GitHub-star contributions with service-credit thank-you grants.',        'implemented_shell', 210, TRUE),
   ('bug-reporting',      'Bug Reporting',        'In-app problem reports that flow to a private triage repo; raw text stays private and a human approves any fix.','planned', 220, FALSE),
   ('beacon',             'Beacon',               'Live one-way broadcasts from Farah. Watch publicly with just a link; sign in to chat and react.','implemented_shell', 230, TRUE),
-  ('recurring-activity', 'Recurring Activity',   'Acknowledge an ongoing activity with another member — one tap, no amounts to report. Recognition of your everyday ties, never a bill.','implemented_shell', 240, TRUE)
+  ('recurring-activity', 'Recurring Activity',   'Acknowledge an ongoing activity with another member — one tap, no amounts to report. Recognition of your everyday ties, never a bill.','implemented_shell', 240, TRUE),
+  ('mutual-time',        'Mutual Time',          'Find a meeting time everyone can make. Share one link; members pick times in their own timezone and the app chooses the slot with the most overlap.','implemented_shell', 250, TRUE)
 ON CONFLICT (plugin_slug) DO UPDATE SET
   display_name       = EXCLUDED.display_name,
   summary            = EXCLUDED.summary,


### PR DESCRIPTION
## Bug
Mutual Time was "not linked anywhere; cannot create a poll."

## Root cause
When Mutual Time shipped (#1782), it was registered in the **code fallback** registry (`lib/plugins/repository.ts`) but **not** in the inline `ctf_plugin_registry` seed in `schema.sql`. The launcher list (`listPluginRegistry`) reads the **DB** registry and only falls back to the code list when the DB query returns **zero** rows. On any database that already had the other 24 plugins seeded, that fallback never triggers — so Mutual Time was absent from the app launcher. The `/apps/mutual-time` page itself still worked by direct URL (because `getPluginBySlug` does fall back per-slug), but nothing linked to it, so an admin couldn't reach the create/manage dashboard → couldn't create a poll.

## Fix
Add the `mutual-time` row (nav_rank 250, visible) to the `schema.sql` registry seed, matching the fallback entry. Idempotent `INSERT … ON CONFLICT DO UPDATE`. **Takes effect when `schema.sql` is applied to the database on deploy.**

Mutual Time is the only plugin that was missing from the seed (verified against the full fallback list).

## Note
Creating a poll is **admin-only** by design (`POST /api/mutual-time/events`); approved members vote via the shared event link. If poll creation should be opened to members, that's a separate change — flagged for your call.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_