### PR TITLE
fix: /knowledge requires completed Unlock, matching the API it always had

### DIFF
--- a/ctf/docs/contracts/COMIC_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/COMIC_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -203,9 +203,13 @@ policies:
 
   - pluginId: comic
     command: comic.contribution.submit
-    version: 1.0.0
+    version: 1.1.0
     requiredRoles:
       - member
+    # Completed Unlock, not merely a signed-in account (owner decision, 2026-07-29). Reviewing is
+    # manual, so the scarce resource is the reviewer's reading time; an unverified throwaway account
+    # could spend it without ever getting near the assistant.
+    minUnlockTier: approved_full
     attributePolicies:
       tenancy: same_workspace
       # Explicit, per-clause consent — every clause id must be present, and the version submitted
@@ -232,6 +236,7 @@ policies:
       requiresAdditionalAudit: true
     denyConditions:
       - actor_not_authenticated
+      - unlock_required
       - consent_not_granted
       - consent_version_mismatch
       - archive_not_readable
@@ -239,9 +244,10 @@ policies:
 
   - pluginId: comic
     command: comic.contribution.withdraw
-    version: 1.0.0
+    version: 1.1.0
     requiredRoles:
       - member
+    minUnlockTier: approved_full
     attributePolicies:
       tenancy: same_workspace
       # A member may only withdraw their own contribution; ownership is enforced inside the query.
@@ -261,6 +267,7 @@ policies:
       requiresAdditionalAudit: true
     denyConditions:
       - actor_not_authenticated
+      - unlock_required
       - contribution_not_found
       - contribution_not_owned
 

--- a/ctf/docs/contracts/COMIC_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/COMIC_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -195,7 +195,9 @@ contracts:
     version: 1.0.0
     description: >-
       Accept a member's own public Quora writing as candidate reference material for the assistant.
