### PR TITLE
feat: moderate questions and answers, and route member flags to an admin

### DIFF
--- a/ctf/docs/contracts/FEED_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/FEED_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -658,3 +658,26 @@ policies:
       - actor_not_admin
       - csrf_denied
       - post_not_found
+
+  - pluginId: feed
+    command: feed.qa.moderation.flagged.list
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      adminOnly: required
+    consentRequirements:
+      scopes:
+        - feed_consumption
+      fallbackLawfulBasis: legitimate_interest_safety_support
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - actor_not_authenticated
+      - actor_not_admin

--- a/ctf/docs/contracts/FEED_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/FEED_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -489,7 +489,7 @@ auditEvents:
       - feed_community_reply_metadata
     targetContext:
       workspaceId: workspace_identifier
-      targetType: feed_community_post_or_reply
+      targetType: feed_community_post_reply_question_or_answer
       targetId: content_identifier
       previousStatus: moderation_status
       newStatus: moderation_status
@@ -519,7 +519,7 @@ auditEvents:
       - feed_community_reply_metadata
     targetContext:
       workspaceId: workspace_identifier
-      targetType: feed_community_post_or_reply
+      targetType: feed_community_post_reply_question_or_answer
       targetId: content_identifier
       previousStatus: moderation_status
       newStatus: moderation_status

--- a/ctf/docs/contracts/FEED_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/FEED_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -627,6 +627,8 @@ contracts:
     dataAccess:
       - feed_community_posts
       - feed_community_replies
+      - feed_questions
+      - feed_answers
     purpose: content_moderation
     retentionClass: transactional_long_lived
     idempotency: true
@@ -658,6 +660,8 @@ contracts:
     dataAccess:
       - feed_community_posts
       - feed_community_replies
+      - feed_questions
+      - feed_answers
     purpose: content_moderation
     retentionClass: transactional_long_lived
     idempotency: true
@@ -688,6 +692,34 @@ contracts:
     dataAccess:
       - feed_community_posts
       - feed_community_replies
+      - feed_questions
+      - feed_answers
+    purpose: content_moderation
+    retentionClass: transactional_long_lived
+    idempotency: true
+
+  - pluginId: feed
+    command: feed.qa.moderation.flagged.list
+    version: 1.0.0
+    description: >-
+      List answers members have flagged, most-flagged first, with each answer's flag and not-helpful
+      counts and its parent question. Closes a gap that existed for as long as flagging did: the counts
+      were aggregated by feed.question.admin.list but no screen ever called it, so a member's flag
+      reached nobody. Hidden answers are included so a moderator can reverse their own calls. Admin
+      only, read-only.
+    inputSchema:
+      limit:
+        type: number
+        required: false
+    outputSchema:
+      answers:
+        type: array
+      pending:
+        type: number
+    dataAccess:
+      - feed_answers
+      - feed_answer_ratings
+      - feed_questions
     purpose: content_moderation
     retentionClass: transactional_long_lived
     idempotency: true

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -180,6 +180,13 @@ Admin routes:
   verdict string, and a truthiness test against it would disable the check entirely. Both directions
   fail **closed**: a read error reports `show: false`, because a database hiccup must not be able to pop
   the notice on every visit, which is how a notice trains people to dismiss it unread.
+- `GET /api/feed/admin/moderation/flagged-answers` — admin lists answers members have flagged, ordered
+  by flag count then newest (`listFlaggedAnswers`), with `pending` = how many flagged answers are still
+  visible (`countPendingFlaggedAnswers`, counted in the database so it is never a page-capped
+  undercount). Each row carries the parent question, the answer, whether it came from the assistant or
+  a member, and its flag / not-helpful counts. Admin-gated, read-only. **This route is what closed the
+  gap**: members could rate an answer `flagged` from the day rating shipped, the count was aggregated by
+  `GET /api/feed/admin/questions`, and no screen ever called that route — so every flag reached nobody.
 - `GET /api/feed/admin/moderation` — also accepts `?author=<userId>` to show one member's entire Commons
   footprint, and returns an `authors` roster (aggregate counts per member, ordered by volume) so a
   moderator can work by person rather than by post. The roster is omitted when `?author=` is set — it
@@ -196,7 +203,7 @@ Admin routes:
   account. An unrecognised or absent code falls back to `other` rather than 400: a hide is
   time-sensitive and must not fail over its label. Restoring ignores `reason` and **clears** the
   stored reason/actor/timestamp, so a post that is visible again carries no standing accusation.
-  `:target` is `post` or `reply` (else 400); body `{ hidden: boolean }` is **required** — an absent
+  `:target` is `post`, `reply`, `question`, or `answer` (else 400); body `{ hidden: boolean }` is **required** — an absent
   field is a 400 rather than defaulting to restore, so a malformed request can never quietly put
   hidden content back in front of members. Admin-gated + `x-ctf-csrf: '1'`; 404 when the row is gone.
   Sets `moderation_status` to `'hidden'` or `'accepted'` under `FOR UPDATE`, so two moderators acting
@@ -333,15 +340,12 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 1. LLM inference for question answers runs against a single configured provider; provider failover and confidence-thresholding policy are not yet contractualized.
 2. Separate `ANNOUNCEMENTS_PLUGIN_*_CONTRACTS.yaml` files are deprecated; their continued presence is intentional historical reference and is a known cleanup item.
