### PR TITLE
fix: Chyme participant avatars show after joining a room

### DIFF
--- a/ctf/packages/web/components/chyme/chyme-audio-room.tsx
+++ b/ctf/packages/web/components/chyme/chyme-audio-room.tsx
@@ -281,7 +281,10 @@ function ChymeAudioFrame({
         </div>
       )}
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-        <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px' }}>{stage}</div>
+        {/* Natural height so the participant avatars always render (a cramped flex/overflow region
+            clipped the single avatar under the "On Stage" label). The page flows; chat stays a
+            bounded internal scroller. */}
+        <div style={{ padding: '20px 24px' }}>{stage}</div>
         {showChat && chatPanel}
       </div>
     </>

--- a/ctf/packages/web/components/chyme/chyme-stage.tsx
+++ b/ctf/packages/web/components/chyme/chyme-stage.tsx
@@ -17,7 +17,7 @@ export function ChymeStage({
   const { theme } = useTheme();
   const t = getChymeTokens(theme);
   return (
-    <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px' }}>
+    <div style={{ padding: '20px 24px' }}>
       <div style={{ marginBottom: 24 }}>
         <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', color: t.FAINT, textTransform: 'uppercase', marginBottom: 16 }}>
           On Stage · {room.participants.length} Participants


### PR DESCRIPTION
## The problem

After joining a Chyme room, the on-stage participant avatar didn't render — you'd see the "ON STAGE · 1 PARTICIPANT" label with empty space below it and no avatar.

## Cause

The stage was a cramped `flex: 1` / `overflow: auto` region. When the surrounding chrome (the Join card, the room header, and the in-call controls) took most of the height, the stage collapsed to just its "On Stage" label and the 72px avatar below it was clipped / scrolled out of view.

## The fix

Render both stage surfaces at their natural height instead of inside a squeezed scroll region:
- the live in-call stage (`chyme-audio-room.tsx`), and
- the pre-join participant preview (`chyme-stage.tsx`).

The page flows naturally and the chat stays a bounded internal scroller (from the previous fix), so the participant avatars are always visible.

## Scope

Follow-up to #1839. Layout-only change to already-shipped Chyme screens. No schema, route, contract, or data-model change.

## Verification

`@ctf/web` typecheck, lint, a11y lint, and `build:ci` all pass.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only layout change per rule 105).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_