### PR TITLE
fix: show how far over the Commons character limit a message is, and stop losing it

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -289,6 +289,23 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 ## 11) Change Log
 
+- 2026-07-27: **Commons composer shows how far over the character limit you are — and no longer
+  destroys an over-limit message (owner report).** A member's long post silently failed: the composer
+  had no character counter and no `maxLength`, and `sendMessage` cleared the input *before* the
+  request, restoring only the reply target on failure — so a post over the 1,200-character cap was
+  rejected by the API and the member's writing was gone, with a generic "must be a valid community
+  post" as the only clue. Three fixes: (1) a live counter under the composer, quiet until the last
+  150 characters, then showing characters remaining and, past the limit, **the exact number to
+  remove** plus a nudge to split the message; (2) the composer text is restored on any failed send
+  (only when the member has not started typing something new, so recovery never overwrites live
+  work), and the send button is disabled while over the limit; (3) the API's 400 now names the
+  overage instead of a generic message. The counter measures the **whitespace-normalized** text the
+  server measures, via a new client-safe `lib/feed/normalize.ts` that `lib/feed/repository.ts` now
+  imports — one implementation, so the counter cannot drift from the check. It uses the caller's own
+  cap (`FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH` 4,000 for admins, `FEED_MAX_COMMUNITY_POST_LENGTH`
+  1,200 for members), so `isAdmin` is now threaded to `ShellChatPanel`. @comic questions are exempt
+  (different route, different limit). No schema or contract change. Web + mobile-responsive (Commons
+  is web-only). Verified: typecheck, lint, build.
 - 2026-07-24: **Added 👋 to the Commons reaction quick set.** The fixed reaction set gains a wave, so it is now 👍 ❤️ 😂 🎉 🙏 😢 👋. Appended at the end of `FEED_REACTION_EMOJIS` (`lib/feed/constants.ts`) so existing reactions keep their order/rank; the set is shared by server and client, so the server accepts 👋 and the picker offers it on both community posts and announcements. Enums + descriptions in `FEED_PLUGIN_COMMAND_CONTRACTS.yaml` (`feed.community.post.reaction.toggle` and `feed.announcement.reaction.toggle`) updated to match. No schema change. Web + mobile-responsive (Commons is web-only). Verified: `@ctf/web` typecheck + eslint clean.
 - 2026-07-22: **"Edit" action on a member's own Commons chat post (edit = delete + repost).** Members could already delete their own community post, and the product model is deliberately no-in-place-edit (a corrected post is a fresh row with its own moderation, no inherited reactions/replies), but the only way to fix a typo was to delete then retype — so people posted follow-up corrections like "*done" instead. Added an **Edit** button next to Delete on the author's own message in both Commons channels: the home channel (`shell-chat-panel.tsx` + `use-home-chat.ts`) and the gated #contributors channel (`gated-chat-panel.tsx` + `use-gated-chat.ts`). It loads the post's text back into the composer, deletes the original (existing `feed.community.post.delete` / the contributor-access channel delete), clears any active reply, and focuses the box; sending posts a fresh message via the existing create path — a new row with a new timestamp. No schema, route, or contract change — reuses the existing delete + create. Web + mobile-responsive (Commons is web-only; the RN app has no Commons surface). Verified: `@ctf/web` typecheck + eslint clean, EOF clean.
 - 2026-07-17: **"Edit" button for draft announcements in the admin surface.** The admin could create, publish, and archive announcements but had no way to edit a draft before publishing — the `feed.announcement.draft.update` command and its `PUT /api/feed/admin/announcements/:id` route already existed but were never exposed in the UI. Added an "Edit" action on each draft row (`feed-announcements-admin-shell.tsx`) that loads the draft (title, body, linked plugin) into the top form; the form switches to "Edit announcement" with a "Save changes" button (PUT) and a "Cancel" that clears edit mode. Create-draft is unchanged (still POST). Edit is offered on drafts only (the update command already rejects non-draft rows server-side). UI-only — no schema, route, or contract change. Verified: typecheck, lint, production build.

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -168,11 +168,25 @@
 2. Type a community post in the composer (fewer than 1,200 characters, no HTML tags, no more than 3 links).
 3. Submit the post.
 4. Confirm the post appears immediately in the feed under the author's handle (`@username` or `user-<first 8 of user id>` if no username is set).