-3. **Questions and answers cannot be moderated.** Commons posts and replies can be hidden (2026-07-29),
-   but `feed_questions` and `feed_answers` carry no `moderation_status` column, so hiding one would
-   need a schema change. Today the only lever on a question is the admin category relabel.
-4. **Member flags route nowhere.** A member can rate an answer `flagged`
-   (`feed_answer_ratings.rating`), and `GET /api/feed/admin/questions` aggregates a `flagged_count` —
-   but no page consumes that route, so nothing puts a flagged answer in front of an admin. Wiring it
-   to the Commons Moderation surface is the natural next step; it was left out rather than half-built
-   because a flag queue for answers needs item 3 first (there is nothing an admin could *do* about a
-   flagged answer yet).
+3. ~~Questions and answers cannot be moderated.~~ **Closed 2026-07-30** — both tables gained
+   `moderation_status`, the read path honours it, and `/admin/commons` can hide either.
+4. ~~Member flags route nowhere.~~ **Closed 2026-07-30** — `GET /api/feed/admin/moderation/flagged-answers`
+   plus the Flagged answers tab on `/admin/commons`. `GET /api/feed/admin/questions` is still orphaned and
+   is recorded in `ctf/scripts/orphan-route-allowlist.json` as a burn-down entry: its `flagged_count` is
+   now superseded by the flag queue, so it should be either wired to a page or deleted.
 
 ---
 
@@ -557,6 +561,35 @@ All three feed channels (announcements, questions, community) are shipped on web
   - Acceptance criteria:
     - Implementation status is tracked; detailed evidence collection deferred to post-MVP.
 
+- 2026-07-30 (later): **Q&A moderation, and member flags now reach somebody.** Closes the gap flagged in
+  the previous pass, and the CI hole that let it survive.
+  - **`feed_questions` and `feed_answers` had no `moderation_status` at all.** That is why the flag queue
+    could not be built: an admin could read a flagged answer and then do nothing about it. Both tables
+    now carry `moderation_status` (default `'accepted'`) plus the same nullable
+    `moderation_reason` / `moderated_by_user_id` / `moderated_at` trio as the Commons tables, so one
+    admin surface drives all four kinds of content. New index
+    `idx_feed_answers_moderation_status (moderation_status, created_at DESC)` serves the queue.
+  - **Read path honours it**, which is the load-bearing half: the timeline's question and answer
+    queries, and `generateFeedQuestionAnswer` (a hidden question cannot be given a new answer, and
+    reports `question_not_found` rather than revealing that it exists).
+  - **`exportQuestionsByCategory` excludes hidden questions.** Hiding something is a judgement that it
+    does not belong; exporting it into training data would launder it straight back in and the model
+    would keep answering in the register of the thing that was removed.
+  - `FeedModerationTarget` widened to `post | reply | question | answer`, with a
+    `MODERATION_TABLES` map and an `isFeedModerationTarget` guard replacing the old two-way ternary, so
+    `POST /api/feed/admin/moderation/:target/:id` covers all four with no new endpoint.
+  - New `GET /api/feed/admin/moderation/flagged-answers` and a **Flagged answers** tab on
+    `/admin/commons`, with the pending count on the tab label. Ordered by flag count, not date: this is
+    triage, and the answer six people objected to matters more than the newest one. Hiding an answer
+    leaves the question up, so the member who asked still has their question and can get a better
+    answer.
+  - **Why no gate caught this**: `check-inventory-drift.mjs` asks whether a route is *documented*, not
+    whether it is *called*. Documented-but-dead is the worse failure, because the inventory then asserts
+    a capability the product does not have. Fixed by `check-orphan-routes.mjs` (`orphan-route-gate`),
+    which fails on any API route with no caller. Its first run found 91 — 3 genuinely external, 88
+    recorded as a burn-down baseline. It cannot see unread database columns, which is the other half of
+    this failure mode and how `moderation_status` sat dead for months.
+  - **Parity:** web + mobile-responsive; Android out of scope (web-only per rule 105).
 ### Change Log
 
 - 2026-07-30 (later): **Three standing Commons notices, three cadences.** The single notice became a

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -631,6 +631,31 @@
 - The point of this case: the cadence alone cannot protect a member who posts something identifying on
   their first visit, before any rotation reaches them. If this card stops appearing for new members, that
   protection is gone even though the periodic notice still looks fine.
+### FD-A21 — A flagged answer reaches an admin, and can be hidden
+**Role:** member + admin | **Surface:** web
+
+**Precondition:** A question in the Commons with at least one answer.
+
+**Steps:**
+1. As a member, open the answer and rate it **flagged**.
+2. As a second member, flag the same answer.
+3. As admin, open `/admin/commons` and look at the tab row.
+4. Open the **Flagged answers** tab.
+5. Click **Hide answer**.
+6. As a member, reload the Commons and find the question.
+7. Back in the admin tab, click **Put back** and accept the confirmation.
+
+**Expected:**
+- Step 3: the tab reads **Flagged answers (1)** — the count of flagged answers still visible. Before
+  this shipped, a flag went nowhere at all: the count was aggregated by an admin route that no screen
+  ever called.
+- Step 4: the answer is listed with **2 flags**, the parent question above it, and a pill saying whether
+  it came from the assistant or a member. Ordering is by flag count, not date — triage, not a feed.
+- Step 5/6: the answer is gone from the member's view of that question, and **the question is still
+  there**. That matters: the member who asked keeps their question and can still get a better answer.
+- Step 7: the answer is visible again, and the pending count returns to 1.
+- Check the audit log: the transition carries `previousStatus`, `newStatus`, and the reason. Not the
+  answer body.
 
 **Result:** web ☐
 
