### PR TITLE
feat: let an admin delete a Beacon draft event

### DIFF
--- a/ctf/docs/contracts/BEACON_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/BEACON_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -165,6 +165,32 @@ policies:
       - event_not_found
 
   - pluginId: beacon
+    command: event.delete
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnly: true
+      # Drafts only. A live or ended event is public broadcast history and is never deletable
+      # through the app; the route refuses it with 409 and the SQL predicate refuses it again.
+      draftStatusOnly: true
+    consentRequirements:
+      scopes:
+        - beacon_event_manage
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - event_not_found
+      - event_not_draft
+
+  - pluginId: beacon
     command: event.admin.list
     version: 1.0.0
     requiredRoles:

--- a/ctf/docs/contracts/BEACON_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/BEACON_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -103,6 +103,28 @@ auditEvents:
       status: success_or_failure
       errorCategory: none_or_error_class
 
+  # Written on both outcomes: allow (a draft was deleted) and deny (an attempt to delete a live or
+  # ended broadcast was refused). The refusal is the more interesting of the two to keep.
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: beacon
+    command: event.delete
+    commandVersion: 1.0.0
+    purpose: event_lifecycle
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - beacon_event_record
+    targetContext:
+      eventId: beacon_event_identifier
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
   - eventId: uuid
     timestamp: rfc3339
     actorId: principal

--- a/ctf/docs/contracts/BEACON_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/BEACON_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -144,6 +144,30 @@ contracts:
     idempotency: true
 
   - pluginId: beacon
+    command: event.delete
+    version: 1.0.0
+    description: >-
+      Delete a DRAFT Beacon event. Admin-only. Drafts only — a live or ended event is refused with a
+      409, because an ended event is public broadcast history with a recording attached and is
+      retained per the Beacon deletion contract. A draft was never broadcast, has no recording, and
+      never appeared in the member view, so deleting a mistyped one removes nothing a member saw.
+      The draft-only rule is enforced in the route AND in the SQL predicate. A refused attempt is
+      itself written to the audit trail.
+    inputSchema:
+      eventId:
+        type: string
+        required: true
+    outputSchema:
+      deletedId:
+        type: string
+    dataAccess:
+      - beacon_events
+      - beacon_events_admin_audit_trail
+    purpose: event_lifecycle
+    retentionClass: transactional_long_lived
+    idempotency: false
+
+  - pluginId: beacon
     command: event.admin.list
     version: 1.0.0
     description: List Beacon events newest-first, including past events and their recordings. Admin-only.

--- a/ctf/docs/contracts/BEACON_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/BEACON_PROFILE_AND_DELETION_CONTRACT.md
@@ -39,13 +39,18 @@ that Stream user (with `mark_messages_deleted`), removing the copy.
   - Contains personal data? minimal — `host_user_id` (an admin) and the saved public recording URL.
     No viewer or chatter identities are stored in this table (chat lives in Stream, not the DB — and
     is cleared from Stream on account deletion via the external-cleanup hook).
-  - Retention period: long-lived (event history and replay links).
+  - Retention period: long-lived (event history and replay links). A `live` or `ended` row is never
+    deletable through the app — the admin surface has no delete control for one, and the
+    `DELETE /api/beacon/[id]` route refuses it with a 409 and records the refusal in the audit trail.
+    A `draft` row is the one exception: an admin can delete it (see below), because a draft was never
+    broadcast, has no recording, and never appeared in the member view.
   - Legal/compliance note: the broadcast and its recording are public by design; the replay is posted
     publicly to the Commons. No private member content is stored here.
 - Table/entity: `beacon_events_admin_audit_trail`
   - Contains personal data? minimal — `actor_id` (the admin) and an optional moderated `target_id`.
   - Retention period: compliance retention window.
-  - Legal/compliance note: admin-action audit trail (create, go-live, end, moderate, recording-ingest).
+  - Legal/compliance note: admin-action audit trail (create, go-live, end, moderate,
+    recording-ingest, and draft delete — including a *refused* delete of a live or ended event).
 
 ## 5) Service-Scoped Deletion Contract
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -104,6 +104,11 @@ feed; when the event ends, Beacon auto-posts the recording to the Commons as a r
 5. **End the event** — stops the broadcast and billing; on recording-ready, auto-posts the replay to
    the Commons.
 6. **See event history** (past events + their recordings).
