### PR TITLE
ci: fail on API routes that nothing calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,21 @@ jobs:
       - name: Enforce feature-inventory coverage of tables and routes
         run: node ctf/scripts/check-inventory-drift.mjs
 
+  orphan-route-gate:
+    name: Orphan Route Gate
+    runs-on: ubuntu-latest
+    needs: rules-integrity
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The inventory gate above asks whether every route is DOCUMENTED. This one asks whether every
+      # route is CALLED. Documented-but-dead is the worse failure: the inventory then asserts a
+      # capability the product does not have. That is exactly how a member flagging an answer reached
+      # nobody — the admin route existed, was documented, and no page ever called it.
+      - name: Fail on API routes that nothing calls
+        run: node ctf/scripts/check-orphan-routes.mjs
+
   taxonomy-change-gate:
     name: Taxonomy Change Gate
     runs-on: ubuntu-latest

--- a/ctf/package.json
+++ b/ctf/package.json
@@ -38,6 +38,7 @@
     "schema:report-live-drift": "bash ./scripts/audit_schema_drift.sh",
     "schema:audit-queries": "node ./scripts/audit-schema-queries.mjs",
     "check:inventory-drift": "node ./scripts/check-inventory-drift.mjs",
+    "check:orphan-routes": "node ./scripts/check-orphan-routes.mjs",
     "lint:a11y": "eslint --no-config-lookup --config ./a11y-audit.config.mjs --max-warnings=0 \"packages/web/app/**/*.tsx\" \"packages/web/components/**/*.tsx\"",
     "check:taxonomy-changes": "node ./scripts/check-taxonomy-change.mjs",
     "check:test-script-drift": "node ./scripts/check-test-script-drift.mjs",