@@ -745,6 +770,26 @@ where you can reach the next multiple of 50 without posting hundreds of times �
   post's transaction rather than running after it commits.
 - In every case, a failure in the notice must never cost a member their post. If the notice cannot be
   published, the post still succeeds.
+### FD-A22 — A hidden question stops being answerable and stops feeding training
+**Role:** member + admin | **Surface:** web
+
+**Precondition:** A question in the Commons with LLM consent granted and no answer yet.
+
+**Steps:**
+1. As admin, open `/admin/commons`, find that question and hide it.
+2. As the member who asked, reload the Commons.
+3. Attempt to generate an answer for it (`POST /api/feed/questions/<id>/answer`).
+4. As admin, run the training export (`GET /api/comic/training/export` / the questions export) and search
+   it for the hidden question's text.
+5. Put the question back and repeat step 4.
+
+**Expected:**
+- Step 2: the question is gone from the timeline.
+- Step 3: refused as **not found** — not "forbidden". A hidden question must not confirm it exists.
+- Step 4: the hidden question does **not** appear in the export. This is the check that matters: hiding
+  something is a judgement it does not belong, and exporting it into training data would launder it back
+  in, with the model then answering in the register of the thing that was removed.
+- Step 5: it appears again once restored.
 
 **Result:** web ☐
 
@@ -952,13 +997,5 @@ The following cases are the highest-signal functional checks that must remain co
 ## Known gaps — do not file these as bugs
 
 1. **LLM provider failover not contractualized.** The Q&A pipeline runs against a single configured LLM provider. If that provider is unavailable the answer generation fails. Provider failover and confidence-thresholding policy are tracked as future work — a failure here is expected behavior, not a bug.
-
-3. **Questions and answers cannot be hidden.** Commons posts and replies can be moderated (FD-A14/A15),
-   but `feed_questions` and `feed_answers` have no `moderation_status` column, so there is no hide
-   control for them. The only admin lever on a question is the category relabel (FD-A10). Not a bug.
-
-4. **Flagging an answer notifies nobody.** A member can rate an answer `flagged`, and the count is
-   aggregated by `GET /api/feed/admin/questions`, but no page reads that route — so a flag reaches no
-   admin queue. Known and tracked; do not file it.
 
 2. **Deprecated contract YAML files.** Separate `ANNOUNCEMENTS_PLUGIN_*_CONTRACTS.yaml` files remain in the repository as intentional historical reference. Their presence is not a bug; they are a known cleanup item.

--- a/ctf/packages/web/app/admin/commons/page.tsx
+++ b/ctf/packages/web/app/admin/commons/page.tsx
@@ -1,6 +1,12 @@
 import { redirect } from 'next/navigation';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { countHiddenCommonsRows, listCommonsAuthors, listCommonsModerationQueue } from 'lib/feed/moderation';
+import {
+  countHiddenCommonsRows,
+  countPendingFlaggedAnswers,
+  listCommonsAuthors,
+  listCommonsModerationQueue,
+  listFlaggedAnswers,
+} from 'lib/feed/moderation';
 import { CommonsModerationAdminShell } from '@/components/feed-announcements/commons-moderation-admin-shell';
 
 export const dynamic = 'force-dynamic';
