### PR TITLE
fix: deep-link Commons notifications to the exact message

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
@@ -33,8 +33,11 @@ received. The trauma-informed answer (owner decision, 2026-07-20):
    replaces the message stream while open; the composer hides (you read notifications, you don't post
    into them).
 2. Each row: a calm unread dot (never a red count), a short neutral statement of what happened, a
-   relative time, and — when there is somewhere to go — an "Open" pill that deep-links into the
-   plugin (same pill pattern as linked announcements). Opening or hovering a row marks it read.
+   relative time, and — when there is somewhere to go — an "Open" pill that deep-links to the exact
+   thing (same pill pattern as linked announcements). A Commons reply or @mention opens the Commons and
+   scrolls to that message, flashing it briefly (`/?post=<id>`); an announcement reply opens that
+   announcement (`/?announcement=<id>`); a plugin event opens that plugin's surface. Opening or
+   hovering a row marks it read.
 3. "Mark all read".
 4. "Manage what pings your device": three plain opt-in switches — Safety/rides/calls,
    Your activity and credits, Community — plus a "keep device pings discreet" switch. All push
@@ -133,6 +136,14 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 
 ## Change Log
 
+- 2026-07-21: Deep links on "Open". Commons notifications now link to the exact message instead of the
+  Commons home. A reply or @mention links to `/?post=<postId>` and an announcement reply to
+  `/?announcement=<announcementId>`; the Commons shell reads that query param on load, scrolls the
+  message (or announcement card) into view and flashes it, then clears the param so a refresh does not
+  re-jump (it retries briefly while the recent page streams in, then gives up quietly for a post older
+  than the loaded window). The earliest Commons rows were written before deep links and stored the
+  bare `/`; a reply/mention row is upgraded to its `/?post=<id>` link on read from its `target_ref`, so
+  no backfill migration is needed. Plugin-event notifications keep their existing `/apps/<plugin>` link.
 - 2026-07-21: @mention notifications. A new Commons community post now notifies each member it
   @-mentions (`commons.mention`, category `community`), deduped per post via `target_ref` so a member
   mentioned twice in one post is notified once, never self-notifying, and skipping the parent author

--- a/ctf/packages/web/components/community-shell/announcement-card.tsx
+++ b/ctf/packages/web/components/community-shell/announcement-card.tsx
@@ -132,7 +132,11 @@ export function AnnouncementCard({
   const replyLabel = localCount > 0 ? `${localCount} ${localCount === 1 ? 'reply' : 'replies'}` : 'Reply';
 
   return (
-    <article className={styles.announcementCard} aria-label="Official announcement">
+    <article
+      className={styles.announcementCard}
+      aria-label="Official announcement"
+      data-announcement-id={announcementId ?? undefined}
+    >
       <div className={styles.announcementHead}>
         <div className={styles.announcementAvatar} aria-hidden="true">SH</div>
         <div className={styles.announcementHeadText}>

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -273,6 +273,49 @@ function AuthenticatedChatPanel({ currentUser }: AuthenticatedChatPanelProps) {
     window.setTimeout(() => target.classList.remove(styles.chatBubbleFlash), 1600);
   }, []);
 
+  // Deep link from a notification's "Open": /?post=<id> (a reply or @mention) or /?announcement=<id>
+  // (an announcement reply) lands the member on that exact message and flashes it — the same jump a
+  // quoted-reply tap gives, instead of dumping them at the top of the Commons. The target streams in
+  // asynchronously, so this retries briefly while the recent page loads, then gives up quietly (a post
+  // older than the loaded window is not fetched — the notification already summarized it). The query
+  // param is cleared once handled so a refresh or Back does not re-jump. Runs once on mount.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const postId = params.get('post');
+    const announcementId = params.get('announcement');
+    const selector = postId
+      ? `[data-post-id="${postId}"]`
+      : announcementId
+        ? `[data-announcement-id="${announcementId}"]`
+        : null;
+    if (!selector) return;
+    // Show the message stream, not the notifications panel, so the target is in the DOM to scroll to.
+    setNotificationsOpen(false);
+    let attempts = 0;
+    let timer = 0;
+    const tryScroll = () => {
+      const container = messagesContainerRef.current;
+      const target = container?.querySelector<HTMLElement>(selector);
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        target.classList.add(styles.chatBubbleFlash);
+        window.setTimeout(() => target.classList.remove(styles.chatBubbleFlash), 1600);
+        window.history.replaceState(null, '', window.location.pathname);
+        return;
+      }
+      attempts += 1;
+      if (attempts < 20) {
+        timer = window.setTimeout(tryScroll, 300);
+      }
+    };
+    tryScroll();
+    return () => {
+      if (timer) window.clearTimeout(timer);
+    };
+    // Mount-only: the deep link is read from the entry URL once.
+  }, []);
+
   // Auto-grow the composer as the member types multiple lines (capped, then it scrolls). Runs on
   // every input change — including the reset to '' after a send, which shrinks it back to one line.
   useEffect(() => {

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -1816,7 +1816,8 @@ export async function createFeedCommunityPost(
       notificationType: 'commons.reply',
       category: 'community',
       summary: 'Someone replied to your post in the Commons.',
-      linkPath: '/',
+      // Deep link to the reply itself so "Open" lands on the new message, not the top of the Commons.
+      linkPath: `/?post=${encodeURIComponent(result.postId)}`,
       targetRef: result.postId,
     });
   }
