### PR TITLE
fix: AI Assistant consent "Not now" no longer prefills the composer

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -2677,10 +2677,11 @@
 .comicConsentTrigger {
   font-size: 13px;
   color: #A78BFA;
-  display: flex;
-  align-items: center;
-  gap: 5px;
+  /* Normal text flow (NOT flex): the sentence and the @comic token must read as one line and wrap
+     together. As a flex row the wrapped text and the token became two items, floating @comic to the
+     right, vertically centered against the wrapped subtitle. */
   margin: 2px 0 0;
+  line-height: 1.4;
 }
 
 .comicConsentTriggerToken {

--- a/ctf/packages/web/components/community-shell/use-home-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-home-chat.ts
@@ -830,15 +830,15 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
     }
   }, [currentUser.userId, pendingConsentText, routeToComic]);
 
-  // Consent modal "Not now": do not route; keep the question in the composer so the asker can edit
-  // or send it as a normal post.
+  // Consent modal "Not now": do not route, and do NOT populate the composer. When the modal was
+  // opened from a composer-typed @comic message the text is already in the input (the send path never
+  // cleared it), so it stays put on its own. When it was opened from a one-tap suggestion chip the
+  // input was empty, so we must leave it empty — dropping the chip's "@comic …" question into the box
+  // (the old behavior) looked like a message queued to send that the member never wrote.
   const dismissConsent = useCallback(() => {
     setConsentModalOpen(false);
-    if (pendingConsentText) {
-      setInput(pendingConsentText);
-    }
     setPendingConsentText(null);
-  }, [pendingConsentText]);
+  }, []);
 
   // Rate an answered AI Assistant card. Optimistically reflects the choice; reverts on failure.
   const rateComicAnswer = useCallback(


### PR DESCRIPTION
Two small Commons (Survivor Hub) fixes that were built earlier but never got a PR (the PR-create endpoint was returning 500s at the time). The first bug is still live on `main`.

## What changed

- **"Not now" no longer prefills the composer.** In `use-home-chat.ts`, `dismissConsent` used to call `setInput(pendingConsentText)`, so dismissing the first-use AI Assistant (@comic) consent dropped the pending question into the message box — which reads as a peer post about to be sent. It now just closes the prompt and clears the pending text.
- **@comic reads inline in the consent header.** In `community-shell.module.css`, `.comicConsentTrigger` was a flex row that pushed "@comic" onto its own line; it now flows as normal inline text.

UI-only — no schema, route, or contract change.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_