--- a/ctf/scripts/check-orphan-routes.mjs
+++ b/ctf/scripts/check-orphan-routes.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// Orphan API route gate.
+//
+// WHY THIS EXISTS. The inventory-drift gate asks one question — is every route and table *documented*?
+// It is blind to the opposite failure: code that exists, is documented, and does nothing. Two real bugs
+// found by hand on 2026-07-29/30 were exactly that shape, and both passed every gate:
+//
+//   - `GET /api/feed/admin/questions` aggregates a `flagged_count` so an admin can review flagged
+//     answers. No page has ever called it, so a member flagging an answer reached nobody.
+//   - `moderation_status` on the Commons tables looked like the mechanism for hiding a post, but no
+//     query read it, so setting it did nothing. (A column, not a route — this gate does not catch that
+//     case. See the note at the bottom.)
+//
+// Documented-but-dead is worse than undocumented, because the docs actively assert a capability the
+// product does not have. This gate fails when a route under app/api has no caller anywhere in the
+// repo and is not on the allowlist.
+//
+// HOW IT MATCHES. A route's static prefix is everything up to its first dynamic ([param]) segment.
+// A reference counts when that prefix appears in a source file AND the character after it is
+// consistent with this route rather than a longer sibling path:
+//   - a route with no dynamic segments needs the path to END there (quote, backtick, ?, #, or space)
+//   - a route with dynamic segments needs a `/` after the prefix
+//
+// KNOWN LIMIT, stated so nobody mistakes a pass for proof. When a static route and a dynamic sibling
+// share a prefix (`/api/x/export` next to `/api/x/[id]`), a call to one satisfies the other. That is a
+// false negative — this gate under-reports rather than blocking CI on a guess. It also cannot see
+// unread database columns, which is the other half of the same failure mode.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const API_ROOT = join(REPO_ROOT, 'ctf', 'packages', 'web', 'app', 'api');
+const ALLOWLIST_PATH = join(import.meta.dirname, 'orphan-route-allowlist.json');
+
+// Where a caller could plausibly live. The route files themselves are excluded — a route referencing
+// its own path in a comment must not count as a caller.
+const SEARCH_ROOTS = [
+  join(REPO_ROOT, 'ctf', 'packages', 'web'),
+  join(REPO_ROOT, 'ctf', 'packages', 'mobile'),
+  join(REPO_ROOT, 'ctf', 'packages', 'shared'),
+  join(REPO_ROOT, 'ctf', 'scripts'),
+  join(REPO_ROOT, '.github'),
+];
+
+const SKIP_DIRS = new Set(['node_modules', '.next', '.git', 'dist', 'build', 'coverage', '.expo', 'android', 'ios']);
+const SEARCHABLE = /\.(ts|tsx|js|jsx|mjs|cjs|yml|yaml|md|json)$/;
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+// Turn app/api/feed/admin/moderation/[target]/[id]/route.ts into /api/feed/admin/moderation/[target]/[id].
+function routePathFor(file) {
+  const rel = relative(join(REPO_ROOT, 'ctf', 'packages', 'web', 'app'), file).replace(/\\/g, '/');
+  const withoutFile = rel.replace(/\/route\.(ts|tsx|js)$/, '');
+  // Next.js route groups — (marketing) — are organisational and carry no URL segment.
+  const segments = withoutFile.split('/').filter((s) => !(s.startsWith('(') && s.endsWith(')')));
+  return `/${segments.join('/')}`;
+}
+
+function staticPrefixOf(routePath) {
+  const segments = routePath.split('/');
+  const out = [];
+  for (const segment of segments) {
+    if (segment.startsWith('[')) break;
+    out.push(segment);
+  }
+  return out.join('/') || '/';
+}
+
+const routeFiles = walk(API_ROOT).filter((f) => /\/route\.(ts|tsx|js)$/.test(f));
+const routeFileSet = new Set(routeFiles);
+
+const searchFiles = [];
+for (const root of SEARCH_ROOTS) {
+  for (const file of walk(root)) {
+    if (!SEARCHABLE.test(file)) continue;
+    if (routeFileSet.has(file)) continue;
+    searchFiles.push(file);
+  }
+}
+
+// One pass over every searchable file, so this stays linear rather than re-reading the tree per route.
+const haystack = searchFiles.map((file) => {
+  try {
+    return { file, text: readFileSync(file, 'utf8') };
+  } catch {
+    return { file, text: '' };
+  }
+});
+
+let allowlist = { routes: [] };
+try {
+  allowlist = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8'));
+} catch {
+  // A missing allowlist is treated as empty rather than fatal, so the gate still runs.
+}
+const allowed = new Map((allowlist.routes ?? []).map((entry) => [entry.route, entry.reason]));
+
+// True when `text` references this exact route rather than a longer path that merely starts the same.
+function referencesRoute(text, prefix, hasDynamic) {
+  let from = 0;
+  for (;;) {
+    const at = text.indexOf(prefix, from);
+    if (at === -1) return false;
+    const after = text[at + prefix.length] ?? '';
+    if (hasDynamic) {
+      if (after === '/') return true;
+    } else if (after === '' || !/[A-Za-z0-9/_-]/.test(after)) {
+      // End of the path: a quote, backtick, ?, #, whitespace, ) and so on all mean the path stops here.
+      return true;
+    }
+    from = at + 1;
+  }
+}
+
+const orphans = [];
+const usedAllowlistEntries = new Set();
+
+for (const file of routeFiles) {
+  const routePath = routePathFor(file);
+  const prefix = staticPrefixOf(routePath);
+  const hasDynamic = routePath.includes('[');
+
+  if (allowed.has(routePath)) {
+    usedAllowlistEntries.add(routePath);
+    continue;
+  }
+
+  const called = haystack.some(({ text }) => referencesRoute(text, prefix, hasDynamic));
+  if (!called) {
+    orphans.push({ routePath, file: relative(REPO_ROOT, file) });
+  }
+}
+
+const staleAllowlist = [...allowed.keys()].filter((route) => !usedAllowlistEntries.has(route));
+
+console.log(`check-orphan-routes: scanned ${routeFiles.length} API routes against ${haystack.length} source files.`);
+
+if (staleAllowlist.length > 0) {
+  // Not a failure: an allowlisted route that no longer exists just means the entry can go. Reported so
+  // the allowlist shrinks over time instead of accumulating dead entries nobody dares remove.
+  console.log('\nAllowlist entries for routes that no longer exist (safe to delete):');
+  for (const route of staleAllowlist) console.log(`  • ${route}`);
+}
+
+if (orphans.length === 0) {
+  console.log('\n✅ No orphan routes: every API route has a caller in the repo (or a documented reason not to).');
+  process.exit(0);
+}
+
+console.error(`\n❌ ${orphans.length} API route(s) exist but nothing calls them:\n`);
+for (const orphan of orphans) {
+  console.error(`  • ${orphan.routePath}`);
+  console.error(`      ${orphan.file}`);
+}
+console.error(`
+A route with no caller is dead code that the feature inventory still advertises as a capability. That
+is how a member's flag on an answer reached nobody for weeks: the route existed, it was documented, and
+no page ever called it.
+
+Fix it one of two ways:
+  1. Wire it up — if the capability is supposed to exist, give it a caller.
+  2. Delete it — if it is not needed, remove the route and its inventory entry.
+
+If it is genuinely called from outside this repository (a provider webhook, an uptime check, an embed on
+another site), add it to ctf/scripts/orphan-route-allowlist.json with a reason that says WHO calls it.
+Do not add an entry just to silence this gate.
+`);
+process.exit(1);

