### PR TITLE
fix: declare the gdp countries route's unspecified field in its contract

### DIFF
--- a/ctf/docs/contracts/GDP_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/GDP_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -119,6 +119,10 @@ contracts:
     outputSchema:
       countries:
         type: array
+      # Active members on the roster with no country recorded (totalMembers minus the located
+      # per-country sum, floored at 0). The web shell renders it as one "Location not set" row.
+      unspecified:
+        type: integer
       totalMembers:
         type: integer
     dataAccess:

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -330,6 +330,16 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 
 ## 10) Change Log
 
+- 2026-07-28: **Declared the `unspecified` field in the `countries.read` command contract, and stopped
+  the web shell deriving a second copy of it.** `GET /api/gdp/countries` has returned `unspecified`
+  (active members with no country recorded) since 2026-07-16, but the contract's `outputSchema` in
+  `GDP_PLUGIN_COMMAND_CONTRACTS.yaml` listed only `countries` and `totalMembers`, so the documented
+  shape did not match the shipped response. The field is now declared as an integer. `gdp-shell.tsx`
+  previously fell back to recomputing `totalMembers - located` when the field was absent, giving two
+  independent derivations of the same number; it now reads the field as sent (defaulting to 0, which
+  omits the "Location not set" row) since the route already floors it at 0 and omits it when the
+  roster read fails. Response shape and rendered output are unchanged; contract text and one client
+  line only — no schema or route-signature change.
 - 2026-07-17: **History-aware back navigation (app-wide sweep).** The member shell's hand-rolled
   back chevron was replaced by the shared `BackChevronButton` — it returns to the previous in-app
   page and falls back to All Apps when there is no in-app history. UI-only; no schema, route, or

--- a/ctf/docs/developer/test-scripts/gdp-test-script.md
+++ b/ctf/docs/developer/test-scripts/gdp-test-script.md
@@ -113,6 +113,7 @@ Result: web ☐
 **Expected:**
 - The panel is headed "All Countries" (not "Top Countries").
 - A "Location not set" row appears when there are active members with no country recorded; it is styled differently (muted / italic) and carries a caption like "no country recorded".
+- The "Location not set" count is the API's `unspecified` field — a documented integer in the `countries.read` command contract (`GDP_PLUGIN_COMMAND_CONTRACTS.yaml` outputSchema) — rendered as sent. The shell reads it directly and no longer recomputes `totalMembers − located` itself, so there is a single source for the number.
 - The sum of all country rows + "Location not set" equals the hero "Members" total exactly.
 - The "Location not set" row does not increment the "N countries" line in the hero.
 - Every country with at least one member is listed — no small-count suppression.

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -111,7 +111,9 @@ export default function GdpShell() {
       // total is the full member roster; shares are a % of it, so the located countries plus the
       // "Location not set" bucket reconcile to the same member count the hero shows.
       const total = data.totalMembers ?? located;
-      const unspecified = data.unspecified ?? Math.max(0, total - located);
+      // The route owns this bucket (it already floors it at 0 and omits it when the roster read
+      // fails), so read it as sent rather than deriving a second copy here from total - located.
+      const unspecified = data.unspecified ?? 0;
       if (signal?.aborted) return;
       const mapped: GdpCountry[] = rows.map((r) => ({ country: r.country, members: r.members, share: total > 0 ? (r.members / total) * 100 : 0 }));
       if (unspecified > 0) {


### PR DESCRIPTION
Closes #1935

`GET /api/gdp/countries` returns `{ ok, countries, unspecified, totalMembers }`, but the
`countries.read` command contract declared only `countries` and `totalMembers`. The documented
shape did not match the shipped response, and the web shell held a second derivation of the same
number (`totalMembers - located`) as a fallback.

Took path (a) from the finding: declare the field, and let the client trust it.

- `ctf/docs/contracts/GDP_PLUGIN_COMMAND_CONTRACTS.yaml` — `unspecified` is now declared as an
  integer in the `countries.read` output schema, with a note on what it counts (active members with
  no country recorded) and how the shell renders it.
- `ctf/packages/web/components/gdp/gdp-shell.tsx` — reads `data.unspecified` as sent, defaulting to
  0, instead of recomputing it locally. The route already floors it at 0 and omits the bucket when
  the roster read fails, so it is the single owner of the number.
- GDP feature inventory change log records the contract update.

Response shape and rendered output are unchanged: contract text plus one client line. No schema,
route-signature, or behavior change. `pnpm --filter @ctf/web typecheck` passes.

One note on the issue text: the shell could not actually double-add the bucket — the `??` fallback
only ran when the field was absent. The real defect was the contract/response mismatch and the
duplicate derivation, both fixed here.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — the Android GDP screen has no country panel.