### PR TITLE
feat: block spam-marked members from the app and keep a spam Quora-URL denylist

### DIFF
--- a/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -62,8 +62,11 @@ contracts:
 
   - pluginId: unlock
     command: unlock.admin.submission.review
-    version: 1.0.0
-    description: Apply admin moderation decision and unlock access tier transition.
+    version: 1.1.0
+    description: >-
+      Apply admin moderation decision and unlock access tier transition. A spam decision also places
+      a platform-wide ('all'-scope) account restriction so the member loses Commons/app access; an
+      approved or rejected decision lifts a restriction previously placed by a spam decision.
     inputSchema:
       submissionId:
         type: integer
@@ -86,6 +89,8 @@ contracts:
     dataAccess:
       - unlock_verification_submissions
       - unlock_audit_log
+      - account_restrictions
+      - account_restrictions_audit
     purpose: moderation_and_unlock_transition
     retentionClass: audit_long_lived
     idempotency: true

--- a/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -102,6 +102,27 @@ contracts:
     idempotency: true
 
   - pluginId: unlock
+    command: unlock.admin.spam_denylist.remove
+    version: 1.0.0
+    description: >-
+      Remove a normalized Quora URL from the spam denylist. Stops future submissions of that URL from
+      being auto-blocked; does not lift the restriction on a member already blocked for it (that is
+      reversed by re-reviewing their submission to approved/rejected).
+    inputSchema:
+      quoraProfileUrlNormalized:
+        type: string
+        required: true
+    outputSchema:
+      ok:
+        type: boolean
+    dataAccess:
+      - unlock_spam_quora_urls
+      - unlock_audit_log
+    purpose: moderation_denylist_maintenance
+    retentionClass: audit_long_lived
+    idempotency: true
+
+  - pluginId: unlock
     command: unlock.admin.submission.url.edit
     version: 1.0.0
     description: Admin correction of a submission's Quora profile URL (e.g. fixing a typo). Re-validates and re-normalizes the URL with the same rules as the member submit path. Does not change review status, access tier, or the verification window.

--- a/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -1,8 +1,10 @@
 contracts:
   - pluginId: unlock
     command: unlock.verification.submit
-    version: 1.0.0
-    description: Submit or update Quora profile URL for staged unlock verification.
+    version: 1.1.0
+    description: >-
+      Submit or update Quora profile URL for staged unlock verification. A submitted URL that is on the
+      spam denylist is auto-marked spam and app-blocked instead of entering the pending queue.
     inputSchema:
       quoraProfileUrl:
         type: string
@@ -19,6 +21,9 @@ contracts:
     dataAccess:
       - unlock_verification_submissions
       - unlock_audit_log
+      - unlock_spam_quora_urls
+      - account_restrictions
+      - account_restrictions_audit
     purpose: identity_signal_submission
     retentionClass: transactional_long_lived
     idempotency: true
@@ -91,6 +96,7 @@ contracts:
       - unlock_audit_log
       - account_restrictions
       - account_restrictions_audit
+      - unlock_spam_quora_urls
     purpose: moderation_and_unlock_transition
     retentionClass: audit_long_lived
     idempotency: true

--- a/ctf/docs/contracts/UNLOCK_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/UNLOCK_PROFILE_AND_DELETION_CONTRACT.md
@@ -50,12 +50,19 @@ Unlock uses canonical identity for authentication, submission ownership, and mod
 - `unlock_runtime_config`
 - `unlock_verification_submissions`
 - `unlock_audit_log`
+- `unlock_spam_quora_urls`
 
 Retention summary:
 
 1. submission and moderation records are retained as long-lived trust/audit evidence.
 2. audit records are append-only and retained per compliance policy.
 3. no direct financial ledger ownership (service-credits remains separate owner).
+4. `unlock_spam_quora_urls` is a spam denylist keyed on the normalized Quora URL and holding **no
+   member identifier**. It is retained through account/data deletion (registered `retain` in the
+   account deletion registry) for abuse prevention, so a URL an admin flagged as spam is not lost when
+   the flagged member deletes their data. As shipped, `unlock_verification_submissions` is hard-deleted
+   on deletion (see the account deletion registry, which is the source of truth over the intent
+   described in sections 5–6 below).
 
 ## 5) Service-Scoped Deletion Contract
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -63,6 +63,12 @@ This plugin must:
    retained), and any later submission of that URL — even from a brand-new account — is auto-marked
    `spam` and app-blocked at submission time instead of re-entering the pending queue. Approving or
    rejecting the URL removes it from the denylist.
+6. **Spam denylist panel.** The admin shell shows a "Spam Quora-URL denylist" panel (component
+   `unlock-spam-denylist-panel.tsx`, fed by `listSpamQuoraUrls` from the admin page) listing every
+   denylisted URL with when/how many times it was flagged, and a confirm-gated **Remove** button
+   (`POST /api/unlock/admin/spam-denylist/remove`). Removing a URL only stops future submissions of it
+   from being auto-blocked; it does not unblock a member already restricted for it (re-review their
+   submission to approved/rejected for that).
 
 ### 2.2 Incentive Governance
 
@@ -89,6 +95,7 @@ This plugin must:
 7. `unlock.admin.submission.revoke`
 8. `unlock.admin.reward.grant`
 9. `unlock.admin.experiment.read`
+10. `unlock.admin.spam_denylist.remove`
 
 ### 3.2 HTTP Projection Routes
 
@@ -106,6 +113,7 @@ Admin routes:
 - `POST /api/unlock/admin/reconcile-rewards` — admin-session-gated (`requireUnlockAdminAccess`, no `CRON_SECRET`). Runs the same idempotent reward drain as the cron and returns `{ scanned, granted, alreadyGranted, withheld, failed }`. Lets an admin grant any approved-but-uncredited reward on demand from the Unlock admin screen (the "Retry pending rewards" button), independent of the GitHub cron. Audited as `unlock.admin.rewards.reconcile`.
 - `POST /api/unlock/admin/submissions/:submissionId/revoke` — admin-session-gated (`requireUnlockAdminAccess`) + CSRF (`x-ctf-csrf: '1'` + same-origin). Duplicate-identity determination "loser" path: claws a granted reward back (best-effort `burnCredits`, key `unlock-revoke-submission-<id>`) and sets the submission to `rejected` + `locked_support_only` with `reward_revoked_at`, so reconcile never re-grants it. Body `{ reviewNote? }`. Returns `{ ok, submission, creditsReclaimed, reclaimAmount }`; idempotent (a second call on an already-revoked submission is a no-op). Audited as `unlock.admin.submission.revoke` (+ `service-credits.governance.burn.unlock.revoke` when credits were reclaimed).
 - `POST /api/unlock/admin/submissions/:submissionId/grant-reward` — admin-session-gated + CSRF. Duplicate-identity determination "winner" path: clears the hold and grants the reward to the chosen account through the shared guard. Returns 409 `unlock_reward_still_held` (with `holderUserId`) if another account still holds the identity's reward (revoke that one first); 409 if the submission is not approved; otherwise `{ ok, submission }`. Idempotent if the reward already landed. Audited as `unlock.admin.reward.grant` (+ `service-credits.governance.mint.grant.unlock.determination` on a fresh grant).
+- `POST /api/unlock/admin/spam-denylist/remove` — admin-session-gated (`requireUnlockAdminAccess`) + CSRF (`x-ctf-csrf: '1'`). Removes one normalized Quora URL from `unlock_spam_quora_urls`. Body `{ quoraProfileUrlNormalized }`; returns `{ ok: true }`, 400 if missing. Only stops future submissions of that URL from being auto-blocked — it does not lift the restriction on a member already blocked for it (re-review their submission to approved/rejected for that). The denylist itself is read server-side by the admin page (`listSpamQuoraUrls`) and shown in the admin shell's denylist panel. Audited as `unlock.admin.spam_denylist.remove`.
 
 Internal (cron) routes:
 
