### PR TITLE
feat: LevelUp cohort proposal queue from Workforce gaps (closes #904)

### DIFF
--- a/.github/workflows/level-up-auto-cohorts.yml
+++ b/.github/workflows/level-up-auto-cohorts.yml
@@ -1,11 +1,13 @@
 name: LevelUp — Auto Cohorts from Workforce Gaps
 
-# Stands up LevelUp training cohorts from the Workforce talent gaps once a day, without an admin
-# hand-building each cohort (issue #904). Workforce shows where the population is short of workers;
-# this asks production to turn the largest of those gaps into cohorts. The run is idempotent — a
-# cohort is never created twice for the same occupation (a partial unique index guards it), and
-# cohorts past their fixed term are closed — so a re-run can never double-create. The manual
-# "Run now" button on the LevelUp admin screen does the same thing as a fallback/override.
+# Keeps the LevelUp cohort-proposal queue and auto-cohort lifecycle current from the Workforce talent
+# gaps (issue #904, proposal-queue model, owner decision 2026-07-23). Workforce shows where the
+# population is short of workers; each day this asks production to (1) close any auto cohort past its
+# term and (2) — at most every generation_interval_days (default 90) — re-read the largest gaps into a
+# ranked, sector-diverse proposal queue. It does NOT create cohorts: an admin approves a proposal on the
+# LevelUp admin screen (choosing the term) to open one. The daily schedule keeps expiry-close frequent
+# while the cadence guard keeps proposal regeneration to ~every 90 days. The run is idempotent (cadence
+# guard + one pending proposal per occupation). The admin "Refresh proposals" button forces a re-read.
 #
 # What it needs (Settings → Secrets and variables → Actions):
 #   NEXT_PUBLIC_APP_URL secret — your production base URL (e.g. https://app.example.com). This is the

--- a/ctf/docs/contracts/LEVEL_UP_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/LEVEL_UP_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -311,3 +311,47 @@ policies:
       requiresAdditionalAudit: true
     denyConditions:
       - insufficient_role
+
+  - pluginId: level-up
+    command: cohort.proposal_approve
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+    consentRequirements:
+      scopes:
+        - level_up_manage_cohorts
+      fallbackLawfulBasis: contract_performance
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - proposal_not_pending
+
+  - pluginId: level-up
+    command: cohort.proposal_dismiss
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+    consentRequirements:
+      scopes:
+        - level_up_manage_cohorts
+      fallbackLawfulBasis: contract_performance
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - insufficient_role
+      - proposal_not_pending

--- a/ctf/docs/contracts/LEVEL_UP_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/LEVEL_UP_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -209,3 +209,46 @@ auditEvents:
     result:
       status: success_or_failure
       errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: level-up
+    command: cohort.proposal_approve
+    commandVersion: 1.0.0
+    purpose: training_cohort_management
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - cohort_configuration
+      - workforce_gap_signal
+    targetContext:
+      workspaceId: workspace_identifier
+      cohortId: cohort_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: level-up
+    command: cohort.proposal_dismiss
+    commandVersion: 1.0.0
+    purpose: training_cohort_management
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - cohort_configuration
+    targetContext:
+      workspaceId: workspace_identifier
+      proposalId: proposal_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class

--- a/ctf/docs/contracts/LEVEL_UP_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/LEVEL_UP_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -319,23 +319,26 @@ contracts:
   - pluginId: level-up
     command: cohort.auto_create
     version: 1.0.0
-    description: Read the Workforce occupation training gaps and stand up LevelUp cohorts for the largest of them, idempotently. Cron-triggered (CRON_SECRET) or admin-triggered. Reads the Workforce/Skills Taxonomy gap signal only; never writes Workforce, Directory, or Skills Taxonomy.
+    description: Read the Workforce occupation training gaps and refresh the ranked, sector-diverse cohort proposal queue (does NOT create cohorts — an admin approves a proposal to open one). Also closes any expired auto cohort. Cron-triggered (CRON_SECRET, cadence-gated) or admin-triggered (force). Reads the Workforce/Skills Taxonomy gap signal only; never writes Workforce, Directory, or Skills Taxonomy.
     inputSchema:
       source:
         type: string
         required: false
+      force:
+        type: boolean
+        required: false
     outputSchema:
-      created:
-        type: array
+      generated:
+        type: number
+      superseded:
+        type: number
       closed:
         type: array
     dataAccess:
       - level_up_auto_cohort_config
       - level_up_auto_cohort_term_overrides
+      - level_up_cohort_proposals
       - level_up_cohorts
-      - level_up_curriculum_items
-      - level_up_milestones
-      - level_up_command_idempotency
       - level_up_audit_events
       - skills_taxonomy_sectors
       - skills_taxonomy_job_titles
@@ -361,6 +364,52 @@ contracts:
     dataAccess:
       - level_up_cohorts
       - level_up_enrollments
+      - level_up_audit_events
+    purpose: training_cohort_management
+    retentionClass: transactional_long_lived
+    idempotency: false
+
+  - pluginId: level-up
+    command: cohort.proposal_approve
+    version: 1.0.0
+    description: Admin approves a pending cohort proposal, opening a real cohort with the chosen term (1, 3, or 5 months). Guarded so a proposal cannot be double-approved; if the occupation already has an open auto cohort the proposal is superseded and no cohort is opened.
+    inputSchema:
+      proposalId:
+        type: string
+        required: true
+      termMonths:
+        type: number
+        required: true
+    outputSchema:
+      status:
+        type: string
+      cohortId:
+        type: string
+    dataAccess:
+      - level_up_cohort_proposals
+      - level_up_auto_cohort_config
+      - level_up_cohorts
+      - level_up_curriculum_items
+      - level_up_milestones
+      - level_up_command_idempotency
+      - level_up_audit_events
+    purpose: training_cohort_management
+    retentionClass: transactional_long_lived
+    idempotency: true
+
+  - pluginId: level-up
+    command: cohort.proposal_dismiss
+    version: 1.0.0
+    description: Admin dismisses a pending cohort proposal so it no longer appears in the queue. No cohort is created.
+    inputSchema:
+      proposalId:
+        type: string
+        required: true
+    outputSchema:
+      status:
+        type: string
+    dataAccess:
+      - level_up_cohort_proposals
       - level_up_audit_events
     purpose: training_cohort_management
     retentionClass: transactional_long_lived

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
@@ -33,45 +33,55 @@
 1. Admin credit grant endpoint (`mint`/`adjustment` path), wired to a real admin UI on both web and Android. Owner decision (2026-06-06): the admin UI is grant-only — it only ever grants ServiceCredits to a member ("earn or earn nothing") and exposes no remove/negative path; the amount input accepts positive values only and submit is disabled client-side for non-positive amounts. (The backend endpoint still technically accepts a signed amount so a mistaken grant can be corrected later, but the UI never sends a negative.) Every grant requires a member user ID, an amount greater than zero, a reason, and a governance ticket ID, and goes behind an explicit in-screen confirm step that restates exactly what will change ("add N credits to member X") before submit. The mutation carries the `x-ctf-csrf: '1'` header and is written to the audit log.
 2. Dispute resolution endpoint with optional adjustment transfer.
 3. Admin panel with operational KPIs (enrollments, completions, avg days to first trainer payout) plus a read-only cohort overview (title, track, status, seats open, required deposit, trainer split, completion bonus) from `GET /api/level-up/cohorts`.
-4. Auto-cohort run control (issue #904): a "Run now" button that triggers the same auto-cohort creation the daily cron runs (reads the Workforce talent gaps and opens cohorts for the largest of them). The admin cohort overview shows `auto` and `needs trainer` badges on auto-created cohorts that have no human trainer yet.
+4. Cohort proposal queue (issue #904, proposal-queue model — owner decision 2026-07-23): a ranked, sector-diverse list of proposed cohorts derived from the Workforce talent gaps. Each row shows the occupation, sector, and gap, with a 1/3/5-month **term** selector and **Approve & open** / **Dismiss** actions; a **Refresh proposals** button re-reads the current gaps. Approving opens a real cohort (the admin picks the term); dismissing removes the proposal. The admin cohort overview shows `auto` and `needs trainer` badges on cohorts opened from proposals that have no human trainer yet.
 5. Review queues on the admin panel (read-only lists): **Open disputes** (`level_up_disputes` `status='open'`, newest first, with title, description, opener name, and time) and **Pending milestone validations** (`level_up_milestone_validations` `status='pending'`, newest first). Both are server-rendered from `getAdminPanelData()` (`listOpenDisputes` / `listPendingMilestoneValidations`) and drive the admin-landing "new to review" dot (an item created since the admin last opened this area). Resolving a dispute / approving a validation stays in the existing dispute and trainer-validation flows; these lists exist so the dot leads somewhere that shows what is new.
 
-## Auto-Cohort Creation from Workforce Gaps (issue #904)
+## Cohort Proposals from Workforce Gaps (issue #904)
 
-LevelUp stands up training cohorts from the Workforce talent gaps without an admin hand-building each
-one. The behaviour is deliberately lean for the current small active user base; the gap×talent-spread
-algorithm that will later set cadence and caps is deferred (see the deferral issues in the Change Log).
+LevelUp turns the Workforce talent gaps into a **ranked, admin-approved proposal queue** — it does not
+create cohorts on its own. Owner decision (2026-07-23, small active user base): the admin opens and
+closes cohorts at their discretion by approving proposals; full auto-create and a demand-*prediction*
+algorithm (tracking Workforce trends over time to forecast demand, not just today's snapshot) are
+deferred. That future model is where `max_concurrent` becomes load-bearing again.
 
 **LevelUp ↔ Workforce read interface (the contract the issue asked for before build):**
 
 - LevelUp reads the gap signal **server-side, in-process** via `fetchOccupationGapReport()` from
   `lib/workforce/repository` — it does not call Workforce over HTTP. The return is the per-occupation
   list `{ jobTitleId, occupation, sector, skillLevel, target, recruited, gap }`, sorted largest-gap-first.
-- The read is **one-way**: LevelUp never writes Workforce, Directory, or Skills Taxonomy. The cohort's
-  `source_job_title_id` is the gap's `jobTitleId` (a Skills Taxonomy job title id), so a cohort ties to
-  the exact occupation with no fuzzy title match.
+- The read is **one-way**: LevelUp never writes Workforce, Directory, or Skills Taxonomy. A proposal's
+  and the resulting cohort's `source_job_title_id` is the gap's `jobTitleId` (a Skills Taxonomy job title
+  id), so it ties to the exact occupation with no fuzzy title match.
 - **Cadence:** a daily GitHub Actions cron (`.github/workflows/level-up-auto-cohorts.yml`) calls
-  `POST /api/internal/level-up/auto-cohorts/run` (CRON_SECRET bearer). An admin "Run now" button is the
-  manual fallback.
-- **Selection / caps (admin-editable in `level_up_auto_cohort_config`):** filter to the configured skill
-  level (default `Foundational`), require `gap ≥ min_gap_threshold`, take the `top_n` largest, cap total
-  concurrent auto cohorts at `max_concurrent` (default 3) and at `per_sector_cap` per sector (default 1).
-- **Lifecycle:** fixed term — each cohort's end date is start + the per-occupation term override (or
-  `default_term_days`). The run closes any auto cohort whose term has elapsed (status → `completed`).
-- **Economics (one global policy, admin-editable):** every auto cohort is stamped with the deposit
+  `POST /api/internal/level-up/auto-cohorts/run` (CRON_SECRET bearer). Each run closes expired auto
+  cohorts, and — at most every `generation_interval_days` (default 90) — re-reads the gaps into the
+  proposal queue. The admin **Refresh proposals** button forces a re-read on demand.
+- **Selection (admin-editable in `level_up_auto_cohort_config`):** filter to the configured skill level
+  (default `Foundational`), require `gap ≥ min_gap_threshold`, exclude occupations already covered by an
+  open/active auto cohort or already holding a pending proposal, then rank **sector-diverse**:
+  round-robin across sectors (each sector's occupations largest-gap-first; sectors ordered by their top
+  gap) up to `per_sector_cap` per sector, bounded by `top_n` for a reviewable queue. There is **no**
+  max-concurrent cap on proposals — the admin opens on demand.
+- **Approval → term:** the admin approves a proposal and picks a **1/3/5-month** term; a real cohort
+  opens with `start = today`, `end = today + term`, `auto_created = true`, and the `source_*` fields. If
+  the occupation already has an open auto cohort (the `uq_level_up_auto_cohort_active_source` guard
+  fires), the proposal is marked `superseded` and no second cohort opens.
+- **Economics (one global policy, admin-editable):** every approved cohort is stamped with the deposit
   (`default_required_credits`, default 0 = free to join — sets `allow_no_deposit`), the trainer split
   (`default_trainer_split_percent`, default 25%), the completion bonus (`default_completion_bonus_credits`,
   default 0), and a standard 3-milestone skeleton (`LEVEL_UP_AUTO_COHORT_DEFAULT_MILESTONES`: 40/30/30).
-  Milestones matter because the escrow split, the trainer payout, and the completion bonus only settle on
-  milestone release — a cohort with no milestones has no progression or payout path. Per-occupation
-  economic tuning is deferred (#1197).
-- **Idempotency:** a deterministic command idempotency key plus the partial unique index mean a re-run
-  never duplicates a cohort for an occupation; a concurrent duplicate is caught as the occupation being
-  already covered.
+  Per-occupation economic tuning is deferred (#1197).
+- **Lifecycle:** each approved cohort's end date is `start + term`. The daily run closes any auto cohort
+  whose term has elapsed (status → `completed`). Expiry is checked every run; proposal regeneration is
+  gated to the 90-day cadence.
+- **Queue upkeep / idempotency:** the partial unique index `uq_level_up_cohort_proposal_pending`
+  (one pending proposal per occupation) plus the cadence guard make repeat runs idempotent. On each
+  regeneration, pending proposals no longer valid (occupation now covered, or gap fell below the
+  threshold) are marked `superseded`; still-valid ones keep their row with a refreshed gap/rank.
 - **Pre-flight guard:** if no sector carries a positive `skills_taxonomy_sectors.workforce_share`,
   Workforce demand falls back to an even split and the "largest gap" order is meaningless, so the run
-  does nothing and records `skipped: no_workforce_share`.
-- **Recruiting:** an auto cohort opens with the scheduler as a placeholder owner and `status='open'`
+  generates nothing and records `skipped: no_workforce_share`.
+- **Recruiting:** an approved cohort opens with the scheduler as a placeholder owner and `status='open'`
   (so it shows in the existing cohort browse and trainees can enroll). A trainer claims it via
   `POST /api/level-up/cohorts/[cohortId]/claim-trainer`, which makes them the trainer of record; until
   then the cohort carries a derived `needsTrainer` flag.
@@ -81,8 +91,11 @@ algorithm that will later set cadence and caps is deferred (see the deferral iss
 - `GET /api/level-up/cohorts`
 - `POST /api/level-up/cohorts` — create a cohort; admin or trainer role (per `cohort.create` contract). The cohort list response now also carries `autoCreated`, `sourceJobTitleId`, `sourceSector`, and a derived `needsTrainer` flag.
 - `POST /api/level-up/cohorts/[cohortId]/claim-trainer` — a trainer or admin claims an auto-created cohort that has no human trainer yet, becoming its trainer of record (per `cohort.claim_trainer` contract).
-- `POST /api/level-up/admin/auto-cohorts/run` — admin-only manual trigger for the auto-cohort run (the fallback for the daily cron); CSRF-guarded (per `cohort.auto_create` contract).
-- `POST /api/internal/level-up/auto-cohorts/run` — cron-only auto-cohort run, guarded by `Authorization: Bearer ${CRON_SECRET}` (no user session). Reads the Workforce occupation gaps and stands up cohorts for the largest of them, then closes any auto cohort whose term has elapsed. Idempotent.
+- `POST /api/level-up/admin/auto-cohorts/run` — admin-only "Refresh proposals" action; force-regenerates the cohort proposal queue from the current Workforce gaps and closes expired auto cohorts; CSRF-guarded (per `cohort.auto_create` contract).
+- `POST /api/internal/level-up/auto-cohorts/run` — cron-only run, guarded by `Authorization: Bearer ${CRON_SECRET}` (no user session). Closes any auto cohort whose term has elapsed, and — at most every `generation_interval_days` (default 90) — re-reads the Workforce occupation gaps into the ranked, sector-diverse proposal queue. Does **not** create cohorts. Idempotent.
+- `GET /api/level-up/admin/cohort-proposals` — admin-only; the ranked pending proposal queue (per `cohort.proposal_approve`/`_dismiss` read surface).
+- `POST /api/level-up/admin/cohort-proposals/[proposalId]/approve` — admin-only; opens a cohort from a pending proposal with a chosen term of 1/3/5 months; CSRF-guarded (per `cohort.proposal_approve` contract).
+- `POST /api/level-up/admin/cohort-proposals/[proposalId]/dismiss` — admin-only; removes a pending proposal from the queue; CSRF-guarded (per `cohort.proposal_dismiss` contract).
 - `POST /api/level-up/enroll` — member or admin only; trainer-only accounts are blocked (per `enrollment.create` contract).
 - `POST /api/level-up/milestones/[milestoneId]/validate`
 - `POST /api/level-up/milestones/[milestoneId]/release`
@@ -117,8 +130,9 @@ Core tables:
 15. `level_up_trainers` — trainer directory profile. Columns: `id` (PK), `user_id` (unique), `display_name`, `headline`, `bio`, `tracks` (jsonb array), `status`, `created_at`, `updated_at`. Read-only browse surface.
 16. `level_up_achievements` — grant-only badge definitions. Columns: `id` (PK), `slug` (unique), `name`, `description`, `track`, `icon`, `credit_reward` (display-only grant amount), `sequence_no`, `status`, `created_at`, `updated_at`.
 17. `level_up_user_achievements` — per-user earned badge rows (grant-only: a row means earned). Columns: `id` (PK), `user_id`, `achievement_id`, `earned_at`, `granted_credits`, `source_reference`, `created_at`; unique on `(user_id, achievement_id)`.
-18. `level_up_auto_cohort_config` — singleton config for auto-cohort creation (issue #904). Columns: `singleton_key` (PK bool), `enabled`, `min_gap_threshold`, `max_concurrent` (default 3), `per_sector_cap` (default 1), `skill_level_filter` (default `Foundational`), `top_n` (default 10), `default_term_days` (default 90), `default_seats` (default 12), `default_required_credits` (default 0 = free to join), `default_trainer_split_percent` (default 25), `default_completion_bonus_credits` (default 0), `updated_by_user_id`, `updated_at`. Admin-editable. The economic columns are one global policy applied to every auto cohort; per-occupation tuning is deferred (#1197).
-19. `level_up_auto_cohort_term_overrides` — per-occupation fixed-term overrides (issue #904). Columns: `job_title_id` (PK), `occupation`, `term_days`, `updated_by_user_id`, `updated_at`. Falls back to `default_term_days` when an occupation has no override.
+18. `level_up_auto_cohort_config` — singleton config for the gap-driven proposal queue (issue #904). Columns: `singleton_key` (PK bool), `enabled` (gates proposal generation), `min_gap_threshold`, `max_concurrent` (default 3 — retained for the future full-auto model; **not** used by proposal generation), `per_sector_cap` (default 1 — diversity cap), `skill_level_filter` (default `Foundational`), `top_n` (default 10 — queue-size bound), `default_term_days` (default 90), `default_seats` (default 12), `default_required_credits` (default 0 = free to join), `default_trainer_split_percent` (default 25), `default_completion_bonus_credits` (default 0), `generation_interval_days` (default 90 — the cadence), `last_generated_at` (nullable — cadence guard), `updated_by_user_id`, `updated_at`. Admin-editable. The economic columns are one global policy applied to every approved cohort; per-occupation tuning is deferred (#1197).
+19. `level_up_auto_cohort_term_overrides` — legacy per-occupation fixed-term overrides (issue #904). Columns: `job_title_id` (PK), `occupation`, `term_days`, `updated_by_user_id`, `updated_at`. No longer consulted in the proposal model (the admin picks 1/3/5 months at approval); kept for the future full-auto model.
+20. `level_up_cohort_proposals` — the gap-driven cohort proposal queue (issue #904, proposal-queue model). Columns: `id` (PK), `source_job_title_id` (Skills Taxonomy job title — no hard FK, mirroring `level_up_cohorts.source_job_title_id`), `occupation`, `sector`, `skill_level`, `gap_at_proposal`, `rank`, `status` (`pending`/`approved`/`dismissed`/`superseded`), `generated_source`, `generated_at`, `decided_by_user_id`, `decided_at`, `created_cohort_id` (set when approved), `created_at`, `updated_at`. Partial unique index `uq_level_up_cohort_proposal_pending` on `source_job_title_id WHERE status='pending'` (at most one live proposal per occupation); `idx_level_up_cohort_proposal_pending_rank` on `(status, rank)` for the ranked read.
 
 Auto-cohort columns on `level_up_cohorts` (issue #904): `auto_created` (bool), `source_job_title_id` (UUID, references `skills_taxonomy_job_titles.id` by convention — no hard FK, mirroring `directory_profiles.job_title_id`), `source_sector` (text), `source_gap_at_creation` (numeric). A partial unique index `uq_level_up_auto_cohort_active_source` on `source_job_title_id WHERE auto_created = TRUE AND status IN ('open','active')` enforces at most one open/active auto cohort per occupation (the database-level idempotency guard).
 
@@ -218,6 +232,26 @@ that exist today.
 
 ## Change Log
 
+- 2026-07-23: **#904 delivered as an admin-approved cohort proposal queue (replaces auto-create).**
+  Owner decision (small active user base): instead of the daily cron creating cohorts outright, LevelUp
+  now re-reads the Workforce gaps on a cadence into a ranked, **sector-diverse** proposal queue that the
+  admin approves at their discretion. New table `level_up_cohort_proposals` (pending/approved/dismissed/
+  superseded; one pending per occupation). `level_up_auto_cohort_config` gains `generation_interval_days`
+  (default 90 — the re-read cadence) and `last_generated_at` (cadence guard); `max_concurrent` is no
+  longer used by generation (retained for the future full-auto model). `lib/level-up/auto-cohort.ts` was
+  rewritten: `generateCohortProposals` (sector-diverse round-robin, per-sector cap, supersede-stale),
+  `runAutoCohortProposals` (always close expired cohorts; regenerate only when forced or the 90-day
+  cadence is due), `approveCohortProposal` (admin picks a **1/3/5-month** term → opens a cohort;
+  double-approve-guarded; already-covered → superseded), `dismissCohortProposal`, `listPendingProposals`.
+  The two `auto-cohorts/run` routes were repointed (admin = force refresh, cron = cadence-gated). New
+  admin routes: `GET /api/level-up/admin/cohort-proposals`, `POST …/[proposalId]/approve`,
+  `POST …/[proposalId]/dismiss`. The admin shell (`lu-admin-shell.tsx`) replaces the "Run now" button
+  with a **Refresh proposals** action and a proposal queue (occupation · sector · gap, term selector,
+  Approve & open / Dismiss). New contracts `cohort.proposal_approve` / `cohort.proposal_dismiss` (command
+  / access-policy / audit); `cohort.auto_create` updated to the proposal-generation shape. Cron header
+  and `schema.demo.sql` regenerated. Deferred: full auto-create and the demand-prediction algorithm;
+  per-occupation economic tuning (#1197). The admin picks the term (not the trainer) and the queue is
+  Foundational-only for now — both admin-editable/revisitable.
 - 2026-07-23: **Admin review queues for open disputes + pending validations, and the admin-landing dot.** The admin panel previously showed only KPIs, so open disputes and pending milestone validations had no admin surface. `getAdminPanelData()` now also returns `openDisputes` (`listOpenDisputes`, `level_up_disputes` `status='open'`, opener names resolved via Clerk) and `pendingValidations` (`listPendingMilestoneValidations`, `level_up_milestone_validations` `status='pending'`), both newest first and capped. The web admin shell (`lu-admin-shell.tsx`) renders them as two read-only review lists below the KPIs. LevelUp is now wired into the admin-landing "new to review" dot (`lib/admin/area-attention.ts`): a dot shows when a dispute/validation arrived since the admin last opened the area. Server-rendered (no new API route); no schema or contract change. Resolving/approving stays in the existing dispute/validation flows.
 - 2026-07-21: **Removed the orphaned member-shell right panel (resolves #1761).** The
   desktop-branch-collapse refactor (commit `279831a`) had already dropped the member shell's

--- a/ctf/docs/developer/test-scripts/level-up-test-script.md
+++ b/ctf/docs/developer/test-scripts/level-up-test-script.md
@@ -386,47 +386,49 @@ Result: web ☐
 
 ---
 
-### LU-A4 — Auto-cohorts "Run now" button
-
-**Role:** admin · **Surfaces:** web, android
-**Precondition:** Signed in as seed admin. Workforce gap data available (seeded or present in dev DB).
-
-**Steps:**
-1. Open the admin panel (`/admin/level-up` on web; Admin LevelUp screen on Android).
-2. Locate the "Auto cohorts from Workforce gaps" card.
-3. Click/tap "Run now".
-4. Wait for the result.
-
-**Expected:**
-- The button triggers `POST /api/level-up/admin/auto-cohorts/run`.
-- A result banner appears showing created, closed, and/or skipped summary.
-- If the pre-flight guard fires (no positive `workforce_share`), the banner shows `skipped: no_workforce_share` — not a blank screen or error.
-- After a successful run, the cohort overview refreshes and any newly created cohorts carry an `auto` badge; auto-created cohorts with no trainer yet carry a `needs trainer` badge.
-
-Result: web ☐
-
----
-
-### LU-A5 — Auto-cohort idempotency
+### LU-A4 — Cohort proposals: refresh, ranking, approve, dismiss
 
 **Role:** admin · **Surfaces:** web
-**Precondition:** LU-A4 completed and at least one auto cohort was created.
+**Precondition:** Signed in as seed admin. Workforce gap data available (seeded or present in dev DB), with more than one sector carrying a positive `workforce_share`.
 
 **Steps:**
-1. Click "Run now" a second time immediately.
+1. Open `/admin/level-up` and locate the "Cohort proposals from Workforce gaps" card.
+2. Click **Refresh proposals** (triggers `POST /api/level-up/admin/auto-cohorts/run`).
+3. Read the ranked proposal list.
+4. On one proposal, choose a term of **3 months** and click **Approve & open**.
+5. On another proposal, click **Dismiss**.
 
 **Expected:**
-- No duplicate cohort is created for the same occupation.
-- The result banner reports 0 created (or the existing cohort is counted as already covered).
+- The refresh banner reports how many proposals were ranked / superseded / cohorts closed. If the pre-flight guard fires (no positive `workforce_share`), it shows `skipped: no_workforce_share` — not a blank screen or error.
+- The list is **sector-diverse**: the top rows span different sectors rather than all coming from one sector (no single sector dominates the top of the queue).
+- Approving opens a real cohort: a success banner names the occupation and end date, the proposal leaves the queue, and the cohort overview shows a new cohort with an `auto` badge (and `needs trainer` until a trainer claims it). Its end date is ~3 months out.
+- Dismissing removes that proposal from the queue with no cohort created.
 
 Result: web ☐
 
 ---
 
-### LU-A6 — Trainer claims an auto-created cohort
+### LU-A5 — Proposal queue idempotency and supersede
+
+**Role:** admin · **Surfaces:** web
+**Precondition:** LU-A4 completed (at least one proposal approved into a cohort).
+
+**Steps:**
+1. Click **Refresh proposals** again.
+
+**Expected:**
+- The occupation you approved in LU-A4 does **not** reappear as a new proposal (it is now covered by an open cohort).
+- No occupation appears twice in the queue; each row is a distinct occupation.
+- If a previously pending proposal's gap has since closed below the threshold, it no longer appears (it was superseded).
+
+Result: web ☐
+
+---
+
+### LU-A6 — Trainer claims a cohort opened from a proposal
 
 **Role:** trainer (or admin acting as trainer) · **Surfaces:** web
-**Precondition:** At least one auto-created cohort exists with `needsTrainer` flag set (from LU-A4). Signed in as seed trainer.
+**Precondition:** At least one cohort opened from an approved proposal has the `needsTrainer` flag set (from LU-A4). Signed in as seed trainer.
 
 **Steps:**
 1. Find the auto-created cohort with the `needs trainer` badge in the cohort list.

--- a/ctf/packages/web/app/admin/level-up/page.tsx
+++ b/ctf/packages/web/app/admin/level-up/page.tsx
@@ -3,6 +3,7 @@ import { evaluatePluginAccess } from 'lib/auth/server-authz';
 
 export const dynamic = 'force-dynamic';
 import { getAdminPanelData } from 'lib/level-up/repository';
+import { listPendingProposals } from 'lib/level-up/auto-cohort';
 import { LevelUpAdminShell } from '@/components/level-up/lu-admin-shell';
 
 export default async function LevelUpAdminPage() {
@@ -11,13 +12,14 @@ export default async function LevelUpAdminPage() {
     redirect('/apps/level-up');
   }
 
-  const panel = await getAdminPanelData();
+  const [panel, pendingProposals] = await Promise.all([getAdminPanelData(), listPendingProposals(100)]);
 
   return (
     <LevelUpAdminShell
       kpis={panel.kpis}
       openDisputes={panel.openDisputes}
       pendingValidations={panel.pendingValidations}
+      pendingProposals={pendingProposals}
     />
   );
 }

--- a/ctf/packages/web/app/api/internal/level-up/auto-cohorts/run/route.ts
+++ b/ctf/packages/web/app/api/internal/level-up/auto-cohorts/run/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
-import { runAutoCohortCreation } from 'lib/level-up/auto-cohort';
+import { runAutoCohortProposals } from 'lib/level-up/auto-cohort';
 import { reportError } from 'lib/observability/report';
 
-// Cron-only: reads the Workforce occupation gaps and stands up LevelUp cohorts for the largest of them
-// (issue #904), without an admin hand-building each cohort. Guarded by CRON_SECRET (Bearer), matching
+// Cron-only (issue #904): closes any expired auto cohort, and — at most every generation_interval_days
+// (default 90) — re-reads the Workforce occupation gaps into the admin proposal queue. It does NOT
+// create cohorts; an admin approves a proposal to open one. Guarded by CRON_SECRET (Bearer), matching
 // the Unlock reward-reconciliation and PeerProgramming weekly-assignment convention. Safe to run more
-// than once: a partial unique index and an already-covered check mean a repeat run can never duplicate
-// a cohort for the same occupation. The admin "Run now" action on the LevelUp admin screen is the
-// manual fallback.
+// than once: the cadence guard and the pending-per-occupation unique index make repeats idempotent. The
+// admin "Refresh proposals" action on the LevelUp admin screen forces a re-read on demand.
 function isAuthorized(request: Request): boolean {
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret || cronSecret.trim().length === 0) {
@@ -25,12 +25,12 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await runAutoCohortCreation({ source: 'cron' });
+    const result = await runAutoCohortProposals({ source: 'cron' });
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'level-up', op: 'internal_auto_cohorts_run' });
     return NextResponse.json(
-      { ok: false, code: 'level_up_scheduler_unavailable', message: 'Auto-cohort run unavailable.' },
+      { ok: false, code: 'level_up_scheduler_unavailable', message: 'Proposal run unavailable.' },
       { status: 503 },
     );
   }

--- a/ctf/packages/web/app/api/level-up/admin/auto-cohorts/run/route.ts
+++ b/ctf/packages/web/app/api/level-up/admin/auto-cohorts/run/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { runAutoCohortCreation } from 'lib/level-up/auto-cohort';
+import { runAutoCohortProposals } from 'lib/level-up/auto-cohort';
 import { ensureMutationCsrf, levelUpErrorResponse, requireLevelUpAdminAccess } from 'lib/level-up/_lib';
 import { reportError } from 'lib/observability/report';
 
-// Admin manual fallback for the auto-cohort run (issue #904). Same logic the daily cron calls, behind
-// the admin gate + CSRF so an admin can trigger it on demand from the LevelUp admin screen.
+// Admin "Refresh proposals" action (issue #904): re-read the Workforce gaps into the proposal queue now
+// (force), behind the admin gate + CSRF. Also closes any expired auto cohort, same as the cron.
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -17,10 +17,10 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await runAutoCohortCreation({ source: 'admin' });
+    const result = await runAutoCohortProposals({ source: 'admin', force: true });
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'level-up', op: 'admin_auto_cohorts_run' });
-    return levelUpErrorResponse(error, 'Auto-cohort run unavailable.');
+    return levelUpErrorResponse(error, 'Proposal refresh unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/level-up/admin/cohort-proposals/[proposalId]/approve/route.ts
+++ b/ctf/packages/web/app/api/level-up/admin/cohort-proposals/[proposalId]/approve/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { approveCohortProposal } from 'lib/level-up/auto-cohort';
+import { ensureMutationCsrf, levelUpErrorResponse, requireLevelUpAdminAccess } from 'lib/level-up/_lib';
+import { LEVEL_UP_PROPOSAL_TERM_MONTHS } from 'lib/level-up/constants';
+import { reportError } from 'lib/observability/report';
+
+type RouteProps = {
+  params: Promise<{ proposalId: string }>;
+};
+
+// Admin picks the term (1/3/5 months) at approval (owner decision 2026-07-23).
+const approveSchema = z.object({
+  termMonths: z.union([z.literal(1), z.literal(3), z.literal(5)]),
+});
+
+export async function POST(request: Request, { params }: RouteProps) {
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireLevelUpAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { proposalId } = await params;
+  if (!z.string().uuid().safeParse(proposalId).success) {
+    return NextResponse.json({ ok: false, code: 'level_up_invalid_payload', message: 'Invalid proposal id.' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, code: 'level_up_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const parsed = approveSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, code: 'level_up_invalid_payload', message: `Term must be one of ${LEVEL_UP_PROPOSAL_TERM_MONTHS.join(', ')} months.`, issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await approveCohortProposal({
+      actorId: gate.auth.userId,
+      proposalId,
+      termMonths: parsed.data.termMonths,
+    });
+    return NextResponse.json({ ok: true, ...result }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'level-up', op: 'admin_cohort_proposal_approve' });
+    return levelUpErrorResponse(error, 'Approve proposal unavailable.');
+  }
+}

--- a/ctf/packages/web/app/api/level-up/admin/cohort-proposals/[proposalId]/dismiss/route.ts
+++ b/ctf/packages/web/app/api/level-up/admin/cohort-proposals/[proposalId]/dismiss/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { dismissCohortProposal } from 'lib/level-up/auto-cohort';
+import { ensureMutationCsrf, levelUpErrorResponse, requireLevelUpAdminAccess } from 'lib/level-up/_lib';
+import { reportError } from 'lib/observability/report';
+
+type RouteProps = {
+  params: Promise<{ proposalId: string }>;
+};
+
+export async function POST(request: Request, { params }: RouteProps) {
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireLevelUpAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { proposalId } = await params;
+  if (!z.string().uuid().safeParse(proposalId).success) {
+    return NextResponse.json({ ok: false, code: 'level_up_invalid_payload', message: 'Invalid proposal id.' }, { status: 400 });
+  }
+
+  try {
+    const result = await dismissCohortProposal({ actorId: gate.auth.userId, proposalId });
+    return NextResponse.json({ ok: true, ...result }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'level-up', op: 'admin_cohort_proposal_dismiss' });
+    return levelUpErrorResponse(error, 'Dismiss proposal unavailable.');
+  }
+}

--- a/ctf/packages/web/app/api/level-up/admin/cohort-proposals/route.ts
+++ b/ctf/packages/web/app/api/level-up/admin/cohort-proposals/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { listPendingProposals } from 'lib/level-up/auto-cohort';
+import { levelUpErrorResponse, requireLevelUpAdminAccess } from 'lib/level-up/_lib';
+import { reportError } from 'lib/observability/report';
+
+// Admin-only: the pending cohort-proposal queue (issue #904), ranked sector-diverse. Read-only; the
+// admin approves or dismisses each via the sibling routes.
+export async function GET() {
+  const gate = await requireLevelUpAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const proposals = await listPendingProposals(100);
+    return NextResponse.json({ ok: true, proposals }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'level-up', op: 'admin_cohort_proposals_list' });
+    return levelUpErrorResponse(error, 'Cohort proposals unavailable.');
+  }
+}

--- a/ctf/packages/web/components/level-up/lu-admin-shared.ts
+++ b/ctf/packages/web/components/level-up/lu-admin-shared.ts
@@ -29,14 +29,33 @@ export type AdminCohort = {
   sourceSector?: string | null;
 };
 
-// Summary returned by POST /api/level-up/admin/auto-cohorts/run (and the cron route).
+// Summary returned by POST /api/level-up/admin/auto-cohorts/run (the "Refresh proposals" action) and
+// the cron route. The run refreshes the proposal queue and closes expired auto cohorts — it does not
+// create cohorts (issue #904, proposal-queue model).
 export type AutoCohortRunResult = {
   ok: boolean;
-  skipped?: 'disabled' | 'no_workforce_share';
-  created?: Array<{ cohortId: string; occupation: string; sector: string; gap: number; endDate: string }>;
+  skipped?: 'disabled' | 'no_workforce_share' | 'cadence_not_due';
+  generated?: number;
+  superseded?: number;
   closed?: Array<{ cohortId: string; occupation: string }>;
   message?: string;
 };
+
+// One pending cohort proposal in the admin queue (mirrors PendingProposal from lib/level-up/auto-cohort).
+export type AdminProposal = {
+  id: string;
+  sourceJobTitleId: string;
+  occupation: string;
+  sector: string;
+  skillLevel: string;
+  gap: number;
+  rank: number;
+  generatedAtIso: string;
+};
+
+// Term choices offered at approval (owner decision 2026-07-23), mirrors LEVEL_UP_PROPOSAL_TERM_MONTHS.
+export const PROPOSAL_TERM_MONTHS = [1, 3, 5] as const;
+export type ProposalTermMonths = (typeof PROPOSAL_TERM_MONTHS)[number];
 
 export type AdminKpis = {
   enrollments: number;

--- a/ctf/packages/web/components/level-up/lu-admin-shell.tsx
+++ b/ctf/packages/web/components/level-up/lu-admin-shell.tsx
@@ -14,11 +14,14 @@ import { TrendingUp } from 'lucide-react';
 import {
   idempotencyKey,
   luAdminMutate,
+  PROPOSAL_TERM_MONTHS,
   type AdminCohort,
   type AdminDispute,
   type AdminKpis,
+  type AdminProposal,
   type AdminValidation,
   type AutoCohortRunResult,
+  type ProposalTermMonths,
 } from './lu-admin-shared';
 import { getLevelUpTokens, type LevelUpTokens } from './lu-shared';
 import { useTheme } from '@/hooks/useTheme';
@@ -69,15 +72,24 @@ export function LevelUpAdminShell({
   kpis,
   openDisputes,
   pendingValidations,
+  pendingProposals,
 }: {
   kpis: AdminKpis;
   openDisputes: AdminDispute[];
   pendingValidations: AdminValidation[];
+  pendingProposals: AdminProposal[];
 }) {
   const { theme } = useTheme();
   const t = getLevelUpTokens(theme);
   const [cohorts, setCohorts] = useState<AdminCohort[] | null>(null);
   const [cohortsError, setCohortsError] = useState<string | null>(null);
+
+  // Cohort proposal queue (issue #904). Seeded from the server prop, re-fetched after any action.
+  const [proposals, setProposals] = useState<AdminProposal[]>(pendingProposals);
+  const [proposalTerms, setProposalTerms] = useState<Record<string, ProposalTermMonths>>({});
+  const [busyProposalId, setBusyProposalId] = useState<string | null>(null);
+  const [proposalNotice, setProposalNotice] = useState<string | null>(null);
+  const [proposalError, setProposalError] = useState<string | null>(null);
 
   // Credit-adjustment form state.
   const [targetUserId, setTargetUserId] = useState('');
@@ -166,7 +178,20 @@ export function LevelUpAdminShell({
     setGovernanceTicketId('');
   }, [targetUserId, parsedAmount, reason, governanceTicketId, magnitude]);
 
-  const runAutoCohorts = useCallback(async () => {
+  const loadProposals = useCallback(async () => {
+    try {
+      const res = await fetch('/api/level-up/admin/cohort-proposals');
+      if (!res.ok) {
+        return;
+      }
+      const data = (await res.json()) as { ok: boolean; proposals?: AdminProposal[] };
+      setProposals(data.proposals ?? []);
+    } catch {
+      // Non-fatal: keep the current list on a transient fetch error.
+    }
+  }, []);
+
+  const refreshProposals = useCallback(async () => {
     setAutoRunning(true);
     setAutoNotice(null);
     setAutoError(null);
@@ -178,16 +203,62 @@ export function LevelUpAdminShell({
     }
     const data = result.data;
     if (data.skipped === 'disabled') {
-      setAutoNotice('Auto-cohort creation is turned off in config — nothing was created.');
+      setAutoNotice('Proposal generation is turned off in config — the queue was not refreshed.');
     } else if (data.skipped === 'no_workforce_share') {
       setAutoNotice('Skipped: no sector carries a workforce share yet, so the gap ranking is not meaningful.');
     } else {
-      const createdCount = data.created?.length ?? 0;
+      const generated = data.generated ?? 0;
+      const superseded = data.superseded ?? 0;
       const closedCount = data.closed?.length ?? 0;
-      setAutoNotice(`Run complete: ${createdCount} cohort(s) created, ${closedCount} closed (term ended).`);
+      setAutoNotice(`Queue refreshed: ${generated} proposal(s) ranked, ${superseded} superseded, ${closedCount} cohort(s) closed (term ended).`);
     }
-    await loadCohorts();
-  }, [loadCohorts]);
+    await Promise.all([loadProposals(), loadCohorts()]);
+  }, [loadCohorts, loadProposals]);
+
+  const approveProposal = useCallback(
+    async (proposal: AdminProposal) => {
+      setBusyProposalId(proposal.id);
+      setProposalNotice(null);
+      setProposalError(null);
+      const termMonths = proposalTerms[proposal.id] ?? 3;
+      const result = await luAdminMutate<{ status?: string; occupation?: string; endDate?: string }>(
+        `/api/level-up/admin/cohort-proposals/${proposal.id}/approve`,
+        { termMonths },
+      );
+      setBusyProposalId(null);
+      if (!result.ok) {
+        setProposalError(result.message);
+        return;
+      }
+      if (result.data.status === 'already_covered') {
+        setProposalNotice(`${proposal.occupation} already has an open cohort — the proposal was removed.`);
+      } else {
+        setProposalNotice(`Opened a ${termMonths}-month cohort for ${proposal.occupation} (ends ${result.data.endDate ?? ''}).`);
+      }
+      await Promise.all([loadProposals(), loadCohorts()]);
+    },
+    [proposalTerms, loadProposals, loadCohorts],
+  );
+
+  const dismissProposal = useCallback(
+    async (proposal: AdminProposal) => {
+      setBusyProposalId(proposal.id);
+      setProposalNotice(null);
+      setProposalError(null);
+      const result = await luAdminMutate<{ status?: string }>(
+        `/api/level-up/admin/cohort-proposals/${proposal.id}/dismiss`,
+        {},
+      );
+      setBusyProposalId(null);
+      if (!result.ok) {
+        setProposalError(result.message);
+        return;
+      }
+      setProposalNotice(`Dismissed the proposal for ${proposal.occupation}.`);
+      await loadProposals();
+    },
+    [loadProposals],
+  );
 
   return (
     <div
@@ -272,13 +343,25 @@ export function LevelUpAdminShell({
           )}
         </div>
 
-        {/* Auto cohorts (issue #904) */}
+        {/* Cohort proposals from Workforce gaps (issue #904) */}
         <div style={{ marginBottom: 24, padding: '16px 18px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-          <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 6 }}>Auto cohorts from Workforce gaps</h2>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 6 }}>
+            <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, margin: 0 }}>
+              Cohort proposals from Workforce gaps {proposals.length > 0 ? `(${proposals.length})` : ''}
+            </h2>
+            <button
+              type="button"
+              onClick={refreshProposals}
+              disabled={autoRunning}
+              style={{ marginLeft: 'auto', padding: '8px 16px', borderRadius: 8, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: autoRunning ? 'not-allowed' : 'pointer', opacity: autoRunning ? 0.6 : 1 }}
+            >
+              {autoRunning ? 'Refreshing…' : 'Refresh proposals'}
+            </button>
+          </div>
           <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, marginBottom: 14 }}>
-            The daily run reads the Workforce talent gaps and opens cohorts for the largest of them. Run
-            it now to apply the current gaps right away. It is safe to run more than once — a cohort is
-            never created twice for the same occupation, and cohorts past their term are closed.
+            The gaps are re-read on a cadence into a ranked, sector-diverse queue. Approve a proposal to
+            open a cohort — you choose the term — or dismiss it. Approving never opens two cohorts for the
+            same occupation; refreshing supersedes proposals whose gap has closed.
           </p>
           {autoError ? (
             <div role="alert" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>
@@ -290,14 +373,66 @@ export function LevelUpAdminShell({
               {autoNotice}
             </div>
           ) : null}
-          <button
-            type="button"
-            onClick={runAutoCohorts}
-            disabled={autoRunning}
-            style={{ padding: '9px 18px', borderRadius: 8, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: autoRunning ? 'not-allowed' : 'pointer', opacity: autoRunning ? 0.6 : 1 }}
-          >
-            {autoRunning ? 'Running…' : 'Run now'}
-          </button>
+          {proposalError ? (
+            <div role="alert" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>
+              {proposalError}
+            </div>
+          ) : null}
+          {proposalNotice ? (
+            <div style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13 }}>
+              {proposalNotice}
+            </div>
+          ) : null}
+          {proposals.length === 0 ? (
+            <div style={{ padding: '20px 16px', textAlign: 'center', color: t.MUTED, fontSize: 13, borderRadius: 10, background: t.BG, border: `1px solid ${t.BORDER_SOLID}` }}>
+              No pending proposals. Use “Refresh proposals” to re-read the current Workforce gaps.
+            </div>
+          ) : (
+            proposals.map((proposal) => {
+              const term = proposalTerms[proposal.id] ?? 3;
+              const busy = busyProposalId === proposal.id;
+              return (
+                <div key={proposal.id} style={{ marginBottom: 10, padding: '12px 14px', borderRadius: 10, background: t.BG, border: `1px solid ${t.BORDER_SOLID}` }}>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>#{proposal.rank} · {proposal.occupation}</span>
+                    <Pill>{proposal.sector}</Pill>
+                    <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>gap {Math.round(proposal.gap)}</span>
+                  </div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginTop: 10 }}>
+                    <label style={{ fontSize: 12, color: t.MUTED }}>
+                      Term:{' '}
+                      <select
+                        value={term}
+                        disabled={busy}
+                        onChange={(event) => setProposalTerms((prev) => ({ ...prev, [proposal.id]: Number(event.target.value) as ProposalTermMonths }))}
+                        style={{ borderRadius: 6, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, padding: '5px 8px', fontSize: 12 }}
+                      >
+                        {PROPOSAL_TERM_MONTHS.map((months) => (
+                          <option key={months} value={months}>{months} month{months === 1 ? '' : 's'}</option>
+                        ))}
+                      </select>
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => void approveProposal(proposal)}
+                      disabled={busy}
+                      style={{ marginLeft: 'auto', padding: '7px 14px', borderRadius: 7, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 12, fontWeight: 700, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+                    >
+                      {busy ? 'Working…' : 'Approve & open'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void dismissProposal(proposal)}
+                      disabled={busy}
+                      style={{ padding: '7px 14px', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          )}
         </div>
 
         {/* Cohorts */}

--- a/ctf/packages/web/lib/level-up/auto-cohort.ts
+++ b/ctf/packages/web/lib/level-up/auto-cohort.ts
@@ -1,23 +1,26 @@
-// Auto-cohort creation (issue #904).
+// Cohort proposals from Workforce gaps (issue #904).
 //
-// Workforce is the single source of the talent-gap signal. This module reads the per-occupation
-// training gaps that Workforce computes live (`fetchOccupationGapReport`), and stands up LevelUp
-// cohorts for the largest gaps — without an admin hand-building each cohort. It never writes back into
-// Workforce, Directory, or Skills Taxonomy; it only reads the gap list and creates LevelUp rows.
+// Workforce is the single source of the talent-gap signal. On a cadence this module reads the
+// per-occupation training gaps that Workforce computes live (`fetchOccupationGapReport`) and turns the
+// largest of them into a ranked, sector-diverse **proposal queue** — it does NOT create cohorts
+// outright. An admin reviews the queue and either approves a proposal (choosing a 1/3/5-month term,
+// which opens a real cohort) or dismisses it. It never writes back into Workforce, Directory, or Skills
+// Taxonomy; it only reads the gap list and writes LevelUp proposal/cohort rows.
 //
-// Lean launch policy (small active user base): take the top N Foundational-level gaps above a minimum
-// gap, cap the number of concurrent auto cohorts and the number per sector, and give each cohort a
-// fixed term. All knobs live in `level_up_auto_cohort_config` (admin-editable); per-occupation term
-// overrides live in `level_up_auto_cohort_term_overrides`. The gap×talent-spread algorithm that will
-// later set cadence and caps from the spread of people who already hold a skill is deferred.
-import { queryDb } from 'lib/db/postgres';
+// Owner decision (2026-07-23, small active user base): proposal queue, not auto-create; re-read gaps at
+// most every `generation_interval_days` (default 90); no max-concurrent cap on proposals (the admin
+// opens cohorts on demand); keep a per-sector cap so one big-gap sector does not crowd the queue; the
+// admin picks the term at approval. Fully automatic creation and a demand-*prediction* algorithm are
+// deferred (that is where `max_concurrent` becomes load-bearing again). All knobs live in
+// `level_up_auto_cohort_config` (admin-editable).
+import { queryDb, withDbTransaction } from 'lib/db/postgres';
 import { fetchOccupationGapReport } from 'lib/workforce/repository';
-import type { WorkforceOccupationGapItem } from 'lib/workforce/types';
 import { createCohort, insertLevelUpAudit } from 'lib/level-up/repository';
 import {
   LEVEL_UP_AUTO_COHORT_ACTOR_ID,
   LEVEL_UP_AUTO_COHORT_DEFAULT_MILESTONES,
   LEVEL_UP_AUTO_COHORT_DEFAULTS,
+  type LevelUpProposalTermMonths,
 } from 'lib/level-up/constants';
 
 export type AutoCohortConfig = {
@@ -32,17 +35,29 @@ export type AutoCohortConfig = {
   defaultRequiredCredits: number;
   defaultTrainerSplitPercent: number;
   defaultCompletionBonusCredits: number;
+  generationIntervalDays: number;
+  lastGeneratedAt: string | null;
 };
 
 export type AutoCohortRunSummary = {
   ranAtIso: string;
   enabled: boolean;
-  skipped?: 'disabled' | 'no_workforce_share';
-  created: Array<{ cohortId: string; jobTitleId: string; occupation: string; sector: string; gap: number; endDate: string }>;
-  closed: Array<{ cohortId: string; occupation: string }>;
+  skipped?: 'disabled' | 'no_workforce_share' | 'cadence_not_due';
+  generated: number;
+  superseded: number;
   consideredOccupations: number;
-  alreadyCovered: number;
-  capacityRemaining: number;
+  closed: Array<{ cohortId: string; occupation: string }>;
+};
+
+export type PendingProposal = {
+  id: string;
+  sourceJobTitleId: string;
+  occupation: string;
+  sector: string;
+  skillLevel: string;
+  gap: number;
+  rank: number;
+  generatedAtIso: string;
 };
 
 type ConfigRow = {
@@ -57,13 +72,16 @@ type ConfigRow = {
   default_required_credits: string;
   default_trainer_split_percent: string;
   default_completion_bonus_credits: string;
+  generation_interval_days: number;
+  last_generated_at: string | null;
 };
 
 export async function getAutoCohortConfig(): Promise<AutoCohortConfig> {
   const result = await queryDb<ConfigRow>(
     `SELECT enabled, min_gap_threshold::text, max_concurrent, per_sector_cap, skill_level_filter, top_n,
             default_term_days, default_seats, default_required_credits::text,
-            default_trainer_split_percent::text, default_completion_bonus_credits::text
+            default_trainer_split_percent::text, default_completion_bonus_credits::text,
+            generation_interval_days, last_generated_at::text AS last_generated_at
      FROM level_up_auto_cohort_config
      WHERE singleton_key = TRUE
      LIMIT 1`,
@@ -84,6 +102,8 @@ export async function getAutoCohortConfig(): Promise<AutoCohortConfig> {
       defaultRequiredCredits: LEVEL_UP_AUTO_COHORT_DEFAULTS.defaultRequiredCredits,
       defaultTrainerSplitPercent: LEVEL_UP_AUTO_COHORT_DEFAULTS.defaultTrainerSplitPercent,
       defaultCompletionBonusCredits: LEVEL_UP_AUTO_COHORT_DEFAULTS.defaultCompletionBonusCredits,
+      generationIntervalDays: LEVEL_UP_AUTO_COHORT_DEFAULTS.generationIntervalDays,
+      lastGeneratedAt: null,
     };
   }
 
@@ -99,23 +119,14 @@ export async function getAutoCohortConfig(): Promise<AutoCohortConfig> {
     defaultRequiredCredits: Number(row.default_required_credits),
     defaultTrainerSplitPercent: Number(row.default_trainer_split_percent),
     defaultCompletionBonusCredits: Number(row.default_completion_bonus_credits),
+    generationIntervalDays: Number(row.generation_interval_days),
+    lastGeneratedAt: row.last_generated_at,
   };
-}
-
-async function getTermOverrideDays(): Promise<Map<string, number>> {
-  const result = await queryDb<{ job_title_id: string; term_days: number }>(
-    `SELECT job_title_id::text AS job_title_id, term_days FROM level_up_auto_cohort_term_overrides`,
-  );
-  const map = new Map<string, number>();
-  for (const row of result.rows) {
-    map.set(row.job_title_id, Number(row.term_days));
-  }
-  return map;
 }
 
 // Workforce demand depends on skills_taxonomy_sectors.workforce_share. If no sector carries a positive
 // share, Workforce falls back to an even split and the "largest gap" ordering is meaningless — so we
-// refuse to auto-create off that degenerate signal (issue #904 dependency note).
+// refuse to generate proposals off that degenerate signal (issue #904 dependency note).
 async function hasPositiveWorkforceShare(): Promise<boolean> {
   const result = await queryDb<{ total: string }>(
     `SELECT COUNT(*)::text AS total
@@ -125,15 +136,22 @@ async function hasPositiveWorkforceShare(): Promise<boolean> {
   return Number(result.rows[0]?.total ?? '0') > 0;
 }
 
-type ActiveAutoCohort = { job_title_id: string | null; sector: string | null };
-
-async function getActiveAutoCohorts(): Promise<ActiveAutoCohort[]> {
-  const result = await queryDb<ActiveAutoCohort>(
-    `SELECT source_job_title_id::text AS job_title_id, source_sector AS sector
+async function getActiveAutoCohortJobTitleIds(): Promise<Set<string>> {
+  const result = await queryDb<{ job_title_id: string | null }>(
+    `SELECT source_job_title_id::text AS job_title_id
      FROM level_up_cohorts
      WHERE auto_created = TRUE AND status IN ('open', 'active')`,
   );
-  return result.rows;
+  return new Set(result.rows.map((row) => row.job_title_id).filter((id): id is string => Boolean(id)));
+}
+
+async function getPendingProposalJobTitleIds(): Promise<Set<string>> {
+  const result = await queryDb<{ job_title_id: string }>(
+    `SELECT source_job_title_id::text AS job_title_id
+     FROM level_up_cohort_proposals
+     WHERE status = 'pending'`,
+  );
+  return new Set(result.rows.map((row) => row.job_title_id));
 }
 
 // Fixed-term lifecycle: an auto cohort whose term has elapsed is closed. A plain status flip is safe
@@ -148,169 +166,382 @@ async function closeExpiredAutoCohorts(): Promise<Array<{ cohortId: string; occu
   return result.rows.map((row) => ({ cohortId: row.id, occupation: row.track }));
 }
 
-function addDaysIso(days: number): string {
-  // Deterministic date math without Date.now timing concerns at the day grain.
-  const base = new Date();
-  base.setUTCHours(0, 0, 0, 0);
-  base.setUTCDate(base.getUTCDate() + days);
-  return base.toISOString().slice(0, 10);
-}
-
 function todayIso(): string {
   const base = new Date();
   base.setUTCHours(0, 0, 0, 0);
   return base.toISOString().slice(0, 10);
 }
 
+function addMonthsIso(startIso: string, months: number): string {
+  const [year, month, day] = startIso.split('-').map((part) => Number(part));
+  const base = new Date(Date.UTC(year, month - 1, day));
+  base.setUTCMonth(base.getUTCMonth() + months);
+  return base.toISOString().slice(0, 10);
+}
+
+function daysBetween(fromIso: string, toIso: string): number {
+  return (new Date(toIso).getTime() - new Date(fromIso).getTime()) / 86_400_000;
+}
+
 function isUniqueViolation(error: unknown): boolean {
   return Boolean(error) && typeof error === 'object' && (error as { code?: string }).code === '23505';
 }
 
+type Candidate = { jobTitleId: string; occupation: string; sector: string; skillLevel: string; gap: number };
+
 /**
- * Read the Workforce occupation gaps and stand up LevelUp cohorts for the largest of them, idempotently.
- * Safe to run repeatedly: the partial unique index and the already-covered check mean a re-run never
- * duplicates a cohort for an occupation. Also closes any auto cohort whose fixed term has elapsed.
+ * Sector-diverse ranking (owner decision 2026-07-23): pick round-robin across sectors so the top of the
+ * queue spans sectors rather than being dominated by one big-gap sector. Input `candidates` is already
+ * sorted largest-gap-first, so the first time we meet a sector it is at its largest gap — Map insertion
+ * order therefore orders sectors by their top gap. Each sector contributes at most `perSectorCap`; the
+ * whole queue is bounded by `topN` for reviewability.
  */
-export async function runAutoCohortCreation(input: { source: string } = { source: 'manual' }): Promise<AutoCohortRunSummary> {
-  const ranAtIso = new Date().toISOString();
-  const config = await getAutoCohortConfig();
-
-  const closed = await closeExpiredAutoCohorts();
-
-  if (!config.enabled) {
-    await insertLevelUpAudit({
-      actorId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
-      command: 'level-up.cohort.auto_create',
-      policyStatus: 'allow',
-      reason: 'disabled',
-      targetType: 'auto_cohort_run',
-      targetId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
-      metadata: { source: input.source, skipped: 'disabled', closed: closed.length },
-    });
-    return { ranAtIso, enabled: false, skipped: 'disabled', created: [], closed, consideredOccupations: 0, alreadyCovered: 0, capacityRemaining: 0 };
-  }
-
-  if (!(await hasPositiveWorkforceShare())) {
-    await insertLevelUpAudit({
-      actorId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
-      command: 'level-up.cohort.auto_create',
-      policyStatus: 'allow',
-      reason: 'no_workforce_share',
-      targetType: 'auto_cohort_run',
-      targetId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
-      metadata: { source: input.source, skipped: 'no_workforce_share', closed: closed.length },
-    });
-    return { ranAtIso, enabled: true, skipped: 'no_workforce_share', created: [], closed, consideredOccupations: 0, alreadyCovered: 0, capacityRemaining: 0 };
-  }
-
-  const [gaps, active, termOverrides] = await Promise.all([
-    fetchOccupationGapReport(),
-    getActiveAutoCohorts(),
-    getTermOverrideDays(),
-  ]);
-
-  const coveredJobTitleIds = new Set(active.map((row) => row.job_title_id).filter((id): id is string => Boolean(id)));
-  const perSectorCount = new Map<string, number>();
-  for (const row of active) {
-    const sector = row.sector ?? 'Unassigned';
-    perSectorCount.set(sector, (perSectorCount.get(sector) ?? 0) + 1);
-  }
-
-  let capacityRemaining = Math.max(0, config.maxConcurrent - active.length);
-
-  // Candidates: the configured skill level, gap at or above the threshold, largest gap first
-  // (the report is already sorted that way), capped at top N, and not already covered.
-  const candidates: WorkforceOccupationGapItem[] = gaps
-    .filter((item) => item.skillLevel === config.skillLevelFilter)
-    .filter((item) => item.gap >= config.minGapThreshold)
-    .slice(0, config.topN)
-    .filter((item) => !coveredJobTitleIds.has(item.jobTitleId));
-
-  const start = todayIso();
-  const created: AutoCohortRunSummary['created'] = [];
-
-  for (const item of candidates) {
-    if (capacityRemaining <= 0) {
-      break;
+function sectorDiverseOrder(candidates: Candidate[], perSectorCap: number, topN: number): Candidate[] {
+  const bySector = new Map<string, Candidate[]>();
+  for (const candidate of candidates) {
+    const list = bySector.get(candidate.sector);
+    if (list) {
+      list.push(candidate);
+    } else {
+      bySector.set(candidate.sector, [candidate]);
     }
-    const sector = item.sector || 'Unassigned';
-    if ((perSectorCount.get(sector) ?? 0) >= config.perSectorCap) {
-      continue;
-    }
+  }
 
-    const termDays = termOverrides.get(item.jobTitleId) ?? config.defaultTermDays;
-    const endDate = addDaysIso(termDays);
+  const sectors = [...bySector.keys()];
+  const takenPerSector = new Map<string, number>();
+  const ranked: Candidate[] = [];
+  const cap = Math.max(1, perSectorCap);
+  const limit = Math.max(0, topN);
 
-    try {
-      const result = await createCohort({
-        actorId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
-        // Deterministic key so a same-run retry maps to the same cohort row.
-        idempotencyKey: `auto-cohort:${item.jobTitleId}:${start}`,
-        title: `LevelUp: ${item.occupation}`,
-        description: `Auto-created training cohort for ${item.occupation} (${sector}). Stood up from the Workforce talent gap for this occupation.`,
-        track: item.occupation,
-        seats: config.defaultSeats,
-        startDate: start,
-        endDate,
-        // Economic policy: one global, admin-editable default applied to every auto cohort (per-occupation
-        // tuning deferred — issue #1197). A deposit is only required when defaultRequiredCredits > 0.
-        requiredCredits: config.defaultRequiredCredits,
-        allowNoDeposit: config.defaultRequiredCredits <= 0,
-        trainerSplitPercent: config.defaultTrainerSplitPercent,
-        completionBonusCredits: config.defaultCompletionBonusCredits,
-        // Milestones drive the escrow split, the trainer payout, and the completion bonus on release.
-        milestones: LEVEL_UP_AUTO_COHORT_DEFAULT_MILESTONES.map((m) => ({ ...m })),
-        status: 'open',
-        autoCreated: true,
-        sourceJobTitleId: item.jobTitleId,
-        sourceSector: sector,
-        sourceGapAtCreation: item.gap,
-      });
-
-      created.push({ cohortId: result.cohortId, jobTitleId: item.jobTitleId, occupation: item.occupation, sector, gap: item.gap, endDate });
-      coveredJobTitleIds.add(item.jobTitleId);
-      perSectorCount.set(sector, (perSectorCount.get(sector) ?? 0) + 1);
-      capacityRemaining -= 1;
-
-      await insertLevelUpAudit({
-        actorId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
-        command: 'level-up.cohort.auto_create',
-        policyStatus: 'allow',
-        reason: 'ok',
-        targetType: 'cohort',
-        targetId: result.cohortId,
-        metadata: { source: input.source, jobTitleId: item.jobTitleId, occupation: item.occupation, sector, gap: item.gap, termDays },
-      });
-    } catch (error) {
-      // A concurrent run may have created the same occupation's cohort between our read and write.
-      // The partial unique index rejects the duplicate — treat it as already covered, not a failure.
-      if (isUniqueViolation(error)) {
-        coveredJobTitleIds.add(item.jobTitleId);
+  let progressed = true;
+  while (progressed && ranked.length < limit) {
+    progressed = false;
+    for (const sector of sectors) {
+      if (ranked.length >= limit) {
+        break;
+      }
+      const taken = takenPerSector.get(sector) ?? 0;
+      if (taken >= cap) {
         continue;
       }
-      throw error;
+      const list = bySector.get(sector);
+      if (!list || taken >= list.length) {
+        continue;
+      }
+      ranked.push(list[taken]);
+      takenPerSector.set(sector, taken + 1);
+      progressed = true;
     }
   }
 
+  return ranked;
+}
+
+/**
+ * Read the Workforce gaps and refresh the pending proposal queue. Ranked, sector-diverse, deduped
+ * against occupations already covered by an open/active auto cohort. Existing pending proposals that
+ * are no longer valid (occupation now covered, or gap fell below the threshold) are superseded. Does
+ * NOT create cohorts.
+ */
+export async function generateCohortProposals(input: {
+  config: AutoCohortConfig;
+  source: string;
+}): Promise<{ generated: number; superseded: number; considered: number; skipped?: 'no_workforce_share' }> {
+  if (!(await hasPositiveWorkforceShare())) {
+    return { generated: 0, superseded: 0, considered: 0, skipped: 'no_workforce_share' };
+  }
+
+  const [gaps, coveredJobTitleIds] = await Promise.all([fetchOccupationGapReport(), getActiveAutoCohortJobTitleIds()]);
+
+  const candidates: Candidate[] = gaps
+    .filter((item) => item.skillLevel === input.config.skillLevelFilter)
+    .filter((item) => item.gap >= input.config.minGapThreshold)
+    .filter((item) => !coveredJobTitleIds.has(item.jobTitleId))
+    .map((item) => ({
+      jobTitleId: item.jobTitleId,
+      occupation: item.occupation,
+      sector: item.sector || 'Unassigned',
+      skillLevel: item.skillLevel,
+      gap: item.gap,
+    }));
+
+  const ranked = sectorDiverseOrder(candidates, input.config.perSectorCap, input.config.topN);
+  const freshIds = ranked.map((candidate) => candidate.jobTitleId);
+
+  const pendingBefore = await getPendingProposalJobTitleIds();
+
+  const outcome = await withDbTransaction(async (client) => {
+    // Supersede pending proposals no longer in the fresh set (occupation covered or gap below threshold).
+    const superseded = await client.query(
+      `UPDATE level_up_cohort_proposals
+       SET status = 'superseded', updated_at = NOW()
+       WHERE status = 'pending' AND NOT (source_job_title_id = ANY($1::uuid[]))`,
+      [freshIds],
+    );
+
+    for (let index = 0; index < ranked.length; index += 1) {
+      const candidate = ranked[index];
+      const rank = index + 1;
+      if (pendingBefore.has(candidate.jobTitleId)) {
+        await client.query(
+          `UPDATE level_up_cohort_proposals
+           SET occupation = $2, sector = $3, skill_level = $4, gap_at_proposal = $5, rank = $6,
+               generated_source = $7, generated_at = NOW(), updated_at = NOW()
+           WHERE source_job_title_id = $1::uuid AND status = 'pending'`,
+          [candidate.jobTitleId, candidate.occupation, candidate.sector, candidate.skillLevel, candidate.gap, rank, input.source],
+        );
+      } else {
+        await client.query(
+          `INSERT INTO level_up_cohort_proposals
+             (source_job_title_id, occupation, sector, skill_level, gap_at_proposal, rank, status, generated_source)
+           VALUES ($1::uuid, $2, $3, $4, $5, $6, 'pending', $7)`,
+          [candidate.jobTitleId, candidate.occupation, candidate.sector, candidate.skillLevel, candidate.gap, rank, input.source],
+        );
+      }
+    }
+
+    // Stamp the cadence timestamp (upsert so a missing singleton row does not stall the 90-day cadence).
+    await client.query(
+      `INSERT INTO level_up_auto_cohort_config (singleton_key, last_generated_at)
+       VALUES (TRUE, NOW())
+       ON CONFLICT (singleton_key) DO UPDATE SET last_generated_at = NOW(), updated_at = NOW()`,
+    );
+
+    return { superseded: superseded.rowCount ?? 0 };
+  });
+
+  return { generated: ranked.length, superseded: outcome.superseded, considered: candidates.length };
+}
+
+async function auditRun(reason: string, metadata: Record<string, unknown>): Promise<void> {
   await insertLevelUpAudit({
     actorId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
     command: 'level-up.cohort.auto_create',
     policyStatus: 'allow',
-    reason: 'ok',
+    reason,
     targetType: 'auto_cohort_run',
     targetId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
-    metadata: { source: input.source, created: created.length, closed: closed.length, consideredOccupations: candidates.length },
+    metadata,
+  });
+}
+
+/**
+ * The entry the cron and the admin "Refresh proposals" button call. Always closes expired auto cohorts;
+ * regenerates the proposal queue only when forced (admin refresh) or the 90-day cadence is due (cron).
+ */
+export async function runAutoCohortProposals(
+  input: { source: string; force?: boolean } = { source: 'manual' },
+): Promise<AutoCohortRunSummary> {
+  const ranAtIso = new Date().toISOString();
+  const config = await getAutoCohortConfig();
+  const closed = await closeExpiredAutoCohorts();
+
+  if (!config.enabled) {
+    await auditRun('disabled', { source: input.source, skipped: 'disabled', closed: closed.length });
+    return { ranAtIso, enabled: false, skipped: 'disabled', generated: 0, superseded: 0, consideredOccupations: 0, closed };
+  }
+
+  const due =
+    Boolean(input.force) ||
+    config.lastGeneratedAt == null ||
+    daysBetween(config.lastGeneratedAt, ranAtIso) >= config.generationIntervalDays;
+
+  if (!due) {
+    await auditRun('cadence_not_due', { source: input.source, skipped: 'cadence_not_due', closed: closed.length });
+    return { ranAtIso, enabled: true, skipped: 'cadence_not_due', generated: 0, superseded: 0, consideredOccupations: 0, closed };
+  }
+
+  const generation = await generateCohortProposals({ config, source: input.source });
+
+  await auditRun(generation.skipped ?? 'ok', {
+    source: input.source,
+    skipped: generation.skipped,
+    generated: generation.generated,
+    superseded: generation.superseded,
+    considered: generation.considered,
+    closed: closed.length,
   });
 
   return {
     ranAtIso,
     enabled: true,
-    created,
+    skipped: generation.skipped,
+    generated: generation.generated,
+    superseded: generation.superseded,
+    consideredOccupations: generation.considered,
     closed,
-    consideredOccupations: candidates.length,
-    alreadyCovered: coveredJobTitleIds.size,
-    capacityRemaining,
   };
+}
+
+export async function listPendingProposals(limit = 100): Promise<PendingProposal[]> {
+  const result = await queryDb<{
+    id: string;
+    source_job_title_id: string;
+    occupation: string;
+    sector: string;
+    skill_level: string;
+    gap_at_proposal: string;
+    rank: number;
+    generated_at: string;
+  }>(
+    `SELECT id::text, source_job_title_id::text, occupation, sector, skill_level,
+            gap_at_proposal::text, rank, generated_at
+     FROM level_up_cohort_proposals
+     WHERE status = 'pending'
+     ORDER BY rank ASC, gap_at_proposal DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    sourceJobTitleId: row.source_job_title_id,
+    occupation: row.occupation,
+    sector: row.sector,
+    skillLevel: row.skill_level,
+    gap: Number(row.gap_at_proposal),
+    rank: row.rank,
+    generatedAtIso: new Date(row.generated_at).toISOString(),
+  }));
+}
+
+export type ApproveProposalResult =
+  | { status: 'approved'; proposalId: string; cohortId: string; occupation: string; endDate: string }
+  | { status: 'already_covered'; proposalId: string; occupation: string };
+
+/**
+ * Admin approves a pending proposal: opens a real cohort with the chosen 1/3/5-month term. The proposal
+ * is claimed atomically (guarded on `status='pending'`) before the cohort is created, so it cannot be
+ * double-approved. If the occupation already has an open auto cohort (the unique-cohort guard fires),
+ * the proposal is marked superseded and no cohort is opened.
+ */
+export async function approveCohortProposal(input: {
+  actorId: string;
+  proposalId: string;
+  termMonths: LevelUpProposalTermMonths;
+}): Promise<ApproveProposalResult> {
+  const config = await getAutoCohortConfig();
+
+  const claim = await queryDb<{
+    source_job_title_id: string;
+    occupation: string;
+    sector: string;
+    gap_at_proposal: string;
+  }>(
+    `UPDATE level_up_cohort_proposals
+     SET status = 'approved', decided_by_user_id = $2, decided_at = NOW(), updated_at = NOW()
+     WHERE id = $1::uuid AND status = 'pending'
+     RETURNING source_job_title_id::text, occupation, sector, gap_at_proposal::text`,
+    [input.proposalId, input.actorId],
+  );
+
+  const proposal = claim.rows[0];
+  if (!proposal) {
+    throw new Error('invalid_state');
+  }
+
+  const startDate = todayIso();
+  const endDate = addMonthsIso(startDate, input.termMonths);
+
+  try {
+    const created = await createCohort({
+      actorId: LEVEL_UP_AUTO_COHORT_ACTOR_ID,
+      idempotencyKey: `proposal-approve:${input.proposalId}`,
+      title: `LevelUp: ${proposal.occupation}`,
+      description: `Training cohort for ${proposal.occupation} (${proposal.sector}). Approved from the Workforce talent-gap proposal queue.`,
+      track: proposal.occupation,
+      seats: config.defaultSeats,
+      startDate,
+      endDate,
+      // One global economic policy (per-occupation tuning deferred, #1197). A deposit is only required
+      // when defaultRequiredCredits > 0.
+      requiredCredits: config.defaultRequiredCredits,
+      allowNoDeposit: config.defaultRequiredCredits <= 0,
+      trainerSplitPercent: config.defaultTrainerSplitPercent,
+      completionBonusCredits: config.defaultCompletionBonusCredits,
+      milestones: LEVEL_UP_AUTO_COHORT_DEFAULT_MILESTONES.map((milestone) => ({ ...milestone })),
+      status: 'open',
+      autoCreated: true,
+      sourceJobTitleId: proposal.source_job_title_id,
+      sourceSector: proposal.sector,
+      sourceGapAtCreation: Number(proposal.gap_at_proposal),
+    });
+
+    await queryDb(
+      `UPDATE level_up_cohort_proposals SET created_cohort_id = $2::uuid, updated_at = NOW() WHERE id = $1::uuid`,
+      [input.proposalId, created.cohortId],
+    );
+
+    await insertLevelUpAudit({
+      actorId: input.actorId,
+      command: 'level-up.cohort.proposal_approve',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'cohort',
+      targetId: created.cohortId,
+      metadata: {
+        proposalId: input.proposalId,
+        occupation: proposal.occupation,
+        sector: proposal.sector,
+        termMonths: input.termMonths,
+        endDate,
+        targetContext: { cohortId: created.cohortId },
+      },
+    });
+
+    return { status: 'approved', proposalId: input.proposalId, cohortId: created.cohortId, occupation: proposal.occupation, endDate };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      // The occupation already has an open auto cohort — do not open a second. Mark the proposal
+      // superseded rather than leaving it stuck in 'approved' with no cohort.
+      await queryDb(
+        `UPDATE level_up_cohort_proposals
+         SET status = 'superseded', created_cohort_id = NULL, updated_at = NOW()
+         WHERE id = $1::uuid`,
+        [input.proposalId],
+      );
+      return { status: 'already_covered', proposalId: input.proposalId, occupation: proposal.occupation };
+    }
+
+    // Unexpected failure — return the proposal to the queue so it can be retried.
+    await queryDb(
+      `UPDATE level_up_cohort_proposals
+       SET status = 'pending', decided_by_user_id = NULL, decided_at = NULL, updated_at = NOW()
+       WHERE id = $1::uuid`,
+      [input.proposalId],
+    );
+    throw error;
+  }
+}
+
+export async function dismissCohortProposal(input: {
+  actorId: string;
+  proposalId: string;
+}): Promise<{ status: 'dismissed'; proposalId: string; occupation: string }> {
+  const result = await queryDb<{ occupation: string }>(
+    `UPDATE level_up_cohort_proposals
+     SET status = 'dismissed', decided_by_user_id = $2, decided_at = NOW(), updated_at = NOW()
+     WHERE id = $1::uuid AND status = 'pending'
+     RETURNING occupation`,
+    [input.proposalId, input.actorId],
+  );
+
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error('invalid_state');
+  }
+
+  await insertLevelUpAudit({
+    actorId: input.actorId,
+    command: 'level-up.cohort.proposal_dismiss',
+    policyStatus: 'allow',
+    reason: 'ok',
+    targetType: 'cohort_proposal',
+    targetId: input.proposalId,
+    metadata: { proposalId: input.proposalId, occupation: row.occupation, targetContext: { proposalId: input.proposalId } },
+  });
+
+  return { status: 'dismissed', proposalId: input.proposalId, occupation: row.occupation };
 }
 
 /**

--- a/ctf/packages/web/lib/level-up/constants.ts
+++ b/ctf/packages/web/lib/level-up/constants.ts
@@ -35,7 +35,15 @@ export const LEVEL_UP_AUTO_COHORT_DEFAULTS = {
   defaultRequiredCredits: 0,
   defaultTrainerSplitPercent: 25,
   defaultCompletionBonusCredits: 0,
+  // Proposal-queue cadence (owner decision 2026-07-23): re-read the Workforce gaps into proposals at
+  // most this often. Cohort expiry is still checked on every run.
+  generationIntervalDays: 90,
 } as const;
+
+// Term choices offered to the admin when approving a proposal (owner decision 2026-07-23): the admin
+// picks one and the cohort opens with that end date. Months, not days, so the term reads naturally.
+export const LEVEL_UP_PROPOSAL_TERM_MONTHS = [1, 3, 5] as const;
+export type LevelUpProposalTermMonths = (typeof LEVEL_UP_PROPOSAL_TERM_MONTHS)[number];
 
 // Default milestone skeleton stamped onto every auto-created cohort (issue #904). Milestones are what
 // drive the escrow split, the trainer payout, and the completion bonus on release — without them an

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -2849,6 +2849,10 @@ CREATE TABLE IF NOT EXISTS level_up_auto_cohort_config (
   default_required_credits NUMERIC NOT NULL DEFAULT 0,
   default_trainer_split_percent NUMERIC NOT NULL DEFAULT 25,
   default_completion_bonus_credits NUMERIC NOT NULL DEFAULT 0,
+  -- Proposal-queue cadence (issue #904, 2026-07-23): how often gaps are re-read into proposals,
+  -- and when they were last read.
+  generation_interval_days INTEGER NOT NULL DEFAULT 90,
+  last_generated_at TIMESTAMPTZ,
   updated_by_user_id TEXT NOT NULL DEFAULT 'system',
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -2865,6 +2869,11 @@ ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS defau
 ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS default_completion_bonus_credits NUMERIC NOT NULL DEFAULT 0;
 ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS updated_by_user_id TEXT NOT NULL DEFAULT 'system';
 ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Proposal-queue model (issue #904, owner decision 2026-07-23): gaps are re-read on a cadence and
+-- turned into an admin-approved proposal queue, not auto-created cohorts. generation_interval_days is
+-- how often the gaps are re-read (default 90); last_generated_at gates the cadence.
+ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS generation_interval_days INTEGER NOT NULL DEFAULT 90;
+ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS last_generated_at TIMESTAMPTZ;
 
 -- Per-occupation term overrides (issue #904): admins set how long a given occupation's auto cohort
 -- runs ("Mechanics × term", "Elementary teachers × term"); falls back to default_term_days when absent.
@@ -2879,6 +2888,51 @@ ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXIS
 ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXISTS term_days INTEGER NOT NULL DEFAULT 90;
 ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXISTS updated_by_user_id TEXT NOT NULL DEFAULT 'system';
 ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Cohort proposal queue (issue #904, owner decision 2026-07-23). Instead of auto-creating cohorts,
+-- the scheduled run reads the Workforce gaps and writes ranked, sector-diverse *proposals* here; an
+-- admin approves one (choosing a 1/3/5-month term, which opens a real cohort) or dismisses it. Status:
+-- pending (awaiting a decision), approved (a cohort was opened — see created_cohort_id), dismissed
+-- (admin declined), superseded (a later generation invalidated it — occupation now covered or gap fell
+-- below threshold).
+CREATE TABLE IF NOT EXISTS level_up_cohort_proposals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_job_title_id UUID NOT NULL,
+  occupation TEXT NOT NULL,
+  sector TEXT NOT NULL DEFAULT 'Unassigned',
+  skill_level TEXT NOT NULL DEFAULT '',
+  gap_at_proposal NUMERIC NOT NULL DEFAULT 0,
+  rank INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'pending',
+  generated_source TEXT NOT NULL DEFAULT 'cron',
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  decided_by_user_id TEXT,
+  decided_at TIMESTAMPTZ,
+  created_cohort_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS source_job_title_id UUID;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS occupation TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS sector TEXT NOT NULL DEFAULT 'Unassigned';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS skill_level TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS gap_at_proposal NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS rank INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS generated_source TEXT NOT NULL DEFAULT 'cron';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS decided_by_user_id TEXT;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS decided_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS created_cohort_id UUID;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- At most one live (pending) proposal per occupation — mirrors uq_level_up_auto_cohort_active_source.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_level_up_cohort_proposal_pending
+  ON level_up_cohort_proposals (source_job_title_id)
+  WHERE status = 'pending';
+-- Ranked read of the live queue for the admin surface.
+CREATE INDEX IF NOT EXISTS idx_level_up_cohort_proposal_pending_rank
+  ON level_up_cohort_proposals (status, rank);
 
 CREATE TABLE IF NOT EXISTS level_up_curriculum_items (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2851,6 +2851,10 @@ CREATE TABLE IF NOT EXISTS level_up_auto_cohort_config (
   default_required_credits NUMERIC NOT NULL DEFAULT 0,
   default_trainer_split_percent NUMERIC NOT NULL DEFAULT 25,
   default_completion_bonus_credits NUMERIC NOT NULL DEFAULT 0,
+  -- Proposal-queue cadence (issue #904, 2026-07-23): how often gaps are re-read into proposals,
+  -- and when they were last read.
+  generation_interval_days INTEGER NOT NULL DEFAULT 90,
+  last_generated_at TIMESTAMPTZ,
   updated_by_user_id TEXT NOT NULL DEFAULT 'system',
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -2867,6 +2871,11 @@ ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS defau
 ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS default_completion_bonus_credits NUMERIC NOT NULL DEFAULT 0;
 ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS updated_by_user_id TEXT NOT NULL DEFAULT 'system';
 ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- Proposal-queue model (issue #904, owner decision 2026-07-23): gaps are re-read on a cadence and
+-- turned into an admin-approved proposal queue, not auto-created cohorts. generation_interval_days is
+-- how often the gaps are re-read (default 90); last_generated_at gates the cadence.
+ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS generation_interval_days INTEGER NOT NULL DEFAULT 90;
+ALTER TABLE IF EXISTS level_up_auto_cohort_config ADD COLUMN IF NOT EXISTS last_generated_at TIMESTAMPTZ;
 
 -- Per-occupation term overrides (issue #904): admins set how long a given occupation's auto cohort
 -- runs ("Mechanics × term", "Elementary teachers × term"); falls back to default_term_days when absent.
@@ -2881,6 +2890,51 @@ ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXIS
 ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXISTS term_days INTEGER NOT NULL DEFAULT 90;
 ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXISTS updated_by_user_id TEXT NOT NULL DEFAULT 'system';
 ALTER TABLE IF EXISTS level_up_auto_cohort_term_overrides ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Cohort proposal queue (issue #904, owner decision 2026-07-23). Instead of auto-creating cohorts,
+-- the scheduled run reads the Workforce gaps and writes ranked, sector-diverse *proposals* here; an
+-- admin approves one (choosing a 1/3/5-month term, which opens a real cohort) or dismisses it. Status:
+-- pending (awaiting a decision), approved (a cohort was opened — see created_cohort_id), dismissed
+-- (admin declined), superseded (a later generation invalidated it — occupation now covered or gap fell
+-- below threshold).
+CREATE TABLE IF NOT EXISTS level_up_cohort_proposals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_job_title_id UUID NOT NULL,
+  occupation TEXT NOT NULL,
+  sector TEXT NOT NULL DEFAULT 'Unassigned',
+  skill_level TEXT NOT NULL DEFAULT '',
+  gap_at_proposal NUMERIC NOT NULL DEFAULT 0,
+  rank INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'pending',
+  generated_source TEXT NOT NULL DEFAULT 'cron',
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  decided_by_user_id TEXT,
+  decided_at TIMESTAMPTZ,
+  created_cohort_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS source_job_title_id UUID;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS occupation TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS sector TEXT NOT NULL DEFAULT 'Unassigned';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS skill_level TEXT NOT NULL DEFAULT '';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS gap_at_proposal NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS rank INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS generated_source TEXT NOT NULL DEFAULT 'cron';
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS decided_by_user_id TEXT;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS decided_at TIMESTAMPTZ;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS created_cohort_id UUID;
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS level_up_cohort_proposals ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- At most one live (pending) proposal per occupation — mirrors uq_level_up_auto_cohort_active_source.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_level_up_cohort_proposal_pending
+  ON level_up_cohort_proposals (source_job_title_id)
+  WHERE status = 'pending';
+-- Ranked read of the live queue for the admin surface.
+CREATE INDEX IF NOT EXISTS idx_level_up_cohort_proposal_pending_rank
+  ON level_up_cohort_proposals (status, rank);
 
 CREATE TABLE IF NOT EXISTS level_up_curriculum_items (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
Closes #904.

Delivers #904 as an **admin-approved proposal queue** rather than auto-creating cohorts, per your decisions (small active user base): LevelUp re-reads the Workforce gaps on a cadence into a ranked, sector-diverse queue; you approve a proposal (choosing the term) to open a cohort, and open/close at your discretion. Full auto-create and a demand-prediction algorithm are deferred.

## Your decisions → what this builds

| Decision | Implementation |
|---|---|
| Proposal queue, not auto-create | New `level_up_cohort_proposals` table; the run **generates proposals**, never cohorts |
| Re-read every 90 days | `generation_interval_days` (default 90) + `last_generated_at` cadence guard; daily cron still closes expired cohorts |
| No max-concurrent; per-sector limit for diversity | Generation ignores `max_concurrent`; ranks **sector-diverse** (round-robin across sectors, `per_sector_cap` per sector) |
| You pick the term (1/3/5 mo) at approval | Approve route takes `termMonths ∈ {1,3,5}`; cohort opens `end = today + term` |
| Foundational only | `skill_level_filter` unchanged (admin-editable) |
| Sector first, then job title | Sectors ordered by top gap; occupations largest-gap-first within a sector |

## What's here

- **Schema:** `level_up_cohort_proposals` (status `pending`/`approved`/`dismissed`/`superseded`; partial unique index → one pending per occupation) + two config columns. `schema.demo.sql` regenerated.
- **Engine** (`lib/level-up/auto-cohort.ts` rewritten): `generateCohortProposals`, `runAutoCohortProposals` (close expired always; regenerate on force or 90-day cadence), `approveCohortProposal` (double-approve-guarded; already-covered → superseded), `dismissCohortProposal`, `listPendingProposals`.
- **Routes:** repointed `admin/auto-cohorts/run` (force refresh) and the cron route (cadence-gated); new `GET admin/cohort-proposals`, `POST …/[proposalId]/approve`, `POST …/[proposalId]/dismiss` (admin + CSRF).
- **Admin UI:** the "Run now" button becomes **Refresh proposals**, plus a ranked proposal queue (occupation · sector · gap) with a term selector and **Approve & open** / **Dismiss**.
- **Contracts / cron / inventory / manual test script (LU-A4/A5/A6)** all updated.

## Deferred (documented in inventory + here)

Full auto-create without approval and the demand-*prediction* algorithm (tracking Workforce trends to forecast demand — where `max_concurrent` becomes load-bearing again); per-occupation economic tuning (#1197); trainer-adjustable term at claim (you chose admin-picks-at-approval).

## Verification

Typecheck (all workspaces), eslint, EOF, inventory-drift, test-script-drift, and schema-drift gates pass locally. I traced the generation/approve/supersede paths against the SQL and route shapes. A full click-through needs a seeded DB with Workforce gap data + a Clerk admin session, which isn't available in this sandbox — the manual test script (LU-A4–A6) covers that end-to-end pass.

This touches schema, new stateful logic, and new API contracts, so per the repo's two-lane policy it's in the **owner-review lane**: opened ready for review, **auto-merge not enabled** — for you to review and merge.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (LevelUp is web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_014xGYLddtzF7x2vnTh8dzu8)_