-5. Now try to submit a post that is exactly 1,201 characters long.
+5. Now paste a post that is exactly 1,201 characters long.
+6. Watch the line under the composer as you approach and pass the limit, then press send.
+7. Delete one character and check the line again.
 
 **Expected:**
 - The valid post appears in the feed attributed to the correct member handle.
-- The 1,201-character post is rejected with a validation error before it reaches the server (or returns a 400); it does not silently post.
+- From roughly 1,050 characters the composer shows "N characters left"; past 1,200 it turns red and
+  reads **"1 character over the limit — remove it to post."** (at 1,201), naming the exact number to
+  cut rather than a raw "1,201 / 1,200" count.
+- The send button is **disabled** while over, so the post cannot be attempted at all.
+- **The message is never lost.** If a send does fail (force one by shrinking the cap, or by going
+  offline), the text comes back into the composer rather than being cleared — unless you have already
+  started typing something new, which is never overwritten.
+- Indentation and double spaces do not count against you: the counter measures the same
+  whitespace-normalized text the server measures, so a post padded with spaces or blank lines is not
+  falsely reported as over.
+- As an **admin**, the cap is 4,000 and the counter reflects that — it must not warn at 1,200.
+- An `@comic` question shows no counter (it goes to the AI Assistant on a different route with its
+  own limit).
 
 **Result:** web ☐
 

--- a/ctf/packages/web/app/api/hub/messages/route.ts
+++ b/ctf/packages/web/app/api/hub/messages/route.ts
@@ -16,6 +16,7 @@ import {
   resolveAnnouncementLinkedPlugins,
   validateFeedCommunityPostInput,
 } from 'lib/feed/repository';
+import { feedPostLength as normalizedPostLength } from 'lib/feed/normalize';
 import { requireHubAccess } from '../_lib';
 import { ensureMutationCsrf } from '../../feed/_lib';
 