@@ -1855,7 +1856,8 @@ async function notifyMentionedMembers(
         notificationType: 'commons.mention',
         category: 'community',
         summary: 'Someone mentioned you in the Commons.',
-        linkPath: '/',
+        // Deep link to the post that mentions them so "Open" lands on that exact message.
+        linkPath: `/?post=${encodeURIComponent(postId)}`,
         targetRef: postId,
       });
     }
@@ -2140,7 +2142,9 @@ export async function replyToAnnouncement(
       notificationType: 'commons.announcement_reply',
       category: 'community',
       summary: 'Someone replied to your announcement.',
-      linkPath: '/',
+      // Deep link to the announcement so "Open" lands on it (the reply thread opens from there),
+      // rather than the top of the Commons.
+      linkPath: `/?announcement=${encodeURIComponent(normalizedId)}`,
       targetRef: result.replyId,
     });
   }

--- a/ctf/packages/web/lib/notifications/repository.ts
+++ b/ctf/packages/web/lib/notifications/repository.ts
@@ -17,9 +17,27 @@ type NotificationRow = {
   category: string;
   summary: string;
   link_path: string | null;
+  target_ref: string | null;
   read_at: Date | null;
   created_at: Date;
 };
+
+// Deep link for a notification. Producers set link_path directly, but the earliest Commons rows were
+// written before deep links existed and stored the bare '/'. Those rows still carry the post id in
+// target_ref, so a reply/mention is upgraded to its per-message deep link on read — no backfill
+// migration needed. Newer rows already carry the right link and pass through unchanged.
+function resolveLinkPath(row: NotificationRow): string | null {
+  const stored = row.link_path ?? null;
+  const isBare = stored === null || stored === '' || stored === '/';
+  if (
+    isBare &&
+    row.target_ref &&
+    (row.notification_type === 'commons.reply' || row.notification_type === 'commons.mention')
+  ) {
+    return `/?post=${encodeURIComponent(row.target_ref)}`;
+  }
+  return stored;
+}
 
 function mapNotification(row: NotificationRow): Notification {
   return {
@@ -29,7 +47,7 @@ function mapNotification(row: NotificationRow): Notification {
     // The column is constrained by producers, but fall back to 'activity' if an unknown value slips in.
     category: isNotificationCategory(row.category) ? row.category : 'activity',
     summary: row.summary,
-    linkPath: row.link_path ?? null,
+    linkPath: resolveLinkPath(row),
     isRead: row.read_at !== null,
     createdAtIso: row.created_at.toISOString(),
   };
@@ -119,7 +137,7 @@ export async function listNotifications(userId: string, limit: number): Promise<
   const pageSize = Math.min(Math.max(1, limit), NOTIFICATIONS_MAX_PAGE_SIZE);
   const result = await queryDb<NotificationRow>(
     `
-      SELECT id, source_plugin, notification_type, category, summary, link_path, read_at, created_at
+      SELECT id, source_plugin, notification_type, category, summary, link_path, target_ref, read_at, created_at
       FROM notifications
       WHERE user_id = $1
       ORDER BY created_at DESC, id DESC


### PR DESCRIPTION
The "Open" pill on every Commons notification pointed at the Commons home (`/`), so a reply, @mention, or announcement reply dropped the member at the top of the feed instead of the message it was about (reported with a screenshot).

## What changed

- Producers now set a per-message deep link: a reply/@mention links to `/?post=<postId>` and an announcement reply to `/?announcement=<announcementId>`.
- The Commons shell reads that query param on load, scrolls the message (or the announcement card) into view and flashes it — the same landing a quoted-reply tap gives — then clears the param so a refresh or Back doesn't re-jump. It retries briefly while the recent page streams in, then gives up quietly for a post older than the loaded window (the notification text already said what happened).
- Added `data-announcement-id` to the announcement card so it's a scroll target, matching the existing `data-post-id` on peer posts.
- Existing rows: the earliest Commons notifications were written before deep links and stored the bare `/`. A reply/mention row is upgraded to its `/?post=<id>` link on read from its `target_ref`, so the notifications already in a member's list deep-link too — no backfill migration.
- Plugin-event notifications (ServiceCredits, LevelUp, rides, etc.) keep their existing `/apps/<plugin>` link.

No schema change, no new route or contract — a behavior fix on the existing notifications backbone.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN

---
_Generated by [Claude Code](https://claude.ai/code/session_018L8vnujeeWg2RH37RBUaUN)_