### PR TITLE
feat: /knowledge gets a landing page, and contributing verifies you

### DIFF
--- a/ctf/docs/contracts/COMIC_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/COMIC_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -203,11 +203,19 @@ policies:
 
   - pluginId: comic
     command: comic.contribution.submit
-    version: 1.0.0
+    version: 1.1.0
     requiredRoles:
       - member
+    # ANY signed-in member — deliberately looser than the rest of comic (owner decision, 2026-07-29).
+    # Contributing is a route INTO verification: judging a contribution means opening the
+    # contributor's Quora account, the same look Unlock asks for, so gating it behind Unlock would
+    # review the same account twice.
+    minUnlockTier: any_authenticated
     attributePolicies:
       tenancy: same_workspace
+      # With no Quora URL on file, the submission opens a PENDING Unlock submission from the one
+      # supplied. Never an auto-approval; the owner still reviews.
+      maySeedPendingUnlockSubmission: true
       # Explicit, per-clause consent — every clause id must be present, and the version submitted
       # must match the wording currently served. This is the lawful basis for using the content, so
       # it is checked before the uploaded file is read at all.
@@ -239,9 +247,10 @@ policies:
 
   - pluginId: comic
     command: comic.contribution.withdraw
-    version: 1.0.0
+    version: 1.1.0
     requiredRoles:
       - member
+    minUnlockTier: any_authenticated
     attributePolicies:
       tenancy: same_workspace
       # A member may only withdraw their own contribution; ownership is enforced inside the query.

--- a/ctf/docs/contracts/COMIC_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/COMIC_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -228,12 +228,20 @@ contracts:
       thirdPartyNote:
         type: string
         required: false
+      quoraProfileUrl:
+        type: string
+        required: false
     outputSchema:
       contribution:
         type: object
+      unlockLink:
+        type: string
+        enum: [submitted, already_on_file, invalid_url, not_provided, failed]
     dataAccess:
       - comic_contributions
       - comic_contribution_entries
