### PR TITLE
fix: drop the duplicate in-page title from admin screens; add a refresh button to the admin landing

### DIFF
--- a/.claude/rules/131-admin-surface-design-and-build-rules.mdc
+++ b/.claude/rules/131-admin-surface-design-and-build-rules.mdc
@@ -57,9 +57,14 @@ per-resource grants, but the real Unlock backend is a Quora-profile-URL **verifi
 
 Therefore, when building an admin page from a mockup:
 
-1. Implement the admin **visual design** — the header with icon + `ADMIN` badge, snapshot/stat blocks,
-   tabs, status-pill cards, and action buttons — bound to that plugin's **real data and real
-   endpoints**.
+1. Implement the admin **visual design** — snapshot/stat blocks, tabs, status-pill cards, and action
+   buttons — bound to that plugin's **real data and real endpoints**.
+   **No in-page title card (owner report, 2026-07-27).** `MobileScreenHeader` already names the
+   screen and carries the icon, the back control, and the Member view link, so an admin shell goes
+   **straight to content** after it. Mockups often draw a second title card with an icon chip and an
+   `ADMIN` badge below the nav bar — do not build it. It repeats what is directly above it and costs
+   a whole screen of phone height. (Every shell that had one was stripped on 2026-07-27; each now
+   carries a comment saying why, so it does not creep back.)
 2. **Never fabricate data and never invent a backend** to match a mockup. "Design only what the backend
    supports." If the mockup shows a feature the backend does not have, build the real feature the
    backend does have, in the mockup's visual language, and note the divergence in the plugin's inventory
@@ -72,5 +77,6 @@ Therefore, when building an admin page from a mockup:
 
 Dark admin palette: bg `#0F1117`, panel `#0D0F14`, far rail `#090B0F`, surface `#161B27`, border
 `#1E2A3A`, text `#F9FAFB`, subtle `#6B7280`. Per-app accents come from the "App accent colors" table in
-`DESIGN_GUIDE.md`. Use neutral `#6366F1` for cross-cutting admin chrome (the `ADMIN` badge, etc.). Admin
+`DESIGN_GUIDE.md`. Use neutral `#6366F1` for cross-cutting admin chrome (the admin landing's chrome, the deny view's
+`ADMIN` badge, etc. — the badge no longer appears on a plugin admin shell; see above). Admin
 surfaces have Loading / Empty / Populated states and no public/anonymous state.

--- a/ctf/packages/web/app/admin/admin-refresh-button.tsx
+++ b/ctf/packages/web/app/admin/admin-refresh-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { RefreshCw } from 'lucide-react';
+
+// Refresh control for the admin landing page (owner request, 2026-07-27).
+//
+// The landing is a server component: its per-area "new to review" dots come from
+// getAdminAreaAttention() at render time, so once the page is open those dots go out of date as work
+// arrives. router.refresh() re-runs the server render in place — it keeps scroll position and does
+// not clear client state, which a full browser reload would.
+//
+// The spin is driven by useTransition, so it lasts exactly as long as the server round-trip rather
+// than a guessed timeout. It also disables the button, so an impatient double-tap cannot queue a
+// second refresh on top of the first.
+export function AdminRefreshButton({ accent = '#6366F1' }: { accent?: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  // Announced to screen readers after a refresh completes. Without it the refresh is silent for
+  // anyone not watching the dots — the page looks identical when nothing changed.
+  const [announcement, setAnnouncement] = useState('');
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setAnnouncement('');
+          startTransition(() => {
+            router.refresh();
+            setAnnouncement('Admin areas refreshed.');
+          });
+        }}
+        disabled={pending}
+        aria-label="Refresh the admin areas"
+        title="Refresh"
+        style={{
+          width: 38,
+          height: 38,
+          borderRadius: 10,
+          background: `${accent}1A`,
+          border: `1px solid ${accent}4D`,
+          color: accent,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 0,
+          flexShrink: 0,
+          cursor: pending ? 'default' : 'pointer',
+          opacity: pending ? 0.6 : 1,
+        }}
+      >
+        <RefreshCw size={18} aria-hidden="true" style={pending ? { animation: 'ctf-spin 0.9s linear infinite' } : undefined} />
+      </button>
+      <span aria-live="polite" style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap' }}>
+        {announcement}
+      </span>
+    </>
+  );
+}

