### PR TITLE
fix: Chyme chat window no longer clips its input off the phone screen

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-audio-room.tsx
+++ b/ctf/packages/web/components/chyme/chyme-audio-room.tsx
@@ -280,10 +280,8 @@ function ChymeAudioFrame({
           </button>
         </div>
       )}
-      <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        {/* Stage scrolls within its own share of the height; the chat panel (flex-grow 2) takes the
-            larger share and scrolls internally, so incoming messages never stretch the page. */}
-        <div style={{ flex: '1 1 0', minHeight: 0, overflowY: 'auto', padding: '20px 24px' }}>{stage}</div>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px' }}>{stage}</div>
         {showChat && chatPanel}
       </div>
     </>

--- a/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
+++ b/ctf/packages/web/components/chyme/chyme-chat-panel.tsx
@@ -26,12 +26,15 @@ export function ChymeChatPanel({
   const { theme } = useTheme();
   const t = getChymeTokens(theme);
   return (
-    <div style={{ width: '100%', borderLeft: 'none', borderTop: `1px solid ${t.BORDER}`, display: 'flex', flexDirection: 'column', background: t.HEADER, flex: '2 1 0', minHeight: 0 }}>
+    <div style={{ width: '100%', borderLeft: 'none', borderTop: `1px solid ${t.BORDER}`, display: 'flex', flexDirection: 'column', background: t.HEADER, flexShrink: 0 }}>
       <div style={{ flexShrink: 0, padding: '14px 16px', borderBottom: `1px solid ${t.BORDER}`, display: 'flex', alignItems: 'center', gap: 8 }}>
         <Hash size={14} style={{ color: t.ACCENT }} />
         <span style={{ fontSize: 14, fontWeight: 600, color: t.TITLE }}>Room Chat</span>
       </div>
-      <div style={{ flex: 1, overflowY: 'auto', padding: '12px 14px', minHeight: 0 }}>
+      {/* The message list is a bounded window: it grows with content up to ~half the viewport, then
+          scrolls inside itself. This keeps the chat a fixed-size window (new messages scroll within
+          it, they don't stretch the page) without a full-height lock that clipped the input below. */}
+      <div style={{ overflowY: 'auto', padding: '12px 14px', minHeight: 200, maxHeight: '50vh' }}>
         {messages.length === 0 ? (
           <div style={{ color: t.FAINT, fontSize: 13 }}>No messages yet.</div>
         ) : (

--- a/ctf/packages/web/components/chyme/chyme-live-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-live-shell.tsx
@@ -158,7 +158,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
   }
 
   return (
-    <div style={{ flex: 1, minHeight: 0, width: '100%', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <div style={{ minHeight: '100dvh', width: '100%', background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT, display: 'flex', flexDirection: 'column' }}>
       <ChymeHeader
         participantCount={room?.participants.length ?? 0}
         isLive={Boolean(room)}
@@ -166,7 +166,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
         refreshing={refreshing}
       />
 
-      <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         <ChymeSidebar
           loading={loading}
           room={room}
@@ -176,7 +176,7 @@ export function ChymeLiveShell({ currentUser }: { currentUser: CurrentUser }) {
           refreshing={refreshing}
         />
 
-        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           {error && (
             <div style={{ padding: '12px 24px', background: '#2b0b0b', border: `1px solid #7f1d1d`, color: '#fecaca', fontSize: 13, margin: 16, borderRadius: 12 }}>
               {error}

--- a/ctf/packages/web/components/chyme/chyme-room-view.tsx
+++ b/ctf/packages/web/components/chyme/chyme-room-view.tsx
@@ -94,7 +94,7 @@ export function ChymeRoomView(props: ChymeRoomViewProps) {
           raisedHandUserIds={raisedHandUserIds}
         />
       ) : (
-        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <ChymeStage room={room} currentUserId={currentUser.userId} />
           {showChat && chatPanel}
         </div>

--- a/ctf/packages/web/components/chyme/chyme-shell.tsx
+++ b/ctf/packages/web/components/chyme/chyme-shell.tsx
@@ -18,13 +18,13 @@ export function ChymeShell({ currentUser }: ChymeShellProps) {
   const { theme } = useTheme();
   const t = getChymeTokens(theme);
 
-  // Chyme is a fixed-height app shell (like Commons): the whole surface fills the viewport and does
-  // NOT grow the page. The compact top bar (back + brand) is pinned, and the live shell below it owns
-  // the remaining height and scrolls internally — so incoming chat scrolls inside the chat window
-  // instead of stretching the document taller.
+  // The compact top bar (back + brand) is pinned with position:sticky, and the page below flows
+  // naturally. The chat message list is capped (see chyme-chat-panel) so incoming messages scroll
+  // inside the chat window instead of stretching the document — without a hard viewport lock that
+  // clipped the chat's input off the bottom of the screen on phones.
   return (
-      <div style={{ height: '100dvh', background: t.BG, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
+      <div style={{ minHeight: '100dvh', background: t.BG }}>
+        <div style={{ position: 'sticky', top: 0, zIndex: 20, display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
           <BackChevronButton accent={t.ACCENT} />
           <div style={{ width: 32, height: 32, borderRadius: 9, background: t.ACCENT_TINT_15, border: `1px solid ${t.ACCENT_TINT_40}`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.ACCENT, flexShrink: 0 }}>
             <Radio size={18} />

--- a/ctf/packages/web/components/chyme/chyme-stage.tsx
+++ b/ctf/packages/web/components/chyme/chyme-stage.tsx
@@ -17,7 +17,7 @@ export function ChymeStage({
   const { theme } = useTheme();
   const t = getChymeTokens(theme);
   return (
-    <div style={{ flex: '1 1 0', minHeight: 0, overflowY: 'auto', padding: '20px 24px' }}>
+    <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px' }}>
       <div style={{ marginBottom: 24 }}>
         <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: t.FAINT, textTransform: 'uppercase', marginBottom: 16 }}>
           On Stage · {room.participants.length} Participants


### PR DESCRIPTION
## The problem

After the last change, the Chyme chat window was cut off — on a phone the message input (and the bottom of the chat) ran off the bottom of the screen, behind the browser bar.

## Cause

The last fix locked the whole Chyme surface to `100dvh` with `overflow: hidden`. On a phone the pre-join chrome — the big "Join Room" card plus the room header — is tall, so the locked column extended past the visible area and the clipped-overflow cut the bottom of the chat (including the input) off the screen.

## The fix

Keep the chat from growing the page, but never clip it:

- The top bar (back + brand) is pinned with `position: sticky`; the page below flows naturally, so nothing is clipped off the bottom.
- The chat message list is now a **bounded window**: it grows with content up to about half the viewport (`min-height: 200px`, `max-height: 50vh`), then scrolls inside itself — so new messages scroll within the chat window instead of stretching the page.
- Removed the `min-height: 0` / `overflow: hidden` height lock from the shell, live-shell, room-view, audio-room frame, and stage that caused the clipping.

Net: the chat is a fixed-size window you scroll within (the original ask), the page no longer grows as messages arrive, and the input is always on-screen.

## Scope

Layout-only change to already-shipped Chyme screens. No schema, route, contract, or data-model change.

## Verification

`@ctf/web` typecheck, lint, a11y lint, and `build:ci` all pass.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only layout change per rule 105).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_