### PR TITLE
refactor: reduce complexity in feed and workforce repositories

### DIFF
--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -776,68 +776,63 @@ function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, (char) => `\\${char}`);
 }
 
-export async function listFeedTimeline(
-  userId: string,
-  role: string | null,
-  pagination: { page: number; pageSize: number },
-  filters: {
-    pluginId?: string | null;
-    channel?: FeedChannel;
-    // Literal @-handle tokens (e.g. '@farah', '@user-3gysu61f') the item body must
-    // contain (case-insensitive, any one of them). Derived server-side from the
-    // authenticated user — never from client input. Null/empty means no filter.
-    mentionHandles?: string[] | null;
-    // Deep-link "load around": when set, the returned page is centered on the feed item that projects
-    // this community post / announcement, so a notification can land on a message older than the recent
-    // page. Ignored when the item is not found (falls back to the normal page). One or the other, not
-    // both — the community post form wins if both are somehow set.
-    aroundCommunityPostId?: string | null;
-    aroundAnnouncementId?: string | null;
-  },
-): Promise<{ items: FeedTimelineItem[]; pagination: FeedPagination }> {
-  return withDbTransaction(async (client) => {
-    const config = await client.query<FeedConfigRow>(
-      `
+// Shared query filter values for the feed timeline. Derived once per request from the actor's role
+// and the requested channel/plugin/mention filters, then reused by the count, "load around", and
+// main timeline queries so all three share exactly the same visibility filter.
+type FeedTimelineQueryParams = {
+  actorRole: string;
+  pluginFilter: string | null;
+  allowedItemTypes: FeedTimelineRow['item_type'][];
+  mentionPatterns: string[] | null;
+};
+
+// Load the singleton feed render config for the timeline read. Returns the mapped config, or null
+// when the config row is missing (the caller then falls back to the full allowed channel set).
+async function loadFeedTimelineConfig(client: PoolClient): Promise<FeedConfig | null> {
+  const config = await client.query<FeedConfigRow>(
+    `
         SELECT render_mode, max_timeline_page_size, enabled_channels, is_public, updated_by_user_id, updated_at
         FROM feed_render_config
         WHERE singleton_key = TRUE
         LIMIT 1
       `,
-    );
+  );
 
-    const resolvedConfig = config.rows[0] ? mapFeedConfig(config.rows[0]) : null;
+  return config.rows[0] ? mapFeedConfig(config.rows[0]) : null;
+}
 
-    const offset = (pagination.page - 1) * pagination.pageSize;
-    const actorRole = role ?? 'member';
-    const pluginFilter = normalizeNullableText(filters.pluginId);
-    const enabledChannels = resolvedConfig?.enabledChannels ?? [...FEED_ALLOWED_CHANNELS];
-    const requestedChannel = filters.channel ?? 'all';
-    const allowedChannels = requestedChannel === 'all'
-      ? enabledChannels
-      : enabledChannels.filter((channel: string) => channel === requestedChannel);
-    // Channel names are plural; feed_items.item_type is singular. Map channel -> item_type so the
-    // filter below matches the rows (an 'announcements' channel matching the 'announcement' rows).
-    const allowedItemTypes = allowedChannels.map((channel) => FEED_CHANNEL_TO_ITEM_TYPE[channel]);
-    // Mentions filter: parameterized, LIKE-escaped `%@handle%` patterns matched with
-    // ILIKE ANY (case-insensitive). Null disables the filter entirely.
-    const mentionHandles = (filters.mentionHandles ?? []).filter((handle) => handle.length > 0);
-    const mentionPatterns = mentionHandles.length > 0
-      ? mentionHandles.map((handle) => `%${escapeLikePattern(handle)}%`)
-      : null;
+// Resolve the shared visibility filter for the timeline read from the actor's role and the requested
+// channel/plugin/mention filters. Channel names are plural; feed_items.item_type is singular, so the
+// requested channels are mapped to item types. Mentions become LIKE-escaped `%@handle%` patterns
+// matched with ILIKE ANY; null disables the filter entirely.
+function resolveFeedTimelineQueryParams(
+  role: string | null,
+  filters: {
+    pluginId?: string | null;
+    channel?: FeedChannel;
+    mentionHandles?: string[] | null;
+  },
+  enabledChannels: FeedEnabledChannel[],
+): FeedTimelineQueryParams {
+  const actorRole = role ?? 'member';
+  const pluginFilter = normalizeNullableText(filters.pluginId);
+  const requestedChannel = filters.channel ?? 'all';
+  const allowedChannels = requestedChannel === 'all'
+    ? enabledChannels
+    : enabledChannels.filter((channel: string) => channel === requestedChannel);
+  const allowedItemTypes = allowedChannels.map((channel) => FEED_CHANNEL_TO_ITEM_TYPE[channel]);
+  const mentionHandles = (filters.mentionHandles ?? []).filter((handle) => handle.length > 0);
+  const mentionPatterns = mentionHandles.length > 0
+    ? mentionHandles.map((handle) => `%${escapeLikePattern(handle)}%`)
+    : null;
 
-    if (allowedItemTypes.length === 0) {
-      return {
-        items: [],
-        pagination: {
-          page: pagination.page,
-          pageSize: pagination.pageSize,
-          total: 0,
-        },
-      };
-    }
+  return { actorRole, pluginFilter, allowedItemTypes, mentionPatterns };
+}
 
-    const count = await client.query<CountRow>(
-      `
+// Count the timeline items visible under the shared filter, for pagination totals.
+async function countFeedTimeline(client: PoolClient, params: FeedTimelineQueryParams): Promise<number> {
+  const count = await client.query<CountRow>(
+    `
         SELECT COUNT(*)::text AS total
         FROM feed_items f
         WHERE f.is_active = TRUE
@@ -853,41 +848,71 @@ export async function listFeedTimeline(
               AND ($2::text IS NULL OR t.target_plugin IS NULL OR t.target_plugin = $2)
           )
       `,
-      [actorRole, pluginFilter, allowedItemTypes, mentionPatterns],
-    );
+    [params.actorRole, params.pluginFilter, params.allowedItemTypes, params.mentionPatterns],
+  );
 
-    const total = Number.parseInt(count.rows[0]?.total ?? '0', 10);
+  return Number.parseInt(count.rows[0]?.total ?? '0', 10);
+}
 
-    // Deep-link "load around": center the page on the target item so a notification's "Open" lands on a
-    // message older than the recent page. Resolve the target feed item, count how many items are newer
-    // than it under the same visibility filters (its 0-indexed rank in the DESC ordering), then offset
-    // back by half a page so the target sits mid-window. Falls back to the normal page when the target
-    // is not found (deleted, expired, or outside this member's visibility).
-    const aroundCommunityPostId = normalizeUuid(filters.aroundCommunityPostId ?? null);
-    const aroundAnnouncementId = aroundCommunityPostId
-      ? null
-      : normalizeUuid(filters.aroundAnnouncementId ?? null);
-    let effectiveOffset = offset;
-    if (aroundCommunityPostId || aroundAnnouncementId) {
-      const targetColumn = aroundCommunityPostId ? 'source_community_post_id' : 'source_announcement_id';
-      const targetValue = aroundCommunityPostId ?? aroundAnnouncementId;
-      const targetRes = await client.query<{ id: string; published_at: Date }>(
-        `
+// Resolve the deep-link "load around" target to a { column, value } pair, or null when neither a
+// community post nor an announcement id is supplied (both absent, malformed, or filtered out). The
+// community post form wins when both are somehow set — the same precedence the timeline used inline.
+function resolveAroundTarget(
+  aroundCommunityPostId: string | null | undefined,
+  aroundAnnouncementId: string | null | undefined,
+): { column: 'source_community_post_id' | 'source_announcement_id'; value: string } | null {
+  const communityId = normalizeUuid(aroundCommunityPostId ?? null);
+  const announcementId = communityId ? null : normalizeUuid(aroundAnnouncementId ?? null);
+  if (communityId) {
+    return { column: 'source_community_post_id', value: communityId };
+  }
+  if (announcementId) {
+    return { column: 'source_announcement_id', value: announcementId };
+  }
+  return null;
+}
+
+// Deep-link "load around": center the page on the target item so a notification's "Open" lands on a
+// message older than the recent page. Resolve the target feed item, count how many items are newer
+// than it under the same visibility filters (its 0-indexed rank in the DESC ordering), then offset
+// back by half a page so the target sits mid-window. Falls back to the normal page when the target
+// is not found (deleted, expired, or outside this member's visibility).
+async function resolveEffectiveOffset(
+  client: PoolClient,
+  options: {
+    offset: number;
+    pageSize: number;
+    aroundCommunityPostId: string | null | undefined;
+    aroundAnnouncementId: string | null | undefined;
+    params: FeedTimelineQueryParams;
+  },
+): Promise<number> {
+  const around = resolveAroundTarget(options.aroundCommunityPostId, options.aroundAnnouncementId);
+  if (!around) {
+    return options.offset;
+  }
+
+  const targetRes = await client.query<{ id: string; published_at: Date }>(
+    `
           SELECT id, published_at
           FROM feed_items
           WHERE is_active = TRUE
             AND published_at <= NOW()
             AND (expires_at IS NULL OR expires_at > NOW())
-            AND ${targetColumn} = $1::uuid
+            AND ${around.column} = $1::uuid
           ORDER BY published_at DESC, id DESC
           LIMIT 1
         `,
-        [targetValue],
-      );
-      const target = targetRes.rows[0];
-      if (target) {
-        const rankRes = await client.query<{ rank: string }>(
-          `
+    [around.value],
+  );
+  const target = targetRes.rows[0];
+  if (!target) {
+    return options.offset;
+  }
+
+  const { params } = options;
+  const rankRes = await client.query<{ rank: string }>(
+    `
             SELECT COUNT(*)::text AS rank
             FROM feed_items f
             WHERE f.is_active = TRUE
@@ -904,15 +929,26 @@ export async function listFeedTimeline(
               )
               AND (f.published_at > $5 OR (f.published_at = $5 AND f.id > $6::uuid))
           `,
-          [actorRole, pluginFilter, allowedItemTypes, mentionPatterns, target.published_at, target.id],
-        );
-        const rank = Number.parseInt(rankRes.rows[0]?.rank ?? '0', 10);
-        effectiveOffset = Math.max(0, rank - Math.floor(pagination.pageSize / 2));
-      }
-    }
+    [params.actorRole, params.pluginFilter, params.allowedItemTypes, params.mentionPatterns, target.published_at, target.id],
+  );
+  const rank = Number.parseInt(rankRes.rows[0]?.rank ?? '0', 10);
+  return Math.max(0, rank - Math.floor(options.pageSize / 2));
+}
 
