### PR TITLE
feat: show the full Skills Economy lockup on the signed-out phone bar

### DIFF
--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1866,6 +1866,39 @@
   user-select: none;
 }
 
+/* Full brand lockup shown only to signed-out visitors on the phone bar. It mirrors the layout of
+   public/brand/se-lockup.svg — large "SE" above small letter-spaced "SKILLS ECONOMY" — but is drawn
+   with theme tokens instead of the file's hard-coded dark background and light text, so it stays
+   readable in every theme. min-width: 0 + overflow: hidden means it gives up its space first if a
+   very narrow phone can't fit everything, rather than pushing the tabs off the right edge. */
+.mobileBarWordmark {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  line-height: 1;
+  min-width: 0;
+  overflow: hidden;
+  user-select: none;
+}
+
+.mobileBarWordmarkInitials {
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  color: var(--ctf-text-shell);
+  white-space: nowrap;
+}
+
+.mobileBarWordmarkName {
+  margin-top: 2px;
+  font-size: 7px;
+  font-weight: 600;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--ctf-text-subtle);
+  white-space: nowrap;
+}
+
 .mobileBarTitle {
   font-size: 14px;
   font-weight: 700;

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -292,6 +292,16 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
         <div className={styles.mobileBarLogo}>
           <SeMark size={26} />
         </div>
+        {/* Signed out, the bar carries far fewer controls (no gift reminder, help, settings or
+            avatar), so the full "SE / SKILLS ECONOMY" lockup fits beside the mark and a first-time
+            visitor sees the product name, not just a symbol. Signed in, the name is dropped again
+            so the mark, gift reminder, tabs and account controls all fit a 390px phone. */}
+        {!isAuthenticated ? (
+          <span className={styles.mobileBarWordmark} aria-hidden="true">
+            <span className={styles.mobileBarWordmarkInitials}>SE</span>
+            <span className={styles.mobileBarWordmarkName}>Skills Economy</span>
+          </span>
+        ) : null}
         {/* Fundraiser gift reminder — sits between the brand mark and the section tabs (owner
             placement). Renders only on phone widths while a drive is active and the full banner is
             dismissed or snoozed; the banner itself (when open) stays in the content area below. */}

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -193,7 +193,7 @@ function PublicCommunityPanel({ plugins, signInUrl }: { stats: ShellStats; plugi
         </Link>
         <p className={styles.chatSuggestionsInfo}>
           {hasPosts
-            ? 'You are reading the community. Sign in — free — to post, reply, and access housing, work, and safety resources.'
+            ? 'You are reading the Commons. Sign in — free — to post, reply, and access housing, work, and safety resources.'
             : 'Survivor Hub is free and helps you access housing, work, safety resources, and connect with others in the community.'}
         </p>
       </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

Signed out, the phone top bar carries far fewer controls — no gift reminder, no help, no settings, no avatar — so the brand mark sat alone on the left with visible empty space before the `Commons` / `Apps` / `Sign in` cluster.

That space now carries the full brand lockup: the large `SE` initials over small letter-spaced `SKILLS ECONOMY`, matching the layout of `public/brand/se-lockup.svg`. A first-time visitor sees the product name, not just a symbol.

## Notes

- **Drawn inline, not loaded from the SVG file.** `se-lockup.svg` hard-codes a `#0F0E17` background rectangle and light text fills, so dropping it into the bar would not read correctly in the comic theme. The wordmark uses the theme tokens (`--ctf-text-shell`, `--ctf-text-subtle`) instead, so it works in every theme.
- **Signed in it is not rendered at all**, so the mark, gift reminder, tabs and account controls keep the width they need on a 390px phone.
- The wordmark is `aria-hidden` because the mark's SVG already carries the `Skills Economy` label — without it a screen reader would announce the name twice.
- `min-width: 0` + `overflow: hidden` on the wordmark means it gives up its space first on a very narrow phone, rather than pushing the tabs off the right edge.

Web only, presentation only — no schema, contract, route, or data-model change, so no inventory section applies.

## Checks

- `pnpm --filter @ctf/web exec tsc --noEmit` — clean
- `pnpm --filter @ctf/web lint` — clean
- `pnpm --filter @ctf/web build` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_