### PR TITLE
fix: point the Unlock admin Member view button at /plugin/unlock

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -170,6 +170,12 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
+- 2026-07-26: **Fix: the "Member view" button in the Unlock admin header 404'd.** It pointed at
+  `/apps/unlock`, but Unlock is registered with `isVisible: false` (it is deliberately kept out of
+  the app launcher) and `app/apps/[pluginSlug]/page.tsx` calls `notFound()` for any plugin that is
+  not visible — so the link 404'd for everyone, admins included, even though the member Unlock
+  screen was live. Unlock's member surface is its own route, `/plugin/unlock`; the button now points
+  there. One-line href fix in `unlock-admin-shell.tsx`; no route, schema, or contract change.
 - 2026-07-23: **Quora URL history in the admin queue + revoke (web).** The Quora profile URL is the only social proof and can be changed after approval (in Directory). The admin queue now surfaces the trail so a reviewer can catch someone gaming it: each submission row shows a `quoraUrlChangeCount` badge ("URL changed N×"), and a "URL history" toggle opens the full change list from a new admin route `GET /api/unlock/admin/quora-history?userId=<id>` (`listQuoraUrlHistory` over the new `directory_quora_url_history` table). Each entry shows the previous → new URL, when, and the source (set at onboarding / changed by the member in Directory / changed by an admin). The existing `POST /revoke` is the manual response (drops the member to `rejected` + `locked_support_only` and claws the reward). The Unlock onboarding submission now records the captured URL into the shared history (best-effort, `recordQuoraUrlChangeStandalone`, source `unlock_onboarding`) so the trail includes the baseline. Framed as a human watch tool, never an automatic flag — a change is legitimate when Quora deletes an account. New audit command `unlock.admin.quora.history.read`. Schema change: `directory_quora_url_history` (owned by Directory). Verified: `@ctf/web` typecheck, lint, a11y lint, build. Owner-review lane.
 - 2026-07-17: **History-aware back + admin↔member navigation (app-wide sweep).** The member
   shell's hand-rolled back chevron was replaced by the shared `BackChevronButton` — it returns to

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -72,7 +72,10 @@ bucket or flag state. The link opens the network's Quora space. There is no long
 Commons" link on the Unlock screen — help points to Quora.
 The header back chevron returns to the page you came from (falling back to All Apps when opened
 directly), admins see the shared Admin pill in the member shell header, and the admin screen
-header shows a "Member view" pill opening `/apps/unlock`.
+header shows a "Member view" pill that opens the member Unlock screen at `/plugin/unlock` — click it
+and confirm the screen loads. It must NOT point at `/apps/unlock`: Unlock is hidden from the app
+launcher (`isVisible: false`), and the `/apps/<slug>` route 404s any hidden plugin, so that link
+404s for admins too (fixed 2026-07-26).
 **Result:** web ☐ android ☐ — notes:
 
 ### UNLOCK-M2 · Verify prompt on the Commons (A/B treatment)

--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -354,7 +354,11 @@ export function UnlockAdminShell({
         fontFamily: "'Inter',system-ui,sans-serif",
       }}
     >
-      <MobileScreenHeader title="Unlock Admin" accent={t.ACCENT} icon={<Unlock size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/unlock" accent={t.ACCENT} />} />
+      {/* Unlock's member surface is /plugin/unlock, NOT /apps/unlock. The plugin is registered with
+          isVisible: false so it stays out of the app launcher, and /apps/[pluginSlug] calls
+          notFound() on any plugin that is not visible — so an /apps/unlock link 404s for everyone,
+          admins included (owner report, 2026-07-26). */}
+      <MobileScreenHeader title="Unlock Admin" accent={t.ACCENT} icon={<Unlock size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/plugin/unlock" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## The bug

Owner report: the **Member view** button in the Unlock Admin header 404s, even though the member Unlock page is live.

## Why

The button pointed at `/apps/unlock`. That route does not exist for Unlock:

- Unlock is registered with `isVisible: false` in `lib/plugins/repository.ts` — deliberate, so it stays out of the app launcher.
- `app/apps/[pluginSlug]/page.tsx` calls `notFound()` for any plugin that is not visible, before the access check runs.

So the link 404'd for everyone, admins included. Unlock's member surface has always lived at its own route, `app/plugin/unlock/page.tsx` → `/plugin/unlock`.

## The fix

One href change in `components/unlock/unlock-admin-shell.tsx`, plus a comment recording why `/apps/unlock` is not the right target so it does not get "corrected" back.

I checked every other `PluginUserShellButton` href in the app — all the rest point at plugins that are visible in the registry, so Unlock was the only broken one. The only other invisible plugin, `bug-reporting`, has no admin shell link.

Inventory change-log updated in `ctf-unlock-feature-inventory.md`. No route, schema, or contract change.

## Checks

- typecheck (all packages) — clean
- `pnpm --filter @ctf/web lint` — clean
- `pnpm --filter @ctf/web build` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_