@@ -191,6 +199,14 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
+- 2026-07-30: **Admin denylist panel — view and remove spam Quora URLs.** Added a "Spam Quora-URL
+  denylist" panel to the Unlock admin shell (`unlock-spam-denylist-panel.tsx`, in its own component to
+  keep the shell under the rule-116 size/complexity limits), fed by `listSpamQuoraUrls` from the admin
+  page. Each row shows the URL, when it was last flagged, and the flag count, with a confirm-gated
+  Remove that calls the new `POST /api/unlock/admin/spam-denylist/remove` (admin-gated + CSRF, audited
+  `unlock.admin.spam_denylist.remove`, command contract `unlock.admin.spam_denylist.remove` v1.0.0).
+  Removing a URL only stops future auto-blocking of it; it does not lift an existing member's
+  restriction. No schema change.
 - 2026-07-30: **Persistent spam Quora-URL denylist — the same spam account is never reviewed twice.**
   Added `unlock_spam_quora_urls` (new table), keyed on the normalized Quora URL and holding no member
   id. Marking a submission `spam` records its normalized URL here; approving/rejecting removes it. Two

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -50,6 +50,13 @@ This plugin must:
 1. List submissions by status/access-tier filters.
 2. Review with decisions: `approved`, `rejected`, `spam`.
 3. Capture reviewer and optional moderation note.
+4. A `spam` decision blocks the member from the whole app, not just the Unlock tier: in addition to
+   dropping the access tier to `locked_support_only`, it places a platform-wide (`all`-scope)
+   `account_restrictions` record (reason `unlock:spam`), which the auth gate enforces across every
+   product surface (Commons/Hub included). The member keeps only their own status and
+   account/data-deletion routes. An `approved` or `rejected` decision lifts a restriction that carries
+   the `unlock:spam` marker (leaving any unrelated admin restriction untouched), so a mistaken spam
+   mark is fully reversible.
 
 ### 2.2 Incentive Governance
 
