### PR TITLE
chore: drop the retired "TI" from the product name across the repo

### DIFF
--- a/ctf/README.md
+++ b/ctf/README.md
@@ -1,4 +1,4 @@
-# TI Skills Economy Monorepo (ctf)
+# Skills Economy Monorepo (ctf)
 
 This folder contains the rewrite monorepo scaffold for:
 

--- a/ctf/docs/BRAND_VOICE_LEXICON.md
+++ b/ctf/docs/BRAND_VOICE_LEXICON.md
@@ -19,6 +19,11 @@ This document is the canonical source of truth for brand language across:
 - Skills Economy: product name for the ecosystem. Short form: **SE**. The mark is the Stack logo.
   The old name "TI Skills Economy (TSE)" is retired (owner decision, commit `bb0aa50`) — do not use
   it in any new copy, and drop the "TI" when updating existing copy.
+  - **Which form to use.** Write **Skills Economy (SE)** where the reader is meeting the product for
+    the first time and the abbreviation is about to be used — a link preview, a page title, the top
+    of a document. Everywhere after that, write plain **Skills Economy**, or plain **SE** where space
+    is tight (a phone top bar, an app icon). Never "TI Skills Economy" and never "TSE", in either
+    position.
 - Psyop-Free Economy: positioning phrase used in campaign and mission framing.
 - TI: Targeted Individual. Still valid when describing a person; never part of the product name.
 

--- a/ctf/docs/BRAND_VOICE_LEXICON.md
+++ b/ctf/docs/BRAND_VOICE_LEXICON.md
@@ -16,9 +16,11 @@ This document is the canonical source of truth for brand language across:
 ## Brand Identity Hierarchy
 
 - Charging the Future: organization and umbrella brand name.
-- TI Skills Economy: product name for the ecosystem.
+- Skills Economy: product name for the ecosystem. Short form: **SE**. The mark is the Stack logo.
+  The old name "TI Skills Economy (TSE)" is retired (owner decision, commit `bb0aa50`) — do not use
+  it in any new copy, and drop the "TI" when updating existing copy.
 - Psyop-Free Economy: positioning phrase used in campaign and mission framing.
-- TI: Targeted Individual.
+- TI: Targeted Individual. Still valid when describing a person; never part of the product name.
 
 ## Mission and Core Line
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -18,7 +18,7 @@
 Beacon lets an admin go live ad hoc — a one-way broadcast — so the community can watch and take part
 in real time. The broadcast is primarily a **live demo of the app**: the admin streams their **phone
 screen** (or a desktop screen/window) to show features live, not just a face cam. Its flagship use is