+      - unlock_verification_submissions
+      - unlock_audit_log
     purpose: assistant_knowledge_contribution
     retentionClass: transactional_long_lived
     idempotency: false

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -173,7 +173,13 @@ its plugin-routing role (today's hardcoded `getActionForText`) becomes Rasa-back
 3. When unsure, the bot shows a clear pre-approved holding response and hands the question
    to a human — the user is never shown speculative content.
 4. Users can rate any answer (`helpful / not_helpful / flagged`) — feeds the training loop.
-5. **Contribute your own writing (`/knowledge`).** The path is `/knowledge`, deliberately **not**
+5. **Contribute your own writing (`/knowledge`).** **Open to any signed-in member, and it is a route
+   INTO verification** (owner decision, 2026-07-29): judging a contribution means opening the
+   contributor's Quora account and seeing a real person writing real things, which is the same look
+   Unlock asks for — so gating it behind Unlock would review the same account twice. A **signed-out
+   visitor gets a public landing page**, because this is the URL the invitation post links to from
+   Quora and most people opening it have no account yet.
+   The path is `/knowledge`, deliberately **not**
    `/contribute` — the Contributions plugin is a different thing entirely (the fundraiser and donation
    surface), and two member-facing paths a word apart would be a standing source of confusion (owner
    decision, 2026-07-29). The screen is titled "Knowledge library" for the same reason. A member can lend their own public Quora
@@ -262,7 +268,13 @@ Built on `feat/comic-ai-assistant`; all server-only routes (no rendered surface)
   via Ollama (captured as a bot turn), enqueues to `comic_review_queue`, and returns **only a
   safe holding response (HTTP 202)** — never the unreviewed draft. Safety-flagged turns skip
   generation and are queued human-first.
-- `POST /api/comic/contributions` (`comic.contribution.submit`) — signed-in member. Accepts either
+- `POST /api/comic/contributions` (`comic.contribution.submit`) — **any signed-in member**
+  (`requireComicContributionAccess`, `minUnlockTier: 'any_authenticated'` — deliberately looser than
+  the rest of comic, which stays `approved_full`). Optionally carries `quoraProfileUrl`: when the
+  member has **no Quora URL on file**, it opens a **pending** Unlock submission from it (never an
+  approval) audited as `unlock.verification.submit` with `source: comic_knowledge_contribution`.
+  Best-effort and run *after* the contribution is stored, so a failure cannot lose the writing.
+  Accepts either
   **`kind=links`** (the default: pasted posts, each with a quora.com URL as provenance — nothing is
   fetched) or **`kind=export`** (a Quora export `.zip`, multipart, 25 MB cap), plus the consent
   payload. **Consent is validated before the
@@ -674,6 +686,28 @@ buckets are not reproduced — only real provenance (engine / intent / safety ca
 `nlu_confidence`, surfaced as "Not yet scored" when null) is shown.
 
 ## Change Log
+
+- 2026-07-29 (later): **Contributing is a route INTO verification, and `/knowledge` gets a public
+  landing page (owner decision).** Judging a contribution means opening the contributor's Quora
+  account and seeing a real person writing real things — exactly the look Unlock verification asks
+  for. Gating contribution behind Unlock reviews the same account twice and makes the most useful
+  thing a new member can do into something they wait for. (This settles a mismatch found the same
+  day: the page was `any_authenticated` while the routes were `approved_full`, so a member could fill
+  in the whole form and only then be refused. Resolved by loosening the routes, not tightening the
+  page — PR #1963, which did the opposite, was closed unmerged.)
+  - **Access:** new `requireComicContributionAccess` (`any_authenticated`) on the three contribution
+    routes; the rest of comic stays `approved_full`.
+  - **Unlock linkage** (`lib/comic/contribution-unlock-link.ts`): the submission may carry a Quora
+    profile URL. With **no URL on file** it opens a normal **pending** Unlock submission, audited
+    `source: comic_knowledge_contribution`. Never an auto-approval — one review now answers both
+    questions instead of one blocking the other. Best-effort, after the contribution is stored, so a
+    failure cannot lose someone's writing; the receipt states whether verification started. A member
+    who already has a URL on file is **never asked again** (owner decision), and the server re-checks
+    rather than trusting the page, so two conflicting URLs cannot reach one account this way.
+  - **Public landing page** (`comic-knowledge-public-shell.tsx`) for signed-out visitors.
+  - `normalizeQuoraProfileUrl` moved to `lib/unlock/quora-url.ts` and re-exported from
+    `app/api/unlock/_lib.ts`: `lib` must not import from `app`. It stays separate from the looser
+    `lib/directory/quora-url.ts` — verification needs the profile itself.
 
 - 2026-07-29: **Third-party identifier scrub applied to production; the one-time tooling is deleted
   (#1912 closed out).** The first seed import ran before `redact()` covered Quora profile links and

--- a/ctf/docs/developer/test-scripts/comic-test-script.md
+++ b/ctf/docs/developer/test-scripts/comic-test-script.md
@@ -11,6 +11,39 @@ the tests worth running slowly.
 
 ---
 
+## CMC-C0 · The landing page, and contributing as the way in
+**Role:** a signed-out visitor, then a brand-new signed-in member who has NOT verified
+**Steps:**
+1. Signed out, open `/knowledge`.
+2. Sign up as a fresh account that has never submitted a Quora URL, and open `/knowledge` again.
+3. Tick the six consent lines, paste a post, paste your own Quora **profile** link in the field that
+   appears, and send.
+4. Open `/admin/unlock` as admin.
+5. As a member who **already** has a Quora URL on file, open `/knowledge`.
+6. As a fresh unverified member, send a contribution with a Quora **post** link (not `/profile/`) in
+   that field.
+
+**Expected:**
+- Step 1 → the **public landing page**, not a redirect to sign-in. It says what the library is, what
+  happens to your writing, that you can take it back, and that contributing also verifies you. This
+  is the page the invitation post links to from Quora, so a visitor with no account has to be able to
+  read it and decide.
+- Step 2 → the form loads. An unverified member is **not** turned away — contributing is the way in,
+  not something behind the gate.
+- Step 3 → send is blocked until the profile field is filled; the receipt then says the Quora profile
+  went in for verification at the same time.
+- Step 4 → a **pending** submission for that member is in the queue, with an audit row tagged
+  `source: comic_knowledge_contribution`. **Pending, never auto-approved** — the point is that one
+  review covers both questions, not that review is skipped.
+- Step 5 → **no Quora URL field at all.** A member who already has one on file is never asked again,
+  so two conflicting URLs cannot reach one account by this route.
+- Step 6 → the writing is still kept and the receipt says verification did not start. Losing
+  someone's writing over a malformed link would be the wrong trade.
+
+**Result:** web ☐
+
+---
+
 ## CMC-C1 · Pick a few posts (the default path)
 **Role:** signed-in member · **Surfaces:** web + mobile-responsive
 **Precondition:** two of your own public Quora posts.

--- a/ctf/packages/web/app/api/comic/_lib.ts
+++ b/ctf/packages/web/app/api/comic/_lib.ts
@@ -29,6 +29,27 @@ export async function requireComicReadAccess(): Promise<ComicApiGate> {
   };
 }
 
+// Contribution routes only. Unlike the rest of comic (which needs `approved_full`), lending your
+// own public writing is open to ANY signed-in member — because contributing is now a route INTO
+// verification, not something gated behind it (owner decision, 2026-07-29). A member submits their
+// writing with their Quora profile URL; the owner has to look at that URL to judge the contribution
+// anyway, and that same look is the Unlock review. Requiring Unlock first would make the front door
+// depend on the room behind it.
+export async function requireComicContributionAccess(): Promise<ComicApiGate> {
+  const decision = await evaluatePluginAccess({ minUnlockTier: 'any_authenticated', requireUsername: false });
+  if (!decision.allowed) {
+    return {
+      allowed: false,
+      response: NextResponse.json(decision, { status: decision.status }),
+    };
+  }
+
+  return {
+    allowed: true,
+    auth: decision,
+  };
+}
+
 export async function requireComicAdminAccess(): Promise<ComicApiGate> {
   const decision = await evaluatePluginAccess({ requireUsername: false });
   if (!decision.allowed) {

--- a/ctf/packages/web/app/api/comic/contributions/[id]/withdraw/route.ts
+++ b/ctf/packages/web/app/api/comic/contributions/[id]/withdraw/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { ensureMutationCsrf, requireComicReadAccess } from '../../../_lib';
+import { ensureMutationCsrf, requireComicContributionAccess } from '../../../_lib';
 import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { logComicAudit } from 'lib/comic/audit';
 import { withdrawContribution } from 'lib/comic/contribution-repository';
@@ -18,7 +18,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 // that marks it withdrawn, so there is no window where the submission reads as withdrawn while the
 // assistant is still quoting it.
 export async function POST(request: Request, context: RouteContext) {
-  const gate = await requireComicReadAccess();
+  const gate = await requireComicContributionAccess();
   if (!gate.allowed) return gate.response;
 
   const csrfDeny = ensureMutationCsrf(request);

--- a/ctf/packages/web/app/api/comic/contributions/route.ts
+++ b/ctf/packages/web/app/api/comic/contributions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { ensureMutationCsrf, requireComicReadAccess } from '../_lib';
+import { ensureMutationCsrf, requireComicContributionAccess } from '../_lib';
 import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { logComicAudit } from 'lib/comic/audit';
 import { readQuoraExportArchive } from 'lib/comic/contribution-archive';
@@ -14,6 +14,7 @@ import {
   listContributionsForUser,
 } from 'lib/comic/contribution-repository';
 import { validateLinkedPosts } from 'lib/comic/contribution-links';
+import { linkContributionToUnlock } from 'lib/comic/contribution-unlock-link';
 import { reportError } from 'lib/observability/report';
 
 export const dynamic = 'force-dynamic';
@@ -31,7 +32,7 @@ function badRequest(message: string, code: string = COMIC_ERROR_CODE.invalidPayl
 
 // GET: the member's own contribution history, for the page's status list.
 export async function GET() {
-  const gate = await requireComicReadAccess();
+  const gate = await requireComicContributionAccess();
   if (!gate.allowed) return gate.response;
 
   try {
@@ -56,7 +57,7 @@ export async function GET() {
 //   4. store only what survived. The uploaded archive is never written to disk and is gone as soon
 //      as this request ends.
 export async function POST(request: Request) {
-  const gate = await requireComicReadAccess();
+  const gate = await requireComicContributionAccess();
   if (!gate.allowed) return gate.response;
 
   const csrfDeny = ensureMutationCsrf(request);
@@ -175,6 +176,16 @@ export async function POST(request: Request) {
       entries,
     });
 
+    // Contributing is a route into verification: if this member has no Quora URL on file and gave
+    // one here, open an Unlock submission from it. Best-effort and AFTER the contribution is stored —
+    // the writing is already safe, and a failure here just means they verify the ordinary way.
+    // It creates a pending submission, never an approval; the owner still decides.
+    const unlockLink = await linkContributionToUnlock({
+      userId: gate.auth.userId,
+      quoraProfileUrl: typeof form.get('quoraProfileUrl') === 'string' ? String(form.get('quoraProfileUrl')) : null,
+      contributionId: contribution.id,
+    });
+
     // Audit the consent, never the content. What matters for the record is that this member agreed
     // to this version of the wording at this time.
     logComicAudit({
@@ -192,10 +203,11 @@ export async function POST(request: Request) {
         entryCount: contribution.entryCount,
         kind,
         discardedSections: discarded,
+        unlockLink: unlockLink.status,
       },
     });
 
-    return NextResponse.json({ ok: true, contribution }, { status: 201 });
+    return NextResponse.json({ ok: true, contribution, unlockLink: unlockLink.status }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'comic', op: 'contribution_submit' });
     return NextResponse.json(

--- a/ctf/packages/web/app/api/unlock/_lib.ts
+++ b/ctf/packages/web/app/api/unlock/_lib.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { ensureUnlockAdmin } from 'lib/unlock/policy';
 import { checkMutationOrigin } from 'lib/auth/csrf';
-import { reportError } from 'lib/observability/report';
 
 // CSRF guard for unlock admin mutations that move ServiceCredits (reward grant determination, revoke).
 // Requires the same `x-ctf-csrf: 1` confirmation header + same-origin check the ServiceCredits admin uses,
@@ -33,29 +32,10 @@ export function resolveUnlockRequestId(request: Request): string {
   );
 }
 
-// Validate and normalize a Quora profile URL. Returns the canonical form (host lowercased, hash and
-// query stripped) or null when the URL is not a valid Quora profile link. Shared by the member
-// submission path and the admin URL-edit path so both apply the exact same rules.
-export function normalizeQuoraProfileUrl(rawUrl: string): string | null {
-  try {
-    const parsed = new URL(rawUrl.trim());
-    const host = parsed.hostname.toLowerCase();
-    if (host !== 'quora.com' && host !== 'www.quora.com') {
-      return null;
-    }
-
-    if (!parsed.pathname.startsWith('/profile/')) {
-      return null;
-    }
-
-    parsed.hash = '';
-    parsed.search = '';
-    return parsed.toString();
-  } catch (error) {
-    reportError(error, { area: 'unlock', op: 'normalize_quora_url' });
-    return null;
-  }
-}
+// Re-exported from lib/unlock/quora-url.ts so every existing caller here is unchanged. It moved to
+// lib/ because the knowledge-library contribution path opens an Unlock submission too, and lib must
+// not import from app.
+export { normalizeQuoraProfileUrl } from 'lib/unlock/quora-url';
 
 export async function requireUnlockUserAccess() {
   const decision = await evaluatePluginAccess({ requireUsername: false, minUnlockTier: 'any_authenticated' });

--- a/ctf/packages/web/app/knowledge/page.tsx
+++ b/ctf/packages/web/app/knowledge/page.tsx
@@ -1,29 +1,38 @@
-import { redirect } from 'next/navigation';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { getHostedSignInUrl } from 'lib/auth/provider-env';
+import { needsQuoraProfileUrl } from 'lib/comic/contribution-unlock-link';
 import { ComicKnowledgeShell } from '@/components/comic/comic-knowledge-shell';
+import { ComicKnowledgePublicShell } from '@/components/comic/comic-knowledge-public-shell';
 
 export const dynamic = 'force-dynamic';
 
 // Where a member lends their own public Quora writing to the assistant's reference library, and
 // where the consent that permits it is given.
 //
-// Signed-in only, at `any_authenticated` rather than full Unlock access: someone who has not finished
-// verifying can still have years of public writing worth contributing, and consent is the thing that
-// makes it usable — not their verification tier. It stays gated to a signed-in account because a
-// contribution has to be attributable to the person consenting, and withdrawal has to be something
-// only they can do.
+// OPEN TO ANY SIGNED-IN MEMBER, not only verified ones (owner decision, 2026-07-29). Contributing is
+// a route INTO verification rather than something gated behind it: judging a contribution means
+// opening the contributor's Quora account and seeing a real person writing real things, which is the
+// same look Unlock asks for. Gating this behind Unlock would review the same account twice and make
+// the most useful thing a new member can do into something they have to wait for.
 //
-// A short top-level path (`/knowledge`) rather than one under /apps, because the invitation post
-// links here from outside the app and the link should be easy to type and read. Deliberately NOT
-// `/contribute`: the Contributions plugin is a different thing entirely — the fundraiser and donation
-// surface — and two member-facing paths a word apart would be a standing source of confusion (owner
-// decision, 2026-07-29).
+// A signed-out visitor gets the public landing page rather than a redirect. This page is what the
+// invitation post links to from Quora, so most people opening it have no account yet — bouncing them
+// to a sign-in form would explain nothing about what they were being asked for.
+//
+// A short top-level path (`/knowledge`) rather than one under /apps, because that link is read
+// outside the app and should be easy to type. Deliberately NOT `/contribute`: the Contributions
+// plugin is the fundraiser and donation surface, and two member-facing paths a word apart would be a
+// standing source of confusion.
 export default async function KnowledgePage() {
   const decision = await evaluatePluginAccess({ minUnlockTier: 'any_authenticated', requireUsername: false });
   if (!decision.allowed) {
-    redirect(getHostedSignInUrl() ?? '/sign-in');
+    return <ComicKnowledgePublicShell signInUrl={getHostedSignInUrl() ?? '/sign-in'} />;
   }
 
-  return <ComicKnowledgeShell />;
+  // Ask for a Quora profile URL only when this member has none on file. Someone who already
+  // submitted through Unlock is never asked again (owner decision): the contribution attaches to the
+  // account they already have, and two conflicting URLs can never reach one account via this page.
+  const askForQuoraUrl = await needsQuoraProfileUrl(decision.userId);
+
+  return <ComicKnowledgeShell askForQuoraUrl={askForQuoraUrl} />;
 }

--- a/ctf/packages/web/components/comic/comic-knowledge-public-shell.tsx
+++ b/ctf/packages/web/components/comic/comic-knowledge-public-shell.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { BookOpen, ShieldCheck, PenLine, KeyRound } from 'lucide-react';
+import { useTheme } from '@/hooks/useTheme';
+import { getComicTokens } from './comic-shared';
+
+// The signed-out landing page for the knowledge library.
+//
+// Every other plugin has one; this one carries more weight, because it is the page the invitation
+// post links to from Quora. Most people who open it will not have an account, and what they read
+// here decides whether they make one.
+//
+// It answers three questions in order — what is this, what happens to my writing, what do I get —
+// because those are the three a survivor asks before handing anything over, and the second one is
+// the one that decides it.
+
+export function ComicKnowledgePublicShell({ signInUrl }: { signInUrl: string }) {
+  const { theme } = useTheme();
+  const t = getComicTokens(theme);
+
+  return (
+    <main style={{ minHeight: '100dvh', background: t.BG, color: t.TITLE, fontFamily: "'Inter',system-ui,sans-serif" }}>
+      <div style={{ maxWidth: 720, margin: '0 auto', padding: '32px 16px 56px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+          <BookOpen size={22} color={t.ACCENT} />
+          <h1 style={{ fontSize: 24, fontWeight: 800, margin: 0 }}>Knowledge library</h1>
+        </div>
+
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: t.TEXT }}>
+          Ask a commercial chat bot about organized stalking and you get the institutional line: deny,
+          deflect, call the authorities. So I built one differently — self-hosted, and answering only
+          from what our own community has written.
+        </p>
+        <p style={{ fontSize: 16, lineHeight: 1.65, color: t.TEXT }}>
+          Right now it knows one person&apos;s experience. Yours is different, and the next person
+          asking for help at 3am deserves both.
+        </p>
+
+        <section style={cardStyle(t)}>
+          <h2 style={cardTitleStyle}>
+            <PenLine size={16} color={t.ACCENT} style={{ verticalAlign: '-2px', marginRight: 6 }} />
+            What you would be lending
+          </h2>
+          <p style={bodyStyle(t)}>
+            Your own public Quora posts about what you have lived through and — the part that actually
+            helps someone — <strong>how you manage it</strong>. What you tried, what failed, what you
+            would tell someone in their first year.
+          </p>
+          <p style={{ ...bodyStyle(t), marginBottom: 0 }}>
+            You pick the posts. Most people write about all sorts of things, and only you can say
+            which of yours belong here.
+          </p>
+        </section>
+
+        <section style={{ ...cardStyle(t), borderColor: `${t.ACCENT}55` }}>
+          <h2 style={cardTitleStyle}>
+            <ShieldCheck size={16} color={t.ACCENT} style={{ verticalAlign: '-2px', marginRight: 6 }} />
+            What happens to it
+          </h2>
+          <ul style={{ ...bodyStyle(t), paddingLeft: 18, margin: 0 }}>
+            <li style={{ marginBottom: 10 }}>
+              Only what you choose. Nothing private, ever — and if you send a whole Quora export
+              instead, your messages and drafts are deleted automatically on arrival, before a person
+              opens it.
+            </li>
+            <li style={{ marginBottom: 10 }}>
+              <strong>You can take it back.</strong> Your words go into a table the assistant searches,
+              not into a trained model — so withdrawing actually removes them. A bot trained the usual
+              way could not honestly promise that.
+            </li>
+            <li style={{ marginBottom: 10 }}>
+              A person reads everything before it is used, and not everything is used. No answer
+              reaches a member without a human reviewing it first.
+            </li>
+            <li style={{ marginBottom: 0 }}>
+              You keep every right to your own writing. You are lending it, not signing it over.
+            </li>
+          </ul>
+        </section>
+
+        <section style={cardStyle(t)}>
+          <h2 style={cardTitleStyle}>
+            <KeyRound size={16} color={t.ACCENT} style={{ verticalAlign: '-2px', marginRight: 6 }} />
+            It also gets you in
+          </h2>
+          <p style={{ ...bodyStyle(t), marginBottom: 0 }}>
+            Joining asks for your Quora profile so it can be checked you are a real person. If you
+            contribute, that check happens on the writing you send — one step instead of two. An
+            accepted contribution also earns a ServiceCredits grant: an internal credits unit inside
+            this app, not money, and never cashable.
+          </p>
+        </section>
+
+        <a
+          href={signInUrl}
+          style={{
+            display: 'block',
+            marginTop: 20,
+            padding: '15px',
+            borderRadius: 12,
+            background: t.ACCENT,
+            color: '#fff',
+            fontSize: 16,
+            fontWeight: 800,
+            textAlign: 'center',
+            textDecoration: 'none',
+          }}
+        >
+          Join Skills Economy — Free
+        </a>
+        <p style={{ fontSize: 13, color: t.MUTED, textAlign: 'center', marginTop: 10 }}>
+          Already have an account? <a href={signInUrl} style={{ color: t.ACCENT }}>Sign in</a> to
+          contribute.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+const cardStyle = (t: ReturnType<typeof getComicTokens>): React.CSSProperties => ({
+  marginTop: 18,
+  borderRadius: 14,
+  background: t.HEADER,
+  border: `1px solid ${t.BORDER_SOLID}`,
+  padding: 18,
+});
+const cardTitleStyle: React.CSSProperties = { fontSize: 16, fontWeight: 700, margin: '0 0 10px' };
+const bodyStyle = (t: ReturnType<typeof getComicTokens>): React.CSSProperties => ({
+  fontSize: 14,
+  lineHeight: 1.65,
+  color: t.TEXT,
+  marginTop: 0,
+  marginBottom: 10,
+});

--- a/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
+++ b/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
@@ -46,7 +46,7 @@ const STATUS_LABEL: Record<ContributionSummary['status'], string> = {
   withdrawn: 'Withdrawn',
 };
 
-export function ComicKnowledgeShell() {
+export function ComicKnowledgeShell({ askForQuoraUrl = false }: { askForQuoraUrl?: boolean }) {
   const { theme } = useTheme();
   const t = getComicTokens(theme);
 
@@ -57,10 +57,16 @@ export function ComicKnowledgeShell() {
   const [posts, setPosts] = useState<LinkedPostDraft[]>([{ url: '', text: '' }]);
   const [agreed, setAgreed] = useState<Set<string>>(new Set());
   const [thirdPartyNote, setThirdPartyNote] = useState('');
+  // Only rendered when the member has no Quora URL on file. Submitting it opens an Unlock
+  // submission, so contributing doubles as verification instead of waiting behind it.
+  const [quoraProfileUrl, setQuoraProfileUrl] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [receipt, setReceipt] = useState<ContributionSummary | null>(null);
+  // What happened to the Unlock submission this contribution opened, so the receipt can say so.
+  // Silence here would leave a member unsure whether they still need to verify separately.
+  const [unlockLink, setUnlockLink] = useState<string | null>(null);
   const [history, setHistory] = useState<ContributionSummary[]>([]);
 
   const allAgreed = CONTRIBUTION_CONSENT_CLAUSES.every((clause) => agreed.has(clause.id));
@@ -90,7 +96,10 @@ export function ComicKnowledgeShell() {
   }
 
   const filledPosts = posts.filter((post) => post.url.trim().length > 0 || post.text.trim().length > 0);
-  const canSend = allAgreed && (mode === 'export' ? file !== null : filledPosts.length > 0);
+  const canSend =
+    allAgreed
+    && (mode === 'export' ? file !== null : filledPosts.length > 0)
+    && (!askForQuoraUrl || quoraProfileUrl.trim().length > 0);
 
   async function submit() {
     if (!canSend || submitting) return;
@@ -107,20 +116,25 @@ export function ComicKnowledgeShell() {
       body.set('consentVersion', CONTRIBUTION_CONSENT_VERSION);
       body.set('agreedClauseIds', JSON.stringify([...agreed]));
       body.set('thirdPartyNote', thirdPartyNote.trim());
+      if (askForQuoraUrl) {
+        body.set('quoraProfileUrl', quoraProfileUrl.trim());
+      }
       const res = await fetch('/api/comic/contributions', {
         method: 'POST',
         headers: { 'x-ctf-csrf': '1' },
         body,
       });
       const data = (await res.json().catch(() => null)) as
-        | { contribution?: ContributionSummary; message?: string }
+        | { contribution?: ContributionSummary; message?: string; unlockLink?: string }
         | null;
       if (!res.ok || !data?.contribution) {
         setError(data?.message ?? 'Could not send that file. Nothing was kept.');
       } else {
         setReceipt(data.contribution);
+        setUnlockLink(data.unlockLink ?? null);
         setFile(null);
         setPosts([{ url: '', text: '' }]);
+        setQuoraProfileUrl('');
         setAgreed(new Set());
         setThirdPartyNote('');
         void loadHistory();
@@ -286,6 +300,37 @@ export function ComicKnowledgeShell() {
               <span>{clause.text}</span>
             </label>
           ))}
+
+          {/* Shown only to a member with no Quora URL on file. Submitting it opens an Unlock
+              submission, so contributing IS the verification step rather than something waiting
+              behind it — the reviewer opens this account to judge the writing either way. */}
+          {askForQuoraUrl ? (
+            <>
+              <label
+                htmlFor="quora-profile-url"
+                style={{ display: 'block', marginTop: 16, fontSize: 13, fontWeight: 600, color: t.SUBTLE }}
+              >
+                Your Quora profile link
+              </label>
+              <p style={{ fontSize: 12, lineHeight: 1.55, color: t.MUTED, margin: '4px 0 0' }}>
+                Open your own Quora profile and copy the address. It is how it gets checked that you
+                are a real person — the same check joining asks for, done once instead of twice.
+              </p>
+              <input
+                id="quora-profile-url"
+                type="url"
+                inputMode="url"
+                value={quoraProfileUrl}
+                disabled={!allAgreed}
+                onChange={(event) => {
+                  setQuoraProfileUrl(event.target.value);
+                  setError(null);
+                }}
+                placeholder="https://www.quora.com/profile/..."
+                style={fieldStyle(t)}
+              />
+            </>
+          ) : null}
 
           <label
             htmlFor="third-party-note"
@@ -462,6 +507,17 @@ export function ComicKnowledgeShell() {
               {receipt.entryCount === 1 ? 'piece' : 'pieces'} of your writing were kept and are waiting
               to be read.
             </p>
+            {unlockLink === 'submitted' ? (
+              <p style={{ ...bodyStyle(t), color: t.ACCENT }}>
+                Your Quora profile went in for verification at the same time — you do not need to do
+                that separately.
+              </p>
+            ) : unlockLink === 'invalid_url' ? (
+              <p style={{ ...bodyStyle(t), color: '#F59E0B' }}>
+                Your writing was received, but that Quora link was not a profile address, so
+                verification did not start. Finish it on the Unlock screen.
+              </p>
+            ) : null}
             {receipt.kind === 'export' ? (
               receipt.discardedSections.length > 0 ? (
                 <p style={{ ...bodyStyle(t), marginBottom: 0 }}>

--- a/ctf/packages/web/lib/comic/contribution-unlock-link.ts
+++ b/ctf/packages/web/lib/comic/contribution-unlock-link.ts
@@ -1,0 +1,89 @@
+import { normalizeQuoraProfileUrl } from 'lib/unlock/quora-url';
+import { createOrUpdateUnlockSubmission, getUnlockStatusForUser, insertUnlockAudit } from 'lib/unlock/repository';
+
+// Contributing to the knowledge library is a route INTO verification, not something gated behind it
+// (owner decision, 2026-07-29).
+//
+// The reasoning: to judge a contribution the owner has to open the contributor's Quora account and
+// see that it is a real person writing real things. That is the same look Unlock verification asks
+// for. Making someone complete Unlock first, then contribute, means reviewing the same account
+// twice — and it turns the most useful thing a new member can do into something they have to wait
+// for. So the submission carries a Quora profile URL, and that URL opens an Unlock submission.
+//
+// This is deliberately NOT an auto-approval. It creates a `pending` submission in the normal queue,
+// exactly as if the member had used the Unlock screen. The owner still decides. What changes is that
+// one review now answers both questions — is this account real, and is this writing usable — instead
+// of the member being stuck behind the first before they can attempt the second.
+
+export type UnlockLinkOutcome =
+  | { status: 'already_on_file' }
+  | { status: 'submitted' }
+  | { status: 'invalid_url' }
+  | { status: 'not_provided' }
+  | { status: 'failed' };
+
+// True when this member has no Quora URL on file, so the knowledge page should ask for one.
+// A member who already submitted through Unlock is never asked again (owner decision): the
+// contribution simply attaches to the account they already have, and two conflicting URLs can never
+// end up on one account by way of this page.
+export async function needsQuoraProfileUrl(userId: string): Promise<boolean> {
+  try {
+    const status = await getUnlockStatusForUser(userId);
+    return !status.hasSubmission;
+  } catch {
+    // If the check fails, do not ask. A contribution is still worth having, and a member who does
+    // have a URL on file must never be prompted for a second one because of a transient error.
+    return false;
+  }
+}
+
+// Open an Unlock submission from a contribution's Quora profile URL, when the member has none yet.
+//
+// Best-effort by design: the contribution has already been stored by the time this runs, and a
+// failure here must not lose the member's writing. The worst case is that they verify the ordinary
+// way afterwards.
+export async function linkContributionToUnlock(input: {
+  userId: string;
+  quoraProfileUrl: string | null;
+  contributionId: string;
+}): Promise<UnlockLinkOutcome> {
+  const raw = input.quoraProfileUrl?.trim() ?? '';
+  if (raw.length === 0) {
+    return { status: 'not_provided' };
+  }
+
+  try {
+    // Re-check rather than trusting the page's own view of it: the member may have submitted through
+    // the Unlock screen in another tab between the page rendering and this request.
+    const status = await getUnlockStatusForUser(input.userId);
+    if (status.hasSubmission) {
+      return { status: 'already_on_file' };
+    }
+
+    const normalized = normalizeQuoraProfileUrl(raw);
+    if (!normalized) {
+      return { status: 'invalid_url' };
+    }
+
+    await createOrUpdateUnlockSubmission({
+      userId: input.userId,
+      quoraProfileUrl: raw,
+      quoraProfileUrlNormalized: normalized,
+    });
+
+    // Audited as a normal Unlock submission so the queue and the trail read the same as any other,
+    // with the contribution named in metadata so a reviewer can see where it came from.
+    await insertUnlockAudit({
+      actorUserId: input.userId,
+      command: 'unlock.verification.submit',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetUserId: input.userId,
+      metadata: { source: 'comic_knowledge_contribution', contributionId: input.contributionId },
+    });
+
+    return { status: 'submitted' };
+  } catch {
+    return { status: 'failed' };
+  }
+}

--- a/ctf/packages/web/lib/unlock/quora-url.ts
+++ b/ctf/packages/web/lib/unlock/quora-url.ts
@@ -1,0 +1,33 @@
+import { reportError } from 'lib/observability/report';
+
+// Validate and normalize a Quora PROFILE URL — the strict form Unlock verification requires: the
+// host must be quora.com and the path must start with /profile/. Returns the canonical form (host
+// lowercased, hash and query stripped) or null.
+//
+// It lives in lib/ rather than beside the Unlock routes because the knowledge-library contribution
+// path now opens an Unlock submission too (lib/comic/contribution-unlock-link.ts), and lib must not
+// import from app. `app/api/unlock/_lib.ts` re-exports it so every existing caller is unchanged.
+//
+// NOT the same as `normalizeQuoraProfileUrl` in lib/directory/quora-url.ts, which deliberately
+// accepts any quora.com path because a Directory profile may carry a post link rather than a profile
+// link. Verification needs the profile itself, so this one is stricter. Do not merge them.
+export function normalizeQuoraProfileUrl(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl.trim());
+    const host = parsed.hostname.toLowerCase();
+    if (host !== 'quora.com' && host !== 'www.quora.com') {
+      return null;
+    }
+
+    if (!parsed.pathname.startsWith('/profile/')) {
+      return null;
+    }
+
+    parsed.hash = '';
+    parsed.search = '';
+    return parsed.toString();
+  } catch (error) {
+    reportError(error, { area: 'unlock', op: 'normalize_quora_url' });
+    return null;
+  }
+}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**Owner-review lane** — changes an access gate and writes into the Unlock queue. Auto-merge not enabled.

Supersedes #1963 (closed). That PR tightened `/knowledge` to require Unlock; this reverses it, on the reason the owner named:

> **Judging a contribution means opening the contributor's Quora account and seeing a real person writing real things — which is exactly the look Unlock verification asks for.**

Gating contribution behind Unlock reviews the same account twice, and turns the most useful thing a new member can do into something they wait for.

## Contributing is now the way in

- New `requireComicContributionAccess` (`any_authenticated`) on the three contribution routes. The rest of comic stays `approved_full`.
- The submission may carry a **Quora profile URL**. When the member has none on file, it opens a normal **pending** Unlock submission and audits it as `source: comic_knowledge_contribution`.

**It is never an auto-approval.** The submission lands in the ordinary queue and you still decide. What changes is that one review answers both questions — is this account real, is this writing usable — instead of the first blocking the second.

Three details that matter:

- **Runs after the contribution is stored, best-effort.** A failure in the Unlock hop must not lose someone's writing. The receipt says plainly whether verification started, so nobody is left guessing.
- **A member who already has a URL on file is never asked again** (owner decision). The field does not render, and the server re-checks rather than trusting the page — so two conflicting URLs cannot reach one account by this route even if they submitted in another tab.
- **A bad link keeps the writing.** A post URL rather than a `/profile/` one means verification does not start, the contribution is still kept, and the receipt says so.

## The landing page

A signed-out visitor now gets a real page instead of a redirect. This is the URL the invitation post links to from Quora, so most people opening it have no account — a sign-in form would explain none of what they are being asked for. It answers what this is, what happens to your writing, that you can take it back, and that contributing also verifies you.

## One boundary fix

`normalizeQuoraProfileUrl` moved from `app/api/unlock/_lib.ts` to `lib/unlock/quora-url.ts`, re-exported so every caller is unchanged. `lib` importing from `app` was the only such import in the tree, and I introduced it — worth fixing rather than leaving as precedent. It stays separate from the looser `lib/directory/quora-url.ts`: verification needs the profile itself, a Directory URL may be any Quora path.

## Docs

Inventory (user feature, route map, change log recording that this supersedes the earlier entry and why), both contracts, and **CMC-C0** rewritten to cover the landing page, the pending-not-approved requirement, the never-ask-twice rule, and the bad-link case.

## Checks

- typecheck (all packages), lint, a11y lint, build — clean
- inventory drift, test-script drift, deletion registry, EOF format — clean locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_