### PR TITLE
docs: PeerProgramming copy — placement is for active members, not everyone

### DIFF
--- a/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
@@ -40,7 +40,7 @@ function MobilePeerProgrammingPublic({ signInUrl, verifyUrl }: { signInUrl: stri
           <span style={{ fontSize: 20, fontWeight: 800 }}>PeerProgramming</span>
         </div>
         <span style={{ padding: '3px 12px', borderRadius: 20, background: t.ACCENT + '20', border: `1px solid ${t.ACCENT}40`, fontSize: 11, color: t.ACCENT, fontWeight: 600, width: 'fit-content' }}>Deterministic global cohorts</span>
-        <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Weekly cohorts of up to 12 people, open worldwide. You&apos;re always placed — no competitive selection, guaranteed spot.</p>
+        <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Weekly cohorts of up to 12 people, open worldwide. Active members are placed automatically each week — no competitive selection.</p>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
           <Globe size={13} color={t.MUTED} />
           <span style={{ fontSize: 12, color: t.MUTED }}>Open to members worldwide</span>

--- a/ctf/packages/web/components/peer-programming/pp-cohorts-tab.tsx
+++ b/ctf/packages/web/components/peer-programming/pp-cohorts-tab.tsx
@@ -189,7 +189,7 @@ export function PeerProgrammingCohortsTab({
     <div style={{ flex: 1, overflowY: "auto", minHeight: 0, padding: 24 }}>
       <div style={{ marginBottom: 20, padding: "18px 24px", borderRadius: 16, background: `linear-gradient(135deg,${t.ACCENT}15 0%,rgba(139,92,246,0.05) 100%)`, border: `1px solid ${t.ACCENT}25` }}>
         <div style={{ fontSize: 20, fontWeight: 800, color: t.TITLE, marginBottom: 4 }}>Weekly Global Masterminds</div>
-        <div style={{ fontSize: 14, color: t.SUBTLE }}>Deterministic placement — you always get a cohort. No one left behind.</div>
+        <div style={{ fontSize: 14, color: t.SUBTLE }}>Active members get placed each week — sign in during the week and you&apos;re in a cohort. No competitive selection.</div>
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
         {!myCohortId ? (


### PR DESCRIPTION
The "Weekly Global Masterminds" title is correct, but the placement description overpromised — it implied **everyone** gets a cohort. Placement only covers **active members** (login within the last 7 days), which is how the weekly assignment actually works (and what the feature inventory already says).

Changed:
- **Cohorts hero** (`pp-cohorts-tab.tsx`): "Deterministic placement — you always get a cohort. No one left behind." → "Active members get placed each week — sign in during the week and you're in a cohort. No competitive selection."
- **Public landing** (`peer-programming-public-shell.tsx`): "You're always placed — no competitive selection, guaranteed spot." → "Active members are placed automatically each week — no competitive selection."

Copy-only; no schema, route, or contract change. Title unchanged. The inventory already documents active-only placement, so no docs update was needed.

Parity Status: web + mobile-responsive + android complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9MrCqXg3EkpfnEAbpotd3)_