### PR TITLE
chore: remove the deprecated "Hub" from every landing page

### DIFF
--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -139,7 +139,7 @@ function PublicCommunityPanel({ plugins, signInUrl }: { stats: ShellStats; plugi
       <div className={styles.heroBanner}>
         <div className={styles.heroBannerContent}>
           <p className={styles.heroBannerTag}>✦ From Survivor to Thriver</p>
-          <h1 className={styles.heroBannerTitle}>Welcome to Survivor Hub</h1>
+          <h1 className={styles.heroBannerTitle}>Welcome to Skills Economy</h1>
           <p className={styles.heroBannerSub}>Connect with your community. Access {implementedCount} live plugins for housing, work, safety, and support.</p>
         </div>
         {/* Stats are hidden on phones, where the three blocks filled a quarter of the first screen
@@ -185,7 +185,7 @@ function PublicCommunityPanel({ plugins, signInUrl }: { stats: ShellStats; plugi
             <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
               {isPublic
                 ? 'No community posts yet. Sign in to start the conversation.'
-                : 'To start connecting with Survivor Hub and accessing community support, please sign in.'}
+                : 'To start connecting with the community and accessing support, please sign in.'}
             </div>
           </div>
         )}
@@ -198,7 +198,7 @@ function PublicCommunityPanel({ plugins, signInUrl }: { stats: ShellStats; plugi
         <p className={styles.chatSuggestionsInfo}>
           {hasPosts
             ? 'You are reading the Commons. Sign in — free — to post, reply, and access housing, work, and safety resources.'
-            : 'Survivor Hub is free and helps you access housing, work, safety resources, and connect with others in the community.'}
+            : 'Skills Economy is free and helps you access housing, work, safety resources, and connect with others in the community.'}
         </p>
       </div>
     </div>
@@ -478,7 +478,7 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
               ) : announcementsOnly ? (
                 <>No announcements yet. Official updates from the team show here.</>
               ) : (
-                <>Survivor Hub is live. Share with the community, or type <strong>@comic</strong> to ask the AI Assistant.</>
+                <>You are connected. Share with the community, or type <strong>@comic</strong> to ask the AI Assistant.</>
               )}
             </div>
           </div>

--- a/ctf/packages/web/components/community-shell/shell-right-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-right-rail.tsx
@@ -38,7 +38,7 @@ export function ShellRightRail({ currentUser, trust, isAuthenticated = false, si
       <aside className={`${styles.panel} ${styles.rightRail}`}>
         <section className={styles.profileCard}>
           {avatar}
-          <p className={styles.profileName}>Welcome to Survivor Hub</p>
+          <p className={styles.profileName}>Welcome to Skills Economy</p>
           <p className={styles.profileMeta}>Sign in to access full features and connect with your community</p>
           <Link href={signInUrl} className={styles.profileLoginBtn}>Sign In</Link>
         </section>
@@ -49,7 +49,7 @@ export function ShellRightRail({ currentUser, trust, isAuthenticated = false, si
         </section>
 
         <section>
-          <p className={styles.rightRailSectionTitle}>About Survivor Hub</p>
+          <p className={styles.rightRailSectionTitle}>About Skills Economy</p>
           <p className={styles.sectionDesc}>Not sure where to start? Just say what you need in the chat — housing, work, safety, or someone to talk to — and we&apos;ll point you to the right place.</p>
         </section>
       </aside>

--- a/ctf/packages/web/components/directory/directory-public-shell.tsx
+++ b/ctf/packages/web/components/directory/directory-public-shell.tsx
@@ -25,7 +25,7 @@ function MobileDirectoryPublic({ signInUrl, verifyUrl }: { signInUrl: string; ve
         </div>
         <span style={{ padding: '3px 12px', borderRadius: 20, background: t.ACCENT + '20', border: `1px solid ${t.ACCENT}40`, fontSize: 11, color: t.ACCENT, fontWeight: 600, width: 'fit-content' }}>Community members</span>
         <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Therapists, housing navigators, legal advocates, and more — searchable by location and specialty.</p>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       {/* SkillsHunt pinned reward card */}

--- a/ctf/packages/web/components/foundation/foundation-public-shell.tsx
+++ b/ctf/packages/web/components/foundation/foundation-public-shell.tsx
@@ -22,7 +22,7 @@ function MobileFoundationPublic({ signInUrl, verifyUrl }: { signInUrl: string; v
           <span style={{ fontSize: 20, fontWeight: 800 }}>Foundation</span>
         </div>
         <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Electricians, plumbers, carpenters, and more — fellow community members. Pay with ServiceCredits.</p>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       {/* Sign-in gate (no fabricated provider cards) */}

--- a/ctf/packages/web/components/gdp/gdp-public-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-public-shell.tsx
@@ -30,7 +30,7 @@ function MobileGDPPublic({ signInUrl, verifyUrl }: { signInUrl: string; verifyUr
           <div style={{ fontSize: 13, fontWeight: 600, color: t.TITLE }}>Economy totals are coming soon</div>
           <div style={{ fontSize: 12, color: t.SUBTLE, lineHeight: 1.5 }}>Live totals build up as members exchange value in the community — credits sent, calls paid, favors completed. Sign in to contribute.</div>
         </div>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       <div style={{ flex: 1, padding: '0 20px 20px' }}>

--- a/ctf/packages/web/components/level-up/level-up-public-shell.tsx
+++ b/ctf/packages/web/components/level-up/level-up-public-shell.tsx
@@ -55,7 +55,7 @@ function MobileLevelUpPublic({ signInUrl, verifyUrl }: { signInUrl: string; veri
             </div>
           ))}
         </div>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>

--- a/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
+++ b/ctf/packages/web/components/lighthouse/lighthouse-public-shell.tsx
@@ -60,7 +60,7 @@ function MobileLightHousePublic({ signInUrl, verifyUrl }: { signInUrl: string; v
         </div>
         <span style={{ padding: '3px 12px', borderRadius: 20, background: t.ACCENT + '20', border: `1px solid ${t.ACCENT}40`, fontSize: 11, color: t.ACCENT, fontWeight: 600, width: 'fit-content' }}>Community housing</span>
         <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Trauma-informed hosts. ServiceCredits accepted.</p>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#000', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>

--- a/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
+++ b/ctf/packages/web/components/peer-programming/peer-programming-public-shell.tsx
@@ -45,7 +45,7 @@ function MobilePeerProgrammingPublic({ signInUrl, verifyUrl }: { signInUrl: stri
           <Globe size={13} color={t.MUTED} />
           <span style={{ fontSize: 12, color: t.MUTED }}>Open to members worldwide</span>
         </div>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textDecoration: 'none', textAlign: 'center' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative' }}>

--- a/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-public-shell.tsx
@@ -12,11 +12,11 @@ import { getServiceCreditsTokens } from './sc-shared';
 const EARN_GREEN = '#22C55E';
 const FONT_FAMILY = "'Inter', system-ui, sans-serif";
 
-// The earn/spend lists describe how the Hub economy works (program rules), not per-user balances or
+// The earn/spend lists describe how the Skills Economy works (program rules), not per-user balances or
 // fabricated transactions, so they are safe to render in a signed-out public shell. They are derived
 // from the SAME shared constants the signed-in Earn tab (sc-earn-tab.tsx) renders, so the public
 // teaser can never drift from the real earn model: a few platform-funded rewards (verify your
-// account, SkillsHunt, fundraiser contributions) plus peer-to-peer trading across the Hub. No
+// account, SkillsHunt, fundraiser contributions) plus peer-to-peer trading across Skills Economy. No
 // invented amounts — each value comes straight from the shared model, and peer-to-peer spend is
 // member-set, so it shows as "Variable".
 const EARN_WAYS = PLATFORM_EARN_METHODS.map((m) => ({ action: m.title, credits: m.credits }));
@@ -70,7 +70,7 @@ function MobileServiceCreditsPublic({ signInUrl, verifyUrl }: { signInUrl: strin
  * experience pixel-faithful to the ServiceCreditsPublic (desktop) and
  * MobileServiceCreditsPublic (phone) design mockups, with sign-in affordances
  * pointing at the real hosted sign-in URL. It shows no private or per-user data:
- * the earn/spend lists are static marketing copy describing the Hub economy's
+ * the earn/spend lists are static marketing copy describing the Skills Economy's
  * rules, not any per-user balance or transaction history.
  */
 export function ServiceCreditsPublicShell({ signInUrl, verifyUrl }: PublicVisitorShellProps) {

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-public-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-public-shell.tsx
@@ -36,7 +36,7 @@ function MobileSkillsHuntPublic({ signInUrl, verifyUrl }: { signInUrl: string; v
           This is not a referral button. You nominate someone you believe may be a survivor — first name, bio, Quora profile, skills, and professions. Their profile seeds the Directory so we can trade and stop depending on traffickers.
         </p>
 
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       {/* Blurred form preview + lock (neutral placeholders) */}

--- a/ctf/packages/web/components/socket-relay/socket-relay-public-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-public-shell.tsx
@@ -26,7 +26,7 @@ function MobileSocketRelayPublic({ signInUrl, verifyUrl }: { signInUrl: string; 
         </div>
         <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Peer-to-peer needs board</span>
         <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Post what you need, offer what you have. Clothing, furniture, skills, time — the survivor community connects directly.</p>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       {/* Blurred feed preview + lock (neutral placeholders) */}

--- a/ctf/packages/web/components/trust-transport/trust-transport-public-shell.tsx
+++ b/ctf/packages/web/components/trust-transport/trust-transport-public-shell.tsx
@@ -42,7 +42,7 @@ function MobileTrustTransportPublic({ signInUrl, verifyUrl }: { signInUrl: strin
             </div>
           ))}
         </div>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       {/* Blurred driver preview + lock (neutral placeholders) */}

--- a/ctf/packages/web/components/trust/trust-public-shell.tsx
+++ b/ctf/packages/web/components/trust/trust-public-shell.tsx
@@ -64,7 +64,7 @@ function MobileTrustPublic({ signInUrl, verifyUrl }: { signInUrl: string; verify
             <div style={{ fontSize: 11, color: t.MUTED, marginTop: 2 }}>Sign in to build yours</div>
           </div>
           <a href={verifyUrl ?? signInUrl} style={{ width: '100%', padding: '13px', borderRadius: 10, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', textAlign: 'center', boxSizing: 'border-box', textDecoration: 'none' }}>
-            {verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}
+            {verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}
           </a>
         </div>
       </div>

--- a/ctf/packages/web/components/workforce/workforce-public-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-public-shell.tsx
@@ -91,7 +91,7 @@ function MobileWorkforcePublic({ signInUrl, verifyUrl, snapshot }: { signInUrl: 
             })}
           </div>
         </div>
-        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join the Hub — Free'}</a>
+        <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: t.ACCENT, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
       </div>
 
       <div style={{ flex: 1, padding: '0 20px 20px', position: 'relative', minHeight: 300 }}>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What

Owner report, with screenshots of Foundation and GDP: the landing pages still say **"Join the Hub — Free"**. Hub is the retired product name.

Swept every surface a visitor sees *before* signing in:

- **The join CTA on all 11 public plugin shells** — Directory, Foundation, GDP, LevelUp, LightHouse, PeerProgramming, SkillsHunt, SocketRelay, TrustTransport, Trust, Workforce. Now "Join Skills Economy — Free".
- **The signed-out Commons** — hero title, both sign-in prompts, and the "is live" line.
- **The right rail** — "Welcome to / About Survivor Hub".
- **ServiceCredits landing copy** about "the Hub economy".

Verified nothing is left: the only remaining `Hub` matches on those files are the word "GitHub".

## Two left alone on purpose

- The `// "SH" for the Survivor Hub system/AI` comment, next to the avatar-glyph function that still matches on `'survivor hub'`.
- The `'Survivor Hub'` **fallback sender label** in the chat stream.

That label is not just copy — it feeds the dedup key that matches an optimistic send against the next polled copy of the same message. Changing it while messages are in flight risks duplicate rows in the stream. It is a data question, not a wording one, and belongs in its own change with the matching-logic checked.

## Still says Hub elsewhere (not landing pages, not in scope here)

Signed-in surfaces: Unlock submission and status, Account & Data, the AI consent modal, and the account identity screen. Say the word and I will do those as a second pass.

## Checks

- typecheck (all packages), lint, build — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_