@@ -16,11 +22,21 @@ export default async function CommonsModerationAdminPage() {
 
   // Failing soft on the read: an empty queue with a working page beats a 500 on the admin surface,
   // and the page's own reload button retries.
-  const [rows, hidden, authors] = await Promise.all([
+  const [rows, hidden, authors, flagged, pendingFlagged] = await Promise.all([
     listCommonsModerationQueue({ limit: 50 }).catch(() => []),
     countHiddenCommonsRows().catch(() => ({ posts: 0, replies: 0 })),
     listCommonsAuthors(50).catch(() => []),
+    listFlaggedAnswers(50).catch(() => []),
+    countPendingFlaggedAnswers().catch(() => 0),
   ]);
 
-  return <CommonsModerationAdminShell rows={rows} hidden={hidden} authors={authors} />;
+  return (
+    <CommonsModerationAdminShell
+      rows={rows}
+      hidden={hidden}
+      authors={authors}
+      flagged={flagged}
+      pendingFlagged={pendingFlagged}
+    />
+  );
 }

--- a/ctf/packages/web/app/api/feed/admin/moderation/[target]/[id]/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/moderation/[target]/[id]/route.ts
@@ -6,13 +6,14 @@ import {
   FEED_MODERATION_STATUS,
   isFeedModerationReason,
 } from 'lib/feed/constants';
-import { setCommunityModerationStatus, type FeedModerationTarget } from 'lib/feed/moderation';
+import { isFeedModerationTarget, setCommunityModerationStatus } from 'lib/feed/moderation';
 import { logFeedAudit } from 'lib/feed/audit';
 import { reportError } from 'lib/observability/report';
 
 export const dynamic = 'force-dynamic';
 
-// POST: hide or un-hide one Commons post or reply.
+// POST: hide or un-hide one piece of member-facing content — a Commons post or reply, or a question or
+// answer in the Q&A.
 //
 // Hiding rather than deleting is the whole point. Deletion is unrecoverable and takes the member's
 // own words plus the reply thread with it; hiding is reversible, so a moderator making a fast
@@ -38,9 +39,9 @@ export async function POST(
   }
 
   const { target, id } = await params;
-  if (target !== 'post' && target !== 'reply') {
+  if (!isFeedModerationTarget(target)) {
     return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Target must be post or reply.' },
+      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Target must be post, reply, question, or answer.' },
       { status: 400 },
     );
   }
@@ -76,7 +77,7 @@ export async function POST(
 
   try {
     const outcome = await setCommunityModerationStatus({
-      target: target as FeedModerationTarget,
+      target,
       id,
       next,
       reason,
@@ -85,7 +86,7 @@ export async function POST(
 
     if (outcome.status === 'not_found') {
       return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.notFound, message: 'That post or reply no longer exists.' },
+        { ok: false, code: FEED_ERROR_CODE.notFound, message: 'That content no longer exists.' },
         { status: 404 },
       );
     }
@@ -103,7 +104,7 @@ export async function POST(
       command: body.hidden ? 'feed.community.moderation.hide' : 'feed.community.moderation.restore',
       status: 'allow',
       reason: 'admin_moderation_allowed',
-      targetType: target === 'post' ? 'feed_community_post' : 'feed_community_reply',
+      targetType: `feed_${target}`,
       targetId: id,
       result: 'success',
       errorCategory: null,
@@ -119,7 +120,7 @@ export async function POST(
       {
         ok: false,
         code: FEED_ERROR_CODE.persistenceUnavailable,
-        message: 'Could not change that post. Nothing was altered — try again.',
+        message: 'Could not change that. Nothing was altered — try again.',
       },
       { status: 503 },
     );

--- a/ctf/packages/web/app/api/feed/admin/moderation/flagged-answers/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/moderation/flagged-answers/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { requireFeedAdminAccess } from '../../../_lib';
+import { FEED_ERROR_CODE } from 'lib/feed/constants';
+import { countPendingFlaggedAnswers, listFlaggedAnswers } from 'lib/feed/moderation';
+import { reportError } from 'lib/observability/report';
+
+export const dynamic = 'force-dynamic';
+
+// GET: answers members have flagged, most-flagged first.
+//
+// This closes a gap that existed for as long as flagging did. A member could rate an answer `flagged`,
+// the count was aggregated by `GET /api/feed/admin/questions` — and no page ever called that route, so
+// the flag reached nobody. The signal was being collected and discarded.
+//
+// Ordered by flag count rather than date because this is a triage queue: the answer six people objected
+// to matters more than the one that arrived most recently. Hidden answers are included so a moderator
+// can see and reverse their own calls.
+export async function GET(request: Request) {
+  const gate = await requireFeedAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const limitParam = Number(new URL(request.url).searchParams.get('limit') ?? '50');
+  const limit = Number.isFinite(limitParam) ? limitParam : 50;
+
+  try {
+    const [answers, pending] = await Promise.all([
+      listFlaggedAnswers(limit),
+      countPendingFlaggedAnswers(),
+    ]);
+
+    return NextResponse.json({ ok: true, answers, pending }, { status: 200 });
+  } catch (error) {
+    reportError(error, { area: 'feed', op: 'admin_flagged_answers' });
+    return NextResponse.json(
+      {
+        ok: false,
+        code: FEED_ERROR_CODE.persistenceUnavailable,
+        message: 'Could not load flagged answers.',
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/ctf/packages/web/components/feed-announcements/commons-moderation-admin-shell.tsx
+++ b/ctf/packages/web/components/feed-announcements/commons-moderation-admin-shell.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { useCallback, useState } from 'react';
-import { EyeOff, Eye, MessageSquare, ShieldAlert } from 'lucide-react';
+import { EyeOff, Eye, Flag, MessageSquare, ShieldAlert } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import { PluginUserShellButton } from '@/components/shared/plugin-user-shell-button';
-import type { FeedModerationAuthorSummary, FeedModerationQueueRow } from 'lib/feed/moderation';
+import type {
+  FeedFlaggedAnswerRow,
+  FeedModerationAuthorSummary,
+  FeedModerationQueueRow,
+} from 'lib/feed/moderation';
 import {
   FEED_MODERATION_REASON,
   FEED_MODERATION_REASONS,
@@ -52,17 +56,23 @@ export function CommonsModerationAdminShell({
   rows: initialRows,
   hidden: initialHidden,
   authors: initialAuthors,
+  flagged: initialFlagged,
+  pendingFlagged: initialPendingFlagged,
 }: {
   rows: FeedModerationQueueRow[];
   hidden: { posts: number; replies: number };
   authors: FeedModerationAuthorSummary[];
+  flagged: FeedFlaggedAnswerRow[];
+  pendingFlagged: number;
 }) {
   const { theme } = useTheme();
   const t = getFeedAnnouncementsTokens(theme);
   const [rows, setRows] = useState(initialRows);
   const [hidden, setHidden] = useState(initialHidden);
   const [authors, setAuthors] = useState(initialAuthors);
-  const [tab, setTab] = useState<'all' | 'hidden' | 'authors'>('all');
+  const [tab, setTab] = useState<'all' | 'hidden' | 'authors' | 'flagged'>('all');
+  const [flagged, setFlagged] = useState(initialFlagged);
+  const [pendingFlagged, setPendingFlagged] = useState(initialPendingFlagged);
   const [focusAuthor, setFocusAuthor] = useState<FeedModerationAuthorSummary | null>(null);
   // The reason applied to the next hide. Defaults to off-topic because that is the actual
   // day-to-day judgement — Quora-style discussion unrelated to the economy — so a sweep of twenty
@@ -103,10 +113,65 @@ export function CommonsModerationAdminShell({
     }
   }, []);
 
-  function switchTab(next: 'all' | 'hidden' | 'authors') {
+  const reloadFlagged = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch('/api/feed/admin/moderation/flagged-answers', { cache: 'no-store' });
+      const data = (await res.json().catch(() => null)) as
+        | { ok?: boolean; answers?: FeedFlaggedAnswerRow[]; pending?: number; message?: string }
+        | null;
+      if (res.ok && data?.ok && Array.isArray(data.answers)) {
+        setFlagged(data.answers);
+        if (typeof data.pending === 'number') setPendingFlagged(data.pending);
+      } else {
+        setError(data?.message ?? 'Could not load flagged answers.');
+      }
+    } catch {
+      setError('Could not load flagged answers.');
+    }
+  }, []);
+
+  function switchTab(next: 'all' | 'hidden' | 'authors' | 'flagged') {
     setTab(next);
     setFocusAuthor(null);
-    if (next !== 'authors') void reload(next === 'hidden', null);
+    if (next === 'flagged') void reloadFlagged();
+    else if (next !== 'authors') void reload(next === 'hidden', null);
+  }
+
+  // Hide or restore one flagged answer. Same endpoint as the Commons rows, target 'answer'.
+  async function setAnswerHidden(row: FeedFlaggedAnswerRow, nextHidden: boolean) {
+    if (!nextHidden && !window.confirm('Put this answer back where members can see it?')) {
+      return;
+    }
+    setBusyId(row.answerId);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch(`/api/feed/admin/moderation/answer/${row.answerId}`, {
+        method: 'POST',
+        headers: CSRF_HEADERS,
+        body: JSON.stringify(nextHidden ? { hidden: true, reason } : { hidden: false }),
+      });
+      const data = (await res.json().catch(() => null)) as
+        | { ok?: boolean; changed?: boolean; message?: string }
+        | null;
+      if (!res.ok || !data?.ok) {
+        setError(data?.message ?? 'Could not change that answer.');
+        return;
+      }
+      setNotice(
+        data.changed === false
+          ? 'Already in that state — nothing changed.'
+          : nextHidden
+            ? 'Answer hidden. The question stays up.'
+            : 'Answer is visible again.',
+      );
+      await reloadFlagged();
+    } catch {
+      setError('Could not change that answer.');
+    } finally {
+      setBusyId(null);
+    }
   }
 
   function openAuthor(author: FeedModerationAuthorSummary) {
@@ -182,6 +247,9 @@ export function CommonsModerationAdminShell({
           <button type="button" onClick={() => switchTab('authors')} aria-pressed={tab === 'authors'} style={tabStyle(t, tab === 'authors')}>
             By member
           </button>
+          <button type="button" onClick={() => switchTab('flagged')} aria-pressed={tab === 'flagged'} style={tabStyle(t, tab === 'flagged')}>
+            Flagged answers{pendingFlagged > 0 ? ` (${pendingFlagged})` : ''}
+          </button>
         </div>
 
         {/* The reason applied to the next hide. One picker for the whole list rather than one per row:
@@ -226,7 +294,69 @@ export function CommonsModerationAdminShell({
           <div role="status" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13 }}>{notice}</div>
         ) : null}
 
-        {tab === 'authors' ? (
+        {tab === 'flagged' ? (
+          flagged.length === 0 ? (
+            <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+              No answers have been flagged.
+            </div>
+          ) : (
+            <>
+              <p style={{ fontSize: 12.5, color: t.MUTED, marginTop: 0, marginBottom: 12 }}>
+                Answers members flagged, most-flagged first. Until now these went nowhere — the count was
+                being collected and no screen showed it. Hiding an answer leaves the question up, so the
+                member who asked still has their question and can get a better answer.
+              </p>
+              {flagged.map((row) => {
+                const isHidden = row.moderationStatus === 'hidden';
+                const busy = busyId === row.answerId;
+                return (
+                  <div key={row.answerId} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${isHidden ? 'rgba(245,158,11,0.35)' : t.BORDER_SOLID}` }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
+                      <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(239,68,68,0.12)', color: '#EF4444', border: '1px solid rgba(239,68,68,0.3)' }}>
+                        <Flag size={10} style={{ verticalAlign: '-1px', marginRight: 3 }} />
+                        {row.flaggedCount} flag{row.flaggedCount === 1 ? '' : 's'}
+                      </span>
+                      {row.notHelpfulCount > 0 ? (
+                        <span style={{ fontSize: 11.5, color: t.MUTED }}>{row.notHelpfulCount} marked not helpful</span>
+                      ) : null}
+                      <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: `${t.ACCENT}1f`, color: t.ACCENT, border: `1px solid ${t.ACCENT}4d` }}>
+                        {row.answerType === 'llm' ? 'Assistant' : 'Member'}
+                      </span>
+                      {isHidden ? (
+                        <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
+                          Hidden{row.moderationReason ? ` · ${FEED_MODERATION_REASON_LABEL[row.moderationReason]}` : ''}
+                        </span>
+                      ) : null}
+                    </div>
+
+                    <div style={{ fontSize: 12.5, color: t.MUTED, marginBottom: 6 }}>
+                      Asked: {row.questionBody}
+                    </div>
+                    <div style={{ fontSize: 14, lineHeight: 1.6, color: t.TITLE, whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginBottom: 10 }}>
+                      {row.answerBody}
+                    </div>
+
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void setAnswerHidden(row, !isHidden)}
+                      style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8,
+                        background: isHidden ? 'rgba(34,197,94,0.12)' : 'rgba(245,158,11,0.12)',
+                        border: `1px solid ${isHidden ? 'rgba(34,197,94,0.3)' : 'rgba(245,158,11,0.3)'}`,
+                        color: isHidden ? '#22C55E' : '#F59E0B',
+                        fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1,
+                      }}
+                    >
+                      {isHidden ? <Eye size={13} /> : <EyeOff size={13} />}
+                      {busy ? 'Saving…' : isHidden ? 'Put back' : 'Hide answer'}
+                    </button>
+                  </div>
+                );
+              })}
+            </>
+          )
+        ) : tab === 'authors' ? (
           authors.length === 0 ? (
             <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
               Nobody has posted in the Commons yet.

--- a/ctf/packages/web/lib/feed/moderation.ts
+++ b/ctf/packages/web/lib/feed/moderation.ts
@@ -22,7 +22,22 @@ import { normalizeUuid } from 'lib/feed/repository';
 // Deliberately NOT here: editing someone else's words. A moderator can take a post down or put it
 // back; they cannot rewrite it and leave it attributed to the author.
 
-export type FeedModerationTarget = 'post' | 'reply';
+// The four kinds of member-facing content a moderator can hide. `question` and `answer` joined the set
+// on 2026-07-30: until then neither table had a `moderation_status` column at all, so a flagged answer
+// could be read by an admin and then nothing could be done about it — which is why the flag queue could
+// not be built and member flags reached nobody.
+export type FeedModerationTarget = 'post' | 'reply' | 'question' | 'answer';
+
+const MODERATION_TABLES: Record<FeedModerationTarget, string> = {
+  post: 'feed_community_posts',
+  reply: 'feed_community_replies',
+  question: 'feed_questions',
+  answer: 'feed_answers',
+};
+
+export function isFeedModerationTarget(value: unknown): value is FeedModerationTarget {
+  return value === 'post' || value === 'reply' || value === 'question' || value === 'answer';
+}
 
 export type FeedModerationOutcome =
   | { status: 'ok'; previous: FeedModerationStatus; next: FeedModerationStatus }
@@ -81,7 +96,7 @@ export async function setCommunityModerationStatus(input: {
     return { status: 'not_found' };
   }
 
-  const table = input.target === 'post' ? 'feed_community_posts' : 'feed_community_replies';
+  const table = MODERATION_TABLES[input.target];
 
   return withDbTransaction(async (client) => {
     // Locked for the read-then-write so two moderators acting at once cannot both believe they made
@@ -250,6 +265,105 @@ export async function listCommonsAuthors(limit = 50): Promise<FeedModerationAuth
     firstPostedAtIso: toIso(row.first_posted_at),
     lastPostedAtIso: toIso(row.last_posted_at),
   }));
+}
+
+// One flagged answer awaiting review. `flaggedCount` is how many members rated it `flagged` — the
+// signal that was already being collected and reaching nobody, because no page called the route that
+// aggregated it.
+export type FeedFlaggedAnswerRow = {
+  answerId: string;
+  questionId: string;
+  questionBody: string;
+  answerType: 'llm' | 'community';
+  answerBody: string;
+  authorUserId: string | null;
+  moderationStatus: FeedModerationStatus;
+  moderationReason: FeedModerationReason | null;
+  flaggedCount: number;
+  notHelpfulCount: number;
+  createdAtIso: string;
+};
+
+// Answers members have flagged, most-flagged first, then newest.
+//
+// Ordered by flag count rather than by date on purpose: this is a triage queue, and the answer six
+// people objected to matters more than the one that arrived most recently. Hidden answers are included
+// so a moderator can see and reverse their own calls.
+export async function listFlaggedAnswers(limit = 50): Promise<FeedFlaggedAnswerRow[]> {
+  const safeLimit = Math.min(Math.max(limit, 1), 200);
+
+  const result = await queryDb<{
+    answer_id: string;
+    question_id: string;
+    question_body: string;
+    answer_type: string;
+    answer_body: string;
+    author_user_id: string | null;
+    moderation_status: string;
+    moderation_reason: string | null;
+    flagged_count: string;
+    not_helpful_count: string;
+    created_at: Date;
+  }>(
+    `
+      SELECT
+        fa.id AS answer_id,
+        fa.question_id,
+        fq.body AS question_body,
+        fa.answer_type,
+        fa.body AS answer_body,
+        fa.author_user_id,
+        fa.moderation_status,
+        fa.moderation_reason,
+        COUNT(*) FILTER (WHERE r.rating = 'flagged')::text AS flagged_count,
+        COUNT(*) FILTER (WHERE r.rating = 'not_helpful')::text AS not_helpful_count,
+        fa.created_at
+      FROM feed_answers fa
+      JOIN feed_questions fq ON fq.id = fa.question_id
+      JOIN feed_answer_ratings r ON r.answer_id = fa.id
+      GROUP BY fa.id, fa.question_id, fq.body, fa.answer_type, fa.body, fa.author_user_id,
+               fa.moderation_status, fa.moderation_reason, fa.created_at
+      HAVING COUNT(*) FILTER (WHERE r.rating = 'flagged') > 0
+      ORDER BY COUNT(*) FILTER (WHERE r.rating = 'flagged') DESC, fa.created_at DESC
+      LIMIT $1
+    `,
+    [safeLimit],
+  );
+
+  return result.rows.map((row) => ({
+    answerId: row.answer_id,
+    questionId: row.question_id,
+    questionBody: row.question_body,
+    answerType: row.answer_type === 'community' ? 'community' : 'llm',
+    answerBody: row.answer_body,
+    authorUserId: row.author_user_id,
+    moderationStatus:
+      row.moderation_status === FEED_MODERATION_STATUS.hidden
+        ? FEED_MODERATION_STATUS.hidden
+        : FEED_MODERATION_STATUS.accepted,
+    moderationReason: (row.moderation_reason as FeedModerationReason | null) ?? null,
+    flaggedCount: Number(row.flagged_count ?? 0),
+    notHelpfulCount: Number(row.not_helpful_count ?? 0),
+    createdAtIso: toIso(row.created_at),
+  }));
+}
+
+// How many flagged answers are still visible — the number that actually needs attention, as opposed to
+// the total ever flagged. Counted in the database so it is never a page-capped undercount.
+export async function countPendingFlaggedAnswers(): Promise<number> {
+  const result = await queryDb<{ total: string }>(
+    `
+      SELECT COUNT(*)::text AS total FROM (
+        SELECT fa.id
+        FROM feed_answers fa
+        JOIN feed_answer_ratings r ON r.answer_id = fa.id
+        WHERE fa.moderation_status = 'accepted'
+        GROUP BY fa.id
+        HAVING COUNT(*) FILTER (WHERE r.rating = 'flagged') > 0
+      ) pending
+    `,
+  );
+  return Number(result.rows[0]?.total ?? 0);
 }
 
 // How many Commons rows are currently hidden, for the admin dashboard counter. Counted from the

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -1095,6 +1095,7 @@ async function loadQuestionDetails(
             SELECT id, asked_by_user_id, body, category, location_context, llm_consent_granted, created_at
             FROM feed_questions
             WHERE id = ANY($1::uuid[])
+              AND moderation_status = 'accepted'
           `,
       [questionIds],
     ),
@@ -1103,6 +1104,7 @@ async function loadQuestionDetails(
             SELECT id, question_id, answer_type, body, confidence::text, model_id, sources, author_user_id, created_at
             FROM feed_answers
             WHERE question_id = ANY($1::uuid[])
+              AND moderation_status = 'accepted'
             ORDER BY created_at ASC
           `,
       [questionIds],
@@ -1958,6 +1960,7 @@ export async function generateFeedQuestionAnswer(actorId: string, questionId: st
         SELECT id, asked_by_user_id, body, category, location_context, llm_consent_granted, created_at
         FROM feed_questions
         WHERE id = $1::uuid
+          AND moderation_status = 'accepted'
         LIMIT 1
       `,
       [questionId],
@@ -2772,11 +2775,16 @@ type QuestionExportRow = {
 };
 
 // Group every feed question by category. Used by the admin training export.
+//
+// Hidden questions are excluded. A moderator hiding something is a judgement that it does not belong in
+// the Commons; exporting it into training data would launder it straight back in, and the model would
+// keep answering in the register of the thing that was removed.
 export async function exportQuestionsByCategory(): Promise<Record<FeedQuestionCategory, string[]>> {
   const result = await queryDb<QuestionExportRow>(
     `
       SELECT id, body, category
       FROM feed_questions
+      WHERE moderation_status = 'accepted'
       ORDER BY category ASC, created_at ASC
     `,
   );

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -1028,7 +1028,21 @@ ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS sources JSONB NOT NU
 ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS author_user_id TEXT NULL;
 ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
-
+-- Moderation for member-facing Q&A (2026-07-30). These tables had no moderation_status at all, so a
+-- flagged answer could be read by an admin and then nothing could be done about it — the flag queue was
+-- unbuildable. Same two states and same reason vocabulary as the Commons post tables, so one admin
+-- surface can drive both. Nullable reason/actor/timestamp, null until a moderator acts.
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderation_status TEXT NOT NULL DEFAULT 'accepted';
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderation_reason TEXT NULL;
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderated_by_user_id TEXT NULL;
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderated_at TIMESTAMPTZ NULL;
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderation_status TEXT NOT NULL DEFAULT 'accepted';
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderation_reason TEXT NULL;
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderated_by_user_id TEXT NULL;
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderated_at TIMESTAMPTZ NULL;
+-- Serves the flag queue: flagged answers, newest first, without scanning every answer.
+CREATE INDEX IF NOT EXISTS idx_feed_answers_moderation_status
+  ON feed_answers (moderation_status, created_at DESC);
 CREATE TABLE IF NOT EXISTS feed_answer_ratings (
   user_id TEXT NOT NULL,
   answer_id UUID NOT NULL REFERENCES feed_answers(id) ON DELETE CASCADE,

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1030,7 +1030,21 @@ ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS sources JSONB NOT NU
 ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS author_user_id TEXT NULL;
 ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
-
+-- Moderation for member-facing Q&A (2026-07-30). These tables had no moderation_status at all, so a
+-- flagged answer could be read by an admin and then nothing could be done about it — the flag queue was
+-- unbuildable. Same two states and same reason vocabulary as the Commons post tables, so one admin
+-- surface can drive both. Nullable reason/actor/timestamp, null until a moderator acts.
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderation_status TEXT NOT NULL DEFAULT 'accepted';
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderation_reason TEXT NULL;
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderated_by_user_id TEXT NULL;
+ALTER TABLE IF EXISTS feed_questions ADD COLUMN IF NOT EXISTS moderated_at TIMESTAMPTZ NULL;
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderation_status TEXT NOT NULL DEFAULT 'accepted';
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderation_reason TEXT NULL;
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderated_by_user_id TEXT NULL;
+ALTER TABLE IF EXISTS feed_answers ADD COLUMN IF NOT EXISTS moderated_at TIMESTAMPTZ NULL;
+-- Serves the flag queue: flagged answers, newest first, without scanning every answer.
+CREATE INDEX IF NOT EXISTS idx_feed_answers_moderation_status
+  ON feed_answers (moderation_status, created_at DESC);
 CREATE TABLE IF NOT EXISTS feed_answer_ratings (
   user_id TEXT NOT NULL,
   answer_id UUID NOT NULL REFERENCES feed_answers(id) ON DELETE CASCADE,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**Owner-review lane** — schema change plus new admin power over member content. Auto-merge not enabled.

Items 2 and 3 of the three. Item 1 (the orphan-route CI gate) merged as #1987.

## The gap, and why it couldn't be fixed before

Members have been able to rate an answer `flagged` since rating shipped. The count was aggregated by `GET /api/feed/admin/questions`. **No screen ever called that route**, so every flag reached nobody.

The reason I couldn't just wire it up last time: `feed_questions` and `feed_answers` had **no `moderation_status` column at all**. An admin would have opened a flag queue, read a flagged answer, and been able to do nothing about it. So the queue needed the column first.

## What changed

**Schema.** Both tables gain `moderation_status` (default `'accepted'`) plus the same nullable `moderation_reason` / `moderated_by_user_id` / `moderated_at` trio as the Commons tables, so one admin surface drives all four kinds of content. New index `idx_feed_answers_moderation_status (moderation_status, created_at DESC)` serves the queue.

**The read path honours it** — the load-bearing half, same as last time:
- the timeline's question and answer queries
- `generateFeedQuestionAnswer`: a hidden question can't be given a new answer, and reports **`question_not_found`** rather than "forbidden" — a hidden question must not confirm it exists

**`exportQuestionsByCategory` excludes hidden questions.** This one I'd flag specifically: hiding something is a judgement that it doesn't belong, and exporting it into training data would launder it straight back in — the model would keep answering in the register of the thing that was removed.

**One endpoint, four targets.** `FeedModerationTarget` widened to `post | reply | question | answer` behind a table map and a type guard, replacing the old two-way ternary. `POST /api/feed/admin/moderation/:target/:id` now covers all four with no new surface to gate.

**The flag queue.** `GET /api/feed/admin/moderation/flagged-answers` and a **Flagged answers** tab on `/admin/commons`, with the pending count on the tab label.

- **Ordered by flag count, not date.** This is triage — the answer six people objected to matters more than the newest one.
- **Hiding an answer leaves the question up.** The member who asked keeps their question and can still get a better answer. That's the whole reason this is per-answer rather than per-thread.
- `pending` counts only *visible* flagged answers, computed in the database so it's never a page-capped undercount.

## On the CI question

You were right that a gate should have caught this, and the honest answer is that the existing one asks the wrong question — `check-inventory-drift.mjs` checks whether a route is *documented*, not whether it's *called*. The orphan-route gate from #1987 now fails on any route with no caller; its first run found 91, and it would have caught this one on the day it was written.

It still can't see unread database columns, which is the other half of the same failure mode — that's how `moderation_status` sat dead. I've written that limit into the script rather than leaving it to be discovered.

`GET /api/feed/admin/questions` remains orphaned and stays on the burn-down allowlist: its `flagged_count` is now superseded by this queue, so it should be wired to a page or deleted. I didn't delete it in this PR because that's a separate decision about the admin questions view.

## Docs

Command contract `feed.qa.moderation.flagged.list`, access policy, the hide/restore `dataAccess` widened to the Q&A tables, and the audit `targetType` widened. Inventory route map and change log. **Two inventory Gaps and two test-script do-not-file entries struck through as closed** — they were mine, and leaving them would have the docs still claiming a gap that's shut.

New cases FD-A21 (flag round trip: two flags, the count on the tab, hide, question survives, restore) and FD-A22 (hidden question is unanswerable, reports not-found, and is absent from the training export).

## Checks

Web typecheck, lint (`--max-warnings=0`), a11y lint, full Turbopack build, schema drift (`db_impacting_changed=true`, `contract_changed=true`, `versioning_note_changed=true`), inventory drift, test-script drift, **orphan-route gate**, EOF format — all pass. All three contract YAMLs re-parsed with a loader after editing.

## After merge

`schema.sql` changed, so production applies on merge. The demo database needs `schema.demo.sql` re-applied by hand.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_