+7. **Delete a draft** — a draft that was mistyped or abandoned can be removed from the Event history
+   list. Two clicks: `Delete` arms the row, `Confirm delete` does it. **Drafts only** — a live or
+   ended event has no delete control, and the route refuses one with a 409, because an ended event is
+   public broadcast history with a recording attached. A draft was never broadcast, has no recording,
+   and never appeared in the member view, so removing one takes away nothing a member saw.
 
 ## API Surface and Route Map
 
@@ -125,6 +130,9 @@ feed; when the event ends, Beacon auto-posts the recording to the Commons as a r
 - `POST /api/beacon/[id]/end` — end the call; flips status to `ended`.
 - `GET /api/beacon/admin` — list events.
 - `POST /api/beacon/[id]/moderate` — mute / ban / slow-mode actions on the event chat.
+- `DELETE /api/beacon/[id]` — delete a **draft** event. Refuses a `live` or `ended` event with a 409
+  (`beacon_conflict`); the draft-only rule is enforced in the route and again in the SQL predicate of
+  `deleteDraftBeaconEvent`. Both the deletion and a refused attempt are written to the audit trail.
 
 ### Webhook
 - `POST /api/beacon/stream-webhook` — Stream recording-ready (and call lifecycle) events; verifies the
@@ -157,7 +165,11 @@ default on the ALTER (the `id` default lesson from the announcements fix). Regen
    states recording is on; the replay is posted publicly to the Commons.
 6. Webhook signature verification on the Stream webhook; idempotent recording-post (never double-post
    the replay).
-7. Survivor-safety: the admin is the only person on camera; members are never required to appear; chat
+7. **Broadcast history cannot be deleted from the app.** The only delete path is `DELETE
+   /api/beacon/[id]`, and it is restricted to `status = 'draft'` in two independent places (the route
+   check and the SQL predicate). A `live` or `ended` event — the rows the deletion contract retains —
+   has no delete control in the UI and is refused by the route.
+8. Survivor-safety: the admin is the only person on camera; members are never required to appear; chat
    is text only.
 
 ## Web and Android Delivery Status
@@ -234,6 +246,19 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 
 ## Change Log
 
+- 2026-07-27: **Admins can delete a draft event (owner report).** A mistyped or abandoned draft was
+  permanent from the app's side — there was no delete control, no `DELETE` route, and no repository
+  function — so the only way to remove one was a hand-written `DELETE` straight against the
+  production database. Added `DELETE /api/beacon/[id]` (admin-gated, CSRF-checked, audited) plus
+  `deleteDraftBeaconEvent()` in `lib/beacon/repository.ts`, and a two-click `Delete` → `Confirm
+  delete` control on each draft row in the admin Event history.
+  **Drafts only, guarded three times:** the button renders only for `status === 'draft'`; the route
+  refuses anything else with a 409 and records the refusal in the audit trail; and the SQL itself
+  carries `AND status = 'draft'`, so no future caller can delete broadcast history even by mistake.
+  A draft has never been broadcast — no viewer saw it, it has no recording, and it is absent from the
+  member view — so deleting one removes nothing a member ever saw, which is why this is not treated
+  as destroying history. Contracts updated: new `event.delete` command, access policy
+  (`draftStatusOnly`, deny condition `event_not_draft`), and audit event. No schema change.
 - 2026-07-26: **Brand name: the flagship broadcast is the "State of the Skills Economy" address.** The
   product was renamed from "TI Skills Economy (TSE)" to **Skills Economy** in commit `bb0aa50`, but the
   old name survived in Beacon's seed data and docs. Renamed in `ctf/scripts/seedBeaconPhase0.mjs` (the

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -128,6 +128,24 @@ logged for retry.
 commands are deny-by-default).
 **Result:** web ☐ mobile ☐ — notes:
 
