### PR TITLE
chore: correct product name to Skills Economy in agent rules

### DIFF
--- a/.claude/rules/100-product-context-and-experience-rules.mdc
+++ b/.claude/rules/100-product-context-and-experience-rules.mdc
@@ -4,7 +4,7 @@
 Provide mandatory context so implementation decisions protect users and prevent harmful product behavior.
 
 ## Product Identity
-- Product name: TI Skills Economy.
+- Product name: Skills Economy (short form SE). The old "TI Skills Economy (TSE)" is retired (see `ctf/docs/BRAND_VOICE_LEXICON.md`).
 - Mission: a psyop-free skills economy designed exclusively for human trafficking survivors.
 - Operating model: single secure account with multiple plugins under one cohesive platform.
 

--- a/.claude/rules/124-brand-voice-and-language-rules.mdc
+++ b/.claude/rules/124-brand-voice-and-language-rules.mdc
@@ -14,7 +14,7 @@ Enforce a unified, trauma-informed brand language.
 
 ## Brand Identity Rules
 - Use Charging the Future as the organization and umbrella brand.
-- Use TI Skills Economy as the product name.
+- Use Skills Economy (short form SE) as the product name. The old "TI Skills Economy" / "TSE" is retired (owner decision, commit `bb0aa50`); drop the "TI" when updating existing copy. See the lexicon.
 - Use Psyop-Free Economy as positioning language, not as a replacement product name.
 
 ## Terminology Rules


### PR DESCRIPTION
Completes the product rename "TI Skills Economy" → "Skills Economy" in the places that were still wrong.

The brand lexicon (`ctf/docs/BRAND_VOICE_LEXICON.md`, the canonical source of truth) already retired "TI Skills Economy (TSE)" in favor of "Skills Economy" (short form SE) in commit `bb0aa50`. But two agent rule files still declared the old name as current — and rule 124 explicitly says it defers to the lexicon for wording conflicts, so its own line contradicted itself. Agents reading these as source-of-truth would keep reintroducing the retired name.

## Changed
- `.claude/rules/100-product-context-and-experience-rules.mdc` — "Product name: TI Skills Economy." → "Skills Economy (short form SE)".
- `.claude/rules/124-brand-voice-and-language-rules.mdc` — "Use TI Skills Economy as the product name." → "Skills Economy (short form SE); the old name is retired".

## Deliberately not changed
- The lexicon's own retirement note, the two design audits, and the beacon inventory that document the rename — accurate historical records; they must keep naming the old form.
- `ctf/package.json` name `ti-skills-economy` — CLAUDE.md forbids renaming the package without an explicit instruction (kept for build/CI stability). This is an internal identifier, not user-facing.
- `ctf/scripts/seedBeaconPhase0.mjs` deterministic UUID seed string (`...state-of-the-ti-skills-economy-2026-05-30`) — the string is hashed into the event's UUID; changing it would produce a different id and break seed idempotency.

## Already clean (no change needed)
- The live app UI (`packages/web`, `packages/mobile`) has zero "TI Skills Economy" occurrences — already on the new name.
- The `landing-page` repo has zero occurrences.

## Separate follow-up (not in this repo)
The `wiki-site` blog still shows "TI Skills Economy" in article titles/excerpts, but those mirror the article bodies in the GitHub Wiki content repo (`chargingthefuture.wiki.git`), which is not in this session's scope. The rename there needs to happen in the wiki content repo so the titles, excerpts, and bodies stay consistent; doing it in the `wiki-site` registry alone would drift from the bodies. I can handle it if that repo is added to scope.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (docs/rules-only, no rendered surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2FHy6AVTZ59kQDaYN2ATx)_