### PR TITLE
feat: filter the Unlock admin queue by support-only access

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -192,6 +192,19 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
   not visible — so the link 404'd for everyone, admins included, even though the member Unlock
   screen was live. Unlock's member surface is its own route, `/plugin/unlock`; the button now points
   there. One-line href fix in `unlock-admin-shell.tsx`; no route, schema, or contract change.
+- 2026-07-29: **Support-only filter in the admin queue (web).** The admin dashboard already counted
+  Support-only members, but there was no way to see *who* they were — only Pending and All submissions.
+  Added a third tab, `Support-only`, filtering the loaded page on `accessTier === 'locked_support_only'`.
+  Filtered on access **tier**, not review status, on purpose: a member reaches that tier by more than
+  one route — rejected, marked spam, or a `pending` submission whose window lapsed and was swept by
+  `supportOnlyAfterExpiry` — and the tier is the only thing all of those share. It is also exactly what
+  the Support-only counter counts, so the number and the list cannot disagree. Two supporting bits: each
+  card now shows a grey `Support-only` pill when the member is on that tier (review status alone does not
+  explain a swept `pending` row), and the tab prints how many of the counter's total this page is
+  actually showing, so once there are more submissions than the page cap a short list reads as a
+  shortfall rather than as everyone. Client-side filter over already-loaded data; combines with the
+  existing search box. No route, schema, or contract change. **Parity:** web + mobile-responsive;
+  Android out of scope (web-only per rule 105).
 - 2026-07-23: **Quora URL history in the admin queue + revoke (web).** The Quora profile URL is the only social proof and can be changed after approval (in Directory). The admin queue now surfaces the trail so a reviewer can catch someone gaming it: each submission row shows a `quoraUrlChangeCount` badge ("URL changed N×"), and a "URL history" toggle opens the full change list from a new admin route `GET /api/unlock/admin/quora-history?userId=<id>` (`listQuoraUrlHistory` over the new `directory_quora_url_history` table). Each entry shows the previous → new URL, when, and the source (set at onboarding / changed by the member in Directory / changed by an admin). The existing `POST /revoke` is the manual response (drops the member to `rejected` + `locked_support_only` and claws the reward). The Unlock onboarding submission now records the captured URL into the shared history (best-effort, `recordQuoraUrlChangeStandalone`, source `unlock_onboarding`) so the trail includes the baseline. Framed as a human watch tool, never an automatic flag — a change is legitimate when Quora deletes an account. New audit command `unlock.admin.quora.history.read`. Schema change: `directory_quora_url_history` (owned by Directory). Verified: `@ctf/web` typecheck, lint, a11y lint, build. Owner-review lane.
 - 2026-07-17: **History-aware back + admin↔member navigation (app-wide sweep).** The member
   shell's hand-rolled back chevron was replaced by the shared `BackChevronButton` — it returns to

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -118,10 +118,17 @@ not see this banner. On android the client Unlock gate lets a treatment member t
 **Steps:**
 1. Open `/admin/unlock`.
 2. Read the snapshot counts at the top.
-3. Switch between the Pending and All views.
+3. Switch between the Pending, Support-only, and All views.
+4. On the Support-only view, compare the number of rows listed against the Support-only counter in
+   the snapshot, and check that each row carries a grey "Support-only" pill.
 **Expected:** The queue lists submissions; the Pending view shows only pending rows, the All view
 shows every status. Each row shows the submitter's Quora profile link and its review status. A
-non-admin cannot reach this page (`requireUnlockAdminAccess`).
+non-admin cannot reach this page (`requireUnlockAdminAccess`). Step 3/4: the Support-only view shows
+only members on the `locked_support_only` access tier — which includes rejected and spam rows **and**
+any `pending` row whose window lapsed and was swept by `supportOnlyAfterExpiry`, so do not expect it
+to equal rejected + spam. The row count matches the Support-only counter; if the page holds fewer
+than the counter reports, the view says so ("Showing N of M …") rather than presenting a short list as
+the whole set. Every listed row shows the Support-only pill.
 **Result:** web ☐ — notes:
 
 ### UNLOCK-A2 · Review decision — approve / reject / spam

--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -15,7 +15,17 @@ import { getUnlockTokens } from './unlock-shared';
 // solid admin border. The default theme keeps the shipped hex values.
 
 type ReviewStatus = UnlockSubmission['reviewStatus'];
