### PR TITLE
fix: resolve two GDP code-review findings (refresh AbortController, parallel recognition sources)

### DIFF
--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Globe } from "lucide-react";
 import { BackChevronButton } from "@/lib/nav/back-history";
 import { Badge } from "@/components/ui/badge";
@@ -136,9 +136,17 @@ export default function GdpShell() {
   }, [fetchCountries]);
 
   // Header refresh: re-pull the report and the country panel without the full-screen loading state.
+  // Track the refresh AbortController in a ref so a new refresh (or an unmount) cancels an in-flight one:
+  // the initial-load effects already abort on unmount, and this gives the refresh path the same cleanup
+  // and stops two rapid refreshes from racing.
+  const refreshControllerRef = useRef<AbortController | null>(null);
   const handleRefresh = useCallback(async () => {
-    await Promise.all([fetchReport(false), fetchCountries()]);
+    refreshControllerRef.current?.abort();
+    const controller = new AbortController();
+    refreshControllerRef.current = controller;
+    await Promise.all([fetchReport(false, controller.signal), fetchCountries(controller.signal)]);
   }, [fetchReport, fetchCountries]);
+  useEffect(() => () => refreshControllerRef.current?.abort(), []);
 
   if (loading) return <GdpLoading />;
 

--- a/ctf/packages/web/lib/gdp/recognition.ts
+++ b/ctf/packages/web/lib/gdp/recognition.ts
@@ -381,8 +381,14 @@ export async function recognizeCommunityValueIndex(): Promise<RecognitionBreakdo
   const unweighted = new Set<string>();
   const perCurrency = new Map<string, number>();
   const perSource: Array<{ pluginSlug: string; label: string; valueIndex: number }> = [];
-  for (const source of RECOGNITION_SOURCES) {
-    const volumes = await source.loadVolumes();
+  // Each source's loadVolumes() is an independent, read-only DB round trip, and this runs live on every
+  // dashboard request — so fire them concurrently instead of awaiting one at a time. Promise.all keeps
+  // result order, so the folded per-source breakdown stays in the same RECOGNITION_SOURCES order it had
+  // when this loop was sequential. Failure semantics are unchanged: if any source throws, the whole
+  // recognition rejects, exactly as the sequential await did.
+  const volumesBySource = await Promise.all(RECOGNITION_SOURCES.map((source) => source.loadVolumes()));
+  RECOGNITION_SOURCES.forEach((source, index) => {
+    const volumes = volumesBySource[index];
     const result = foldVolumesIntoIndex(volumes, weights);
     valueIndex += result.valueIndex;
     result.unweightedCurrencies.forEach((code) => unweighted.add(code));
@@ -390,7 +396,7 @@ export async function recognizeCommunityValueIndex(): Promise<RecognitionBreakdo
       perCurrency.set(volume.currencyCode, (perCurrency.get(volume.currencyCode) ?? 0) + volume.amount);
     }
     perSource.push({ pluginSlug: source.pluginSlug, label: source.label, valueIndex: result.valueIndex });
-  }
+  });
   return {
     valueIndex,
     unweightedCurrencies: [...unweighted],


### PR DESCRIPTION
Resolves two GDP code-review findings (the other two from the same sweep are handled separately: #1935 by PR #1941, #1936 closed as a false positive).

Closes #1939
Closes #1937

## #1939 — parallelize the recognition sources (quality/perf)

`recognizeCommunityValueIndex` awaited each of the 8 registered sources' `loadVolumes()` **one at a time**, so the live dashboard did 8 sequential DB round trips on every request. The sources are independent, read-only reads, so they now fire concurrently with `Promise.all` and fold in a synchronous pass.

- `Promise.all` preserves order → the per-source breakdown stays in the same `RECOGNITION_SOURCES` order.
- Failure semantics unchanged: if any source throws, the whole recognition rejects, exactly as the sequential `await` did.

## #1937 — AbortController on the refresh path (bug/robustness)

`handleRefresh` called `fetchReport`/`fetchCountries` with no `AbortSignal`, so a refresh in flight was never cancelled on unmount and two rapid refreshes could race. Now the refresh `AbortController` is tracked in a ref: each refresh aborts the prior one and passes its signal to both fetches, and an unmount effect aborts the last one — the same cleanup the initial-load effects already have.

## Scope

Internal correctness/perf only — no feature, route, schema, or contract change (no inventory/test-script update required).

## Checks

Local: web typecheck, web lint (`--max-warnings=0`), full-workspace typecheck (pre-commit), web `build:ci`, and EOF all pass.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — this touches the web recognition layer and the web GDP shell; the Android GDP screen reads the same report payload and has no country panel.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P6mB6ZPTUcFBxdUVB9CpmV)_