-the **State of the TI Skills Economy** address (a "state of the union"-style update the owner gives
+the **State of the Skills Economy** address (a "state of the union"-style update the owner gives
 whenever there is something to say, not on a fixed cadence).
 
 It exists because the previous approach (Twitch) had friction the community could not get past: Twitch
@@ -32,7 +32,7 @@ feed; when the event ends, Beacon auto-posts the recording to the Commons as a r
 
 ## Owner-Locked Decisions (2026-06-21)
 
-1. **Name = Beacon; slug = `beacon`.** Flagship event = the "State of the TI Skills Economy" address.
+1. **Name = Beacon; slug = `beacon`.** Flagship event = the "State of the Skills Economy" address.
 2. **Watching is public; chatting/reacting requires sign-in.** Anyone with the link watches without an
    account (max reach, no phone-number wall). To post a chat message or a reaction you must be a
    signed-in member, so every comment is tied to a real account the admin can moderate. This is a
@@ -179,7 +179,7 @@ default on the ALTER (the `id` default lesson from the announcements fix). Regen
 
 ## Seed Coverage Status
 
-`ctf/scripts/seedBeaconPhase0.mjs` inserts one past `ended` event ("State of the TI Skills Economy")
+`ctf/scripts/seedBeaconPhase0.mjs` inserts one past `ended` event ("State of the Skills Economy")
 with a recording URL and a deterministic UUID, plus one matching admin audit row. This makes the
 viewer idle/replay state and the admin history list render with real data in demos. Re-runnable
 (`ON CONFLICT (id) DO NOTHING`). No per-member rows are seeded (Beacon stores none).
@@ -234,6 +234,14 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 
 ## Change Log
 
+- 2026-07-26: **Brand name: the flagship broadcast is the "State of the Skills Economy" address.** The
+  product was renamed from "TI Skills Economy (TSE)" to **Skills Economy** in commit `bb0aa50`, but the
+  old name survived in Beacon's seed data and docs. Renamed in `ctf/scripts/seedBeaconPhase0.mjs` (the
+  seeded past event's title), the `schema.sql` / `schema.demo.sql` Beacon comment, this inventory, the
+  Beacon test script, and the Beacon quota-impact note. Copy only — no schema, route, or contract
+  change. Note for the owner: the seed inserts with `ON CONFLICT DO NOTHING`, so a production row
+  already carrying the old title keeps it until renamed by hand; fresh and demo databases get the new
+  title.
 - 2026-07-20: **Account deletion now clears the member's Beacon Stream chat copy, and Beacon joined the deletion registry (privacy).** Two gaps: (1) Beacon had **no entry** in the account-deletion registry at all, so the orchestrator did not know about it; (2) a member's per-event live chat is sent into Stream Chat under `beacon-<userId>` and **persists** there (Stream retains chat with no expiry — it is not "ephemeral" as the older deletion contract assumed), yet nothing removed it on account deletion. Added a Beacon `deletion-registry` entry (`beacon_events` and `beacon_events_admin_audit_trail` are **retained** — public broadcast history and the admin audit trail, per the Beacon deletion contract — so Beacon deletes no Postgres rows, matching "no per-member rows"), and registered `deleteBeaconStreamData(userId)` (in `lib/beacon/stream.ts` — hard-deletes the Stream user `beacon-<userId>` with `mark_messages_deleted`; never throws) into the shared external-cleanup hook (`lib/account/external-cleanup-registry.ts`). The orchestrator runs it after the DB transaction commits on every whole-account deletion path (full-account route, internal delete, Clerk webhook), best-effort. Also corrected the deletion contract's "chat is ephemeral in Stream" claim. No schema change.
 - 2026-07-19: **Copy: broadcasts are "from Farah", not "from the team" (owner report).** The
   platform has a single operator, so "the team" was inaccurate. Updated everywhere the phrase

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -304,7 +304,7 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
   (never surfaced to members). No contract or new-table change.
 - 2026-07-19: **Phone gift reminder moved into the top bar (owner report: the collapsed strip read
   as wasted space).** After dismissing the fundraiser banner on phone width, the 🎁 reminder now
-  renders in the top bar between the TSE mark and the section tabs (`ContributionsGiftTrigger` in
+  renders in the top bar between the SE mark and the section tabs (`ContributionsGiftTrigger` in
   `contributions-banner.tsx`, mounted by `community-shell.tsx`) instead of keeping a dedicated
   strip where the banner was. The open banner is unchanged and stays at the top of the content
   area; desktop dismiss behavior is unchanged (nothing until the snooze lapses). UI-only.

--- a/ctf/docs/developer/design-branding-parity-audit.md
+++ b/ctf/docs/developer/design-branding-parity-audit.md
@@ -108,7 +108,8 @@ E5-adoption (incremental screen migration onto the primitives/typeScale) and E6 
 Main has since narrowed the native Android app to a small **keep-list** (rule 105): `FeatureKey` in
 `App.tsx` is now just `chyme | account-data | blocked-members | bug-report`; everything else is served
 by the **web app**, which is now an installable **PWA** covering the whole product on phones. The
-product also rebranded to **"TI Skills Economy (TSE)"** (see `app/layout.tsx` metadata).
+product also rebranded — at the time of this audit to "TI Skills Economy (TSE)", and since then (commit
+`bb0aa50`) to **"Skills Economy" / "SE"** with the Stack mark (see `app/layout.tsx` metadata).
 
 Consequences for E5-adoption:
 - **E5 is scoped to the Android keep-list screens** (Chyme + account-data + blocked-members +
@@ -118,9 +119,9 @@ Consequences for E5-adoption:
   rather than re-scaling onto `typeScale` or forcing the generic `Card`/gradient-`CtaButton`
   primitives — Chyme has an intentional deep-green identity and is already fully theme-aware, so a
   blanket primitive swap would regress it. The brand-font adoption is the concrete "same branding" win.
-- **OPEN — brand-name reconciliation (for owner):** web is now "TI Skills Economy (TSE)"; the mobile
-  launcher still shows the "SH" gradient chip + a "Charging The Future" wordmark. These should be
-  reconciled to one brand name/mark — flagged for the owner (do not silently change shipped brand copy).
+- **RESOLVED — brand-name reconciliation.** Settled by the owner in commit `bb0aa50`: the one product
+  name is **Skills Economy** (short form **SE**) with the Stack mark. The old "TI Skills Economy (TSE)"
+  name and the mobile launcher's "SH" gradient chip are both retired.
 
 ## 4. Progress log
 

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -55,7 +55,7 @@ One-way admin broadcast; public watch, sign-in to chat. Member role unless noted
 
 ### BCN-1 · Watch the idle / replay state
 **Role:** member · **Surfaces:** all · **Seed:** `seed:demo`
-**Precondition:** seed inserts one past `ended` event ("State of the TI Skills Economy") with a
+**Precondition:** seed inserts one past `ended` event ("State of the Skills Economy") with a
 recording URL.
 **Steps:**
 1. Open `/apps/beacon` with no live event.

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -108,11 +108,11 @@ plain language. An empty history shows the empty state, not an error.
 **Steps:**
 1. With the banner showing in the Hub, press **Contribute**.
 2. Press **Not now** to dismiss.
-3. On phone width, look at the top bar (between the TSE mark and the Commons tab). On desktop, look
+3. On phone width, look at the top bar (between the SE mark and the Commons tab). On desktop, look
    at where the banner was.
 **Expected:** **Contribute** opens the drive at `/apps/contributions` — the page renders (not a 404).
 The banner shows a **Not now** dismiss on both layouts. After dismissing on **phone width**, the full
-banner disappears and a small gift emoji (🎁) appears in the top bar between the TSE mark and the
+banner disappears and a small gift emoji (🎁) appears in the top bar between the SE mark and the
 section tabs — no leftover strip where the banner was — and it still opens the plugin when tapped
 (the full banner returns on its own after the snooze lapses, in its usual place at the top of the
 content area). After dismissing on **desktop**, the banner is gone until the snooze lapses (no

--- a/ctf/docs/quota-impact/2026-06-21-beacon-livestream-video.md
+++ b/ctf/docs/quota-impact/2026-06-21-beacon-livestream-video.md
@@ -3,7 +3,7 @@
 ## Summary
 
 - Feature/Change: Beacon, an admin-only one-way livestream plugin. An admin goes live ad hoc to
-  broadcast a live demo (screen content); the flagship use is the "State of the TI Skills Economy"
+  broadcast a live demo (screen content); the flagship use is the "State of the Skills Economy"
   address. Watching is public over HLS (no sign-in); chatting/reacting needs a signed-in member
   (Stream Chat). Recording is on; the replay is posted to the Commons.
 - PR: branch `feat/beacon-plugin` (no PR opened yet)

--- a/ctf/packages/web/app/layout.tsx
+++ b/ctf/packages/web/app/layout.tsx
@@ -25,7 +25,10 @@ import './globals.css';
 // The site title doubles as the link-preview descriptor other sites (e.g. Quora) show when a page
 // here is shared: they read og:title, falling back to <title>. Both are set to the same string so
 // the unfurl reads exactly this, on every surface.
-const SITE_TITLE = 'Skills Economy; Exit their economy, exit the psyop.';
+// The parenthetical short form belongs here (owner decision, 2026-07-27): a link preview is where
+// most people meet the product for the first time, so it introduces the abbreviation. Elsewhere in
+// the app, once the name is established, plain "Skills Economy" or plain "SE" is correct.
+const SITE_TITLE = 'Skills Economy (SE); Exit their economy, exit the psyop.';
 const SITE_DESCRIPTION = 'A skills-based community economy for survivors — mutual support, real participation, no outside systems needed.';
 
 export const metadata: Metadata = {

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -5392,7 +5392,7 @@ ON CONFLICT (user_id) DO NOTHING;
 
 -- === beacon-plugin ===
 -- Beacon: admin-only one-way livestream. An admin goes live ad hoc to broadcast a live demo
--- (screen content), flagship use the "State of the TI Skills Economy" address. Watching is public
+-- (screen content), flagship use the "State of the Skills Economy" address. Watching is public
 -- (HLS, no sign-in); chatting/reacting needs a signed-in member (Stream Chat). Live chat is
 -- ephemeral (Stream only) and is NOT stored here — only the event lifecycle and the saved recording.
 BEGIN;

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -5394,7 +5394,7 @@ ON CONFLICT (user_id) DO NOTHING;
 
 -- === beacon-plugin ===
 -- Beacon: admin-only one-way livestream. An admin goes live ad hoc to broadcast a live demo
--- (screen content), flagship use the "State of the TI Skills Economy" address. Watching is public
+-- (screen content), flagship use the "State of the Skills Economy" address. Watching is public
 -- (HLS, no sign-in); chatting/reacting needs a signed-in member (Stream Chat). Live chat is
 -- ephemeral (Stream only) and is NOT stored here — only the event lifecycle and the saved recording.
 BEGIN;

--- a/ctf/scripts/seedBeaconPhase0.mjs
+++ b/ctf/scripts/seedBeaconPhase0.mjs
@@ -54,7 +54,7 @@ async function seed() {
        ON CONFLICT (id) DO NOTHING`,
       [
         EVENT_ID,
-        'State of the TI Skills Economy',
+        'State of the Skills Economy',
         'A live walkthrough of where the survivor skills economy stands and what is shipping next.',
         HOST_USER_ID,
         `beacon-${EVENT_ID}`,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## Why

The product was renamed from "TI Skills Economy (TSE)" to **Skills Economy** in commit `bb0aa50`. That commit changed `app/layout.tsx` — the site title, `og:title`, and the Twitter card — but the old name survived elsewhere in the repo, including in the one file agents read before writing any copy.

## What changed

**Brand lexicon** (`ctf/docs/BRAND_VOICE_LEXICON.md`) — the Brand Identity Hierarchy listed "TI Skills Economy" as the product name. It now names **Skills Economy** (short form **SE**, Stack mark), records that the old name is retired, and keeps "TI" as valid only when describing a person, never as part of the product name.

**Beacon's flagship broadcast** — the seeded event was titled "State of the TI Skills Economy". Renamed in `ctf/scripts/seedBeaconPhase0.mjs`, the Beacon comment in `schema.sql` / `schema.demo.sql`, the Beacon inventory, the Beacon test script, and the Beacon quota-impact note.

**"TSE mark"** in the Contributions inventory and test script → "SE mark".

**`ctf/README.md`** heading.

**`design-branding-parity-audit.md`** — its open "brand-name reconciliation (for owner)" item is now resolved, so it says so and names the settled brand.

Left alone on purpose: `design-audit-2026-05-29.md` and one line of the parity audit quote what a screen said at the time those audits were written — changing a quote would misrepresent the record.

## Owner note

The Beacon seed inserts with `ON CONFLICT (id) DO NOTHING`, so a production row that already carries the old title keeps it until it is renamed by hand. Fresh and demo databases get the new title.

## Checks

- typecheck (all packages) — clean
- `pnpm --filter @ctf/web build` — clean
- test-script drift, inventory drift, EOF format — all clean locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_