-      Signed-in members. TWO PATHS: kind=links (DEFAULT) takes posts the member picked, each with a
+      Requires COMPLETED UNLOCK (approved_full), not merely a signed-in account — reviewing is manual,
+      so an unverified throwaway account could spend the reviewer's time without ever getting near the
+      assistant. TWO PATHS: kind=links (DEFAULT) takes posts the member picked, each with a
       quora.com URL kept as provenance and NEVER fetched — most accounts are mixed, nothing here sorts
       on-topic from off-topic automatically, and picking is both far less reviewer reading and a more
       honest consent than handing over a whole account. kind=export takes the whole Quora export for

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -173,7 +173,8 @@ its plugin-routing role (today's hardcoded `getActionForText`) becomes Rasa-back
 3. When unsure, the bot shows a clear pre-approved holding response and hands the question
    to a human — the user is never shown speculative content.
 4. Users can rate any answer (`helpful / not_helpful / flagged`) — feeds the training loop.
-5. **Contribute your own writing (`/knowledge`).** The path is `/knowledge`, deliberately **not**
+5. **Contribute your own writing (`/knowledge`).** **Requires completed Unlock** (owner decision,
+   2026-07-29) — see the change log for why this tightened after launch. The path is `/knowledge`, deliberately **not**
    `/contribute` — the Contributions plugin is a different thing entirely (the fundraiser and donation
    surface), and two member-facing paths a word apart would be a standing source of confusion (owner
    decision, 2026-07-29). The screen is titled "Knowledge library" for the same reason. A member can lend their own public Quora
@@ -262,7 +263,8 @@ Built on `feat/comic-ai-assistant`; all server-only routes (no rendered surface)
   via Ollama (captured as a bot turn), enqueues to `comic_review_queue`, and returns **only a
   safe holding response (HTTP 202)** — never the unreviewed draft. Safety-flagged turns skip
   generation and are queued human-first.
-- `POST /api/comic/contributions` (`comic.contribution.submit`) — signed-in member. Accepts either
+- `POST /api/comic/contributions` (`comic.contribution.submit`) — **verified member** (`approved_full`,
+   the default `minUnlockTier` on `requireComicReadAccess`). Accepts either
   **`kind=links`** (the default: pasted posts, each with a quora.com URL as provenance — nothing is
   fetched) or **`kind=export`** (a Quora export `.zip`, multipart, 25 MB cap), plus the consent
   payload. **Consent is validated before the
@@ -272,8 +274,8 @@ Built on `feat/comic-ai-assistant`; all server-only routes (no rendered surface)
   decompressed, entry names are validated, and a decompressed-size ceiling guards against a zip
   bomb; nothing is written to disk or executed. Public sections are kept, everything else discarded.
   Rate-limited to 5 per member per 24h. Audits the **consent**, never the content.
-- `GET /api/comic/contributions` — signed-in member. The caller's own contribution history.
-- `POST /api/comic/contributions/[id]/withdraw` (`comic.contribution.withdraw`) — signed-in member,
+- `GET /api/comic/contributions` — verified member. The caller's own contribution history.
+- `POST /api/comic/contributions/[id]/withdraw` (`comic.contribution.withdraw`) — verified member,
   own contribution only (scoped inside the query, so another member's id is indistinguishable from a
   missing one). Marks it withdrawn and deactivates its `comic_knowledge_entries` rows in one
   transaction, so there is no window where it reads as withdrawn while still being quoted.
@@ -674,6 +676,26 @@ buckets are not reproduced — only real provenance (engine / intent / safety ca
 `nlu_confidence`, surfaced as "Not yet scored" when null) is shown.
 
 ## Change Log
+
+- 2026-07-29: **Contributing requires completed Unlock; the page now matches the API it always had
+  (owner report).** The `/knowledge` page was gated at `any_authenticated` while
+  `requireComicReadAccess` — which the submit, list, and withdraw routes all use — takes the default
+  `minUnlockTier: 'approved_full'`. So an unverified member could open the page, read six consent
+  clauses, paste their posts, and only then hit a 403 on send. Not a security hole (nothing
+  unverified was ever accepted) but a bad wall to walk someone into, and the page's own comment
+  asserted an openness the API never honoured.
+  Settled the other way per the owner: **contributing requires Unlock.** The page now redirects an
+  unverified member to `/plugin/unlock` rather than the sign-in page — they are already signed in, so
+  "sign in" would explain nothing. Reasoning: reviewing a contribution is manual and slow, so the
+  scarce resource is the reviewer's reading time, and an unverified throwaway account could spend it
+  (5/day) without ever getting near the assistant. Verification is the cost that makes that not worth
+  doing.
+  Consent notes and the page copy no longer say a member can contribute before verifying — that was
+  the openness the API never allowed. `CONTRIBUTION_CONSENT_VERSION` bumped to `2026-07-29.2`, so any
+  page cached with the old wording is refused rather than recorded as agreement to it. The
+  `isUserUnlocked` check in `contribution-grant.ts` is now unreachable in practice and documented as
+  defence in depth: it is the last gate before credits are minted, and a money-adjacent path must not
+  quietly start paying out if the submit-side requirement is ever relaxed again.
 
 - 2026-07-29: **Third-party identifier scrub applied to production; the one-time tooling is deleted
   (#1912 closed out).** The first seed import ran before `redact()` covered Quora profile links and

--- a/ctf/docs/developer/test-scripts/comic-test-script.md
+++ b/ctf/docs/developer/test-scripts/comic-test-script.md
@@ -11,8 +11,25 @@ the tests worth running slowly.
 
 ---
 
+## CMC-C0 · An unverified member cannot get in
+**Role:** signed-in member who has NOT completed Unlock
+**Steps:**
+1. Open `/knowledge`.
+2. Signed out entirely, open `/knowledge`.
+
+**Expected:**
+- Step 1 → redirected to `/plugin/unlock`, **not** to sign-in. They are already signed in; telling
+  them to sign in again would explain nothing. They must never reach the form and fill it in only to
+  be refused on send (that mismatch was the 2026-07-29 fix).
+- Step 2 → redirected to sign-in.
+- `POST /api/comic/contributions` called directly by an unverified member → 403 `unlock_required`.
+
+**Result:** web ☐
+
+---
+
 ## CMC-C1 · Pick a few posts (the default path)
-**Role:** signed-in member · **Surfaces:** web + mobile-responsive
+**Role:** verified member (Unlock complete) · **Surfaces:** web + mobile-responsive
 **Precondition:** two of your own public Quora posts.
 
 **Steps:**
@@ -139,16 +156,14 @@ the tests worth running slowly.
 
 ---
 
-## CMC-A1 · Review: accept, and what the credits do
-**Role:** admin, plus two contributors — one **verified (Unlock complete)** and one **not yet verified**
+## CMC-A1 · Review: accept, and the credits
+**Role:** admin, plus a verified contributor
 **Steps:**
-1. Have both contributors send a contribution from `/knowledge`.
+1. Have the contributor send a contribution from `/knowledge`.
 2. Open `/admin/comic/contributions`.
-3. On the verified member's card, press **Leave out** on one entry, then press it again and confirm
-   it toggles back with **Put back**.
+3. Press **Leave out** on one entry, then press it again and confirm it toggles back with **Put back**.
 4. Press **Accept N of M**.
-5. Repeat on the not-yet-verified member's card.
-6. Check `comic_knowledge_entries` and the contributors' ServiceCredits balances.
+5. Check `comic_knowledge_entries` and the contributor's ServiceCredits balance.
 
 **Expected:**
 - Every entry is shown **in full**, not summarised — the decision cannot be made from a count.
@@ -157,11 +172,10 @@ the tests worth running slowly.
 - If the contributor wrote a third-party note, it appears **at the top of the card**, highlighted —
   that is the thing to check before promoting anything.
 - After step 4: the left-out entry is **not** in `comic_knowledge_entries`; the kept ones are, each
-  carrying `contribution_id`. The screen says how many were added and that the credits were granted.
-- After step 5: the writing is in the library, and the screen says **no credits, because that member
-  is not verified yet**, and that the grant can be made once they finish Unlock. This is a decision,
-  not a failure — it must never look like a silent no-op.
-- `granted_at` is set only on the verified member's row.
+  carrying `contribution_id`. The screen says how many were added and that the credits were granted,
+  and `granted_at` is set.
+- The "no credits — not verified yet" branch is **unreachable** now that contributing requires Unlock
+  (CMC-C0). It is kept as the last gate before a mint; there is nothing to test by hand.
 
 **Result:** web ☐
 

--- a/ctf/packages/web/app/knowledge/page.tsx
+++ b/ctf/packages/web/app/knowledge/page.tsx
@@ -8,11 +8,16 @@ export const dynamic = 'force-dynamic';
 // Where a member lends their own public Quora writing to the assistant's reference library, and
 // where the consent that permits it is given.
 //
-// Signed-in only, at `any_authenticated` rather than full Unlock access: someone who has not finished
-// verifying can still have years of public writing worth contributing, and consent is the thing that
-// makes it usable — not their verification tier. It stays gated to a signed-in account because a
-// contribution has to be attributable to the person consenting, and withdrawal has to be something
-// only they can do.
+// Requires COMPLETED UNLOCK, not merely a signed-in account (owner decision, 2026-07-29). It first
+// shipped open to any authenticated member, on the reasoning that someone mid-verification may have
+// years of writing worth contributing. What that reasoning missed: reviewing a contribution is
+// manual and slow, so the scarce resource is the reviewer's reading time — and an unverified account
+// can spend it without ever getting near the assistant. Nothing unreviewed reaches the bot either
+// way, but a throwaway account could still put junk in front of a human every day. Verification is
+// the cost that makes that not worth doing.
+//
+// A member who has not verified is sent to the Unlock flow rather than the sign-in page, because
+// they are already signed in and telling them to sign in again explains nothing.
 //
 // A short top-level path (`/knowledge`) rather than one under /apps, because the invitation post
 // links here from outside the app and the link should be easy to type and read. Deliberately NOT
@@ -20,8 +25,12 @@ export const dynamic = 'force-dynamic';
 // surface — and two member-facing paths a word apart would be a standing source of confusion (owner
 // decision, 2026-07-29).
 export default async function KnowledgePage() {
-  const decision = await evaluatePluginAccess({ minUnlockTier: 'any_authenticated', requireUsername: false });
+  const decision = await evaluatePluginAccess({ requireUsername: false });
   if (!decision.allowed) {
+    // Signed in but not yet verified → the Unlock flow. Not signed in at all → sign-in.
+    if (decision.reason === 'unlock_required') {
+      redirect('/plugin/unlock');
+    }
     redirect(getHostedSignInUrl() ?? '/sign-in');
   }
 

--- a/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
+++ b/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
@@ -534,15 +534,7 @@ export function ComicKnowledgeShell() {
           unit inside this app — they are not money, not cash, and cannot be cashed out. It is
           recognition for building something we all use, not a payment for your story.
         </p>
-        {/* Said plainly and up front, because finding out afterwards would feel like a bait. Anyone
-            signed in may contribute — someone still working through Unlock may have years of writing
-            worth having, and turning it away would cost the library more than it protects. The grant
-            is the part that waits. */}
-        <p style={{ fontSize: 13, color: t.MUTED, lineHeight: 1.6 }}>
-          You need to have finished verifying (Unlock) to receive the credits. You can contribute
-          before then — your writing is read and used the same way — and the grant can be made once
-          you are verified.
-        </p>
+
       </div>
     </main>
   );

--- a/ctf/packages/web/lib/comic/contribution-consent.ts
+++ b/ctf/packages/web/lib/comic/contribution-consent.ts
@@ -13,7 +13,7 @@
 // HOW TO CHANGE IT: if you alter what a contributor is agreeing to — the use, the scope, the
 // revocability — bump the version. Fixing a typo that changes no meaning can keep the version.
 
-export const CONTRIBUTION_CONSENT_VERSION = '2026-07-29.1';
+export const CONTRIBUTION_CONSENT_VERSION = '2026-07-29.2';
 
 export type ConsentClause = {
   id: string;
@@ -59,7 +59,7 @@ export const CONTRIBUTION_CONSENT_NOTES: string[] = [
   'Only your public answers and posts are kept. If you send a whole export, everything else Quora bundles into it — your private messages, your unpublished drafts, your profile details — is deleted automatically as soon as it arrives, before any person opens it. You do not have to clean the file yourself.',
   'A file you upload is never stored. It is read once, in memory, and the archive itself is discarded — there is no copy of it sitting anywhere afterwards.',
   'Your words are not used to train a model. They go into a table the assistant searches when it needs them, which is why withdrawing is something that can actually be done: the row comes out and the assistant stops quoting it. A bot trained the usual way could not honestly promise that.',
-  'An accepted contribution earns a ServiceCredits grant — an internal credits unit inside this app, not money and never cashable. You need to have finished verifying (Unlock) to receive it. You can contribute before then and your writing is used the same way; the grant simply waits.',
+  'An accepted contribution earns a ServiceCredits grant — an internal credits unit inside this app, not money and never cashable. It is recognition for building something we all use, not a payment for your story.',
   'Contact details are stripped automatically — email addresses, phone numbers, links, and account handles. This narrows what gets through; it does not replace a person reading it, which is why one does.',
 ];
 

--- a/ctf/packages/web/lib/comic/contribution-grant.ts
+++ b/ctf/packages/web/lib/comic/contribution-grant.ts
@@ -5,13 +5,13 @@
 //
 // TWO RULES, and they are the reason this is its own module rather than a few lines in the route.
 //
-// 1. ONLY AN UNLOCKED MEMBER RECEIVES CREDITS (owner decision, 2026-07-29). Contributing is open to
-//    any signed-in member — someone still working through verification may have years of writing
-//    worth having, and refusing it would cost the library more than it protects. The grant is the
-//    part that requires full Unlock access. It is also the part a bad actor would want: paying for
-//    contributions is an invitation to submit poisoned material, and requiring verification puts a
-//    real cost in front of that. An accepted contribution from a not-yet-verified member stays
-//    accepted and ungranted; nothing is lost, and the grant can be made later once they verify.
+// 1. ONLY AN UNLOCKED MEMBER RECEIVES CREDITS. As of 2026-07-29 contributing ITSELF requires
+//    completed Unlock (the /knowledge page and the submit route both enforce it), so in practice no
+//    unverified member can reach an accepted contribution and this check should never fire. It is
+//    kept as defence in depth: it is the last gate before credits are minted, and if the submit-side
+//    requirement is ever relaxed again, the money-adjacent path must not quietly start paying out.
+//    A contribution that somehow arrives from an unverified member stays accepted and ungranted
+//    rather than failing — the writing is still worth having.
 //
 // 2. NEVER GRANT TWICE. `granted_at` is stamped in the database before the mint is attempted, and
 //    the mint itself carries a per-contribution idempotency key, so a retried review, a double-click,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was actually wrong

Owner asked whether an unverified member can submit. They **could not** — but they could get all the way to the point of failure.

The `/knowledge` page was gated at `any_authenticated`, while `requireComicReadAccess` — used by the submit, list, and withdraw routes — takes the default `minUnlockTier: 'approved_full'`. So an unverified member could open the page, read six consent clauses, paste their posts, and only then hit a 403 on send.

Not a security hole: nothing unverified was ever accepted, and nothing reached the assistant. But it is a bad wall to walk someone into, and the page's own comment asserted an openness the API never honoured.

## Settled the other way

Per the owner: **contributing requires Unlock.** The argument that changed it — reviewing a contribution is manual and slow, so the scarce resource is the reviewer's reading time, and an unverified throwaway account could spend it (5/day, the rate limit) without ever getting near the assistant. Verification is the cost that makes that not worth doing. That consideration did not exist when the review step was still hypothetical.

An unverified member is redirected to `/plugin/unlock`, **not** to sign-in — they are already signed in, so "sign in" would explain nothing.

## Copy that was making a promise the API never kept

The consent notes and page copy said a member could contribute before verifying and the grant would wait. Removed. `CONTRIBUTION_CONSENT_VERSION` bumped to `2026-07-29.2`, so a page cached with the old wording is refused rather than recorded as agreement to text that is no longer true — which is exactly what the version field is for.

## The now-unreachable grant check

`isUserUnlocked` in `contribution-grant.ts` can no longer fire, since nobody unverified can reach an accepted contribution. **Kept**, and the comment now says why: it is the last gate before credits are minted, and a money-adjacent path must not quietly start paying out if the submit-side requirement is ever relaxed again. Deleting it would make a future relaxation silently expensive.

## Docs

- Comic inventory — user feature, route map, and a change-log entry explaining the mismatch and the decision.
- Access-policy contract — `minUnlockTier: approved_full` and an `unlock_required` deny condition on both contribution commands, bumped to 1.1.0.
- Command contract — the description now states the requirement.
- Test script — new **CMC-C0** (unverified is redirected to Unlock, signed-out to sign-in, direct POST is 403). **CMC-A1** no longer needs a second unverified contributor, and records that the "not verified yet" branch is unreachable by hand.

## Checks

- typecheck (all packages), lint, a11y lint, build — clean
- inventory drift, test-script drift, EOF format — clean locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_