### PR TITLE
feat: JSON data export on Account &amp; Data (download your data)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,9 @@ jobs:
       - name: Validate account deletion engine SQL generation
         run: node ctf/scripts/check-deletion-engine.mjs
 
+      - name: Validate account data-export engine SQL generation
+        run: node ctf/scripts/check-export-engine.mjs
+
   inventory-drift-gate:
     name: Inventory Drift Gate
     runs-on: ubuntu-latest

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -36,17 +36,41 @@
   deletion in a single transaction, records one `account_deletion_events` row, logs an
   `[account.audit]` line. Money is settled only by the existing ServiceCredits reclaim flow, never
   hard-deleted here.
+- `ctf/packages/web/lib/account/export-engine.ts` + `export-orchestrator.ts` — the read-side twin of
+  the deletion engine (issue #1264, JSON data export). The engine is a pure planner over the SAME
+  deletion registry: every table with a `userColumn` becomes
+  `SELECT * FROM <table> WHERE <userColumn> = $1` (the authenticated user id is always the bound
+  parameter, never inlined); `retain` tables (money ledgers, audit trails, shared content) have no
+  user column and are skipped — the MVP export scope, stated honestly in the file's `notes`.
+  Checked without a DB by `ctf/scripts/check-export-engine.mjs` (wired into CI beside the deletion
+  engine check). The orchestrator assembles the self-describing envelope
+  `{ exportVersion: 1, generatedAtIso, userId, scope, services[], notes[] }` in ONE transaction so
+  the file is a consistent snapshot; each service carries
+  `{ slug, name, tables: [{ table, userColumn, rowCount, rows }] }`.
 - API:
   - `GET /api/account/services` — read-only projection of the deletion registry for the Account &
     Data UI. Returns `{ ok, deletable[], retained[], counts }`, where each entry is
-    `{ slug, name, summary, serviceScopeSupported }` taken straight from the registry (no copy is
-    stored in the route or the UI). `deletable` = `serviceScopeSupported === true`; `retained` =
-    `false` (ServiceCredits wallet/ledger kept for financial integrity, settled at full-account
-    deletion; GDP / Weekly Performance hold only community-wide aggregate totals). Gated by
-    `requireAccountAccess` (any signed-in identity, read-only — no CSRF needed).
+    `{ slug, name, summary, serviceScopeSupported, exportable }` taken straight from the registry (no
+    copy is stored in the route or the UI). `deletable` = `serviceScopeSupported === true`;
+    `retained` = `false` (ServiceCredits wallet/ledger kept for financial integrity, settled at
+    full-account deletion; GDP / Weekly Performance hold only community-wide aggregate totals).
+    `exportable` marks services with ≥1 user-scoped table, i.e. where the JSON export has anything to
+    read — independent of deletability (Notifications and Contributor Access are retained-scope for
+    delete but still exportable). Gated by `requireAccountAccess` (any signed-in identity, read-only
+    — no CSRF needed).
   - `DELETE /api/account/services/:slug` (one plugin) and `DELETE /api/account/full-account`
     (every plugin + ServiceCredits reclaim). Both are self-service (caller's own rows only) and
     same-origin CSRF-guarded (`x-ctf-csrf: 1`).
+  - `GET /api/account/services/:slug/export` and `GET /api/account/full-account/export` (issue
+    #1264) — download the member's own data as JSON, per service or whole account. Both gated by
+    `requireAccountAccess`, read-only (no CSRF needed on GET), returned with
+    `Content-Disposition: attachment; filename="ctf-account-data-<scope>-<date>.json"` and
+    `Cache-Control: no-store`. Any registry slug is exportable (a service with nothing user-scoped
+    returns an honest zero-table envelope; an unknown slug is 404 `ACCOUNT_UNKNOWN_SERVICE`).
+    Audit-logged as `account.data.export.service` / `account.data.export.full` (`[account.audit]`
+    line with table/row counts, no personal data), and rate-limited per user (10 service exports /
+    3 full exports per 10 minutes → 429 `ACCOUNT_RATE_LIMITED` with `Retry-After`; per-process
+    fixed-window brake from `lib/security/rate-limit.ts`).
 - Data model: `account_deletion_events` (id, user_id, scope, service_name, requested_at,
   completed_at, status, summary). The `GET /api/account/services` projection adds no tables — it
   reads only the in-code registry.
@@ -56,6 +80,11 @@
     One responsive component set switches desktop/mobile on `useIsMobile()` (768px), with loading,
     empty, populated, and confirm-delete states matching the survivor-hub mockups. Per-service delete
     uses a two-step confirm; full-account delete requires typing the exact phrase `delete my account`.
+    The data view also carries the JSON export controls (issue #1264): a "Download all my data
+    (JSON)" action at the top, and a per-service Download button beside each Delete button (also on
+    retained-list services whose registry entry is `exportable`), with in-flight spinners and inline
+    per-row error states; downloads go through fetch → blob so a failure shows inline instead of
+    replacing the page.
     Reached from the community shell icon rail (the previously-disabled settings slot now links to
     `/account/data`).
   - Android: `ctf/packages/mobile/src/features/account-data/` (`AccountData.tsx` + `api.ts`),
@@ -223,6 +252,7 @@ The admin landing (`/admin`) shows a small amber dot on an area's tile when that
 
 ## 5) Change Log
 
+- 2026-07-26: **JSON data export on Account & Data — download your data, the read-side twin of delete (issue #1264, web).** A signed-in member can now download their data as a JSON file from `/account/data`: per service (a Download button beside each Delete button, and on retained-list services that still hold the member's own rows, e.g. Notifications), or the whole account ("Download all my data (JSON)" at the top of the data view). New pure `lib/account/export-engine.ts` mirrors the deletion engine over the SAME schema-validated registry (`SELECT * FROM <table> WHERE <userColumn> = $1`; retain tables skipped — MVP scope 2a, stated in the file's own `notes`), with `lib/account/export-orchestrator.ts` assembling the self-describing envelope (`exportVersion: 1`, `generatedAtIso`, `userId`, `scope`, `services[].tables[]` with `rowCount` + `rows`) in one transaction for a consistent snapshot. New routes `GET /api/account/services/:slug/export` and `GET /api/account/full-account/export` — auth-gated (`requireAccountAccess`), self-only ($1-bound user id), audit-logged (`account.data.export.service` / `.full`), per-user rate-limited (10 service / 3 full per 10 min → 429), downloaded via `Content-Disposition: attachment`. `GET /api/account/services` gains `exportable` per entry. New CI check `ctf/scripts/check-export-engine.mjs` validates every generated SELECT without a DB, exactly like the deletion-engine check. No schema change (read-only; no new table). Follow-ups deliberately deferred: exporting user-owned retained rows (money/audit ledgers — scope 2b) and the Android share-sheet flow.
 - 2026-07-23: **Admin landing "new to review" dots (§1.14).** The admin landing (`/admin`) now shows an amber dot on an area's tile when that area has actionable items an admin has not seen yet — a new pending review, report, or dispute since they last opened it — so an admin knows which area to open without checking each. New table `admin_area_seen` (per-admin, per-area last-opened marker) and route `POST /api/admin/area-seen` (admin-only, CSRF-guarded) that clears a dot on open. The per-area signal registry (`lib/admin/area-attention.ts`) counts actionable rows newer than the marker for: unlock, comic, bug-reports, contributions, safety, skills-hunt (nominations + reports), trust-transport (disputes + risk signals), and what-works. Areas that are dashboards/config/browse (directory et al.) get no dot. Server-computed on the landing (`app/admin/page.tsx`), rendered by the new client tile grid (`app/admin/admin-area-grid.tsx`). Best-effort throughout: any failure degrades to "no dot" and never breaks the landing. `schema.demo.sql` regenerated. Admin-facing and separate from the member notifications center.
 - 2026-07-22: **Standardized internal-route "not configured" responses and small cleanups (code-review sweep #1819–#1824).** No behavior change for correctly-configured callers. The internal service routes returned inconsistent status codes when their secret env var was absent; they now uniformly return **503** ("not configured") so a workflow/cron caller can tell a misconfigured deployment from a wrong credential (401/403): `POST /api/internal/product-update` and `POST /api/internal/weekly-performance/goal-snapshot` and `POST /api/internal/contributor-access/recompute` were **501 → 503** (#1821, #1822); `POST /api/internal/service-credits/accounts/[accountId]/deletion-reclaims/[deletionRequestId]/execute` now returns **503** (`service_credits_internal_not_configured`) when its token is unset instead of a 403 that looked like an auth failure (#1823). In `account/delete` and the service-credits reclaim route the env-var presence check now lives only in the 503 guard, and `isAuthorized` takes the validated secret and checks correctness only (removes the duplicated/unreachable check, #1820). Added a comment in `account/delete` clarifying that the failure-path audit's `status: 'allow'` is the policy-gate decision (not the outcome, which is `result: 'failure'`) — semantically correct, no change (#1819). `unlock/reconcile-rewards` now coerces `body.limit` with a `typeof`/`Number.isFinite` guard instead of a redundant `Number()` cast (#1824). Copy of the §1.9 product-update status code updated to 503. No schema or contract change.
 - 2026-07-20: **Privacy policy corrected — Formance is self-hosted, not a third party (owner report).** The `/terms` Privacy Policy listed Formance under "Service providers we share information with," stated it was "bound by a data-processing agreement," and said it "Receives transaction records" — implying member transaction data is sent to an outside company. That is inaccurate: Formance is the open-source ledger, self-hosted inside our own infrastructure (`ctf-formance-ledger` on our hosting, with a Postgres we own and back up nightly via `backup-formance.yml`), so no member data leaves to a third party. `policy-content.ts` now: (1) removes the Formance bullet from the third-party sharing list (§4) and instead names the self-hosted ledger inside the "hosting and infrastructure (our own systems)" bullet; (2) §1 "What we collect" describes transactions as "recorded in our own self-hosted ledger (Formance), which runs inside our infrastructure"; (3) the ServiceCredits/payments section describes real-money payouts as "recorded in our own self-hosted ledger (Formance)…" rather than "handled through our ledger provider, Formance." The other listed providers (Clerk, GetStream, Sentry, hosting/push transports) are genuine third parties and are unchanged; Supabase is not listed because the web app does not use it for any member data. Also added an **automated-processing disclosure** to §3 ("How we use your information"): the Questions feature sends the member's question text to our own self-hosted AI model (Ollama, running on our compute infrastructure) to draft an answer, the content is not used to train any third-party model, and a draft answer is a suggestion (not a decision with a legal/similarly significant effect). Infrastructure hosts (Render/Railway/RunPod) are deliberately kept as categories, not named, per owner decision — category disclosure is sufficient and avoids drift on host migrations. Copy-only; no route, schema, or contract change.

--- a/ctf/docs/developer/test-scripts/account-data-test-script.md
+++ b/ctf/docs/developer/test-scripts/account-data-test-script.md
@@ -1,0 +1,83 @@
+# Account & Data — Manual Test Script
+
+> **Android: not applicable.** This surface is web-only (rule 105); the installable web app (PWA)
+> serves phones. Test on web only: the phone-width layout at desktop and ~390px.
+
+> Walk these steps on a real device to confirm the Account & Data page (`/account/data`) works end
+> to end. Source of truth: the account deletion registry
+> (`ctf/packages/web/lib/account/deletion-registry.ts`) and the non-plugin feature inventory §1.2.
+
+| | |
+|---|---|
+| **Surface** | `/account/data` (Your Data & Privacy) |
+| **Visibility** | Any signed-in identity (including unlock-pending) |
+| **Roles to test** | member |
+| **Surfaces** | web (phone-width layout) |
+| **Generated** | 2026-07-26 (hand-written on the JSON-export build, issue #1264) |
+
+## How to run this
+
+- Each case is **precondition → steps → expected**. Mark each box: ✅ pass · ❌ fail · ⛔ blocked.
+- A ❌ becomes a row in the **Bug Reporting** plugin; link it in the notes line.
+
+---
+
+## AD-1 · Page loads and lists services from the registry
+
+**Role:** member · **Precondition:** signed in; some plugin data exists (post in Commons, etc.).
+**Steps:**
+1. Open `/account/data`.
+2. Read both lists: "Personal data" (deletable services) and "Always retained".
+**Expected:** Every service and its one-line summary comes from the deletion registry (no
+hardcoded copy). Retained entries (ServiceCredits, GDP, Weekly Performance…) show a lock and are
+honestly framed as kept by design.
+**Result:** web ☐ — notes:
+
+## AD-2 · Export one service (JSON download)
+
+**Role:** member · **Precondition:** the member has data in at least one service (e.g. Commons posts).
+**Steps:**
+1. On a service card, tap the Download (export) button beside Delete.
+2. Open the downloaded file.
+**Expected:** A file named `ctf-account-data-<slug>-<date>.json` downloads without leaving the
+page. It is valid JSON with the envelope `exportVersion: 1`, `generatedAtIso`, `userId` (yours),
+`scope: "service:<slug>"`, one `services[]` entry with `tables[]` (`table`, `userColumn`,
+`rowCount`, `rows`), and `notes[]` stating the retained-data scope. Every row is the member's own
+(the `userColumn` value is their user id); no other member's profile is joined in. A service with
+no data still downloads an honest zero-table/zero-row file.
+**Result:** web ☐ — notes:
+
+## AD-3 · Export the whole account
+
+**Role:** member
+**Steps:**
+1. At the top of the data view, tap **Download all my data (JSON)** (spinner shows while preparing).
+2. Open the downloaded `ctf-account-data-full-account-<date>.json`.
+**Expected:** One valid JSON document, `scope: "full-account"`, with a `services[]` entry for every
+registry service that has user-scoped tables — including retained-list services that still hold the
+member's own rows (e.g. Notifications). Money ledgers and audit trails are absent, and the `notes`
+say so. Contents match what the page shows (a service you deleted in this session exports zero rows).
+**Result:** web ☐ — notes:
+
+## AD-4 · Export errors and rate limit
+
+**Role:** member
+**Steps:**
+1. Trigger the full-account export 4+ times within a few minutes.
+2. (If reachable) request `/api/account/services/not-a-service/export` directly.
+**Expected:** Past the per-user limit (3 full exports / 10 min; 10 per-service / 10 min) the page
+shows the inline "Too many exports" message (HTTP 429 with `Retry-After`) instead of replacing the
+page with an error. An unknown slug returns 404 `ACCOUNT_UNKNOWN_SERVICE`. Signed out, the export
+routes return the auth denial, never data.
+**Result:** web ☐ — notes:
+
+## AD-5 · Per-service delete (existing flow unchanged)
+
+**Role:** member · **Precondition:** a service with data you are willing to delete.
+**Steps:**
+1. Tap Delete on a service card; read the confirm dialog; confirm.
+2. Re-export the whole account.
+**Expected:** The two-step confirm names the service and states permanence. After deletion the card
+leaves the list and a fresh full export shows zero rows for that service. Full-account deletion
+still requires typing `delete my account` (do not run this casually).
+**Result:** web ☐ — notes:

--- a/ctf/packages/web/app/api/account/full-account/export/route.ts
+++ b/ctf/packages/web/app/api/account/full-account/export/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { requireAccountAccess } from '../../_lib';
+import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
+import { exportAllAccountData } from 'lib/account/export-orchestrator';
+import { logAccountAudit } from 'lib/account/audit';
+import { checkRateLimit } from 'lib/security/rate-limit';
+import { reportError } from 'lib/observability/report';
+
+// Whole-account JSON data export — the read-side twin of DELETE /api/account/full-account
+// (issue #1264). Walks every service in the account deletion registry and returns all of this
+// member's own rows in one downloadable, self-describing JSON document (one consistent snapshot —
+// the whole read runs in a single transaction). Read-only; nothing is changed.
+//
+// A member can only ever export their own data: the registry-derived SELECTs always bind the
+// authenticated user id as $1 (validated without a DB by ctf/scripts/check-export-engine.mjs).
+// Every export is audited (a data-access event) and rate-limited per user — the full export reads
+// every user-scoped table in the registry, so its brake is tighter than the per-service one.
+//
+// GET /api/account/full-account/export
+export async function GET() {
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const limit = checkRateLimit(`account-export:full:${gate.auth.userId}`, 3, 10 * 60_000);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.rateLimited, message: 'Too many exports. Wait a few minutes and try again.' },
+      { status: 429, headers: { 'Retry-After': String(limit.retryAfterSeconds) } },
+    );
+  }
+
+  try {
+    const document = await exportAllAccountData(gate.auth.userId);
+    const totalRows = document.services.reduce(
+      (sum, service) => sum + service.tables.reduce((s, t) => s + t.rowCount, 0),
+      0,
+    );
+
+    logAccountAudit({
+      command: 'account.data.export.full',
+      actorId: gate.auth.userId,
+      status: 'allow',
+      reason: 'self_service_export',
+      scope: 'account',
+      result: 'success',
+      errorCategory: null,
+      metadata: { services: document.services.length, totalRows },
+    });
+
+    const date = document.generatedAtIso.slice(0, 10);
+    return NextResponse.json(document, {
+      status: 200,
+      headers: {
+        'Content-Disposition': `attachment; filename="ctf-account-data-full-account-${date}.json"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    reportError(error, { area: 'account', op: 'full_account_export' });
+    logAccountAudit({
+      command: 'account.data.export.full',
+      actorId: gate.auth.userId,
+      status: 'allow',
+      reason: 'self_service_export',
+      scope: 'account',
+      result: 'failure',
+      errorCategory: 'persistence',
+    });
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.persistenceUnavailable, message: 'Unable to export your account data.' },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/account/services/[slug]/export/route.ts
+++ b/ctf/packages/web/app/api/account/services/[slug]/export/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { requireAccountAccess } from '../../../_lib';
+import { ACCOUNT_ERROR_CODE } from 'lib/account/constants';
+import { getDeletionEntry } from 'lib/account/deletion-registry';
+import { exportServiceData } from 'lib/account/export-orchestrator';
+import { UnknownServiceError } from 'lib/account/deletion-orchestrator';
+import { logAccountAudit } from 'lib/account/audit';
+import { checkRateLimit } from 'lib/security/rate-limit';
+import { reportError } from 'lib/observability/report';
+
+// Per-service JSON data export — the read-side twin of DELETE /api/account/services/:slug
+// (issue #1264). Returns every row of this member's own data held by one service, as a
+// downloadable, self-describing JSON file. Read-only; nothing is changed.
+//
+// Unlike the delete route this does NOT require `serviceScopeSupported` — that flag is about
+// standalone deletion semantics. Any registry slug can be exported; a service with nothing
+// user-scoped (aggregate-only or all-retained) returns an honest envelope with zero tables.
+//
+// A member can only ever export their own data: the registry-derived SELECTs always bind the
+// authenticated user id as $1 (validated without a DB by ctf/scripts/check-export-engine.mjs).
+// Every export is audited (a data-access event) and rate-limited per user (a multi-table read).
+//
+// GET /api/account/services/:slug/export
+export async function GET(_request: Request, context: { params: Promise<{ slug: string }> }) {
+  const gate = await requireAccountAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { slug } = await context.params;
+  const entry = getDeletionEntry(slug);
+  if (!entry) {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.unknownService, message: `Unknown service "${slug}".` },
+      { status: 404 },
+    );
+  }
+
+  // Per-user brake: an export is a heavy multi-table read, so bound how often one member can pull
+  // it. Keyed by user id (the route is auth-gated, so the key cannot be spoofed via headers).
+  const limit = checkRateLimit(`account-export:service:${gate.auth.userId}`, 10, 10 * 60_000);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.rateLimited, message: 'Too many exports. Wait a few minutes and try again.' },
+      { status: 429, headers: { 'Retry-After': String(limit.retryAfterSeconds) } },
+    );
+  }
+
+  try {
+    const document = await exportServiceData(slug, gate.auth.userId);
+    const totalRows = document.services.reduce(
+      (sum, service) => sum + service.tables.reduce((s, t) => s + t.rowCount, 0),
+      0,
+    );
+
+    logAccountAudit({
+      command: 'account.data.export.service',
+      actorId: gate.auth.userId,
+      status: 'allow',
+      reason: 'self_service_export',
+      scope: 'service',
+      serviceName: slug,
+      result: 'success',
+      errorCategory: null,
+      metadata: { tables: document.services[0]?.tables.length ?? 0, totalRows },
+    });
+
+    const date = document.generatedAtIso.slice(0, 10);
+    return NextResponse.json(document, {
+      status: 200,
+      headers: {
+        'Content-Disposition': `attachment; filename="ctf-account-data-${slug}-${date}.json"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    reportError(error, { area: 'account', op: 'services_slug_export' });
+    if (error instanceof UnknownServiceError) {
+      return NextResponse.json(
+        { ok: false, code: ACCOUNT_ERROR_CODE.unknownService, message: `Unknown service "${slug}".` },
+        { status: 404 },
+      );
+    }
+    logAccountAudit({
+      command: 'account.data.export.service',
+      actorId: gate.auth.userId,
+      status: 'allow',
+      reason: 'self_service_export',
+      scope: 'service',
+      serviceName: slug,
+      result: 'failure',
+      errorCategory: 'persistence',
+    });
+    return NextResponse.json(
+      { ok: false, code: ACCOUNT_ERROR_CODE.persistenceUnavailable, message: `Unable to export ${slug} data.` },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/app/api/account/services/route.ts
+++ b/ctf/packages/web/app/api/account/services/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAccountAccess } from '../_lib';
 import { accountDeletionRegistry } from 'lib/account/deletion-registry';
+import { isExportable } from 'lib/account/export-engine';
 
 // Read-only projection of the account deletion registry for the Account & Data UI.
 //
@@ -23,6 +24,10 @@ export async function GET() {
     return gate.response;
   }
 
+  // `exportable` marks services with at least one user-scoped table, i.e. where the JSON export
+  // (GET /api/account/services/:slug/export) has anything to read — independent of whether the
+  // service supports standalone deletion (e.g. Notifications is retained-scope for delete but
+  // still holds the member's own exportable rows).
   const deletable = accountDeletionRegistry
     .filter((entry) => entry.serviceScopeSupported)
     .map((entry) => ({
@@ -30,6 +35,7 @@ export async function GET() {
       name: entry.name,
       summary: entry.dataSummary,
       serviceScopeSupported: true as const,
+      exportable: isExportable(entry),
     }));
 
   const retained = accountDeletionRegistry
@@ -39,6 +45,7 @@ export async function GET() {
       name: entry.name,
       summary: entry.dataSummary,
       serviceScopeSupported: false as const,
+      exportable: isExportable(entry),
     }));
 
   return NextResponse.json(

--- a/ctf/packages/web/components/account-data/account-data-mobile.tsx
+++ b/ctf/packages/web/components/account-data/account-data-mobile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {
-  Shield, Trash2, Lock, AlertTriangle, Info, ChevronRight, Loader2,
+  Shield, Trash2, Lock, AlertTriangle, Info, ChevronRight, Loader2, Download,
 } from 'lucide-react';
 import { BackChevronButton } from '@/lib/nav/back-history';
 import {
@@ -20,14 +20,18 @@ type MobileProps = {
   deletedSlugs: string[];
   pendingSlug: string | null;
   rowError: { slug: string; message: string } | null;
+  /** The export currently in flight: a service slug, or 'full-account'. */
+  exportingKey: string | null;
   onDeleteService: (service: AccountService) => void;
+  onExportService: (service: AccountService) => void;
+  onExportAll: () => void;
   onOpenAccountDelete: () => void;
 };
 
 // Mobile (<768px) Account & Data layout. Matches MobileAccountData.tsx / MobileAccountDataEmpty.tsx.
 export function AccountDataMobile({
-  view, onViewChange, deletable, retained, deletedSlugs, pendingSlug, rowError,
-  onDeleteService, onOpenAccountDelete,
+  view, onViewChange, deletable, retained, deletedSlugs, pendingSlug, rowError, exportingKey,
+  onDeleteService, onExportService, onExportAll, onOpenAccountDelete,
 }: MobileProps) {
   const { theme } = useTheme();
   const tokens = getAccountDataTokens(theme);
@@ -76,7 +80,10 @@ export function AccountDataMobile({
               retained={retained}
               pendingSlug={pendingSlug}
               rowError={rowError}
+              exportingKey={exportingKey}
               onDeleteService={onDeleteService}
+              onExportService={onExportService}
+              onExportAll={onExportAll}
               tokens={tokens}
             />
           )
@@ -88,28 +95,74 @@ export function AccountDataMobile({
   );
 }
 
+// The export affordance shared by every service card: a small download button that mirrors the
+// delete button's shape, in the brand color instead of the danger red (export is safe/read-only).
+function ExportButton({ service, isExporting, tokens, onExportService }: {
+  service: AccountService;
+  isExporting: boolean;
+  tokens: AccountDataTokens;
+  onExportService: (service: AccountService) => void;
+}) {
+  const { BRAND } = tokens;
+  return (
+    <button
+      type="button"
+      onClick={() => onExportService(service)}
+      disabled={isExporting}
+      aria-label={`Download your ${service.name} data as JSON`}
+      title="Download this data (JSON)"
+      style={{ flexShrink: 0, padding: '5px 8px', borderRadius: 7, background: `${BRAND}08`, border: `1px solid ${BRAND}25`, color: BRAND, fontSize: 11, fontWeight: 700, cursor: isExporting ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center' }}
+    >
+      {isExporting ? <Loader2 size={12} className="account-data-spin" /> : <Download size={12} />}
+    </button>
+  );
+}
+
 function MobileDataView({
-  remaining, retained, pendingSlug, rowError, onDeleteService, tokens,
+  remaining, retained, pendingSlug, rowError, exportingKey, onDeleteService, onExportService, onExportAll, tokens,
 }: {
   remaining: AccountService[];
   retained: AccountService[];
   pendingSlug: string | null;
   rowError: { slug: string; message: string } | null;
+  exportingKey: string | null;
   onDeleteService: (service: AccountService) => void;
+  onExportService: (service: AccountService) => void;
+  onExportAll: () => void;
   tokens: AccountDataTokens;
 }) {
   const { BRAND, SURFACE, BORDER, TEXT, SUBTLE } = tokens;
+  const exportingAll = exportingKey === 'full-account';
+  const fullExportError = rowError?.slug === 'full-account' ? rowError.message : null;
   return (
     <>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 10, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 16 }}>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 10, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 12 }}>
         <Info size={13} color={BRAND} style={{ flexShrink: 0, marginTop: 1 }} />
         <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.5 }}>Deleting from a service is permanent. Some audit records are retained for platform integrity.</div>
       </div>
+
+      {/* Take your data with you (issue #1264): one action downloads every service's data as a
+          single JSON file. The per-service download sits on each card below. */}
+      <button
+        type="button"
+        onClick={onExportAll}
+        disabled={exportingAll}
+        style={{ width: '100%', padding: '10px 12px', borderRadius: 10, background: `${BRAND}0C`, border: `1px solid ${fullExportError ? 'rgba(239,68,68,0.35)' : `${BRAND}30`}`, color: BRAND, fontSize: 13, fontWeight: 700, cursor: exportingAll ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, marginBottom: 6 }}
+      >
+        {exportingAll ? <Loader2 size={14} className="account-data-spin" /> : <Download size={14} />}
+        {exportingAll ? 'Preparing your download…' : 'Download all my data (JSON)'}
+      </button>
+      {fullExportError ? (
+        <div style={{ fontSize: 11, color: '#F87171', lineHeight: 1.4, marginBottom: 10 }}>{fullExportError}</div>
+      ) : (
+        <div style={{ fontSize: 11, color: '#4B5563', lineHeight: 1.4, marginBottom: 10 }}>One JSON file with your own rows from every service. Money ledgers and audit records are retained by design and not included.</div>
+      )}
 
       <div style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 10 }}>Personal data — {remaining.length} {remaining.length === 1 ? 'service' : 'services'}</div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginBottom: 24 }}>
         {remaining.map((service) => {
           const isPending = pendingSlug === service.slug;
+          const isExporting = exportingKey === service.slug;
           const error = rowError?.slug === service.slug ? rowError.message : null;
           return (
             <div key={service.slug} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '11px 12px', borderRadius: 12, background: SURFACE, border: `1px solid ${error ? 'rgba(239,68,68,0.35)' : BORDER}`, opacity: isPending ? 0.7 : 1 }}>
@@ -120,6 +173,9 @@ function MobileDataView({
                 <div style={{ fontSize: 13, fontWeight: 600, color: TEXT }}>{service.name}</div>
                 <div style={{ fontSize: 11, color: error ? '#F87171' : '#4B5563', lineHeight: 1.3, marginTop: 1 }}>{error ?? service.summary}</div>
               </div>
+              {service.exportable ? (
+                <ExportButton service={service} isExporting={isExporting} tokens={tokens} onExportService={onExportService} />
+              ) : null}
               <button
                 type="button"
                 onClick={() => onDeleteService(service)}
@@ -138,18 +194,26 @@ function MobileDataView({
         <>
           <div style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 10 }}>Always retained — {retained.length} {retained.length === 1 ? 'service' : 'services'}</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
-            {retained.map((service) => (
-              <div key={service.slug} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '11px 12px', borderRadius: 12, background: 'rgba(255,255,255,0.01)', border: `1px solid ${BORDER}` }}>
-                <div style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, flexShrink: 0 }}>{glyphForService(service.slug)}</div>
-                <div style={{ flex: 1 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: SUBTLE }}>{service.name}</span>
-                    <Lock size={10} color="#374151" />
+            {retained.map((service) => {
+              const error = rowError?.slug === service.slug ? rowError.message : null;
+              return (
+                <div key={service.slug} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '11px 12px', borderRadius: 12, background: 'rgba(255,255,255,0.01)', border: `1px solid ${error ? 'rgba(239,68,68,0.35)' : BORDER}` }}>
+                  <div style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, flexShrink: 0 }}>{glyphForService(service.slug)}</div>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
+                      <span style={{ fontSize: 13, fontWeight: 600, color: SUBTLE }}>{service.name}</span>
+                      <Lock size={10} color="#374151" />
+                    </div>
+                    <div style={{ fontSize: 11, color: error ? '#F87171' : '#4B5563', lineHeight: 1.4 }}>{error ?? service.summary}</div>
                   </div>
-                  <div style={{ fontSize: 11, color: '#4B5563', lineHeight: 1.4 }}>{service.summary}</div>
+                  {/* A retained service can still hold the member's own exportable rows (e.g.
+                      Notifications) — export is read-only, so it is offered even where delete is not. */}
+                  {service.exportable ? (
+                    <ExportButton service={service} isExporting={exportingKey === service.slug} tokens={tokens} onExportService={onExportService} />
+                  ) : null}
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </>
       ) : null}

--- a/ctf/packages/web/components/account-data/account-data-shared.ts
+++ b/ctf/packages/web/components/account-data/account-data-shared.ts
@@ -52,6 +52,9 @@ export type AccountService = {
   name: string;
   summary: string;
   serviceScopeSupported: boolean;
+  // Whether the JSON export has anything to read for this service (≥1 user-scoped table). Drives
+  // the per-service Export button; absent on older payloads, treated as false.
+  exportable?: boolean;
 };
 
 export type AccountServicesResponse = {

--- a/ctf/packages/web/components/account-data/account-data-shell.tsx
+++ b/ctf/packages/web/components/account-data/account-data-shell.tsx
@@ -26,6 +26,8 @@ export function AccountDataShell() {
   const [pendingSlug, setPendingSlug] = useState<string | null>(null);
   const [rowError, setRowError] = useState<{ slug: string; message: string } | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  // Which export is in flight: a service slug, or 'full-account' for the download-all action.
+  const [exportingKey, setExportingKey] = useState<string | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -85,6 +87,61 @@ export function AccountDataShell() {
     }
   }, []);
 
+  // Download a JSON export (issue #1264): fetch the export route, then hand the payload to the
+  // browser as a file download. fetch → blob (rather than a bare navigation) so a failure can show
+  // an inline error instead of replacing the page with raw JSON.
+  const downloadExport = useCallback(async (url: string, filename: string, key: string, errorSlug: string) => {
+    setExportingKey(key);
+    setRowError(null);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        let message = 'Unable to export this data. Please try again.';
+        try {
+          const body = (await res.json()) as { message?: string };
+          if (body.message) message = body.message;
+        } catch {
+          // keep default message
+        }
+        setRowError({ slug: errorSlug, message });
+        return;
+      }
+      const blob = await res.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = objectUrl;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch {
+      setRowError({ slug: errorSlug, message: 'Network error. Please try again.' });
+    } finally {
+      setExportingKey(null);
+    }
+  }, []);
+
+  const handleExportService = useCallback((service: AccountService) => {
+    const date = new Date().toISOString().slice(0, 10);
+    void downloadExport(
+      `/api/account/services/${encodeURIComponent(service.slug)}/export`,
+      `ctf-account-data-${service.slug}-${date}.json`,
+      service.slug,
+      service.slug,
+    );
+  }, [downloadExport]);
+
+  const handleExportAll = useCallback(() => {
+    const date = new Date().toISOString().slice(0, 10);
+    void downloadExport(
+      '/api/account/full-account/export',
+      `ctf-account-data-full-account-${date}.json`,
+      'full-account',
+      'full-account',
+    );
+  }, [downloadExport]);
+
   const handleConfirmFullAccount = useCallback(async () => {
     const res = await fetch('/api/account/full-account', {
       method: 'DELETE',
@@ -119,7 +176,10 @@ export function AccountDataShell() {
       deletedSlugs={deletedSlugs}
       pendingSlug={pendingSlug}
       rowError={rowError}
+      exportingKey={exportingKey}
       onDeleteService={handleDeleteService}
+      onExportService={handleExportService}
+      onExportAll={handleExportAll}
       onOpenAccountDelete={() => setConfirmOpen(true)}
     />
   );

--- a/ctf/packages/web/lib/account/constants.ts
+++ b/ctf/packages/web/lib/account/constants.ts
@@ -8,6 +8,7 @@ export const ACCOUNT_ERROR_CODE = {
   serviceScopeUnsupported: 'ACCOUNT_SERVICE_SCOPE_UNSUPPORTED',
   unknownService: 'ACCOUNT_UNKNOWN_SERVICE',
   persistenceUnavailable: 'ACCOUNT_PERSISTENCE_UNAVAILABLE',
+  rateLimited: 'ACCOUNT_RATE_LIMITED',
 } as const;
 
 export type AccountErrorCode = (typeof ACCOUNT_ERROR_CODE)[keyof typeof ACCOUNT_ERROR_CODE];

--- a/ctf/packages/web/lib/account/export-engine.ts
+++ b/ctf/packages/web/lib/account/export-engine.ts
@@ -1,0 +1,109 @@
+// Account data-export engine — the read-side twin of the deletion engine (issue #1264). Turns a
+// plugin's entry in the account deletion registry into the SELECT statements that read that user's
+// rows, and runs them.
+//
+// Mirrors `deletion-engine.ts` exactly in structure and safety properties: `planTableExport` is a
+// pure function (no database, no clock) so its output can be checked exactly — see
+// `ctf/scripts/check-export-engine.mjs`, which asserts the generated SQL for every registry entry
+// without needing a database. `executeExportEntry` is the thin part that runs the plan against a
+// live client.
+//
+// Scope (issue #1264, decision 2a — MVP): only tables with a `userColumn` are exported, i.e. the
+// registry's `delete` and `soft-delete` tables. `retain` tables (money ledgers, audit trails,
+// shared content) record no user column today, so they are skipped; including user-owned retained
+// rows (e.g. the ServiceCredits ledger) is the follow-up once per-table export columns are
+// reviewed. The export envelope says this in its `notes` so the file is honest about what it holds.
+//
+//   - delete / soft-delete → SELECT * FROM <table> WHERE <userColumn> = $1
+//   - retain               → no operation
+//
+// Identifiers (table / column names) come only from the registry, which is itself validated
+// against `schema.sql` by `check-deletion-registry.mjs`, so they are never user input. The user id
+// is always the bound parameter `$1`, never inlined — a member can only ever read their own rows.
+
+import type { PoolClient } from 'pg';
+import type { OwnedTable, PluginDeletionEntry } from './deletion-registry';
+
+/** A single read statement produced from one owned table. */
+export type ExportStatement = {
+  /** Real table this reads from. */
+  readonly table: string;
+  /** The column that scopes the read to the requesting user. */
+  readonly userColumn: string;
+  /** Parameterized SQL with `$1` bound to the user id. */
+  readonly sql: string;
+};
+
+/**
+ * Pure translation of one owned table into a SELECT statement, or `null` when the table has no
+ * user column to scope by (`retain` tables — skipped in the MVP export scope).
+ */
+export function planTableExport(owned: OwnedTable): ExportStatement | null {
+  if (!owned.userColumn) {
+    return null;
+  }
+  return {
+    table: owned.table,
+    userColumn: owned.userColumn,
+    sql: `SELECT * FROM ${owned.table} WHERE ${owned.userColumn} = $1`,
+  };
+}
+
+/**
+ * Pure plan for a whole plugin entry: the ordered list of read statements (unscoped `retain`
+ * tables dropped), in registry order.
+ */
+export function planExport(entry: PluginDeletionEntry): ExportStatement[] {
+  const statements: ExportStatement[] = [];
+  for (const owned of entry.tables) {
+    const statement = planTableExport(owned);
+    if (statement) {
+      statements.push(statement);
+    }
+  }
+  return statements;
+}
+
+/** Whether a registry entry has anything a personal export can read (≥1 user-scoped table). */
+export function isExportable(entry: PluginDeletionEntry): boolean {
+  return planExport(entry).length > 0;
+}
+
+/** Per-table result of running an export: the rows exactly as stored, scoped to this user. */
+export type ExportTableResult = {
+  readonly table: string;
+  /** The column the rows were scoped by (self-describing for the reader of the file). */
+  readonly userColumn: string;
+  readonly rowCount: number;
+  /** The user's own rows. Date values serialize to ISO strings via JSON.stringify. */
+  readonly rows: Record<string, unknown>[];
+};
+
+/** One service's export: its identity plus every user-scoped table's rows. */
+export type ExportServiceResult = {
+  readonly slug: string;
+  readonly name: string;
+  readonly tables: readonly ExportTableResult[];
+};
+
+/**
+ * Run a plugin entry's export plan against a client. Read-only; the caller may batch several
+ * entries on one client/transaction for a consistent snapshot. Returns the per-table rows.
+ */
+export async function executeExportEntry(
+  client: PoolClient,
+  entry: PluginDeletionEntry,
+  userId: string,
+): Promise<ExportServiceResult> {
+  const tables: ExportTableResult[] = [];
+  for (const statement of planExport(entry)) {
+    const result = await client.query<Record<string, unknown>>(statement.sql, [userId]);
+    tables.push({
+      table: statement.table,
+      userColumn: statement.userColumn,
+      rowCount: result.rowCount ?? 0,
+      rows: result.rows,
+    });
+  }
+  return { slug: entry.slug, name: entry.name, tables };
+}

--- a/ctf/packages/web/lib/account/export-orchestrator.ts
+++ b/ctf/packages/web/lib/account/export-orchestrator.ts
@@ -1,0 +1,85 @@
+// Account data-export orchestrator — assembles the downloadable JSON document for a user's data,
+// driven entirely by the account deletion registry (issue #1264). The read-side twin of
+// `deletion-orchestrator.ts`.
+//
+// Two entry points:
+//   - `exportServiceData(slug, userId)` — one plugin's data for this user.
+//   - `exportAllAccountData(userId)`    — every plugin the registry knows, in one document.
+//
+// Both run the registry-derived SELECT plan inside a single `withDbTransaction`, so the whole file
+// is one consistent snapshot. Read-only: nothing here writes, and the audit line is the only side
+// effect (emitted by the routes). Unlike deletion, export does NOT require `serviceScopeSupported` —
+// that flag is about standalone *deletion* semantics; any registry entry with at least one
+// user-scoped table can be read (e.g. Notifications and Contributor Access have no standalone
+// delete but do hold a member's own rows).
+
+import { withDbTransaction } from 'lib/db/postgres';
+import {
+  accountDeletionRegistry,
+  getDeletionEntry,
+} from './deletion-registry';
+import { executeExportEntry, isExportable, type ExportServiceResult } from './export-engine';
+import { UnknownServiceError } from './deletion-orchestrator';
+
+export const ACCOUNT_EXPORT_VERSION = 1;
+
+// The honest scope statement embedded in every export file (issue #1264, decision 2a — MVP).
+const EXPORT_SCOPE_NOTES = [
+  'This file contains only rows scoped to your own user id, read from the same schema-validated registry the delete flow uses.',
+  'Money ledgers (e.g. ServiceCredits), audit trails, and shared platform content are retained by design and are not included in this export yet.',
+  'Where a row references another member (for example a message recipient), only their id appears — never their profile.',
+];
+
+/** The self-describing envelope the export routes serialize to the downloaded JSON file. */
+export type AccountExportDocument = {
+  readonly exportVersion: number;
+  readonly generatedAtIso: string;
+  readonly userId: string;
+  readonly scope: string;
+  readonly services: readonly ExportServiceResult[];
+  readonly notes: readonly string[];
+};
+
+function buildDocument(userId: string, scope: string, services: ExportServiceResult[]): AccountExportDocument {
+  return {
+    exportVersion: ACCOUNT_EXPORT_VERSION,
+    generatedAtIso: new Date().toISOString(),
+    userId,
+    scope,
+    services,
+    notes: EXPORT_SCOPE_NOTES,
+  };
+}
+
+/**
+ * Export one plugin's data for a user. Throws `UnknownServiceError` when the slug is not in the
+ * registry (the route maps it to 404). A known service with nothing exportable (aggregate-only or
+ * all-retained, e.g. GDP or ServiceCredits) returns an envelope whose one service has zero tables —
+ * an honest "no personal rows here", not an error.
+ */
+export async function exportServiceData(slug: string, userId: string): Promise<AccountExportDocument> {
+  const entry = getDeletionEntry(slug);
+  if (!entry) {
+    throw new UnknownServiceError(slug);
+  }
+
+  const service = await withDbTransaction((client) => executeExportEntry(client, entry, userId));
+  return buildDocument(userId, `service:${slug}`, [service]);
+}
+
+/**
+ * Export every service's data for a user in one document. Only registry entries with at least one
+ * user-scoped table appear (the others have nothing a personal export can read). One transaction,
+ * so the whole file is a consistent snapshot.
+ */
+export async function exportAllAccountData(userId: string): Promise<AccountExportDocument> {
+  const entries = accountDeletionRegistry.filter(isExportable);
+  const services = await withDbTransaction(async (client) => {
+    const results: ExportServiceResult[] = [];
+    for (const entry of entries) {
+      results.push(await executeExportEntry(client, entry, userId));
+    }
+    return results;
+  });
+  return buildDocument(userId, 'full-account', services);
+}

--- a/ctf/scripts/check-export-engine.mjs
+++ b/ctf/scripts/check-export-engine.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+// Checks the account data-export engine's SQL generation without a database (issue #1264).
+//
+// The engine (`ctf/packages/web/lib/account/export-engine.ts`) is a pure translator from the
+// account deletion registry into read statements:
+//   - any table with a userColumn → SELECT * FROM <table> WHERE <userColumn> = $1
+//   - retain tables (no userColumn) → (no statement)
+//
+// Like `check-deletion-engine.mjs`, this extracts the SQL template literal straight from the
+// engine source and renders it for every registry entry — so if someone changes the engine's SQL
+// (drops the `$1` binding, inlines a value, widens the read past the user's own rows), the
+// rendered output changes here and the invariant assertions fail. Plain Node (no TypeScript
+// import) so it runs on the CI runners, and it fails closed: an unrecognized registry or engine
+// shape stops the check rather than passing silently.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..');
+const registryPath = path.join(root, 'packages', 'web', 'lib', 'account', 'deletion-registry.ts');
+const enginePath = path.join(root, 'packages', 'web', 'lib', 'account', 'export-engine.ts');
+
+let failures = 0;
+function fail(message) {
+  console.error(`Export engine check failed: ${message}`);
+  failures += 1;
+}
+
+// Parse the registry's owned-table builder calls in source order. Mirrors the parser in
+// check-deletion-engine.mjs, and fails closed on shapes it does not understand.
+function parseOwnedTables(src) {
+  if (/\{\s*table\s*:/.test(src)) {
+    throw new Error(
+      'OwnedTable object literals are not supported by this check; use del()/soft()/retain() or extend the parser.',
+    );
+  }
+  if (/\b(?:del|soft|retain)\(\s*"/.test(src)) {
+    throw new Error(
+      'Double-quoted registry literals are not supported by this check; use single-quoted literals or extend the parser.',
+    );
+  }
+
+  const callRe = /\b(del|soft|retain)\(\s*'([^']+)'(?:\s*,\s*'([^']+)')?(?:\s*,\s*'([^']+)')?/g;
+  const owned = [];
+  let m;
+  while ((m = callRe.exec(src)) !== null) {
+    const [, kind, a, b] = m;
+    if (kind === 'del') {
+      owned.push({ action: 'delete', table: a, userColumn: b });
+    } else if (kind === 'soft') {
+      owned.push({ action: 'soft-delete', table: a, userColumn: b });
+    } else {
+      owned.push({ action: 'retain', table: a });
+    }
+  }
+  return owned;
+}
+
+// Pull the SELECT template literal out of the engine source so this check renders the engine's
+// real SQL, not a copy. If the engine's SQL shape changes in a way this pattern no longer
+// matches, the check fails closed (the engine must be re-read).
+function extractEngineTemplate(engineSrc) {
+  // select: `SELECT * FROM ${owned.table} WHERE ${owned.userColumn} = $1`
+  const selectRe = /`(SELECT \* FROM \$\{owned\.table\} WHERE \$\{owned\.userColumn\} = \$1)`/;
+  const sel = engineSrc.match(selectRe);
+  if (!sel) {
+    throw new Error('could not find the engine SELECT template; the engine SQL shape changed — re-read export-engine.ts.');
+  }
+
+  return (owned) =>
+    sel[1]
+      .replaceAll('${owned.table}', owned.table)
+      .replaceAll('${owned.userColumn}', owned.userColumn ?? '');
+}
+
+function main() {
+  for (const [label, p] of [['registry', registryPath], ['engine', enginePath]]) {
+    if (!fs.existsSync(p)) {
+      fail(`${label} not found at ${p}`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  let owned;
+  let selectSql;
+  try {
+    owned = parseOwnedTables(fs.readFileSync(registryPath, 'utf8'));
+    selectSql = extractEngineTemplate(fs.readFileSync(enginePath, 'utf8'));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (owned.length === 0) {
+    fail('no owned tables parsed from the registry — parser or registry is broken.');
+    process.exitCode = 1;
+    return;
+  }
+
+  let statements = 0;
+  for (const entry of owned) {
+    // Retain tables have no user column, so the export engine must skip them (no statement).
+    if (entry.action === 'retain') {
+      continue;
+    }
+    if (!entry.userColumn) {
+      fail(`table "${entry.table}" (${entry.action}) has no userColumn — the export cannot scope it.`);
+      continue;
+    }
+
+    const sql = selectSql(entry);
+    statements += 1;
+
+    // Every statement must bind exactly the user id as $1 and no other parameter.
+    if (!sql.includes('$1')) {
+      fail(`table "${entry.table}" statement does not bind $1: ${sql}`);
+    }
+    if (sql.includes('$2')) {
+      fail(`table "${entry.table}" statement binds more than one parameter: ${sql}`);
+    }
+    // The read must be scoped to the user's own rows via the bound parameter — never unscoped.
+    if (!sql.includes(`WHERE ${entry.userColumn} = $1`)) {
+      fail(`table "${entry.table}" does not scope by its user column via $1: ${sql}`);
+    }
+    if (!sql.startsWith(`SELECT * FROM ${entry.table} `)) {
+      fail(`table "${entry.table}" produced unexpected SQL: ${sql}`);
+    }
+  }
+
+  if (failures > 0) {
+    console.error(`Checked ${statements} generated statement(s); see failures above.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Export engine check passed: ${statements} engine-rendered statement(s) validated.`);
+}
+
+main();


### PR DESCRIPTION
Implements #1264 — the read-side twin of the per-service delete. A signed-in member can now download their data as a JSON file from `/account/data`: one service at a time, or their whole account.

Closes #1264

## How it works

The insight from the issue holds: an export is the same registry walk as a delete, with `SELECT` instead of `DELETE`.

- **Export engine** (`lib/account/export-engine.ts`) — a pure planner over the **same schema-validated deletion registry** the delete flow uses. Every table with a `userColumn` becomes `SELECT * FROM <table> WHERE <userColumn> = $1`; the user id is always the bound parameter, never inlined, so a member can only ever read their own rows. `retain` tables (money ledgers, audit trails, shared content) have no user column and are skipped — **scope (a) from the issue's decision point 2**, shipped first as recommended; scope (b) (user-owned retained rows like the ServiceCredits ledger) is the noted follow-up.
- **Export orchestrator** (`lib/account/export-orchestrator.ts`) — assembles the self-describing envelope (`exportVersion: 1`, `generatedAtIso`, `userId`, `scope`, `services[].tables[]` with `rowCount` + `rows`, `notes[]` stating the retained-data scope) in **one transaction**, so the file is a consistent snapshot. Unlike delete, export does not require `serviceScopeSupported` — Notifications and Contributor Access have no standalone delete but still hold the member's own exportable rows.

## Routes

- `GET /api/account/services/:slug/export` — one service's data.
- `GET /api/account/full-account/export` — every service in one document.
- Both behind `requireAccountAccess` (same gate as delete), read-only, **audit-logged** (`account.data.export.service` / `.full` — table/row counts only, no personal data), **rate-limited per user** (10 service / 3 full per 10 minutes → 429 with `Retry-After`), returned with `Content-Disposition: attachment; filename="ctf-account-data-<scope>-<date>.json"` and `Cache-Control: no-store`. Unknown slug → 404; a service with nothing user-scoped returns an honest zero-table envelope.
- `GET /api/account/services` gains `exportable` per entry so the UI knows which cards get the button.

## UI (additive — delete flow untouched)

- **"Download all my data (JSON)"** at the top of the data view, with an in-flight spinner and inline error.
- A **Download button beside each Delete button**, and on retained-list services whose registry entry is exportable. fetch → blob download so a failure shows inline instead of replacing the page.

## Validation + CI parity with the delete side

- New `ctf/scripts/check-export-engine.mjs` extracts the engine's real SQL template from source and asserts every generated statement for all 77 registry tables — `$1` bound, single parameter, scoped by the user column — exactly like `check-deletion-engine.mjs`. Wired into `ci.yml` beside the deletion checks.

## Docs

- Non-plugin feature inventory §1.2: export engine/orchestrator, both routes, the `exportable` field, UI description, and a change-log entry.
- New manual test script `account-data-test-script.md` (AD-1…AD-5: page load, per-service export, full export, errors + rate limit, delete interplay).

## Checks run

- `pnpm --filter @ctf/web typecheck` — passes
- `eslint --max-warnings=0` on changed files — passes
- `pnpm --filter @ctf/web build` — passes
- `node ctf/scripts/check-export-engine.mjs` — 77 statements validated
- `node ctf/scripts/check-deletion-registry.mjs` / `check-deletion-engine.mjs` — still pass
- inventory-drift gate — passes (new routes documented)

Read-only feature; no schema change. Deferred per the issue: scope (b) retained-row export and Android share-sheet parity.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — the Android share-sheet flow is the noted follow-up if wanted on the Chyme-only native app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_