### PR TITLE
refactor: reduce complexity in community-shell components

### DIFF
--- a/ctf/packages/web/components/community-shell/announcement-card.tsx
+++ b/ctf/packages/web/components/community-shell/announcement-card.tsx
@@ -40,6 +40,12 @@ function formatReplyTime(iso: string): string {
   return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 }
 
+// The reply-toggle label: a count once there are replies, otherwise the plain "Reply" call to action.
+function formatReplyLabel(count: number): string {
+  if (count <= 0) return 'Reply';
+  return `${count} ${count === 1 ? 'reply' : 'replies'}`;
+}
+
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, { cache: 'no-store', ...init });
   const payload = (await response.json().catch(() => null)) as T | { message?: string } | null;
@@ -48,6 +54,147 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
     throw new Error(typeof message === 'string' ? message : 'Request failed.');
   }
   return payload as T;
+}
+
+// The clickable "Open <Plugin>" chips below the body. Nothing to show when the announcement links to
+// no plugins.
+function AnnouncementLinkedPlugins({ linkedPlugins }: { linkedPlugins?: Array<{ slug: string; name: string }> }) {
+  if (!linkedPlugins || linkedPlugins.length === 0) return null;
+  return (
+    <div className={styles.announcementChipRow}>
+      {linkedPlugins.map((plugin) => (
+        <Link key={plugin.slug} href={`/apps/${plugin.slug}`} className={styles.announcementChip}>
+          <ArrowUpRight size={13} color="currentColor" /> Open {plugin.name}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+// A single reply within the thread.
+function AnnouncementReplyItem({ reply }: { reply: HubAnnouncementReply }) {
+  return (
+    <div className={styles.announcementReply}>
+      <div className={styles.announcementReplyMeta}>
+        <span className={styles.announcementReplyAuthor}>{reply.isMine ? 'You' : reply.author}</span>
+        <span className={styles.announcementReplyTime}>{formatReplyTime(reply.sentAtIso)}</span>
+      </div>
+      <p className={styles.announcementReplyBody}>{reply.body}</p>
+    </div>
+  );
+}
+
+type AnnouncementThreadProps = {
+  loading: boolean;
+  loaded: boolean;
+  replies: HubAnnouncementReply[];
+  error: string | null;
+  replyInput: string;
+  sending: boolean;
+  onReplyInputChange: (value: string) => void;
+  onSend: () => void;
+};
+
+// The expanded reply thread: loading/empty notes, the list of replies, an error line, and the
+// composer. Loaded on demand by the parent when the thread is first opened.
+function AnnouncementThread({
+  loading,
+  loaded,
+  replies,
+  error,
+  replyInput,
+  sending,
+  onReplyInputChange,
+  onSend,
+}: AnnouncementThreadProps) {
+  const showEmpty = !loading && loaded && replies.length === 0;
+  const canSend = replyInput.trim().length > 0;
+  const sendClassName = canSend
+    ? `${styles.announcementReplySend} ${styles.announcementReplySendActive}`
+    : styles.announcementReplySend;
+  return (
+    <div className={styles.announcementThread}>
+      {loading ? <p className={styles.announcementThreadNote}>Loading replies…</p> : null}
+      {showEmpty ? (
+        <p className={styles.announcementThreadNote}>No replies yet. Be the first to reply.</p>
+      ) : null}
+      {replies.map((reply) => (
+        <AnnouncementReplyItem key={reply.id} reply={reply} />
+      ))}
+
+      {error ? <p className={styles.announcementThreadError} role="status">{error}</p> : null}
+
+      <div className={styles.announcementReplyComposer}>
+        <textarea
+          className={styles.announcementReplyInput}
+          placeholder="Write a reply…"
+          rows={1}
+          value={replyInput}
+          maxLength={FEED_MAX_COMMUNITY_REPLY_LENGTH}
+          onChange={(event) => onReplyInputChange(event.target.value)}
+          // Enter inserts a line break, it does not send — matches the main composer (owner
+          // request 2026-07-20). Sending is only via the send button.
+        />
+        <button
+          type="button"
+          className={sendClassName}
+          onClick={onSend}
+          disabled={sending || !canSend}
+          aria-label="Post reply"
+        >
+          <Send size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type AnnouncementEngagementProps = {
+  announcementId: string;
+  reactions?: ChatReactionSummary[];
+  onToggleReaction?: (announcementId: string, emoji: string) => void;
+  threadOpen: boolean;
+  localCount: number;
+  onToggleThread: () => void;
+  thread: AnnouncementThreadProps;
+};
+
+// The reaction row plus the reply toggle, and the thread itself when open.
+function AnnouncementEngagement({
+  announcementId,
+  reactions,
+  onToggleReaction,
+  threadOpen,
+  localCount,
+  onToggleThread,
+  thread,
+}: AnnouncementEngagementProps) {
+  const replyLabel = formatReplyLabel(localCount);
+  const toggleClassName = threadOpen
+    ? `${styles.announcementReplyToggle} ${styles.announcementReplyToggleActive}`
+    : styles.announcementReplyToggle;
+  return (
+    <div className={styles.announcementEngagement}>
+      <div className={styles.announcementActions}>
+        <ChatReactionRow
+          postId={announcementId}
+          reactions={reactions}
+          onToggle={(id, emoji) => onToggleReaction?.(id, emoji)}
+        />
+        <button
+          type="button"
+          className={toggleClassName}
+          onClick={onToggleThread}
+          aria-expanded={threadOpen}
+          aria-label={threadOpen ? 'Hide replies' : `Show replies (${localCount})`}
+        >
+          <MessageCircle size={13} /> {replyLabel}
+        </button>
+      </div>
+
+      {threadOpen ? <AnnouncementThread {...thread} /> : null}
+    </div>
+  );
 }
 
 // Official Survivor Hub announcement, rendered as a distinct card (emerald treatment, shield
@@ -129,8 +276,6 @@ export function AnnouncementCard({
     }
   }, [announcementId, replyInput, sending]);
 
-  const replyLabel = localCount > 0 ? `${localCount} ${localCount === 1 ? 'reply' : 'replies'}` : 'Reply';
-
   return (
     <article
       className={styles.announcementCard}
@@ -151,77 +296,27 @@ export function AnnouncementCard({
       </div>
       {title ? <p className={styles.announcementTitle}>{title}</p> : null}
       <p className={styles.announcementBody}>{body}</p>
-      {linkedPlugins && linkedPlugins.length > 0 ? (
-        <div className={styles.announcementChipRow}>
-          {linkedPlugins.map((plugin) => (
-            <Link key={plugin.slug} href={`/apps/${plugin.slug}`} className={styles.announcementChip}>
-              <ArrowUpRight size={13} color="currentColor" /> Open {plugin.name}
-            </Link>
-          ))}
-        </div>
-      ) : null}
+      <AnnouncementLinkedPlugins linkedPlugins={linkedPlugins} />
 
       {announcementId ? (
-        <div className={styles.announcementEngagement}>
-          <div className={styles.announcementActions}>
-            <ChatReactionRow
-              postId={announcementId}
-              reactions={reactions}
-              onToggle={(id, emoji) => onToggleReaction?.(id, emoji)}
-            />
-            <button
-              type="button"
-              className={threadOpen ? `${styles.announcementReplyToggle} ${styles.announcementReplyToggleActive}` : styles.announcementReplyToggle}
-              onClick={toggleThread}
-              aria-expanded={threadOpen}
-              aria-label={threadOpen ? 'Hide replies' : `Show replies (${localCount})`}
-            >
-              <MessageCircle size={13} /> {replyLabel}
-            </button>
-          </div>
-
-          {threadOpen ? (
-            <div className={styles.announcementThread}>
-              {loading ? <p className={styles.announcementThreadNote}>Loading replies…</p> : null}
-              {!loading && loaded && replies.length === 0 ? (
-                <p className={styles.announcementThreadNote}>No replies yet. Be the first to reply.</p>
-              ) : null}
-              {replies.map((reply) => (
-                <div key={reply.id} className={styles.announcementReply}>
-                  <div className={styles.announcementReplyMeta}>
-                    <span className={styles.announcementReplyAuthor}>{reply.isMine ? 'You' : reply.author}</span>
-                    <span className={styles.announcementReplyTime}>{formatReplyTime(reply.sentAtIso)}</span>
-                  </div>
-                  <p className={styles.announcementReplyBody}>{reply.body}</p>
-                </div>
-              ))}
-
-              {error ? <p className={styles.announcementThreadError} role="status">{error}</p> : null}
-
-              <div className={styles.announcementReplyComposer}>
-                <textarea
-                  className={styles.announcementReplyInput}
-                  placeholder="Write a reply…"
-                  rows={1}
-                  value={replyInput}
-                  maxLength={FEED_MAX_COMMUNITY_REPLY_LENGTH}
-                  onChange={(event) => setReplyInput(event.target.value)}
-                  // Enter inserts a line break, it does not send — matches the main composer (owner
-                  // request 2026-07-20). Sending is only via the send button.
-                />
-                <button
-                  type="button"
-                  className={replyInput.trim() ? `${styles.announcementReplySend} ${styles.announcementReplySendActive}` : styles.announcementReplySend}
-                  onClick={() => void sendReply()}
-                  disabled={sending || !replyInput.trim()}
-                  aria-label="Post reply"
-                >
-                  <Send size={14} />
-                </button>
-              </div>
-            </div>
-          ) : null}
-        </div>
+        <AnnouncementEngagement
+          announcementId={announcementId}
+          reactions={reactions}
+          onToggleReaction={onToggleReaction}
+          threadOpen={threadOpen}
+          localCount={localCount}
+          onToggleThread={toggleThread}
+          thread={{
+            loading,
+            loaded,
+            replies,
+            error,
+            replyInput,
+            sending,
+            onReplyInputChange: setReplyInput,
+            onSend: () => void sendReply(),
+          }}
+        />
       ) : null}
     </article>
   );

--- a/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
+++ b/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
@@ -23,6 +23,30 @@ const POINTS = [
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
 
+// Focus trap for a single Tab / Shift+Tab press: keep focus cycling within the dialog root.
+function cycleFocusTrap(root: HTMLElement, event: KeyboardEvent) {
+  const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => element.offsetParent !== null || element === document.activeElement,
+  );
+  if (focusable.length === 0) return;
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+
+  if (event.shiftKey) {
+    if (active === first || !root.contains(active)) {
+      event.preventDefault();
+      last.focus();
+    }
+    return;
+  }
+  if (active === last || !root.contains(active)) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
 export function ComicConsentModal({ open, onConfirm, onDismiss }: ComicConsentModalProps) {
   const confirmRef = useRef<HTMLButtonElement | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
@@ -53,26 +77,7 @@ export function ComicConsentModal({ open, onConfirm, onDismiss }: ComicConsentMo
 
       // Focus trap: keep Tab / Shift+Tab cycling within the dialog.
       const root = modalRef.current;
-      if (!root) return;
-
-      const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
-        (element) => element.offsetParent !== null || element === document.activeElement,
-      );
-      if (focusable.length === 0) return;
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-
-      if (event.shiftKey) {
-        if (active === first || !root.contains(active)) {
-          event.preventDefault();
-          last.focus();
-        }
-      } else if (active === last || !root.contains(active)) {
-        event.preventDefault();
-        first.focus();
-      }
+      if (root) cycleFocusTrap(root, event);
     }
 
     window.addEventListener('keydown', onKeyDown);

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -91,6 +91,35 @@ function parseStoredUsageCounts(value: string | null): Record<string, number> {
   }
 }
 
+// Optional shell flags resolved to concrete values so the component body carries no
+// destructuring defaults (each default counts toward complexity). Behavior matches the
+// former `= default` params: an undefined flag falls back exactly as before.
+type NormalizedShellFlags = {
+  initialSection: ShellSection;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  signInUrl: string;
+  verification: ShellVerification | null;
+};
+
+function normalizeShellProps(props: CommunityShellProps): NormalizedShellFlags {
+  return {
+    initialSection: props.initialSection ?? 'chat',
+    isAuthenticated: props.isAuthenticated ?? false,
+    isAdmin: props.isAdmin ?? false,
+    signInUrl: props.signInUrl ?? '/sign-in',
+    verification: props.verification ?? null,
+  };
+}
+
+function sectionTabClass(isActive: boolean): string {
+  return isActive ? `${styles.mobileBarSectionBtn} ${styles.mobileBarSectionBtnActive}` : styles.mobileBarSectionBtn;
+}
+
+function channelSwitchClass(isActive: boolean): string {
+  return isActive ? `${styles.channelSwitchBtn} ${styles.channelSwitchBtnActive}` : styles.channelSwitchBtn;
+}
+
 function sortPluginsForUi(
   items: PluginRegistryItem[],
   sortMode: PluginSortMode,
@@ -132,7 +161,296 @@ function sortPluginsForUi(
   });
 }
 
-export function CommunityShell({ initialPlugins, shellStats, currentUser, trust, initialSection = 'chat', isAuthenticated = false, isAdmin = false, signInUrl = '/sign-in', verification = null }: CommunityShellProps) {
+type MobileTopBarProps = {
+  section: ShellSection;
+  onSectionChange: (section: ShellSection) => void;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  signInUrl: string;
+};
+
+function MobileTopBar({ section, onSectionChange, isAuthenticated, isAdmin, signInUrl }: MobileTopBarProps) {
+  return (
+    <header className={styles.mobileBar}>
+      {/* Brand mark on the phone bar: it is the first product identity a member sees on a phone.
+          It sits on the left; the section tabs keep their margin-left:auto so the tabs + controls
+          cluster on the right. The Skills Economy "Stack" mark matches the site title in layout.tsx. */}
+      <div className={styles.mobileBarLogo}>
+        <SeMark size={26} />
+      </div>
+      {/* Signed out, the bar carries far fewer controls (no gift reminder, help, settings or
+          avatar), so the full "SE / SKILLS ECONOMY" lockup fits beside the mark and a first-time
+          visitor sees the product name, not just a symbol. Signed in, the name is dropped again
+          so the mark, gift reminder, tabs and account controls all fit a 390px phone. */}
+      {!isAuthenticated ? (
+        <span className={styles.mobileBarWordmark} aria-hidden="true">
+          <span className={styles.mobileBarWordmarkInitials}>SE</span>
+          <span className={styles.mobileBarWordmarkName}>Skills Economy</span>
+        </span>
+      ) : null}
+      {/* Fundraiser gift reminder — sits between the brand mark and the section tabs (owner
+          placement). Renders only on phone widths while a drive is active and the full banner is
+          dismissed or snoozed; the banner itself (when open) stays in the content area below. */}
+      {isAuthenticated ? <ContributionsGiftTrigger /> : null}
+      <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={section === 'chat'}
+          className={sectionTabClass(section === 'chat')}
+          onClick={() => onSectionChange('chat')}
+        >
+          Commons
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={section === 'apps'}
+          className={sectionTabClass(section === 'apps')}
+          onClick={() => onSectionChange('apps')}
+        >
+          Apps
+        </button>
+      </div>
+      {/* Admins reach /admin straight from the top bar on phones — the left rail
+          (which used to carry this link) is hidden on phones, so this replaces the
+          extra tap through the drawer. Admins only; hidden for everyone else. */}
+      {isAdmin ? (
+        <Link href="/admin" className={styles.mobileBarAdminBtn} aria-label="Admin" title="Admin — manage plugins and review queues">
+          <SlidersHorizontal size={15} aria-hidden="true" />
+          {/* Label hidden at phone widths so the full bar (tabs + admin + help + settings +
+              avatar) fits without pushing the avatar off the right edge. */}
+          <span className={styles.mobileBarAdminLabel}>Admin</span>
+        </Link>
+      ) : null}
+      <div className={styles.mobileBarAuth}>
+        {/* Help control on the phone-width top bar: the desktop icon rail (which
+            hosts it) is hidden below 900px, so signed-in members reach the
+            "Report a problem" modal from here instead. */}
+        {isAuthenticated ? <HelpControl /> : null}
+        {/* Account hub link on the phone-width bar: the desktop icon rail's
+            account button (which leads to /account — identity, trust, profile,
+            data, blocked members) is hidden below 900px, so this gear restores
+            the one tap to the full account page. The avatar's own menu only
+            edits Clerk identity, so it is not a substitute for this link. */}
+        {isAuthenticated ? (
+          <Link href="/account" className={styles.iconRailBtn} aria-label="Account and settings" title="Account and settings">
+            <Settings size={18} aria-hidden="true" />
+          </Link>
+        ) : null}
+        {isAuthenticated ? (
+          // Clerk's account widget on the phone-width bar too: avatar opens
+          // Clerk's menu; "Manage account" edits name, username, and email.
+          <span className={styles.clerkAvatarSlot} title="Your account — edit name, username, and email">
+            <UserButton appearance={{ elements: { avatarBox: styles.clerkMobileAvatarBox } }} />
+          </span>
+        ) : (
+          <Link className={styles.mobileBarSignIn} href={signInUrl}>Sign in</Link>
+        )}
+      </div>
+    </header>
+  );
+}
+
+type ChannelSwitchRowProps = {
+  channels: HubChannelInfo[];
+  activeChannel: string | null;
+  onChannelSelect: (slug: string) => void;
+  onLockedChannelClick: () => void;
+};
+
+// Channel switch pills — phone widths only (the desktop channel rail is hidden there).
+// The general channel is always shown. The contributor channel is shown to everyone:
+// eligible members get it as a real, selectable chip (the server includes it in their
+// channel list); everyone else gets a locked chip that opens the same "Weavers of the
+// Commons" explainer the Directory braided badge shows — so the space is visible and
+// its bar is public, never a hidden back-room.
+function ChannelSwitchRow({ channels, activeChannel, onChannelSelect, onLockedChannelClick }: ChannelSwitchRowProps) {
+  const fallbackSlug = activeChannel ?? channels[0]?.slug;
+  const hasGatedChannel = channels.some((ch) => ch.slug === GATED_CHANNEL_SLUG);
+
+  return (
+    <div className={styles.channelSwitchRow} role="tablist" aria-label="Channels">
+      {channels.map((ch) => (
+        <button
+          key={ch.slug}
+          type="button"
+          role="tab"
+          aria-selected={fallbackSlug === ch.slug}
+          className={channelSwitchClass(fallbackSlug === ch.slug)}
+          onClick={() => onChannelSelect(ch.slug)}
+        >
+          #{ch.slug}
+        </button>
+      ))}
+      {!hasGatedChannel ? (
+        <button
+          type="button"
+          className={`${styles.channelSwitchBtn} ${styles.channelSwitchBtnLocked}`}
+          onClick={onLockedChannelClick}
+          aria-haspopup="dialog"
+          title="Weavers of the Commons"
+        >
+          <WeaversBadge size={13} />
+          <span>#{GATED_CHANNEL_SLUG}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+type ChatSectionProps = {
+  activeChannel: string | null;
+  currentUser: ShellCurrentUser;
+  isAdmin: boolean;
+  shellStats: ShellStats;
+  filteredPlugins: PluginRegistryItem[];
+  isAuthenticated: boolean;
+  signInUrl: string;
+};
+
+function ChatSection({ activeChannel, currentUser, isAdmin, shellStats, filteredPlugins, isAuthenticated, signInUrl }: ChatSectionProps) {
+  if (activeChannel === GATED_CHANNEL_SLUG) {
+    return <GatedChatPanel currentUser={currentUser} isAdmin={isAdmin} />;
+  }
+  return <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} isAdmin={isAdmin} signInUrl={signInUrl} />;
+}
+
+type ShellMainContentProps = {
+  section: ShellSection;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  signInUrl: string;
+  verification: ShellVerification | null;
+  loadError: string | null;
+  channels: HubChannelInfo[];
+  activeChannel: string | null;
+  onChannelSelect: (slug: string) => void;
+  onLockedChannelClick: () => void;
+  shellStats: ShellStats;
+  filteredPlugins: PluginRegistryItem[];
+  currentUser: ShellCurrentUser;
+  activeApp: string | null;
+  onAppSelect: (slug: string | null) => void;
+  sortMode: PluginSortMode;
+  onSortModeChange: (mode: PluginSortMode) => void;
+  query: string;
+  onQueryChange: (value: string) => void;
+};
+
+function ShellMainContent({
+  section,
+  isAuthenticated,
+  isAdmin,
+  signInUrl,
+  verification,
+  loadError,
+  channels,
+  activeChannel,
+  onChannelSelect,
+  onLockedChannelClick,
+  shellStats,
+  filteredPlugins,
+  currentUser,
+  activeApp,
+  onAppSelect,
+  sortMode,
+  onSortModeChange,
+  query,
+  onQueryChange,
+}: ShellMainContentProps) {
+  return (
+    <main className={`${styles.panel} ${styles.content}`}>
+      {/* App-wide fundraiser banner — non-blocking, top of the content area, signed-in only.
+          The banner self-hides unless a drive is active and visible for this member. */}
+      {isAuthenticated ? <ContributionsBanner /> : null}
+      {/* Not-yet-verified members (notably the early-Commons A/B treatment bucket) get a persistent
+          prompt to submit their Quora URL right here, with a nudge to ask in the Commons if stuck. */}
+      {isAuthenticated && verification ? (
+        <UnlockVerifyBanner hasSubmission={verification.hasSubmission} reviewStatus={verification.reviewStatus} />
+      ) : null}
+      {loadError ? (
+        <section className={styles.usernameAlert} role="alert">{loadError}</section>
+      ) : null}
+      {section === 'chat' && isAuthenticated ? (
+        <ChannelSwitchRow
+          channels={channels}
+          activeChannel={activeChannel}
+          onChannelSelect={onChannelSelect}
+          onLockedChannelClick={onLockedChannelClick}
+        />
+      ) : null}
+      {section === 'chat' ? (
+        <ChatSection
+          activeChannel={activeChannel}
+          currentUser={currentUser}
+          isAdmin={isAdmin}
+          shellStats={shellStats}
+          filteredPlugins={filteredPlugins}
+          isAuthenticated={isAuthenticated}
+          signInUrl={signInUrl}
+        />
+      ) : (
+        <ShellAppsPanel
+          plugins={filteredPlugins}
+          activeApp={activeApp}
+          onAppSelect={onAppSelect}
+          sortMode={sortMode}
+          onSortModeChange={onSortModeChange}
+          query={query}
+          onQueryChange={onQueryChange}
+        />
+      )}
+    </main>
+  );
+}
+
+// Contributor-channel explainer — shown when a non-eligible member taps the locked
+// contributor chip. Same honest copy the Directory braided badge shows (proposal
+// section 3: no "verified", no "vetted"). "Anyone can earn this."
+function ContributorExplainerModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className={styles.explainerOverlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Weavers of the Commons"
+    >
+      <button
+        type="button"
+        aria-label="Close"
+        className={styles.explainerBackdrop}
+        onClick={onClose}
+      />
+      <div className={styles.explainerCard}>
+        <div className={styles.explainerHead}>
+          <WeaversBadge size={30} />
+          <div className={styles.explainerTitle}>Weavers of the Commons</div>
+        </div>
+        <div className={styles.explainerBody}>
+          The contributor channel is for consistent, broad contributors to the community — real
+          help, delivered over time. Anyone can earn it; when you do, the channel opens here.
+        </div>
+        <div className={styles.explainerActions}>
+          <Link href="/apps/directory/weavers-of-the-commons" className={styles.explainerLink}>
+            How it&rsquo;s earned
+          </Link>
+          <button
+            type="button"
+            className={styles.explainerClose}
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CommunityShell(props: CommunityShellProps) {
+  const { initialPlugins, shellStats, currentUser, trust } = props;
+  const { initialSection, isAuthenticated, isAdmin, signInUrl, verification } = normalizeShellProps(props);
   const [section, setSection] = useState<ShellSection>(initialSection);
   const [query, setQuery] = useState('');
   const [plugins, setPlugins] = useState(initialPlugins);
@@ -285,84 +603,13 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
 
   return (
     <div className={`${styles.shell} ctf-self-responsive`}>
-      <header className={styles.mobileBar}>
-        {/* Brand mark on the phone bar: it is the first product identity a member sees on a phone.
-            It sits on the left; the section tabs keep their margin-left:auto so the tabs + controls
-            cluster on the right. The Skills Economy "Stack" mark matches the site title in layout.tsx. */}
-        <div className={styles.mobileBarLogo}>
-          <SeMark size={26} />
-        </div>
-        {/* Signed out, the bar carries far fewer controls (no gift reminder, help, settings or
-            avatar), so the full "SE / SKILLS ECONOMY" lockup fits beside the mark and a first-time
-            visitor sees the product name, not just a symbol. Signed in, the name is dropped again
-            so the mark, gift reminder, tabs and account controls all fit a 390px phone. */}
-        {!isAuthenticated ? (
-          <span className={styles.mobileBarWordmark} aria-hidden="true">
-            <span className={styles.mobileBarWordmarkInitials}>SE</span>
-            <span className={styles.mobileBarWordmarkName}>Skills Economy</span>
-          </span>
-        ) : null}
-        {/* Fundraiser gift reminder — sits between the brand mark and the section tabs (owner
-            placement). Renders only on phone widths while a drive is active and the full banner is
-            dismissed or snoozed; the banner itself (when open) stays in the content area below. */}
-        {isAuthenticated ? <ContributionsGiftTrigger /> : null}
-        <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={section === 'chat'}
-            className={section === 'chat' ? `${styles.mobileBarSectionBtn} ${styles.mobileBarSectionBtnActive}` : styles.mobileBarSectionBtn}
-            onClick={() => setSection('chat')}
-          >
-            Commons
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={section === 'apps'}
-            className={section === 'apps' ? `${styles.mobileBarSectionBtn} ${styles.mobileBarSectionBtnActive}` : styles.mobileBarSectionBtn}
-            onClick={() => setSection('apps')}
-          >
-            Apps
-          </button>
-        </div>
-        {/* Admins reach /admin straight from the top bar on phones — the left rail
-            (which used to carry this link) is hidden on phones, so this replaces the
-            extra tap through the drawer. Admins only; hidden for everyone else. */}
-        {isAdmin ? (
-          <Link href="/admin" className={styles.mobileBarAdminBtn} aria-label="Admin" title="Admin — manage plugins and review queues">
-            <SlidersHorizontal size={15} aria-hidden="true" />
-            {/* Label hidden at phone widths so the full bar (tabs + admin + help + settings +
-                avatar) fits without pushing the avatar off the right edge. */}
-            <span className={styles.mobileBarAdminLabel}>Admin</span>
-          </Link>
-        ) : null}
-        <div className={styles.mobileBarAuth}>
-          {/* Help control on the phone-width top bar: the desktop icon rail (which
-              hosts it) is hidden below 900px, so signed-in members reach the
-              "Report a problem" modal from here instead. */}
-          {isAuthenticated ? <HelpControl /> : null}
-          {/* Account hub link on the phone-width bar: the desktop icon rail's
-              account button (which leads to /account — identity, trust, profile,
-              data, blocked members) is hidden below 900px, so this gear restores
-              the one tap to the full account page. The avatar's own menu only
-              edits Clerk identity, so it is not a substitute for this link. */}
-          {isAuthenticated ? (
-            <Link href="/account" className={styles.iconRailBtn} aria-label="Account and settings" title="Account and settings">
-              <Settings size={18} aria-hidden="true" />
-            </Link>
-          ) : null}
-          {isAuthenticated ? (
-            // Clerk's account widget on the phone-width bar too: avatar opens
-            // Clerk's menu; "Manage account" edits name, username, and email.
-            <span className={styles.clerkAvatarSlot} title="Your account — edit name, username, and email">
-              <UserButton appearance={{ elements: { avatarBox: styles.clerkMobileAvatarBox } }} />
-            </span>
-          ) : (
-            <Link className={styles.mobileBarSignIn} href={signInUrl}>Sign in</Link>
-          )}
-        </div>
-      </header>
+      <MobileTopBar
+        section={section}
+        onSectionChange={setSection}
+        isAuthenticated={isAuthenticated}
+        isAdmin={isAdmin}
+        signInUrl={signInUrl}
+      />
       <div className={styles.frame}>
         <ShellIconRail section={section} onSectionChange={setSection} initial={currentUser.initial} isAuthenticated={isAuthenticated} isAdmin={isAdmin} />
         {/* Channel rail — desktop only. It is hidden on phones (single "general"
@@ -375,73 +622,27 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
           shellStats={shellStats}
           isAdmin={isAdmin}
         />
-        <main className={`${styles.panel} ${styles.content}`}>
-          {/* App-wide fundraiser banner — non-blocking, top of the content area, signed-in only.
-              The banner self-hides unless a drive is active and visible for this member. */}
-          {isAuthenticated ? <ContributionsBanner /> : null}
-          {/* Not-yet-verified members (notably the early-Commons A/B treatment bucket) get a persistent
-              prompt to submit their Quora URL right here, with a nudge to ask in the Commons if stuck. */}
-          {isAuthenticated && verification ? (
-            <UnlockVerifyBanner hasSubmission={verification.hasSubmission} reviewStatus={verification.reviewStatus} />
-          ) : null}
-          {loadError ? (
-            <section className={styles.usernameAlert} role="alert">{loadError}</section>
-          ) : null}
-          {/* Channel switch pills — phone widths only (the desktop channel rail is hidden there).
-              The general channel is always shown. The contributor channel is shown to everyone:
-              eligible members get it as a real, selectable chip (the server includes it in their
-              channel list); everyone else gets a locked chip that opens the same "Weavers of the
-              Commons" explainer the Directory braided badge shows — so the space is visible and
-              its bar is public, never a hidden back-room. */}
-          {section === 'chat' && isAuthenticated ? (
-            <div className={styles.channelSwitchRow} role="tablist" aria-label="Channels">
-              {channels.map((ch) => {
-                const isActive = (activeChannel ?? channels[0]?.slug) === ch.slug;
-                return (
-                  <button
-                    key={ch.slug}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActive}
-                    className={isActive ? `${styles.channelSwitchBtn} ${styles.channelSwitchBtnActive}` : styles.channelSwitchBtn}
-                    onClick={() => handleChannelSelect(ch.slug)}
-                  >
-                    #{ch.slug}
-                  </button>
-                );
-              })}
-              {!channels.some((ch) => ch.slug === GATED_CHANNEL_SLUG) ? (
-                <button
-                  type="button"
-                  className={`${styles.channelSwitchBtn} ${styles.channelSwitchBtnLocked}`}
-                  onClick={() => setContributorExplainerOpen(true)}
-                  aria-haspopup="dialog"
-                  title="Weavers of the Commons"
-                >
-                  <WeaversBadge size={13} />
-                  <span>#{GATED_CHANNEL_SLUG}</span>
-                </button>
-              ) : null}
-            </div>
-          ) : null}
-          {section === 'chat' ? (
-            activeChannel === GATED_CHANNEL_SLUG ? (
-              <GatedChatPanel currentUser={currentUser} isAdmin={isAdmin} />
-            ) : (
-              <ShellChatPanel stats={shellStats} plugins={filteredPlugins} currentUser={currentUser} isAuthenticated={isAuthenticated} isAdmin={isAdmin} signInUrl={signInUrl} />
-            )
-          ) : (
-            <ShellAppsPanel
-              plugins={filteredPlugins}
-              activeApp={activeApp}
-              onAppSelect={handleAppSelect}
-              sortMode={sortMode}
-              onSortModeChange={handleSortModeChange}
-              query={query}
-              onQueryChange={setQuery}
-            />
-          )}
-        </main>
+        <ShellMainContent
+          section={section}
+          isAuthenticated={isAuthenticated}
+          isAdmin={isAdmin}
+          signInUrl={signInUrl}
+          verification={verification}
+          loadError={loadError}
+          channels={channels}
+          activeChannel={activeChannel}
+          onChannelSelect={handleChannelSelect}
+          onLockedChannelClick={() => setContributorExplainerOpen(true)}
+          shellStats={shellStats}
+          filteredPlugins={filteredPlugins}
+          currentUser={currentUser}
+          activeApp={activeApp}
+          onAppSelect={handleAppSelect}
+          sortMode={sortMode}
+          onSortModeChange={handleSortModeChange}
+          query={query}
+          onQueryChange={setQuery}
+        />
         <ShellRightRail
           currentUser={currentUser}
           trust={trust}
@@ -449,45 +650,8 @@ export function CommunityShell({ initialPlugins, shellStats, currentUser, trust,
           signInUrl={signInUrl}
         />
       </div>
-      {/* Contributor-channel explainer — shown when a non-eligible member taps the locked
-          contributor chip. Same honest copy the Directory braided badge shows (proposal
-          section 3: no "verified", no "vetted"). "Anyone can earn this." */}
       {contributorExplainerOpen ? (
-        <div
-          className={styles.explainerOverlay}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Weavers of the Commons"
-        >
-          <button
-            type="button"
-            aria-label="Close"
-            className={styles.explainerBackdrop}
-            onClick={() => setContributorExplainerOpen(false)}
-          />
-          <div className={styles.explainerCard}>
-            <div className={styles.explainerHead}>
-              <WeaversBadge size={30} />
-              <div className={styles.explainerTitle}>Weavers of the Commons</div>
-            </div>
-            <div className={styles.explainerBody}>
-              The contributor channel is for consistent, broad contributors to the community — real
-              help, delivered over time. Anyone can earn it; when you do, the channel opens here.
-            </div>
-            <div className={styles.explainerActions}>
-              <Link href="/apps/directory/weavers-of-the-commons" className={styles.explainerLink}>
-                How it&rsquo;s earned
-              </Link>
-              <button
-                type="button"
-                className={styles.explainerClose}
-                onClick={() => setContributorExplainerOpen(false)}
-              >
-                Close
-              </button>
-            </div>
-          </div>
-        </div>
+        <ContributorExplainerModal onClose={() => setContributorExplainerOpen(false)} />
       ) : null}
     </div>
   );

--- a/ctf/packages/web/components/community-shell/gated-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/gated-chat-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type RefObject } from 'react';
 import { Eye, Pencil, Reply, Trash2, X } from 'lucide-react';
 import {
   GATED_CHANNEL_DISPLAY_NAME,
@@ -10,7 +10,7 @@ import {
 } from '../../lib/contributor-access/gated-channel-shared';
 import type { ShellCurrentUser } from './shell-types';
 import { ChatReactionRow } from './chat-reaction-row';
-import { useGatedChat } from './use-gated-chat';
+import { useGatedChat, type GatedChatMessage } from './use-gated-chat';
 import styles from './community-shell.module.css';
 
 // Gated contributor channel panel. Reuses the Commons chat design (same CSS module, same row and
@@ -19,12 +19,210 @@ import styles from './community-shell.module.css';
 // deliberately NO image/file upload affordance anywhere in this panel — uploads are also disabled
 // on the Stream channel type — and no AI assistant or concierge (those are Commons features).
 
+type QuotedMessage = NonNullable<GatedChatMessage['quotedMessage']>;
+
+// Class-name pickers for the two-sided bubble layout (the member's own posts sit on the right with
+// the "user" variant classes; peers on the left). Hoisted so the repeated `from === 'user'` ternary
+// lives in one place instead of being inlined at every element.
+const rowClassName = (fromUser: boolean) =>
+  fromUser ? `${styles.chatRow} ${styles.chatRowUser}` : styles.chatRow;
+const senderClassName = (fromUser: boolean) =>
+  fromUser ? `${styles.chatSender} ${styles.chatSenderUser}` : styles.chatSender;
+const bubbleClassName = (fromUser: boolean) =>
+  fromUser ? `${styles.chatBubble} ${styles.chatBubbleUser}` : `${styles.chatBubble} ${styles.chatBubbleHub}`;
+const metaRowClassName = (fromUser: boolean) =>
+  fromUser ? `${styles.chatMetaRow} ${styles.chatMetaRowUser}` : styles.chatMetaRow;
+const timeClassName = (fromUser: boolean) =>
+  fromUser ? `${styles.chatTime} ${styles.chatTimeUser}` : styles.chatTime;
+
+// First letter of the sender's handle for the peer avatar, falling back to 'C' when empty.
+function avatarInitial(senderLabel: string): string {
+  return senderLabel.replace(/^@/, '').charAt(0).toUpperCase() || 'C';
+}
+
+function deleteAriaLabel(fromUser: boolean, senderLabel: string): string {
+  return fromUser ? 'Delete your message' : `Delete message from ${senderLabel}`;
+}
+
+// Confirm before removing a post (destructive, no undo) — same prompt as the Commons.
+function requestDeleteMessage(
+  deleteMessage: (postId: string) => void | Promise<void>,
+  postId: string,
+) {
+  if (window.confirm('Delete this message? This cannot be undone. To change it, delete and post again.')) {
+    void deleteMessage(postId);
+  }
+}
+
 type GatedChatPanelProps = {
   currentUser: ShellCurrentUser;
   // Admins may delete ANY post (the moderator power the in-channel disclosure line discloses);
   // members only their own. The server enforces this again — the flag only shows the affordance.
   isAdmin?: boolean;
 };
+
+function PeerAvatar({ senderLabel }: { senderLabel: string }) {
+  return (
+    <div className={styles.chatAvatar} aria-hidden="true">
+      {avatarInitial(senderLabel)}
+    </div>
+  );
+}
+
+// The quoted-reply block above a threaded message. When the original post is still on screen the
+// block is a button that jumps to it; otherwise (original deleted/out of range) it is a static block.
+function QuotedReplyBlock({ quoted, onJump }: { quoted: QuotedMessage; onJump: (postId: string) => void }) {
+  const author = <span className={styles.chatQuotedAuthor}>{quoted.author}</span>;
+  const snippet = <span className={styles.chatQuotedSnippet}>{quoted.snippet}</span>;
+  if (!quoted.postId) {
+    return (
+      <div className={styles.chatQuotedBlock}>
+        {author}
+        {snippet}
+      </div>
+    );
+  }
+  const postId = quoted.postId;
+  return (
+    <button
+      type="button"
+      className={`${styles.chatQuotedBlock} ${styles.chatQuotedBlockClickable}`}
+      onClick={() => onJump(postId)}
+      aria-label={`Go to the message from ${quoted.author} that this replies to`}
+    >
+      {author}
+      {snippet}
+    </button>
+  );
+}
+
+function EditButton({ onEdit }: { onEdit: () => void }) {
+  return (
+    <button type="button" className={styles.chatEditBtn} onClick={onEdit} aria-label="Edit your message">
+      <Pencil size={12} /> Edit
+    </button>
+  );
+}
+
+function DeleteButton({ label, onDelete }: { label: string; onDelete: () => void }) {
+  return (
+    <button type="button" className={styles.chatDeleteBtn} onClick={onDelete} aria-label={label}>
+      <Trash2 size={12} /> Delete
+    </button>
+  );
+}
+
+// The row of controls under a bubble: timestamp, reply, and (for the member's own posts, or any post
+// when the viewer is an admin) edit/delete.
+function MessageMetaRow({
+  msg,
+  fromUser,
+  isAdmin,
+  onBeginReply,
+  onEdit,
+  onDelete,
+}: {
+  msg: GatedChatMessage;
+  fromUser: boolean;
+  isAdmin: boolean;
+  onBeginReply: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className={metaRowClassName(fromUser)}>
+      <span className={timeClassName(fromUser)}>{msg.timeLabel}</span>
+      <button
+        type="button"
+        className={styles.chatReplyBtn}
+        onClick={onBeginReply}
+        aria-label={`Reply to ${msg.senderLabel}`}
+      >
+        <Reply size={12} /> Reply
+      </button>
+      {fromUser ? <EditButton onEdit={onEdit} /> : null}
+      {fromUser || isAdmin ? (
+        <DeleteButton label={deleteAriaLabel(fromUser, msg.senderLabel)} onDelete={onDelete} />
+      ) : null}
+    </div>
+  );
+}
+
+// One full chat message: peer avatar (peers only), sender label, optional quoted reply, the bubble,
+// the meta/controls row, and the reaction row.
+function GatedMessageRow({
+  msg,
+  isAdmin,
+  inputRef,
+  onBeginReply,
+  onEditMessage,
+  onDeleteMessage,
+  onToggleReaction,
+  onJumpToQuoted,
+}: {
+  msg: GatedChatMessage;
+  isAdmin: boolean;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  onBeginReply: (msg: GatedChatMessage) => void;
+  onEditMessage: (postId: string, text: string) => void;
+  onDeleteMessage: (postId: string) => void | Promise<void>;
+  onToggleReaction: (postId: string, emoji: string) => void;
+  onJumpToQuoted: (postId: string) => void;
+}) {
+  const fromUser = msg.from === 'user';
+
+  const handleEdit = () => {
+    // Editing is delete + repost: pull the text into the composer, delete the original,
+    // and focus the box so the member fixes it and sends a fresh message.
+    onEditMessage(msg.id, msg.text);
+    inputRef.current?.focus();
+  };
+  const handleDelete = () => requestDeleteMessage(onDeleteMessage, msg.id);
+
+  return (
+    <div className={rowClassName(fromUser)}>
+      {msg.from === 'peer' ? <PeerAvatar senderLabel={msg.senderLabel} /> : null}
+      <div className={styles.chatBubbleGroup} data-post-id={msg.id}>
+        <span className={senderClassName(fromUser)}>{msg.senderLabel}</span>
+        {msg.quotedMessage ? <QuotedReplyBlock quoted={msg.quotedMessage} onJump={onJumpToQuoted} /> : null}
+        <div className={bubbleClassName(fromUser)}>{msg.text}</div>
+        <MessageMetaRow
+          msg={msg}
+          fromUser={fromUser}
+          isAdmin={isAdmin}
+          onBeginReply={() => onBeginReply(msg)}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+        />
+        <ChatReactionRow
+          postId={msg.id}
+          reactions={msg.reactions}
+          onToggle={(postId, emoji) => void onToggleReaction(postId, emoji)}
+          emojis={GATED_REACTION_EMOJIS}
+        />
+      </div>
+    </div>
+  );
+}
+
+// The loading footnote and the empty-channel hub bubble. Mutually exclusive with a populated list,
+// so this renders one of them (or nothing) exactly as the two sequential conditionals used to.
+function ChatMessagesPlaceholder({ isLoading, messageCount }: { isLoading: boolean; messageCount: number }) {
+  if (isLoading && messageCount === 0) {
+    return <p className={styles.chatFootnote}>Loading channel messages…</p>;
+  }
+  if (!isLoading && messageCount === 0) {
+    return (
+      <div className={styles.chatBubbleGroup}>
+        <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
+          This is the contributor channel. Threads, a wider reaction set, and longer messages — start
+          the first conversation.
+        </div>
+      </div>
+    );
+  }
+  return null;
+}
 
 export function GatedChatPanel({ currentUser, isAdmin = false }: GatedChatPanelProps) {
   const {
@@ -102,101 +300,20 @@ export function GatedChatPanel({ currentUser, isAdmin = false }: GatedChatPanelP
       ) : null}
 
       <div className={styles.chatMessages} ref={messagesContainerRef}>
-        {isLoading && messages.length === 0 ? (
-          <p className={styles.chatFootnote}>Loading channel messages…</p>
-        ) : null}
-
-        {!isLoading && messages.length === 0 ? (
-          <div className={styles.chatBubbleGroup}>
-            <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
-              This is the contributor channel. Threads, a wider reaction set, and longer messages — start
-              the first conversation.
-            </div>
-          </div>
-        ) : null}
+        <ChatMessagesPlaceholder isLoading={isLoading} messageCount={messages.length} />
 
         {messages.map((msg) => (
-          <div key={msg.id} className={msg.from === 'user' ? `${styles.chatRow} ${styles.chatRowUser}` : styles.chatRow}>
-            {msg.from === 'peer' ? (
-              <div className={styles.chatAvatar} aria-hidden="true">
-                {msg.senderLabel.replace(/^@/, '').charAt(0).toUpperCase() || 'C'}
-              </div>
-            ) : null}
-            <div className={styles.chatBubbleGroup} data-post-id={msg.id}>
-              <span className={msg.from === 'user' ? `${styles.chatSender} ${styles.chatSenderUser}` : styles.chatSender}>
-                {msg.senderLabel}
-              </span>
-              {msg.quotedMessage ? (
-                msg.quotedMessage.postId ? (
-                  <button
-                    type="button"
-                    className={`${styles.chatQuotedBlock} ${styles.chatQuotedBlockClickable}`}
-                    onClick={() => jumpToQuotedPost(msg.quotedMessage?.postId ?? null)}
-                    aria-label={`Go to the message from ${msg.quotedMessage.author} that this replies to`}
-                  >
-                    <span className={styles.chatQuotedAuthor}>{msg.quotedMessage.author}</span>
-                    <span className={styles.chatQuotedSnippet}>{msg.quotedMessage.snippet}</span>
-                  </button>
-                ) : (
-                  <div className={styles.chatQuotedBlock}>
-                    <span className={styles.chatQuotedAuthor}>{msg.quotedMessage.author}</span>
-                    <span className={styles.chatQuotedSnippet}>{msg.quotedMessage.snippet}</span>
-                  </div>
-                )
-              ) : null}
-              <div className={msg.from === 'user' ? `${styles.chatBubble} ${styles.chatBubbleUser}` : `${styles.chatBubble} ${styles.chatBubbleHub}`}>
-                {msg.text}
-              </div>
-              <div className={msg.from === 'user' ? `${styles.chatMetaRow} ${styles.chatMetaRowUser}` : styles.chatMetaRow}>
-                <span className={msg.from === 'user' ? `${styles.chatTime} ${styles.chatTimeUser}` : styles.chatTime}>
-                  {msg.timeLabel}
-                </span>
-                <button
-                  type="button"
-                  className={styles.chatReplyBtn}
-                  onClick={() => beginReply(msg)}
-                  aria-label={`Reply to ${msg.senderLabel}`}
-                >
-                  <Reply size={12} /> Reply
-                </button>
-                {msg.from === 'user' ? (
-                  <button
-                    type="button"
-                    className={styles.chatEditBtn}
-                    onClick={() => {
-                      // Editing is delete + repost: pull the text into the composer, delete the original,
-                      // and focus the box so the member fixes it and sends a fresh message.
-                      editMessage(msg.id, msg.text);
-                      inputRef.current?.focus();
-                    }}
-                    aria-label="Edit your message"
-                  >
-                    <Pencil size={12} /> Edit
-                  </button>
-                ) : null}
-                {msg.from === 'user' || isAdmin ? (
-                  <button
-                    type="button"
-                    className={styles.chatDeleteBtn}
-                    onClick={() => {
-                      if (window.confirm('Delete this message? This cannot be undone. To change it, delete and post again.')) {
-                        void deleteMessage(msg.id);
-                      }
-                    }}
-                    aria-label={msg.from === 'user' ? 'Delete your message' : `Delete message from ${msg.senderLabel}`}
-                  >
-                    <Trash2 size={12} /> Delete
-                  </button>
-                ) : null}
-              </div>
-              <ChatReactionRow
-                postId={msg.id}
-                reactions={msg.reactions}
-                onToggle={(postId, emoji) => void toggleReaction(postId, emoji)}
-                emojis={GATED_REACTION_EMOJIS}
-              />
-            </div>
-          </div>
+          <GatedMessageRow
+            key={msg.id}
+            msg={msg}
+            isAdmin={isAdmin}
+            inputRef={inputRef}
+            onBeginReply={beginReply}
+            onEditMessage={editMessage}
+            onDeleteMessage={deleteMessage}
+            onToggleReaction={toggleReaction}
+            onJumpToQuoted={jumpToQuotedPost}
+          />
         ))}
         <div ref={messagesEndRef} />
       </div>

--- a/ctf/packages/web/components/community-shell/notifications-panel.tsx
+++ b/ctf/packages/web/components/community-shell/notifications-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 import { ArrowUpRight, Check } from 'lucide-react';
 import type {
   Notification,
@@ -113,6 +113,149 @@ async function ensureDeviceSubscribed(): Promise<string | null> {
 // a client-side navigation to the same route would not remount the shell. It returns true when it
 // handled the link (this component then blocks the Link's own navigation), false for a link that
 // should navigate normally (e.g. /apps/<plugin>).
+// The loading / error / empty note that sits above the feed. Returns null once real rows exist.
+function NotificationsFeedStatus({
+  loading,
+  error,
+  count,
+}: {
+  loading: boolean;
+  error: string | null;
+  count: number;
+}) {
+  if (loading && count === 0) {
+    return <p className={styles.notificationsNote}>Loading…</p>;
+  }
+  if (!loading && error && count === 0) {
+    return <p className={styles.notificationsNote} role="status">{error}</p>;
+  }
+  if (!loading && !error && count === 0) {
+    return (
+      <div className={styles.notificationsEmpty}>
+        <p className={styles.notificationsEmptyTitle}>You&apos;re all caught up</p>
+        <p className={styles.notificationsEmptyBody}>
+          Updates you can act on — replies, credits, rides, and calls — show here as they happen.
+        </p>
+      </div>
+    );
+  }
+  return null;
+}
+
+// A single notification row: dot, summary, time, and an optional in-app "Open" deep link.
+function NotificationRow({
+  item,
+  markRead,
+  onOpenDeepLink,
+}: {
+  item: Notification;
+  markRead: (id: string) => void;
+  onOpenDeepLink?: (linkPath: string) => boolean;
+}) {
+  return (
+    <div
+      className={item.isRead ? styles.notificationRow : `${styles.notificationRow} ${styles.notificationRowUnread}`}
+      onMouseEnter={() => (item.isRead ? undefined : markRead(item.id))}
+    >
+      <span className={item.isRead ? styles.notificationDotRead : styles.notificationDot} aria-hidden="true" />
+      <div className={styles.notificationBody}>
+        <p className={styles.notificationSummary}>{item.summary}</p>
+        <span className={styles.notificationTime}>{formatTime(item.createdAtIso)}</span>
+        {item.linkPath ? (
+          <Link
+            href={item.linkPath}
+            className={styles.announcementChip}
+            onClick={(event) => {
+              markRead(item.id);
+              // Let the shell handle an in-Commons deep link in place (it can't rely on a remount);
+              // if it did, block the Link's own navigation. A plugin link falls through and navigates.
+              if (item.linkPath && onOpenDeepLink?.(item.linkPath)) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <ArrowUpRight size={13} color="currentColor" /> Open
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// Device-push opt-ins — the in-app feed is always on; these control the lock-screen ping only, and
+// all default off. Placed with the feed (not in account settings) so a member manages what pings them
+// right where they see what pinged them. Returns null until preferences have loaded.
+function NotificationsManage({
+  prefs,
+  savingPref,
+  pushNote,
+  manageOpen,
+  setManageOpen,
+  togglePref,
+}: {
+  prefs: NotificationPreferences | null;
+  savingPref: string | null;
+  pushNote: string | null;
+  manageOpen: boolean;
+  setManageOpen: Dispatch<SetStateAction<boolean>>;
+  togglePref: (key: keyof NotificationPreferences) => void;
+}) {
+  if (!prefs) return null;
+  return (
+    <div className={styles.notificationsManage}>
+      <button
+        type="button"
+        className={styles.notificationsManageToggle}
+        onClick={() => setManageOpen((open) => !open)}
+        aria-expanded={manageOpen}
+      >
+        {manageOpen ? 'Hide' : 'Manage what pings your device'}
+      </button>
+      {manageOpen ? (
+        <div className={styles.notificationsManageBody}>
+          <p className={styles.notificationsManageNote}>
+            Everything shows in this list either way. These switches only control whether your
+            device also pings you. All are off unless you turn them on.
+          </p>
+          {pushNote ? (
+            <p className={styles.notificationsManageNote} role="status">{pushNote}</p>
+          ) : null}
+          {PUSH_TOGGLES.map((toggle) => (
+            <label key={toggle.key} className={styles.notificationsPrefRow} aria-label={toggle.label}>
+              <input
+                type="checkbox"
+                aria-label={toggle.label}
+                checked={prefs[toggle.key]}
+                disabled={savingPref === toggle.key}
+                onChange={() => togglePref(toggle.key)}
+              />
+              <span className={styles.notificationsPrefText}>
+                <span className={styles.notificationsPrefLabel}>{toggle.label}</span>
+                <span className={styles.notificationsPrefDetail}>{toggle.detail}</span>
+              </span>
+            </label>
+          ))}
+          <label className={styles.notificationsPrefRow} aria-label="Keep device pings discreet">
+            <input
+              type="checkbox"
+              aria-label="Keep device pings discreet"
+              checked={prefs.discreetPush}
+              disabled={savingPref === 'discreetPush'}
+              onChange={() => togglePref('discreetPush')}
+            />
+            <span className={styles.notificationsPrefText}>
+              <span className={styles.notificationsPrefLabel}>Keep device pings discreet</span>
+              <span className={styles.notificationsPrefDetail}>
+                The ping just says you have an update — no plugin name or details on your lock screen.
+              </span>
+            </span>
+          </label>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function NotificationsPanel({ onOpenDeepLink }: { onOpenDeepLink?: (linkPath: string) => boolean }) {
   const [items, setItems] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
@@ -207,109 +350,20 @@ export function NotificationsPanel({ onOpenDeepLink }: { onOpenDeepLink?: (linkP
         ) : null}
       </div>
 
-      {loading && items.length === 0 ? (
-        <p className={styles.notificationsNote}>Loading…</p>
-      ) : null}
-
-      {!loading && error && items.length === 0 ? (
-        <p className={styles.notificationsNote} role="status">{error}</p>
-      ) : null}
-
-      {!loading && !error && items.length === 0 ? (
-        <div className={styles.notificationsEmpty}>
-          <p className={styles.notificationsEmptyTitle}>You&apos;re all caught up</p>
-          <p className={styles.notificationsEmptyBody}>
-            Updates you can act on — replies, credits, rides, and calls — show here as they happen.
-          </p>
-        </div>
-      ) : null}
+      <NotificationsFeedStatus loading={loading} error={error} count={items.length} />
 
       {items.map((item) => (
-        <div
-          key={item.id}
-          className={item.isRead ? styles.notificationRow : `${styles.notificationRow} ${styles.notificationRowUnread}`}
-          onMouseEnter={() => (item.isRead ? undefined : markRead(item.id))}
-        >
-          <span className={item.isRead ? styles.notificationDotRead : styles.notificationDot} aria-hidden="true" />
-          <div className={styles.notificationBody}>
-            <p className={styles.notificationSummary}>{item.summary}</p>
-            <span className={styles.notificationTime}>{formatTime(item.createdAtIso)}</span>
-            {item.linkPath ? (
-              <Link
-                href={item.linkPath}
-                className={styles.announcementChip}
-                onClick={(event) => {
-                  markRead(item.id);
-                  // Let the shell handle an in-Commons deep link in place (it can't rely on a remount);
-                  // if it did, block the Link's own navigation. A plugin link falls through and navigates.
-                  if (item.linkPath && onOpenDeepLink?.(item.linkPath)) {
-                    event.preventDefault();
-                  }
-                }}
-              >
-                <ArrowUpRight size={13} color="currentColor" /> Open
-              </Link>
-            ) : null}
-          </div>
-        </div>
+        <NotificationRow key={item.id} item={item} markRead={markRead} onOpenDeepLink={onOpenDeepLink} />
       ))}
 
-      {/* Device-push opt-ins — the in-app feed above is always on; these control the lock-screen ping
-          only, and all default off. Placed here (not in account settings) so a member manages what
-          pings them right where they see what pinged them. */}
-      {prefs ? (
-        <div className={styles.notificationsManage}>
-          <button
-            type="button"
-            className={styles.notificationsManageToggle}
-            onClick={() => setManageOpen((open) => !open)}
-            aria-expanded={manageOpen}
-          >
-            {manageOpen ? 'Hide' : 'Manage what pings your device'}
-          </button>
-          {manageOpen ? (
-            <div className={styles.notificationsManageBody}>
-              <p className={styles.notificationsManageNote}>
-                Everything shows in this list either way. These switches only control whether your
-                device also pings you. All are off unless you turn them on.
-              </p>
-              {pushNote ? (
-                <p className={styles.notificationsManageNote} role="status">{pushNote}</p>
-              ) : null}
-              {PUSH_TOGGLES.map((toggle) => (
-                <label key={toggle.key} className={styles.notificationsPrefRow} aria-label={toggle.label}>
-                  <input
-                    type="checkbox"
-                    aria-label={toggle.label}
-                    checked={prefs[toggle.key]}
-                    disabled={savingPref === toggle.key}
-                    onChange={() => togglePref(toggle.key)}
-                  />
-                  <span className={styles.notificationsPrefText}>
-                    <span className={styles.notificationsPrefLabel}>{toggle.label}</span>
-                    <span className={styles.notificationsPrefDetail}>{toggle.detail}</span>
-                  </span>
-                </label>
-              ))}
-              <label className={styles.notificationsPrefRow} aria-label="Keep device pings discreet">
-                <input
-                  type="checkbox"
-                  aria-label="Keep device pings discreet"
-                  checked={prefs.discreetPush}
-                  disabled={savingPref === 'discreetPush'}
-                  onChange={() => togglePref('discreetPush')}
-                />
-                <span className={styles.notificationsPrefText}>
-                  <span className={styles.notificationsPrefLabel}>Keep device pings discreet</span>
-                  <span className={styles.notificationsPrefDetail}>
-                    The ping just says you have an update — no plugin name or details on your lock screen.
-                  </span>
-                </span>
-              </label>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+      <NotificationsManage
+        prefs={prefs}
+        savingPref={savingPref}
+        pushNote={pushNote}
+        manageOpen={manageOpen}
+        setManageOpen={setManageOpen}
+        togglePref={togglePref}
+      />
     </div>
   );
 }

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -1,18 +1,27 @@
 'use client';
 
 import Link from 'next/link';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { AtSign, Pencil, Reply, Trash2, X } from 'lucide-react';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
 import type { PublicCommunityPost } from '../../lib/feed/types';
 import { feedAuthorHandle } from '../../lib/feed/author-handle';
-import type { ChatMessage, ComicStreamItem, ShellCurrentUser, ShellStats } from './shell-types';
-import { useHomeChat } from './use-home-chat';
+import type {
+  ChatMessage,
+  ChatQuotedMessage,
+  ComicAnswerRating,
+  ComicStreamItem,
+  ShellCurrentUser,
+  ShellStats,
+} from './shell-types';
+import { useHomeChat, type ReplyTarget } from './use-home-chat';
 import { ComicAnswerCard, ComicPendingCard } from './comic-cards';
 import { AnnouncementCard } from './announcement-card';
 import { NotificationsPanel } from './notifications-panel';
 import { ChatReactionRow } from './chat-reaction-row';
 import { ComicConsentModal } from './comic-consent-modal';
+import type { HubTypingUser } from '../../lib/hub/live-stream';
+import type { HubSuggestionChip } from '../../lib/concierge/hub-suggestions';
 import styles from './community-shell.module.css';
 import { feedPostLength } from '../../lib/feed/normalize';
 import { FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH, FEED_MAX_COMMUNITY_POST_LENGTH } from '../../lib/feed/constants';
@@ -151,35 +160,7 @@ function PublicCommunityPanel({ plugins, signInUrl }: { stats: ShellStats; plugi
         {loading ? (
           <p className={styles.chatFootnote}>Loading community posts…</p>
         ) : hasPosts ? (
-          posts.map((post) => {
-            const authorLabel = post.authorUsername ? `@${post.authorUsername}` : 'Community member';
-            const initial = post.authorUsername ? post.authorUsername.charAt(0).toUpperCase() : 'C';
-            return (
-              // Discord-style full-width row: avatar left, handle + timestamp on top, body below.
-              // The faint per-author background makes adjacent posts from different members
-              // visibly distinct without turning the message into a colored blob.
-              <div
-                key={post.id}
-                className={styles.publicChatRow}
-                style={{ background: publicRowBackground(post.authorUsername) }}
-              >
-                <div
-                  className={styles.chatAvatar}
-                  style={{ background: publicAvatarBackground(post.authorUsername) }}
-                  aria-hidden="true"
-                >
-                  {initial}
-                </div>
-                <div className={styles.publicChatContent}>
-                  <div className={styles.publicChatMeta}>
-                    <span className={styles.chatSender}>{authorLabel}</span>
-                    <span className={styles.publicChatTime}>{formatPostTime(post.createdAtIso)}</span>
-                  </div>
-                  <div className={styles.publicChatBody}>{post.body}</div>
-                </div>
-              </div>
-            );
-          })
+          posts.map((post) => <PublicCommunityRow key={post.id} post={post} />)
         ) : (
           <div className={styles.chatBubbleGroup}>
             <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
@@ -205,6 +186,134 @@ function PublicCommunityPanel({ plugins, signInUrl }: { stats: ShellStats; plugi
   );
 }
 
+// Discord-style full-width row: avatar left, handle + timestamp on top, body below. The faint
+// per-author background makes adjacent posts from different members visibly distinct without turning
+// the message into a colored blob.
+function PublicCommunityRow({ post }: { post: PublicCommunityPost }) {
+  const authorLabel = post.authorUsername ? `@${post.authorUsername}` : 'Community member';
+  const initial = post.authorUsername ? post.authorUsername.charAt(0).toUpperCase() : 'C';
+  return (
+    <div
+      className={styles.publicChatRow}
+      style={{ background: publicRowBackground(post.authorUsername) }}
+    >
+      <div
+        className={styles.chatAvatar}
+        style={{ background: publicAvatarBackground(post.authorUsername) }}
+        aria-hidden="true"
+      >
+        {initial}
+      </div>
+      <div className={styles.publicChatContent}>
+        <div className={styles.publicChatMeta}>
+          <span className={styles.chatSender}>{authorLabel}</span>
+          <span className={styles.publicChatTime}>{formatPostTime(post.createdAtIso)}</span>
+        </div>
+        <div className={styles.publicChatBody}>{post.body}</div>
+      </div>
+    </div>
+  );
+}
+
+// Length cap for a member: admins get the higher cap the API grants them, so the counter never warns
+// the owner about a post the server would happily accept.
+function maxPostLength(isAdmin: boolean): number {
+  return isAdmin ? FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH : FEED_MAX_COMMUNITY_POST_LENGTH;
+}
+
+// How many characters an @comic-free post is over the limit (0 for an @comic question, which routes
+// to the AI Assistant on its own route with its own limit, so the Commons cap does not apply).
+function computeComposerOverBy(mentionsComic: boolean, length: number, maxLength: number): number {
+  if (mentionsComic) return 0;
+  return Math.max(0, length - maxLength);
+}
+
+// Show the character count only in the last stretch before the limit — an always-on counter is noise
+// on a two-line message. Hidden entirely for @comic questions.
+function computeShowComposerCount(mentionsComic: boolean, length: number, maxLength: number): boolean {
+  return !mentionsComic && length > maxLength - 150;
+}
+
+// The @-form other members type to mention this member — shown in the mentions empty state.
+// feedAuthorHandle already prefixes a set username with '@'; the id pseudonym needs it added.
+function mentionLabel(handle: string): string {
+  return handle.startsWith('@') ? handle : `@${handle}`;
+}
+
+// "X is typing…" line shown above the composer when the live connection is up and someone else is
+// typing. One name reads "X is typing…", two read "X and Y are typing…", more collapse to a count.
+function computeTypingLabel(typingUsers: HubTypingUser[]): string | null {
+  if (typingUsers.length === 0) return null;
+  if (typingUsers.length === 1) return `${typingUsers[0].name} is typing…`;
+  if (typingUsers.length === 2) return `${typingUsers[0].name} and ${typingUsers[1].name} are typing…`;
+  return `${typingUsers[0].name} and ${typingUsers.length - 1} others are typing…`;
+}
+
+function selectorForDeepLink(postId: string | null, announcementId: string | null): string | null {
+  if (postId) return `[data-post-id="${postId}"]`;
+  if (announcementId) return `[data-announcement-id="${announcementId}"]`;
+  return null;
+}
+
+// Scroll a target element into view and flash it, so the eye lands on it. Shared by the quoted-reply
+// jump and the deep-link jump.
+function scrollAndFlash(target: HTMLElement): void {
+  target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  target.classList.add(styles.chatBubbleFlash);
+  window.setTimeout(() => target.classList.remove(styles.chatBubbleFlash), 1600);
+}
+
+// Build the interleaved, time-ordered stream: tag hub messages and comic items with a numeric epoch,
+// then sort once so AI cards weave chronologically among community posts. `order` (source index) is a
+// stable tiebreaker for equal/absent timestamps. A filtered mode (mentions or announcements) shows
+// only the matching messages the server returned; the AI (@comic) cards are local to this member and
+// are hidden while any filter is on.
+function buildStreamEntries(
+  messages: ChatMessage[],
+  comicItems: ComicStreamItem[],
+  mentionsOnly: boolean,
+  announcementsOnly: boolean,
+): StreamEntry[] {
+  const toEpoch = (iso: string | undefined, fallback: number): number => {
+    if (!iso) return fallback;
+    const epoch = new Date(iso).getTime();
+    return Number.isNaN(epoch) ? fallback : epoch;
+  };
+
+  const filterActive = mentionsOnly || announcementsOnly;
+  const entries: StreamEntry[] = [
+    ...messages.map((message, index): StreamEntry => ({
+      kind: 'message',
+      message,
+      epoch: toEpoch(message.sentAtIso, index),
+      order: index,
+    })),
+    ...(filterActive ? [] : comicItems).map((item, index): StreamEntry => ({
+      kind: 'comic',
+      item,
+      epoch: toEpoch(item.askedAtIso, index),
+      order: index,
+    })),
+  ];
+
+  entries.sort((a, b) => (a.epoch - b.epoch) || (a.order - b.order));
+  return entries;
+}
+
+// Index of the first stream entry newer than the member's last-seen marker — where the single
+// "New messages" divider is drawn. -1 means "nothing new" (no divider).
+function computeUnreadDividerIndex(streamEntries: StreamEntry[], lastSeenAtIso: string | null): number {
+  if (!lastSeenAtIso) return -1;
+  const lastSeenEpoch = new Date(lastSeenAtIso).getTime();
+  if (Number.isNaN(lastSeenEpoch)) return -1;
+  return streamEntries.findIndex((entry) => entry.epoch > lastSeenEpoch);
+}
+
+// The React key for a stream entry, matching the per-branch keys the entries used to carry inline.
+function streamEntryKey(entry: StreamEntry): string {
+  return entry.kind === 'comic' ? `comic-${entry.item.questionTurnId}` : entry.message.id;
+}
+
 function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedChatPanelProps) {
   // A member who hasn't set a username posts under a stable per-user handle
   // (matching the server's feedAuthorHandle and Chyme), so they stay recognizable
@@ -212,9 +321,7 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
   // them to set a real username below.
   const ownHandle = feedAuthorHandle(currentUser.username, currentUser.userId);
   const needsUsername = !currentUser.username;
-  // Length cap for THIS member: admins get the higher cap the API grants them, so the counter never
-  // warns the owner about a post the server would happily accept.
-  const maxLength = isAdmin ? FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH : FEED_MAX_COMMUNITY_POST_LENGTH;
+  const maxLength = maxPostLength(isAdmin);
   const {
     messages,
     comicItems,
@@ -254,27 +361,11 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
   // Live length of what is in the composer, measured exactly the way the server measures it: on the
   // whitespace-normalized text, not the raw characters (see lib/feed/normalize.ts). Counting raw
   // characters would tell a member who indents or double-spaces that they are over when they are not.
-  //
-  // An @comic question goes to the AI Assistant on a different route with its own limit, so the
-  // Commons cap does not apply and the counter stays out of the way for those.
   const composerLength = useMemo(() => feedPostLength(input), [input]);
-  const composerOverBy = composerMentionsComic ? 0 : Math.max(0, composerLength - maxLength);
-  // Stay quiet until the last stretch. A counter that is always on is noise on a two-line message;
-  // what a member needs is a warning while there is still time to shape the ending, and then an
-  // exact number to cut.
-  const showComposerCount = !composerMentionsComic && composerLength > maxLength - 150;
-
-  // The @-form other members type to mention this member — shown in the mentions empty state.
-  // feedAuthorHandle already prefixes a set username with '@'; the id pseudonym needs it added.
-  const ownMentionLabel = ownHandle.startsWith('@') ? ownHandle : `@${ownHandle}`;
-  // "X is typing…" line shown above the composer when the live connection is up and someone else is
-  // typing. One name reads "X is typing…", two read "X and Y are typing…", more collapse to a count.
-  const typingLabel = useMemo<string | null>(() => {
-    if (typingUsers.length === 0) return null;
-    if (typingUsers.length === 1) return `${typingUsers[0].name} is typing…`;
-    if (typingUsers.length === 2) return `${typingUsers[0].name} and ${typingUsers[1].name} are typing…`;
-    return `${typingUsers[0].name} and ${typingUsers.length - 1} others are typing…`;
-  }, [typingUsers]);
+  const composerOverBy = computeComposerOverBy(composerMentionsComic, composerLength, maxLength);
+  const showComposerCount = computeShowComposerCount(composerMentionsComic, composerLength, maxLength);
+  const ownMentionLabel = mentionLabel(ownHandle);
+  const typingLabel = useMemo<string | null>(() => computeTypingLabel(typingUsers), [typingUsers]);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   // The 🔔 notifications center replaces the message stream + composer when open. It is a separate
@@ -283,17 +374,13 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
   // Tapping a quoted-reply block jumps to the original message (a common chat behavior): find the
-  // rendered bubble with that community post id, scroll it into view, and flash a highlight so the
-  // eye lands on it. No-op when the quoted post is not in the loaded window (older than the recent
-  // page) — the snippet in the quote block already shows what was said.
+  // rendered bubble with that community post id, scroll it into view, and flash a highlight. No-op
+  // when the quoted post is not in the loaded window (older than the recent page) — the snippet in
+  // the quote block already shows what was said.
   const jumpToQuotedPost = useCallback((postId: string | null) => {
     if (!postId) return;
-    const container = messagesContainerRef.current;
-    const target = container?.querySelector<HTMLElement>(`[data-post-id="${postId}"]`);
-    if (!target) return;
-    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    target.classList.add(styles.chatBubbleFlash);
-    window.setTimeout(() => target.classList.remove(styles.chatBubbleFlash), 1600);
+    const target = messagesContainerRef.current?.querySelector<HTMLElement>(`[data-post-id="${postId}"]`);
+    if (target) scrollAndFlash(target);
   }, []);
 
   // Scroll a deep-link target (a post bubble or announcement card) into view and flash it. The target
@@ -304,12 +391,9 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
     let attempts = 0;
     let timer = 0;
     const tryScroll = () => {
-      const container = messagesContainerRef.current;
-      const target = container?.querySelector<HTMLElement>(selector);
+      const target = messagesContainerRef.current?.querySelector<HTMLElement>(selector);
       if (target) {
-        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        target.classList.add(styles.chatBubbleFlash);
-        window.setTimeout(() => target.classList.remove(styles.chatBubbleFlash), 1600);
+        scrollAndFlash(target);
         if (window.location.search) {
           window.history.replaceState(null, '', window.location.pathname);
         }
@@ -325,13 +409,6 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
       if (timer) window.clearTimeout(timer);
     };
   }, []);
-
-  const selectorForDeepLink = (postId: string | null, announcementId: string | null): string | null =>
-    postId
-      ? `[data-post-id="${postId}"]`
-      : announcementId
-        ? `[data-announcement-id="${announcementId}"]`
-        : null;
 
   // Cold entry via URL (a fresh page load / device-push tap opening /?post=<id> or /?announcement=<id>):
   // show the stream and jump to the target. The chat hook has already pulled the target's window on
@@ -386,51 +463,15 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
   }, [input]);
 
-  // Build the interleaved, time-ordered stream: tag hub messages and comic items with a numeric
-  // epoch, then sort once so AI cards weave chronologically among community posts. `order` (source
-  // index) is a stable tiebreaker for equal/absent timestamps. The asker's own questions show their
-  // display name; this hub only renders the current user's @comic items (server-scoped).
-  const streamEntries = useMemo<StreamEntry[]>(() => {
-    const toEpoch = (iso: string | undefined, fallback: number): number => {
-      if (!iso) return fallback;
-      const epoch = new Date(iso).getTime();
-      return Number.isNaN(epoch) ? fallback : epoch;
-    };
-
-    // A filtered mode (mentions or announcements) shows only the matching messages the server
-    // returned; the AI (@comic) cards are local to this member and are hidden while any filter is on.
-    const filterActive = mentionsOnly || announcementsOnly;
-    const entries: StreamEntry[] = [
-      ...messages.map((message, index): StreamEntry => ({
-        kind: 'message',
-        message,
-        epoch: toEpoch(message.sentAtIso, index),
-        order: index,
-      })),
-      ...(filterActive ? [] : comicItems).map((item, index): StreamEntry => ({
-        kind: 'comic',
-        item,
-        epoch: toEpoch(item.askedAtIso, index),
-        order: index,
-      })),
-    ];
-
-    entries.sort((a, b) => (a.epoch - b.epoch) || (a.order - b.order));
-    return entries;
-  }, [messages, comicItems, mentionsOnly, announcementsOnly]);
+  // The asker's own questions show their display name; this hub only renders the current user's
+  // @comic items (server-scoped).
+  const streamEntries = useMemo<StreamEntry[]>(() => buildStreamEntries(messages, comicItems, mentionsOnly, announcementsOnly), [messages, comicItems, mentionsOnly, announcementsOnly]);
 
   const hasContent = streamEntries.length > 0;
 
-  // Index of the first stream entry newer than the member's last-seen marker — where the single
-  // "New messages" divider is drawn. -1 means "nothing new" (no divider). The marker is frozen
-  // for the life of this mount (captured once on entry) so the divider does not creep down as the
-  // member reads or as best-effort "mark seen" runs.
-  const unreadDividerIndex = useMemo<number>(() => {
-    if (!lastSeenAtIso) return -1;
-    const lastSeenEpoch = new Date(lastSeenAtIso).getTime();
-    if (Number.isNaN(lastSeenEpoch)) return -1;
-    return streamEntries.findIndex((entry) => entry.epoch > lastSeenEpoch);
-  }, [streamEntries, lastSeenAtIso]);
+  // The last-seen marker is frozen for the life of this mount (captured once on entry) so the divider
+  // does not creep down as the member reads or as best-effort "mark seen" runs.
+  const unreadDividerIndex = useMemo<number>(() => computeUnreadDividerIndex(streamEntries, lastSeenAtIso), [streamEntries, lastSeenAtIso]);
 
   // Auto-scroll the chat to the latest entry when the stream grows (a sent message, a concierge
   // reply, or new polled history), so members always land on what they saw last — like a normal chat.
@@ -463,269 +504,557 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
       {notificationsOpen ? (
         <NotificationsPanel onOpenDeepLink={handleNotificationOpen} />
       ) : (
-      <div className={styles.chatMessages} ref={messagesContainerRef}>
-        {(isLoading || isFilterRefreshing) && !hasContent ? (
-          <p className={styles.chatFootnote}>
-            {mentionsOnly ? 'Looking for your mentions…' : announcementsOnly ? 'Loading announcements…' : 'Loading live messages…'}
-          </p>
-        ) : null}
-
-        {!isLoading && !isFilterRefreshing && !hasContent ? (
-          <div className={styles.chatBubbleGroup}>
-            <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
-              {mentionsOnly ? (
-                <>No mentions yet. When someone writes <strong>{ownMentionLabel}</strong>, it shows here.</>
-              ) : announcementsOnly ? (
-                <>No announcements yet. Official updates from the team show here.</>
-              ) : (
-                <>You are connected. Share with the community, or type <strong>@comic</strong> to ask the AI Assistant.</>
-              )}
-            </div>
-          </div>
-        ) : null}
-
-        {streamEntries.map((entry, index) => {
-          // A single "New messages" divider sits immediately before the first entry newer than
-          // the member's last-seen marker. Rendered ahead of whichever entry follows it.
-          const divider = index === unreadDividerIndex ? (
-            <div key="unread-divider" className={styles.unreadDivider} role="separator" aria-label="New messages">
-              <span className={styles.unreadDividerLabel}>New messages</span>
-            </div>
-          ) : null;
-
-          if (entry.kind === 'comic') {
-            const { item } = entry;
-            if (item.status === 'answered') {
-              return (
-                <Fragment key={`comic-${item.questionTurnId}`}>
-                  {divider}
-                  <ComicAnswerCard
-                    item={item}
-                    askedByLabel={currentUser.displayName}
-                    onRate={rateComicAnswer}
-                  />
-                </Fragment>
-              );
-            }
-            return (
-              <Fragment key={`comic-${item.questionTurnId}`}>
-                {divider}
-                <ComicPendingCard
-                  item={item}
-                  askedByLabel={currentUser.displayName}
-                />
-              </Fragment>
-            );
-          }
-
-          const msg = entry.message;
-          // The author shown above the bubble. Your own messages are attributed to you (handle when
-          // we have it) so every message has a visible author, not just other people's — peer posts
-          // were rendering with no name on the sender's own side.
-          const ownLabel = ownHandle;
-          const senderName = msg.from === 'user' ? ownLabel : (msg.senderLabel ?? 'Survivor Hub');
-
-          // An official announcement renders as its own distinct card (badge + optional title),
-          // not a chat bubble, so it stands apart from peer posts and AI answers.
-          if (msg.kind === 'announcement') {
-            return (
-              <Fragment key={msg.id}>
-                {divider}
-                <AnnouncementCard
-                  senderName={senderName}
-                  title={msg.announcementTitle ?? null}
-                  body={msg.text}
-                  time={msg.time}
-                  linkedPlugins={msg.linkedPlugins ?? []}
-                  announcementId={msg.announcementId ?? null}
-                  reactions={msg.reactions}
-                  replyCount={msg.replyCount}
-                  onToggleReaction={(id, emoji) => void toggleAnnouncementReaction(id, emoji)}
-                />
-              </Fragment>
-            );
-          }
-
-          // A peer post (it carries a community post id) can be replied to Signal-style.
-          const canReply = Boolean(msg.communityPostId);
-          // The member can delete their own peer post (there is no edit — delete and repost instead).
-          const canDelete = msg.from === 'user' && Boolean(msg.communityPostId);
-          return (
-            <Fragment key={msg.id}>
-              {divider}
-              <div
-                className={msg.from === 'user' ? `${styles.chatRow} ${styles.chatRowUser}` : styles.chatRow}
-              >
-                {msg.from === 'hub' ? <div className={styles.chatAvatar} aria-hidden="true">{avatarFromSender(senderName)}</div> : null}
-                <div className={styles.chatBubbleGroup} data-post-id={msg.communityPostId ?? undefined}>
-                  <span className={msg.from === 'user' ? `${styles.chatSender} ${styles.chatSenderUser}` : styles.chatSender}>{senderName}</span>
-                  {msg.quotedMessage ? (
-                    msg.quotedMessage.postId ? (
-                      <button
-                        type="button"
-                        className={`${styles.chatQuotedBlock} ${styles.chatQuotedBlockClickable}`}
-                        onClick={() => jumpToQuotedPost(msg.quotedMessage?.postId ?? null)}
-                        aria-label={`Go to the message from ${msg.quotedMessage.author} that this replies to`}
-                      >
-                        <span className={styles.chatQuotedAuthor}>{msg.quotedMessage.author}</span>
-                        <span className={styles.chatQuotedSnippet}>{msg.quotedMessage.snippet}</span>
-                      </button>
-                    ) : (
-                      <div className={styles.chatQuotedBlock}>
-                        <span className={styles.chatQuotedAuthor}>{msg.quotedMessage.author}</span>
-                        <span className={styles.chatQuotedSnippet}>{msg.quotedMessage.snippet}</span>
-                      </div>
-                    )
-                  ) : null}
-                  <div className={msg.from === 'user' ? `${styles.chatBubble} ${styles.chatBubbleUser}` : `${styles.chatBubble} ${styles.chatBubbleHub}`}>
-                    {msg.text}
-                  </div>
-                  {msg.actionLabel && msg.actionSlug ? (
-                    <Link href={`/apps/${msg.actionSlug}`} className={styles.chatActionBtn}>
-                      {msg.actionLabel}
-                    </Link>
-                  ) : null}
-                  <div className={msg.from === 'user' ? `${styles.chatMetaRow} ${styles.chatMetaRowUser}` : styles.chatMetaRow}>
-                    <span className={msg.from === 'user' ? `${styles.chatTime} ${styles.chatTimeUser}` : styles.chatTime}>
-                      {msg.time}
-                    </span>
-                    {canReply ? (
-                      <button
-                        type="button"
-                        className={styles.chatReplyBtn}
-                        onClick={() => beginReply(msg)}
-                        aria-label={`Reply to ${senderName}`}
-                      >
-                        <Reply size={12} /> Reply
-                      </button>
-                    ) : null}
-                    {canDelete && msg.communityPostId ? (
-                      <button
-                        type="button"
-                        className={styles.chatEditBtn}
-                        onClick={() => {
-                          // Editing is delete + repost: pull the text back into the composer, delete the
-                          // original, and focus the box so the member fixes it and sends a fresh post.
-                          editMessage(msg.communityPostId as string, msg.text);
-                          inputRef.current?.focus();
-                        }}
-                        aria-label="Edit your post"
-                      >
-                        <Pencil size={12} /> Edit
-                      </button>
-                    ) : null}
-                    {canDelete && msg.communityPostId ? (
-                      <button
-                        type="button"
-                        className={styles.chatDeleteBtn}
-                        onClick={() => {
-                          if (window.confirm('Delete this post? This cannot be undone. To change it, delete and post again.')) {
-                            void deleteMessage(msg.communityPostId as string);
-                          }
-                        }}
-                        aria-label="Delete your post"
-                      >
-                        <Trash2 size={12} /> Delete
-                      </button>
-                    ) : null}
-                  </div>
-                  {msg.communityPostId ? (
-                    <ChatReactionRow
-                      postId={msg.communityPostId}
-                      reactions={msg.reactions}
-                      onToggle={(postId, emoji) => void toggleReaction(postId, emoji)}
-                      // A member may only react to posts they did not author. On the member's own
-                      // post the row is read-only: it shows others' reactions but offers no way to add.
-                      readOnly={msg.from === 'user'}
-                    />
-                  ) : null}
-                </div>
-              </div>
-            </Fragment>
-          );
-        })}
-        <div ref={messagesEndRef} />
-      </div>
+        <MessageStream
+          messagesContainerRef={messagesContainerRef}
+          messagesEndRef={messagesEndRef}
+          inputRef={inputRef}
+          isLoading={isLoading}
+          isFilterRefreshing={isFilterRefreshing}
+          hasContent={hasContent}
+          mentionsOnly={mentionsOnly}
+          announcementsOnly={announcementsOnly}
+          ownMentionLabel={ownMentionLabel}
+          ownHandle={ownHandle}
+          currentUser={currentUser}
+          streamEntries={streamEntries}
+          unreadDividerIndex={unreadDividerIndex}
+          onRate={rateComicAnswer}
+          onToggleAnnouncementReaction={toggleAnnouncementReaction}
+          onJumpToQuoted={jumpToQuotedPost}
+          onBeginReply={beginReply}
+          onEdit={editMessage}
+          onDelete={deleteMessage}
+          onToggleReaction={toggleReaction}
+        />
       )}
 
-      {/* One-tap suggestion chips (#471) — persistent (shown whether or not the chat already has
-          messages), so a member can always tap one. Each chip does the right thing on a single tap,
-          never just a composer pre-fill (the original #471 complaint): a NAVIGATE chip opens that
-          plugin directly (it is an action, not a question), and an ASK chip routes the question to the
-          @comic AI assistant, which shows the "reviewing for safety" pending card immediately and the
-          human-approved answer when it is ready. The "@ Mentions" filter chip leads this row at every
-          width (owner directive, 2026-07-17; it previously floated alone above the desktop stream) —
-          same pill size as the suggestion chips, sky-blue so it stays visually distinct; it scrolls
-          with the row. The rail always renders because the chip is always present. */}
-      <div className={styles.conciergeChipRail} role="group" aria-label="Ask what you need">
-        {/* Mentions filter — icon-only "@" chip (the word was dropped to match the 📣 chip), so the
-            two stream filters read as a matched pair of small glyph pills. */}
-        <button
-          type="button"
-          className={mentionsOnly && !notificationsOpen ? `${styles.mentionsFilterBtn} ${styles.mentionsFilterBtnActive}` : styles.mentionsFilterBtn}
-          onClick={() => { setNotificationsOpen(false); toggleMentionsOnly(); }}
-          aria-pressed={mentionsOnly && !notificationsOpen}
-          aria-label={mentionsOnly ? 'Show all messages' : 'Show only messages that mention you'}
-          title={mentionsOnly ? 'Show all messages' : 'Show only messages that mention you'}
-        >
-          <AtSign size={15} aria-hidden="true" />
-        </button>
-        {/* Announcements filter — "Announcements" is too long for a chip, so it shows the 📣 emoji
-            alone. Filtering to announcements lets a member with limited message history still surface
-            official updates that scrolled off the recent page. */}
-        <button
-          type="button"
-          className={announcementsOnly && !notificationsOpen ? `${styles.announcementsFilterBtn} ${styles.announcementsFilterBtnActive}` : styles.announcementsFilterBtn}
-          onClick={() => { setNotificationsOpen(false); toggleAnnouncementsOnly(); }}
-          aria-pressed={announcementsOnly && !notificationsOpen}
-          aria-label={announcementsOnly ? 'Show all messages' : 'Show only announcements'}
-          title={announcementsOnly ? 'Show all messages' : 'Show only announcements'}
-        >
-          <span aria-hidden="true">📣</span>
-        </button>
-        {/* Notifications center — the 🔔 chip opens the member's cross-plugin notifications feed in
-            place of the chat stream (a separate view, not a filter). Styled like the filter chips so
-            the three read as a row of glyph pills. */}
-        <button
-          type="button"
-          className={notificationsOpen ? `${styles.notificationsFilterBtn} ${styles.notificationsFilterBtnActive}` : styles.notificationsFilterBtn}
-          onClick={() => setNotificationsOpen((open) => !open)}
-          aria-pressed={notificationsOpen}
-          aria-label={notificationsOpen ? 'Back to the conversation' : 'Show your notifications'}
-          title={notificationsOpen ? 'Back to the conversation' : 'Show your notifications'}
-        >
-          <span aria-hidden="true">🔔</span>
-        </button>
-        {notificationsOpen
-          ? null
-          : suggestionChips.map((chip) =>
-              chip.kind === 'navigate' ? (
-                <Link
-                  key={chip.id}
-                  href={`/apps/${chip.slug}`}
-                  className={styles.conciergeChip}
-                  title={chip.label}
-                >
-                  {chip.label}
-                </Link>
-              ) : (
-                <button
-                  key={chip.id}
-                  type="button"
-                  className={styles.conciergeChip}
-                  title={chip.label}
-                  onClick={() => askComic(chip.question)}
-                >
-                  {chip.label}
-                </button>
-              ),
-            )}
-      </div>
+      <ConciergeChipRail
+        mentionsOnly={mentionsOnly}
+        announcementsOnly={announcementsOnly}
+        notificationsOpen={notificationsOpen}
+        chips={suggestionChips}
+        onToggleMentions={() => { setNotificationsOpen(false); toggleMentionsOnly(); }}
+        onToggleAnnouncements={() => { setNotificationsOpen(false); toggleAnnouncementsOnly(); }}
+        onToggleNotifications={() => setNotificationsOpen((open) => !open)}
+        onAsk={askComic}
+      />
 
       {/* Composer + helpers hide while the notifications center is open — you read notifications
           there, you don't post into them. The chip row above stays so 🔔 can toggle back. */}
       {notificationsOpen ? null : (
+        <ChatComposer
+          input={input}
+          setInput={setInput}
+          notifyTyping={notifyTyping}
+          inputRef={inputRef}
+          replyTarget={replyTarget}
+          onCancelReply={cancelReply}
+          typingLabel={typingLabel}
+          composerMentionsComic={composerMentionsComic}
+          composerOverBy={composerOverBy}
+          isSending={isSending}
+          onSend={sendMessage}
+          showComposerCount={showComposerCount}
+          composerLength={composerLength}
+          maxLength={maxLength}
+          isLive={isLive}
+        />
+      )}
+
+      <ComicConsentModal open={consentModalOpen} onConfirm={() => void confirmConsent()} onDismiss={dismissConsent} />
+    </div>
+  );
+}
+
+type StreamCallbacks = {
+  onRate: (turnId: string, rating: ComicAnswerRating) => void;
+  onToggleAnnouncementReaction: (announcementId: string, emoji: string) => void;
+  onJumpToQuoted: (postId: string | null) => void;
+  onBeginReply: (message: ChatMessage) => void;
+  onEdit: (postId: string, text: string) => void;
+  onDelete: (postId: string) => void;
+  onToggleReaction: (postId: string, emoji: string) => void;
+};
+
+type MessageStreamProps = StreamCallbacks & {
+  messagesContainerRef: RefObject<HTMLDivElement | null>;
+  messagesEndRef: RefObject<HTMLDivElement | null>;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  isLoading: boolean;
+  isFilterRefreshing: boolean;
+  hasContent: boolean;
+  mentionsOnly: boolean;
+  announcementsOnly: boolean;
+  ownMentionLabel: string;
+  ownHandle: string;
+  currentUser: ShellCurrentUser;
+  streamEntries: StreamEntry[];
+  unreadDividerIndex: number;
+};
+
+function MessageStream({
+  messagesContainerRef,
+  messagesEndRef,
+  inputRef,
+  isLoading,
+  isFilterRefreshing,
+  hasContent,
+  mentionsOnly,
+  announcementsOnly,
+  ownMentionLabel,
+  ownHandle,
+  currentUser,
+  streamEntries,
+  unreadDividerIndex,
+  ...callbacks
+}: MessageStreamProps) {
+  return (
+    <div className={styles.chatMessages} ref={messagesContainerRef}>
+      {(isLoading || isFilterRefreshing) && !hasContent ? (
+        <StreamLoadingFootnote mentionsOnly={mentionsOnly} announcementsOnly={announcementsOnly} />
+      ) : null}
+
+      {!isLoading && !isFilterRefreshing && !hasContent ? (
+        <StreamEmptyState mentionsOnly={mentionsOnly} announcementsOnly={announcementsOnly} ownMentionLabel={ownMentionLabel} />
+      ) : null}
+
+      {streamEntries.map((entry, index) => (
+        <StreamEntryView
+          key={streamEntryKey(entry)}
+          entry={entry}
+          showDivider={index === unreadDividerIndex}
+          ownHandle={ownHandle}
+          currentUser={currentUser}
+          inputRef={inputRef}
+          {...callbacks}
+        />
+      ))}
+      <div ref={messagesEndRef} />
+    </div>
+  );
+}
+
+function StreamLoadingFootnote({ mentionsOnly, announcementsOnly }: { mentionsOnly: boolean; announcementsOnly: boolean }) {
+  const text = mentionsOnly ? 'Looking for your mentions…' : announcementsOnly ? 'Loading announcements…' : 'Loading live messages…';
+  return <p className={styles.chatFootnote}>{text}</p>;
+}
+
+function StreamEmptyState({ mentionsOnly, announcementsOnly, ownMentionLabel }: { mentionsOnly: boolean; announcementsOnly: boolean; ownMentionLabel: string }) {
+  return (
+    <div className={styles.chatBubbleGroup}>
+      <div className={`${styles.chatBubble} ${styles.chatBubbleHub}`}>
+        {mentionsOnly ? (
+          <>No mentions yet. When someone writes <strong>{ownMentionLabel}</strong>, it shows here.</>
+        ) : announcementsOnly ? (
+          <>No announcements yet. Official updates from the team show here.</>
+        ) : (
+          <>You are connected. Share with the community, or type <strong>@comic</strong> to ask the AI Assistant.</>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// A single "New messages" divider sits immediately before the first entry newer than the member's
+// last-seen marker. Rendered ahead of whichever entry follows it.
+function UnreadDivider() {
+  return (
+    <div className={styles.unreadDivider} role="separator" aria-label="New messages">
+      <span className={styles.unreadDividerLabel}>New messages</span>
+    </div>
+  );
+}
+
+type StreamEntryViewProps = StreamCallbacks & {
+  entry: StreamEntry;
+  showDivider: boolean;
+  ownHandle: string;
+  currentUser: ShellCurrentUser;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+};
+
+function StreamEntryView({ entry, showDivider, ownHandle, currentUser, inputRef, ...callbacks }: StreamEntryViewProps) {
+  const divider = showDivider ? <UnreadDivider key="unread-divider" /> : null;
+
+  if (entry.kind === 'comic') {
+    return <ComicEntry item={entry.item} askedByLabel={currentUser.displayName} divider={divider} onRate={callbacks.onRate} />;
+  }
+
+  const msg = entry.message;
+  // The author shown above the bubble. Your own messages are attributed to you (handle when we have
+  // it) so every message has a visible author, not just other people's — peer posts were rendering
+  // with no name on the sender's own side.
+  const senderName = msg.from === 'user' ? ownHandle : (msg.senderLabel ?? 'Survivor Hub');
+
+  // An official announcement renders as its own distinct card (badge + optional title), not a chat
+  // bubble, so it stands apart from peer posts and AI answers.
+  if (msg.kind === 'announcement') {
+    return (
+      <AnnouncementEntry
+        msg={msg}
+        senderName={senderName}
+        divider={divider}
+        onToggleReaction={callbacks.onToggleAnnouncementReaction}
+      />
+    );
+  }
+
+  return (
+    <PeerMessageEntry
+      msg={msg}
+      senderName={senderName}
+      divider={divider}
+      inputRef={inputRef}
+      onJumpToQuoted={callbacks.onJumpToQuoted}
+      onBeginReply={callbacks.onBeginReply}
+      onEdit={callbacks.onEdit}
+      onDelete={callbacks.onDelete}
+      onToggleReaction={callbacks.onToggleReaction}
+    />
+  );
+}
+
+function ComicEntry({
+  item,
+  askedByLabel,
+  divider,
+  onRate,
+}: {
+  item: ComicStreamItem;
+  askedByLabel: string;
+  divider: ReactNode;
+  onRate: (turnId: string, rating: ComicAnswerRating) => void;
+}) {
+  if (item.status === 'answered') {
+    return (
       <>
+        {divider}
+        <ComicAnswerCard item={item} askedByLabel={askedByLabel} onRate={onRate} />
+      </>
+    );
+  }
+  return (
+    <>
+      {divider}
+      <ComicPendingCard item={item} askedByLabel={askedByLabel} />
+    </>
+  );
+}
+
+function AnnouncementEntry({
+  msg,
+  senderName,
+  divider,
+  onToggleReaction,
+}: {
+  msg: ChatMessage;
+  senderName: string;
+  divider: ReactNode;
+  onToggleReaction: (announcementId: string, emoji: string) => void;
+}) {
+  return (
+    <>
+      {divider}
+      <AnnouncementCard
+        senderName={senderName}
+        title={msg.announcementTitle ?? null}
+        body={msg.text}
+        time={msg.time}
+        linkedPlugins={msg.linkedPlugins ?? []}
+        announcementId={msg.announcementId ?? null}
+        reactions={msg.reactions}
+        replyCount={msg.replyCount}
+        onToggleReaction={(id, emoji) => void onToggleReaction(id, emoji)}
+      />
+    </>
+  );
+}
+
+type PeerMessageEntryProps = {
+  msg: ChatMessage;
+  senderName: string;
+  divider: ReactNode;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  onJumpToQuoted: (postId: string | null) => void;
+  onBeginReply: (message: ChatMessage) => void;
+  onEdit: (postId: string, text: string) => void;
+  onDelete: (postId: string) => void;
+  onToggleReaction: (postId: string, emoji: string) => void;
+};
+
+function PeerMessageEntry({ msg, senderName, divider, inputRef, onJumpToQuoted, onBeginReply, onEdit, onDelete, onToggleReaction }: PeerMessageEntryProps) {
+  return (
+    <>
+      {divider}
+      <div className={msg.from === 'user' ? `${styles.chatRow} ${styles.chatRowUser}` : styles.chatRow}>
+        {msg.from === 'hub' ? <div className={styles.chatAvatar} aria-hidden="true">{avatarFromSender(senderName)}</div> : null}
+        <div className={styles.chatBubbleGroup} data-post-id={msg.communityPostId ?? undefined}>
+          <span className={msg.from === 'user' ? `${styles.chatSender} ${styles.chatSenderUser}` : styles.chatSender}>{senderName}</span>
+          <QuotedBlock quoted={msg.quotedMessage} onJump={onJumpToQuoted} />
+          <div className={msg.from === 'user' ? `${styles.chatBubble} ${styles.chatBubbleUser}` : `${styles.chatBubble} ${styles.chatBubbleHub}`}>
+            {msg.text}
+          </div>
+          {msg.actionLabel && msg.actionSlug ? (
+            <Link href={`/apps/${msg.actionSlug}`} className={styles.chatActionBtn}>
+              {msg.actionLabel}
+            </Link>
+          ) : null}
+          <MessageMetaRow msg={msg} senderName={senderName} inputRef={inputRef} onBeginReply={onBeginReply} onEdit={onEdit} onDelete={onDelete} />
+          {msg.communityPostId ? (
+            <ChatReactionRow
+              postId={msg.communityPostId}
+              reactions={msg.reactions}
+              onToggle={(postId, emoji) => void onToggleReaction(postId, emoji)}
+              // A member may only react to posts they did not author. On the member's own post the row
+              // is read-only: it shows others' reactions but offers no way to add.
+              readOnly={msg.from === 'user'}
+            />
+          ) : null}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// The quoted block above a Signal-style reply. When the quoted post is still in the loaded window it
+// renders as a button that jumps to the original; otherwise a plain block (the snippet is enough).
+function QuotedBlock({ quoted, onJump }: { quoted: ChatQuotedMessage | null | undefined; onJump: (postId: string | null) => void }) {
+  if (!quoted) return null;
+  if (quoted.postId) {
+    return (
+      <button
+        type="button"
+        className={`${styles.chatQuotedBlock} ${styles.chatQuotedBlockClickable}`}
+        onClick={() => onJump(quoted.postId)}
+        aria-label={`Go to the message from ${quoted.author} that this replies to`}
+      >
+        <span className={styles.chatQuotedAuthor}>{quoted.author}</span>
+        <span className={styles.chatQuotedSnippet}>{quoted.snippet}</span>
+      </button>
+    );
+  }
+  return (
+    <div className={styles.chatQuotedBlock}>
+      <span className={styles.chatQuotedAuthor}>{quoted.author}</span>
+      <span className={styles.chatQuotedSnippet}>{quoted.snippet}</span>
+    </div>
+  );
+}
+
+function MessageMetaRow({
+  msg,
+  senderName,
+  inputRef,
+  onBeginReply,
+  onEdit,
+  onDelete,
+}: {
+  msg: ChatMessage;
+  senderName: string;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  onBeginReply: (message: ChatMessage) => void;
+  onEdit: (postId: string, text: string) => void;
+  onDelete: (postId: string) => void;
+}) {
+  // A peer post (it carries a community post id) can be replied to Signal-style.
+  const canReply = Boolean(msg.communityPostId);
+  // The member can delete their own peer post (there is no edit — delete and repost instead).
+  const canDelete = msg.from === 'user' && Boolean(msg.communityPostId);
+  return (
+    <div className={msg.from === 'user' ? `${styles.chatMetaRow} ${styles.chatMetaRowUser}` : styles.chatMetaRow}>
+      <span className={msg.from === 'user' ? `${styles.chatTime} ${styles.chatTimeUser}` : styles.chatTime}>
+        {msg.time}
+      </span>
+      {canReply ? (
+        <button
+          type="button"
+          className={styles.chatReplyBtn}
+          onClick={() => onBeginReply(msg)}
+          aria-label={`Reply to ${senderName}`}
+        >
+          <Reply size={12} /> Reply
+        </button>
+      ) : null}
+      {canDelete && msg.communityPostId ? (
+        <button
+          type="button"
+          className={styles.chatEditBtn}
+          onClick={() => {
+            // Editing is delete + repost: pull the text back into the composer, delete the original,
+            // and focus the box so the member fixes it and sends a fresh post.
+            onEdit(msg.communityPostId as string, msg.text);
+            inputRef.current?.focus();
+          }}
+          aria-label="Edit your post"
+        >
+          <Pencil size={12} /> Edit
+        </button>
+      ) : null}
+      {canDelete && msg.communityPostId ? (
+        <button
+          type="button"
+          className={styles.chatDeleteBtn}
+          onClick={() => {
+            if (window.confirm('Delete this post? This cannot be undone. To change it, delete and post again.')) {
+              void onDelete(msg.communityPostId as string);
+            }
+          }}
+          aria-label="Delete your post"
+        >
+          <Trash2 size={12} /> Delete
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+type ConciergeChipRailProps = {
+  mentionsOnly: boolean;
+  announcementsOnly: boolean;
+  notificationsOpen: boolean;
+  chips: HubSuggestionChip[];
+  onToggleMentions: () => void;
+  onToggleAnnouncements: () => void;
+  onToggleNotifications: () => void;
+  onAsk: (question: string) => void;
+};
+
+// One-tap suggestion chips (#471) — persistent (shown whether or not the chat already has messages),
+// so a member can always tap one. Each chip does the right thing on a single tap, never just a
+// composer pre-fill: a NAVIGATE chip opens that plugin directly (it is an action, not a question), and
+// an ASK chip routes the question to the @comic AI assistant. The "@ Mentions" filter chip leads this
+// row at every width (owner directive, 2026-07-17); same pill size as the suggestion chips, sky-blue
+// so it stays visually distinct; it scrolls with the row. The rail always renders because the chips
+// are always present.
+function ConciergeChipRail({
+  mentionsOnly,
+  announcementsOnly,
+  notificationsOpen,
+  chips,
+  onToggleMentions,
+  onToggleAnnouncements,
+  onToggleNotifications,
+  onAsk,
+}: ConciergeChipRailProps) {
+  return (
+    <div className={styles.conciergeChipRail} role="group" aria-label="Ask what you need">
+      <MentionsFilterButton active={mentionsOnly && !notificationsOpen} on={mentionsOnly} onClick={onToggleMentions} />
+      <AnnouncementsFilterButton active={announcementsOnly && !notificationsOpen} on={announcementsOnly} onClick={onToggleAnnouncements} />
+      <NotificationsFilterButton open={notificationsOpen} onClick={onToggleNotifications} />
+      {notificationsOpen ? null : <SuggestionChips chips={chips} onAsk={onAsk} />}
+    </div>
+  );
+}
+
+// Mentions filter — icon-only "@" chip (the word was dropped to match the 📣 chip), so the two stream
+// filters read as a matched pair of small glyph pills. `active` drives the styling (off while the
+// notifications center is open); `on` drives the label (the raw filter state).
+function MentionsFilterButton({ active, on, onClick }: { active: boolean; on: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className={active ? `${styles.mentionsFilterBtn} ${styles.mentionsFilterBtnActive}` : styles.mentionsFilterBtn}
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={on ? 'Show all messages' : 'Show only messages that mention you'}
+      title={on ? 'Show all messages' : 'Show only messages that mention you'}
+    >
+      <AtSign size={15} aria-hidden="true" />
+    </button>
+  );
+}
+
+// Announcements filter — "Announcements" is too long for a chip, so it shows the 📣 emoji alone.
+// Filtering to announcements lets a member with limited message history still surface official updates
+// that scrolled off the recent page.
+function AnnouncementsFilterButton({ active, on, onClick }: { active: boolean; on: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className={active ? `${styles.announcementsFilterBtn} ${styles.announcementsFilterBtnActive}` : styles.announcementsFilterBtn}
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={on ? 'Show all messages' : 'Show only announcements'}
+      title={on ? 'Show all messages' : 'Show only announcements'}
+    >
+      <span aria-hidden="true">📣</span>
+    </button>
+  );
+}
+
+// Notifications center — the 🔔 chip opens the member's cross-plugin notifications feed in place of the
+// chat stream (a separate view, not a filter). Styled like the filter chips so the three read as a row
+// of glyph pills.
+function NotificationsFilterButton({ open, onClick }: { open: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className={open ? `${styles.notificationsFilterBtn} ${styles.notificationsFilterBtnActive}` : styles.notificationsFilterBtn}
+      onClick={onClick}
+      aria-pressed={open}
+      aria-label={open ? 'Back to the conversation' : 'Show your notifications'}
+      title={open ? 'Back to the conversation' : 'Show your notifications'}
+    >
+      <span aria-hidden="true">🔔</span>
+    </button>
+  );
+}
+
+function SuggestionChips({ chips, onAsk }: { chips: HubSuggestionChip[]; onAsk: (question: string) => void }) {
+  return (
+    <>
+      {chips.map((chip) =>
+        chip.kind === 'navigate' ? (
+          <Link key={chip.id} href={`/apps/${chip.slug}`} className={styles.conciergeChip} title={chip.label}>
+            {chip.label}
+          </Link>
+        ) : (
+          <button key={chip.id} type="button" className={styles.conciergeChip} title={chip.label} onClick={() => onAsk(chip.question)}>
+            {chip.label}
+          </button>
+        ),
+      )}
+    </>
+  );
+}
+
+type ChatComposerProps = {
+  input: string;
+  setInput: (value: string) => void;
+  notifyTyping: () => void;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  replyTarget: ReplyTarget | null;
+  onCancelReply: () => void;
+  typingLabel: string | null;
+  composerMentionsComic: boolean;
+  composerOverBy: number;
+  isSending: boolean;
+  onSend: () => void;
+  showComposerCount: boolean;
+  composerLength: number;
+  maxLength: number;
+  isLive: boolean;
+};
+
+function ChatComposer({
+  input,
+  setInput,
+  notifyTyping,
+  inputRef,
+  replyTarget,
+  onCancelReply,
+  typingLabel,
+  composerMentionsComic,
+  composerOverBy,
+  isSending,
+  onSend,
+  showComposerCount,
+  composerLength,
+  maxLength,
+  isLive,
+}: ChatComposerProps) {
+  return (
+    <>
       {/* @comic mention affordance + helper copy (per the locked design / naming rules). On phones
           the standalone "@comic" chip duplicated the "@comic" in the helper text, so the chip is
           dropped and the line is relabeled to name the assistant and its human-in-the-loop review. */}
@@ -735,37 +1064,13 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
         </span>
       </div>
 
-      {/* "Replying to …" banner: shows a one-line quote preview and a cancel (X). Sending while
-          this is set posts the message as a Signal-style reply to that peer post. */}
-      {replyTarget ? (
-        <div className={styles.composerReplyBanner}>
-          <div className={styles.composerReplyPreview}>
-            <span className={styles.composerReplyLabel}>Replying to {replyTarget.quote.author}</span>
-            <span className={styles.composerReplySnippet}>{replyTarget.quote.snippet}</span>
-          </div>
-          <button
-            type="button"
-            className={styles.composerReplyCancel}
-            onClick={cancelReply}
-            aria-label="Cancel reply"
-          >
-            <X size={14} />
-          </button>
-        </div>
-      ) : null}
+      {/* "Replying to …" banner: shows a one-line quote preview and a cancel (X). Sending while this
+          is set posts the message as a Signal-style reply to that peer post. */}
+      {replyTarget ? <ReplyBanner replyTarget={replyTarget} onCancel={onCancelReply} /> : null}
 
       {/* Subtle "X is typing…" line, only when the live connection surfaces someone typing. Kept on
           one quiet line above the composer so it sits with the existing dark design. */}
-      {typingLabel ? (
-        <div className={styles.typingIndicator} role="status" aria-live="polite">
-          <span className={styles.typingDots} aria-hidden="true">
-            <span />
-            <span />
-            <span />
-          </span>
-          {typingLabel}
-        </div>
-      ) : null}
+      {typingLabel ? <TypingIndicator label={typingLabel} /> : null}
 
       <div className={styles.chatInputWrap}>
         <label className={styles.visuallyHidden} htmlFor="chat-input">Share with the community, or type @comic to ask the AI Assistant</label>
@@ -789,7 +1094,7 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
           type="button"
           className={input.trim() && composerOverBy === 0 ? `${styles.chatSendBtn} ${styles.chatSendBtnActive}` : styles.chatSendBtn}
           onClick={() => {
-            void sendMessage();
+            void onSend();
           }}
           aria-label={composerMentionsComic ? 'Ask the AI Assistant' : 'Send message'}
           // Blocked while over the limit: the server would reject it anyway, and a rejection the
@@ -800,31 +1105,63 @@ function AuthenticatedChatPanel({ currentUser, isAdmin = false }: AuthenticatedC
         </button>
       </div>
 
-      {/* Character count, shown only near and past the limit. Over the limit it names the exact
-          number to remove, which is the number a member actually needs — "1,318 / 1,200" makes them
-          do the subtraction themselves. aria-live is polite so it does not interrupt typing, and the
-          announcement is throttled by only rendering in the last stretch. */}
-      {showComposerCount ? (
-        <p
-          className={styles.chatFootnote}
-          role="status"
-          aria-live="polite"
-          style={{ color: composerOverBy > 0 ? '#F87171' : undefined, marginTop: 6, marginBottom: 0 }}
-        >
-          {composerOverBy > 0
-            ? `${composerOverBy.toLocaleString()} character${composerOverBy === 1 ? '' : 's'} over the limit — remove ${composerOverBy === 1 ? 'it' : 'that many'} to post. Or split this into two messages.`
-            : `${(maxLength - composerLength).toLocaleString()} character${maxLength - composerLength === 1 ? '' : 's'} left.`}
-        </p>
-      ) : null}
+      {/* Character count, shown only near and past the limit. */}
+      {showComposerCount ? <ComposerCharacterCount composerOverBy={composerOverBy} charsLeft={maxLength - composerLength} /> : null}
 
       <p className={styles.chatFootnote}>
         {isLive ? 'Human-in-the-loop AI support and community support channel.' : 'Support channel keeps syncing as new messages arrive.'}{' '}
         <a href="/guidelines" style={{ color: 'inherit', textDecoration: 'underline' }}>Community guidelines</a>
       </p>
-      </>
-      )}
+    </>
+  );
+}
 
-      <ComicConsentModal open={consentModalOpen} onConfirm={() => void confirmConsent()} onDismiss={dismissConsent} />
+function ReplyBanner({ replyTarget, onCancel }: { replyTarget: ReplyTarget; onCancel: () => void }) {
+  return (
+    <div className={styles.composerReplyBanner}>
+      <div className={styles.composerReplyPreview}>
+        <span className={styles.composerReplyLabel}>Replying to {replyTarget.quote.author}</span>
+        <span className={styles.composerReplySnippet}>{replyTarget.quote.snippet}</span>
+      </div>
+      <button
+        type="button"
+        className={styles.composerReplyCancel}
+        onClick={onCancel}
+        aria-label="Cancel reply"
+      >
+        <X size={14} />
+      </button>
     </div>
+  );
+}
+
+function TypingIndicator({ label }: { label: string }) {
+  return (
+    <div className={styles.typingIndicator} role="status" aria-live="polite">
+      <span className={styles.typingDots} aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </span>
+      {label}
+    </div>
+  );
+}
+
+// Over the limit it names the exact number to remove, which is the number a member actually needs —
+// "1,318 / 1,200" makes them do the subtraction themselves. aria-live is polite so it does not
+// interrupt typing, and the announcement is throttled by only rendering in the last stretch.
+function ComposerCharacterCount({ composerOverBy, charsLeft }: { composerOverBy: number; charsLeft: number }) {
+  return (
+    <p
+      className={styles.chatFootnote}
+      role="status"
+      aria-live="polite"
+      style={{ color: composerOverBy > 0 ? '#F87171' : undefined, marginTop: 6, marginBottom: 0 }}
+    >
+      {composerOverBy > 0
+        ? `${composerOverBy.toLocaleString()} character${composerOverBy === 1 ? '' : 's'} over the limit — remove ${composerOverBy === 1 ? 'it' : 'that many'} to post. Or split this into two messages.`
+        : `${charsLeft.toLocaleString()} character${charsLeft === 1 ? '' : 's'} left.`}
+    </p>
   );
 }

--- a/ctf/packages/web/components/community-shell/unlock-verify-banner.tsx
+++ b/ctf/packages/web/components/community-shell/unlock-verify-banner.tsx
@@ -4,6 +4,129 @@ import { useState } from 'react';
 import { ExternalLink, Send, ShieldCheck } from 'lucide-react';
 import type { UnlockReviewStatus } from '../../lib/unlock/types';
 
+// The calm "under review" note shown once a submission is in the queue. The member keeps Commons
+// access while a human reviews.
+function UnlockPendingNote() {
+  return (
+    <p style={{ fontSize: 13, color: 'var(--ctf-text-secondary)', lineHeight: 1.6, margin: 0 }}>
+      Thanks — your Quora profile is submitted and a human is reviewing it. You have Commons access
+      while you wait.
+    </p>
+  );
+}
+
+type UnlockSubmitFormProps = {
+  url: string;
+  submitting: boolean;
+  error: string | null;
+  wasRejected: boolean;
+  onUrlChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+// The inline verification form: prompt copy, the Quora profile URL input, the submit button, any
+// error, and the universal help note for a member who can't find their profile URL.
+function UnlockSubmitForm({ url, submitting, error, wasRejected, onUrlChange, onSubmit }: UnlockSubmitFormProps) {
+  const disabled = url.trim().length === 0 || submitting;
+  const inputBorderColor = url ? 'rgba(192,132,252,0.5)' : 'rgba(255,255,255,0.12)';
+  const buttonBackground = disabled ? 'rgba(255,255,255,0.10)' : '#C084FC';
+  const buttonColor = disabled ? 'var(--ctf-text-secondary)' : '#1A1030';
+  const buttonCursor = disabled ? 'default' : 'pointer';
+  return (
+    <>
+      <p style={{ fontSize: 13, color: 'var(--ctf-text-secondary)', lineHeight: 1.6, margin: '0 0 10px' }}>
+        {wasRejected
+          ? 'Your last submission could not be verified. Re-submit your Quora profile URL below — a human reviews every one.'
+          : 'Submit your Quora profile URL so we can confirm you are a real person. A human reviews every submission.'}
+      </p>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            flex: 1,
+            minWidth: 240,
+            padding: '10px 12px',
+            background: 'rgba(0,0,0,0.25)',
+            border: `1px solid ${inputBorderColor}`,
+            borderRadius: 10,
+          }}
+        >
+          {/* stroke defaults to currentColor, so the CSS color var themes the icon */}
+          <ExternalLink size={14} style={{ color: 'var(--ctf-text-secondary)', flexShrink: 0 }} />
+          <input
+            value={url}
+            onChange={(e) => onUrlChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onSubmit();
+            }}
+            placeholder="https://quora.com/profile/your-name"
+            aria-label="Your Quora profile URL"
+            style={{
+              flex: 1,
+              background: 'transparent',
+              border: 'none',
+              outline: 'none',
+              fontSize: 14,
+              color: 'var(--ctf-text)',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={disabled}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '10px 18px',
+            borderRadius: 10,
+            border: 'none',
+            background: buttonBackground,
+            color: buttonColor,
+            fontSize: 14,
+            fontWeight: 700,
+            cursor: buttonCursor,
+          }}
+        >
+          <Send size={14} /> {submitting ? 'Submitting…' : 'Submit for verification'}
+        </button>
+      </div>
+      {error ? <div style={{ fontSize: 12, color: '#F87171', marginTop: 8 }}>{error}</div> : null}
+
+      {/* Prominent, universal help for a member who can't find their Quora profile URL. */}
+      <div
+        role="note"
+        style={{
+          marginTop: 12,
+          padding: '10px 12px',
+          borderRadius: 10,
+          background: 'rgba(192,132,252,0.12)',
+          border: '1.5px solid rgba(192,132,252,0.45)',
+          fontSize: 12.5,
+          color: 'var(--ctf-text-secondary)',
+          lineHeight: 1.55,
+        }}
+      >
+        <strong style={{ color: 'var(--ctf-text)' }}>Can’t find your Quora profile URL?</strong> Go to{' '}
+        <a
+          href="https://skillseconomy.quora.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: '#C084FC', fontWeight: 700 }}
+        >
+          skillseconomy.quora.com
+        </a>{' '}
+        and comment on any post asking for help — I&apos;ll reply with your profile URL.
+      </div>
+    </>
+  );
+}
+
 // Shown at the top of the Commons for a signed-in member who has not yet completed Quora verification
 // (including members in the early-Commons A/B treatment bucket, who now land on the Commons instead of
 // the Unlock screen). Without this, a treatment member sees the chat with no indication they still need
@@ -71,102 +194,16 @@ export function UnlockVerifyBanner({
       </div>
 
       {isPending ? (
-        <p style={{ fontSize: 13, color: 'var(--ctf-text-secondary)', lineHeight: 1.6, margin: 0 }}>
-          Thanks — your Quora profile is submitted and a human is reviewing it. You have Commons access
-          while you wait.
-        </p>
+        <UnlockPendingNote />
       ) : (
-        <>
-          <p style={{ fontSize: 13, color: 'var(--ctf-text-secondary)', lineHeight: 1.6, margin: '0 0 10px' }}>
-            {wasRejected
-              ? 'Your last submission could not be verified. Re-submit your Quora profile URL below — a human reviews every one.'
-              : 'Submit your Quora profile URL so we can confirm you are a real person. A human reviews every submission.'}
-          </p>
-
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                flex: 1,
-                minWidth: 240,
-                padding: '10px 12px',
-                background: 'rgba(0,0,0,0.25)',
-                border: `1px solid ${url ? 'rgba(192,132,252,0.5)' : 'rgba(255,255,255,0.12)'}`,
-                borderRadius: 10,
-              }}
-            >
-              {/* stroke defaults to currentColor, so the CSS color var themes the icon */}
-              <ExternalLink size={14} style={{ color: 'var(--ctf-text-secondary)', flexShrink: 0 }} />
-              <input
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') void submit();
-                }}
-                placeholder="https://quora.com/profile/your-name"
-                aria-label="Your Quora profile URL"
-                style={{
-                  flex: 1,
-                  background: 'transparent',
-                  border: 'none',
-                  outline: 'none',
-                  fontSize: 14,
-                  color: 'var(--ctf-text)',
-                  fontFamily: 'inherit',
-                }}
-              />
-            </div>
-            <button
-              type="button"
-              onClick={() => void submit()}
-              disabled={url.trim().length === 0 || submitting}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                padding: '10px 18px',
-                borderRadius: 10,
-                border: 'none',
-                background: url.trim().length === 0 || submitting ? 'rgba(255,255,255,0.10)' : '#C084FC',
-                color: url.trim().length === 0 || submitting ? 'var(--ctf-text-secondary)' : '#1A1030',
-                fontSize: 14,
-                fontWeight: 700,
-                cursor: url.trim().length === 0 || submitting ? 'default' : 'pointer',
-              }}
-            >
-              <Send size={14} /> {submitting ? 'Submitting…' : 'Submit for verification'}
-            </button>
-          </div>
-          {error ? <div style={{ fontSize: 12, color: '#F87171', marginTop: 8 }}>{error}</div> : null}
-
-          {/* Prominent, universal help for a member who can't find their Quora profile URL. */}
-          <div
-            role="note"
-            style={{
-              marginTop: 12,
-              padding: '10px 12px',
-              borderRadius: 10,
-              background: 'rgba(192,132,252,0.12)',
-              border: '1.5px solid rgba(192,132,252,0.45)',
-              fontSize: 12.5,
-              color: 'var(--ctf-text-secondary)',
-              lineHeight: 1.55,
-            }}
-          >
-            <strong style={{ color: 'var(--ctf-text)' }}>Can’t find your Quora profile URL?</strong> Go to{' '}
-            <a
-              href="https://skillseconomy.quora.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: '#C084FC', fontWeight: 700 }}
-            >
-              skillseconomy.quora.com
-            </a>{' '}
-            and comment on any post asking for help — I&apos;ll reply with your profile URL.
-          </div>
-        </>
+        <UnlockSubmitForm
+          url={url}
+          submitting={submitting}
+          error={error}
+          wasRejected={wasRejected}
+          onUrlChange={setUrl}
+          onSubmit={() => void submit()}
+        />
       )}
     </section>
   );

--- a/ctf/packages/web/components/community-shell/use-gated-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-gated-chat.ts
@@ -90,6 +90,49 @@ function applyReactionToggle(message: GatedChatMessage, emoji: string): GatedCha
   return { ...message, reactions: [...message.reactions, { emoji, count: 1, reactedByMe: true }] };
 }
 
+// Pull the human-readable text off a caught error, falling back to a fixed message.
+function errorMessage(caught: unknown, fallback: string): string {
+  if (caught instanceof Error) return caught.message;
+  return fallback;
+}
+
+// Best-effort disconnect that tolerates a null connection.
+function disconnectLive(live: HubLiveConnection | null): void {
+  if (live) void live.disconnect();
+}
+
+// Poll DB-backed history on a fixed cadence; transient failures are covered by the next tick.
+function startHistoryPoll(intervalMs: number, refresh: () => Promise<void>): number {
+  return window.setInterval(() => {
+    void refresh().catch(() => {
+      // Keep polling while mounted; transient failures are covered by the next tick.
+    });
+  }, intervalMs);
+}
+
+type HubLiveHandlers = {
+  onActivity: () => void;
+  onTypingChange: (typing: HubTypingUser[]) => void;
+};
+
+// Open the Stream live layer when the join response is configured; otherwise there is no live layer.
+async function connectLiveIfConfigured(
+  join: GatedJoinResponse,
+  handlers: HubLiveHandlers,
+): Promise<HubLiveConnection | null> {
+  if (!join.configured) return null;
+  return connectHubLive(
+    {
+      streamApiKey: join.streamApiKey,
+      streamToken: join.streamToken,
+      streamUserId: join.streamUserId,
+      streamChannelId: join.streamChannelId,
+      streamChannelType: join.streamChannelType,
+    },
+    handlers,
+  );
+}
+
 export function useGatedChat(currentUser: ShellCurrentUser) {
   const [messages, setMessages] = useState<GatedChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -120,67 +163,49 @@ export function useGatedChat(currentUser: ShellCurrentUser) {
     setError(null);
     setMessages([]);
 
+    const poll = () => refreshHistoryRef.current();
+
     async function bootstrap() {
       try {
         await refreshHistory();
       } catch (loadError) {
         if (active) {
-          setError(loadError instanceof Error ? loadError.message : 'Unable to load the channel.');
+          setError(errorMessage(loadError, 'Unable to load the channel.'));
         }
       } finally {
         if (active) setIsLoading(false);
       }
 
-      const startPoll = (intervalMs: number) => {
-        pollId = window.setInterval(() => {
-          void refreshHistoryRef.current().catch(() => {
-            // Keep polling while mounted; transient failures are covered by the next tick.
-          });
-        }, intervalMs);
-      };
-
       try {
         const join = await requestJson<GatedJoinResponse>('/api/contributor-access/channel/join', { method: 'POST' });
         if (!active) return;
 
-        let live: HubLiveConnection | null = null;
-        if (join.configured) {
-          live = await connectHubLive(
-            {
-              streamApiKey: join.streamApiKey,
-              streamToken: join.streamToken,
-              streamUserId: join.streamUserId,
-              streamChannelId: join.streamChannelId,
-              streamChannelType: join.streamChannelType,
-            },
-            {
-              onActivity: () => {
-                void refreshHistoryRef.current().catch(() => undefined);
-              },
-              onTypingChange: (typing) => {
-                if (active) setTypingUsers(typing);
-              },
-            },
-          );
-        }
+        const live = await connectLiveIfConfigured(join, {
+          onActivity: () => {
+            void refreshHistoryRef.current().catch(() => undefined);
+          },
+          onTypingChange: (typing) => {
+            if (active) setTypingUsers(typing);
+          },
+        });
 
         if (!active) {
-          if (live) void live.disconnect();
+          disconnectLive(live);
           return;
         }
 
         if (live) {
           liveConnectionRef.current = live;
           setIsLive(true);
-          startPoll(POLL_INTERVAL_LIVE_MS);
+          pollId = startHistoryPoll(POLL_INTERVAL_LIVE_MS, poll);
         } else {
           setTypingUsers([]);
-          startPoll(POLL_INTERVAL_FALLBACK_MS);
+          pollId = startHistoryPoll(POLL_INTERVAL_FALLBACK_MS, poll);
         }
       } catch {
         if (!active) return;
         // The live layer is best-effort — polling keeps the channel fully functional.
-        startPoll(POLL_INTERVAL_FALLBACK_MS);
+        pollId = startHistoryPoll(POLL_INTERVAL_FALLBACK_MS, poll);
       }
     }
 
@@ -193,9 +218,7 @@ export function useGatedChat(currentUser: ShellCurrentUser) {
       }
       const live = liveConnectionRef.current;
       liveConnectionRef.current = null;
-      if (live) {
-        void live.disconnect();
-      }
+      disconnectLive(live);
     };
   }, [currentUser.userId, refreshHistory]);
 
@@ -226,7 +249,7 @@ export function useGatedChat(currentUser: ShellCurrentUser) {
       if (activeReply) {
         setReplyTarget(activeReply);
       }
-      setError(sendError instanceof Error ? sendError.message : 'Unable to send your message right now.');
+      setError(errorMessage(sendError, 'Unable to send your message right now.'));
     } finally {
       setIsSending(false);
     }
@@ -258,7 +281,7 @@ export function useGatedChat(currentUser: ShellCurrentUser) {
           [...previous, ...removed].sort((a, b) => a.sentAtIso.localeCompare(b.sentAtIso)),
         );
       }
-      setError(deleteError instanceof Error ? deleteError.message : 'Unable to delete the message right now.');
+      setError(errorMessage(deleteError, 'Unable to delete the message right now.'));
     }
   }, [refreshHistory]);
 
@@ -302,7 +325,7 @@ export function useGatedChat(currentUser: ShellCurrentUser) {
       setMessages((previous) =>
         previous.map((message) => (message.id === postId ? applyReactionToggle(message, emoji) : message)),
       );
-      setError(reactError instanceof Error ? reactError.message : 'Unable to update your reaction right now.');
+      setError(errorMessage(reactError, 'Unable to update your reaction right now.'));
     }
   }, []);
 

--- a/ctf/packages/web/components/community-shell/use-home-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-home-chat.ts
@@ -1,6 +1,15 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from 'react';
 import type { HubJoinResponse, HubLastSeenResponse, HubMessage, HubMessagesResponse } from '../../lib/hub/types';
 import { connectHubLive, type HubLiveConnection, type HubTypingUser } from '../../lib/hub/live-stream';
 import { resolveConcierge, conciergeStarterPrompts } from '../../lib/concierge/resolver';
@@ -14,6 +23,9 @@ import { FEED_REACTION_EMOJIS } from '../../lib/feed/constants';
 const POLL_INTERVAL_FALLBACK_MS = 10_000;
 const POLL_INTERVAL_LIVE_MS = 30_000;
 
+// Shared headers for a JSON POST that also carries the CSRF marker the backend expects.
+const JSON_CSRF_HEADERS = { 'content-type': 'application/json', 'x-ctf-csrf': '1' } as const;
+
 // The peer message the composer is currently replying to (Signal-style quote). Carries the
 // quoted post's id (the reply target) plus a quote preview for the composer banner.
 export type ReplyTarget = {
@@ -22,6 +34,29 @@ export type ReplyTarget = {
 };
 
 type ChatConnectionState = 'loading' | 'live' | 'fallback';
+
+// The active stream filter: mentions and announcements are mutually exclusive; 'all' is the
+// unfiltered blended stream.
+type FilterKey = 'mentions' | 'announcements' | 'all';
+
+// A stable bundle of every state setter. Action helpers live at module scope and take this one
+// argument instead of a long list of setters; the setters never change identity, so the hook holds
+// the bundle in a ref that is written once.
+type ChatSetters = {
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
+  setComicItems: Dispatch<SetStateAction<ComicStreamItem[]>>;
+  setInput: Dispatch<SetStateAction<string>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setReplyTarget: Dispatch<SetStateAction<ReplyTarget | null>>;
+  setIsSending: Dispatch<SetStateAction<boolean>>;
+  setConsentGranted: Dispatch<SetStateAction<boolean>>;
+  setConsentModalOpen: Dispatch<SetStateAction<boolean>>;
+  setPendingConsentText: Dispatch<SetStateAction<string | null>>;
+  setLastSeenAtIso: Dispatch<SetStateAction<string | null>>;
+  setConnectionState: Dispatch<SetStateAction<ChatConnectionState>>;
+  setTypingUsers: Dispatch<SetStateAction<HubTypingUser[]>>;
+  setIsFilterRefreshing: Dispatch<SetStateAction<boolean>>;
+};
 
 // localStorage key for the one-time AI-processing consent (the llm_consent_granted gate the
 // backend expects). Scoped per user so a shared browser does not leak consent between accounts.
@@ -41,6 +76,11 @@ function stripComicMention(text: string): string {
 
 function consentStorageKey(userId: string): string {
   return `${COMIC_CONSENT_STORAGE_PREFIX}.${userId}`;
+}
+
+// Collapse the repeated "surface an Error message or a fallback" pattern used by every catch block.
+function toErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
 }
 
 function formatTimeLabel(value: string | Date | null | undefined): string {
@@ -239,6 +279,610 @@ type ComicMessageResponse = {
   holdingResponse?: string;
 };
 
+// The query-string fragment the server expects for each filter mode.
+function filterParamForKey(key: FilterKey): string {
+  if (key === 'mentions') return '&mentions=me';
+  if (key === 'announcements') return '&channel=announcements';
+  return '';
+}
+
+// The "load around" query-string fragment for a deep-linked post/announcement, empty when neither.
+function aroundParamFor(postId: string | null, announcementId: string | null): string {
+  if (postId) return `&aroundPost=${encodeURIComponent(postId)}`;
+  if (announcementId) return `&aroundAnnouncement=${encodeURIComponent(announcementId)}`;
+  return '';
+}
+
+// Read a page of history and merge it into the stream, but ignore a response that raced a mode flip
+// (e.g. a slow read landing after the member changed the filter) so a filtered view never gets
+// polluted with the wrong stream.
+async function fetchHistoryIntoState(
+  extraParam: string,
+  readFilterKey: () => FilterKey,
+  expectedKey: FilterKey,
+  currentUserId: string,
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
+): Promise<void> {
+  const payload = await requestJson<HubMessagesResponse>(`/api/hub/messages?limit=50${extraParam}`);
+  if (readFilterKey() !== expectedKey) {
+    return;
+  }
+  const nextMessages = payload.messages.map((message) => mapStoredMessage(message, currentUserId));
+  setMessages((previous) => mergeMessages(previous, nextMessages));
+}
+
+// Read the comic conversation stream and merge it over the local (optimistic) items.
+async function readComicInto(setters: ChatSetters): Promise<void> {
+  const payload = await requestJson<ComicConversationResponse>('/api/comic/conversation?limit=30');
+  const serverItems: ComicStreamItem[] = payload.items.map((item) => ({ ...item }));
+  setters.setComicItems((previous) => mergeComicItems(serverItems, previous));
+}
+
+// Read the member's last-seen marker once on entry so the chat can place the "New messages"
+// divider. Best-effort: a failure leaves the marker null (everything reads as already seen, i.e.
+// no divider) and never blocks the chat.
+async function readLastSeenInto(setters: ChatSetters): Promise<void> {
+  try {
+    const payload = await requestJson<HubLastSeenResponse>('/api/hub/last-seen');
+    setters.setLastSeenAtIso(payload.lastSeenAtIso);
+  } catch {
+    setters.setLastSeenAtIso(null);
+  }
+}
+
+// Clear the loaded messages and re-fetch in the current filter mode. The list is cleared first so
+// modes never blend (merge is additive, so a shared list would keep old rows around).
+function runFilterRefresh(setters: ChatSetters, refreshHistory: () => Promise<void>): void {
+  setters.setMessages([]);
+  setters.setIsFilterRefreshing(true);
+  void refreshHistory()
+    .catch(() => {
+      // Best-effort: the poll retries shortly; the empty state covers the gap.
+    })
+    .finally(() => setters.setIsFilterRefreshing(false));
+}
+
+// The stable refs and setters the mutually-exclusive filter toggles read and write.
+type FilterRefs = {
+  mentionsOnlyRef: RefObject<boolean>;
+  announcementsOnlyRef: RefObject<boolean>;
+  setMentionsOnly: Dispatch<SetStateAction<boolean>>;
+  setAnnouncementsOnly: Dispatch<SetStateAction<boolean>>;
+};
+
+// Apply a mutually-exclusive filter selection to the refs + state mirrors, then re-fetch. Mentions
+// and announcements can never both be on, so callers pass the exact pair they want.
+function flipFilter(mentions: boolean, announcements: boolean, refs: FilterRefs, refreshForFilterChange: () => void): void {
+  refs.mentionsOnlyRef.current = mentions;
+  refs.announcementsOnlyRef.current = announcements;
+  refs.setMentionsOnly(mentions);
+  refs.setAnnouncementsOnly(announcements);
+  refreshForFilterChange();
+}
+
+// The composer's "replying to …" target for a peer message, or null when the message is not a peer
+// post (only peer posts carry a communityPostId, so AI answers / concierge lines cannot be replied to).
+function buildReplyTarget(message: ChatMessage): ReplyTarget | null {
+  if (!message.communityPostId) return null;
+  const author = message.senderLabel ?? 'Community member';
+  const snippet = message.text.trim().slice(0, 120);
+  return { postId: message.communityPostId, quote: { author, snippet, postId: message.communityPostId } };
+}
+
+// Editing IS delete + repost — there is no in-place edit — so load the post's text back into the
+// composer, clear any active reply, and delete the original.
+function runEditMessage(
+  postId: string,
+  text: string,
+  setters: ChatSetters,
+  deleteMessage: (postId: string) => Promise<void>,
+): void {
+  setters.setReplyTarget(null);
+  setters.setInput(text);
+  void deleteMessage(postId);
+}
+
+// Mark "seen" at most once per mount and never push the marker backwards.
+function markSeenOnce(markedSeenRef: RefObject<boolean>): void {
+  if (markedSeenRef.current) return;
+  markedSeenRef.current = true;
+  void postSeenMarker();
+}
+
+// POST the member's last-seen marker. Best-effort: a failure is swallowed so it can never break the
+// chat, and the caller leaves its "already marked" guard set so a transient failure does not retry-spam.
+async function postSeenMarker(): Promise<void> {
+  try {
+    await requestJson<HubLastSeenResponse>('/api/hub/last-seen', {
+      method: 'POST',
+      headers: JSON_CSRF_HEADERS,
+      body: JSON.stringify({ seenAtIso: new Date().toISOString() }),
+    });
+  } catch {
+    // Best-effort: leave the guard set so a transient failure does not retry-spam.
+  }
+}
+
+// The optimistic "Reviewing for safety" card shown while an @comic ask awaits human approval.
+function buildOptimisticComicItem(question: string): ComicStreamItem {
+  // Unique per ask (random suffix) so two rapid identical-text asks get distinct React keys and
+  // are tracked independently by the count-aware merge.
+  const localId = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    questionTurnId: localId,
+    conversationId: 'optimistic',
+    status: 'pending',
+    question,
+    answer: null,
+    answerTurnId: null,
+    currentUserRating: null,
+    linkedPlugins: [],
+    askedAtIso: new Date().toISOString(),
+    optimistic: true,
+  };
+}
+
+// Route an @comic question to the assistant. The server returns ONLY a holding response (202) —
+// never the unreviewed draft — so we optimistically render the pending card and rely on the polling
+// stream to surface the answer once a human approves it.
+async function runRouteToComic(questionText: string, refreshComic: () => Promise<void>, setters: ChatSetters): Promise<void> {
+  const question = stripComicMention(questionText);
+  const optimisticItem = buildOptimisticComicItem(question);
+  setters.setComicItems((previous) => [...previous, optimisticItem]);
+
+  try {
+    await requestJson<ComicMessageResponse>('/api/comic/message', {
+      method: 'POST',
+      headers: JSON_CSRF_HEADERS,
+      body: JSON.stringify({ body: questionText, channel: 'hub', consentGranted: true }),
+    });
+    // Pull the server stream so the pending card reflects the persisted turn.
+    await refreshComic().catch(() => undefined);
+  } catch (sendError) {
+    // Drop the optimistic card on failure and surface the error.
+    setters.setComicItems((previous) => previous.filter((item) => item.questionTurnId !== optimisticItem.questionTurnId));
+    setters.setError(toErrorMessage(sendError, 'Unable to reach the AI Assistant right now.'));
+  }
+}
+
+// Everything the composer send path needs. Values are read once per send; setters are stable.
+type SendMessageContext = {
+  input: string;
+  isSending: boolean;
+  consentGranted: boolean;
+  replyTarget: ReplyTarget | null;
+  currentUserId: string;
+  routeToComic: (questionText: string) => Promise<void>;
+  notifyStopTyping: () => void;
+  setters: ChatSetters;
+};
+
+// The JSON body for a peer post: with a reply target it carries the reply reference and the quote
+// the sender saw; otherwise just the text.
+function buildPeerMessageBody(text: string, activeReply: ReplyTarget | null): string {
+  return JSON.stringify(
+    activeReply
+      ? { text, replyToPostId: activeReply.postId, quotedMessage: activeReply.quote }
+      : { text },
+  );
+}
+
+// Send a peer-to-peer community post and merge the saved copy in. On failure, restore the reply
+// target and the composer text so the member can retry.
+async function postPeerMessage(text: string, activeReply: ReplyTarget | null, ctx: SendMessageContext): Promise<void> {
+  try {
+    const payload = await requestJson<{ ok: true; message: HubMessage }>('/api/hub/messages', {
+      method: 'POST',
+      headers: JSON_CSRF_HEADERS,
+      body: buildPeerMessageBody(text, activeReply),
+    });
+    const savedMessage = mapStoredMessage(payload.message, ctx.currentUserId);
+    ctx.setters.setMessages((previous) => mergeMessages(previous, [savedMessage]));
+  } catch (sendError) {
+    // Restore the reply target so the member can retry the reply.
+    if (activeReply) {
+      ctx.setters.setReplyTarget(activeReply);
+    }
+    // Put the text back in the composer (owner report, 2026-07-27). The input is cleared
+    // optimistically by the caller so the send feels instant; before this, a rejected send — a
+    // message over the length cap, or any network failure — cleared the box and the member's writing
+    // was gone with nothing to retry. Only restore when the member has not started typing something
+    // new in the meantime, so a recovery never overwrites live work.
+    ctx.setters.setInput((current) => (current.trim().length === 0 ? text : current));
+    ctx.setters.setError(toErrorMessage(sendError, 'Unable to send your message right now.'));
+  }
+}
+
+// @comic mention → AI Assistant. Gate the first use behind the consent modal, holding the text.
+async function sendComicFromComposer(text: string, ctx: SendMessageContext): Promise<void> {
+  if (!ctx.consentGranted) {
+    ctx.setters.setPendingConsentText(text);
+    ctx.setters.setConsentModalOpen(true);
+    return;
+  }
+
+  ctx.setters.setIsSending(true);
+  ctx.setters.setError(null);
+  ctx.setters.setInput('');
+  try {
+    await ctx.routeToComic(text);
+  } finally {
+    ctx.setters.setIsSending(false);
+  }
+}
+
+// No mention → peer-to-peer community post via the existing hub path. Capture the active reply
+// target (Signal-style quote) before clearing it, and clear the typing indicator right away.
+async function sendPeerFromComposer(text: string, ctx: SendMessageContext): Promise<void> {
+  const activeReply = ctx.replyTarget;
+  ctx.setters.setIsSending(true);
+  ctx.setters.setError(null);
+  ctx.setters.setInput('');
+  ctx.setters.setReplyTarget(null);
+  ctx.notifyStopTyping();
+  try {
+    await postPeerMessage(text, activeReply, ctx);
+  } finally {
+    ctx.setters.setIsSending(false);
+  }
+}
+
+async function runSendMessage(ctx: SendMessageContext): Promise<void> {
+  const text = ctx.input.trim();
+  if (!text || ctx.isSending) {
+    return;
+  }
+
+  if (mentionsComic(text)) {
+    await sendComicFromComposer(text, ctx);
+    return;
+  }
+
+  await sendPeerFromComposer(text, ctx);
+}
+
+// Toggle the current member's emoji reaction on every message matching the predicate. Optimistically
+// flips the chip (count + reactedByMe), then POSTs; on failure the optimistic change is reverted
+// (toggling the same emoji again undoes it). A fresh history load reconciles to the server aggregate.
+async function toggleMessageReaction(
+  matchesTarget: (message: ChatMessage) => boolean,
+  emoji: string,
+  url: string,
+  setters: ChatSetters,
+): Promise<void> {
+  const flip = (previous: ChatMessage[]): ChatMessage[] =>
+    previous.map((message) => (matchesTarget(message) ? applyReactionToggle(message, emoji) : message));
+
+  setters.setMessages(flip);
+
+  try {
+    await requestJson<{ ok: true; reacted: boolean }>(url, {
+      method: 'POST',
+      headers: JSON_CSRF_HEADERS,
+      body: JSON.stringify({ emoji }),
+    });
+  } catch (reactError) {
+    setters.setMessages(flip);
+    setters.setError(toErrorMessage(reactError, 'Unable to update your reaction right now.'));
+  }
+}
+
+// Toggle the member's reaction on a peer post, keyed on the community post id.
+function togglePostReaction(postId: string, emoji: string, setters: ChatSetters): Promise<void> {
+  return toggleMessageReaction(
+    (message) => message.communityPostId === postId,
+    emoji,
+    `/api/hub/messages/${encodeURIComponent(postId)}/reactions`,
+    setters,
+  );
+}
+
+// Toggle the member's reaction on an official announcement, keyed on the announcement id.
+function toggleAnnouncementReactionFor(announcementId: string, emoji: string, setters: ChatSetters): Promise<void> {
+  return toggleMessageReaction(
+    (message) => message.announcementId === announcementId,
+    emoji,
+    `/api/announcements/${encodeURIComponent(announcementId)}/reactions`,
+    setters,
+  );
+}
+
+// Delete one of the member's own peer posts. Optimistically drops it from the stream, then DELETEs;
+// on failure the post is restored and an error is shown. Server enforces author-only.
+async function runDeleteMessage(postId: string, setters: ChatSetters): Promise<void> {
+  let removed: ChatMessage[] = [];
+  setters.setMessages((previous) => {
+    removed = previous.filter((message) => message.communityPostId === postId);
+    return previous.filter((message) => message.communityPostId !== postId);
+  });
+
+  try {
+    await requestJson<{ ok: true; postId: string }>(`/api/hub/messages/${encodeURIComponent(postId)}`, {
+      method: 'DELETE',
+      headers: { 'x-ctf-csrf': '1' },
+    });
+  } catch (deleteError) {
+    // Restore the optimistically removed post(s) and surface the error.
+    if (removed.length > 0) {
+      setters.setMessages((previous) => mergeMessages(previous, removed));
+    }
+    setters.setError(toErrorMessage(deleteError, 'Unable to delete your post right now.'));
+  }
+}
+
+// Rate an answered AI Assistant card. Optimistically reflects the choice; reverts on failure.
+async function runRateComicAnswer(turnId: string, rating: ComicAnswerRating, setters: ChatSetters): Promise<void> {
+  let previousRating: ComicAnswerRating | null = null;
+  setters.setComicItems((previous) =>
+    previous.map((item) => {
+      if (item.answerTurnId !== turnId) return item;
+      previousRating = item.currentUserRating;
+      return { ...item, currentUserRating: rating };
+    }),
+  );
+
+  try {
+    await requestJson<{ ok: true }>(`/api/comic/answers/${turnId}/rate`, {
+      method: 'POST',
+      headers: JSON_CSRF_HEADERS,
+      body: JSON.stringify({ rating }),
+    });
+  } catch (rateError) {
+    setters.setComicItems((previous) =>
+      previous.map((item) => (item.answerTurnId === turnId ? { ...item, currentUserRating: previousRating } : item)),
+    );
+    setters.setError(toErrorMessage(rateError, 'Unable to record your rating right now.'));
+  }
+}
+
+// Build the member's question message plus the instant local concierge reply for a concierge ask.
+// Purely local — points at the best-matching feature (with an "Open X" button), or a gentle
+// fall-back when nothing matches. Returns an empty array for empty input.
+function buildConciergeMessages(promptText: string): ChatMessage[] {
+  const text = promptText.trim();
+  if (!text) {
+    return [];
+  }
+  const now = new Date();
+  const time = formatTimeLabel(now);
+  // Stamp a real sentAtIso: the home stream sorts by epoch(sentAtIso) and falls back to the array
+  // index when it is missing — without this, concierge messages got a tiny fallback epoch and sorted
+  // to the TOP of the chat instead of the bottom. A real timestamp keeps them newest-last.
+  const sentAtIso = now.toISOString();
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const matches = resolveConcierge(text);
+  const userMsg: ChatMessage = { id: `concierge-q-${stamp}`, from: 'user', text, time, sentAtIso };
+
+  const top = matches[0];
+  const second = matches[1];
+  const reply: ChatMessage = top
+    ? {
+      id: `concierge-a-${stamp}`,
+      from: 'hub',
+      text: second ? `${top.blurb} (Or try ${second.name}.)` : top.blurb,
+      time,
+      sentAtIso,
+      actionLabel: `Open ${top.name} →`,
+      actionSlug: top.slug,
+    }
+    : {
+      id: `concierge-a-${stamp}`,
+      from: 'hub',
+      text: 'I’m not sure which feature fits that yet — type @comic to ask the AI Assistant, or share it with the community below.',
+      time,
+      sentAtIso,
+    };
+
+  return [userMsg, reply];
+}
+
+// Run a concierge ask: append the member's question plus the instant local reply. No-op for empty input.
+function applyConciergeAsk(promptText: string, setters: ChatSetters): void {
+  const next = buildConciergeMessages(promptText);
+  if (next.length === 0) {
+    return;
+  }
+  setters.setMessages((previous) => mergeMessages(previous, next));
+}
+
+// One-tap "ask @comic" for a suggestion chip (issue #471): route a fixed question straight to the AI
+// assistant, no composer step. The @comic mention is added by the caller. Same consent gate and
+// holding-card flow the composer uses; on first use the consent modal opens holding the mentioned text.
+type AskComicContext = {
+  isSending: boolean;
+  consentGranted: boolean;
+  routeToComic: (questionText: string) => Promise<void>;
+  setters: ChatSetters;
+};
+
+function runAskComic(question: string, ctx: AskComicContext): void {
+  const clean = question.trim();
+  if (!clean || ctx.isSending) return;
+  const mentioned = `@comic ${clean}`;
+  if (!ctx.consentGranted) {
+    ctx.setters.setPendingConsentText(mentioned);
+    ctx.setters.setConsentModalOpen(true);
+    return;
+  }
+  ctx.setters.setIsSending(true);
+  ctx.setters.setError(null);
+  void ctx.routeToComic(mentioned).finally(() => ctx.setters.setIsSending(false));
+}
+
+type ConfirmConsentContext = {
+  userId: string;
+  pendingConsentText: string | null;
+  routeToComic: (questionText: string) => Promise<void>;
+  setters: ChatSetters;
+};
+
+// Consent modal "Not now": close the modal and drop the held text.
+function dismissConsentState(setters: ChatSetters): void {
+  setters.setConsentModalOpen(false);
+  setters.setPendingConsentText(null);
+}
+
+// Consent modal "Confirm": persist consent and send the held @comic question.
+async function runConfirmConsent(ctx: ConfirmConsentContext): Promise<void> {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(consentStorageKey(ctx.userId), '1');
+  }
+  ctx.setters.setConsentGranted(true);
+  ctx.setters.setConsentModalOpen(false);
+
+  const held = ctx.pendingConsentText;
+  ctx.setters.setPendingConsentText(null);
+  if (!held) return;
+
+  ctx.setters.setIsSending(true);
+  ctx.setters.setError(null);
+  ctx.setters.setInput('');
+  try {
+    await ctx.routeToComic(held);
+  } finally {
+    ctx.setters.setIsSending(false);
+  }
+}
+
+// A single mount's bootstrap lifecycle flags: `active` guards against work after unmount, `pollId`
+// holds the running poll so cleanup can clear it.
+type BootstrapController = { active: boolean; pollId: number | undefined };
+
+// Everything the bootstrap needs from the hook: refresh callbacks, the refs the live handler and
+// cleanup reach through, and the state setters.
+type ChatBootstrapContext = {
+  controller: BootstrapController;
+  refreshHistory: () => Promise<void>;
+  refreshComic: () => Promise<void>;
+  refreshLastSeen: () => Promise<void>;
+  loadAroundDeepLink: () => Promise<void>;
+  refreshHistoryRef: RefObject<() => Promise<void>>;
+  liveConnectionRef: RefObject<HubLiveConnection | null>;
+  setters: ChatSetters;
+};
+
+// Reset per-mount state so re-entering the chat reads the marker afresh and can mark seen once more.
+function resetChatForMount(setters: ChatSetters, markedSeenRef: RefObject<boolean>): void {
+  setters.setConnectionState('loading');
+  setters.setError(null);
+  setters.setMessages([]);
+  setters.setComicItems([]);
+  markedSeenRef.current = false;
+  setters.setLastSeenAtIso(null);
+}
+
+// Both the live path and the polling-only path keep a poll running. `intervalMs` is short when we
+// are polling-only and long when a healthy live connection is the primary refresh path.
+function startChatPoll(ctx: ChatBootstrapContext, intervalMs: number): void {
+  ctx.controller.pollId = window.setInterval(() => {
+    void ctx.refreshHistory().catch(() => {
+      // Keep polling while the shell is mounted.
+    });
+    void ctx.refreshComic().catch(() => {
+      // The comic stream poll is best-effort; failures must not break hub polling.
+    });
+  }, intervalMs);
+}
+
+// Read the last-seen marker before history settles so the divider can be placed on the first render
+// of the stream, then load the recent page, comic stream, and any deep-link window. Best-effort.
+async function loadInitialChatHistory(ctx: ChatBootstrapContext): Promise<void> {
+  void ctx.refreshLastSeen();
+  try {
+    await Promise.all([ctx.refreshHistory(), ctx.refreshComic().catch(() => undefined)]);
+    // After the recent page loads, pull the deep-link target's window (if any) and merge it in.
+    void ctx.loadAroundDeepLink().catch(() => undefined);
+  } catch (loadError) {
+    if (ctx.controller.active) {
+      ctx.setters.setError(toErrorMessage(loadError, 'Unable to load live chat history.'));
+    }
+  }
+}
+
+// Open the live Stream connection only when the server actually minted credentials. When Stream is
+// not configured (configured: false) we never attempt a connection and simply poll — Commons must
+// keep working without Stream.
+async function connectLiveWhenConfigured(
+  join: HubJoinResponse,
+  ctx: ChatBootstrapContext,
+): Promise<HubLiveConnection | null> {
+  if (!join.configured) {
+    return null;
+  }
+  return connectHubLive(
+    {
+      streamApiKey: join.streamApiKey,
+      streamToken: join.streamToken,
+      streamUserId: join.streamUserId,
+      streamChannelId: join.streamChannelId,
+    },
+    {
+      // A new post (or a recovered connection) pulls fresh history right away, so posts appear
+      // immediately instead of waiting for the next poll.
+      onActivity: () => {
+        void ctx.refreshHistoryRef.current().catch(() => undefined);
+      },
+      onTypingChange: (typing) => {
+        if (ctx.controller.active) ctx.setters.setTypingUsers(typing);
+      },
+    },
+  );
+}
+
+// Join the hub, open the live connection when possible, and start the appropriate poll. On join
+// failure, fall back to the frequent poll.
+async function joinAndConnect(ctx: ChatBootstrapContext): Promise<void> {
+  try {
+    const join = await requestJson<HubJoinResponse>('/api/hub/join', { method: 'POST' });
+    if (!ctx.controller.active) return;
+    ctx.setters.setConnectionState('live');
+    ctx.setters.setError(null);
+
+    const live = await connectLiveWhenConfigured(join, ctx);
+
+    if (!ctx.controller.active) {
+      // Unmounted while connecting; tear the connection down rather than leak it.
+      if (live) void live.disconnect();
+      return;
+    }
+
+    if (live) {
+      ctx.liveConnectionRef.current = live;
+      // Live connection drives refreshes; the poll becomes a slow backstop.
+      startChatPoll(ctx, POLL_INTERVAL_LIVE_MS);
+    } else {
+      // Stream not configured, or the live connection failed to open: silently stay on the frequent
+      // poll. The chat is fully functional this way.
+      ctx.setters.setTypingUsers([]);
+      startChatPoll(ctx, POLL_INTERVAL_FALLBACK_MS);
+    }
+  } catch (joinError) {
+    if (!ctx.controller.active) return;
+
+    ctx.setters.setConnectionState('fallback');
+    ctx.setters.setError(toErrorMessage(joinError, 'Live chat is reconnecting.'));
+    startChatPoll(ctx, POLL_INTERVAL_FALLBACK_MS);
+  }
+}
+
+async function runChatBootstrap(ctx: ChatBootstrapContext): Promise<void> {
+  await loadInitialChatHistory(ctx);
+  await joinAndConnect(ctx);
+}
+
+// Unmount cleanup: stop the poll and disconnect the live Stream client so we never leak a connection.
+function teardownBootstrap(controller: BootstrapController, liveConnectionRef: RefObject<HubLiveConnection | null>): void {
+  controller.active = false;
+  if (controller.pollId) {
+    window.clearInterval(controller.pollId);
+  }
+  const live = liveConnectionRef.current;
+  liveConnectionRef.current = null;
+  if (live) {
+    void live.disconnect();
+  }
+}
+
 export function useHomeChat(currentUser: ShellCurrentUser) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [comicItems, setComicItems] = useState<ComicStreamItem[]>([]);
@@ -279,6 +923,30 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
   // show a loading line instead of a premature empty state.
   const [isFilterRefreshing, setIsFilterRefreshing] = useState(false);
 
+  // Stable bundles so module-scope helpers can update state / read filter refs without long argument
+  // lists. Setters and refs never change identity, so each ref is written once on first render.
+  const settersRef = useRef<ChatSetters>({
+    setMessages,
+    setComicItems,
+    setInput,
+    setError,
+    setReplyTarget,
+    setIsSending,
+    setConsentGranted,
+    setConsentModalOpen,
+    setPendingConsentText,
+    setLastSeenAtIso,
+    setConnectionState,
+    setTypingUsers,
+    setIsFilterRefreshing,
+  });
+  const filtersRef = useRef<FilterRefs>({
+    mentionsOnlyRef,
+    announcementsOnlyRef,
+    setMentionsOnly,
+    setAnnouncementsOnly,
+  });
+
   // Whether the composer currently contains an @comic mention — used to show the mention chip
   // affordance live as the asker types.
   const composerMentionsComic = useMemo(() => mentionsComic(input), [input]);
@@ -286,21 +954,12 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
   // The active stream filter, derived from the refs so the poll/live handlers (which hold older
   // callback identities) always read the current mode. Mentions and announcements are mutually
   // exclusive; 'all' is the unfiltered blended stream.
-  const currentFilterKey = (): 'mentions' | 'announcements' | 'all' =>
+  const currentFilterKey = (): FilterKey =>
     mentionsOnlyRef.current ? 'mentions' : announcementsOnlyRef.current ? 'announcements' : 'all';
 
   const refreshHistory = useCallback(async () => {
     const filterKey = currentFilterKey();
-    const filterParam =
-      filterKey === 'mentions' ? '&mentions=me' : filterKey === 'announcements' ? '&channel=announcements' : '';
-    const payload = await requestJson<HubMessagesResponse>(`/api/hub/messages?limit=50${filterParam}`);
-    // Ignore a response that raced a mode flip (e.g. a slow read landing after the member changed
-    // the filter) so the filtered view never gets polluted with the wrong stream.
-    if (currentFilterKey() !== filterKey) {
-      return;
-    }
-    const nextMessages = payload.messages.map((message) => mapStoredMessage(message, currentUser.userId));
-    setMessages((previous) => mergeMessages(previous, nextMessages));
+    await fetchHistoryIntoState(filterParamForKey(filterKey), currentFilterKey, filterKey, currentUser.userId, setMessages);
   }, [currentUser.userId]);
 
   // Deep-link "load around": pull a page centered on a specific message/announcement from the server
@@ -309,16 +968,9 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
   // message and current activity. Only applies to the unfiltered stream (a deep link is not a
   // mentions/announcements view), so it no-ops while a filter is active.
   const loadAround = useCallback(async (postId: string | null, announcementId: string | null) => {
-    const aroundParam = postId
-      ? `&aroundPost=${encodeURIComponent(postId)}`
-      : announcementId
-        ? `&aroundAnnouncement=${encodeURIComponent(announcementId)}`
-        : '';
+    const aroundParam = aroundParamFor(postId, announcementId);
     if (!aroundParam || currentFilterKey() !== 'all') return;
-    const payload = await requestJson<HubMessagesResponse>(`/api/hub/messages?limit=50${aroundParam}`);
-    if (currentFilterKey() !== 'all') return;
-    const nextMessages = payload.messages.map((message) => mapStoredMessage(message, currentUser.userId));
-    setMessages((previous) => mergeMessages(previous, nextMessages));
+    await fetchHistoryIntoState(aroundParam, currentFilterKey, 'all', currentUser.userId, setMessages);
     // currentFilterKey reads refs, so it is intentionally not a dependency.
   }, [currentUser.userId]);
 
@@ -336,103 +988,44 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
     refreshHistoryRef.current = refreshHistory;
   }, [refreshHistory]);
 
-  const refreshComic = useCallback(async () => {
-    const payload = await requestJson<ComicConversationResponse>('/api/comic/conversation?limit=30');
-    const serverItems: ComicStreamItem[] = payload.items.map((item) => ({ ...item }));
-    setComicItems((previous) => mergeComicItems(serverItems, previous));
-  }, []);
+  const refreshComic = useCallback(() => readComicInto(settersRef.current), []);
 
-  // Read the member's last-seen marker once on entry so the chat can place the "New messages"
-  // divider. Best-effort: a failure leaves the marker null (everything reads as already seen,
-  // i.e. no divider) and never blocks the chat.
-  const refreshLastSeen = useCallback(async () => {
-    try {
-      const payload = await requestJson<HubLastSeenResponse>('/api/hub/last-seen');
-      setLastSeenAtIso(payload.lastSeenAtIso);
-    } catch {
-      setLastSeenAtIso(null);
-    }
-  }, []);
+  const refreshLastSeen = useCallback(() => readLastSeenInto(settersRef.current), []);
 
-  // Move the last-seen marker to now after the member has viewed the chat. Best-effort and at
-  // most once per mount; a failure is swallowed so it can never break the chat.
-  const markSeen = useCallback(() => {
-    if (markedSeenRef.current) return;
-    markedSeenRef.current = true;
-    void (async () => {
-      try {
-        await requestJson<HubLastSeenResponse>('/api/hub/last-seen', {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            'x-ctf-csrf': '1',
-          },
-          body: JSON.stringify({ seenAtIso: new Date().toISOString() }),
-        });
-      } catch {
-        // Best-effort: leave markedSeenRef set so a transient failure does not retry-spam.
-      }
-    })();
-  }, []);
+  // Move the last-seen marker to now after the member has viewed the chat. Best-effort and at most
+  // once per mount; a failure is swallowed so it can never break the chat.
+  const markSeen = useCallback(() => markSeenOnce(markedSeenRef), []);
 
-  // Clear the loaded messages and re-fetch in the current filter mode. The list is cleared first so
-  // modes never blend (merge is additive, so a shared list would keep old rows around).
-  const refreshForFilterChange = useCallback(() => {
-    setMessages([]);
-    setIsFilterRefreshing(true);
-    void refreshHistory()
-      .catch(() => {
-        // Best-effort: the poll retries shortly; the empty state covers the gap.
-      })
-      .finally(() => setIsFilterRefreshing(false));
-  }, [refreshHistory]);
+  const refreshForFilterChange = useCallback(
+    () => runFilterRefresh(settersRef.current, refreshHistory),
+    [refreshHistory],
+  );
 
   // Flip the "@ Mentions" filter. Turning it on clears the mutually-exclusive announcements filter.
-  const toggleMentionsOnly = useCallback(() => {
-    const next = !mentionsOnlyRef.current;
-    mentionsOnlyRef.current = next;
-    setMentionsOnly(next);
-    if (next) {
-      announcementsOnlyRef.current = false;
-      setAnnouncementsOnly(false);
-    }
-    refreshForFilterChange();
-  }, [refreshForFilterChange]);
+  const toggleMentionsOnly = useCallback(
+    () => flipFilter(!mentionsOnlyRef.current, false, filtersRef.current, refreshForFilterChange),
+    [refreshForFilterChange],
+  );
 
   // Flip the announcements (📣) filter. Turning it on clears the mutually-exclusive mentions filter.
-  const toggleAnnouncementsOnly = useCallback(() => {
-    const next = !announcementsOnlyRef.current;
-    announcementsOnlyRef.current = next;
-    setAnnouncementsOnly(next);
-    if (next) {
-      mentionsOnlyRef.current = false;
-      setMentionsOnly(false);
-    }
-    refreshForFilterChange();
-  }, [refreshForFilterChange]);
+  const toggleAnnouncementsOnly = useCallback(
+    () => flipFilter(false, !announcementsOnlyRef.current, filtersRef.current, refreshForFilterChange),
+    [refreshForFilterChange],
+  );
 
-  // Force the unfiltered blended stream (used when a deep link must land but a filter is active). Clears
-  // both filters and re-fetches; a no-op when neither filter is on.
+  // Force the unfiltered blended stream (used when a deep link must land but a filter is active).
+  // Clears both filters and re-fetches; a no-op when neither filter is on.
   const showAllStream = useCallback(() => {
     if (!mentionsOnlyRef.current && !announcementsOnlyRef.current) return;
-    mentionsOnlyRef.current = false;
-    announcementsOnlyRef.current = false;
-    setMentionsOnly(false);
-    setAnnouncementsOnly(false);
-    refreshForFilterChange();
+    flipFilter(false, false, filtersRef.current, refreshForFilterChange);
   }, [refreshForFilterChange]);
 
   // Emit a typing event as the member writes in the composer. No-op when there is no live
   // connection (polling-only mode), so the composer can call it unconditionally on every keystroke.
-  const notifyTyping = useCallback(() => {
-    liveConnectionRef.current?.sendTyping();
-  }, []);
+  const notifyTyping = useCallback(() => liveConnectionRef.current?.sendTyping(), []);
 
-  // Tell the channel the member has stopped typing (e.g. after sending). Best-effort; no-op when not
-  // live.
-  const notifyStopTyping = useCallback(() => {
-    liveConnectionRef.current?.stopTyping();
-  }, []);
+  // Tell the channel the member has stopped typing (e.g. after sending). Best-effort; no-op when not live.
+  const notifyStopTyping = useCallback(() => liveConnectionRef.current?.stopTyping(), []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -440,440 +1033,94 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
   }, [currentUser.userId]);
 
   useEffect(() => {
-    let active = true;
-    let pollId: number | undefined;
-
-    setConnectionState('loading');
-    setError(null);
-    setMessages([]);
-    setComicItems([]);
-    // Reset per-mount "seen" state so re-entering the chat reads the marker afresh and can
-    // mark seen once more.
-    markedSeenRef.current = false;
-    setLastSeenAtIso(null);
-
-    async function bootstrapChat() {
-      // Read the last-seen marker before history settles so the divider can be placed on the
-      // first render of the stream. Best-effort; failure leaves it null (no divider).
-      void refreshLastSeen();
-      try {
-        await Promise.all([refreshHistory(), refreshComic().catch(() => undefined)]);
-        // After the recent page loads, pull the deep-link target's window (if any) and merge it in.
-        void loadAroundDeepLink().catch(() => undefined);
-      } catch (loadError) {
-        if (active) {
-          setError(loadError instanceof Error ? loadError.message : 'Unable to load live chat history.');
-        }
-      }
-
-      // Both the live path and the polling-only path keep a poll running. `intervalMs` is short when
-      // we are polling-only and long when a healthy live connection is the primary refresh path.
-      const startPoll = (intervalMs: number) => {
-        pollId = window.setInterval(() => {
-          void refreshHistory().catch(() => {
-            // Keep polling while the shell is mounted.
-          });
-          void refreshComic().catch(() => {
-            // The comic stream poll is best-effort; failures must not break hub polling.
-          });
-        }, intervalMs);
-      };
-
-      try {
-        const join = await requestJson<HubJoinResponse>('/api/hub/join', { method: 'POST' });
-        if (!active) return;
-        setConnectionState('live');
-        setError(null);
-
-        // Try to open the live Stream connection only when the server actually minted credentials.
-        // When Stream is not configured (configured: false) we never attempt a connection and simply
-        // poll — Commons must keep working without Stream.
-        let live: HubLiveConnection | null = null;
-        if (join.configured) {
-          live = await connectHubLive(
-            {
-              streamApiKey: join.streamApiKey,
-              streamToken: join.streamToken,
-              streamUserId: join.streamUserId,
-              streamChannelId: join.streamChannelId,
-            },
-            {
-              // A new post (or a recovered connection) pulls fresh history right away, so posts appear
-              // immediately instead of waiting for the next poll.
-              onActivity: () => {
-                void refreshHistoryRef.current().catch(() => undefined);
-              },
-              onTypingChange: (typing) => {
-                if (active) setTypingUsers(typing);
-              },
-            },
-          );
-        }
-
-        if (!active) {
-          // Unmounted while connecting; tear the connection down rather than leak it.
-          if (live) void live.disconnect();
-          return;
-        }
-
-        if (live) {
-          liveConnectionRef.current = live;
-          // Live connection drives refreshes; the poll becomes a slow backstop.
-          startPoll(POLL_INTERVAL_LIVE_MS);
-        } else {
-          // Stream not configured, or the live connection failed to open: silently stay on the
-          // frequent poll. The chat is fully functional this way.
-          setTypingUsers([]);
-          startPoll(POLL_INTERVAL_FALLBACK_MS);
-        }
-      } catch (joinError) {
-        if (!active) return;
-
-        setConnectionState('fallback');
-        setError(joinError instanceof Error ? joinError.message : 'Live chat is reconnecting.');
-        startPoll(POLL_INTERVAL_FALLBACK_MS);
-      }
-    }
-
-    void bootstrapChat();
-
-    return () => {
-      active = false;
-      if (pollId) {
-        window.clearInterval(pollId);
-      }
-      // Disconnect the live Stream client on unmount so we never leak a connection.
-      const live = liveConnectionRef.current;
-      liveConnectionRef.current = null;
-      if (live) {
-        void live.disconnect();
-      }
-    };
+    const controller: BootstrapController = { active: true, pollId: undefined };
+    resetChatForMount(settersRef.current, markedSeenRef);
+    void runChatBootstrap({
+      controller,
+      refreshHistory,
+      refreshComic,
+      refreshLastSeen,
+      loadAroundDeepLink,
+      refreshHistoryRef,
+      liveConnectionRef,
+      setters: settersRef.current,
+    });
+    return () => teardownBootstrap(controller, liveConnectionRef);
   }, [currentUser.displayName, currentUser.userId, refreshHistory, refreshComic, refreshLastSeen, loadAroundDeepLink]);
 
-  // Route an @comic question to the assistant. The server returns ONLY a holding response (202) —
-  // never the unreviewed draft — so we optimistically render the pending "Reviewing for safety"
-  // card and rely on the polling stream to surface the answer once a human approves it.
   const routeToComic = useCallback(
-    async (questionText: string) => {
-      const question = stripComicMention(questionText);
-      // Unique per ask (random suffix) so two rapid identical-text asks get distinct React keys and
-      // are tracked independently by the count-aware merge.
-      const localId = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const optimisticItem: ComicStreamItem = {
-        questionTurnId: localId,
-        conversationId: 'optimistic',
-        status: 'pending',
-        question,
-        answer: null,
-        answerTurnId: null,
-        currentUserRating: null,
-        linkedPlugins: [],
-        askedAtIso: new Date().toISOString(),
-        optimistic: true,
-      };
-      setComicItems((previous) => [...previous, optimisticItem]);
-
-      try {
-        await requestJson<ComicMessageResponse>('/api/comic/message', {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            'x-ctf-csrf': '1',
-          },
-          body: JSON.stringify({ body: questionText, channel: 'hub', consentGranted: true }),
-        });
-        // Pull the server stream so the pending card reflects the persisted turn.
-        await refreshComic().catch(() => undefined);
-      } catch (sendError) {
-        // Drop the optimistic card on failure and surface the error.
-        setComicItems((previous) => previous.filter((item) => item.questionTurnId !== optimisticItem.questionTurnId));
-        setError(sendError instanceof Error ? sendError.message : 'Unable to reach the AI Assistant right now.');
-      }
-    },
+    (questionText: string) => runRouteToComic(questionText, refreshComic, settersRef.current),
     [refreshComic],
   );
 
-  const sendMessage = useCallback(async () => {
-    const text = input.trim();
-    if (!text || isSending) {
-      return;
-    }
+  const sendMessage = useCallback(
+    () =>
+      runSendMessage({
+        input,
+        isSending,
+        consentGranted,
+        replyTarget,
+        currentUserId: currentUser.userId,
+        routeToComic,
+        notifyStopTyping,
+        setters: settersRef.current,
+      }),
+    [consentGranted, currentUser.userId, input, isSending, notifyStopTyping, replyTarget, routeToComic],
+  );
 
-    // @comic mention → AI Assistant. Gate the first use behind the consent modal.
-    if (mentionsComic(text)) {
-      if (!consentGranted) {
-        setPendingConsentText(text);
-        setConsentModalOpen(true);
-        return;
-      }
-
-      setIsSending(true);
-      setError(null);
-      setInput('');
-      try {
-        await routeToComic(text);
-      } finally {
-        setIsSending(false);
-      }
-      return;
-    }
-
-    // No mention → peer-to-peer community post via the existing hub path. Capture the active
-    // reply target (Signal-style quote) before clearing it, and send its post id + the quote
-    // the sender saw so the server stores the reference and the optimistic copy renders it.
-    const activeReply = replyTarget;
-    setIsSending(true);
-    setError(null);
-    setInput('');
-    setReplyTarget(null);
-    // The member just sent; clear the typing indicator on the live channel right away.
-    notifyStopTyping();
-
-    try {
-      const payload = await requestJson<{ ok: true; message: HubMessage }>('/api/hub/messages', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'x-ctf-csrf': '1',
-        },
-        body: JSON.stringify(
-          activeReply
-            ? { text, replyToPostId: activeReply.postId, quotedMessage: activeReply.quote }
-            : { text },
-        ),
-      });
-      const savedMessage = mapStoredMessage(payload.message, currentUser.userId);
-      setMessages((previous) => mergeMessages(previous, [savedMessage]));
-    } catch (sendError) {
-      // Restore the reply target so the member can retry the reply.
-      if (activeReply) {
-        setReplyTarget(activeReply);
-      }
-      // Put the text back in the composer (owner report, 2026-07-27). The input is cleared
-      // optimistically above so the send feels instant; before this, a rejected send — a message
-      // over the length cap, or any network failure — cleared the box and the member's writing was
-      // gone with nothing to retry. Only restore when the member has not started typing something
-      // new in the meantime, so a recovery never overwrites live work.
-      setInput((current) => (current.trim().length === 0 ? text : current));
-      setError(sendError instanceof Error ? sendError.message : 'Unable to send your message right now.');
-    } finally {
-      setIsSending(false);
-    }
-  }, [consentGranted, currentUser.userId, input, isSending, notifyStopTyping, replyTarget, routeToComic]);
-
-  // One-tap "ask @comic" for a suggestion chip (issue #471): route a fixed question straight to the
-  // AI assistant, no composer step. Same consent gate and same holding-card flow the composer uses —
-  // the @comic mention is added here because the server only routes a body that mentions @comic
-  // (an unmentioned body is treated as a peer post and the assistant does nothing). On first use the
-  // consent modal opens holding the mentioned text; confirming sends it via routeToComic.
   const askComic = useCallback(
-    (question: string) => {
-      const clean = question.trim();
-      if (!clean || isSending) return;
-      const mentioned = `@comic ${clean}`;
-      if (!consentGranted) {
-        setPendingConsentText(mentioned);
-        setConsentModalOpen(true);
-        return;
-      }
-      setIsSending(true);
-      setError(null);
-      void routeToComic(mentioned).finally(() => setIsSending(false));
-    },
+    (question: string) => runAskComic(question, { isSending, consentGranted, routeToComic, setters: settersRef.current }),
     [consentGranted, isSending, routeToComic],
   );
 
   // Begin a Signal-style reply to a peer message: set the composer's "replying to …" state.
-  // Only peer posts carry a communityPostId, so AI answers / concierge lines cannot be replied to.
   const beginReply = useCallback((message: ChatMessage) => {
-    if (!message.communityPostId) return;
-    const author = message.senderLabel ?? 'Community member';
-    const snippet = message.text.trim().slice(0, 120);
-    setReplyTarget({ postId: message.communityPostId, quote: { author, snippet, postId: message.communityPostId } });
+    const target = buildReplyTarget(message);
+    if (target) setReplyTarget(target);
   }, []);
 
-  const cancelReply = useCallback(() => {
-    setReplyTarget(null);
-  }, []);
+  const cancelReply = useCallback(() => setReplyTarget(null), []);
 
-  // Toggle the current member's emoji reaction on a peer post. Optimistically flips the chip
-  // (count + reactedByMe) right away, then POSTs; on failure the optimistic change is reverted.
-  // The 10s history poll reconciles to the authoritative server aggregate.
+  // Toggle the current member's emoji reaction on a peer post, keyed on the community post id.
   const toggleReaction = useCallback(
-    async (postId: string, emoji: string) => {
-      // Optimistically flip every message backed by this community post.
-      setMessages((previous) =>
-        previous.map((message) =>
-          message.communityPostId === postId ? applyReactionToggle(message, emoji) : message,
-        ),
-      );
-
-      try {
-        await requestJson<{ ok: true; reacted: boolean }>(
-          `/api/hub/messages/${encodeURIComponent(postId)}/reactions`,
-          {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-              'x-ctf-csrf': '1',
-            },
-            body: JSON.stringify({ emoji }),
-          },
-        );
-      } catch (reactError) {
-        // Revert the optimistic flip (toggling the same emoji again undoes it).
-        setMessages((previous) =>
-          previous.map((message) =>
-            message.communityPostId === postId ? applyReactionToggle(message, emoji) : message,
-          ),
-        );
-        setError(reactError instanceof Error ? reactError.message : 'Unable to update your reaction right now.');
-      }
-    },
+    (postId: string, emoji: string) => togglePostReaction(postId, emoji, settersRef.current),
     [],
   );
 
-  // Toggle the current member's emoji reaction on an official announcement. Mirrors toggleReaction
-  // but keyed on the announcement id: optimistically flips the chip on every message backed by this
-  // announcement, then POSTs; on failure the optimistic change is reverted. The next fresh history
-  // load reconciles to the authoritative server aggregate.
+  // Toggle the current member's emoji reaction on an official announcement, keyed on the announcement id.
   const toggleAnnouncementReaction = useCallback(
-    async (announcementId: string, emoji: string) => {
-      setMessages((previous) =>
-        previous.map((message) =>
-          message.announcementId === announcementId ? applyReactionToggle(message, emoji) : message,
-        ),
-      );
-
-      try {
-        await requestJson<{ ok: true; reacted: boolean }>(
-          `/api/announcements/${encodeURIComponent(announcementId)}/reactions`,
-          {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-              'x-ctf-csrf': '1',
-            },
-            body: JSON.stringify({ emoji }),
-          },
-        );
-      } catch (reactError) {
-        // Revert the optimistic flip (toggling the same emoji again undoes it).
-        setMessages((previous) =>
-          previous.map((message) =>
-            message.announcementId === announcementId ? applyReactionToggle(message, emoji) : message,
-          ),
-        );
-        setError(reactError instanceof Error ? reactError.message : 'Unable to update your reaction right now.');
-      }
-    },
+    (announcementId: string, emoji: string) => toggleAnnouncementReactionFor(announcementId, emoji, settersRef.current),
     [],
   );
 
   // Delete one of the member's own peer posts. The product has no edit — to change a post you
-  // delete and repost — so this removes the post outright. Optimistically drops it from the stream,
-  // then DELETEs; on failure the post is restored and an error is shown. Server enforces author-only.
-  const deleteMessage = useCallback(
-    async (postId: string) => {
-      let removed: ChatMessage[] = [];
-      setMessages((previous) => {
-        removed = previous.filter((message) => message.communityPostId === postId);
-        return previous.filter((message) => message.communityPostId !== postId);
-      });
+  // delete and repost — so this removes the post outright.
+  const deleteMessage = useCallback((postId: string) => runDeleteMessage(postId, settersRef.current), []);
 
-      try {
-        await requestJson<{ ok: true; postId: string }>(
-          `/api/hub/messages/${encodeURIComponent(postId)}`,
-          {
-            method: 'DELETE',
-            headers: { 'x-ctf-csrf': '1' },
-          },
-        );
-      } catch (deleteError) {
-        // Restore the optimistically removed post(s) and surface the error.
-        if (removed.length > 0) {
-          setMessages((previous) => mergeMessages(previous, removed));
-        }
-        setError(deleteError instanceof Error ? deleteError.message : 'Unable to delete your post right now.');
-      }
-    },
-    [],
-  );
-
-  // Edit one of the member's own peer posts. The product has no in-place edit — editing IS delete +
-  // repost — so this loads the post's text back into the composer and deletes the original. The member
-  // tweaks it and sends a fresh post (new timestamp, its own moderation, no inherited reactions or
-  // replies). Clears any active reply so the reposted text starts clean.
+  // Edit one of the member's own peer posts. Editing IS delete + repost — load the text back into the
+  // composer and delete the original; the member tweaks it and sends a fresh post.
   const editMessage = useCallback(
-    (postId: string, text: string) => {
-      setReplyTarget(null);
-      setInput(text);
-      void deleteMessage(postId);
-    },
+    (postId: string, text: string) => runEditMessage(postId, text, settersRef.current, deleteMessage),
     [deleteMessage],
   );
 
   // Consent modal "Confirm": persist consent and send the held @comic question.
-  const confirmConsent = useCallback(async () => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(consentStorageKey(currentUser.userId), '1');
-    }
-    setConsentGranted(true);
-    setConsentModalOpen(false);
-
-    const held = pendingConsentText;
-    setPendingConsentText(null);
-    if (!held) return;
-
-    setIsSending(true);
-    setError(null);
-    setInput('');
-    try {
-      await routeToComic(held);
-    } finally {
-      setIsSending(false);
-    }
-  }, [currentUser.userId, pendingConsentText, routeToComic]);
+  const confirmConsent = useCallback(
+    () =>
+      runConfirmConsent({ userId: currentUser.userId, pendingConsentText, routeToComic, setters: settersRef.current }),
+    [currentUser.userId, pendingConsentText, routeToComic],
+  );
 
   // Consent modal "Not now": do not route, and do NOT populate the composer. When the modal was
   // opened from a composer-typed @comic message the text is already in the input (the send path never
   // cleared it), so it stays put on its own. When it was opened from a one-tap suggestion chip the
   // input was empty, so we must leave it empty — dropping the chip's "@comic …" question into the box
   // (the old behavior) looked like a message queued to send that the member never wrote.
-  const dismissConsent = useCallback(() => {
-    setConsentModalOpen(false);
-    setPendingConsentText(null);
-  }, []);
+  const dismissConsent = useCallback(() => dismissConsentState(settersRef.current), []);
 
   // Rate an answered AI Assistant card. Optimistically reflects the choice; reverts on failure.
   const rateComicAnswer = useCallback(
-    async (turnId: string, rating: ComicAnswerRating) => {
-      let previousRating: ComicAnswerRating | null = null;
-      setComicItems((previous) =>
-        previous.map((item) => {
-          if (item.answerTurnId !== turnId) return item;
-          previousRating = item.currentUserRating;
-          return { ...item, currentUserRating: rating };
-        }),
-      );
-
-      try {
-        await requestJson<{ ok: true }>(`/api/comic/answers/${turnId}/rate`, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            'x-ctf-csrf': '1',
-          },
-          body: JSON.stringify({ rating }),
-        });
-      } catch (rateError) {
-        setComicItems((previous) =>
-          previous.map((item) => (item.answerTurnId === turnId ? { ...item, currentUserRating: previousRating } : item)),
-        );
-        setError(rateError instanceof Error ? rateError.message : 'Unable to record your rating right now.');
-      }
-    },
+    (turnId: string, rating: ComicAnswerRating) => runRateComicAnswer(turnId, rating, settersRef.current),
     [],
   );
 
@@ -887,46 +1134,9 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
   const starterPrompts = useMemo(() => conciergeStarterPrompts(5), []);
 
   // Run a concierge ask: show the question as the member's own message, then an instant local reply
-  // that points at the best-matching feature (with an "Open X" button), or a gentle fall-back to the
-  // AI Assistant / community when nothing matches. Purely local — it does not post to the community
-  // and does not touch the @comic or peer-post paths.
-  const sendConciergeAsk = useCallback((promptText: string) => {
-    const text = promptText.trim();
-    if (!text) {
-      return;
-    }
-    const now = new Date();
-    const time = formatTimeLabel(now);
-    // Stamp a real sentAtIso: the home stream sorts by epoch(sentAtIso) and falls back to the array
-    // index when it is missing — without this, concierge messages got a tiny fallback epoch and sorted
-    // to the TOP of the chat instead of the bottom. A real timestamp keeps them newest-last.
-    const sentAtIso = now.toISOString();
-    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    const matches = resolveConcierge(text);
-    const userMsg: ChatMessage = { id: `concierge-q-${stamp}`, from: 'user', text, time, sentAtIso };
-
-    const top = matches[0];
-    const second = matches[1];
-    const reply: ChatMessage = top
-      ? {
-        id: `concierge-a-${stamp}`,
-        from: 'hub',
-        text: second ? `${top.blurb} (Or try ${second.name}.)` : top.blurb,
-        time,
-        sentAtIso,
-        actionLabel: `Open ${top.name} →`,
-        actionSlug: top.slug,
-      }
-      : {
-        id: `concierge-a-${stamp}`,
-        from: 'hub',
-        text: 'I’m not sure which feature fits that yet — type @comic to ask the AI Assistant, or share it with the community below.',
-        time,
-        sentAtIso,
-      };
-
-    setMessages((previous) => mergeMessages(previous, [userMsg, reply]));
-  }, []);
+  // that points at the best-matching feature. Purely local — it does not post to the community and
+  // does not touch the @comic or peer-post paths.
+  const sendConciergeAsk = useCallback((promptText: string) => applyConciergeAsk(promptText, settersRef.current), []);
 
   return {
     messages,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — these are web components/hooks).

## What

Rule-116 complexity/length cleanup for the Commons shell and its chat surface (9 files). **Behavior-preserving** — rendered UI, state, effects, Stream subscriptions, handlers, and network calls unchanged; React hooks kept in stable, unconditional order (only non-hook logic lifted out of hook bodies).

- `announcement-card.tsx`, `comic-consent-modal.tsx`, `community-shell.tsx`, `gated-chat-panel.tsx`, `notifications-panel.tsx`, `shell-chat-panel.tsx` (the 505-line / complexity-47 `AuthenticatedChatPanel` and its complexity-28 map fully decomposed), `unlock-verify-banner.tsx`
- `use-gated-chat.ts`, `use-home-chat.ts` (the 539-line hook split into module helpers driven by a stable setters/refs bundle so identities never change and effect deps are unchanged)

## Verification
- `pnpm --filter @ctf/web run typecheck` / `lint` — pass (caught and fixed one `RefObject<… | null>` prop-type nit introduced during extraction)
- complexity/length rule on all nine files — pass
- `check-eof-format` — pass
- pre-push gate (repo-wide typecheck) — pass

No schema/route/contract changes.

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_