@@ -140,6 +147,7 @@ Index `idx_unlock_verification_submissions_url_normalized` on `quora_profile_url
 7. Admins always pass the tier check.
 8. **Chyme is no longer granted to not-yet-unlocked members.** Chyme requires `approved_full`; degraded members are pointed at the Hub general channel and the Unlock flow instead. Chyme's anonymous public visitor shell (for signed-out browsing) is unchanged.
 9. **Duplicate-identity guard (one Quora profile, one reward).** A normalized Quora URL earns the verification reward on a single account. The shared reward grant (`grantUnlockRewardForSubmission`, used by the approval handler, the hourly reconcile, and the admin determination) checks `getUnlockRewardHolderForUrl` before minting: if another non-revoked account already holds the identity's reward, the reward is **held** (`reward_withheld_at`) for an admin determination rather than auto-minting a second reward for the same person. The admin then awards the chosen account (`grant-reward`) and/or revokes the others (`revoke`, which burns the credits back and locks the account). This blocks both honest cross-account reuse and a perp who pastes a victim's Quora URL onto an impersonation account. The reward verbs are admin-gated + CSRF-guarded and fully audited.
+10. **A `spam` decision is a whole-app block, not just a tier drop (2026-07-30).** `rejected` and `spam` both drop the Unlock tier to `locked_support_only`, which by itself still lets a member into the Commons/Hub support surface and every `any_authenticated` route. To make `spam` mean "removed from the app", the review handler (`POST /api/unlock/admin/submissions/[submissionId]/review`) additionally places a platform-wide (`all`-scope) `account_restrictions` record with reason `unlock:spam`. The central auth gate (`evaluatePluginAccess`) denies every `support_only` and `approved_full` route for an `all`-scope restriction (reason `account_restricted`), so a spammed member is shut out of the Commons and all plugins — only their own status and account/data-deletion (`any_authenticated`) routes stay reachable, preserving the right to be forgotten. A subsequent `approved` or `rejected` decision lifts the restriction **only** when the stored reason is the `unlock:spam` marker, so it never clears an unrelated admin restriction; this makes a mistaken spam mark fully reversible. The restriction upsert and its audit row are written by `restrictAccount` / `unrestrictAccount` (tables `account_restrictions`, `account_restrictions_audit`).
 
 ## 6) Web and Android Delivery Strategy
 
@@ -170,6 +178,19 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
+- 2026-07-30: **A `spam` decision now removes the member from the app, not just from the full tier.**
+  Before this change, marking a submission `spam` set the same `locked_support_only` tier a `rejected`
+  submission gets, which still left the member inside the Commons/Hub support surface and every
+  `any_authenticated` route — so a spammed member could keep using the support surfaces. The review
+  handler (`POST /api/unlock/admin/submissions/[submissionId]/review`) now also places a platform-wide
+  (`all`-scope) `account_restrictions` record (reason `unlock:spam`) on a `spam` decision, which the
+  central auth gate enforces across every product surface — the member is shut out of the Commons and
+  all plugins, keeping only their own status and account/data-deletion routes. An `approved` or
+  `rejected` decision lifts a restriction carrying the `unlock:spam` marker (never an unrelated admin
+  restriction), so a mistaken spam mark is fully reversible. The command contract
+  `unlock.admin.submission.review` was bumped to `1.1.0` and its `dataAccess` now lists
+  `account_restrictions` and `account_restrictions_audit`. Route logic only — no schema change (both
+  tables already exist).
 - 2026-07-29: **Quora space renamed — help links now point to `skillseconomy.quora.com`.** The owner
   renamed the network's Quora space from `tiskillsnetwork.quora.com` to `skillseconomy.quora.com`, so
   every "Can't find your Quora profile URL?" help callout that pointed members at the old address was

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -57,6 +57,12 @@ This plugin must:
    account/data-deletion routes. An `approved` or `rejected` decision lifts a restriction that carries
    the `unlock:spam` marker (leaving any unrelated admin restriction untouched), so a mistaken spam
    mark is fully reversible.
+5. A `spam` decision also records the submission's normalized Quora URL on the persistent
+   `unlock_spam_quora_urls` denylist, so the admin does not have to review the same spam Quora account
+   again: the URL survives the member's account/data deletion (the denylist holds no member id and is
+   retained), and any later submission of that URL — even from a brand-new account — is auto-marked
+   `spam` and app-blocked at submission time instead of re-entering the pending queue. Approving or
+   rejecting the URL removes it from the denylist.
 
 ### 2.2 Incentive Governance
 
@@ -116,6 +122,13 @@ Admin page:
 1. `unlock_runtime_config`
 2. `unlock_verification_submissions`
 3. `unlock_audit_log`
+4. `unlock_spam_quora_urls` — persistent spam denylist of normalized Quora profile URLs. Keyed on
+   `quora_profile_url_normalized` (primary key); also stores `quora_profile_url` (last-seen original, for
+   admin readability), `flagged_by_user_id` (admin who flagged, or the system actor on an auto-block),
+   `flag_count`, `first_flagged_at`, `last_flagged_at`, `updated_at`. It holds **no member identifier**,
+   so it is retained through account/data deletion (registered `retain` in the account deletion
+   registry). Written when a submission is marked spam; a row is removed when the same URL is later
+   approved or rejected (the spam mark is reversible).
 
 Multi-currency (issue #120): `unlock_runtime_config` carries `incentive_currency` (FK → `currencies.code`),
 naming the currency of `incentive_amount`. It defaults to ServiceCredits (code `SC`) — the approval
@@ -178,6 +191,20 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
+- 2026-07-30: **Persistent spam Quora-URL denylist — the same spam account is never reviewed twice.**
+  Added `unlock_spam_quora_urls` (new table), keyed on the normalized Quora URL and holding no member
+  id. Marking a submission `spam` records its normalized URL here; approving/rejecting removes it. Two
+  effects: (1) the URL survives the flagged member's account/data deletion — the per-member submission
+  row is hard-deleted, but this denylist is registered `retain` in the account deletion registry — so
+  the flag is not lost; (2) a later submission of a denylisted URL (even from a new account) is
+  auto-marked `spam` and app-blocked at submission time (`createOrUpdateUnlockSubmission` sets the
+  status; the submission route places the `unlock:spam` account restriction, attributed to the system
+  actor `system:unlock-spam-denylist`) instead of re-entering the pending queue. New module
+  `lib/unlock/spam-denylist.ts` holds the denylist read/write and the shared `unlock:spam`
+  restriction-reason constant. Contracts `unlock.verification.submit` (→ `1.1.0`) and
+  `unlock.admin.submission.review` gained `unlock_spam_quora_urls` in `dataAccess` (submit also gained
+  `account_restrictions`/`account_restrictions_audit` for the auto-block). Schema adds one table; the
+  deletion registry, deletion contract, and manual test script were updated to match.
 - 2026-07-30: **A `spam` decision now removes the member from the app, not just from the full tier.**
   Before this change, marking a submission `spam` set the same `locked_support_only` tier a `rejected`
   submission gets, which still left the member inside the Commons/Hub support surface and every

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -182,6 +182,22 @@ Quora account. Step 5: the second member is blocked from the Commons and all plu
 URL to approved/rejected (in the admin queue) removes it from the denylist and lifts the block.
 **Result:** web ☐ — notes:
 
+### UNLOCK-A2d · Spam denylist panel — view and remove a URL
+**Role:** admin / reviewer · **Surfaces:** web (admin surface)
+**Precondition:** at least one URL on the denylist (mark a submission spam first, per UNLOCK-A2c).
+**Steps:**
+1. On `/admin/unlock`, scroll to the "Spam Quora-URL denylist" panel.
+2. Confirm the flagged URL is listed with its last-flagged date (and flag count if more than one).
+3. Click **Remove**, then **Confirm remove**.
+4. Re-submit that URL as a member (per UNLOCK-A2c).
+**Expected:** Step 2: the panel lists every denylisted URL. Step 3: `POST
+/api/unlock/admin/spam-denylist/remove` deletes the row (audited
+`unlock.admin.spam_denylist.remove`) and it disappears from the panel. Step 4: because the URL is no
+longer denylisted, the submission is now accepted as `pending` (not auto-spam) — removal affects future
+submissions only; a member already blocked for that URL stays blocked until their submission is
+re-reviewed. A non-admin cannot reach the route.
+**Result:** web ☐ — notes:
+
 ### UNLOCK-A3 · Approval reward — granted or pending, never double
 **Role:** admin / reviewer · **Surfaces:** web (admin surface)
 **Precondition:** a freshly approved submission.

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -137,10 +137,29 @@ the whole set. Every listed row shows the Support-only pill.
 **Steps:**
 1. On a pending submission, choose **Approve**.
 2. On another, choose **Reject**.
-3. Confirm a third can be marked **spam** (the route accepts `approved`, `rejected`, `spam`).
+3. On a third, click **Spam**, then click **Confirm spam + block** in the inline confirm (or
+   **Cancel** to back out — the route accepts `approved`, `rejected`, `spam`).
 **Expected:** Each decision posts to the review route, records the reviewer, and refreshes the row
 to its new status. Approve moves the account to full access; reject/spam drop it out of pending.
 The decision is audited (`unlock.admin.submission.review`).
+**Result:** web ☐ — notes:
+
+### UNLOCK-A2b · Spam removes the member from the app; a later approve/reject restores access
+**Role:** admin / reviewer · **Surfaces:** web (admin surface)
+**Precondition:** a submission that can be marked spam, and the ability to sign in as that member.
+**Steps:**
+1. Mark the submission **spam** (confirm the block).
+2. As that member, try to open the Commons / Hub general channel and any plugin.
+3. As that member, open the Unlock status page and the account / data-deletion pages.
+4. Back as admin, re-review the same submission to **Approved** (or **Rejected**).
+5. As the member, retry the Commons / a plugin (approved) or the Commons support channel (rejected).
+**Expected:** Step 1 also places a platform-wide (`all`-scope) `account_restrictions` record with
+reason `unlock:spam` (audited in `account_restrictions_audit`). Step 2: the member is denied on every
+product surface — Commons and all plugins — with reason `account_restricted`. Step 3: their own Unlock
+status and the account / data-deletion routes still load (`any_authenticated` — the block deliberately
+leaves the right to be forgotten open). Step 4/5: re-reviewing lifts the `unlock:spam` restriction, so
+the member regains the access their new tier grants (full app on approve; Commons/support on reject). A
+restriction an admin set for any other reason is left untouched.
 **Result:** web ☐ — notes:
 
 ### UNLOCK-A3 · Approval reward — granted or pending, never double

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -162,6 +162,26 @@ the member regains the access their new tier grants (full app on approve; Common
 restriction an admin set for any other reason is left untouched.
 **Result:** web ☐ — notes:
 
+### UNLOCK-A2c · Spam denylist — a known-spam Quora URL never re-enters the queue, and survives deletion
+**Role:** admin / reviewer + member · **Surfaces:** web (admin surface + member submission)
+**Precondition:** a member with a submission that can be marked spam; the ability to sign in as a
+second, different member.
+**Steps:**
+1. As admin, mark the first member's submission **spam** (confirm the block).
+2. As admin, delete that first member's account/data (or have them delete it).
+3. As the second member, submit the **same** Quora profile URL the first member used.
+4. As admin, open the Pending queue.
+5. As the second member, try to open the Commons / a plugin.
+**Expected:** Step 1 records the normalized URL on `unlock_spam_quora_urls`. Step 2 hard-deletes the
+first member's `unlock_verification_submissions` row but leaves the denylist row intact (it holds no
+member id and is retained). Step 3: the second member's submission is auto-marked `spam` /
+`locked_support_only` at submission time (not `pending`), and an `all`-scope `account_restrictions`
+record is placed (actor `system:unlock-spam-denylist`, reason `unlock:spam`). Step 4: the second
+member's submission does **not** appear in Pending — the admin never has to re-review the same spam
+Quora account. Step 5: the second member is blocked from the Commons and all plugins. Re-reviewing that
+URL to approved/rejected (in the admin queue) removes it from the denylist and lifts the block.
+**Result:** web ☐ — notes:
+
 ### UNLOCK-A3 · Approval reward — granted or pending, never double
 **Role:** admin / reviewer · **Surfaces:** web (admin surface)
 **Precondition:** a freshly approved submission.

--- a/ctf/packages/web/app/admin/unlock/page.tsx
+++ b/ctf/packages/web/app/admin/unlock/page.tsx
@@ -4,6 +4,7 @@ import {
   getUnlockExperimentSplit,
   listUnlockSubmissions,
 } from 'lib/unlock/repository';
+import { listSpamQuoraUrls } from 'lib/unlock/spam-denylist';
 import { redirect } from 'next/navigation';
 import { UnlockAdminShell } from '@/components/unlock/unlock-admin-shell';
 
@@ -15,13 +16,19 @@ export default async function UnlockAdminPage() {
     redirect('/');
   }
 
-  const [dashboard, submissions, experimentSplit] = await Promise.all([
+  const [dashboard, submissions, experimentSplit, spamDenylist] = await Promise.all([
     getUnlockDashboardSnapshot(),
     listUnlockSubmissions({ limit: 50 }),
     getUnlockExperimentSplit(),
+    listSpamQuoraUrls(),
   ]);
 
   return (
-    <UnlockAdminShell dashboard={dashboard} submissions={submissions} experimentSplit={experimentSplit} />
+    <UnlockAdminShell
+      dashboard={dashboard}
+      submissions={submissions}
+      experimentSplit={experimentSplit}
+      spamDenylist={spamDenylist}
+    />
   );
 }

--- a/ctf/packages/web/app/api/unlock/admin/spam-denylist/remove/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/spam-denylist/remove/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { ensureUnlockMutationCsrf, requireUnlockAdminAccess, resolveUnlockRequestId, unlockErrorResponse } from 'lib/unlock/_lib';
+import { insertUnlockAudit } from 'lib/unlock/repository';
+import { removeSpamQuoraUrl } from 'lib/unlock/spam-denylist';
+import { reportError } from 'lib/observability/report';
+
+type RemoveBody = {
+  quoraProfileUrlNormalized?: string;
+};
+
+// Admin action: drop a URL from the spam denylist. This only stops FUTURE submissions of that URL from
+// being auto-blocked; it does not lift the app restriction on any member already blocked for it (that is
+// reversed by re-reviewing their submission to approved/rejected). Admin-gated + CSRF-guarded + audited.
+export async function POST(request: Request) {
+  const csrfDeny = ensureUnlockMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireUnlockAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const requestId = resolveUnlockRequestId(request);
+
+  let body: RemoveBody;
+  try {
+    body = (await request.json()) as RemoveBody;
+  } catch {
+    return unlockErrorResponse('Invalid JSON payload.', 400);
+  }
+
+  const normalized = body.quoraProfileUrlNormalized?.trim();
+  if (!normalized) {
+    return unlockErrorResponse('quoraProfileUrlNormalized is required.', 400);
+  }
+
+  try {
+    await removeSpamQuoraUrl(normalized);
+
+    await insertUnlockAudit({
+      actorUserId: gate.auth.userId,
+      command: 'unlock.admin.spam_denylist.remove',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetUserId: gate.auth.userId,
+      requestId,
+      metadata: { quoraProfileUrlNormalized: normalized },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    reportError(error, { area: 'unlock', op: 'admin_spam_denylist_remove' });
+    return unlockErrorResponse('Spam denylist update unavailable.', 503);
+  }
+}

--- a/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
@@ -4,9 +4,15 @@ import { insertUnlockAudit, reviewUnlockSubmission } from 'lib/unlock/repository
 import { grantUnlockRewardForSubmission } from 'lib/unlock/reconcile-rewards';
 import { insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { grantUnleashFlagForUser } from 'lib/feature-flags/unleash-admin';
+import { getAccountRestrictionStatus, restrictAccount, unrestrictAccount } from 'lib/auth/account-restrictions';
 import { UNLOCK_FLAGS } from '@ctf/shared';
 import type { ReviewUnlockSubmissionInput } from 'lib/unlock/types';
 import { reportError } from 'lib/observability/report';
+
+// Reason marker written on the platform-wide restriction we place when a submission is marked spam.
+// A later non-spam decision lifts the restriction only when it carries this exact marker, so an
+// unrelated admin restriction on the same member is never disturbed.
+const UNLOCK_SPAM_RESTRICTION_REASON = 'unlock:spam';
 
 type RouteParams = {
   params: Promise<{
@@ -75,6 +81,29 @@ export async function POST(request: Request, { params }: RouteParams) {
         reviewStatus: body.reviewStatus,
       },
     });
+
+    // Platform-wide access on a spam decision. Dropping the Unlock tier to locked_support_only (done
+    // above) still leaves a spammed member inside the Commons/support surfaces and every
+    // 'any_authenticated' route. Spam means "not a real member" — so also place a full-account
+    // ('all'-scope) restriction, which the auth gate enforces across every product surface. The
+    // member can still reach their own status and account/data-deletion routes ('any_authenticated'),
+    // which the restriction gate intentionally leaves open. A later non-spam decision lifts it below.
+    if (body.reviewStatus === 'spam') {
+      await restrictAccount({
+        targetUserId: submission.userId,
+        actorId: gate.auth.userId,
+        scope: 'all',
+        reason: UNLOCK_SPAM_RESTRICTION_REASON,
+      });
+    } else {
+      // Approved or rejected: undo a restriction we placed for spam so the member regains the access
+      // their new tier grants. Only lift a restriction that carries our spam marker — never one an
+      // admin set for an unrelated reason.
+      const restriction = await getAccountRestrictionStatus(submission.userId, 'all');
+      if (restriction.isRestricted && restriction.reason === UNLOCK_SPAM_RESTRICTION_REASON) {
+        await unrestrictAccount({ targetUserId: submission.userId, actorId: gate.auth.userId });
+      }
+    }
 
     let rewardWithheld = false;
     if (body.reviewStatus === 'approved') {

--- a/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
@@ -7,7 +7,7 @@ import { grantUnleashFlagForUser } from 'lib/feature-flags/unleash-admin';
 import { getAccountRestrictionStatus, restrictAccount, unrestrictAccount } from 'lib/auth/account-restrictions';
 import { UNLOCK_SPAM_RESTRICTION_REASON } from 'lib/unlock/spam-denylist';
 import { UNLOCK_FLAGS } from '@ctf/shared';
-import type { ReviewUnlockSubmissionInput } from 'lib/unlock/types';
+import type { ReviewUnlockSubmissionInput, UnlockSubmission } from 'lib/unlock/types';
 import { reportError } from 'lib/observability/report';
 
 type RouteParams = {
@@ -22,6 +22,74 @@ type ReviewBody = {
 };
 
 const ALLOWED_REVIEW_STATUSES = new Set<ReviewUnlockSubmissionInput['reviewStatus']>(['approved', 'rejected', 'spam']);
+
+// Keep the platform-wide account restriction in step with the review decision. A spam decision places a
+// full-account ('all'-scope) restriction — dropping the Unlock tier to locked_support_only alone still
+// leaves a spammed member inside the Commons/support surfaces and every 'any_authenticated' route, so the
+// restriction is what actually removes them from the app (their own status and account/data-deletion
+// routes stay reachable). Approved/rejected lifts a restriction only when it carries our spam marker, so
+// an unrelated admin restriction is never disturbed.
+async function syncSpamAccountRestriction(
+  targetUserId: string,
+  reviewStatus: ReviewUnlockSubmissionInput['reviewStatus'],
+  actorUserId: string,
+): Promise<void> {
+  if (reviewStatus === 'spam') {
+    await restrictAccount({ targetUserId, actorId: actorUserId, scope: 'all', reason: UNLOCK_SPAM_RESTRICTION_REASON });
+    return;
+  }
+  const restriction = await getAccountRestrictionStatus(targetUserId, 'all');
+  if (restriction.isRestricted && restriction.reason === UNLOCK_SPAM_RESTRICTION_REASON) {
+    await unrestrictAccount({ targetUserId, actorId: actorUserId });
+  }
+}
+
+// Best-effort follow-ups after an approval decision (already committed). The Unleash flag grant and the
+// ServiceCredits reward must NOT fail the approval if a provider (Unleash admin API, Formance ledger) is
+// temporarily unavailable — the mint is idempotent, so a later retry won't double-grant. Returns whether
+// the reward was HELD by the duplicate-identity guard (another account holds this Quora identity's reward).
+async function grantApprovalRewardBestEffort(
+  submission: UnlockSubmission,
+  actorUserId: string,
+  submissionId: number,
+  reviewStatus: ReviewUnlockSubmissionInput['reviewStatus'],
+): Promise<boolean> {
+  if (reviewStatus !== 'approved') {
+    return false;
+  }
+  try {
+    // Grant the Unleash flag so flag-based evaluation returns true on subsequent requests without a DB
+    // lookup. Best-effort: if the Admin API is unavailable, the DB fallback in isUserUnlocked() is authoritative.
+    await grantUnleashFlagForUser(UNLOCK_FLAGS.QUORA_ONBOARDING, submission.userId);
+
+    // Skip if this submission's reward already landed or was clawed back. Otherwise grant through the shared
+    // duplicate-identity guard: if another account already holds this Quora identity's reward, the reward is
+    // HELD for an admin determination instead of minting a second one for the same person.
+    if (!submission.incentiveGrantedAt && !submission.rewardRevokedAt) {
+      const outcome = await grantUnlockRewardForSubmission(submission);
+      if (outcome.status === 'granted') {
+        await insertServiceCreditsAudit({
+          actorId: actorUserId,
+          command: 'service-credits.governance.mint.grant.unlock',
+          policyStatus: 'allow',
+          reason: 'unlock_approved_reward',
+          targetType: 'governance_event',
+          targetId: outcome.governanceEventId,
+          metadata: {
+            unlockSubmissionId: submission.id,
+            targetUserId: submission.userId,
+            amount: outcome.amount,
+          },
+        });
+      } else if (outcome.status === 'withheld') {
+        return true;
+      }
+    }
+  } catch (incentiveError) {
+    reportError(incentiveError, { area: 'unlock', op: 'admin_submissions_submissionid_review_incentive', extra: { submissionId } });
+  }
+  return false;
+}
 
 export async function POST(request: Request, { params }: RouteParams) {
   const csrfDeny = ensureUnlockMutationCsrf(request);
@@ -78,68 +146,9 @@ export async function POST(request: Request, { params }: RouteParams) {
       },
     });
 
-    // Platform-wide access on a spam decision. Dropping the Unlock tier to locked_support_only (done
-    // above) still leaves a spammed member inside the Commons/support surfaces and every
-    // 'any_authenticated' route. Spam means "not a real member" — so also place a full-account
-    // ('all'-scope) restriction, which the auth gate enforces across every product surface. The
-    // member can still reach their own status and account/data-deletion routes ('any_authenticated'),
-    // which the restriction gate intentionally leaves open. A later non-spam decision lifts it below.
-    if (body.reviewStatus === 'spam') {
-      await restrictAccount({
-        targetUserId: submission.userId,
-        actorId: gate.auth.userId,
-        scope: 'all',
-        reason: UNLOCK_SPAM_RESTRICTION_REASON,
-      });
-    } else {
-      // Approved or rejected: undo a restriction we placed for spam so the member regains the access
-      // their new tier grants. Only lift a restriction that carries our spam marker — never one an
-      // admin set for an unrelated reason.
-      const restriction = await getAccountRestrictionStatus(submission.userId, 'all');
-      if (restriction.isRestricted && restriction.reason === UNLOCK_SPAM_RESTRICTION_REASON) {
-        await unrestrictAccount({ targetUserId: submission.userId, actorId: gate.auth.userId });
-      }
-    }
+    await syncSpamAccountRestriction(submission.userId, body.reviewStatus, gate.auth.userId);
 
-    let rewardWithheld = false;
-    if (body.reviewStatus === 'approved') {
-      // The verification decision is already committed above. The flag grant and the
-      // ServiceCredits reward are best-effort follow-ups: if a provider (Unleash admin
-      // API, Formance ledger) is temporarily unavailable, that must NOT fail the approval.
-      // The mint is idempotent, so a later retry won't double-grant.
-      try {
-        // Grant the Unleash flag for this user so flag-based evaluation returns true on
-        // subsequent requests without requiring a DB lookup. Best-effort: if the Admin API
-        // is unavailable, the DB fallback in isUserUnlocked() remains authoritative.
-        await grantUnleashFlagForUser(UNLOCK_FLAGS.QUORA_ONBOARDING, submission.userId);
-
-        // Skip if this submission's reward already landed or was clawed back. Otherwise grant through the
-        // shared duplicate-identity guard: if another account already holds this Quora identity's reward,
-        // the reward is HELD for an admin determination instead of minting a second one for the same person.
-        if (!submission.incentiveGrantedAt && !submission.rewardRevokedAt) {
-          const outcome = await grantUnlockRewardForSubmission(submission);
-          if (outcome.status === 'granted') {
-            await insertServiceCreditsAudit({
-              actorId: gate.auth.userId,
-              command: 'service-credits.governance.mint.grant.unlock',
-              policyStatus: 'allow',
-              reason: 'unlock_approved_reward',
-              targetType: 'governance_event',
-              targetId: outcome.governanceEventId,
-              metadata: {
-                unlockSubmissionId: submission.id,
-                targetUserId: submission.userId,
-                amount: outcome.amount,
-              },
-            });
-          } else if (outcome.status === 'withheld') {
-            rewardWithheld = true;
-          }
-        }
-      } catch (incentiveError) {
-        reportError(incentiveError, { area: 'unlock', op: 'admin_submissions_submissionid_review_incentive', extra: { submissionId } });
-      }
-    }
+    const rewardWithheld = await grantApprovalRewardBestEffort(submission, gate.auth.userId, submissionId, body.reviewStatus);
 
     return NextResponse.json({ ok: true, submission, rewardWithheld });
   } catch (error) {

--- a/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/review/route.ts
@@ -5,14 +5,10 @@ import { grantUnlockRewardForSubmission } from 'lib/unlock/reconcile-rewards';
 import { insertServiceCreditsAudit } from 'lib/service-credits/repository';
 import { grantUnleashFlagForUser } from 'lib/feature-flags/unleash-admin';
 import { getAccountRestrictionStatus, restrictAccount, unrestrictAccount } from 'lib/auth/account-restrictions';
+import { UNLOCK_SPAM_RESTRICTION_REASON } from 'lib/unlock/spam-denylist';
 import { UNLOCK_FLAGS } from '@ctf/shared';
 import type { ReviewUnlockSubmissionInput } from 'lib/unlock/types';
 import { reportError } from 'lib/observability/report';
-
-// Reason marker written on the platform-wide restriction we place when a submission is marked spam.
-// A later non-spam decision lifts the restriction only when it carries this exact marker, so an
-// unrelated admin restriction on the same member is never disturbed.
-const UNLOCK_SPAM_RESTRICTION_REASON = 'unlock:spam';
 
 type RouteParams = {
   params: Promise<{

--- a/ctf/packages/web/app/api/unlock/submission/route.ts
+++ b/ctf/packages/web/app/api/unlock/submission/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { normalizeQuoraProfileUrl, requireUnlockUserAccess, resolveUnlockRequestId, unlockErrorResponse } from 'lib/unlock/_lib';
 import { createOrUpdateUnlockSubmission, insertUnlockAudit } from 'lib/unlock/repository';
 import { isUnlockEarlyCommonsEnabled } from 'lib/unlock/access';
+import { restrictAccount } from 'lib/auth/account-restrictions';
+import { UNLOCK_SPAM_DENYLIST_ACTOR, UNLOCK_SPAM_RESTRICTION_REASON } from 'lib/unlock/spam-denylist';
 import { reportError } from 'lib/observability/report';
 
 type SubmissionBody = {
@@ -51,11 +53,28 @@ export async function POST(request: Request) {
       quoraProfileUrlNormalized: normalizedUrl,
     });
 
+    // The submitted URL is on the spam denylist, so the row was auto-marked spam instead of pending.
+    // Apply the same app-wide block the admin spam path applies, so a spammer who deleted their data
+    // and made a new account is shut out again without an admin ever re-reviewing them. Attributed to
+    // the system (no admin acted). Best-effort: a retry re-applies it, and the restriction is idempotent.
+    if (submission.reviewStatus === 'spam') {
+      try {
+        await restrictAccount({
+          targetUserId: gate.auth.userId,
+          actorId: UNLOCK_SPAM_DENYLIST_ACTOR,
+          scope: 'all',
+          reason: UNLOCK_SPAM_RESTRICTION_REASON,
+        });
+      } catch (restrictionError) {
+        reportError(restrictionError, { area: 'unlock', op: 'submission_denylist_restrict' });
+      }
+    }
+
     await insertUnlockAudit({
       actorUserId: gate.auth.userId,
       command: 'unlock.verification.submit',
-      policyStatus: 'allow',
-      reason: 'ok',
+      policyStatus: submission.reviewStatus === 'spam' ? 'deny' : 'allow',
+      reason: submission.reviewStatus === 'spam' ? 'spam_denylisted' : 'ok',
       targetUserId: gate.auth.userId,
       requestId,
       metadata: { submissionId: submission.id, experimentBucket },

--- a/ctf/packages/web/app/api/unlock/submission/route.ts
+++ b/ctf/packages/web/app/api/unlock/submission/route.ts
@@ -10,6 +10,26 @@ type SubmissionBody = {
   quoraProfileUrl?: string;
 };
 
+// A submitted URL on the spam denylist is auto-marked spam by createOrUpdateUnlockSubmission. Apply the
+// same app-wide block the admin spam path applies, so a spammer who deleted their data and made a new
+// account is shut out again without an admin re-reviewing them. Attributed to the system (no admin
+// acted). Best-effort: a retry re-applies it, and the restriction is idempotent.
+async function applyDenylistBlockIfSpam(reviewStatus: string, targetUserId: string): Promise<void> {
+  if (reviewStatus !== 'spam') {
+    return;
+  }
+  try {
+    await restrictAccount({
+      targetUserId,
+      actorId: UNLOCK_SPAM_DENYLIST_ACTOR,
+      scope: 'all',
+      reason: UNLOCK_SPAM_RESTRICTION_REASON,
+    });
+  } catch (restrictionError) {
+    reportError(restrictionError, { area: 'unlock', op: 'submission_denylist_restrict' });
+  }
+}
+
 export async function POST(request: Request) {
   const gate = await requireUnlockUserAccess();
   if (!gate.allowed) {
@@ -53,22 +73,7 @@ export async function POST(request: Request) {
       quoraProfileUrlNormalized: normalizedUrl,
     });
 
-    // The submitted URL is on the spam denylist, so the row was auto-marked spam instead of pending.
-    // Apply the same app-wide block the admin spam path applies, so a spammer who deleted their data
-    // and made a new account is shut out again without an admin ever re-reviewing them. Attributed to
-    // the system (no admin acted). Best-effort: a retry re-applies it, and the restriction is idempotent.
-    if (submission.reviewStatus === 'spam') {
-      try {
-        await restrictAccount({
-          targetUserId: gate.auth.userId,
-          actorId: UNLOCK_SPAM_DENYLIST_ACTOR,
-          scope: 'all',
-          reason: UNLOCK_SPAM_RESTRICTION_REASON,
-        });
-      } catch (restrictionError) {
-        reportError(restrictionError, { area: 'unlock', op: 'submission_denylist_restrict' });
-      }
-    }
+    await applyDenylistBlockIfSpam(submission.reviewStatus, gate.auth.userId);
 
     await insertUnlockAudit({
       actorUserId: gate.auth.userId,

--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -125,6 +125,9 @@ export function UnlockAdminShell({
   // Which submission is awaiting an explicit revoke confirmation (revoke burns the reward, so it is a
   // money action — never one-click).
   const [confirmRevokeId, setConfirmRevokeId] = useState<number | null>(null);
+  // Marking spam blocks the member from the whole app (an 'all'-scope account restriction), so it is
+  // guarded by an inline confirm the same way the reward-revoke lock is.
+  const [confirmSpamId, setConfirmSpamId] = useState<number | null>(null);
   // Quora URL history, loaded on demand per member. Which member's history panel is open, plus a
   // per-member cache and loading marker. A member who changed their social-proof URL after approval
   // (or tried to remove it — an empty submission keeps the previous URL) shows up here.
@@ -644,9 +647,21 @@ export function UnlockAdminShell({
                     <button type="button" disabled={busy} onClick={() => review(s.id, 'rejected')} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
                       <XCircle size={13} /> Reject
                     </button>
-                    <button type="button" disabled={busy} onClick={() => review(s.id, 'spam')} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(107,114,128,0.12)', border: '1px solid rgba(107,114,128,0.3)', color: '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                      <Ban size={13} /> Spam
-                    </button>
+                    {confirmSpamId === s.id ? (
+                      <>
+                        <span style={{ fontSize: 12, color: '#FCD34D' }}>Mark spam and block this member from the app?</span>
+                        <button type="button" disabled={busy} onClick={() => { setConfirmSpamId(null); review(s.id, 'spam'); }} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.35)', color: '#EF4444', fontSize: 13, fontWeight: 700, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
+                          {busy ? 'Blocking…' : 'Confirm spam + block'}
+                        </button>
+                        <button type="button" disabled={busy} onClick={() => setConfirmSpamId(null)} style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button type="button" disabled={busy} onClick={() => setConfirmSpamId(s.id)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(107,114,128,0.12)', border: '1px solid rgba(107,114,128,0.3)', color: '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
+                        <Ban size={13} /> Spam
+                      </button>
+                    )}
                   </div>
                 ) : rewardHeld || canRevoke ? (
                   <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>

--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -6,9 +6,10 @@ import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import { PluginUserShellButton } from '@/components/shared/plugin-user-shell-button';
 import { Unlock, Key, CheckCircle, XCircle, Ban, RefreshCw, Pencil } from 'lucide-react';
 import { UNLOCK_REWARD_SLA_HOURS } from 'lib/unlock/constants';
-import type { UnlockDashboardSnapshot, UnlockExperimentBucketStat, UnlockSubmission } from 'lib/unlock/types';
+import type { SpamQuoraUrlEntry, UnlockDashboardSnapshot, UnlockExperimentBucketStat, UnlockSubmission } from 'lib/unlock/types';
 import { useTheme } from '@/hooks/useTheme';
 import { getUnlockTokens } from './unlock-shared';
+import { UnlockSpamDenylistPanel } from './unlock-spam-denylist-panel';
 
 // Admin design tokens (shared admin look from the design system) come from the theme-aware
 // Unlock tokens: accent (purple), page background, panel/header, admin card surface, and the
@@ -101,10 +102,12 @@ export function UnlockAdminShell({
   dashboard,
   submissions: initialSubmissions,
   experimentSplit = [],
+  spamDenylist = [],
 }: {
   dashboard: UnlockDashboardSnapshot;
   submissions: UnlockSubmission[];
   experimentSplit?: UnlockExperimentBucketStat[];
+  spamDenylist?: SpamQuoraUrlEntry[];
 }) {
   const router = useRouter();
   const { theme } = useTheme();
@@ -695,8 +698,10 @@ export function UnlockAdminShell({
         )}
 
         <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, marginTop: 16 }}>
-          Approving grants full access and mints the ServiceCredits verification reward. Rejecting or marking spam keeps the member on support-only access. Rewards are issued on approval and the background self-heal retries any that did not land within {UNLOCK_REWARD_SLA_HOURS} hours. If a reward is still showing pending, use Retry pending rewards above to grant it now. A Quora profile earns the reward on one account: if the same profile is approved on another account, its reward is <strong>held</strong> for your determination — use <strong>Grant reward</strong> to award the account you choose, and <strong>Revoke reward</strong> to claw it back from the others (a perp impersonating a victim is exactly this case).
+          Approving grants full access and mints the ServiceCredits verification reward. Rejecting keeps the member on support-only access; marking spam blocks them from the whole app and adds their Quora URL to the denylist below. Rewards are issued on approval and the background self-heal retries any that did not land within {UNLOCK_REWARD_SLA_HOURS} hours. If a reward is still showing pending, use Retry pending rewards above to grant it now. A Quora profile earns the reward on one account: if the same profile is approved on another account, its reward is <strong>held</strong> for your determination — use <strong>Grant reward</strong> to award the account you choose, and <strong>Revoke reward</strong> to claw it back from the others (a perp impersonating a victim is exactly this case).
         </p>
+
+        <UnlockSpamDenylistPanel initialEntries={spamDenylist} />
       </div>
     </div>
   );

--- a/ctf/packages/web/components/unlock/unlock-spam-denylist-panel.tsx
+++ b/ctf/packages/web/components/unlock/unlock-spam-denylist-panel.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ShieldOff, Trash2 } from 'lucide-react';
+import type { SpamQuoraUrlEntry } from 'lib/unlock/types';
+import { useTheme } from '@/hooks/useTheme';
+import { getUnlockTokens } from './unlock-shared';
+
+// Admin panel: view and remove entries on the persistent spam Quora-URL denylist. Marking a submission
+// spam records its normalized URL here so the same Quora account is auto-blocked on re-submission (even
+// from a new account) and never re-enters the review queue. Removing a URL here only stops FUTURE
+// submissions of it from being auto-blocked — it does not unblock a member already restricted for it
+// (that is reversed by re-reviewing their submission to approved/rejected).
+export function UnlockSpamDenylistPanel({ initialEntries }: { initialEntries: SpamQuoraUrlEntry[] }) {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const t = getUnlockTokens(theme);
+  const [entries, setEntries] = useState(initialEntries);
+  const [busyUrl, setBusyUrl] = useState<string | null>(null);
+  const [confirmUrl, setConfirmUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function remove(normalized: string) {
+    setBusyUrl(normalized);
+    setError(null);
+    try {
+      const res = await fetch('/api/unlock/admin/spam-denylist/remove', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+        body: JSON.stringify({ quoraProfileUrlNormalized: normalized }),
+      });
+      const data = (await res.json().catch(() => null)) as { ok?: boolean; reason?: string; code?: string } | null;
+      if (!res.ok) {
+        setError(data?.reason ?? data?.code ?? `Remove failed (${res.status}).`);
+        return;
+      }
+      setConfirmUrl(null);
+      setEntries((prev) => prev.filter((e) => e.quoraProfileUrlNormalized !== normalized));
+      router.refresh();
+    } catch {
+      setError('Network error. Try again.');
+    } finally {
+      setBusyUrl(null);
+    }
+  }
+
+  return (
+    <div style={{ marginTop: 24, padding: '14px 16px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+        <ShieldOff size={15} color={t.ACCENT} />
+        <div style={{ fontSize: 13, fontWeight: 700, color: t.TITLE }}>Spam Quora-URL denylist</div>
+      </div>
+      <div style={{ fontSize: 11, color: t.MUTED, marginBottom: 12, lineHeight: 1.6 }}>
+        A URL lands here when you mark a submission spam. Any later submission of it — even from a new
+        account — is auto-marked spam and blocked, so you never review the same Quora account twice. The
+        URL is kept even after the member deletes their data. Removing a URL here only stops future
+        submissions from being auto-blocked; it does not unblock a member already restricted for it — to
+        do that, re-review their submission to approved or rejected.
+      </div>
+
+      {error ? (
+        <div style={{ fontSize: 12, color: '#EF4444', marginBottom: 10 }}>{error}</div>
+      ) : null}
+
+      {entries.length === 0 ? (
+        <div style={{ fontSize: 12, color: t.MUTED }}>No Quora URLs are on the spam denylist.</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {entries.map((entry) => {
+            const busy = busyUrl === entry.quoraProfileUrlNormalized;
+            return (
+              <div
+                key={entry.quoraProfileUrlNormalized}
+                style={{ padding: '10px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}
+              >
+                <div style={{ fontSize: 13, fontWeight: 600, color: t.TITLE, wordBreak: 'break-all' }}>
+                  {entry.quoraProfileUrlNormalized}
+                </div>
+                <div style={{ fontSize: 11, color: t.MUTED, marginTop: 4, marginBottom: 8 }}>
+                  Flagged {new Date(entry.lastFlaggedAt).toLocaleDateString()}
+                  {entry.flagCount > 1 ? ` · ${entry.flagCount} times` : ''}
+                </div>
+                {confirmUrl === entry.quoraProfileUrlNormalized ? (
+                  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+                    <span style={{ fontSize: 12, color: '#FCD34D' }}>Remove from the denylist?</span>
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => remove(entry.quoraProfileUrlNormalized)}
+                      style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.35)', color: '#EF4444', fontSize: 13, fontWeight: 700, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+                    >
+                      {busy ? 'Removing…' : 'Confirm remove'}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => setConfirmUrl(null)}
+                      style={{ padding: '6px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmUrl(entry.quoraProfileUrlNormalized)}
+                    style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+                  >
+                    <Trash2 size={13} /> Remove
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -356,6 +356,10 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     tables: [
       del('unlock_verification_submissions', 'user_id', 'Your verification submissions.'),
       retain('unlock_audit_log', 'Access/verification audit log; retained for compliance.'),
+      retain(
+        'unlock_spam_quora_urls',
+        'Spam Quora-URL denylist; keyed on the URL (holds no member id), retained for abuse prevention so a URL an admin flagged as spam is not lost when the flagged member deletes their data.',
+      ),
       // unlock_runtime_config is global.
     ],
   },

--- a/ctf/packages/web/lib/unlock/repository.ts
+++ b/ctf/packages/web/lib/unlock/repository.ts
@@ -1,6 +1,7 @@
 import { queryDb } from 'lib/db/postgres';
 import { reportError } from 'lib/observability/report';
 import { recordQuoraUrlChangeStandalone } from 'lib/directory/repository';
+import { addSpamQuoraUrl, isSpamQuoraUrl, removeSpamQuoraUrl } from './spam-denylist';
 import type {
   CreateUnlockSubmissionInput,
   ReviewUnlockSubmissionInput,
@@ -211,6 +212,14 @@ export async function createOrUpdateUnlockSubmission(input: CreateUnlockSubmissi
   const previousUrl = previous.rows[0]?.quora_profile_url ?? null;
   const previousUrlNormalized = previous.rows[0]?.quora_profile_url_normalized ?? null;
 
+  // A URL an admin has already marked spam is auto-marked spam on submission — even from a new account —
+  // so a known-bad Quora profile never re-enters the review queue. Everything else starts pending. The
+  // caller (submission route) reads the returned reviewStatus and applies the app-wide block for a spam
+  // outcome, mirroring the admin review path.
+  const denylisted = await isSpamQuoraUrl(input.quoraProfileUrlNormalized);
+  const initialReviewStatus = denylisted ? 'spam' : 'pending';
+  const initialAccessTier = denylisted ? 'locked_support_only' : 'pending_readonly';
+
   const result = await queryDb<UnlockSubmissionRow>(
     `INSERT INTO unlock_verification_submissions (
        user_id,
@@ -224,16 +233,16 @@ export async function createOrUpdateUnlockSubmission(input: CreateUnlockSubmissi
        $1,
        $2,
        $3,
-       'pending',
-       'pending_readonly',
+       $5,
+       $6,
        NOW() + (($4::text || ' hours')::interval)
      )
      ON CONFLICT (user_id) DO UPDATE
      SET
        quora_profile_url = EXCLUDED.quora_profile_url,
        quora_profile_url_normalized = EXCLUDED.quora_profile_url_normalized,
-       review_status = 'pending',
-       access_tier = 'pending_readonly',
+       review_status = EXCLUDED.review_status,
+       access_tier = EXCLUDED.access_tier,
        unlock_window_expires_at = NOW() + (($4::text || ' hours')::interval),
        reviewed_by_user_id = NULL,
        reviewed_at = NULL,
@@ -265,7 +274,14 @@ export async function createOrUpdateUnlockSubmission(input: CreateUnlockSubmissi
        reward_revoked_at,
        created_at,
        updated_at`,
-    [input.userId, input.quoraProfileUrl, input.quoraProfileUrlNormalized, String(submissionWindowHours)],
+    [
+      input.userId,
+      input.quoraProfileUrl,
+      input.quoraProfileUrlNormalized,
+      String(submissionWindowHours),
+      initialReviewStatus,
+      initialAccessTier,
+    ],
   );
 
   // Record the captured URL in the shared Quora URL history when it is the first submission or a real
@@ -409,7 +425,28 @@ export async function reviewUnlockSubmission(input: ReviewUnlockSubmissionInput)
     return null;
   }
 
-  return mapUnlockSubmission(result.rows[0]);
+  const submission = mapUnlockSubmission(result.rows[0]);
+
+  // Keep the persistent spam denylist in step with the decision. Marking spam records the normalized
+  // URL so it survives the member's data deletion and blocks re-entry on a new account; approving or
+  // rejecting removes it (the spam mark is reversible). Best-effort: the verification decision is
+  // already committed above, so a denylist write failure must not fail the review — a later re-review
+  // re-applies it, and the write is idempotent.
+  try {
+    if (input.reviewStatus === 'spam') {
+      await addSpamQuoraUrl({
+        quoraProfileUrlNormalized: submission.quoraProfileUrlNormalized,
+        quoraProfileUrl: submission.quoraProfileUrl,
+        actorUserId: input.actorUserId,
+      });
+    } else {
+      await removeSpamQuoraUrl(submission.quoraProfileUrlNormalized);
+    }
+  } catch (error) {
+    reportError(error, { area: 'unlock', op: 'sync_spam_denylist', extra: { submissionId: input.submissionId } });
+  }
+
+  return submission;
 }
 
 // Admin correction path: overwrite the stored Quora profile URL (and its normalized form) for a

--- a/ctf/packages/web/lib/unlock/spam-denylist.ts
+++ b/ctf/packages/web/lib/unlock/spam-denylist.ts
@@ -1,4 +1,5 @@
 import { queryDb } from 'lib/db/postgres';
+import type { SpamQuoraUrlEntry } from './types';
 
 // Persistent denylist of normalized Quora profile URLs an admin has marked as spam. It is deliberately
 // keyed on the normalized URL, not on any member id: the per-member submission row is hard-deleted when
@@ -51,4 +52,32 @@ export async function isSpamQuoraUrl(quoraProfileUrlNormalized: string): Promise
     [quoraProfileUrlNormalized],
   );
   return result.rows.length > 0;
+}
+
+// List the denylist for the admin panel, most-recently-flagged first.
+export async function listSpamQuoraUrls(limit = 200): Promise<SpamQuoraUrlEntry[]> {
+  const safeLimit = Number.isFinite(limit) && limit > 0 && limit <= 500 ? Math.floor(limit) : 200;
+  const result = await queryDb<{
+    quora_profile_url_normalized: string;
+    quora_profile_url: string;
+    flagged_by_user_id: string | null;
+    flag_count: number;
+    first_flagged_at: Date;
+    last_flagged_at: Date;
+  }>(
+    `SELECT quora_profile_url_normalized, quora_profile_url, flagged_by_user_id, flag_count, first_flagged_at, last_flagged_at
+     FROM unlock_spam_quora_urls
+     ORDER BY last_flagged_at DESC
+     LIMIT $1`,
+    [safeLimit],
+  );
+
+  return result.rows.map((row) => ({
+    quoraProfileUrlNormalized: row.quora_profile_url_normalized,
+    quoraProfileUrl: row.quora_profile_url,
+    flaggedByUserId: row.flagged_by_user_id,
+    flagCount: row.flag_count,
+    firstFlaggedAt: row.first_flagged_at.toISOString(),
+    lastFlaggedAt: row.last_flagged_at.toISOString(),
+  }));
 }

--- a/ctf/packages/web/lib/unlock/spam-denylist.ts
+++ b/ctf/packages/web/lib/unlock/spam-denylist.ts
@@ -1,0 +1,54 @@
+import { queryDb } from 'lib/db/postgres';
+
+// Persistent denylist of normalized Quora profile URLs an admin has marked as spam. It is deliberately
+// keyed on the normalized URL, not on any member id: the per-member submission row is hard-deleted when
+// a member deletes their data, but this denylist is retained (see the account deletion registry) so the
+// same Quora account cannot slip back into the review queue on a fresh account. A later approve/reject
+// of the same URL removes it here, so a mistaken spam mark is fully reversible.
+
+// Reason marker written on the platform-wide restriction we place when a submission is marked spam
+// (by an admin) or auto-marked spam at submission time (denylist hit). A later non-spam decision lifts
+// the restriction only when it carries this exact marker, so an unrelated admin restriction is never
+// disturbed.
+export const UNLOCK_SPAM_RESTRICTION_REASON = 'unlock:spam';
+
+// Actor recorded on the restriction/audit when a denylisted URL is auto-blocked at submission time —
+// no admin performed the action, so it is attributed to the system rather than to the member.
+export const UNLOCK_SPAM_DENYLIST_ACTOR = 'system:unlock-spam-denylist';
+
+// Record a normalized Quora URL on the denylist (or bump its counters if already present).
+export async function addSpamQuoraUrl(input: {
+  quoraProfileUrlNormalized: string;
+  quoraProfileUrl: string;
+  actorUserId: string;
+}): Promise<void> {
+  await queryDb(
+    `INSERT INTO unlock_spam_quora_urls
+       (quora_profile_url_normalized, quora_profile_url, flagged_by_user_id, flag_count, first_flagged_at, last_flagged_at, updated_at)
+     VALUES ($1, $2, $3, 1, NOW(), NOW(), NOW())
+     ON CONFLICT (quora_profile_url_normalized)
+     DO UPDATE SET
+       quora_profile_url = EXCLUDED.quora_profile_url,
+       flagged_by_user_id = EXCLUDED.flagged_by_user_id,
+       flag_count = unlock_spam_quora_urls.flag_count + 1,
+       last_flagged_at = NOW(),
+       updated_at = NOW()`,
+    [input.quoraProfileUrlNormalized, input.quoraProfileUrl, input.actorUserId],
+  );
+}
+
+// Remove a normalized Quora URL from the denylist (used when a spam mark is reversed).
+export async function removeSpamQuoraUrl(quoraProfileUrlNormalized: string): Promise<void> {
+  await queryDb(`DELETE FROM unlock_spam_quora_urls WHERE quora_profile_url_normalized = $1`, [
+    quoraProfileUrlNormalized,
+  ]);
+}
+
+// Is this normalized Quora URL on the spam denylist?
+export async function isSpamQuoraUrl(quoraProfileUrlNormalized: string): Promise<boolean> {
+  const result = await queryDb(
+    `SELECT 1 FROM unlock_spam_quora_urls WHERE quora_profile_url_normalized = $1 LIMIT 1`,
+    [quoraProfileUrlNormalized],
+  );
+  return result.rows.length > 0;
+}

--- a/ctf/packages/web/lib/unlock/types.ts
+++ b/ctf/packages/web/lib/unlock/types.ts
@@ -31,6 +31,17 @@ export type UnlockSubmission = {
   updatedAt: string;
 };
 
+// One row of the persistent spam Quora-URL denylist (unlock_spam_quora_urls), as shown in the admin
+// denylist panel. Keyed on the normalized URL; holds no member id.
+export type SpamQuoraUrlEntry = {
+  quoraProfileUrlNormalized: string;
+  quoraProfileUrl: string;
+  flaggedByUserId: string | null;
+  flagCount: number;
+  firstFlaggedAt: string;
+  lastFlaggedAt: string;
+};
+
 export type RevokeUnlockRewardInput = {
   actorUserId: string;
   submissionId: number;

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1254,6 +1254,29 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_unlock_verification_submissions_user_id
 CREATE INDEX IF NOT EXISTS idx_unlock_verification_submissions_url_normalized
   ON unlock_verification_submissions (quora_profile_url_normalized);
 
+-- Persistent spam denylist of normalized Quora profile URLs. When an admin marks a submission spam,
+-- its normalized URL is recorded here. This serves two purposes: (1) a member's per-member submission
+-- row is hard-deleted when they delete their account/data, but this denylist is deliberately keyed on
+-- the URL (never on a member id) and retained for abuse prevention, so the spam URL survives that
+-- deletion; (2) a fresh submission of a denylisted URL (even from a new account) is auto-marked spam at
+-- submission time and never re-enters the review queue. A later approve/reject of the same URL removes
+-- it here, so a mistaken spam mark is fully reversible.
+CREATE TABLE IF NOT EXISTS unlock_spam_quora_urls (
+  quora_profile_url_normalized TEXT PRIMARY KEY,
+  quora_profile_url TEXT NOT NULL,
+  flagged_by_user_id TEXT,
+  flag_count INTEGER NOT NULL DEFAULT 1,
+  first_flagged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_flagged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS quora_profile_url TEXT;
+ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS flagged_by_user_id TEXT;
+ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS flag_count INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS first_flagged_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS last_flagged_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 -- Add prod unlock audit/config tables if missing.
 -- `user_id` and `action` are nullable: the current writer (insertUnlockAudit) records the
 -- actor_user_id/command/policy_status/reason columns and does NOT populate the legacy user_id/action


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — the Unlock admin surface is web-only; the member-facing Android Unlock screen is unchanged).

## Why

The question that started this: **when an admin marks an Unlock submission "spam", is the member removed from the Commons / the whole app?** Before: **no** — spam set the same `locked_support_only` tier a `rejected` submission gets, so the member kept Commons/support access. Follow-ups from the owner: **keep the spam Quora URL so the same spam accounts aren't reviewed again**, even after the member deletes their data; and **add an admin screen to view/remove denylist entries**.

## What changed

**1. Spam is now a whole-app block (not just a tier drop).**
On a `spam` decision, the admin review route also places a platform-wide (`all`-scope) `account_restrictions` record (reason `unlock:spam`). The central auth gate already denies every `support_only` / `approved_full` route for an `all`-scope restriction, so the member is shut out of the Commons and all plugins. Their own status and account / data-deletion routes stay reachable (right to be forgotten). An `approved`/`rejected` decision lifts a restriction **only** when it carries the `unlock:spam` marker, so it's reversible and never clears an unrelated admin restriction. The Spam admin button gained an inline confirm.

**2. Persistent spam Quora-URL denylist — the same spam account is never reviewed twice.**
New table `unlock_spam_quora_urls`, keyed on the normalized URL, holding **no member id**:
- Marking spam records the URL; approving/rejecting removes it.
- Registered `retain` in the account deletion registry, so it **survives the flagged member's account/data deletion** (their submission row is still hard-deleted).
- A later submission of a denylisted URL — **even from a new account** — is auto-marked `spam` and app-blocked at submission time (system actor `system:unlock-spam-denylist`) instead of re-entering the pending queue.

**3. Admin denylist panel — view and remove entries.**
A "Spam Quora-URL denylist" panel in the Unlock admin shell lists every denylisted URL (with last-flagged date and flag count) and a confirm-gated Remove (`POST /api/unlock/admin/spam-denylist/remove`, admin-gated + CSRF + audited). Removing a URL only stops future auto-blocking of it; it does not unblock a member already restricted for it (re-review their submission for that). Built as a separate component so the already-large shell isn't grown further.

New module `lib/unlock/spam-denylist.ts` holds the denylist read/write and the shared `unlock:spam` restriction-reason constant.

## Files
- `schema.sql` — new `unlock_spam_quora_urls` table (+ guarded ALTERs).
- New: `lib/unlock/spam-denylist.ts`, `components/unlock/unlock-spam-denylist-panel.tsx`, `app/api/unlock/admin/spam-denylist/remove/route.ts`.
- Changed: `lib/unlock/repository.ts` (auto-spam on submit; denylist sync on review), submission route (auto-block), review route (restriction + denylist; extracted helpers for complexity), admin shell (panel + confirm), admin page (feed panel), deletion registry (`retain`).
- Contracts (`unlock.verification.submit` → 1.1.0; `unlock.admin.submission.review` dataAccess; new `unlock.admin.spam_denylist.remove`), feature inventory, deletion contract, manual test script.

## Verification
- `pnpm --filter @ctf/web run typecheck` / `lint` — pass
- complexity/modularity on new + changed files — pass (pre-existing shell complexity untouched)
- `check-deletion-registry`, `check-inventory-drift`, `check-orphan-routes`, `check-test-script-drift`, `check-eof-format`, `check-schema-drift` — pass
- pre-push gate (repo-wide typecheck) — pass

## Review lane
Auth / access-control + data-retention → owner-review lane. Opened ready for review, **no auto-merge**.

### One decision made without asking
A denylisted URL is **auto-marked spam and app-blocked at submission time** (not just re-queued for review), so a returning spammer never re-enters the queue. Reversible via the admin denylist panel or by re-reviewing. Say if you'd rather it only flag for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT