### PR TITLE
refactor: reduce complexity in four more lib files (batch 4)

### DIFF
--- a/ctf/packages/web/lib/lighthouse/repository.ts
+++ b/ctf/packages/web/lib/lighthouse/repository.ts
@@ -333,26 +333,42 @@ function mapBlock(row: LighthouseBlockRow): LighthouseBlock {
   };
 }
 
+// A budget value is valid when it is absent (null) or a finite, non-negative number.
+function isNonNegativeFiniteOrNull(value: number | null): boolean {
+  return value === null || (Number.isFinite(value) && value >= 0);
+}
+
+// Validate a budget min/max pair: each side must be non-negative-or-null, and when both are present
+// the max must not be below the min.
+function isBudgetPairValid(min: number | null, max: number | null): boolean {
+  const minValid = isNonNegativeFiniteOrNull(min);
+  const maxValid = isNonNegativeFiniteOrNull(max);
+  const rangeValid = min === null || max === null || max >= min;
+  return minValid && maxValid && rangeValid;
+}
+
+// An optional numeric property field is valid when it is undefined/null or a finite, non-negative
+// number.
+function isOptionalNonNegativeNumber(value: number | null | undefined): boolean {
+  return value === undefined || value === null || (Number.isFinite(value) && value >= 0);
+}
+
 export function validateProfileInput(input: LighthouseProfileInput): boolean {
   const profileTypeAllowed = LIGHTHOUSE_PROFILE_TYPES.includes(input.profileType);
   const moveInDate = normalizeNullableText(input.desiredMoveInDateIso);
   const moveInDateAllowed = !moveInDate || isValidIsoDatetime(moveInDate);
 
-  const budgetMin = input.budgetMin ?? null;
-  const budgetMax = input.budgetMax ?? null;
-  const minValid = budgetMin === null || (Number.isFinite(budgetMin) && budgetMin >= 0);
-  const maxValid = budgetMax === null || (Number.isFinite(budgetMax) && budgetMax >= 0);
-  const rangeValid = budgetMin === null || budgetMax === null || budgetMax >= budgetMin;
+  const budgetValid = isBudgetPairValid(input.budgetMin ?? null, input.budgetMax ?? null);
 
-  return profileTypeAllowed && moveInDateAllowed && minValid && maxValid && rangeValid;
+  return profileTypeAllowed && moveInDateAllowed && budgetValid;
 }
 
 export function validatePropertyInput(input: LighthousePropertyInput): boolean {
   const title = normalizeText(input.title ?? '');
   const description = normalizeText(input.description ?? '');
-  const bedroomsValid = input.bedrooms === undefined || input.bedrooms === null || (Number.isFinite(input.bedrooms) && input.bedrooms >= 0);
-  const bathroomsValid = input.bathrooms === undefined || input.bathrooms === null || (Number.isFinite(input.bathrooms) && input.bathrooms >= 0);
-  const monthlyRentValid = input.monthlyRent === undefined || input.monthlyRent === null || (Number.isFinite(input.monthlyRent) && input.monthlyRent >= 0);
+  const bedroomsValid = isOptionalNonNegativeNumber(input.bedrooms);
+  const bathroomsValid = isOptionalNonNegativeNumber(input.bathrooms);
+  const monthlyRentValid = isOptionalNonNegativeNumber(input.monthlyRent);
 
   return title.length > 0 && description.length > 0 && bedroomsValid && bathroomsValid && monthlyRentValid;
 }
@@ -929,6 +945,18 @@ export async function isBlockedPair(userA: string, userB: string): Promise<boole
   return result.rows.length > 0;
 }
 