@@ -227,10 +228,17 @@ export async function POST(request: Request) {
   const isPrivileged = gate.auth.isAdmin;
   const maxLength = isPrivileged ? FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH : FEED_MAX_COMMUNITY_POST_LENGTH;
   if (!text || !validateFeedCommunityPostInput(input, maxLength)) {
+    // Name the length when that is the reason. The composer blocks an over-limit send before it gets
+    // here, but a client with a wrong cap (an out-of-date tab, the API called directly) would
+    // otherwise get "must be a valid community post" and no idea what to change.
+    const overBy = normalizedPostLength(text) - maxLength;
     return NextResponse.json(
       {
         ok: false,
-        message: 'Message text must be a valid community post.',
+        message:
+          overBy > 0
+            ? `That message is ${overBy.toLocaleString()} characters over the ${maxLength.toLocaleString()}-character limit. Shorten it, or split it into two messages.`
+            : 'Message text must be a valid community post.',
       },
       { status: 400 },
     );

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -428,7 +428,7 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
             activeChannel === GATED_CHANNEL_SLUG ? (
               <GatedChatPanel currentUser={currentUser} isAdmin={isAdmin} />
             ) : (
-              <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} signInUrl={signInUrl} />
+              <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} isAdmin={isAdmin} signInUrl={signInUrl} />
             )
           ) : (
             <ShellAppsPanel

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -14,6 +14,8 @@ import { NotificationsPanel } from './notifications-panel';
 import { ChatReactionRow } from './chat-reaction-row';
 import { ComicConsentModal } from './comic-consent-modal';
 import styles from './community-shell.module.css';
+import { feedPostLength } from '../../lib/feed/normalize';
+import { FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH, FEED_MAX_COMMUNITY_POST_LENGTH } from '../../lib/feed/constants';
 
 // Avatar glyph for a chat sender: "SH" for the Survivor Hub system/AI, otherwise the first letter of
 // the member's handle. Keeps each post attributable instead of every row reading as the same "SH".
@@ -35,6 +37,7 @@ type AuthenticatedChatPanelProps = {
   stats: ShellStats;
   plugins: PluginRegistryItem[];
   currentUser: ShellCurrentUser;
+  isAdmin?: boolean;
 };
 
 type ShellChatPanelProps = {
@@ -42,12 +45,13 @@ type ShellChatPanelProps = {
   plugins: PluginRegistryItem[];
   currentUser: ShellCurrentUser;
   isAuthenticated?: boolean;
+  isAdmin?: boolean;
   signInUrl?: string;
 };
 
-export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = false, signInUrl = '/sign-in' }: ShellChatPanelProps) {
+export function ShellChatPanel({ stats, plugins, currentUser, isAuthenticated = false, isAdmin = false, signInUrl = '/sign-in' }: ShellChatPanelProps) {
   if (isAuthenticated) {
-    return <AuthenticatedChatPanel stats={stats} plugins={plugins} currentUser={currentUser} />;
+    return <AuthenticatedChatPanel stats={stats} plugins={plugins} currentUser={currentUser} isAdmin={isAdmin} />;
   }
 
   return <PublicCommunityPanel stats={stats} plugins={plugins} signInUrl={signInUrl} />;
@@ -201,13 +205,16 @@ function PublicCommunityPanel({ plugins, signInUrl }: { stats: ShellStats; plugi
   );
 }
 
-function AuthenticatedChatPanel({ currentUser }: AuthenticatedChatPanelProps) {
+function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedChatPanelProps) {
   // A member who hasn't set a username posts under a stable per-user handle
   // (matching the server's feedAuthorHandle and Chyme), so they stay recognizable
   // and accountable across posts instead of blending into a shared label. We nudge
   // them to set a real username below.
   const ownHandle = feedAuthorHandle(currentUser.username, currentUser.userId);
   const needsUsername = !currentUser.username;
+  // Length cap for THIS member: admins get the higher cap the API grants them, so the counter never
+  // warns the owner about a post the server would happily accept.
+  const maxLength = isAdmin ? FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH : FEED_MAX_COMMUNITY_POST_LENGTH;
   const {
     messages,
     comicItems,
@@ -244,6 +251,19 @@ function AuthenticatedChatPanel({ currentUser }: AuthenticatedChatPanelProps) {
     isLive,
     error,
   } = useHomeChat(currentUser);
+  // Live length of what is in the composer, measured exactly the way the server measures it: on the
+  // whitespace-normalized text, not the raw characters (see lib/feed/normalize.ts). Counting raw
+  // characters would tell a member who indents or double-spaces that they are over when they are not.
+  //
+  // An @comic question goes to the AI Assistant on a different route with its own limit, so the
+  // Commons cap does not apply and the counter stays out of the way for those.
+  const composerLength = useMemo(() => feedPostLength(input), [input]);
+  const composerOverBy = composerMentionsComic ? 0 : Math.max(0, composerLength - maxLength);
+  // Stay quiet until the last stretch. A counter that is always on is noise on a two-line message;
+  // what a member needs is a warning while there is still time to shape the ending, and then an
+  // exact number to cut.
+  const showComposerCount = !composerMentionsComic && composerLength > maxLength - 150;
+
   // The @-form other members type to mention this member — shown in the mentions empty state.
   // feedAuthorHandle already prefixes a set username with '@'; the id pseudonym needs it added.
   const ownMentionLabel = ownHandle.startsWith('@') ? ownHandle : `@${ownHandle}`;
@@ -767,16 +787,35 @@ function AuthenticatedChatPanel({ currentUser }: AuthenticatedChatPanelProps) {
         />
         <button
           type="button"
-          className={input.trim() ? `${styles.chatSendBtn} ${styles.chatSendBtnActive}` : styles.chatSendBtn}
+          className={input.trim() && composerOverBy === 0 ? `${styles.chatSendBtn} ${styles.chatSendBtnActive}` : styles.chatSendBtn}
           onClick={() => {
             void sendMessage();
           }}
           aria-label={composerMentionsComic ? 'Ask the AI Assistant' : 'Send message'}
-          disabled={isSending}
+          // Blocked while over the limit: the server would reject it anyway, and a rejection the
+          // member can see before pressing send beats one they discover afterwards.
+          disabled={isSending || composerOverBy > 0}
         >
           ➤
         </button>
       </div>
+
+      {/* Character count, shown only near and past the limit. Over the limit it names the exact
+          number to remove, which is the number a member actually needs — "1,318 / 1,200" makes them
+          do the subtraction themselves. aria-live is polite so it does not interrupt typing, and the
+          announcement is throttled by only rendering in the last stretch. */}
+      {showComposerCount ? (
+        <p
+          className={styles.chatFootnote}
+          role="status"
+          aria-live="polite"
+          style={{ color: composerOverBy > 0 ? '#F87171' : undefined, marginTop: 6, marginBottom: 0 }}
+        >
+          {composerOverBy > 0
+            ? `${composerOverBy.toLocaleString()} character${composerOverBy === 1 ? '' : 's'} over the limit — remove ${composerOverBy === 1 ? 'it' : 'that many'} to post. Or split this into two messages.`
+            : `${(maxLength - composerLength).toLocaleString()} character${maxLength - composerLength === 1 ? '' : 's'} left.`}
+        </p>
+      ) : null}
 
       <p className={styles.chatFootnote}>
         {isLive ? 'Human-in-the-loop AI support and community support channel.' : 'Support channel keeps syncing as new messages arrive.'}{' '}

--- a/ctf/packages/web/components/community-shell/use-home-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-home-chat.ts
@@ -650,6 +650,12 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
       if (activeReply) {
         setReplyTarget(activeReply);
       }
+      // Put the text back in the composer (owner report, 2026-07-27). The input is cleared
+      // optimistically above so the send feels instant; before this, a rejected send — a message
+      // over the length cap, or any network failure — cleared the box and the member's writing was
+      // gone with nothing to retry. Only restore when the member has not started typing something
+      // new in the meantime, so a recovery never overwrites live work.
+      setInput((current) => (current.trim().length === 0 ? text : current));
       setError(sendError instanceof Error ? sendError.message : 'Unable to send your message right now.');
     } finally {
       setIsSending(false);

--- a/ctf/packages/web/lib/feed/normalize.ts
+++ b/ctf/packages/web/lib/feed/normalize.ts
@@ -1,0 +1,26 @@
+// Client-safe copy of the text normalization the feed applies before storing and before measuring
+// length. It lives here, apart from lib/feed/repository.ts, because the repository imports the
+// database client and cannot be pulled into a browser bundle — and the composer's character counter
+// must measure exactly what the server will measure, or it lies to the member.
+//
+// What it does, in order: normalize CRLF/CR to LF; collapse runs of horizontal whitespace inside
+// each line to one space and trim the line; collapse three-or-more blank lines to one blank line;
+// trim the whole thing.
+//
+// Why the counter cannot just use `value.length`: a member who indents, double-spaces after periods,
+// or leaves a run of blank lines is measured on the collapsed text. Counting raw characters would
+// report them over the limit while the server happily accepts the post.
+export function normalizeMultilineText(value: string): string {
+  return value
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(/[^\S\n]+/g, ' ').trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+// The length the server will check a Commons post against.
+export function feedPostLength(value: string): number {
+  return normalizeMultilineText(value).length;
+}

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -20,6 +20,7 @@ import {
   isAllowedFeedReactionEmoji,
 } from './constants';
 import { extractMentionHandles, feedAuthorHandle, feedMentionTokens } from './author-handle';
+import { normalizeMultilineText } from './normalize';
 import { generateFeedAssistedAnswer, inferFeedQuestionCategory } from './inference';
 import { emitFeedMembershipEventToStream } from './stream';
 import { getPluginBySlug, getPluginRoute, isAdminOnlyPlugin } from 'lib/plugins/repository';
@@ -210,15 +211,11 @@ function normalizeText(value: string): string {
 // member's multi-paragraph message keeps its structure instead of collapsing into one wall of text.
 // Used for conversational bodies (community posts, replies, announcements); the render side pairs
 // this with `white-space: pre-wrap`.
-function normalizeMultilineText(value: string): string {
-  return value
-    .replace(/\r\n?/g, '\n')
-    .split('\n')
-    .map((line) => line.replace(/[^\S\n]+/g, ' ').trim())
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
+//
+// The implementation moved to lib/feed/normalize.ts so the composer's character counter can import
+// it in the browser (this module pulls in the database client and cannot be bundled client-side).
+// Re-exported under the original name so every existing call site here is unchanged — and, more to
+// the point, so the counter and the server's length check can never drift apart.
 
 function normalizeNullableText(value: string | null | undefined): string | null {
   if (typeof value !== 'string') {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — the Commons has no Android surface)

## What was happening

Owner report: a member's long message never appeared in the Commons. Reproduced — and it was worse than a missing counter.

The composer had **no character count and no `maxLength`**, so nothing warned a member approaching the 1,200-character cap. Past it, the API returned a generic *"Message text must be a valid community post"* that never mentions length.

And `sendMessage` cleared the input **before** the request, restoring only the reply target in the `catch`. So a rejected post — over the cap, or any network failure — left the member with an empty box and their writing gone. Nothing to shorten, nothing to retry.

## Three fixes

**1. A live counter.** Quiet until the last 150 characters, then `N characters left`. Past the limit it turns red and names **the exact number to remove**, plus a nudge to split the message. That number is the point — `1,318 / 1,200` makes the member do the subtraction themselves.

**2. The message survives a failed send.** The text goes back into the composer on any failure — but only when the member has not already started typing something new, so recovery can never overwrite live work. The send button is disabled while over the limit, so the rejection happens before the press rather than after.

**3. The API names the overage** in its 400, for any client with an out-of-date cap (a long-open tab, or the route called directly).

## Two details that matter for correctness

**The counter measures what the server measures.** The cap is checked against the *whitespace-normalized* body — horizontal whitespace collapsed per line, blank-line runs squeezed, trimmed. A naive `input.length` would tell a member who indents or double-spaces that they are over when the server would accept the post. The normalizer moved to a new client-safe `lib/feed/normalize.ts`, which `lib/feed/repository.ts` now imports and re-exports under its original name — one implementation, so the counter and the check cannot drift.

**It uses the caller's own cap.** Admins get `FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH` (4,000), members `FEED_MAX_COMMUNITY_POST_LENGTH` (1,200). A counter hard-coded to 1,200 would warn the owner about long welcome posts the API accepts, so `isAdmin` is threaded from `CommunityShell` → `ShellChatPanel` → `AuthenticatedChatPanel`.

`@comic` questions are exempt — they go to the AI Assistant on a different route with its own limit, so no counter appears for them.

## Scope

No schema, route, or contract change. Feed inventory change log and the feed test script (FEED-C1) updated — the test case now covers the counter wording, the disabled send, whitespace normalization, the admin cap, and the restore-on-failure path.

## Checks

- typecheck (all packages) — clean
- `pnpm --filter @ctf/web lint` — clean
- `pnpm --filter @ctf/web build` — clean
- test-script drift, inventory drift, EOF format — clean locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_