### PR TITLE
fix: add Mutual Time to the admin area grid

### DIFF
--- a/ctf/packages/web/app/admin/page.tsx
+++ b/ctf/packages/web/app/admin/page.tsx
@@ -24,6 +24,9 @@ const ADMIN_AREAS: { href: string; name: string }[] = [
   { href: '/admin/foundation', name: 'Foundation' },
   { href: '/admin/level-up', name: 'LevelUp' },
   { href: '/admin/lighthouse', name: 'LightHouse' },
+  // Mutual Time has no /admin/* route — its admin dashboard (create/manage polls) lives at
+  // /apps/mutual-time (MutualTimeAdmin renders there for admins), so this row points there.
+  { href: '/apps/mutual-time', name: 'Mutual Time' },
   { href: '/admin/peer-programming', name: 'PeerProgramming' },
   { href: '/admin/safety', name: 'Safety Reports' },
   { href: '/admin/service-credits', name: 'ServiceCredits' },


### PR DESCRIPTION
## Why it was "still not showing"
The screenshot is the **admin area picker** (`/admin` — "Pick an area to manage"), which is a **hardcoded `ADMIN_AREAS` list** in `app/admin/page.tsx`. Mutual Time was never added to it, so it doesn't appear there.

This is a **different list** from the member apps launcher (which reads the DB `ctf_plugin_registry`). The earlier fix (#1813) added Mutual Time to that launcher's seed — that fix is real, but it (a) only affects the member launcher, and (b) takes effect when `schema.sql` is applied on deploy. Neither touches this hardcoded admin grid.

## Fix
Add a Mutual Time row to `ADMIN_AREAS`. Mutual Time has **no `/admin/mutual-time` route** — its admin dashboard (create/manage polls) lives at `/apps/mutual-time` (renders `MutualTimeAdmin` for admins) — so the row points there.

After this, an admin finds Mutual Time in the grid and lands on the create/manage-polls dashboard.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_