### PR TITLE
refactor: reduce complexity in six more lib server-logic files (batch 2)

### DIFF
--- a/ctf/packages/web/lib/contributions/repository.ts
+++ b/ctf/packages/web/lib/contributions/repository.ts
@@ -687,6 +687,69 @@ async function applyReviewUpdate(
 }
 
 /**
+ * Confirm a locked, still-pending contribution claim. Credits = confirmedAmountUsd x
+ * credits_per_usd, clamped by the per-user-per-cycle cap; a positive grant goes through the
+ * canonical service-credits mintGrant() (idempotency key `contribution-<submissionId>`). A grant
+ * clamped to 0 still confirms the submission with credits_granted = 0.
+ */
+async function applyConfirmReview(
+  client: PoolClient,
+  row: SubmissionRow,
+  input: ReviewContributionSubmissionInput,
+): Promise<SubmissionRow> {
+  const config = await getContributionsConfigWithClient(client);
+  const confirmedAmountUsd = resolveConfirmedAmount(row, input, config);
+  const cycleId = row.cycle_id ?? (await getCurrentCycle())?.id ?? null;
+
+  // Once-per-member-ever github_star: if this member already holds a different confirmed,
+  // credit-earning star, confirming this one grants 0 credits (we still mark it confirmed and
+  // record the reason). This is defense in depth — the create gate already blocks a duplicate
+  // star at submission time — and it never double-grants.
+  const githubStarAlreadyCredited =
+    row.kind === 'github_star' && (await hasCreditedGithubStarWithClient(client, row.user_id, row.id));
+
+  const computedCredits = githubStarAlreadyCredited ? 0 : confirmedAmountUsd * config.creditsPerUsd;
+  const creditsGranted = await computeCycleCappedGrant(client, {
+    userId: row.user_id,
+    cycleId,
+    computedCredits,
+    cap: config.perUserCycleCreditCap,
+  });
+
+  const reviewNote = githubStarAlreadyCredited
+    ? [input.reviewNote, 'No credits: member already received credits for an earlier GitHub star (once-per-member limit).']
+        .filter((part): part is string => Boolean(part && part.trim()))
+        .join(' ')
+    : input.reviewNote ?? null;
+
+  let governanceEventId: string | null = null;
+  if (creditsGranted > 0) {
+    // Canonical mint path — the only way Contributions touches ServiceCredits. mintGrant is
+    // idempotent on its key, so a retried confirm cannot double-grant.
+    const grant = await mintGrant({
+      actorId: input.actorUserId,
+      targetUserId: row.user_id,
+      amount: creditsGranted,
+      grantReason: GRANT_REASON,
+      governanceTicketId: `contribution-${input.submissionId}`,
+      idempotencyKey: `contribution-${input.submissionId}`,
+    });
+    governanceEventId = grant.governanceEventId;
+  }
+
+  return applyReviewUpdate(client, {
+    submissionId: input.submissionId,
+    status: 'confirmed',
+    actorUserId: input.actorUserId,
+    reviewNote,
+    confirmedAmountUsd,
+    creditsGranted,
+    creditGovernanceEventId: governanceEventId,
+    cycleId,
+  });
+}
+
+/**
  * Confirm or reject a pending contribution claim. Exactly-once: the row is locked and must
  * still be 'pending'. On confirm, credits = confirmedAmountUsd x credits_per_usd, clamped by
  * the per-user-per-cycle cap; a positive grant goes through the canonical service-credits
@@ -726,57 +789,7 @@ export async function reviewSubmission(input: ReviewContributionSubmissionInput)
       return mapSubmissionForAdmin(updated);
     }
 
-    const config = await getContributionsConfigWithClient(client);
-    const confirmedAmountUsd = resolveConfirmedAmount(row, input, config);
-    const cycleId = row.cycle_id ?? (await getCurrentCycle())?.id ?? null;
-
-    // Once-per-member-ever github_star: if this member already holds a different confirmed,
-    // credit-earning star, confirming this one grants 0 credits (we still mark it confirmed and
-    // record the reason). This is defense in depth — the create gate already blocks a duplicate
-    // star at submission time — and it never double-grants.
-    const githubStarAlreadyCredited =
-      row.kind === 'github_star' && (await hasCreditedGithubStarWithClient(client, row.user_id, row.id));
-
-    const computedCredits = githubStarAlreadyCredited ? 0 : confirmedAmountUsd * config.creditsPerUsd;
-    const creditsGranted = await computeCycleCappedGrant(client, {
-      userId: row.user_id,
-      cycleId,
-      computedCredits,
-      cap: config.perUserCycleCreditCap,
-    });
-
-    const reviewNote = githubStarAlreadyCredited
-      ? [input.reviewNote, 'No credits: member already received credits for an earlier GitHub star (once-per-member limit).']
-          .filter((part): part is string => Boolean(part && part.trim()))
-          .join(' ')
-      : input.reviewNote ?? null;
-
-    let governanceEventId: string | null = null;
-    if (creditsGranted > 0) {
-      // Canonical mint path — the only way Contributions touches ServiceCredits. mintGrant is
-      // idempotent on its key, so a retried confirm cannot double-grant.
-      const grant = await mintGrant({
-        actorId: input.actorUserId,
-        targetUserId: row.user_id,
-        amount: creditsGranted,
-        grantReason: GRANT_REASON,
-        governanceTicketId: `contribution-${input.submissionId}`,
-        idempotencyKey: `contribution-${input.submissionId}`,
-      });
-      governanceEventId = grant.governanceEventId;
-    }
-
-    const updated = await applyReviewUpdate(client, {
-      submissionId: input.submissionId,
-      status: 'confirmed',
-      actorUserId: input.actorUserId,
-      reviewNote,
-      confirmedAmountUsd,
-      creditsGranted,
-      creditGovernanceEventId: governanceEventId,
-      cycleId,
-    });
-
+    const updated = await applyConfirmReview(client, row, input);
     return mapSubmissionForAdmin(updated);
   });
 }

--- a/ctf/packages/web/lib/foundation/instant-call.ts
+++ b/ctf/packages/web/lib/foundation/instant-call.ts
@@ -315,6 +315,39 @@ async function dispatchRingDelivery(call: FoundationInstantCall): Promise<void> 
   }
 }
 
+// Resolve and validate the ring target inside the ring transaction: work out who the callee is (the other
+// participant of the thread) and run the ring pre-check. Ringing itself moves no credits, but this rejects
+// early if the call can't even fund the first block. The provider must have opted in with a valid
+// whole-credit rate, and the caller's available balance must cover at least one block at the provider's
+// CURRENT rate. (The rate is only LOCKED at answer; this pre-check uses the live rate purely to avoid
+// placing a ring that could never be answered without an immediate failure.) Returns the callee's user id.
+async function resolveRingTarget(
+  client: PoolClient,
+  threadId: string,
+  callerUserId: string,
+): Promise<string> {
+  const thread = await loadThreadForCaller(client, threadId, callerUserId);
+  // The callee is the other participant. A member can ring the provider; the provider could equally ring
+  // the survivor. Whoever is NOT the caller is the callee.
+  const calleeUserId =
+    thread.survivorUserId === callerUserId ? thread.providerUserId : thread.survivorUserId;
+  if (!calleeUserId || calleeUserId === callerUserId) {
+    throw new Error('thread_not_found');
+  }
+
+  const providerSettings = await loadProviderBillingSettings(client, calleeUserId);
+  const rate = providerSettings.rateCredits;
+  if (!providerSettings.enabled || rate === null || !Number.isInteger(rate) || rate < 1) {
+    throw new Error('billing_misconfigured');
+  }
+  const wallet = await getOrCreateWallet(callerUserId);
+  if (wallet.availableBalance < rate) {
+    throw new Error('insufficient_balance');
+  }
+
+  return calleeUserId;
+}
+
 // Place a ring: the caller (a member who tapped "Connect now") rings the provider on an existing Direct
 // Line thread. Audio-only -> modality 'voice'. The callee learns about it two ways: by polling
 // getIncomingRing (the in-app fallback) and, when they have enabled call alerts, by a Web Push that wakes
@@ -334,29 +367,8 @@ export async function ringInstantCall(input: {
     await expireStaleRings(client, input.callerUserId);
     await assertRingRateLimit(client, input.callerUserId);
 
-    const thread = await loadThreadForCaller(client, input.threadId, input.callerUserId);
-    // The callee is the other participant. A member can ring the provider; the provider could equally ring
-    // the survivor. Whoever is NOT the caller is the callee.
-    const calleeUserId =
-      thread.survivorUserId === input.callerUserId ? thread.providerUserId : thread.survivorUserId;
-    if (!calleeUserId || calleeUserId === input.callerUserId) {
-      throw new Error('thread_not_found');
-    }
-
-    // Ring pre-check: ringing itself moves no credits, but reject early if the call can't even fund the
-    // first block. The provider must have opted in with a valid whole-credit rate, and the caller's
-    // available balance must cover at least one block at the provider's CURRENT rate. (The rate is only
-    // LOCKED at answer; this pre-check uses the live rate purely to avoid placing a ring that could never
-    // be answered without an immediate failure.)
-    const providerSettings = await loadProviderBillingSettings(client, calleeUserId);
-    const rate = providerSettings.rateCredits;
-    if (!providerSettings.enabled || rate === null || !Number.isInteger(rate) || rate < 1) {
-      throw new Error('billing_misconfigured');
-    }
-    const wallet = await getOrCreateWallet(input.callerUserId);
-    if (wallet.availableBalance < rate) {
-      throw new Error('insufficient_balance');
-    }
+    // Resolve the callee and run the ring pre-check (billing enabled + caller can fund the first block).
+    const calleeUserId = await resolveRingTarget(client, input.threadId, input.callerUserId);
 
     const ringExpiresAt = new Date(Date.now() + FOUNDATION_INSTANT_CALL_RING_TIMEOUT_SECONDS * 1000);
     const streamCallId = `foundation-call-${randomUUID()}`;

--- a/ctf/packages/web/lib/foundation/repository.ts
+++ b/ctf/packages/web/lib/foundation/repository.ts
@@ -1137,6 +1137,31 @@ function canTransitionQuote(previousState: FoundationQuoteState, targetState: Fo
   return false;
 }
 
+function assertProviderResponsePayload(
+  quote: FoundationQuoteRow,
+  input: {
+    targetState: FoundationQuoteState;
+    actorUserId: string;
+    quotedAmount?: number | null;
+    quotedCurrency?: string | null;
+  },
+): void {
+  // Only the provider attaches a price, and only on the 'provider_responded' transition. The survivor
+  // may move the quote through its lifecycle but can never set the quoted amount/currency.
+  if (input.targetState === 'provider_responded') {
+    if (input.actorUserId !== quote.provider_user_id) {
+      throw new Error('policy_denied');
+    }
+    const amountOk = typeof input.quotedAmount === 'number'
+      && Number.isFinite(input.quotedAmount)
+      && input.quotedAmount >= 0;
+    const currencyOk = typeof input.quotedCurrency === 'string' && input.quotedCurrency.trim().length > 0;
+    if (!amountOk || !currencyOk) {
+      throw new Error('invalid_payload');
+    }
+  }
+}
+
 export async function updateQuoteRequestState(input: {
   quoteRequestId: string;
   actorUserId: string;
@@ -1176,24 +1201,13 @@ export async function updateQuoteRequestState(input: {
       throw new Error('policy_denied');
     }
 
-    // Only the provider attaches a price, and only on the 'provider_responded' transition. The survivor
-    // may move the quote through its lifecycle but can never set the quoted amount/currency.
-    if (input.targetState === 'provider_responded') {
-      if (input.actorUserId !== quote.provider_user_id) {
-        throw new Error('policy_denied');
-      }
-      const amountOk = typeof input.quotedAmount === 'number'
-        && Number.isFinite(input.quotedAmount)
-        && input.quotedAmount >= 0;
-      const currencyOk = typeof input.quotedCurrency === 'string' && input.quotedCurrency.trim().length > 0;
-      if (!amountOk || !currencyOk) {
-        throw new Error('invalid_payload');
-      }
-    }
+    assertProviderResponsePayload(quote, input);
 
     if (!canTransitionQuote(quote.lifecycle_state, input.targetState)) {
       throw new Error('invalid_quote_transition');
     }
+
+    const transitionReason = input.transitionReason ?? null;
 
     // Persist the price only on 'provider_responded'; stamp settled_at on 'closed' when the quote carries
     // a value (the CASE reads the pre-update quoted_amount, which is what we want). settled_at feeds GDP.
@@ -1224,7 +1238,7 @@ export async function updateQuoteRequestState(input: {
         input.quoteRequestId,
         input.targetState,
         quote.lifecycle_state,
-        input.transitionReason ?? null,
+        transitionReason,
         input.quotedAmount ?? null,
         input.quotedCurrency ?? null,
       ],
@@ -1237,7 +1251,7 @@ export async function updateQuoteRequestState(input: {
         VALUES
           ($1::uuid, $2, $3, $4, $5, '{}'::jsonb)
       `,
-      [input.quoteRequestId, input.actorUserId, quote.lifecycle_state, input.targetState, input.transitionReason ?? null],
+      [input.quoteRequestId, input.actorUserId, quote.lifecycle_state, input.targetState, transitionReason],
     );
 
     const recipient = quote.provider_user_id === input.actorUserId ? quote.survivor_user_id : quote.provider_user_id;

--- a/ctf/packages/web/lib/level-up/_lib.ts
+++ b/ctf/packages/web/lib/level-up/_lib.ts
@@ -47,39 +47,26 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
   return null;
 }
 
+// Maps a known LevelUp error message to its response shape. `report` marks the
+// cases that also send the error to observability before responding.
+const LEVEL_UP_ERROR_MAP: Record<string, { code: string; message: string; status: number; report?: boolean }> = {
+  insufficient_balance: { code: 'level_up_insufficient_balance', message: 'Insufficient balance.', status: 409 },
+  invalid_payload: { code: 'level_up_invalid_payload', message: 'Invalid LevelUp payload.', status: 400 },
+  forbidden: { code: 'level_up_forbidden', message: 'You do not have access to this resource.', status: 403 },
+  not_found: { code: 'level_up_not_found', message: 'Requested resource was not found.', status: 404 },
+  invalid_state: { code: 'level_up_invalid_state', message: 'Resource is not in a valid state for this command.', status: 409 },
+  rate_limit_exceeded: { code: 'level_up_rate_limit_exceeded', message: 'Command rate limit exceeded.', status: 429 },
+  external_ledger_not_configured: { code: 'level_up_external_ledger_not_configured', message: 'External ledger is not configured.', status: 503, report: true },
+  external_ledger_unavailable: { code: 'level_up_external_ledger_unavailable', message: 'External ledger rejected or failed the command.', status: 503, report: true },
+};
+
 export function levelUpErrorResponse(error: unknown, fallbackMessage: string): NextResponse {
-  if (error instanceof Error && error.message === 'insufficient_balance') {
-    return NextResponse.json({ ok: false, code: 'level_up_insufficient_balance', message: 'Insufficient balance.' }, { status: 409 });
-  }
-
-  if (error instanceof Error && error.message === 'invalid_payload') {
-    return NextResponse.json({ ok: false, code: 'level_up_invalid_payload', message: 'Invalid LevelUp payload.' }, { status: 400 });
-  }
-
-  if (error instanceof Error && error.message === 'forbidden') {
-    return NextResponse.json({ ok: false, code: 'level_up_forbidden', message: 'You do not have access to this resource.' }, { status: 403 });
-  }
-
-  if (error instanceof Error && error.message === 'not_found') {
-    return NextResponse.json({ ok: false, code: 'level_up_not_found', message: 'Requested resource was not found.' }, { status: 404 });
-  }
-
-  if (error instanceof Error && error.message === 'invalid_state') {
-    return NextResponse.json({ ok: false, code: 'level_up_invalid_state', message: 'Resource is not in a valid state for this command.' }, { status: 409 });
-  }
-
-  if (error instanceof Error && error.message === 'rate_limit_exceeded') {
-    return NextResponse.json({ ok: false, code: 'level_up_rate_limit_exceeded', message: 'Command rate limit exceeded.' }, { status: 429 });
-  }
-
-  if (error instanceof Error && error.message === 'external_ledger_not_configured') {
-    reportError(error, { area: 'level-up', op: 'unknown' });
-    return NextResponse.json({ ok: false, code: 'level_up_external_ledger_not_configured', message: 'External ledger is not configured.' }, { status: 503 });
-  }
-
-  if (error instanceof Error && error.message === 'external_ledger_unavailable') {
-    reportError(error, { area: 'level-up', op: 'unknown' });
-    return NextResponse.json({ ok: false, code: 'level_up_external_ledger_unavailable', message: 'External ledger rejected or failed the command.' }, { status: 503 });
+  const mapped = error instanceof Error ? LEVEL_UP_ERROR_MAP[error.message] : undefined;
+  if (mapped) {
+    if (mapped.report) {
+      reportError(error, { area: 'level-up', op: 'unknown' });
+    }
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   reportError(error, { area: 'level-up', op: 'unknown' });

--- a/ctf/packages/web/lib/level-up/auto-cohort.ts
+++ b/ctf/packages/web/lib/level-up/auto-cohort.ts
@@ -189,14 +189,9 @@ function isUniqueViolation(error: unknown): boolean {
 
 type Candidate = { jobTitleId: string; occupation: string; sector: string; skillLevel: string; gap: number };
 
-/**
- * Sector-diverse ranking (owner decision 2026-07-23): pick round-robin across sectors so the top of the
- * queue spans sectors rather than being dominated by one big-gap sector. Input `candidates` is already
- * sorted largest-gap-first, so the first time we meet a sector it is at its largest gap — Map insertion
- * order therefore orders sectors by their top gap. Each sector contributes at most `perSectorCap`; the
- * whole queue is bounded by `topN` for reviewability.
- */
-function sectorDiverseOrder(candidates: Candidate[], perSectorCap: number, topN: number): Candidate[] {
+// Group candidates by sector, preserving input order within each sector. Because `candidates` is
+// sorted largest-gap-first, Map insertion order also orders sectors by their top gap.
+function groupCandidatesBySector(candidates: Candidate[]): Map<string, Candidate[]> {
   const bySector = new Map<string, Candidate[]>();
   for (const candidate of candidates) {
     const list = bySector.get(candidate.sector);
@@ -206,6 +201,18 @@ function sectorDiverseOrder(candidates: Candidate[], perSectorCap: number, topN:
       bySector.set(candidate.sector, [candidate]);
     }
   }
+  return bySector;
+}
+
+/**
+ * Sector-diverse ranking (owner decision 2026-07-23): pick round-robin across sectors so the top of the
+ * queue spans sectors rather than being dominated by one big-gap sector. Input `candidates` is already
+ * sorted largest-gap-first, so the first time we meet a sector it is at its largest gap — Map insertion
+ * order therefore orders sectors by their top gap. Each sector contributes at most `perSectorCap`; the
+ * whole queue is bounded by `topN` for reviewability.
+ */
+function sectorDiverseOrder(candidates: Candidate[], perSectorCap: number, topN: number): Candidate[] {
+  const bySector = groupCandidatesBySector(candidates);
 
   const sectors = [...bySector.keys()];
   const takenPerSector = new Map<string, number>();

--- a/ctf/packages/web/lib/unlock/repository.ts
+++ b/ctf/packages/web/lib/unlock/repository.ts
@@ -59,6 +59,27 @@ type UnlockDashboardRow = {
   locked_support_only_count: string;
 };
 
+// Coerce the dashboard count columns (Postgres returns them as text) into numbers, defaulting any
+// missing column to 0 so an empty table still yields a well-formed snapshot. Uses destructuring
+// defaults (which apply when a value is undefined) so the caller stays flat.
+function mapUnlockDashboardSnapshot(row: Partial<UnlockDashboardRow> = {}): UnlockDashboardSnapshot {
+  const {
+    pending_count = '0',
+    approved_count = '0',
+    rejected_count = '0',
+    spam_count = '0',
+    locked_support_only_count = '0',
+  } = row;
+
+  return {
+    pendingCount: Number(pending_count),
+    approvedCount: Number(approved_count),
+    rejectedCount: Number(rejected_count),
+    spamCount: Number(spam_count),
+    lockedSupportOnlyCount: Number(locked_support_only_count),
+  };
+}
+
 function mapUnlockSubmission(row: UnlockSubmissionRow): UnlockSubmission {
   return {
     id: row.id,
@@ -603,15 +624,7 @@ export async function getUnlockDashboardSnapshot(): Promise<UnlockDashboardSnaps
      FROM unlock_verification_submissions`,
   );
 
-  const row = result.rows[0];
-
-  return {
-    pendingCount: Number(row?.pending_count ?? 0),
-    approvedCount: Number(row?.approved_count ?? 0),
-    rejectedCount: Number(row?.rejected_count ?? 0),
-    spamCount: Number(row?.spam_count ?? 0),
-    lockedSupportOnlyCount: Number(row?.locked_support_only_count ?? 0),
-  };
+  return mapUnlockDashboardSnapshot(result.rows[0]);
 }
 
 // "Early Commons access" A/B experiment readout. Buckets each member by the experimentBucket recorded


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — server-side `lib/` modules, no React Native change).

## What

Second batch of the rule-116 complexity cleanup. Behavior-preserving helper extraction; no logic, SQL, side-effect, or public-signature changes.

- `lib/contributions/repository.ts` — `reviewSubmission` confirm branch → `applyConfirmReview`
- `lib/foundation/instant-call.ts` — ring pre-check → `resolveRingTarget`
- `lib/foundation/repository.ts` — `updateQuoteRequestState` → `assertProviderResponsePayload`
- `lib/level-up/_lib.ts` — `levelUpErrorResponse` → error-map lookup table
- `lib/level-up/auto-cohort.ts` — `sectorDiverseOrder` → `groupCandidatesBySector`
- `lib/unlock/repository.ts` — `getUnlockDashboardSnapshot` → `mapUnlockDashboardSnapshot`

## Verification
- `pnpm --filter @ctf/web run typecheck` / `lint` — pass
- complexity/length rule on all six files — pass
- `check-eof-format` — pass
- pre-push gate (repo-wide typecheck) — pass

No schema/route/contract changes.

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_