--- a/ctf/packages/web/app/admin/page.tsx
+++ b/ctf/packages/web/app/admin/page.tsx
@@ -5,6 +5,7 @@ import styles from './admin-landing.module.css';
 import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import { getAdminAreaAttention } from 'lib/admin/area-attention';
 import { AdminAreaGrid, type AdminAreaTile } from './admin-area-grid';
+import { AdminRefreshButton } from './admin-refresh-button';
 
 // The area's stable slug is the last segment of its href (e.g. /admin/bug-reports → 'bug-reports'),
 // which is the key the attention signal and the seen-marker are keyed on.
@@ -101,20 +102,16 @@ export default async function AdminPage() {
     <div className={styles.page}>
       {/* Consistent one-level-up back control: from the admin directory, back goes to the home hub.
           The shared header resolves the destination from the path (see resolveBackTarget). */}
-      <MobileScreenHeader title="Admin" accent="#6366F1" icon={<ShieldCheck size={18} color="#6366F1" />} />
+      <MobileScreenHeader
+        title="Admin"
+        accent="#6366F1"
+        icon={<ShieldCheck size={18} color="#6366F1" />}
+        actions={<AdminRefreshButton />}
+      />
+      {/* No in-page title card here: the header above already names the screen and carries the icon
+          and back control. Repeating it cost a screen of phone height for no new information (owner
+          report, 2026-07-27) — every admin surface now goes straight to content after the nav bar. */}
       <div className={styles.inner}>
-        {/* Header */}
-        <div className={styles.header}>
-          <div className={styles.iconChip}>
-            <ShieldCheck size={18} color="#6366F1" />
-          </div>
-          <div>
-            <div className={styles.title}>Admin</div>
-            <div className={styles.subtitle}>Pick an area to manage. Each area is restricted to admins.</div>
-          </div>
-          <span className={styles.badge}>ADMIN</span>
-        </div>
-
         <AdminAreaGrid areas={tiles} />
 
         <div className={styles.footer}>

--- a/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
+++ b/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
@@ -263,14 +263,10 @@ export function BeaconAdminShell() {
     >
       <MobileScreenHeader title="Beacon Admin" accent={t.ACCENT} icon={<Radio size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/beacon" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 980, margin: '0 auto', padding: '32px 20px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <Radio size={22} style={{ color: t.ACCENT }} />
-          <h1 style={{ fontSize: 22, fontWeight: 700, margin: 0 }}>Beacon admin</h1>
-        </div>
-        <p style={{ color: t.SUBTLE, fontSize: 14, marginTop: 4 }}>
-          Go live with a one-way broadcast. Watching is public; chatting needs a signed-in member.
-        </p>
-
+        {/* No in-page title here: MobileScreenHeader above already names the screen and carries the
+            icon, back control, and Member view. Repeating it cost a screen of phone height for no
+            new information (owner report, 2026-07-27) — every admin surface goes straight to
+            content after the nav bar. */}
         {error ? <div style={{ ...bannerStyle(t), color: '#F87171', borderColor: 'rgba(239,68,68,0.35)' }}>{error}</div> : null}
         {notice ? <div style={{ ...bannerStyle(t), color: t.ACCENT, borderColor: `${t.ACCENT}55` }}>{notice}</div> : null}
 

--- a/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
+++ b/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
@@ -164,18 +164,9 @@ export function BugReportsAdminShell() {
     >
       <MobileScreenHeader title="Bug Reports Admin" accent={t.ACCENT} icon={<Bug size={18} color={t.ACCENT} />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Bug size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>Bug Reports</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>In-app report triage</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         <p style={{ fontSize: 13, color: t.MUTED, lineHeight: 1.6, marginBottom: 16 }}>
           Reports filed from inside the app. A report the safety check flagged is{' '}
           <span style={{ color: t.TITLE, fontWeight: 600 }}>held for review</span> and never sent to the triage repo on its

--- a/ctf/packages/web/components/contributor-access/contributor-access-admin-shell.tsx
+++ b/ctf/packages/web/components/contributor-access/contributor-access-admin-shell.tsx
@@ -192,17 +192,9 @@ export function ContributorAccessAdminShell() {
     >
       <MobileScreenHeader title="Contributor Access Admin" accent={t.ACCENT} icon={<KeyRound size={18} color={t.ACCENT} />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <KeyRound size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>Contributor Access</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Earned-standing eligibility</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         <p style={{ fontSize: 13, color: t.MUTED, lineHeight: 1.6, marginBottom: 16 }}>
           Members earn a single categorical standing — eligible or not-yet — through steady, broad contribution across
           plugins. The weekly recompute only ever admits; revoking is for cause only, never for going quiet. No score is

--- a/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
+++ b/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
@@ -185,18 +185,9 @@ export function FeedAnnouncementsAdminShell({
     >
       <MobileScreenHeader title="Feed & Announcements Admin" accent={t.ACCENT} icon={<Megaphone size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/" accent={t.ACCENT} label="Commons" />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Megaphone size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>Feed &amp; Announcements Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Announcement lifecycle and feed config</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 20 }}>
           <StatBlock label="Announcements" value={announcements.length} accent={t.ACCENT} />

--- a/ctf/packages/web/components/foundation/foundation-admin-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-admin-shell.tsx
@@ -130,18 +130,9 @@ export function FoundationAdminShell({
     >
       <MobileScreenHeader title="Foundation Admin" accent={t.ACCENT} icon={<Briefcase size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/foundation" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Briefcase size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>Foundation Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Capacity and rate-limit safeguards</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}>
           <StatBlock label="Providers" value={dashboard.providersTotal} accent={t.ACCENT} />

--- a/ctf/packages/web/components/level-up/lu-admin-shell.tsx
+++ b/ctf/packages/web/components/level-up/lu-admin-shell.tsx
@@ -273,18 +273,9 @@ export function LevelUpAdminShell({
     >
       <MobileScreenHeader title="LevelUp Admin" accent={t.ACCENT} icon={<TrendingUp size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/level-up" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 900, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <TrendingUp size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>LevelUp Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Program metrics, cohorts &amp; grants</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* KPIs */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 24 }}>
           <StatBlock label="Enrollments" value={String(kpis.enrollments)} />

--- a/ctf/packages/web/components/lighthouse/lighthouse-admin-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-admin-shell.tsx
@@ -166,18 +166,9 @@ export function LighthouseAdminShell({
     >
       <MobileScreenHeader title="LightHouse Admin" accent={t.ACCENT} icon={<Home size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/lighthouse" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 920, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Home size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>LightHouse Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Listings and matches</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}>
           <StatBlock label="Seekers" value={stats.seekers} />

--- a/ctf/packages/web/components/safety/safety-admin-shell.tsx
+++ b/ctf/packages/web/components/safety/safety-admin-shell.tsx
@@ -157,18 +157,9 @@ export function SafetyAdminShell() {
     >
       <MobileScreenHeader title="Safety Admin" accent={t.ACCENT} icon={<ShieldAlert size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/" accent={t.ACCENT} label="App home" />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <ShieldAlert size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>Safety reports</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Members flagged as a safety concern</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         <p style={{ fontSize: 13, color: t.MUTED, lineHeight: 1.6, marginBottom: 16 }}>
           When a member blocks someone and flags them as a{' '}
           <span style={{ color: t.TITLE, fontWeight: 600 }}>suspected predator or human trafficker</span>, the

--- a/ctf/packages/web/components/shared/mobile-screen-header.tsx
+++ b/ctf/packages/web/components/shared/mobile-screen-header.tsx
@@ -53,6 +53,12 @@ export function MobileScreenHeader({
         zIndex: 40,
         display: 'flex',
         alignItems: 'center',
+        // Wrap rather than squeeze: see the title comment below. The controls are one flex child, so
+        // when they and a legible title cannot share a row, the whole control cluster drops to a
+        // second row instead of eating the title. On a wide enough bar nothing wraps and this is a
+        // no-op, so it costs height only when it is actually buying legibility.
+        flexWrap: 'wrap',
+        rowGap: 8,
         gap: 10,
         padding: '10px 14px',
         background: 'var(--ctf-bg, rgba(8, 8, 10, 0.96))',
@@ -102,12 +108,38 @@ export function MobileScreenHeader({
         </span>
       ) : null}
 
-      <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--ctf-text, #F9FAFB)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+      {/* The title claims the leftover width instead of being squeezed out of it (owner report,
+          2026-07-27). Every other child of this bar is flexShrink: 0 — back chevron, icon, actions,
+          MobileTopActions — so without `flex: 1` the title was the only thing that could shrink, and
+          on a 390px phone it collapsed to a single letter ("Unlock Admin" rendered as "U"). It still
+          ellipsises when a long name genuinely does not fit, but only after it has taken the space
+          nothing else wanted. `minWidth: 0` is what lets a flex child shrink below its text width at
+          all, which is what makes the ellipsis work rather than overflowing the bar. */}
+      <span
+        style={{
+          flex: 1,
+          // A floor, not zero: the title must claim at least this much before the control cluster is
+          // allowed to share the row. Below it the controls wrap away instead, which is the whole
+          // point — a one-letter title is worse than a two-row bar.
+          minWidth: 140,
+          fontSize: 15,
+          fontWeight: 700,
+          color: 'var(--ctf-text, #F9FAFB)',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
         {title}
       </span>
 
-      {actions}
-      <MobileTopActions />
+      {/* One flex child, so the controls wrap as a group. Splitting them would let the bar break
+          mid-cluster and strand a lone avatar on the second row. marginLeft:auto right-aligns them
+          while they share the title's row; once wrapped it is inert (they already fill the row). */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginLeft: 'auto', flexShrink: 0 }}>
+        {actions}
+        <MobileTopActions />
+      </div>
     </div>
   );
 }

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-admin-shell.tsx
@@ -35,12 +35,10 @@ export function SkillsHuntAdminShell({ rounds }: Props) {
   return (
     <div style={{ minHeight: "100vh", background: t.BG, color: t.TEXT, fontFamily: "'Inter', system-ui, sans-serif", padding: "clamp(12px, 4vw, 24px)" }}>
       <MobileScreenHeader title="SkillsHunt Admin" accent={t.ACCENT} icon={<Search size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/skills-hunt" accent={t.ACCENT} />} />
-      <header style={{ marginBottom: 20, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
-        <div>
-          <h1 style={{ fontSize: 22, fontWeight: 800, color: t.TITLE, margin: 0 }}>SkillsHunt — Admin</h1>
-          <div style={{ fontSize: 13, color: t.MUTED }}>Run rounds, pay scouts in ServiceCredits, review nominations, publish missions, handle reports.</div>
-        </div>      </header>
-
+      {/* No in-page title here: MobileScreenHeader above already names the screen and carries the
+          icon, back control, and Member view. Repeating it cost a screen of phone height for no new
+          information (owner report, 2026-07-27) — every admin surface goes straight to content
+          after the nav bar. */}
       <div role="tablist" aria-label="SkillsHunt admin sections" style={{ display: "flex", gap: 6, marginBottom: 20, flexWrap: "wrap" }}>
         {TABS.map((entry) => {
           const active = tab === entry.key;

--- a/ctf/packages/web/components/socket-relay/socket-relay-admin-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-admin-shell.tsx
@@ -113,18 +113,9 @@ export function SocketRelayAdminShell({
     >
       <MobileScreenHeader title="SocketRelay Admin" accent={t.ACCENT} icon={<Radio size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/socket-relay" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 920, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Radio size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>SocketRelay Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Requests and fulfillments</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 20 }}>
           <StatBlock label="Requests" value={requestsTotal} accent={t.ACCENT} />

--- a/ctf/packages/web/components/trust-transport/trust-transport-admin-shell.tsx
+++ b/ctf/packages/web/components/trust-transport/trust-transport-admin-shell.tsx
@@ -165,18 +165,9 @@ export function TrustTransportAdminShell({
     >
       <MobileScreenHeader title="TrustTransport Admin" accent={t.ACCENT} icon={<ShieldCheck size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/trust-transport" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 920, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <ShieldCheck size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>TrustTransport Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Safety operations</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 20 }}>
           <StatBlock label="Incidents" value={incidents.length} accent={t.ACCENT} />

--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -360,18 +360,9 @@ export function UnlockAdminShell({
           admins included (owner report, 2026-07-26). */}
       <MobileScreenHeader title="Unlock Admin" accent={t.ACCENT} icon={<Unlock size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/plugin/unlock" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Unlock size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>Unlock Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Quora verification queue</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 16 }}>
           <StatBlock label="Pending" value={dashboard.pendingCount} accent="#F59E0B" />

--- a/ctf/packages/web/components/what-works/ww-admin-shell.tsx
+++ b/ctf/packages/web/components/what-works/ww-admin-shell.tsx
@@ -208,18 +208,9 @@ export function WhatWorksAdminShell() {
     >
       <MobileScreenHeader title="WhatWorks Admin" accent={t.ACCENT} icon={<ThumbsUp size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/what-works" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 900, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <ThumbsUp size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>WhatWorks Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Entry moderation</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
 
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 16 }}>

--- a/ctf/packages/web/components/workforce/workforce-admin-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-admin-shell.tsx
@@ -144,18 +144,9 @@ export function WorkforceAdminShell({
     >
       <MobileScreenHeader title="Workforce Admin" accent={t.ACCENT} icon={<Briefcase size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/apps/workforce" accent={t.ACCENT} />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
-          <div style={{ width: 36, height: 36, borderRadius: 9, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Briefcase size={18} color={t.ACCENT} />
-          </div>
-          <div>
-            <div style={{ fontSize: 17, fontWeight: 800 }}>Workforce Admin</div>
-            <div style={{ fontSize: 12, color: t.MUTED }}>Population model</div>
-          </div>
-          <span style={{ marginLeft: 'auto', padding: '3px 9px', borderRadius: 6, background: 'rgba(99,102,241,0.15)', border: '1px solid rgba(99,102,241,0.3)', fontSize: 11, color: '#6366F1', fontWeight: 700 }}>ADMIN</span>
-        </div>
-
+        {/* No in-page title card here: MobileScreenHeader above already names the screen and
+            carries the icon, back control, and Member view. Repeating it cost a screen of phone
+            height for no new information (owner report, 2026-07-27). */}
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 20 }}>
           <StatBlock label="Workforce total" value={dashboard.workforceTotal} accent={t.ACCENT} />


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## The duplicate header

Owner report: Unlock admin (and Beacon) show a title header *in addition to* the nav bar, and not every admin page does.

Most admin shells drew a second title card — icon chip, screen name, subtitle, `ADMIN` badge — directly beneath `MobileScreenHeader`, which already carries the icon, the screen name, the back control, and the Member view link. On a phone the two sat stacked, and the repeat cost roughly a screen of height before any actual content.

It was also inconsistent: **4 shells already went straight to content** after the nav bar (Contributions, Directory, PeerProgramming, ServiceCredits), so the app disagreed with itself about its own pattern.

Removed the duplicate from all 14 that had one:

- **12 title cards** — Bug Reports, Contributor Access, Feed & Announcements, Foundation, LevelUp, LightHouse, Safety, SocketRelay, TrustTransport, Unlock, WhatWorks, Workforce.
- **2 heading blocks** — Beacon and SkillsHunt used an `<h1>` + description instead of the card; same duplication.
- **The admin landing page** itself.

Each stripped shell now carries a short comment saying why, so it does not creep back. **Rule 131 previously instructed a builder to draw it** ("the header with icon + `ADMIN` badge") — that line is corrected, since it was the source of the pattern.

Directory and the AI Assistant dashboard were already correct and are untouched; Directory builds a single combined bar with the title inside it.

## Refresh button

The admin landing's per-area "new to review" dots come from `getAdminAreaAttention()` at server-render time, so they go out of date while the page sits open — and that page is the one you leave open.

New `AdminRefreshButton` in the header calls `router.refresh()`, which re-runs the server render **in place**: scroll position and client state survive, unlike a browser reload. The spin is driven by `useTransition`, so it lasts exactly as long as the round-trip rather than a guessed timeout, and the button disables while in flight so a double-tap cannot queue a second refresh. Completion is announced to screen readers, since the page looks identical when nothing changed.

## Scope

Presentation only — no route, schema, contract, or data-model change, so no inventory section applies. The `ADMIN` badge styles stay in `admin-landing.module.css` because the access-denied view still uses them.

## Checks

- typecheck (all packages) — clean
- `pnpm --filter @ctf/web lint` — clean (`--max-warnings=0`; no icon import was orphaned)
- `pnpm --filter @ctf/web build` — clean
- test-script drift, inventory drift, EOF format — clean locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_