+### BCN-A1b · Delete a draft (and confirm broadcast history cannot be deleted)
+**Role:** admin · **Surfaces:** web (admin surface)
+**Steps:**
+1. Open `/admin/beacon` and create a throwaway draft, e.g. "Delete me".
+2. In Event history, find that row and press `Delete`. The button should change to `Confirm delete`
+   with a `Cancel` beside it.
+3. Press `Cancel` first — the row must still be there, untouched.
+4. Press `Delete` again, then `Confirm delete`.
+5. Now look at any `ended` event in the same list.
+**Expected:** After step 4 the draft disappears from Event history and the page shows "Draft deleted."
+A single click never deletes anything — step 3 proves the first click only arms it. In step 5 the
+`ended` event has **no** Delete button at all: broadcast history is not deletable from the app. If you
+call `DELETE /api/beacon/<id>` directly against a `live` or `ended` event it must come back 409
+(`beacon_conflict`) and leave the row in place, and that refused attempt is written to
+`beacon_events_admin_audit_trail` with `policy_status = 'deny'`. A successful draft delete is written
+there too, with `policy_status = 'allow'`.
+**Result:** web ☐ mobile ☐ — notes:
+
 ### BCN-A2 · Go Live (both input paths)
 **Role:** admin · **Surfaces:** web (admin surface)
 **Steps:**

--- a/ctf/packages/web/app/api/beacon/[id]/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { beaconErrorResponse, ensureBeaconMutationCsrf, requireBeaconAdminAccess } from 'lib/beacon/_lib';
+import { BEACON_ERROR_CODE } from 'lib/beacon/constants';
+import { deleteDraftBeaconEvent, getBeaconEvent, insertBeaconAudit } from 'lib/beacon/repository';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Admin: delete a DRAFT event. Drafts only — a mistyped or abandoned draft was previously permanent
+// from the app's side and could only be removed straight from the database (owner report).
+//
+// A live or ended event is refused with 409. That is deliberate: an ended event is public broadcast
+// history with a recording attached, and the Beacon deletion contract retains it. The guard is
+// enforced twice — here for a clear error message, and again in the SQL predicate of
+// deleteDraftBeaconEvent — so neither layer alone is load-bearing.
+export async function DELETE(request: Request, context: RouteContext) {
+  const csrfDeny = ensureBeaconMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireBeaconAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const { id } = await context.params;
+
+  try {
+    const event = await getBeaconEvent(id);
+    if (!event) {
+      return NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
+        { status: 404 },
+      );
+    }
+
+    if (event.status !== 'draft') {
+      // Record the refusal too: an attempt to delete broadcast history is exactly the kind of thing
+      // the audit trail exists to show.
+      await insertBeaconAudit({
+        actorId: gate.auth.userId,
+        command: 'beacon.event.delete',
+        policyStatus: 'deny',
+        reason: `not_draft:${event.status}`,
+        targetType: 'event',
+        targetId: event.id,
+      });
+      return NextResponse.json(
+        {
+          ok: false,
+          code: BEACON_ERROR_CODE.conflict,
+          message: 'Only a draft can be deleted. A broadcast that went live is kept as history.',
+        },
+        { status: 409 },
+      );
+    }
+
+    const deleted = await deleteDraftBeaconEvent(event.id);
+    if (!deleted) {
+      // The event stopped being a draft between the read and the delete (someone took it live).
+      // Treat it the same as the refusal above rather than reporting a phantom success.
+      return NextResponse.json(
+        {
+          ok: false,
+          code: BEACON_ERROR_CODE.conflict,
+          message: 'That draft is no longer a draft. Reload the list and try again.',
+        },
+        { status: 409 },
+      );
+    }
+
+    await insertBeaconAudit({
+      actorId: gate.auth.userId,
+      command: 'beacon.event.delete',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'event',
+      targetId: event.id,
+    });
+
+    return NextResponse.json({ ok: true, deletedId: event.id }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'beacon', op: 'delete', extra: { eventId: id } });
+    return beaconErrorResponse('Could not delete the draft.');
+  }
+}

--- a/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
+++ b/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
@@ -53,7 +53,7 @@ type ChatCredentials = {
   streamToken: string;
 };
 
