### PR TITLE
fix: address mutual-time code-review findings (#1803-#1809)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
@@ -86,8 +86,10 @@ Defined in `ctf/schema.sql` (CREATE TABLE IF NOT EXISTS + ALTER TABLE IF EXISTS 
 1. **Three access tiers.** Create/close: admin-only (`evaluatePluginAccess({ requiredRoles: ['admin'] })`;
    close also checks the actor is the event's creator). Vote: signed-in AND Unlock-approved
    (`minUnlockTier: 'approved_full'`). Read: public/anonymous, rate-limited per IP.
-2. **CSRF.** Every mutation requires the `x-ctf-csrf: '1'` header and a same-origin check
-   (`ensureMutationCsrf`).
+2. **CSRF / same-origin.** Every mutation requires the `x-ctf-csrf: '1'` header and a same-origin check
+   (`ensureMutationCsrf`). The admin event-list read (`GET /api/mutual-time/events`) additionally runs a
+   same-origin `checkMutationOrigin` check (missing-Origin same-origin requests still pass) so a
+   credentialed cross-origin page cannot read the admin's slugs/voter counts.
 3. **Privacy.** Individual votes are never exposed publicly. The public read returns only aggregate
    fields (voter count; after close the winning slot + how many can make it) plus, for a signed-in
    approved member, that member's own picks for hydration.
@@ -153,6 +155,17 @@ idempotent. Fixed candidate window (`2026-07-21`, 7 days) keeps the seed determi
   fallback), but there was no link to it, so admins could not reach the create/manage dashboard ("not
   linked anywhere; cannot create a poll"). Added the `mutual-time` row (nav_rank 250, visible) to the
   `schema.sql` registry seed. Takes effect when `schema.sql` is applied to the database on deploy.
+- 2026-07-22: **Code-review fixes (issues #1803–#1809).** No behaviour change to the happy path.
+  (1) Audit lines now carry the contract's `policyDecision.evidence` (`role=admin`,
+  `role=admin;owner=true`, `unlockTier=approved_full`) so the emitted audit satisfies
+  `MUTUAL_TIME_PLUGIN_AUDIT_CONTRACTS.yaml` (#1807). (2) `GET /api/mutual-time/events` adds a same-origin
+  check so the admin's event list cannot be read cross-origin (#1806). (3) The public vote view now
+  reconciles the viewer's `canVote`/`picks` from the post-save refresh instead of the load-time snapshot
+  (#1805). (4) `saveVote` rejects a non-string pick element as `invalidPayload` (distinct from a
+  valid-but-unknown slot's `invalidSlot`) (#1804). (5) The admin list computes voter counts in one query
+  (correlated subquery) instead of one round-trip per event (#1809). (6) Comments added explaining why
+  `createEvent` always stores `status='open'` (scheduled is derived by `effectiveState`) (#1803) and the
+  deliberate slug-vs-id route split (public slug surface vs admin id surface) (#1808).
 
 ## Build Checklist
 

--- a/ctf/docs/developer/test-scripts/mutual-time-test-script.md
+++ b/ctf/docs/developer/test-scripts/mutual-time-test-script.md
@@ -11,7 +11,7 @@
 | **Surfaces** | Web (`/apps/mutual-time`, `/mutual-time/[slug]`); mobile-responsive web (same URLs at phone width). No Android surface — out of scope per rule 105. |
 | **Seed first** | `pnpm --dir ctf seed:mutual-time` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md` |
-| **Generated** | 2026-07-21 (commit be96b48f) |
+| **Generated** | 2026-07-21 (commit be96b48f); hand-edited 2026-07-22 for the code-review fixes (#1803–#1809): added MT-A12 (admin-list same-origin read guard) and clarified MT-11 (non-string pick → 400). |
 
 ---
 
@@ -232,8 +232,9 @@ Result: web ☐ mobile ☐
 **Steps:**
 1. Construct a POST to `/api/mutual-time/event/<slug>/vote` with the `x-ctf-csrf: '1'` header and a body containing a `slots` array with one entry set to an arbitrary timestamp that is not in the event's candidate window (e.g., a date outside the 7-day window).
 2. Send the request.
+3. Send a second request whose `slots` array contains a non-string element (e.g. `[null]` or `[123]`).
 
-**Expected:** The server returns HTTP 400. No vote is stored.
+**Expected:** Step 2 returns HTTP 400 with code `invalidSlot` (well-formed but unknown slot). Step 3 returns HTTP 400 with code `invalidPayload` (malformed list — element is not a string). No vote is stored in either case.
 
 Result: web ☐
 
@@ -431,6 +432,22 @@ Result: web ☐
 3. Sign in as admin and repeat the request.
 
 **Expected:** Neither response contains a list of who voted or which slots individual members chose. The response includes only the voter count (aggregate), the candidate slots, and — for the closed case — the winning slot. A signed-in approved member's own picks may appear in a `viewer` field, but no other member's picks are present.
+
+Result: web ☐
+
+---
+
+### MT-A12 — Admin event-list read rejects a cross-origin request
+
+**Role:** Admin
+**Surfaces:** Web (API layer)
+**Precondition:** Signed in as admin (valid session cookie).
+
+**Steps:**
+1. Send a `GET /api/mutual-time/events` from the app itself (same-origin, or with no `Origin` header) — the normal dashboard load.
+2. Send a `GET /api/mutual-time/events` with an `Origin` header set to a different host (e.g. `https://evil.example`) while carrying the admin session cookie.
+
+**Expected:** Step 1 returns HTTP 200 with the admin's event list (a missing or same-origin `Origin` passes). Step 2 returns HTTP 403 with code `csrfDenied` — the admin's slugs and voter counts are not returned to a cross-origin caller.
 
 Result: web ☐
 

--- a/ctf/packages/web/app/api/mutual-time/event/[slug]/vote/route.ts
+++ b/ctf/packages/web/app/api/mutual-time/event/[slug]/vote/route.ts
@@ -37,6 +37,7 @@ export async function POST(request: Request, context: { params: Promise<{ slug: 
       actorId: gate.auth.userId,
       status: 'allow',
       reason: 'approved_member',
+      evidence: 'unlockTier=approved_full',
       target: { slug, pickCount: String(picks.length) },
       result: 'success',
       errorCategory: null,

--- a/ctf/packages/web/app/api/mutual-time/events/[eventId]/close/route.ts
+++ b/ctf/packages/web/app/api/mutual-time/events/[eventId]/close/route.ts
@@ -26,6 +26,7 @@ export async function POST(request: Request, context: { params: Promise<{ eventI
       actorId: gate.auth.userId,
       status: 'allow',
       reason: 'admin',
+      evidence: 'role=admin;owner=true',
       target: { eventId: event.id, slug: event.slug, resultSlotStart: event.resultSlotStartIso },
       result: 'success',
       errorCategory: null,

--- a/ctf/packages/web/app/api/mutual-time/events/route.ts
+++ b/ctf/packages/web/app/api/mutual-time/events/route.ts
@@ -3,10 +3,25 @@ import { MUTUAL_TIME_ERROR_CODE } from 'lib/mutual-time/constants';
 import { createEvent, listEventsForAdmin } from 'lib/mutual-time/repository';
 import { logMutualTimeAudit } from 'lib/mutual-time/audit';
 import { reportError } from 'lib/observability/report';
+import { checkMutationOrigin } from 'lib/auth/csrf';
 import { requireMutualTimeAdmin, ensureMutationCsrf, mutualTimeErrorResponse } from '../_lib';
 
-// GET /api/mutual-time/events — the admin's own events (dashboard list). Admin-only.
-export async function GET() {
+// Route convention (deliberate): admin surfaces are keyed by event id under the plural
+// /api/mutual-time/events/* (create, list, close), while the public shareable surface is keyed by
+// slug under the singular /api/mutual-time/event/[slug]/*. Slugs are the member-facing, guessable-free
+// share token; ids are the internal admin handle.
+
+// GET /api/mutual-time/events — the admin's own events (dashboard list). Admin-only. Adds a
+// same-origin check (in addition to the admin gate) so a credentialed cross-origin page cannot read
+// the admin's event list (slugs, voter counts). Missing-Origin same-origin requests still pass.
+export async function GET(request: Request) {
+  const originCheck = checkMutationOrigin(request);
+  if (originCheck !== 'allow') {
+    return NextResponse.json(
+      { ok: false, code: MUTUAL_TIME_ERROR_CODE.csrfDenied, message: 'Cross-origin read denied.' },
+      { status: 403 },
+    );
+  }
   const gate = await requireMutualTimeAdmin();
   if (!gate.allowed) {
     return gate.response;
@@ -58,6 +73,7 @@ export async function POST(request: Request) {
       actorId: gate.auth.userId,
       status: 'allow',
       reason: 'admin',
+      evidence: 'role=admin',
       target: { eventId: event.id, slug: event.slug, meetingPlugin: event.meetingPlugin },
       result: 'success',
       errorCategory: null,

--- a/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
@@ -48,7 +48,7 @@ export function MutualTimePublic({ initialEvent, initialViewer, isSignedIn, sign
     setTz(detectTimeZone());
   }, []);
 
-  const canVote = initialViewer.canVote;
+  const [canVote, setCanVote] = useState(initialViewer.canVote);
 
   const onCopy = useCallback(async () => {
     const ok = await copyToClipboard(eventShareUrl(event.slug));
@@ -93,6 +93,7 @@ export function MutualTimePublic({ initialEvent, initialViewer, isSignedIn, sign
             picks={picks}
             setPicks={setPicks}
             setEvent={setEvent}
+            setCanVote={setCanVote}
             showTz={showTz}
             setShowTz={setShowTz}
             setTz={setTz}
@@ -191,6 +192,7 @@ function VoteView({
   picks,
   setPicks,
   setEvent,
+  setCanVote,
   showTz,
   setShowTz,
   setTz,
@@ -202,6 +204,7 @@ function VoteView({
   picks: string[];
   setPicks: (next: string[]) => void;
   setEvent: (next: MutualTimePublicEvent) => void;
+  setCanVote: (v: boolean) => void;
   showTz: boolean;
   setShowTz: (v: boolean) => void;
   setTz: (v: string) => void;
@@ -265,10 +268,18 @@ function VoteView({
       });
       setPicks(data.picks);
       setSaved(true);
-      // Refresh the voter count shown in the status area.
+      // Refresh the voter count shown in the status area, and reconcile the viewer's own state
+      // (canVote, picks) from the same fresh read so the UI never renders off a load-time snapshot —
+      // e.g. if the event closed or the viewer's approval changed between load and save.
       try {
-        const refreshed = await requestJson<{ ok: true; event: MutualTimePublicEvent }>(`/api/mutual-time/event/${event.slug}`);
+        const refreshed = await requestJson<{ ok: true; event: MutualTimePublicEvent; viewer: MutualTimeViewerState }>(
+          `/api/mutual-time/event/${event.slug}`,
+        );
         setEvent(refreshed.event);
+        if (refreshed.viewer) {
+          setCanVote(refreshed.viewer.canVote);
+          setPicks(refreshed.viewer.picks);
+        }
       } catch {
         /* count refresh is best-effort */
       }

--- a/ctf/packages/web/lib/mutual-time/audit.ts
+++ b/ctf/packages/web/lib/mutual-time/audit.ts
@@ -20,7 +20,11 @@ export function logMutualTimeAudit(event: MutualTimeAuditEvent): void {
     pluginId: event.pluginId,
     command: event.command,
     commandVersion: '1.0.0',
-    policyDecision: { status: event.status, reason: event.reason },
+    policyDecision: {
+      status: event.status,
+      reason: event.reason,
+      ...(event.evidence ? { evidence: event.evidence } : {}),
+    },
     targetContext: buildTargetContext(event.target),
     result: { status: event.result, errorCategory: event.errorCategory ?? 'none' },
   };

--- a/ctf/packages/web/lib/mutual-time/repository.ts
+++ b/ctf/packages/web/lib/mutual-time/repository.ts
@@ -210,6 +210,11 @@ export async function createEvent(createdByUserId: string, input: CreateEventInp
   const windowStartDate = anchor.toISOString().slice(0, 10);
 
   return withDbTransaction(async (client) => {
+    // We always store status='open' at creation, even when opensAt is in the future. The stored
+    // status is only ever 'open' or 'closed'; the not-yet-open 'scheduled' state is derived at read
+    // time by effectiveState() from opens_at, which every read and the vote guard go through — so a
+    // future-dated event is never votable early. Keeping one lazy source of truth (opens_at) avoids a
+    // second background transition writing 'scheduled'→'open'.
     // Retry slug generation on the rare unique collision.
     for (let attempt = 0; attempt < 5; attempt += 1) {
       const slug = generateEventSlug(title);
@@ -262,16 +267,18 @@ export async function listEventsForAdmin(createdByUserId: string): Promise<Mutua
       await closeAndComputeTx(client, row);
     }
 
-    const result = await client.query<EventRow>(
-      `SELECT ${EVENT_COLUMNS} FROM mutual_time_events WHERE created_by_user_id = $1 ORDER BY created_at DESC`,
+    // One query, no N+1: the distinct voter count is a correlated subquery per row so the whole list
+    // returns in a single round-trip. (The close loop above stays sequential — it holds FOR UPDATE.)
+    const result = await client.query<EventRow & { voter_count: number }>(
+      `SELECT ${EVENT_COLUMNS},
+         (SELECT COUNT(DISTINCT v.voter_user_id)::int
+          FROM mutual_time_votes v WHERE v.event_id = e.id) AS voter_count
+       FROM mutual_time_events e
+       WHERE e.created_by_user_id = $1
+       ORDER BY e.created_at DESC`,
       [createdByUserId],
     );
-    const events: MutualTimeEvent[] = [];
-    for (const row of result.rows) {
-      const count = await voterCountFor(client, row.id);
-      events.push(mapEvent(row, count, now));
-    }
-    return events;
+    return result.rows.map((row) => mapEvent(row, row.voter_count ?? 0, now));
   });
 }
 
@@ -372,6 +379,11 @@ export async function saveVote(slug: string, userId: string, rawSlots: unknown):
     const candidates = candidateSlotSet(row.window_start_date, row.window_days);
     const picks = new Set<string>();
     for (const raw of rawSlots) {
+      // The payload must be a list of non-empty strings; a wrong element type is a malformed payload
+      // (invalidPayload), distinct from a well-formed string that is not a valid candidate (invalidSlot).
+      if (typeof raw !== 'string' || raw.trim().length === 0) {
+        throw new MutualTimeError(MUTUAL_TIME_ERROR_CODE.invalidPayload, 'Picks must be a list of time slots.');
+      }
       const iso = normalizeSlotIso(raw);
       if (!iso || !candidates.has(iso)) {
         throw new MutualTimeError(MUTUAL_TIME_ERROR_CODE.invalidSlot, 'One of your picks is not a valid time slot.');

--- a/ctf/packages/web/lib/mutual-time/types.ts
+++ b/ctf/packages/web/lib/mutual-time/types.ts
@@ -60,6 +60,9 @@ export type MutualTimeAuditEvent = {
   actorId: string;
   status: 'allow' | 'deny';
   reason: string;
+  // The policy evidence string from the access-policy/audit contract (e.g. 'role=admin',
+  // 'role=admin;owner=true', 'unlockTier=approved_full'). Included in the emitted policyDecision.
+  evidence?: string;
   target: Record<string, string | null | undefined>;
   result: 'success' | 'failure';
   errorCategory: string | null;


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — Mutual Time is not on the Chyme keep-list, so it has no native surface.

Fixes the seven open `code-review` issues filed by the sweep for the `mutual-time` plugin. Surgical changes only; no change to the normal (valid-request) behavior.

## Changes

- **#1807 (correctness)** — Audit lines now carry the contract's `policyDecision.evidence` (`role=admin`, `role=admin;owner=true`, `unlockTier=approved_full`) so the emitted audit satisfies `MUTUAL_TIME_PLUGIN_AUDIT_CONTRACTS.yaml`. Added an optional `evidence` field to `MutualTimeAuditEvent` and included it in the payload.
- **#1806 (security)** — `GET /api/mutual-time/events` adds a same-origin `checkMutationOrigin` check (in addition to the admin gate) so a credentialed cross-origin page cannot read the admin's slugs/voter counts. The helper fails open on a missing Origin header, so same-origin dashboard fetches are unaffected.
- **#1805 (bug)** — The public vote view makes `canVote` component state and reconciles `canVote`/`picks` from the post-save refresh (`viewer`) instead of the load-time snapshot, so a mid-session close or approval change renders correctly.
- **#1804 (security)** — `saveVote` rejects a non-string pick element as `invalidPayload`, distinct from a valid-but-unknown slot's `invalidSlot`.
- **#1809 (quality)** — `listEventsForAdmin` computes voter counts in a single correlated subquery instead of one round-trip per event (no N+1). The close loop stays sequential (documented) because it holds `FOR UPDATE`.
- **#1803 (bug)** — Comment explaining why `createEvent` always stores `status='open'` — the not-yet-open `scheduled` state is derived at read time by `effectiveState()` from `opens_at`. Behavior was already correct per the reviewer; documentation-only.
- **#1808 (quality)** — Documented the deliberate slug-vs-id route split (public slug surface `/api/mutual-time/event/[slug]/*` vs admin id surface `/api/mutual-time/events/*`). Routes not renamed to avoid breaking existing shareable links; documentation-only.

## Inventory

`ctf-mutual-time-feature-inventory.md` updated: CSRF/same-origin control note and a change-log entry.

## Verification

- Web typecheck clean (all workspaces via the pre-commit gate).
- ESLint clean on the changed `mutual-time` files.
- Full `next build:ci` succeeds; both mutual-time routes compile.

Closes #1803, closes #1804, closes #1805, closes #1806, closes #1807, closes #1808, closes #1809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt9CksTid72cqRRmSujcFt)_