### PR TITLE
ci: add gitleaks allowlist so the secret scan passes on main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ package-lock.json
 
 # ctf rewrite build artifacts and local env
 ctf/packages/web/.next/
+# Next.js build output anywhere in the monorepo (landing-page/, waitlist-landing-page/, …)
+# — never commit build output; the secret scanner flags the generated preview keys.
+**/.next/
 ctf/packages/web/.env.local
 ctf/packages/web/tsconfig.tsbuildinfo
 ctf/packages/mobile/.expo/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,31 @@
+# gitleaks configuration for the monorepo.
+#
+# The scheduled full-history secret scan (the "Security and Compliance" workflow,
+# "Secret Scanning" job) reads this file automatically. Without it, the history
+# scan flags 22 findings that are all committed build output or documentation
+# false positives — none are real credentials:
+#
+#   - **/.next/**  Next.js build artifacts committed by mistake in old history
+#                  (landing-page/ and waitlist-landing-page/). These are the
+#                  prerender/preview keys Next.js regenerates on every build, the
+#                  server-reference manifest, and *.js.map source maps where a
+#                  github.com/vercel/next.js/commit/<hash> URL is misread as a token.
+#   - .refact/**   Local AI-tool state logs (idempotency keys in a memory log),
+#                  never secrets. Already .gitignored.
+#   - one docs checklist file where prose is matched as a generic key.
+#
+# All of these paths are already removed from the working tree and ignored (see
+# .gitignore), so this allowlist only stops the history scan from re-flagging
+# them, letting the required check go green. Real secrets live in Infisical and
+# are never committed.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Committed build artifacts, local AI-tool logs, and documentation false positives"
+paths = [
+  '''(^|/)\.next/''',
+  '''(^|/)\.refact/''',
+  '''ctf/docs/developer/ctf-plugin-feature-inventories/ctf-skills-hunt-rewrite-checklist\.md$''',
+]


### PR DESCRIPTION
## What

Fixes #1919. The scheduled "Security and Compliance" → "Secret Scanning" job scans the full git history and fails with 22 findings. Every one is committed build output or a documentation false positive — none are real credentials:

- `**/.next/**` (11) — Next.js build artifacts committed by mistake in old history under `landing-page/` and `waitlist-landing-page/`: the preview/encryption keys Next.js regenerates on every build, the server-reference manifest, and `.js.map` source maps where a `github.com/vercel/next.js/commit/<hash>` URL is misread as a token.
- `.refact/buddy/memory_ops.jsonl` (9) — local AI-tool memory log (`idempotency_key` values, not secrets). Already `.gitignore`d.
- `ctf/docs/.../ctf-skills-hunt-rewrite-checklist.md:89` (1) — checklist prose matched as a generic key.

## Fix

- Add a root `.gitleaks.toml` that extends the default ruleset and allowlists those paths, so the full-history scan goes green. (On PRs gitleaks only scans the diff; the scheduled/push run scans all history, which is where the failures came from — so the allowlist must cover the historical paths, which it does.)
- Add `**/.next/` to `.gitignore` so build output can't be recommitted. The offending build dirs are already gone from the working tree.

No real secrets are involved; real secrets live in Infisical and are never committed. The Next.js preview keys are per-build and regenerated, so nothing needs rotating.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (infra/CI change per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACfaB4e7F3zUVrnQWhf8Df)_