-async function adminMutate<T = unknown>(url: string, method: 'POST', body?: unknown): Promise<{ ok: boolean; data: T | null; message?: string }> {
+async function adminMutate<T = unknown>(url: string, method: 'POST' | 'DELETE', body?: unknown): Promise<{ ok: boolean; data: T | null; message?: string }> {
   try {
     const res = await fetch(url, {
       method,
@@ -86,6 +86,10 @@ export function BeaconAdminShell() {
   const [chat, setChat] = useState<ChatCredentials | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
   const [moderateTarget, setModerateTarget] = useState('');
+  // Two-step delete: the first click arms this id and turns the button into "Confirm delete", the
+  // second does it. A single click cannot destroy a draft, and there is no modal to build.
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const broadcastSectionRef = useRef<HTMLElement | null>(null);
 
   const loadEvents = useCallback(async () => {
@@ -141,6 +145,26 @@ export function BeaconAdminShell() {
     }
     setCreating(false);
   }, [title, description, loadEvents]);
+
+  // Delete a draft. Drafts only — the route refuses anything else, and the button below is only
+  // rendered for drafts, so this is the second of three guards (UI, route, SQL predicate).
+  const deleteDraft = useCallback(async (eventId: string) => {
+    setDeletingId(eventId);
+    setError(null);
+    setNotice(null);
+    const result = await adminMutate(`/api/beacon/${eventId}`, 'DELETE');
+    if (!result.ok) {
+      setError(result.message ?? 'Could not delete the draft.');
+    } else {
+      setNotice('Draft deleted.');
+      // If the deleted draft was the one open in the Broadcast panel, close the panel — otherwise it
+      // keeps showing controls for an event that no longer exists.
+      setActiveEventId((current) => (current === eventId ? null : current));
+      try { await loadEvents(); } catch { /* non-fatal */ }
+    }
+    setConfirmDeleteId(null);
+    setDeletingId(null);
+  }, [loadEvents]);
 
   // Fetch the RTMP ingest + host token. Used to populate the broadcaster panel before going live.
   const loadIngest = useCallback(async (eventId: string) => {
@@ -336,6 +360,34 @@ export function BeaconAdminShell() {
                     {event.status !== 'ended' ? (
                       <button type="button" onClick={() => setActiveEventId(event.id)} style={chipButtonStyle(t)}>Open</button>
                     ) : null}
+                    {/* Delete is offered for drafts only. A draft was never broadcast — nobody saw
+                        it, it has no recording, and it does not appear in the member view — so
+                        removing a mistyped one destroys nothing. A live or ended event is public
+                        history and is never deletable from here. */}
+                    {event.status === 'draft' ? (
+                      confirmDeleteId === event.id ? (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => deleteDraft(event.id)}
+                            disabled={deletingId === event.id}
+                            style={dangerButtonStyle(t)}
+                          >
+                            {deletingId === event.id ? 'Deleting…' : 'Confirm delete'}
+                          </button>
+                          <button type="button" onClick={() => setConfirmDeleteId(null)} style={chipButtonStyle(t)}>Cancel</button>
+                        </>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDeleteId(event.id)}
+                          aria-label={`Delete the draft "${event.title}"`}
+                          style={chipButtonStyle(t)}
+                        >
+                          Delete
+                        </button>
+                      )
+                    ) : null}
                   </div>
                 </div>
               ))}
@@ -368,4 +420,8 @@ const labelStyle = (t: BeaconTokens): React.CSSProperties => ({ display: 'block'
 const inputStyle = (t: BeaconTokens): React.CSSProperties => ({ width: '100%', boxSizing: 'border-box', background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, padding: '10px 12px', color: t.TITLE, fontSize: 14, marginBottom: 8 });
 const primaryButtonStyle = (t: BeaconTokens): React.CSSProperties => ({ marginTop: 8, padding: '10px 18px', borderRadius: 10, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}55`, color: t.ACCENT, fontSize: 14, fontWeight: 700, cursor: 'pointer' });
 const chipButtonStyle = (t: BeaconTokens): React.CSSProperties => ({ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontWeight: 600, cursor: 'pointer', textDecoration: 'none' });
+// Armed-delete chip: same shape as chipButtonStyle, tinted red so the confirming click is visibly
+// the destructive one. Red is not derived from the Beacon amber accent on purpose — it must not read
+// as just another action.
+const dangerButtonStyle = (t: BeaconTokens): React.CSSProperties => ({ ...chipButtonStyle(t), background: 'rgba(220,38,38,0.16)', border: '1px solid rgba(220,38,38,0.5)', color: '#F87171' });
 const bannerStyle = (t: BeaconTokens): React.CSSProperties => ({ marginTop: 14, padding: '10px 14px', borderRadius: 10, background: t.SURFACE, border: '1px solid', fontSize: 14 });

--- a/ctf/packages/web/lib/beacon/repository.ts
+++ b/ctf/packages/web/lib/beacon/repository.ts
@@ -122,6 +122,22 @@ export async function listBeaconEvents(limit = 50): Promise<BeaconEvent[]> {
   return result.rows.map(mapEventRow);
 }
 
+// Delete a draft event. DRAFTS ONLY — the `status = 'draft'` predicate is in the SQL, not just in
+// the route, so no future caller can delete a live or ended broadcast even by mistake. A draft has
+// never been broadcast: nobody watched it, it has no recording, and it is absent from the member
+// view, so deleting one destroys nothing a member ever saw. A live or ended event is the opposite —
+// it is public history plus a recording, and removing it is not the app's job.
+//
+// Returns true when a row was deleted, false when the id does not exist OR is not a draft. The
+// caller distinguishes those two cases by loading the event first.
+export async function deleteDraftBeaconEvent(eventId: string): Promise<boolean> {
+  const result = await queryDb(
+    `DELETE FROM beacon_events WHERE id = $1::uuid AND status = 'draft'`,
+    [eventId],
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
 export async function markBeaconEventLive(eventId: string): Promise<BeaconEvent | null> {
   const result = await queryDb<BeaconEventRow>(
     `UPDATE beacon_events


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## Why

Owner report: a mistyped draft in Beacon's Event history could not be removed. There was no delete control in the admin screen, no `DELETE` route under `/api/beacon`, and no delete function in the repository — the only way to get rid of one was a hand-written `DELETE` straight against the production database.

## What changed

- **`DELETE /api/beacon/[id]`** — new route. Admin-gated, CSRF-checked, audited.
- **`deleteDraftBeaconEvent()`** in `lib/beacon/repository.ts`.
- **Admin UI** — each draft row in Event history gets a two-click `Delete` → `Confirm delete` (with `Cancel`). One click can never destroy anything, and no modal was needed. The confirming button is tinted red so it does not read as just another action. If the deleted draft was open in the Broadcast panel, the panel closes.

## Drafts only — guarded three times

An ended event is public broadcast history with a recording attached, and the Beacon deletion contract retains it. So the draft-only rule is enforced at three independent layers, none of which is load-bearing on its own:

1. **UI** — the Delete button renders only when `status === 'draft'`.
2. **Route** — anything else is refused with a 409 (`beacon_conflict`), and *the refusal is written to the audit trail* with `policy_status = 'deny'`. An attempt to delete broadcast history is exactly what an audit trail is for.
3. **SQL** — `DELETE … WHERE id = $1 AND status = 'draft'`, so no future caller can delete a live or ended row even by mistake.

There is also a race guard: if the event stops being a draft between the read and the delete (someone took it live), the route returns 409 rather than reporting a phantom success.

A draft has never been broadcast — no viewer saw it, it has no recording, and it is absent from the member view — so deleting one removes nothing a member ever saw. Nothing else references `beacon_events` by foreign key.

## Docs and contracts

- `BEACON_PLUGIN_COMMAND_CONTRACTS.yaml` — new `event.delete` command.
- `BEACON_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml` — `draftStatusOnly` attribute policy, `event_not_draft` deny condition.
- `BEACON_PLUGIN_AUDIT_CONTRACTS.yaml` — new audit event, noting it is written on both allow and deny.
- `BEACON_PROFILE_AND_DELETION_CONTRACT.md` — records that `live`/`ended` rows are not deletable through the app and that `draft` is the one exception.
- Beacon inventory — admin feature, route map, security controls, change log.
- Beacon test script — new `BCN-A1b`, which also checks that `Cancel` leaves the row alone and that an `ended` event has no Delete button.

No schema change.

## Checks

- typecheck (all packages) — clean
- `pnpm --filter @ctf/web lint` — clean
- `pnpm --filter @ctf/web build` — clean; `/api/beacon/[id]` appears in the route table
- test-script drift, inventory drift, EOF format — clean locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_