--- a/ctf/scripts/orphan-route-allowlist.json
+++ b/ctf/scripts/orphan-route-allowlist.json
@@ -1,0 +1,477 @@
+{
+  "_README": [
+    "Allowlist for check-orphan-routes.mjs.",
+    "",
+    "Two kinds of entry, and the difference matters:",
+    "",
+    "  \"external\" \u2014 genuinely called from outside this repository (a provider webhook, an uptime",
+    "  check, an embed on another site). These are permanent and correct. The reason MUST name who",
+    "  calls it.",
+    "",
+    "  \"baseline\" \u2014 a route that already had no caller when this gate was introduced on 2026-07-30.",
+    "  These are NOT approved; they are a burn-down list. Each is either a capability that was never",
+    "  wired up (fix it) or dead code (delete it, and its inventory entry with it). This list should",
+    "  only ever shrink.",
+    "",
+    "Never add a NEW route here to silence the gate. A new route with no caller means either the",
+    "feature is unfinished or the route should not exist. Both are worth failing the build over \u2014",
+    "that is the whole point of the gate."
+  ],
+  "routes": [
+    {
+      "route": "/api/account/skills-hunt-profile",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/admin/account-restrictions/audit",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/admin/account-restrictions/restrict",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/admin/account-restrictions/unrestrict",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/announcements/admin/[announcementId]/archive",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/announcements/admin/[announcementId]/publish",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/announcements/admin/drafts/[draftId]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/announcements/admin/drafts",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/announcements/admin/targeting/validate",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/announcements/membership/events",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/announcements",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/beacon/stream-webhook",
+      "kind": "external",
+      "reason": "Called by GetStream. Delivers Stream chat/video events for Beacon."
+    },
+    {
+      "route": "/api/comic/admin/ai-status",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/comic/training/export",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/directory/admin/announcements/[id]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/directory/admin/announcements",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/directory/admin/skills",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/directory/announcements",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/admin/config",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/admin/questions/[questionId]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/admin/questions/export",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/answers/[answerId]/rate",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/community/posts/[postId]/reply",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/community/posts",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/config",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/items/[itemId]/dismiss",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/items/[itemId]/read",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/items",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/membership/events",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/questions/[questionId]/answer",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/feed/questions",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/foundation/admin/audit-events",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/foundation/admin/rate-limits/evaluate",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/foundation/connections/history",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/foundation/notifications/[notificationEventId]/ack",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/foundation/notifications/preferences",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/foundation/notifications",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/foundation/service-credits",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/health",
+      "kind": "external",
+      "reason": "Called by the host platform uptime check, not by app code."
+    },
+    {
+      "route": "/api/hub/bots",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/level-up/cohorts/[cohortId]/claim-trainer",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/level-up/disputes/[disputeId]/resolve",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/level-up/disputes",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/level-up/milestones/[milestoneId]/release",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/level-up/milestones/[milestoneId]/validate",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/level-up/transfers",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/admin/audit-events",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/admin/hosts",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/admin/matches",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/admin/profiles",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/admin/properties",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/admin/seekers",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/admin/stats",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/blocks/[blockedUserId]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/blocks/check",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/blocks",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/lighthouse/service-credits",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/notifications/push/unsubscribe",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/peer-programming/messages/[messageId]/replies",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/plugin/policy-probe",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/questions/stream",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/service-credits/disputes",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/service-credits/escrows/[escrowId]/refund",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/service-credits/escrows/[escrowId]/release",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/service-credits/escrows",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-hunt/admin/audit-events",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-hunt/admin/notifications/round-ending-soon",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-hunt/submissions/[submissionId]/report",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/dependency-impact",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/flattened",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/hierarchy",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/job-titles/[id]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/job-titles",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/sectors/[id]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/sectors",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/skills/[id]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/skills-taxonomy/admin/skills",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/socket-relay/admin/fulfillments",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/socket-relay/admin/requests",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/socket-relay/profile",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/socket-relay/service-credits",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/trust/signal/snapshot",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/trust/visibility",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/trust-transport/admin/audit-events",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/trust-transport/admin/incidents",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/trust-transport/service-credits",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/unlock/admin/experiment-split",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/webhooks/clerk",
+      "kind": "external",
+      "reason": "Called by Clerk, not by this app. Auth provider posts user lifecycle events here."
+    },
+    {
+      "route": "/api/weekly-performance/admin/week-selection",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/weekly-performance/weeks/[weekStart]",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    },
+    {
+      "route": "/api/workforce/admin/audit-events",
+      "kind": "baseline",
+      "reason": "Pre-existing orphan recorded when this gate was introduced (2026-07-30). Not yet verified as wanted or unwanted \u2014 burn down: wire it up or delete it."
+    }
+  ]
+}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (CI tooling, no app surface)

First of the three items. Answers a direct question from the owner: *"I thought CI drift would catch these things."*

## Why it didn't

`check-inventory-drift.mjs` asks one question — **is every route and table documented?** It is blind to the opposite failure: code that exists, is documented, and does nothing.

Both bugs found by hand this week were that shape, and both passed every gate:

- `GET /api/feed/admin/questions` aggregates a `flagged_count` so an admin can review flagged answers. **No page has ever called it**, so a member flagging an answer reached nobody.
- `moderation_status` on the Commons tables looked like the mechanism for hiding a post. No query read it, so setting it did nothing.

Documented-but-dead is worse than undocumented, because the inventory then actively asserts a capability the product does not have.

## The gate

`check-orphan-routes.mjs` — matches each route's static prefix against every source file in `web`, `mobile`, `shared`, `scripts` and `.github`, requiring the character after the prefix to be consistent with that route rather than a longer sibling path (a route with no dynamic segments needs the path to end there; one with dynamic segments needs a `/`).

Verified in both directions rather than assumed:
- passes clean on `main`
- adding a route with no caller makes it exit non-zero, then removing it passes again

Runs as `orphan-route-gate` in CI, and locally as `pnpm --dir ctf check:orphan-routes`.

## What the first run found: 91

**3 are genuinely external** and permanently allowlisted, each with the caller named: the Clerk webhook, the GetStream Beacon webhook, and the platform health check.

**88 are recorded as a baseline burn-down list — not approvals.** Each is either a capability that was never wired up or dead code that should be deleted along with its inventory entry. The allowlist distinguishes the two kinds explicitly, and its README states that a **new** route must never be added to silence the gate: a new route with no caller means the feature is unfinished or the route shouldn't exist, and both are worth failing the build over.

Some are informative on their own — a cluster of legacy `/api/feed/*` routes (`items`, `community/posts`, `config`, `items/[itemId]/read`, `items/[itemId]/dismiss`) superseded by `/api/hub/*` when the Commons was consolidated. I checked those by hand before treating them as real; the Commons genuinely calls `/api/hub/*` and nothing calls the old ones.

Seeding a baseline is the same approach `inventory-drift-allowlist.json` already takes for its known gaps. I did not attempt to fix 88 routes in this PR — that is real product work per route, and doing it under a CI change would bury it.

## Limits, stated in the script

Written down rather than left to be discovered:

- A static route sharing a prefix with a dynamic sibling (`/api/x/export` next to `/api/x/[id]`) can be satisfied by a call to the sibling. A false negative — the gate under-reports rather than blocking CI on a guess.
- It cannot see unread database columns, which is the other half of this failure mode. The `moderation_status` bug would still have slipped through.

## Checks

EOF format, JSON validity of both `package.json` and the allowlist, CI YAML parses, typecheck via the pre-commit gate. Low-risk: tooling only, no app code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_