### PR TITLE
feat: add functioning-economy skills progress line to community stats

### DIFF
--- a/ctf/scripts/generate-community-stats.mjs
+++ b/ctf/scripts/generate-community-stats.mjs
@@ -122,7 +122,7 @@ const STAT_PROVIDERS = [
         { label: 'different skills people have listed', value: distinctSkills.rows[0].n },
         { label: 'skills available to pick from in total', value: totalSkills.rows[0].n },
         {
-          label: 'documented skills toward a full economy',
+          label: 'documented skills toward an economy',
           value: `${documentedNow} of ${FULL_ECONOMY_SKILL_BASELINE} (${pctOfBaseline}%) — all ${FULL_ECONOMY_SKILL_BASELINE} would be about $300 billion in community value`,
         },
       ];
@@ -253,7 +253,7 @@ const response = await fetch('https://api.anthropic.com/v1/messages', {
     messages: [
       {
         role: 'user',
-        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. Work in the skills-documented-so-far line — how many of the 650 skills a full economy needs are documented now, and the percentage — since it shows how the economy is filling in; use only the exact numbers given for it. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
+        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. Work in the skills-documented-so-far line — how many of the 650 skills an economy needs are documented now, and the percentage — since it shows how the economy is filling in; use only the exact numbers given for it. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
       },
     ],
   }),

