### PR TITLE
fix: deduplicate active user ids before forming peer-programming cohorts

### DIFF
--- a/ctf/packages/web/app/api/internal/peer-programming/assignments/run/route.ts
+++ b/ctf/packages/web/app/api/internal/peer-programming/assignments/run/route.ts
@@ -32,10 +32,13 @@ export async function POST(request: Request) {
   // them out before forming cohorts.
   const activeCandidates = await getActiveUserIdsLastDays(7);
   const unlocked = await listUnlockedUserIds(activeCandidates);
-  const activeUserIds = activeCandidates.filter((value) => unlocked.has(value.trim()));
-  const membersSelected = new Set(
-    activeUserIds.map((value) => value.trim()).filter((value) => value.length > 0),
-  ).size;
+  const filteredActiveUserIds = activeCandidates.filter((value) => unlocked.has(value.trim()));
+  // Deduplicate (and trim/drop blanks) before forming cohorts: getActiveUserIdsLastDays may return
+  // duplicate ids, and cohort formation must receive the same unique set that membersSelected counts.
+  const activeUserIds = [
+    ...new Set(filteredActiveUserIds.map((value) => value.trim()).filter((value) => value.length > 0)),
+  ];
+  const membersSelected = activeUserIds.length;
 
   try {
     const result = await runWeeklyAssignment({ actorId: SCHEDULER_ACTOR_ID, activeUserIds });


### PR DESCRIPTION
## What

In the peer-programming weekly scheduler route, `runWeeklyAssignment` received the pre-dedup `activeUserIds` array while `membersSelected` was computed from a de-duplicated Set. If `getActiveUserIdsLastDays` returned duplicate ids, cohort formation received the duplicates while the audit and response counts reported the unique total, making the two inconsistent.

## Fix

Deduplicate (trim and drop blanks) once after the unlocked filter, then use that single unique array both to call `runWeeklyAssignment` and for the `membersSelected` count. Smallest change that resolves the finding; no route, schema, contract, or delivery-status change.

Closes #1818

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105 — server-only cron route, no rendered surface)