+// Flatten a participant-token result into the three Stream fields returned to the caller, defaulting
+// each to null when no token was issued.
+function buildStreamTokenFields(
+  token: Awaited<ReturnType<typeof createLighthouseParticipantToken>>,
+): { streamApiKey: string | null; streamUserId: string | null; streamToken: string | null } {
+  return {
+    streamApiKey: token?.streamApiKey ?? null,
+    streamUserId: token?.streamUserId ?? null,
+    streamToken: token?.streamToken ?? null,
+  };
+}
+
 export async function createMatchRequest(input: {
   actorUserId: string;
   actorDisplayName: string;
@@ -1020,10 +1048,11 @@ export async function createMatchRequest(input: {
     // INSERT, so a committed match always carries its real channel id.
     const matchId = randomUUID();
     const fallbackChannelId = `lighthouse-match-${matchId}`;
+    const seekerDisplayName = normalizeText(input.actorDisplayName || input.actorUserId);
     const ensuredChannelId = await ensureLighthouseMatchChannel({
       matchId,
       seekerUserId: input.actorUserId,
-      seekerDisplayName: normalizeText(input.actorDisplayName || input.actorUserId),
+      seekerDisplayName,
       hostUserId,
       hostDisplayName: hostUserId,
     });
@@ -1059,13 +1088,11 @@ export async function createMatchRequest(input: {
       ],
     );
 
-    const token = await createLighthouseParticipantToken(input.actorUserId, normalizeText(input.actorDisplayName || input.actorUserId));
+    const token = await createLighthouseParticipantToken(input.actorUserId, seekerDisplayName);
 
     return {
       match: mapMatch(created.rows[0]),
-      streamApiKey: token?.streamApiKey ?? null,
-      streamUserId: token?.streamUserId ?? null,
-      streamToken: token?.streamToken ?? null,
+      ...buildStreamTokenFields(token),
     };
   });
 }
@@ -1398,6 +1425,50 @@ export async function insertLighthouseAudit(input: {
   );
 }
 
+type NormalizedAuditEnvelope = {
+  commandVersion: string;
+  evidence: Record<string, unknown>;
+  workspaceId: string;
+  requestId: string;
+  traceId: string;
+  result: { status: string; errorCategory: string };
+  metadata: Record<string, unknown>;
+};
+
+// Newer rows store the full contract envelope in the metadata column; older rows stored only the
+// caller's flat metadata. Detect the envelope by its marker keys and fall back gracefully so both
+// shapes read back without error.
+function normalizeAuditEnvelope(stored: Record<string, unknown>): NormalizedAuditEnvelope {
+  const isEnvelope = typeof stored.policyDecision === 'object' && stored.policyDecision !== null;
+  if (!isEnvelope) {
+    return {
+      commandVersion: '1.0.0',
+      evidence: {},
+      workspaceId: 'unknown',
+      requestId: 'unknown',
+      traceId: 'unknown',
+      result: { status: 'success', errorCategory: 'none' },
+      metadata: stored,
+    };
+  }
+
+  const policyDecision = parseJsonObject(stored.policyDecision);
+  const targetContext = parseJsonObject(stored.targetContext);
+  const resultBlock = parseJsonObject(stored.result);
+  return {
+    commandVersion: String(stored.commandVersion ?? '1.0.0'),
+    evidence: parseJsonObject(policyDecision.evidence),
+    workspaceId: String(targetContext.workspaceId ?? 'unknown'),
+    requestId: String(stored.requestId ?? 'unknown'),
+    traceId: String(stored.traceId ?? 'unknown'),
+    result: {
+      status: String(resultBlock.status ?? 'success'),
+      errorCategory: String(resultBlock.errorCategory ?? 'none'),
+    },
+    metadata: parseJsonObject(stored.metadata),
+  };
+}
+
 export async function listLighthouseAuditEvents(limit = 100): Promise<Array<{
   actorId: string;
   command: string;
@@ -1435,33 +1506,22 @@ export async function listLighthouseAuditEvents(limit = 100): Promise<Array<{
   );
 
   return result.rows.map((row) => {
-    // Newer rows store the full contract envelope in the metadata column; older rows stored only
-    // the caller's flat metadata. Detect the envelope by its marker keys and fall back gracefully
-    // so both shapes read back without error.
-    const stored = parseJsonObject(row.metadata);
-    const isEnvelope =
-      typeof stored.policyDecision === 'object' && stored.policyDecision !== null;
-    const policyDecision = isEnvelope ? parseJsonObject(stored.policyDecision) : {};
-    const targetContext = isEnvelope ? parseJsonObject(stored.targetContext) : {};
-    const resultBlock = isEnvelope ? parseJsonObject(stored.result) : {};
+    const envelope = normalizeAuditEnvelope(parseJsonObject(row.metadata));
 
     return {
       actorId: row.actor_id,
       command: row.command,
-      commandVersion: isEnvelope ? String(stored.commandVersion ?? '1.0.0') : '1.0.0',
+      commandVersion: envelope.commandVersion,
       policyStatus: row.policy_status,
       reason: row.reason,
-      evidence: isEnvelope ? parseJsonObject(policyDecision.evidence) : {},
+      evidence: envelope.evidence,
       targetType: row.target_type,
       targetId: row.target_id,
-      workspaceId: isEnvelope ? String(targetContext.workspaceId ?? 'unknown') : 'unknown',
-      requestId: isEnvelope ? String(stored.requestId ?? 'unknown') : 'unknown',
-      traceId: isEnvelope ? String(stored.traceId ?? 'unknown') : 'unknown',
-      result: {
-        status: isEnvelope ? String(resultBlock.status ?? 'success') : 'success',
-        errorCategory: isEnvelope ? String(resultBlock.errorCategory ?? 'none') : 'none',
-      },
-      metadata: isEnvelope ? parseJsonObject(stored.metadata) : stored,
+      workspaceId: envelope.workspaceId,
+      requestId: envelope.requestId,
+      traceId: envelope.traceId,
+      result: envelope.result,
+      metadata: envelope.metadata,
       createdAtIso: toIso(row.created_at),
     };
   });

--- a/ctf/packages/web/lib/socket-relay/repository.ts
+++ b/ctf/packages/web/lib/socket-relay/repository.ts
@@ -260,24 +260,41 @@ export function validateProfileInput(input: SocketRelayProfileInput): boolean {
   return Boolean(input.relayPreferences && typeof input.relayPreferences === 'object' && !Array.isArray(input.relayPreferences));
 }
 
+// Per-field validators for validateRequestInput, split out so the top-level check stays under the
+// complexity limit. Each mirrors the exact rule it replaced.
+function isValidRequestTitle(title: string): boolean {
+  return title.length > 0 && title.length <= SOCKET_RELAY_MAX_TITLE_LENGTH;
+}
+
+function isValidRequestDetails(details: string): boolean {
+  return details.length > 0 && details.length <= SOCKET_RELAY_MAX_DETAILS_LENGTH;
+}
+
+function isValidRequestTags(tags: string[]): boolean {
+  if (tags.length === 0 || tags.length > SOCKET_RELAY_MAX_TAGS_PER_REQUEST) {
+    return false;
+  }
+  return !hasOverlongTag(tags);
+}
+
+function isValidOptionalLocationField(value: string | null): boolean {
+  return !value || value.length <= 120;
+}
+
 export function validateRequestInput(input: SocketRelayRequestInput): boolean {
   const title = normalizeText(input.title);
   const details = normalizeText(input.details);
   const tags = normalizeTags(input.tags);
 
-  if (title.length === 0 || title.length > SOCKET_RELAY_MAX_TITLE_LENGTH) {
+  if (!isValidRequestTitle(title)) {
     return false;
   }
 
-  if (details.length === 0 || details.length > SOCKET_RELAY_MAX_DETAILS_LENGTH) {
+  if (!isValidRequestDetails(details)) {
     return false;
   }
 
-  if (tags.length === 0 || tags.length > SOCKET_RELAY_MAX_TAGS_PER_REQUEST) {
-    return false;
-  }
-
-  if (hasOverlongTag(tags)) {
+  if (!isValidRequestTags(tags)) {
     return false;
   }
 
@@ -288,7 +305,7 @@ export function validateRequestInput(input: SocketRelayRequestInput): boolean {
   const city = normalizeNullableText(input.city);
   const state = normalizeNullableText(input.state);
   const country = normalizeNullableText(input.country);
-  return (!city || city.length <= 120) && (!state || state.length <= 120) && (!country || country.length <= 120);
+  return isValidOptionalLocationField(city) && isValidOptionalLocationField(state) && isValidOptionalLocationField(country);
 }
 
 // Validate the chosen value type + amount against the currency catalog (issue #420). No value type
@@ -812,6 +829,22 @@ async function ensureFulfillmentParticipant(fulfillmentId: string, actorUserId: 
   return fulfillment;
 }
 
+// The status/event triples a resolve applies, derived once from the outcome so resolveFulfillment
+// does not repeat the same `reopen ? … : …` branch three times. `unsuccessful_reopen` cancels this
+// helper and puts the request back to open; every other outcome closes both.
+type ResolveOutcomePlan = {
+  fulfillmentStatus: 'cancelled' | 'closed';
+  requestStatus: 'open' | 'closed';
+  eventName: 'fulfillment_reopened' | 'fulfillment_closed';
+};
+
+function resolveOutcomePlan(outcome: SocketRelayResolveOutcome): ResolveOutcomePlan {
+  if (outcome === 'unsuccessful_reopen') {
+    return { fulfillmentStatus: 'cancelled', requestStatus: 'open', eventName: 'fulfillment_reopened' };
+  }
+  return { fulfillmentStatus: 'closed', requestStatus: 'closed', eventName: 'fulfillment_closed' };
+}
+
 // Resolve a claimed request. Only the REQUESTER (the person who posted it) or an admin may resolve —
 // a helper can chat on the Direct Line but cannot close someone else's request. The requester picks
 // one of four outcomes; `unsuccessful_reopen` cancels this helper and puts the request back to open
@@ -846,14 +879,14 @@ export async function resolveFulfillment(
     }
 
     const reopen = outcome === 'unsuccessful_reopen';
-    const fulfillmentStatus = reopen ? 'cancelled' : 'closed';
+    const plan = resolveOutcomePlan(outcome);
 
     const updated = await client.query<FulfillmentRow>(
       `UPDATE socket_relay_fulfillments
        SET status = $3, close_reason = $2, updated_at = NOW()
        WHERE id = $1::uuid AND status = 'active'
        RETURNING id, request_id, requester_user_id, fulfiller_user_id, requester_username, fulfiller_username, status, close_reason, created_at, updated_at`,
-      [fulfillmentId, outcome, fulfillmentStatus],
+      [fulfillmentId, outcome, plan.fulfillmentStatus],
     );
     if ((updated.rowCount ?? 0) === 0) {
       throw new Error('fulfillment_not_active');
@@ -883,7 +916,7 @@ export async function resolveFulfillment(
     await client.query(
       `INSERT INTO socket_relay_request_events (request_id, actor_user_id, event_name, metadata)
        VALUES ($1::uuid, $2, $3, jsonb_build_object('outcome', $4::text))`,
-      [fulfillment.requestId, actorUserId, reopen ? 'fulfillment_reopened' : 'fulfillment_closed', outcome],
+      [fulfillment.requestId, actorUserId, plan.eventName, outcome],
     );
 
     return {
@@ -891,7 +924,7 @@ export async function resolveFulfillment(
       // The requester is the request owner (see this function's doc comment).
       ownerUserId: fulfillment.requesterUserId,
       requestId: fulfillment.requestId,
-      requestStatus: reopen ? 'open' : 'closed',
+      requestStatus: plan.requestStatus,
     };
   });
 

--- a/ctf/packages/web/lib/trust-transport/repository.ts
+++ b/ctf/packages/web/lib/trust-transport/repository.ts
@@ -758,6 +758,14 @@ function assertTripTransition(currentStatus: TrustTransportTrip['status'], nextS
   }
 }
 
+// A trip's status may be changed only by one of its two participants (requester or provider) or an admin.
+function assertTripActorAllowed(trip: TripRow, actorUserId: string, isAdmin: boolean): void {
+  const isParticipant = trip.requester_user_id === actorUserId || trip.provider_user_id === actorUserId;
+  if (!isParticipant && !isAdmin) {
+    throw new Error('policy_denied');
+  }
+}
+
 function mapRequestStatusFromTrip(nextStatus: TrustTransportTripStatus): TrustTransportRequest['status'] {
   if (nextStatus === 'assigned' || nextStatus === 'en_route' || nextStatus === 'picked_up') {
     return 'in_progress';
@@ -800,10 +808,7 @@ export async function updateTripStatus(
     }
 
     const trip = tripResult.rows[0];
-    const isParticipant = trip.requester_user_id === actorUserId || trip.provider_user_id === actorUserId;
-    if (!isParticipant && !isAdmin) {
-      throw new Error('policy_denied');
-    }
+    assertTripActorAllowed(trip, actorUserId, isAdmin);
 
     // Neither party can unilaterally complete a trip (owner decision, 2026-07-08): completion is what
     // triggers settlement (a ServiceCredits debit from the requester, or an earnings-ledger credit for an
@@ -987,6 +992,72 @@ export async function confirmTripCompletion(
   return result;
 }
 
+// ServiceCredits rail: move credits from the requester's wallet to the provider's, idempotent by trip id,
+// then record the settlement in the admin audit trail.
+async function settleTripViaServiceCredits(
+  trip: TrustTransportTrip,
+  request: TrustTransportRequest,
+  currency: string,
+  amount: number,
+): Promise<void> {
+  const tx = await createTransfer({
+    senderUserId: request.requesterUserId,
+    recipientUserId: trip.providerUserId,
+    amount,
+    idempotencyKey: `trust-transport-settlement-${trip.id}`,
+    originPlugin: 'trust-transport',
+    reasonCode: 'trust-transport.trip.settlement',
+  });
+
+  await insertTrustTransportAudit({
+    actorId: trip.providerUserId,
+    command: 'trust-transport.trip.settlement',
+    policyStatus: 'allow',
+    reason: 'ok',
+    targetType: 'trip',
+    targetId: trip.id,
+    metadata: {
+      rail: 'service_credits',
+      currency,
+      amount,
+      fromUserId: request.requesterUserId,
+      toUserId: trip.providerUserId,
+      transferId: (tx as { id?: string }).id ?? null,
+    },
+  });
+}
+
+// Fiat/crypto rail: credit the provider's earnings ledger in the settlement currency, idempotent by trip id
+// so a re-completion cannot double-credit. Payouts draw from this per-currency balance. Only audits when a
+// new ledger row is actually inserted.
+async function settleTripViaEarningsLedger(
+  trip: TrustTransportTrip,
+  currency: string,
+  amount: number,
+): Promise<void> {
+  const credited = await queryDb(
+    `INSERT INTO trust_transport_earnings_ledger (provider_user_id, trip_id, entry_type, amount, currency, price_currency, status, metadata)
+     SELECT $1, $2::uuid, 'credit', $3, $4, $4, 'posted', jsonb_build_object('reason', 'trip_settlement')
+     WHERE NOT EXISTS (
+       SELECT 1 FROM trust_transport_earnings_ledger
+       WHERE trip_id = $2::uuid AND entry_type = 'credit' AND (metadata->>'reason') = 'trip_settlement'
+     )`,
+    [trip.providerUserId, trip.id, amount, currency],
+  );
+
+  if ((credited.rowCount ?? 0) > 0) {
+    await insertTrustTransportAudit({
+      actorId: trip.providerUserId,
+      command: 'trust-transport.trip.settlement',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'trip',
+      targetId: trip.id,
+      metadata: { rail: 'earnings_ledger', currency, amount, toUserId: trip.providerUserId },
+    });
+  }
+}
+
 // Settle a completed trip against the requester's chosen settlement. Best-effort and idempotent by trip
 // id: the trip is already completed and the work done, so a failure here (e.g. the requester lacks
 // balance) is logged for reconciliation rather than reverting the trip, and the trip-id key means a
@@ -1008,57 +1079,11 @@ async function settleTripOnCompletion(
 
   try {
     if (currency === 'SC') {
-      const tx = await createTransfer({
-        senderUserId: request.requesterUserId,
-        recipientUserId: trip.providerUserId,
-        amount,
-        idempotencyKey: `trust-transport-settlement-${trip.id}`,
-        originPlugin: 'trust-transport',
-        reasonCode: 'trust-transport.trip.settlement',
-      });
-
-      await insertTrustTransportAudit({
-        actorId: trip.providerUserId,
-        command: 'trust-transport.trip.settlement',
-        policyStatus: 'allow',
-        reason: 'ok',
-        targetType: 'trip',
-        targetId: trip.id,
-        metadata: {
-          rail: 'service_credits',
-          currency,
-          amount,
-          fromUserId: request.requesterUserId,
-          toUserId: trip.providerUserId,
-          transferId: (tx as { id?: string }).id ?? null,
-        },
-      });
+      await settleTripViaServiceCredits(trip, request, currency, amount);
       return;
     }
 
-    // Fiat/crypto: credit the provider's earnings ledger in the settlement currency, idempotent by trip id
-    // so a re-completion cannot double-credit. Payouts draw from this per-currency balance.
-    const credited = await queryDb(
-      `INSERT INTO trust_transport_earnings_ledger (provider_user_id, trip_id, entry_type, amount, currency, price_currency, status, metadata)
-       SELECT $1, $2::uuid, 'credit', $3, $4, $4, 'posted', jsonb_build_object('reason', 'trip_settlement')
-       WHERE NOT EXISTS (
-         SELECT 1 FROM trust_transport_earnings_ledger
-         WHERE trip_id = $2::uuid AND entry_type = 'credit' AND (metadata->>'reason') = 'trip_settlement'
-       )`,
-      [trip.providerUserId, trip.id, amount, currency],
-    );
-
-    if ((credited.rowCount ?? 0) > 0) {
-      await insertTrustTransportAudit({
-        actorId: trip.providerUserId,
-        command: 'trust-transport.trip.settlement',
-        policyStatus: 'allow',
-        reason: 'ok',
-        targetType: 'trip',
-        targetId: trip.id,
-        metadata: { rail: 'earnings_ledger', currency, amount, toUserId: trip.providerUserId },
-      });
-    }
+    await settleTripViaEarningsLedger(trip, currency, amount);
   } catch (error) {
     reportError(error, { area: 'trust-transport', op: 'trip_settlement' });
   }

--- a/ctf/packages/web/lib/trust/db.ts
+++ b/ctf/packages/web/lib/trust/db.ts
@@ -99,6 +99,26 @@ function countOf(result: { rows: { count: string }[] }): number {
   return Number(result.rows[0]?.count ?? 0);
 }
 
+// Read one named numeric column off the first row, defaulting a missing row/value to 0. Keeps the
+// `?.`/`??` guards out of computeTrustSignalMetrics so that function stays flat.
+function numCol<T extends Record<string, unknown>>(result: { rows: T[] }, key: keyof T): number {
+  const raw = result.rows[0]?.[key];
+  return Number(raw ?? 0);
+}
+
+// Map the login aggregate row into its three metric fields. Extracted so the login guards don't
+// count against computeTrustSignalMetrics' complexity.
+function buildLoginMetrics(loginAgg: {
+  rows: { login_days: string; login_events: string; last_login_at: Date | null }[];
+}): { loginDays: number; loginEvents: number; lastLoginAt: string | null } {
+  const loginRow = loginAgg.rows[0];
+  return {
+    loginDays: Number(loginRow?.login_days ?? 0),
+    loginEvents: Number(loginRow?.login_events ?? 0),
+    lastLoginAt: loginRow?.last_login_at ? loginRow.last_login_at.toISOString() : null,
+  };
+}
+
 export async function computeTrustSignalMetrics(userId: string): Promise<TrustSignalMetrics> {
   const [
     loginAgg,
@@ -221,16 +241,13 @@ export async function computeTrustSignalMetrics(userId: string): Promise<TrustSi
     ),
   ]);
 
-  const loginRow = loginAgg.rows[0];
   return {
-    loginDays: Number(loginRow?.login_days ?? 0),
-    loginEvents: Number(loginRow?.login_events ?? 0),
-    lastLoginAt: loginRow?.last_login_at ? loginRow.last_login_at.toISOString() : null,
-    socketRelayCompletedTrades: Number(completedTrades.rows[0]?.completed ?? 0),
-    socketRelayRequestsOpened: Number(requestsOpened.rows[0]?.opened ?? 0),
-    serviceCreditsDistinctPayers: Number(scReceived.rows[0]?.payers ?? 0),
-    serviceCreditsCompletedReceived: Number(scReceived.rows[0]?.completed ?? 0),
-    serviceCreditsDisputesAgainst: Number(scDisputes.rows[0]?.disputes ?? 0),
+    ...buildLoginMetrics(loginAgg),
+    socketRelayCompletedTrades: numCol(completedTrades, 'completed'),
+    socketRelayRequestsOpened: numCol(requestsOpened, 'opened'),
+    serviceCreditsDistinctPayers: numCol(scReceived, 'payers'),
+    serviceCreditsCompletedReceived: numCol(scReceived, 'completed'),
+    serviceCreditsDisputesAgainst: numCol(scDisputes, 'disputes'),
     lighthouseMatchesAccepted: countOf(lighthouse),
     trustTransportTripsCompleted: countOf(trustTransport),
     skillsHuntSubmissionsAccepted: countOf(skillsHunt),
@@ -245,46 +262,33 @@ export async function computeTrustSignalMetrics(userId: string): Promise<TrustSi
   };
 }
 
-// Build human-readable, NON-NUMERIC-SCORE evidence from the real metric counts. Real-data-only:
-// any signal whose backing rows are absent (count of 0 / no login) produces NO evidence item, so
-// the panel never claims activity that did not happen.
-export function buildTrustEvidence(metrics: TrustSignalMetrics, nowIso: string): TrustEvidenceItem[] {
-  const evidence: TrustEvidenceItem[] = [];
-
-  if (metrics.socketRelayCompletedTrades > 0) {
-    const n = metrics.socketRelayCompletedTrades;
+// Push one "verb N noun" evidence item when the count is positive. The singular/plural choice lives
+// in the caller's `summarize` callback so its ternary counts against that callback, not the builder.
+function pushCountEvidence(
+  evidence: TrustEvidenceItem[],
+  nowIso: string,
+  count: number,
+  type: string,
+  summarize: (n: number) => string,
+): void {
+  if (count > 0) {
     evidence.push({
-      type: 'engagement-socket-relay-trades',
-      summary: `Completed ${n} SocketRelay ${n === 1 ? 'trade' : 'trades'}`,
+      type,
+      summary: summarize(count),
       createdAt: nowIso,
       createdBy: 'trust-signal',
     });
   }
+}
 
-  if (metrics.socketRelayRequestsOpened > 0) {
-    const n = metrics.socketRelayRequestsOpened;
-    evidence.push({
-      type: 'engagement-socket-relay-requests',
-      summary: `Opened ${n} SocketRelay ${n === 1 ? 'request' : 'requests'}`,
-      createdAt: nowIso,
-      createdBy: 'trust-signal',
-    });
-  }
-
-  // Breadth signal: distinct members chose to pay this member in ServiceCredits.
-  if (metrics.serviceCreditsDistinctPayers > 0) {
-    const n = metrics.serviceCreditsDistinctPayers;
-    evidence.push({
-      type: 'engagement-service-credits-payers',
-      summary: `Received ServiceCredits from ${n} community ${n === 1 ? 'member' : 'members'}`,
-      createdAt: nowIso,
-      createdBy: 'trust-signal',
-    });
-  }
-
-  // Clean-record signal: only shown when there are completed received transfers and none have been
-  // disputed. A dispute withholds this positive signal rather than producing a negative badge —
-  // signal over noise, with dignity. No number is ranked; this is a categorical "clean / not shown".
+// Clean-record signal: only shown when there are completed received transfers and none have been
+// disputed. A dispute withholds this positive signal rather than producing a negative badge —
+// signal over noise, with dignity. No number is ranked; this is a categorical "clean / not shown".
+function pushCleanRecordEvidence(
+  evidence: TrustEvidenceItem[],
+  nowIso: string,
+  metrics: TrustSignalMetrics,
+): void {
   if (metrics.serviceCreditsCompletedReceived > 0 && metrics.serviceCreditsDisputesAgainst === 0) {
     const n = metrics.serviceCreditsCompletedReceived;
     evidence.push({
@@ -294,7 +298,14 @@ export function buildTrustEvidence(metrics: TrustSignalMetrics, nowIso: string):
       createdBy: 'trust-signal',
     });
   }
+}
 
+// Login-frequency signal, which additionally carries the most-recent sign-in in `details`.
+function pushLoginEvidence(
+  evidence: TrustEvidenceItem[],
+  nowIso: string,
+  metrics: TrustSignalMetrics,
+): void {
   if (metrics.loginDays > 0) {
     const n = metrics.loginDays;
     evidence.push({
@@ -305,9 +316,15 @@ export function buildTrustEvidence(metrics: TrustSignalMetrics, nowIso: string):
       createdBy: 'trust-signal',
     });
   }
+}
 
-  // Per-plugin participation signals. Data-driven so the set can grow without raising the function's
-  // complexity; each emits one categorical "verb N noun" item only when the real count is > 0.
+// Per-plugin participation signals. Data-driven so the set can grow without raising complexity; each
+// emits one categorical "verb N noun" item only when the real count is > 0.
+function pushParticipationEvidence(
+  evidence: TrustEvidenceItem[],
+  nowIso: string,
+  metrics: TrustSignalMetrics,
+): void {
   const participationSignals: { count: number; type: string; verb: string; singular: string; plural: string }[] = [
     { count: metrics.lighthouseMatchesAccepted, type: 'engagement-lighthouse-matches', verb: 'Accepted', singular: 'LightHouse match', plural: 'LightHouse matches' },
     { count: metrics.trustTransportTripsCompleted, type: 'engagement-trust-transport-trips', verb: 'Completed', singular: 'TrustTransport trip', plural: 'TrustTransport trips' },
@@ -331,6 +348,44 @@ export function buildTrustEvidence(metrics: TrustSignalMetrics, nowIso: string):
       });
     }
   }
+}
+
+// Build human-readable, NON-NUMERIC-SCORE evidence from the real metric counts. Real-data-only:
+// any signal whose backing rows are absent (count of 0 / no login) produces NO evidence item, so
+// the panel never claims activity that did not happen.
+export function buildTrustEvidence(metrics: TrustSignalMetrics, nowIso: string): TrustEvidenceItem[] {
+  const evidence: TrustEvidenceItem[] = [];
+
+  pushCountEvidence(
+    evidence,
+    nowIso,
+    metrics.socketRelayCompletedTrades,
+    'engagement-socket-relay-trades',
+    (n) => `Completed ${n} SocketRelay ${n === 1 ? 'trade' : 'trades'}`,
+  );
+
+  pushCountEvidence(
+    evidence,
+    nowIso,
+    metrics.socketRelayRequestsOpened,
+    'engagement-socket-relay-requests',
+    (n) => `Opened ${n} SocketRelay ${n === 1 ? 'request' : 'requests'}`,
+  );
+
+  // Breadth signal: distinct members chose to pay this member in ServiceCredits.
+  pushCountEvidence(
+    evidence,
+    nowIso,
+    metrics.serviceCreditsDistinctPayers,
+    'engagement-service-credits-payers',
+    (n) => `Received ServiceCredits from ${n} community ${n === 1 ? 'member' : 'members'}`,
+  );
+
+  pushCleanRecordEvidence(evidence, nowIso, metrics);
+
+  pushLoginEvidence(evidence, nowIso, metrics);
+
+  pushParticipationEvidence(evidence, nowIso, metrics);
 
   return evidence;
 }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — server-side `lib/` modules, no React Native change).

## What

Fourth batch of the rule-116 complexity cleanup. Behavior-preserving helper extraction; no logic, SQL, side-effect, or public-signature changes.

- `lib/lighthouse/repository.ts` — `validateProfileInput`, `validatePropertyInput`, the `createMatchRequest` transaction callback, and the `listLighthouseAuditEvents` mapper
- `lib/socket-relay/repository.ts` — `validateRequestInput`, the `resolveFulfillment` callback
- `lib/trust-transport/repository.ts` — `updateTripStatus` authorization check, `settleTripOnCompletion` (settlement rails split into helpers, arithmetic preserved byte-for-byte)
- `lib/trust/db.ts` — `computeTrustSignalMetrics`, `buildTrustEvidence`

## Verification
- `pnpm --filter @ctf/web run typecheck` / `lint` — pass
- complexity/length rule on all four files — pass
- pre-push gate (repo-wide typecheck) — pass

No schema/route/contract changes.

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_