-type Tab = 'pending' | 'all';
+// Which slice of the loaded submissions the list shows. 'support-only' is not a review status — it is
+// the access tier a member is left on when they are not approved (rejected, marked spam, or their
+// pending window lapsed and the support-only sweep ran). The Support-only counter on the dashboard
+// above is the same set, so the tab is the way to see WHO those people are rather than just how many.
+type Tab = 'pending' | 'support-only' | 'all';
+
+const TAB_LABEL: Record<Tab, string> = {
+  pending: 'Pending',
+  'support-only': 'Support-only',
+  all: 'All submissions',
+};
 
 const STATUS_STYLE: Record<string, { bg: string; color: string; border: string; label: string }> = {
   pending: { bg: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: 'rgba(245,158,11,0.3)', label: 'pending' },
@@ -148,7 +158,16 @@ export function UnlockAdminShell({
     }
   }
 
-  const visible = tab === 'pending' ? submissions.filter((s) => s.reviewStatus === 'pending') : submissions;
+  const visible =
+    tab === 'pending'
+      ? submissions.filter((s) => s.reviewStatus === 'pending')
+      : tab === 'support-only'
+        // Filtered on access tier, not review status, deliberately: a member lands here from more than
+        // one route (rejected, spam, or a lapsed pending window swept by supportOnlyAfterExpiry), and
+        // the tier is the single thing all of those have in common. It also matches exactly what the
+        // Support-only counter above is counting, so the number and the list can never disagree.
+        ? submissions.filter((s) => s.accessTier === 'locked_support_only')
+        : submissions;
   // Client-side search over the loaded page so an admin can find a submission by Quora URL, user id,
   // or submission number without scrolling the whole list.
   const searchQuery = search.trim().toLowerCase();
@@ -422,7 +441,7 @@ export function UnlockAdminShell({
 
         {/* Tabs */}
         <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-          {(['pending', 'all'] as const).map((tabKey) => (
+          {(['pending', 'support-only', 'all'] as const).map((tabKey) => (
             <button
               key={tabKey}
               type="button"
@@ -430,10 +449,22 @@ export function UnlockAdminShell({
               aria-pressed={tab === tabKey}
               style={{ padding: '6px 16px', borderRadius: 8, background: tab === tabKey ? t.ACCENT : t.SURFACE, border: `1px solid ${tab === tabKey ? t.ACCENT : t.BORDER_SOLID}`, color: tab === tabKey ? '#fff' : t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
             >
-              {tabKey === 'pending' ? 'Pending' : 'All submissions'}
+              {TAB_LABEL[tabKey]}
             </button>
           ))}
         </div>
+
+        {/* On the support-only tab, say how many of them this page is actually showing. The page loads a
+            capped number of submissions, so once there are more than that the list can hold fewer
+            support-only rows than the counter above reports — and a short list would otherwise read as
+            "that is everyone". Say the shortfall out loud instead. */}
+        {tab === 'support-only' && !searchQuery ? (
+          <div style={{ marginTop: -8, marginBottom: 16, fontSize: 12, color: t.MUTED }}>
+            {visible.length === dashboard.lockedSupportOnlyCount
+              ? `${visible.length} member${visible.length === 1 ? '' : 's'} on support-only access`
+              : `Showing ${visible.length} of ${dashboard.lockedSupportOnlyCount} on support-only access — the rest are outside this page of submissions.`}
+          </div>
+        ) : null}
 
         {/* Search over the loaded submissions so an admin need not scroll the whole list. */}
         <div style={{ marginBottom: 16 }}>
@@ -466,7 +497,9 @@ export function UnlockAdminShell({
               ? 'No submissions match your search.'
               : tab === 'pending'
                 ? 'No submissions waiting for review.'
-                : 'No submissions yet.'}
+                : tab === 'support-only'
+                  ? 'Nobody is on support-only access. Rejected, spam, and lapsed submissions land here.'
+                  : 'No submissions yet.'}
           </div>
         ) : (
           filteredVisible.map((s) => {
@@ -517,6 +550,15 @@ export function UnlockAdminShell({
                         <Pencil size={12} /> Edit
                       </button>
                       <StatusPill status={s.reviewStatus} />
+                      {/* Access tier, shown only when it is support-only. Review status alone does not
+                          explain why a row is on this tier: a submission left `pending` past its window
+                          is swept to support-only by supportOnlyAfterExpiry, so it would read "pending"
+                          with nothing saying the member is actually locked out of the full app. */}
+                      {s.accessTier === 'locked_support_only' ? (
+                        <span title="This member is on support-only access — they can reach support surfaces but not the full app" style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(148,163,184,0.14)', color: '#94A3B8', border: '1px solid rgba(148,163,184,0.32)' }}>
+                          Support-only
+                        </span>
+                      ) : null}
                       {s.reviewStatus === 'approved' && !s.rewardRevokedAt ? <RewardPill grantedAt={s.incentiveGrantedAt} /> : null}
                       {s.sharedUrlAccountCount && s.sharedUrlAccountCount > 1 ? (
                         <span title="This Quora URL is claimed by more than one account" style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What

The admin dashboard already counted Support-only members, but the queue only offered **Pending** and **All submissions** — so you could see *how many* there were and never *who*. Adds a third tab: **Support-only**.

## The one decision worth knowing

It filters on **access tier**, not review status.

A member lands on `locked_support_only` by more than one route: rejected, marked spam, or a `pending` submission whose window lapsed and got swept by `supportOnlyAfterExpiry`. The tier is the only thing all of those share, and it is exactly what `getUnlockDashboardSnapshot` counts — so the tab and the counter can never disagree.

This also means **the tab is not "rejected + spam."** On the current data those happen to add up (1 + 2 = 3), but a swept `pending` row belongs here too and would break the coincidence. The test-script case says so, so nobody later "fixes" the filter to match the arithmetic.

## Two supporting bits

- **A `Support-only` pill on each card.** Review status alone does not explain a swept row — it would read `pending` with nothing indicating the member is locked out of the full app. Grey, and only rendered when the tier is `locked_support_only`, so the other tabs look unchanged.
- **A count line on the tab.** The page loads a capped number of submissions (currently 50). Once there are more than that, the list can hold fewer support-only rows than the counter reports, and a short list would read as "that's everyone." It now says `Showing N of M on support-only access — the rest are outside this page of submissions.` when they differ, and a plain total when they match.

## Risk

Client-side filter over data the page already loads. No new query, route, schema, contract, or credit change. Nothing an admin can *do* changed — this is read-only navigation of the existing list, and it combines with the existing search box.

## Checks

Web typecheck, web lint (`--max-warnings=0`), test-script drift, EOF format — all pass. The pre-commit gate ran shared, mobile, and web typechecks.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_