-    const result = await client.query<FeedTimelineRow>(
-      `
+// Run the main timeline query: the page of feed items visible under the shared filter, with the
+// requesting member's per-item read/dismissed state joined in. Returns the raw rows in feed order.
+async function queryFeedTimelineRows(
+  client: PoolClient,
+  options: {
+    userId: string;
+    params: FeedTimelineQueryParams;
+    effectiveOffset: number;
+    pageSize: number;
+  },
+): Promise<FeedTimelineRow[]> {
+  const { params } = options;
+  const result = await client.query<FeedTimelineRow>(
+    `
         SELECT
           f.id,
           f.item_type,
@@ -945,37 +981,60 @@ export async function listFeedTimeline(
         ORDER BY f.published_at DESC, f.id DESC
         OFFSET $5 LIMIT $6
       `,
-      [actorRole, pluginFilter, allowedItemTypes, userId, effectiveOffset, pagination.pageSize, mentionPatterns],
-    );
+    [params.actorRole, params.pluginFilter, params.allowedItemTypes, options.userId, options.effectiveOffset, options.pageSize, params.mentionPatterns],
+  );
 
-    const questionIds = result.rows.flatMap((row) => (row.source_question_id ? [row.source_question_id] : []));
-    const communityIds = result.rows.flatMap((row) => (row.source_community_post_id ? [row.source_community_post_id] : []));
-    const announcementIds = result.rows.flatMap((row) =>
-      row.item_type === 'announcement' && row.source_announcement_id ? [row.source_announcement_id] : [],
-    );
+  return result.rows;
+}
 
-    const questionDetails = new Map<string, FeedQuestionDetail>();
-    if (questionIds.length > 0) {
-      const [questionRows, answerRows, ratingRows, currentUserRatings] = await Promise.all([
-        client.query<FeedQuestionRow>(
-          `
+// Collect the distinct source ids referenced by a page of timeline rows, split by kind, so each
+// detail set (questions, community posts, announcements) can be batch-loaded.
+function collectTimelineSourceIds(rows: FeedTimelineRow[]): {
+  questionIds: string[];
+  communityIds: string[];
+  announcementIds: string[];
+} {
+  const questionIds = rows.flatMap((row) => (row.source_question_id ? [row.source_question_id] : []));
+  const communityIds = rows.flatMap((row) => (row.source_community_post_id ? [row.source_community_post_id] : []));
+  const announcementIds = rows.flatMap((row) =>
+    row.item_type === 'announcement' && row.source_announcement_id ? [row.source_announcement_id] : [],
+  );
+
+  return { questionIds, communityIds, announcementIds };
+}
+
+// Batch-load the question detail (body, category, location, and answers with rating summaries and
+// the requesting member's own rating) for the questions on this timeline page. Keyed by question id.
+async function loadQuestionDetails(
+  client: PoolClient,
+  questionIds: string[],
+  userId: string,
+): Promise<Map<string, FeedQuestionDetail>> {
+  const questionDetails = new Map<string, FeedQuestionDetail>();
+  if (questionIds.length === 0) {
+    return questionDetails;
+  }
+
+  const [questionRows, answerRows, ratingRows, currentUserRatings] = await Promise.all([
+    client.query<FeedQuestionRow>(
+      `
             SELECT id, asked_by_user_id, body, category, location_context, llm_consent_granted, created_at
             FROM feed_questions
             WHERE id = ANY($1::uuid[])
           `,
-          [questionIds],
-        ),
-        client.query<FeedAnswerRow>(
-          `
+      [questionIds],
+    ),
+    client.query<FeedAnswerRow>(
+      `
             SELECT id, question_id, answer_type, body, confidence::text, model_id, sources, author_user_id, created_at
             FROM feed_answers
             WHERE question_id = ANY($1::uuid[])
             ORDER BY created_at ASC
           `,
-          [questionIds],
-        ),
-        client.query<FeedAnswerRatingRow>(
-          `
+      [questionIds],
+    ),
+    client.query<FeedAnswerRatingRow>(
+      `
             SELECT answer_id, rating, COUNT(*)::text AS total
             FROM feed_answer_ratings
             WHERE answer_id IN (
@@ -983,10 +1042,10 @@ export async function listFeedTimeline(
             )
             GROUP BY answer_id, rating
           `,
-          [questionIds],
-        ),
-        client.query<{ answer_id: string; rating: FeedAnswerRatingValue }>(
-          `
+      [questionIds],
+    ),
+    client.query<{ answer_id: string; rating: FeedAnswerRatingValue }>(
+      `
             SELECT answer_id, rating
             FROM feed_answer_ratings
             WHERE user_id = $1
@@ -994,208 +1053,341 @@ export async function listFeedTimeline(
                 SELECT id FROM feed_answers WHERE question_id = ANY($2::uuid[])
               )
           `,
-          [userId, questionIds],
-        ),
-      ]);
+      [userId, questionIds],
+    ),
+  ]);
 
-      const currentUserRatingMap = new Map(currentUserRatings.rows.map((row) => [row.answer_id, row.rating]));
-      const answersByQuestion = mapAnswerRows(answerRows.rows, ratingRows.rows, currentUserRatingMap);
+  const currentUserRatingMap = new Map(currentUserRatings.rows.map((row) => [row.answer_id, row.rating]));
+  const answersByQuestion = mapAnswerRows(answerRows.rows, ratingRows.rows, currentUserRatingMap);
 
-      for (const row of questionRows.rows) {
-        const answers = answersByQuestion.get(row.id) ?? [];
-        questionDetails.set(row.id, {
-          id: row.id,
-          body: row.body,
-          category: row.category,
-          location: normalizeLocationContext(row.location_context),
-          llmConsentGranted: row.llm_consent_granted,
-          answerCount: answers.length,
-          answers,
-        });
-      }
-    }
+  for (const row of questionRows.rows) {
+    const answers = answersByQuestion.get(row.id) ?? [];
+    questionDetails.set(row.id, {
+      id: row.id,
+      body: row.body,
+      category: row.category,
+      location: normalizeLocationContext(row.location_context),
+      llmConsentGranted: row.llm_consent_granted,
+      answerCount: answers.length,
+      answers,
+    });
+  }
 
-    const communityDetails = new Map<string, FeedCommunityDetail>();
-    if (communityIds.length > 0) {
-      const [postRows, replyRows, reactionRows] = await Promise.all([
-        client.query<FeedCommunityPostRow>(
-          `
+  return questionDetails;
+}
+
+// Build post id → ordered reaction summaries from the batched reaction aggregate rows. Only emojis
+// with at least one reaction appear; posts with none get an empty array at render time.
+function groupReactionsByPost(reactionRows: FeedReactionAggregateRow[]): Map<string, FeedReactionSummary[]> {
+  const reactionsByPost = new Map<string, FeedReactionSummary[]>();
+  for (const row of reactionRows) {
+    const current = reactionsByPost.get(row.post_id) ?? [];
+    current.push({
+      emoji: row.emoji,
+      count: Number.parseInt(row.count, 10),
+      reactedByMe: row.reacted,
+    });
+    reactionsByPost.set(row.post_id, current);
+  }
+
+  return reactionsByPost;
+}
+
+// Build post id → ordered replies from the batched reply rows (created_at ascending).
+function groupRepliesByPost(replyRows: FeedCommunityReplyRow[]): Map<string, FeedCommunityReply[]> {
+  const repliesByPost = new Map<string, FeedCommunityReply[]>();
+  for (const row of replyRows) {
+    const current = repliesByPost.get(row.post_id) ?? [];
+    current.push({
+      id: row.id,
+      postId: row.post_id,
+      body: row.body,
+      authorUserId: row.author_user_id,
+      createdAtIso: toIso(row.created_at),
+    });
+    repliesByPost.set(row.post_id, current);
+  }
+
+  return repliesByPost;
+}
+
+// Resolve each quoted (replied-to) post's author handle and a short snippet of its body. The quoted
+// post may sit outside this timeline page, so look up the referenced ids directly. Returns a map
+// id → { author, snippet }.
+async function loadQuotedPosts(
+  client: PoolClient,
+  postRows: FeedCommunityPostRow[],
+): Promise<Map<string, FeedQuotedPost>> {
+  const quotedById = new Map<string, FeedQuotedPost>();
+  const quotedIds = Array.from(
+    new Set(postRows.flatMap((row) => (row.reply_to_post_id ? [row.reply_to_post_id] : []))),
+  );
+  if (quotedIds.length === 0) {
+    return quotedById;
+  }
+
+  const quotedRows = await client.query<{
+    id: string;
+    author_user_id: string | null;
+    author_username: string | null;
+    body: string;
+  }>(
+    `
+            SELECT id, author_user_id, author_username, body
+            FROM feed_community_posts
+            WHERE id = ANY($1::uuid[])
+              AND moderation_status = 'accepted'
+          `,
+    [quotedIds],
+  );
+  for (const row of quotedRows.rows) {
+    quotedById.set(row.id, {
+      author: quotedAuthorLabel(row.author_username, row.author_user_id),
+      snippet: buildQuoteSnippet(row.body),
+    });
+  }
+
+  return quotedById;
+}
+
+// Assemble a single community post detail from its row plus the pre-grouped reply/reaction/quote maps.
+function buildCommunityDetail(
+  row: FeedCommunityPostRow,
+  maps: {
+    repliesByPost: Map<string, FeedCommunityReply[]>;
+    reactionsByPost: Map<string, FeedReactionSummary[]>;
+    quotedById: Map<string, FeedQuotedPost>;
+  },
+): FeedCommunityDetail {
+  const quotedPost = row.reply_to_post_id ? maps.quotedById.get(row.reply_to_post_id) ?? null : null;
+  return {
+    id: row.id,
+    body: row.body,
+    category: row.category,
+    authorUserId: row.author_user_id,
+    authorUsername: row.author_username,
+    replyCount: row.reply_count,
+    replies: maps.repliesByPost.get(row.id) ?? [],
+    // The foreign key is ON DELETE SET NULL: if the quoted post was deleted, the
+    // reference resolves to null and no quote block is rendered.
+    replyToPostId: quotedPost ? row.reply_to_post_id : null,
+    quotedPost,
+    reactions: orderReactionsByFixedSet(maps.reactionsByPost.get(row.id) ?? []),
+  };
+}
+
+// Batch-load the community post detail (body, author, replies, quoted post, and reaction chips) for
+// the community posts on this timeline page. Keyed by community post id.
+async function loadCommunityDetails(
+  client: PoolClient,
+  communityIds: string[],
+  userId: string,
+): Promise<Map<string, FeedCommunityDetail>> {
+  const communityDetails = new Map<string, FeedCommunityDetail>();
+  if (communityIds.length === 0) {
+    return communityDetails;
+  }
+
+  const [postRows, replyRows, reactionRows] = await Promise.all([
+    client.query<FeedCommunityPostRow>(
+      `
             SELECT id, author_user_id, author_username, body, category, reply_count, reply_to_post_id, created_at
             FROM feed_community_posts
             WHERE id = ANY($1::uuid[])
               AND moderation_status = 'accepted'
           `,
-          [communityIds],
-        ),
-        client.query<FeedCommunityReplyRow>(
-          `
+      [communityIds],
+    ),
+    client.query<FeedCommunityReplyRow>(
+      `
             SELECT id, post_id, author_user_id, body, created_at
             FROM feed_community_replies
             WHERE post_id = ANY($1::uuid[])
               AND moderation_status = 'accepted'
             ORDER BY created_at ASC
           `,
-          [communityIds],
-        ),
-        // Aggregate reactions for every visible community post in one batched query.
-        // BOOL_OR(user_id = $2) tells us whether the requesting member reacted with each emoji.
-        client.query<FeedReactionAggregateRow>(
-          `
+      [communityIds],
+    ),
+    // Aggregate reactions for every visible community post in one batched query.
+    // BOOL_OR(user_id = $2) tells us whether the requesting member reacted with each emoji.
+    client.query<FeedReactionAggregateRow>(
+      `
             SELECT post_id, emoji, COUNT(*)::text AS count, BOOL_OR(user_id = $2) AS reacted
             FROM feed_community_post_reactions
             WHERE post_id = ANY($1::uuid[])
             GROUP BY post_id, emoji
           `,
-          [communityIds, userId],
-        ),
-      ]);
+      [communityIds, userId],
+    ),
+  ]);
 
-      // Build post id → ordered reaction summaries. Only emojis with at least one reaction
-      // appear; posts with none get an empty array below.
-      const reactionsByPost = new Map<string, FeedReactionSummary[]>();
-      for (const row of reactionRows.rows) {
-        const current = reactionsByPost.get(row.post_id) ?? [];
-        current.push({
-          emoji: row.emoji,
-          count: Number.parseInt(row.count, 10),
-          reactedByMe: row.reacted,
-        });
-        reactionsByPost.set(row.post_id, current);
-      }
+  const reactionsByPost = groupReactionsByPost(reactionRows.rows);
+  const repliesByPost = groupRepliesByPost(replyRows.rows);
+  const quotedById = await loadQuotedPosts(client, postRows.rows);
 
-      const repliesByPost = new Map<string, FeedCommunityReply[]>();
-      for (const row of replyRows.rows) {
-        const current = repliesByPost.get(row.post_id) ?? [];
-        current.push({
-          id: row.id,
-          postId: row.post_id,
-          body: row.body,
-          authorUserId: row.author_user_id,
-          createdAtIso: toIso(row.created_at),
-        });
-        repliesByPost.set(row.post_id, current);
-      }
+  for (const row of postRows.rows) {
+    communityDetails.set(row.id, buildCommunityDetail(row, { repliesByPost, reactionsByPost, quotedById }));
+  }
 
-      // Resolve each quoted (replied-to) post's author handle and a short snippet of its
-      // body. The quoted post may sit outside this timeline page, so look up the referenced
-      // ids directly. Build a map id → { author, snippet } once.
-      const quotedIds = Array.from(
-        new Set(postRows.rows.flatMap((row) => (row.reply_to_post_id ? [row.reply_to_post_id] : []))),
-      );
-      const quotedById = new Map<string, FeedQuotedPost>();
-      if (quotedIds.length > 0) {
-        const quotedRows = await client.query<{
-          id: string;
-          author_user_id: string | null;
-          author_username: string | null;
-          body: string;
-        }>(
-          `
-            SELECT id, author_user_id, author_username, body
-            FROM feed_community_posts
-            WHERE id = ANY($1::uuid[])
-              AND moderation_status = 'accepted'
-          `,
-          [quotedIds],
-        );
-        for (const row of quotedRows.rows) {
-          quotedById.set(row.id, {
-            author: quotedAuthorLabel(row.author_username, row.author_user_id),
-            snippet: buildQuoteSnippet(row.body),
-          });
-        }
-      }
+  return communityDetails;
+}
 
-      for (const row of postRows.rows) {
-        const quotedPost = row.reply_to_post_id ? quotedById.get(row.reply_to_post_id) ?? null : null;
-        communityDetails.set(row.id, {
-          id: row.id,
-          body: row.body,
-          category: row.category,
-          authorUserId: row.author_user_id,
-          authorUsername: row.author_username,
-          replyCount: row.reply_count,
-          replies: repliesByPost.get(row.id) ?? [],
-          // The foreign key is ON DELETE SET NULL: if the quoted post was deleted, the
-          // reference resolves to null and no quote block is rendered.
-          replyToPostId: quotedPost ? row.reply_to_post_id : null,
-          quotedPost,
-          reactions: orderReactionsByFixedSet(reactionsByPost.get(row.id) ?? []),
-        });
-      }
-    }
+// Reaction + reply aggregates for the announcements on this page, resolved for the requesting member
+// in two batched queries so each official card can render its reaction chips and a "N replies"
+// affordance without extra fetches. Keyed on the announcement id.
+async function loadAnnouncementDetails(
+  client: PoolClient,
+  announcementIds: string[],
+  userId: string,
+): Promise<Map<string, FeedAnnouncementDetail>> {
+  const announcementDetailsById = new Map<string, FeedAnnouncementDetail>();
+  if (announcementIds.length === 0) {
+    return announcementDetailsById;
+  }
 
-    // Reaction + reply aggregates for the announcements on this page, resolved for the requesting
-    // member in two batched queries so each official card can render its reaction chips and a
-    // "N replies" affordance without extra fetches. Keyed on the announcement id.
-    const announcementDetailsById = new Map<string, FeedAnnouncementDetail>();
-    if (announcementIds.length > 0) {
-      const [reactionRows, replyCountRows] = await Promise.all([
-        client.query<AnnouncementReactionAggregateRow>(
-          `
+  const [reactionRows, replyCountRows] = await Promise.all([
+    client.query<AnnouncementReactionAggregateRow>(
+      `
             SELECT announcement_id, emoji, COUNT(*)::text AS count, BOOL_OR(user_id = $2) AS reacted
             FROM announcement_reactions
             WHERE announcement_id = ANY($1::uuid[])
             GROUP BY announcement_id, emoji
           `,
-          [announcementIds, userId],
-        ),
-        client.query<AnnouncementReplyCountRow>(
-          `
+      [announcementIds, userId],
+    ),
+    client.query<AnnouncementReplyCountRow>(
+      `
             SELECT announcement_id, COUNT(*)::text AS count
             FROM announcement_replies
             WHERE announcement_id = ANY($1::uuid[])
               AND moderation_status = 'accepted'
             GROUP BY announcement_id
           `,
-          [announcementIds],
-        ),
-      ]);
+      [announcementIds],
+    ),
+  ]);
 
