### PR TITLE
fix: stop long Quora URL wrapping to one character per line in Unlock admin

### DIFF
--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -475,10 +475,10 @@ export function UnlockAdminShell({
             const canRevoke = s.reviewStatus === 'approved' && !s.rewardRevokedAt;
             return (
               <div key={s.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-                  <Key size={14} color={t.ACCENT} />
-                  {editingId === s.id ? (
-                    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {editingId === s.id ? (
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 6 }}>
+                    <Key size={14} color={t.ACCENT} style={{ flexShrink: 0, marginTop: 3 }} />
+                    <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
                       <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
                         <input
                           type="url"
@@ -499,11 +499,20 @@ export function UnlockAdminShell({
                         <div role="alert" style={{ fontSize: 12, color: '#EF4444' }}>{editError}</div>
                       ) : null}
                     </div>
-                  ) : (
-                    <>
-                      <a href={s.quoraProfileUrl} target="_blank" rel="noopener noreferrer" style={{ fontSize: 13, fontWeight: 600, color: t.TITLE, flex: 1, wordBreak: 'break-all' }}>
+                  </div>
+                ) : (
+                  <div style={{ marginBottom: 6 }}>
+                    {/* URL on its own full-width row so a long Quora link wraps across the card width
+                        instead of being crushed to one character per line by the action pills that used
+                        to share this row (owner report, 2026-07-29). */}
+                    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 8 }}>
+                      <Key size={14} color={t.ACCENT} style={{ flexShrink: 0, marginTop: 3 }} />
+                      <a href={s.quoraProfileUrl} target="_blank" rel="noopener noreferrer" style={{ fontSize: 13, fontWeight: 600, color: t.TITLE, flex: 1, minWidth: 0, wordBreak: 'break-all' }}>
                         {s.quoraProfileUrl}
                       </a>
+                    </div>
+                    {/* Action pills and buttons wrap onto as many rows as they need, below the URL. */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
                       <button type="button" aria-label="Edit URL" title="Edit URL" onClick={() => startEditUrl(s)} style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 8px', borderRadius: 6, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, fontWeight: 600, cursor: 'pointer' }}>
                         <Pencil size={12} /> Edit
                       </button>
@@ -536,9 +545,9 @@ export function UnlockAdminShell({
                           Reward revoked
                         </span>
                       ) : null}
-                    </>
-                  )}
-                </div>
+                    </div>
+                  </div>
+                )}
                 {s.quoraProfileUrlNormalized ? (
                   <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 4, display: 'flex', gap: 6, alignItems: 'baseline', flexWrap: 'wrap' }}>
                     <span>Normalized:</span>


### PR DESCRIPTION
## What this fixes

In the web Unlock admin queue, a long Quora profile link was rendering one character per line — the URL ran straight down the card instead of across it (see owner screenshot, submission for "Alicia").

## Cause

Each submission card put the Quora link and every action control (Edit button, status pill, reward pill, "Shared by", "URL changed", URL-history toggle, withheld/revoked markers) in a single flex row that did not wrap. On the phone-width layout those controls left the link almost no width, and because the link uses `word-break: break-all`, the browser broke the text at every character — one letter per line.

## Fix

`ctf/packages/web/components/unlock/unlock-admin-shell.tsx` — the card header now:
- gives the URL its own full-width row (Quora icon + link, with `min-width: 0` so the link can use the whole card width and wrap at character boundaries only when it actually reaches the edge), and
- moves the action pills and buttons to a separate row beneath it that wraps onto as many lines as needed.

The inline URL editor keeps its existing layout. This is a display-only change — no route, schema, contract, or data-model change, so no inventory or manual-test-script update is required. The React Native admin screen lays text out natively and never had this problem, so it is untouched.

## Verification

- `pnpm --filter @ctf/web run typecheck` — passes
- `pnpm --filter @ctf/web run lint` — passes
- EOF format check — passes
- Pre-commit and pre-push gates — passed

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)