### PR TITLE
fix: seed the Knowledge Library row so it shows in the Apps list

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -687,6 +687,14 @@ buckets are not reproduced — only real provenance (engine / intent / safety ca
 
 ## Change Log
 
+- 2026-07-29 (latest): **Knowledge Library now actually appears in the Apps launcher.** The plugin
+  was added to `fallbackPluginRegistry` in `lib/plugins/repository.ts` and to the parity contracts,
+  but never to the `ctf_plugin_registry` seed in `schema.sql` — and `listPluginRegistry` only falls
+  back to the in-code array when that table is empty or unreadable, which never happens in
+  production. So the tile was missing from the member Apps list for three releases while the code
+  looked correct. Added the `knowledge` row (nav rank 66, visible) to `schema.sql` and
+  `schema.demo.sql`, and put a comment above the seed block saying the table — not the in-code array
+  — is what the launcher reads, so the next plugin does not repeat it.
 - 2026-07-29 (later): **Contributing is a route INTO verification, and `/knowledge` gets a public
   landing page (owner decision).** Judging a contribution means opening the contributor's Quora
   account and seeing a real person writing real things — exactly the look Unlock verification asks

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -2230,6 +2230,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('workforce',          'Workforce',            'Real-time work and skills distribution amongst 5 million survivors globally.',                           'implemented_shell', 50,  TRUE),
   ('skills-hunt',        'SkillsHunt',          'Nominate survivors to build the Directory and grow the economy.', 'implemented_shell', 60,  TRUE),
   ('unlock',             'Unlock',               'Internal verification queue and staged unlock orchestration for Quora URL onboarding.',           'implemented_shell', 65,  FALSE),
+  ('knowledge',          'Knowledge Library',    'Lend your own public writing so the assistant answers from more than one person.', 'implemented_shell', 66,  TRUE),
   ('foundation',         'Foundation',           'Find talent, tools, repairs, and infrastructure support in real time.',                      'implemented_shell', 70,  TRUE),
   ('lighthouse',         'LightHouse',           'Community housing listings from trauma-informed hosts; ServiceCredits accepted.', 'implemented_shell', 80,  TRUE),
   ('socket-relay',         'SocketRelay',          'Real-time resource sharing across the network.',                        'implemented_shell', 90,  TRUE),

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -2224,7 +2224,12 @@ DELETE FROM ctf_plugin_registry WHERE plugin_slug IN ('whatworks', 'trusttranspo
 -- GentlePulse decommissioned 2026-07-27 (owner decision): remove its registry row from existing DBs.
 DELETE FROM ctf_plugin_registry WHERE plugin_slug = 'gentle-pulse';
 
--- Seed plugin registry (upsert so re-running is safe)
+-- Seed plugin registry (upsert so re-running is safe).
+--
+-- THIS TABLE IS WHAT THE APPS LIST SHOWS. `fallbackPluginRegistry` in
+-- packages/web/lib/plugins/repository.ts is only used when this table is empty or unreadable, which
+-- is never true in production — so adding a plugin to that array alone puts NO tile in the launcher.
+-- A new plugin needs a row here as well, or it is invisible to members.
 INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availability_state, nav_rank, is_visible) VALUES
   ('chyme',              'Chyme',                'Live social audio rooms. Broadcast, listen, and connect in real time.',                       'implemented_shell', 10,  TRUE),
   ('skills-taxonomy',    'Skills Taxonomy',      'Browse the shared catalog of sectors, job titles, and skills.',                     'implemented_shell', 20,  TRUE),
@@ -2232,6 +2237,7 @@ INSERT INTO ctf_plugin_registry (plugin_slug, display_name, summary, availabilit
   ('workforce',          'Workforce',            'Real-time work and skills distribution amongst 5 million survivors globally.',                           'implemented_shell', 50,  TRUE),
   ('skills-hunt',        'SkillsHunt',          'Nominate survivors to build the Directory and grow the economy.', 'implemented_shell', 60,  TRUE),
   ('unlock',             'Unlock',               'Internal verification queue and staged unlock orchestration for Quora URL onboarding.',           'implemented_shell', 65,  FALSE),
+  ('knowledge',          'Knowledge Library',    'Lend your own public writing so the assistant answers from more than one person.', 'implemented_shell', 66,  TRUE),
   ('foundation',         'Foundation',           'Find talent, tools, repairs, and infrastructure support in real time.',                      'implemented_shell', 70,  TRUE),
   ('lighthouse',         'LightHouse',           'Community housing listings from trauma-informed hosts; ServiceCredits accepted.', 'implemented_shell', 80,  TRUE),
   ('socket-relay',         'SocketRelay',          'Real-time resource sharing across the network.',                        'implemented_shell', 90,  TRUE),


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## The miss

Knowledge Library was added to `fallbackPluginRegistry` in `lib/plugins/repository.ts`, to `plugin-parity-contracts.json`, and to the `/apps/knowledge` redirect — and it still never appeared in the member Apps list. It was reported missing three times.

The reason: `listPluginRegistry` reads the `ctf_plugin_registry` **table**, and only falls back to the in-code array when that table is empty or the query throws. In production the table always has rows, so the in-code entry is dead code for this purpose. The plugin was never added to the seed block in `schema.sql`, so there was no row, so there was no tile — while every file an agent would think to check looked correct.

## The change

- `knowledge` row added to the `ctf_plugin_registry` seed in `schema.sql` and `schema.demo.sql` — `implemented_shell`, nav rank 66, visible. It is the same idempotent `INSERT … ON CONFLICT DO UPDATE` used for every other tile, so re-running is safe and an existing database picks it up on the next schema apply.
- A comment above the seed block now states plainly that this table, not the in-code array, is what the launcher shows, and that adding a plugin to the array alone puts no tile in front of members. That is the part that will stop this recurring.
- Comic feature inventory change-log entry recording the miss and the fix.

The list is ordered by `display_name`, so the tile lands between GDP and LevelUp.

## Risk

One row in a curated registry table, added the same way as the other 23. No structural DDL, no data migration, no auth, contract, or credit change. Nothing else reads or writes differently.

## Checks

Schema drift gate, inventory drift gate, EOF format — pass. Pre-commit gate ran shared, mobile, and web typechecks — all clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_