-      const reactionsByAnnouncement = new Map<string, FeedReactionSummary[]>();
-      for (const row of reactionRows.rows) {
-        const current = reactionsByAnnouncement.get(row.announcement_id) ?? [];
-        current.push({
-          emoji: row.emoji,
-          count: Number.parseInt(row.count, 10),
-          reactedByMe: row.reacted,
-        });
-        reactionsByAnnouncement.set(row.announcement_id, current);
-      }
+  const reactionsByAnnouncement = new Map<string, FeedReactionSummary[]>();
+  for (const row of reactionRows.rows) {
+    const current = reactionsByAnnouncement.get(row.announcement_id) ?? [];
+    current.push({
+      emoji: row.emoji,
+      count: Number.parseInt(row.count, 10),
+      reactedByMe: row.reacted,
+    });
+    reactionsByAnnouncement.set(row.announcement_id, current);
+  }
 
-      const replyCountByAnnouncement = new Map<string, number>();
-      for (const row of replyCountRows.rows) {
-        replyCountByAnnouncement.set(row.announcement_id, Number.parseInt(row.count, 10));
-      }
+  const replyCountByAnnouncement = new Map<string, number>();
+  for (const row of replyCountRows.rows) {
+    replyCountByAnnouncement.set(row.announcement_id, Number.parseInt(row.count, 10));
+  }
 