--- a/ctf/scripts/generate-community-stats.mjs
+++ b/ctf/scripts/generate-community-stats.mjs
@@ -39,11 +39,11 @@ function requireEnv(name) {
 const databaseUrl = requireEnv('DATABASE_URL');
 requireEnv('ANTHROPIC_API_KEY');
 
-// The number of documented skills a fully working Skills Economy needs. Reaching all 650 is the
-// baseline for that full economy — one we size at about $300 billion in community value (the same
-// $300B goal the GDP plugin tracks; an estimate, never money or price). The Directory shows how many
-// skills are documented so far, so the draft can report that count against this 650 baseline as a
-// percentage.
+// The number of documented skills a functioning economy needs — the point at which the community can
+// meet its own needs. Any economy can be any size; covering all 650 skills is what makes it
+// self-sufficient. We size a full 650 at about $300 billion in community value (the same $300B goal
+// the GDP plugin tracks; an estimate, never money or price). The Directory shows how many skills are
+// documented so far, so the draft can report that count against this 650 baseline as a percentage.
 const FULL_ECONOMY_SKILL_BASELINE = 650;
 
 const pool = new Pool({
@@ -122,7 +122,7 @@ const STAT_PROVIDERS = [
         { label: 'different skills people have listed', value: distinctSkills.rows[0].n },
         { label: 'skills available to pick from in total', value: totalSkills.rows[0].n },
         {
-          label: 'documented skills toward an economy',
+          label: 'documented skills toward a functioning economy',
           value: `${documentedNow} of ${FULL_ECONOMY_SKILL_BASELINE} (${pctOfBaseline}%) — all ${FULL_ECONOMY_SKILL_BASELINE} would be about $300 billion in community value`,
         },
       ];
@@ -253,7 +253,7 @@ const response = await fetch('https://api.anthropic.com/v1/messages', {
     messages: [
       {
         role: 'user',
-        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. Work in the skills-documented-so-far line — how many of the 650 skills an economy needs are documented now, and the percentage — since it shows how the economy is filling in; use only the exact numbers given for it. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
+        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. Work in the skills-documented-so-far line — how many of the 650 skills a functioning economy needs are documented now, and the percentage — since it shows how the economy is filling in; use only the exact numbers given for it. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
       },
     ],
   }),

--- a/ctf/scripts/generate-community-stats.mjs
+++ b/ctf/scripts/generate-community-stats.mjs
@@ -39,6 +39,13 @@ function requireEnv(name) {
 const databaseUrl = requireEnv('DATABASE_URL');
 requireEnv('ANTHROPIC_API_KEY');
 
+// The number of documented skills a fully working Skills Economy needs. Reaching all 650 is the
+// baseline for that full economy — one we size at about $300 billion in community value (the same
+// $300B goal the GDP plugin tracks; an estimate, never money or price). The Directory shows how many
+// skills are documented so far, so the draft can report that count against this 650 baseline as a
+// percentage.
+const FULL_ECONOMY_SKILL_BASELINE = 650;
+
 const pool = new Pool({
   connectionString: databaseUrl,
   ssl: { rejectUnauthorized: false },
@@ -105,10 +112,19 @@ const STAT_PROVIDERS = [
          ORDER BY n DESC, s.name ASC
          LIMIT 5`,
       );
+      // How many skills are documented so far, measured against the 650 a full Skills Economy
+      // needs. The percentage is whole-number and can read small early on — that is fine to show
+      // plainly.
+      const documentedNow = totalSkills.rows[0].n;
+      const pctOfBaseline = Math.round((documentedNow / FULL_ECONOMY_SKILL_BASELINE) * 100);
       const facts = [
         { label: 'people listed in the Directory', value: profiles.rows[0].n },
         { label: 'different skills people have listed', value: distinctSkills.rows[0].n },
         { label: 'skills available to pick from in total', value: totalSkills.rows[0].n },
+        {
+          label: `skills documented so far out of the ${FULL_ECONOMY_SKILL_BASELINE} a full Skills Economy needs (a full one is sized at about $300 billion in community value)`,
+          value: `${documentedNow} of ${FULL_ECONOMY_SKILL_BASELINE} documented (${pctOfBaseline}%)`,
+        },
       ];
       if (topSkills.rows.length > 0) {
         const named = topSkills.rows.map((r) => `${r.name} (${r.n})`).join(', ');
@@ -237,7 +253,7 @@ const response = await fetch('https://api.anthropic.com/v1/messages', {
     messages: [
       {
         role: 'user',
-        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
+        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. Work in the skills-documented-so-far line — how many of the 650 skills a full Skills Economy needs are documented now, and the percentage — since it shows how the economy is filling in; use only the exact numbers given for it. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
       },
     ],
   }),

--- a/ctf/scripts/generate-community-stats.mjs
+++ b/ctf/scripts/generate-community-stats.mjs
@@ -122,7 +122,7 @@ const STAT_PROVIDERS = [
         { label: 'different skills people have listed', value: distinctSkills.rows[0].n },
         { label: 'skills available to pick from in total', value: totalSkills.rows[0].n },
         {
-          label: 'documented skills toward a full Skills Economy',
+          label: 'documented skills toward a full economy',
           value: `${documentedNow} of ${FULL_ECONOMY_SKILL_BASELINE} (${pctOfBaseline}%) — all ${FULL_ECONOMY_SKILL_BASELINE} would be about $300 billion in community value`,
         },
       ];
@@ -253,7 +253,7 @@ const response = await fetch('https://api.anthropic.com/v1/messages', {
     messages: [
       {
         role: 'user',
-        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. Work in the skills-documented-so-far line — how many of the 650 skills a full Skills Economy needs are documented now, and the percentage — since it shows how the economy is filling in; use only the exact numbers given for it. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
+        content: `This week's whole-community totals:\n\n${statsForPrompt}\n\nWrite a community snapshot. Return ONLY a JSON object with these exact keys:\n- title: A short, plain in-list title (max 80 chars), e.g. "Community activity — ${today}".\n- quoraDraft: A 2-4 short-paragraph Quora post, written like a personal note. Lead with the SocketRelay open posts and the Directory numbers, since those show need most clearly. Work in the skills-documented-so-far line — how many of the 650 skills a full economy needs are documented now, and the percentage — since it shows how the economy is filling in; use only the exact numbers given for it. When you first name each app, paste its exact direct link (given above as "direct link: ...") right after the name in parentheses, so a reader can tap straight through to it. Remember an open-post count is a count of posts, not people. Plain words, ~6th-grade reading level. Make it concrete: a number, what it means, and one simple thing a reader can do (join, list a skill, answer an open post). One sentence on where the project lives, giving the GitHub URL exactly as ${repoUrl}. Do not invent numbers or links, do not sell importance, no rhetorical questions.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
       },
     ],
   }),

--- a/ctf/scripts/generate-community-stats.mjs
+++ b/ctf/scripts/generate-community-stats.mjs
@@ -122,8 +122,8 @@ const STAT_PROVIDERS = [
         { label: 'different skills people have listed', value: distinctSkills.rows[0].n },
         { label: 'skills available to pick from in total', value: totalSkills.rows[0].n },
         {
-          label: `skills documented so far out of the ${FULL_ECONOMY_SKILL_BASELINE} a full Skills Economy needs (a full one is sized at about $300 billion in community value)`,
-          value: `${documentedNow} of ${FULL_ECONOMY_SKILL_BASELINE} documented (${pctOfBaseline}%)`,
+          label: 'documented skills toward a full Skills Economy',
+          value: `${documentedNow} of ${FULL_ECONOMY_SKILL_BASELINE} (${pctOfBaseline}%) — all ${FULL_ECONOMY_SKILL_BASELINE} would be about $300 billion in community value`,
         },
       ];
       if (topSkills.rows.length > 0) {


### PR DESCRIPTION
## What

Adds one whole-community stat line to the weekly community-stats draft generator (`ctf/scripts/generate-community-stats.mjs`). The line reports how many skills are documented so far against the 650 a functioning economy needs — the point at which the community can meet its own needs — as a count and a percentage:

```
documented skills toward a functioning economy: n of 650 (n%) — all 650 would be about $300 billion in community value
```

## Why

Covering all 650 skills is what makes the community self-sufficient — any economy can be any size, but the full 650 is the baseline for one that meets its own needs. Showing the progress toward 650 gives a reader a plain sense of how close the community is to that.

## Details

- 650 is a named constant (`FULL_ECONOMY_SKILL_BASELINE`) with a comment explaining the self-sufficiency intent.
- `n` reuses the existing Directory active-skill count (no new database read); `n%` is `round(n / 650 × 100)`.
- The $300 billion framing mirrors the repo's existing honest wording (the GDP plugin's $300B community-value goal — an estimate, never money or price), so nothing is framed as fiat.
- The line always appears in the issue's "Source numbers" section, and a short prompt nudge asks the drafted post to work it in using only the exact numbers given.
- Every query stays aggregate-only; no individual person, post, or profile is read.

## Verification

- `node --check` passes.
- EOF formatting check passes.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (operational script, no app surface)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HypXpZkiNVUZEL3S569QJM)_