### PR TITLE
chore: drop the redundant hand-rolled "Back to admin" footer link from three admin shells

### DIFF
--- a/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
+++ b/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
@@ -291,12 +291,6 @@ export function BugReportsAdminShell() {
             </div>
           );
         })}
-
-        <div style={{ marginTop: 16, paddingTop: 16, borderTop: `1px solid ${t.BORDER_SOLID}`, fontSize: 13 }}>
-          <Link href="/admin" style={{ color: t.ACCENT, textDecoration: 'none' }}>
-            ← Back to admin
-          </Link>
-        </div>
       </div>
     </div>
   );

--- a/ctf/packages/web/components/contributor-access/contributor-access-admin-shell.tsx
+++ b/ctf/packages/web/components/contributor-access/contributor-access-admin-shell.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import Link from 'next/link';
 import { KeyRound } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
@@ -229,12 +228,6 @@ export function ContributorAccessAdminShell() {
             <StatusCard t={t} eligibleCount={eligibleCount} needed={config.minEligibleToOpenChannel} channelOpen={config.channelOpen} channelMemberCount={channelMemberCount} />
           </>
         ) : null}
-
-        <div style={{ marginTop: 16, paddingTop: 16, borderTop: `1px solid ${t.BORDER_SOLID}`, fontSize: 13 }}>
-          <Link href="/admin" style={{ color: t.ACCENT, textDecoration: 'none' }}>
-            ← Back to admin
-          </Link>
-        </div>
       </div>
     </div>
   );

--- a/ctf/packages/web/components/safety/safety-admin-shell.tsx
+++ b/ctf/packages/web/components/safety/safety-admin-shell.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
 import { AlertTriangle, ShieldAlert } from 'lucide-react';
 import type { SafetyReportStatus } from 'lib/safety/constants';
 import { useTheme } from '@/hooks/useTheme';
@@ -274,12 +273,6 @@ export function SafetyAdminShell() {
             </div>
           );
         })}
-
-        <div style={{ marginTop: 16, paddingTop: 16, borderTop: `1px solid ${t.BORDER_SOLID}`, fontSize: 13 }}>
-          <Link href="/admin" style={{ color: t.ACCENT, textDecoration: 'none' }}>
-            ← Back to admin
-          </Link>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-up to the audit for the Directory back-button bounce (#1843). The audit confirmed no other shell has that bounce, but flagged three admin shells with a *secondary* footer "← Back to admin" link — a hand-rolled, back-labeled `<Link href="/admin">`. Rule 134 says never hand-roll a back control, so this standardizes them.

## What changed

Removed the footer `← Back to admin` link from:
- `safety-admin-shell.tsx`
- `bug-reports-admin-shell.tsx`
- `contributor-access-admin-shell.tsx`

(and the now-unused `Link` import in safety and contributor-access; bug-reports still uses `Link` elsewhere).

## Why it's safe

- Every other admin shell has **no** such footer — these three were the outliers, so removing them standardizes.
- Each page already has the shared history-aware smart-back at the top (`MobileScreenHeader` → `useSmartBack`), which returns to `/admin` in the normal admin-hub → plugin-admin flow, so the footer link was redundant.
- It doesn't touch the primary back control, so there's no bounce risk change — this is purely removing a duplicate.

UI-only — no schema, route, or contract change.

## Checks run locally

Web typecheck, lint on the three changed files, and EOF format all pass.

Parity Status: web + mobile-responsive + android complete

---
_Generated by [Claude Code](https://claude.ai/code/session_019EDu3sYB3PBN3EWbnkWzd7)_