-      for (const announcementId of new Set(announcementIds)) {
-        announcementDetailsById.set(announcementId, {
-          id: announcementId,
-          reactions: orderReactionsByFixedSet(reactionsByAnnouncement.get(announcementId) ?? []),
-          replyCount: replyCountByAnnouncement.get(announcementId) ?? 0,
-        });
-      }
+  for (const announcementId of new Set(announcementIds)) {
+    announcementDetailsById.set(announcementId, {
+      id: announcementId,
+      reactions: orderReactionsByFixedSet(reactionsByAnnouncement.get(announcementId) ?? []),
+      replyCount: replyCountByAnnouncement.get(announcementId) ?? 0,
+    });
+  }
+
+  return announcementDetailsById;
+}
+
+// Project a raw timeline row into the client-facing FeedTimelineItem, attaching the matching
+// pre-loaded question/community/announcement detail (or null when the source is absent).
+function buildTimelineItem(
+  row: FeedTimelineRow,
+  details: {
+    questionDetails: Map<string, FeedQuestionDetail>;
+    communityDetails: Map<string, FeedCommunityDetail>;
+    announcementDetailsById: Map<string, FeedAnnouncementDetail>;
+  },
+): FeedTimelineItem {
+  return {
+    id: row.id,
+    itemType: row.item_type,
+    sourceAnnouncementId: row.source_announcement_id,
+    sourceQuestionId: row.source_question_id,
+    sourceCommunityPostId: row.source_community_post_id,
+    title: row.title,
+    body: row.body,
+    publishedAtIso: toIso(row.published_at),
+    expiresAtIso: row.expires_at ? toIso(row.expires_at) : null,
+    isRead: row.is_read,
+    isDismissed: row.is_dismissed,
+    question: row.source_question_id ? (details.questionDetails.get(row.source_question_id) ?? null) : null,
+    community: row.source_community_post_id ? (details.communityDetails.get(row.source_community_post_id) ?? null) : null,
+    announcement: row.item_type === 'announcement' && row.source_announcement_id
+      ? (details.announcementDetailsById.get(row.source_announcement_id) ?? null)
+      : null,
+  };
+}
+
+export async function listFeedTimeline(
+  userId: string,
+  role: string | null,
+  pagination: { page: number; pageSize: number },
+  filters: {
+    pluginId?: string | null;
+    channel?: FeedChannel;
+    // Literal @-handle tokens (e.g. '@farah', '@user-3gysu61f') the item body must
+    // contain (case-insensitive, any one of them). Derived server-side from the
+    // authenticated user — never from client input. Null/empty means no filter.
+    mentionHandles?: string[] | null;
+    // Deep-link "load around": when set, the returned page is centered on the feed item that projects
+    // this community post / announcement, so a notification can land on a message older than the recent
+    // page. Ignored when the item is not found (falls back to the normal page). One or the other, not
+    // both — the community post form wins if both are somehow set.
+    aroundCommunityPostId?: string | null;
+    aroundAnnouncementId?: string | null;
+  },
+): Promise<{ items: FeedTimelineItem[]; pagination: FeedPagination }> {
+  return withDbTransaction(async (client) => {
+    const resolvedConfig = await loadFeedTimelineConfig(client);
+    const enabledChannels = resolvedConfig?.enabledChannels ?? [...FEED_ALLOWED_CHANNELS];
+    const params = resolveFeedTimelineQueryParams(role, filters, enabledChannels);
+    const offset = (pagination.page - 1) * pagination.pageSize;
+
+    if (params.allowedItemTypes.length === 0) {
+      return {
+        items: [],
+        pagination: {
+          page: pagination.page,
+          pageSize: pagination.pageSize,
+          total: 0,
+        },
+      };
     }
 
+    const total = await countFeedTimeline(client, params);
+    const effectiveOffset = await resolveEffectiveOffset(client, {
+      offset,
+      pageSize: pagination.pageSize,
+      aroundCommunityPostId: filters.aroundCommunityPostId,
+      aroundAnnouncementId: filters.aroundAnnouncementId,
+      params,
+    });
+
+    const rows = await queryFeedTimelineRows(client, {
+      userId,
+      params,
+      effectiveOffset,
+      pageSize: pagination.pageSize,
+    });
+
+    const { questionIds, communityIds, announcementIds } = collectTimelineSourceIds(rows);
+
+    // These detail loads run sequentially (not in Promise.all) because they share one transaction
+    // client, and a single pg client cannot run overlapping queries.
+    const questionDetails = await loadQuestionDetails(client, questionIds, userId);
+    const communityDetails = await loadCommunityDetails(client, communityIds, userId);
+    const announcementDetailsById = await loadAnnouncementDetails(client, announcementIds, userId);
+
     return {
-      items: result.rows.map((row) => ({
-        id: row.id,
-        itemType: row.item_type,
-        sourceAnnouncementId: row.source_announcement_id,
-        sourceQuestionId: row.source_question_id,
-        sourceCommunityPostId: row.source_community_post_id,
-        title: row.title,
-        body: row.body,
-        publishedAtIso: toIso(row.published_at),
-        expiresAtIso: row.expires_at ? toIso(row.expires_at) : null,
-        isRead: row.is_read,
-        isDismissed: row.is_dismissed,
-        question: row.source_question_id ? (questionDetails.get(row.source_question_id) ?? null) : null,
-        community: row.source_community_post_id ? (communityDetails.get(row.source_community_post_id) ?? null) : null,
-        announcement: row.item_type === 'announcement' && row.source_announcement_id
-          ? (announcementDetailsById.get(row.source_announcement_id) ?? null)
-          : null,
-      })),
+      items: rows.map((row) =>
+        buildTimelineItem(row, { questionDetails, communityDetails, announcementDetailsById }),
+      ),
       pagination: {
         page: pagination.page,
         pageSize: pagination.pageSize,

--- a/ctf/packages/web/lib/workforce/repository.ts
+++ b/ctf/packages/web/lib/workforce/repository.ts
@@ -205,10 +205,21 @@ function buildSectorDemand(sectors: SectorModelRow[], workforceTotal: number): M
   return sectorDemand;
 }
 
-async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
-  const config = await getWorkforceConfig();
-  const workforceTotal = Math.max(0, Math.round(config.population * config.participationRate));
-
+// The three global inputs of the model plus the optional skill arm, loaded together. The skill arm
+// is loaded separately and defensively: skills match by NAME, not by row (owner decision
+// 2026-07-04): a profile counts toward EVERY occupation that lists an active skill with the same
+// normalized name as one the profile holds. A skill is a capability, not a pointer to the one
+// occupation whose copy the member happened to pick — row-based matching funneled every holder of a
+// shared skill into a single sector. The `held` join is the member's own skill row; `other` is every
+// active same-named row across the taxonomy. If this optional query fails on a given database,
+// recruited degrades to the sector and job-title arms rather than failing the whole read-only
+// dashboard with a 503.
+async function fetchWorkforceModelInputs(): Promise<{
+  sectors: SectorModelRow[];
+  jobTitles: JobTitleModelRow[];
+  members: MemberModelRow[];
+  profileSkillRows: ProfileSkillJobTitleRow[];
+}> {
   const [sectorsRes, jobTitlesRes, membersRes] = await Promise.all([
     queryDb<SectorModelRow>(
       `SELECT id::text AS id, name, workforce_share::text AS workforce_share
@@ -236,18 +247,6 @@ async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
     ),
   ]);
 
-  const sectors = sectorsRes.rows;
-  const jobTitles = jobTitlesRes.rows;
-  const members = membersRes.rows;
-
-  // Skill arm of the recruited match, loaded separately and defensively. Skills match by NAME, not
-  // by row (owner decision 2026-07-04): a profile counts toward EVERY occupation that lists an
-  // active skill with the same normalized name as one the profile holds. A skill is a capability,
-  // not a pointer to the one occupation whose copy the member happened to pick — row-based matching
-  // funneled every holder of a shared skill into a single sector. The `held` join is the member's
-  // own skill row; `other` is every active same-named row across the taxonomy. If this optional
-  // query fails on a given database, recruited degrades to the sector and job-title arms rather
-  // than failing the whole read-only dashboard with a 503.
   let profileSkillRows: ProfileSkillJobTitleRow[] = [];
   try {
     const profileSkillsRes = await queryDb<ProfileSkillJobTitleRow>(
@@ -262,17 +261,30 @@ async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
     reportError(error, { area: 'workforce', op: 'computeWorkforceModel_skillArm' });
   }
 
-  // Demand: distribute the workforce total across sectors by each sector's workforce share (shared with
-  // the lightweight dashboard summary so the two can never disagree on the headcount target).
-  const sectorDemand = buildSectorDemand(sectors, workforceTotal);
+  return {
+    sectors: sectorsRes.rows,
+    jobTitles: jobTitlesRes.rows,
+    members: membersRes.rows,
+    profileSkillRows,
+  };
+}
 
-  // Per-occupation demand: split a sector's demand evenly across its active job titles.
+// Group the active job titles by their sector so a sector's demand can be split across them.
+function groupJobTitlesBySector(jobTitles: JobTitleModelRow[]): Map<string, JobTitleModelRow[]> {
   const jobTitlesBySector = new Map<string, JobTitleModelRow[]>();
   for (const jt of jobTitles) {
     const list = jobTitlesBySector.get(jt.sector_id) ?? [];
     list.push(jt);
     jobTitlesBySector.set(jt.sector_id, list);
   }
+  return jobTitlesBySector;
+}
+
+// Per-occupation demand: split a sector's demand evenly across its active job titles.
+function buildJobTitleDemand(
+  jobTitlesBySector: Map<string, JobTitleModelRow[]>,
+  sectorDemand: Map<string, number>,
+): Map<string, number> {
   const jobTitleDemand = new Map<string, number>();
   for (const [sectorId, list] of jobTitlesBySector) {
     const demand = sectorDemand.get(sectorId) ?? 0;
@@ -281,15 +293,14 @@ async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
       jobTitleDemand.set(jt.id, per);
     }
   }
+  return jobTitleDemand;
+}
 
-  // Supply (V2 aspirational match). "members" is the physical count of profiles whose resolved
-  // sector / job title falls in a bucket. "recruited" is the DISTINCT Directory profiles that MATCH a
-  // bucket by ANY of three signals — same sector, same job title, or a skill registered under the job
-  // title — counted live (not just claimed profiles). A profile's own sector expands to every
-  // occupation in that sector, so per-occupation recruited is intentionally generous; this mirrors V2.
-  const jobTitleById = new Map(jobTitles.map((jt) => [jt.id, jt] as const));
-
-  // Per profile, the set of job titles reachable through one of its skills (the skill arm).
+// Per profile, the set of job titles reachable through one of its skills (the skill arm).
+function buildSkillJobTitlesByProfile(
+  profileSkillRows: ProfileSkillJobTitleRow[],
+  jobTitleById: Map<string, JobTitleModelRow>,
+): Map<string, Set<string>> {
   const skillJobTitlesByProfile = new Map<string, Set<string>>();
   for (const r of profileSkillRows) {
     if (!jobTitleById.has(r.job_title_id)) continue;
@@ -300,10 +311,35 @@ async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
     }
     set.add(r.job_title_id);
   }
+  return skillJobTitlesByProfile;
+}
 
-  // Sector each profile's skills map to through the taxonomy. Every skill is mapped to an
-  // occupation and a sector by spec, so a member's picked skills always resolve to a sector: the
-  // one holding the most of their skills (ties broken by sector name for determinism).
+// From a sector -> count tally, pick the sector holding the most of a profile's skills, breaking
+// ties by sector name for determinism.
+function pickBestSector(tally: Map<string, number>, sectorNames: Map<string, string>): string | null {
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [sectorId, count] of tally) {
+    if (
+      count > bestCount
+      || (count === bestCount && best !== null
+        && (sectorNames.get(sectorId) ?? '') < (sectorNames.get(best) ?? ''))
+    ) {
+      best = sectorId;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+// Sector each profile's skills map to through the taxonomy. Every skill is mapped to an
+// occupation and a sector by spec, so a member's picked skills always resolve to a sector: the
+// one holding the most of their skills (ties broken by sector name for determinism).
+function buildSkillDerivedSectorByProfile(
+  skillJobTitlesByProfile: Map<string, Set<string>>,
+  jobTitleById: Map<string, JobTitleModelRow>,
+  sectors: SectorModelRow[],
+): Map<string, string> {
   const sectorNameForTieBreak = new Map(sectors.map((s) => [s.id, s.name] as const));
   const skillDerivedSectorByProfile = new Map<string, string>();
   for (const [profileId, jobTitleIds] of skillJobTitlesByProfile) {
@@ -313,120 +349,208 @@ async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
       if (!sectorId) continue;
       tally.set(sectorId, (tally.get(sectorId) ?? 0) + 1);
     }
-    let best: string | null = null;
-    let bestCount = 0;
-    for (const [sectorId, count] of tally) {
-      if (
-        count > bestCount
-        || (count === bestCount && best !== null
-          && (sectorNameForTieBreak.get(sectorId) ?? '') < (sectorNameForTieBreak.get(best) ?? ''))
-      ) {
-        best = sectorId;
-        bestCount = count;
-      }
-    }
+    const best = pickBestSector(tally, sectorNameForTieBreak);
     if (best) {
       skillDerivedSectorByProfile.set(profileId, best);
     }
   }
+  return skillDerivedSectorByProfile;
+}
+
+// A fresh skill-level -> 0 count map, every level present.
+function newSkillLevelCountMap(): Map<WorkforceSkillLevel, number> {
+  const map = new Map<WorkforceSkillLevel, number>();
+  for (const level of WORKFORCE_SKILL_LEVELS) {
+    map.set(level, 0);
+  }
+  return map;
+}
+
+// A fresh skill-level -> empty set map, every level present.
+function newSkillLevelSetMap(): Map<WorkforceSkillLevel, Set<string>> {
+  const map = new Map<WorkforceSkillLevel, Set<string>>();
+  for (const level of WORKFORCE_SKILL_LEVELS) {
+    map.set(level, new Set<string>());
+  }
+  return map;
+}
+
+// Increment a numeric count keyed by `key`, treating a missing key as 0.
+function bump<K>(map: Map<K, number>, key: K): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+// Add a profile id to the set at `key`, creating the set on first use.
+function addProfileToBucket(map: Map<string, Set<string>>, key: string, profileId: string): void {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set<string>();
+    map.set(key, set);
+  }
+  set.add(profileId);
+}
+
+// The member's own sector, by spec precedence: taxonomy-derived signals first — the chosen
+// occupation maps to a sector, and the chosen skills map to occupations and sectors — then the
+// raw profile sector field (a label with no taxonomy mapping behind it). Only a member with no
+// occupation, no skills, and no sector lands in the Unassigned bucket.
+function resolveMemberSectorId(
+  m: MemberModelRow,
+  skillDerivedSectorByProfile: Map<string, string>,
+): string | null {
+  return m.job_title_sector_id
+    ?? skillDerivedSectorByProfile.get(m.profile_id)
+    ?? m.profile_sector_id
+    ?? null;
+}
+
+// Matched job titles: the profile's own job title plus its skill-derived job titles.
+function buildMatchedJobTitles(
+  m: MemberModelRow,
+  jobTitleById: Map<string, JobTitleModelRow>,
+  skillJobTitlesByProfile: Map<string, Set<string>>,
+): Set<string> {
+  const matchedJobTitles = new Set<string>();
+  if (m.job_title_id && jobTitleById.has(m.job_title_id)) {
+    matchedJobTitles.add(m.job_title_id);
+  }
+  const skillMatched = skillJobTitlesByProfile.get(m.profile_id);
+  if (skillMatched) {
+    for (const id of skillMatched) matchedJobTitles.add(id);
+  }
+  return matchedJobTitles;
+}
+
+// Matched occupations: the matched job titles PLUS every occupation in the profile's own sector
+// (V2's sector arm makes a profile count for all occupations in its sector).
+function buildMatchedOccupations(
+  matchedJobTitles: Set<string>,
+  resolvedSectorId: string | null,
+  jobTitlesBySector: Map<string, JobTitleModelRow[]>,
+): Set<string> {
+  const matchedOccupations = new Set<string>(matchedJobTitles);
+  if (resolvedSectorId) {
+    for (const jt of jobTitlesBySector.get(resolvedSectorId) ?? []) {
+      matchedOccupations.add(jt.id);
+    }
+  }
+  return matchedOccupations;
+}
+
+// Matched sectors: the profile's own sector plus the sectors of every matched job title.
+function buildMatchedSectors(
+  matchedJobTitles: Set<string>,
+  resolvedSectorId: string | null,
+  jobTitleById: Map<string, JobTitleModelRow>,
+): Set<string> {
+  const matchedSectors = new Set<string>();
+  if (resolvedSectorId) matchedSectors.add(resolvedSectorId);
+  for (const id of matchedJobTitles) {
+    const jt = jobTitleById.get(id);
+    if (jt) matchedSectors.add(jt.sector_id);
+  }
+  return matchedSectors;
+}
+
+// Skill levels covered by a member's matched occupations, derived from each job-title name.
+function buildMatchedLevels(
+  matchedOccupations: Set<string>,
+  jobTitleById: Map<string, JobTitleModelRow>,
+): Set<WorkforceSkillLevel> {
+  const matchedLevels = new Set<WorkforceSkillLevel>();
+  for (const jobTitleId of matchedOccupations) {
+    const jt = jobTitleById.get(jobTitleId);
+    if (jt) matchedLevels.add(deriveWorkforceSkillLevel(jt.name));
+  }
+  return matchedLevels;
+}
+
+// The per-bucket member counts and DISTINCT recruited profile sets built from the member rows.
+type WorkforceBuckets = {
+  totalMembers: number;
+  memberCountBySector: Map<string, number>;
+  memberCountByJobTitle: Map<string, number>;
+  memberCountBySkillLevel: Map<WorkforceSkillLevel, number>;
+  recruitedBySector: Map<string, Set<string>>;
+  recruitedByJobTitle: Map<string, Set<string>>;
+  recruitedBySkillLevel: Map<WorkforceSkillLevel, Set<string>>;
+};
+
+// Supply (V2 aspirational match). "members" is the physical count of profiles whose resolved
+// sector / job title falls in a bucket. "recruited" is the DISTINCT Directory profiles that MATCH a
+// bucket by ANY of three signals — same sector, same job title, or a skill registered under the job
+// title — counted live (not just claimed profiles). A profile's own sector expands to every
+// occupation in that sector, so per-occupation recruited is intentionally generous; this mirrors V2.
+function accumulateMemberBuckets(input: {
+  members: MemberModelRow[];
+  jobTitleById: Map<string, JobTitleModelRow>;
+  jobTitlesBySector: Map<string, JobTitleModelRow[]>;
+  skillJobTitlesByProfile: Map<string, Set<string>>;
+  skillDerivedSectorByProfile: Map<string, string>;
+}): WorkforceBuckets {
+  const { members, jobTitleById, jobTitlesBySector, skillJobTitlesByProfile, skillDerivedSectorByProfile } = input;
 
   const memberCountBySector = new Map<string, number>();
   const memberCountByJobTitle = new Map<string, number>();
-  const memberCountBySkillLevel = new Map<WorkforceSkillLevel, number>();
+  const memberCountBySkillLevel = newSkillLevelCountMap();
   const recruitedBySector = new Map<string, Set<string>>();
   const recruitedByJobTitle = new Map<string, Set<string>>();
-  const recruitedBySkillLevel = new Map<WorkforceSkillLevel, Set<string>>();
-  for (const level of WORKFORCE_SKILL_LEVELS) {
-    memberCountBySkillLevel.set(level, 0);
-    recruitedBySkillLevel.set(level, new Set<string>());
-  }
+  const recruitedBySkillLevel = newSkillLevelSetMap();
   let totalMembers = 0;
-
-  const addProfileToBucket = (map: Map<string, Set<string>>, key: string, profileId: string) => {
-    let set = map.get(key);
-    if (!set) {
-      set = new Set<string>();
-      map.set(key, set);
-    }
-    set.add(profileId);
-  };
 
   for (const m of members) {
     totalMembers += 1;
 
-    // The member's own sector, by spec precedence: taxonomy-derived signals first — the chosen
-    // occupation maps to a sector, and the chosen skills map to occupations and sectors — then the
-    // raw profile sector field (a label with no taxonomy mapping behind it). Only a member with no
-    // occupation, no skills, and no sector lands in the Unassigned bucket.
-    const resolvedSectorId = m.job_title_sector_id
-      ?? skillDerivedSectorByProfile.get(m.profile_id)
-      ?? m.profile_sector_id
-      ?? null;
+    const resolvedSectorId = resolveMemberSectorId(m, skillDerivedSectorByProfile);
     const sectorKey = resolvedSectorId ?? UNASSIGNED_BUCKET;
-    memberCountBySector.set(sectorKey, (memberCountBySector.get(sectorKey) ?? 0) + 1);
+    bump(memberCountBySector, sectorKey);
     if (m.job_title_id) {
-      memberCountByJobTitle.set(m.job_title_id, (memberCountByJobTitle.get(m.job_title_id) ?? 0) + 1);
+      bump(memberCountByJobTitle, m.job_title_id);
     }
-    const ownLevel = deriveWorkforceSkillLevel(m.job_title_name);
-    memberCountBySkillLevel.set(ownLevel, (memberCountBySkillLevel.get(ownLevel) ?? 0) + 1);
+    bump(memberCountBySkillLevel, deriveWorkforceSkillLevel(m.job_title_name));
 
-    // Matched job titles: the profile's own job title plus its skill-derived job titles.
-    const matchedJobTitles = new Set<string>();
-    if (m.job_title_id && jobTitleById.has(m.job_title_id)) {
-      matchedJobTitles.add(m.job_title_id);
-    }
-    const skillMatched = skillJobTitlesByProfile.get(m.profile_id);
-    if (skillMatched) {
-      for (const id of skillMatched) matchedJobTitles.add(id);
-    }
-
-    // Matched occupations: the matched job titles PLUS every occupation in the profile's own sector
-    // (V2's sector arm makes a profile count for all occupations in its sector).
-    const matchedOccupations = new Set<string>(matchedJobTitles);
-    if (resolvedSectorId) {
-      for (const jt of jobTitlesBySector.get(resolvedSectorId) ?? []) {
-        matchedOccupations.add(jt.id);
-      }
-    }
-
-    // Matched sectors: the profile's own sector plus the sectors of every matched job title.
-    const matchedSectors = new Set<string>();
-    if (resolvedSectorId) matchedSectors.add(resolvedSectorId);
-    for (const id of matchedJobTitles) {
-      const jt = jobTitleById.get(id);
-      if (jt) matchedSectors.add(jt.sector_id);
-    }
+    const matchedJobTitles = buildMatchedJobTitles(m, jobTitleById, skillJobTitlesByProfile);
+    const matchedOccupations = buildMatchedOccupations(matchedJobTitles, resolvedSectorId, jobTitlesBySector);
+    const matchedSectors = buildMatchedSectors(matchedJobTitles, resolvedSectorId, jobTitleById);
 
     for (const sectorId of matchedSectors) addProfileToBucket(recruitedBySector, sectorId, m.profile_id);
     for (const jobTitleId of matchedOccupations) addProfileToBucket(recruitedByJobTitle, jobTitleId, m.profile_id);
-    const matchedLevels = new Set<WorkforceSkillLevel>();
-    for (const jobTitleId of matchedOccupations) {
-      const jt = jobTitleById.get(jobTitleId);
-      if (jt) matchedLevels.add(deriveWorkforceSkillLevel(jt.name));
-    }
-    for (const level of matchedLevels) {
+    for (const level of buildMatchedLevels(matchedOccupations, jobTitleById)) {
       recruitedBySkillLevel.get(level)!.add(m.profile_id);
     }
   }
 
-  // Top-line recruited mirrors V2 exactly: the count of ALL active Directory profiles.
-  const recruitedTotal = totalMembers;
+  return {
+    totalMembers,
+    memberCountBySector,
+    memberCountByJobTitle,
+    memberCountBySkillLevel,
+    recruitedBySector,
+    recruitedByJobTitle,
+    recruitedBySkillLevel,
+  };
+}
 
-  // Sector breakdown: every active sector (so the view is never blank), plus an Unassigned row when
-  // Directory members have no resolvable sector.
+// Sector breakdown: every active sector (so the view is never blank), plus an Unassigned row when
+// Directory members have no resolvable sector.
+function buildSectorItems(
+  sectors: SectorModelRow[],
+  sectorDemand: Map<string, number>,
+  buckets: WorkforceBuckets,
+): WorkforceGroupedReportItem[] {
   const sectorItems: WorkforceGroupedReportItem[] = sectors.map((s) => {
     const target = sectorDemand.get(s.id) ?? 0;
-    const recruited = recruitedBySector.get(s.id)?.size ?? 0;
+    const recruited = buckets.recruitedBySector.get(s.id)?.size ?? 0;
     return {
       bucket: s.name,
       target,
-      members: memberCountBySector.get(s.id) ?? 0,
+      members: buckets.memberCountBySector.get(s.id) ?? 0,
       recruited,
       gap: Math.max(0, target - recruited),
     };
   });
-  const unassignedMembers = memberCountBySector.get(UNASSIGNED_BUCKET) ?? 0;
-  const unassignedRecruited = recruitedBySector.get(UNASSIGNED_BUCKET)?.size ?? 0;
+  const unassignedMembers = buckets.memberCountBySector.get(UNASSIGNED_BUCKET) ?? 0;
+  const unassignedRecruited = buckets.recruitedBySector.get(UNASSIGNED_BUCKET)?.size ?? 0;
   if (unassignedMembers > 0 || unassignedRecruited > 0) {
     sectorItems.push({
       bucket: UNASSIGNED_BUCKET,
@@ -436,46 +560,94 @@ async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
       gap: 0,
     });
   }
+  return sectorItems;
+}
 
-  // Skill-level breakdown: roll each occupation's demand up by the level derived from its job-title
-  // name (the V2 keyword rule), and pair it with the live matched supply at that level.
-  const demandBySkillLevel = new Map<WorkforceSkillLevel, number>();
-  for (const level of WORKFORCE_SKILL_LEVELS) {
-    demandBySkillLevel.set(level, 0);
-  }
+// Skill-level breakdown: roll each occupation's demand up by the level derived from its job-title
+// name (the V2 keyword rule), and pair it with the live matched supply at that level.
+function buildSkillLevelItems(
+  jobTitles: JobTitleModelRow[],
+  jobTitleDemand: Map<string, number>,
+  buckets: WorkforceBuckets,
+): WorkforceGroupedReportItem[] {
+  const demandBySkillLevel = newSkillLevelCountMap();
   for (const jt of jobTitles) {
     const level = deriveWorkforceSkillLevel(jt.name);
     demandBySkillLevel.set(level, (demandBySkillLevel.get(level) ?? 0) + (jobTitleDemand.get(jt.id) ?? 0));
   }
-  const skillLevelItems: WorkforceGroupedReportItem[] = WORKFORCE_SKILL_LEVELS.map((level) => {
+  return WORKFORCE_SKILL_LEVELS.map((level) => {
     const target = demandBySkillLevel.get(level) ?? 0;
-    const recruited = recruitedBySkillLevel.get(level)?.size ?? 0;
+    const recruited = buckets.recruitedBySkillLevel.get(level)?.size ?? 0;
     return {
       bucket: level,
       target,
-      members: memberCountBySkillLevel.get(level) ?? 0,
+      members: buckets.memberCountBySkillLevel.get(level) ?? 0,
       recruited,
       gap: Math.max(0, target - recruited),
     };
   }).filter((item) => item.target > 0 || item.members > 0);
+}
 
-  // Per-occupation training gaps (sorted largest gap first) — the LevelUp recruiting/training signal.
+// Per-occupation training gaps (sorted largest gap first) — the LevelUp recruiting/training signal.
+function buildOccupationItems(
+  jobTitles: JobTitleModelRow[],
+  jobTitleDemand: Map<string, number>,
+  sectors: SectorModelRow[],
+  buckets: WorkforceBuckets,
+): WorkforceOccupationGapItem[] {
   const sectorNameById = new Map(sectors.map((s) => [s.id, s.name]));
   const occupationItems: WorkforceOccupationGapItem[] = jobTitles.map((jt) => {
     const target = jobTitleDemand.get(jt.id) ?? 0;
-    const recruited = recruitedByJobTitle.get(jt.id)?.size ?? 0;
+    const recruited = buckets.recruitedByJobTitle.get(jt.id)?.size ?? 0;
     return {
       jobTitleId: jt.id,
       occupation: jt.name,
       sector: sectorNameById.get(jt.sector_id) ?? UNASSIGNED_BUCKET,
       skillLevel: deriveWorkforceSkillLevel(jt.name),
       target,
-      members: memberCountByJobTitle.get(jt.id) ?? 0,
+      members: buckets.memberCountByJobTitle.get(jt.id) ?? 0,
       recruited,
       gap: Math.max(0, target - recruited),
     };
   });
   occupationItems.sort((a, b) => b.gap - a.gap || a.occupation.localeCompare(b.occupation));
+  return occupationItems;
+}
+
+async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
+  const config = await getWorkforceConfig();
+  const workforceTotal = Math.max(0, Math.round(config.population * config.participationRate));
+
+  const { sectors, jobTitles, members, profileSkillRows } = await fetchWorkforceModelInputs();
+
+  // Demand: distribute the workforce total across sectors by each sector's workforce share (shared with
+  // the lightweight dashboard summary so the two can never disagree on the headcount target).
+  const sectorDemand = buildSectorDemand(sectors, workforceTotal);
+  const jobTitlesBySector = groupJobTitlesBySector(jobTitles);
+  const jobTitleDemand = buildJobTitleDemand(jobTitlesBySector, sectorDemand);
+
+  const jobTitleById = new Map(jobTitles.map((jt) => [jt.id, jt] as const));
+  const skillJobTitlesByProfile = buildSkillJobTitlesByProfile(profileSkillRows, jobTitleById);
+  const skillDerivedSectorByProfile = buildSkillDerivedSectorByProfile(
+    skillJobTitlesByProfile,
+    jobTitleById,
+    sectors,
+  );
+
+  const buckets = accumulateMemberBuckets({
+    members,
+    jobTitleById,
+    jobTitlesBySector,
+    skillJobTitlesByProfile,
+    skillDerivedSectorByProfile,
+  });
+
+  // Top-line recruited mirrors V2 exactly: the count of ALL active Directory profiles.
+  const recruitedTotal = buckets.totalMembers;
+
+  const sectorItems = buildSectorItems(sectors, sectorDemand, buckets);
+  const skillLevelItems = buildSkillLevelItems(jobTitles, jobTitleDemand, buckets);
+  const occupationItems = buildOccupationItems(jobTitles, jobTitleDemand, sectors, buckets);
 
   const totalHeadcountTarget = Array.from(sectorDemand.values()).reduce((sum, n) => sum + n, 0);
 
@@ -483,7 +655,7 @@ async function computeWorkforceModelUncached(): Promise<WorkforceModel> {
     config,
     workforceTotal,
     totalHeadcountTarget,
-    totalMembers,
+    totalMembers: buckets.totalMembers,
     recruitedTotal,
     sectorsTotal: sectors.length,
     occupationsTotal: jobTitles.length,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — server-side `lib/` modules, no React Native change).

## What

Rule-116 cleanup of the two largest functions in the codebase. **Behavior-preserving** — no logic, SQL, ordering, arithmetic, or public-signature changes.

- `lib/feed/repository.ts` — `listFeedTimeline` (379 lines) and its transaction arrow (complexity 45) split into 14 named helpers (config load, shared query params, count, load-around offset, main row query, per-source detail loads, item builder). Detail loads kept sequential (shared transaction client) exactly as before.
- `lib/workforce/repository.ts` — `computeWorkforceModelUncached` (complexity 58, 232 lines) split into an orchestrator + 18 helpers (input fetch, grouping, per-member computations, report builders). Arithmetic/rounding/tie-breaks preserved.

## Verification
- `pnpm --filter @ctf/web run typecheck` / `lint` — pass
- complexity/length rule on both files — pass
- `check-eof-format` — pass
- pre-push gate (repo-wide typecheck) — pass

No schema/route/contract changes.

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_