### PR TITLE
refactor: reduce complexity in skills-hunt/what-works/socket-relay/recurring-activity components

### DIFF
--- a/ctf/packages/web/components/recurring-activity/recurring-activity-create-form.tsx
+++ b/ctf/packages/web/components/recurring-activity/recurring-activity-create-form.tsx
@@ -49,12 +49,13 @@ export function RecurringActivityCreateForm({
     }
   }, [currencies, currencyCode]);
 
-  const selectedCurrency = currencies.find((c) => c.code === currencyCode) ?? null;
-  const isServiceCredits = selectedCurrency?.isServiceCredits ?? currencyCode === 'SC';
-
-  const scNumber = Number(scValue);
-  const scValid = !isServiceCredits || scValue === '' || (Number.isFinite(scNumber) && scNumber > 0);
-  const canSubmit = !submitting && counterparty !== null && currencyCode !== '' && scValid;
+  const { isServiceCredits, scNumber, canSubmit } = deriveCreateFormState({
+    currencies,
+    currencyCode,
+    submitting,
+    counterparty,
+    scValue,
+  });
 
   const submit = useCallback(() => {
     if (!counterparty || currencyCode === '') {
@@ -138,26 +139,67 @@ export function RecurringActivityCreateForm({
 
       {error ? <div style={{ fontSize: 12, color: t.SUBTLE, marginBottom: 10 }}>{error}</div> : null}
 
-      <button
-        type="button"
-        disabled={!canSubmit}
-        onClick={submit}
-        style={{
-          width: '100%',
-          padding: '11px',
-          borderRadius: 10,
-          background: canSubmit ? t.ACCENT : `${t.ACCENT}55`,
-          border: 'none',
-          color: t.BG,
-          fontSize: 14,
-          fontWeight: 700,
-          cursor: canSubmit ? 'pointer' : 'not-allowed',
-          fontFamily: 'inherit',
-        }}
-      >
-        {submitting ? 'Recording…' : 'Acknowledge activity'}
-      </button>
+      <SubmitButton t={t} canSubmit={canSubmit} submitting={submitting} onSubmit={submit} />
     </div>
+  );
+}
+
+// Pure derivation of the create form's currency/validation state, kept out of the component so its
+// several boolean checks do not inflate the component's complexity.
+function deriveCreateFormState({
+  currencies,
+  currencyCode,
+  submitting,
+  counterparty,
+  scValue,
+}: {
+  currencies: Currency[];
+  currencyCode: string;
+  submitting: boolean;
+  counterparty: MemberOption | null;
+  scValue: string;
+}): { isServiceCredits: boolean; scNumber: number; scValid: boolean; canSubmit: boolean } {
+  const selectedCurrency = currencies.find((c) => c.code === currencyCode) ?? null;
+  const isServiceCredits = selectedCurrency?.isServiceCredits ?? currencyCode === 'SC';
+
+  const scNumber = Number(scValue);
+  const scValid = !isServiceCredits || scValue === '' || (Number.isFinite(scNumber) && scNumber > 0);
+  const canSubmit = !submitting && counterparty !== null && currencyCode !== '' && scValid;
+
+  return { isServiceCredits, scNumber, scValid, canSubmit };
+}
+
+function SubmitButton({
+  t,
+  canSubmit,
+  submitting,
+  onSubmit,
+}: {
+  t: RecurringActivityTokens;
+  canSubmit: boolean;
+  submitting: boolean;
+  onSubmit: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={!canSubmit}
+      onClick={onSubmit}
+      style={{
+        width: '100%',
+        padding: '11px',
+        borderRadius: 10,
+        background: canSubmit ? t.ACCENT : `${t.ACCENT}55`,
+        border: 'none',
+        color: t.BG,
+        fontSize: 14,
+        fontWeight: 700,
+        cursor: canSubmit ? 'pointer' : 'not-allowed',
+        fontFamily: 'inherit',
+      }}
+    >
+      {submitting ? 'Recording…' : 'Acknowledge activity'}
+    </button>
   );
 }
 

--- a/ctf/packages/web/components/recurring-activity/recurring-activity-item.tsx
+++ b/ctf/packages/web/components/recurring-activity/recurring-activity-item.tsx
@@ -40,15 +40,9 @@ export function RecurringActivityItem({
 }) {
   const [visDraft, setVisDraft] = useState<RecurringActivityVisibility>(activity.visibility);
 
-  const withName = activity.counterpartyName ? `with ${activity.counterpartyName}` : 'with a member';
+  const flags = deriveItemFlags(activity);
   const scLine = scValueLabel(activity, currencies);
-  const isCounterpartyPending = activity.status === 'pending' && activity.role === 'counterparty';
-  const canEnd = activity.status === 'pending' || activity.status === 'active';
-  const isOwner = activity.role === 'owner';
-  // Visibility only applies while the activity is live; once it has ended or was declined there is
-  // nothing to surface, so hide the picker (matches the mobile behaviour and the repository guard).
-  const canSetVisibility = isOwner && activity.status === 'active';
-  const busy = busyAction !== null;
+  const withName = flags.withName;
 
   return (
     <div
@@ -85,64 +79,120 @@ export function RecurringActivityItem({
         </span>
       </div>
 
-      {(isCounterpartyPending || canEnd || canSetVisibility) && (
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            alignItems: 'center',
-            gap: 8,
-            marginTop: 14,
-            paddingTop: 14,
-            borderTop: `1px solid ${t.BORDER_SOLID}`,
-          }}
-        >
-          {isCounterpartyPending && (
-            <>
-              <button type="button" disabled={busy} onClick={onConfirm} style={primaryBtn(t, busy)}>
-                {busyAction === 'confirm' ? 'Confirming…' : 'Confirm'}
-              </button>
-              <button type="button" disabled={busy} onClick={onDecline} style={ghostBtn(t, busy)}>
-                {busyAction === 'decline' ? 'Declining…' : 'Decline'}
-              </button>
-            </>
-          )}
-          {canEnd && (
-            <button type="button" disabled={busy} onClick={onEnd} style={ghostBtn(t, busy)}>
-              {busyAction === 'end' ? 'Ending…' : 'End activity'}
-            </button>
-          )}
-          {canSetVisibility && (
-            <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto' }}>
-              <span style={{ fontSize: 12, color: t.MUTED }}>Visible to</span>
-              <select
-                aria-label="Who can see this activity"
-                value={visDraft}
-                disabled={busy}
-                onChange={(e) => {
-                  const next = e.target.value as RecurringActivityVisibility;
-                  setVisDraft(next);
-                  onVisibility(next);
-                }}
-                style={{
-                  padding: '6px 8px',
-                  borderRadius: 8,
-                  fontSize: 12,
-                  color: t.TEXT,
-                  background: t.INPUT_BG,
-                  border: `1px solid ${t.BORDER_STRONG}`,
-                  appearance: 'auto',
-                }}
-              >
-                {VISIBILITY_ORDER.map((v) => (
-                  <option key={v} value={v} style={{ color: t.BG }}>
-                    {VISIBILITY_LABEL[v]}
-                  </option>
-                ))}
-              </select>
-            </label>
-          )}
-        </div>
+      <ItemActions
+        t={t}
+        flags={flags}
+        busyAction={busyAction}
+        visDraft={visDraft}
+        onConfirm={onConfirm}
+        onDecline={onDecline}
+        onEnd={onEnd}
+        onVisibility={(next) => {
+          setVisDraft(next);
+          onVisibility(next);
+        }}
+      />
+    </div>
+  );
+}
+
+interface ItemFlags {
+  withName: string;
+  isCounterpartyPending: boolean;
+  canEnd: boolean;
+  canSetVisibility: boolean;
+  hasActions: boolean;
+}
+
+// Pure derivation of the item's display/action flags, kept out of the component so its several
+// boolean checks do not inflate the component's complexity.
+function deriveItemFlags(activity: Activity): ItemFlags {
+  const withName = activity.counterpartyName ? `with ${activity.counterpartyName}` : 'with a member';
+  const isCounterpartyPending = activity.status === 'pending' && activity.role === 'counterparty';
+  const canEnd = activity.status === 'pending' || activity.status === 'active';
+  const isOwner = activity.role === 'owner';
+  // Visibility only applies while the activity is live; once it has ended or was declined there is
+  // nothing to surface, so hide the picker (matches the mobile behaviour and the repository guard).
+  const canSetVisibility = isOwner && activity.status === 'active';
+  const hasActions = isCounterpartyPending || canEnd || canSetVisibility;
+  return { withName, isCounterpartyPending, canEnd, canSetVisibility, hasActions };
+}
+
+function ItemActions({
+  t,
+  flags,
+  busyAction,
+  visDraft,
+  onConfirm,
+  onDecline,
+  onEnd,
+  onVisibility,
+}: {
+  t: RecurringActivityTokens;
+  flags: ItemFlags;
+  busyAction: ActionKind | null;
+  visDraft: RecurringActivityVisibility;
+  onConfirm: () => void;
+  onDecline: () => void;
+  onEnd: () => void;
+  onVisibility: (visibility: RecurringActivityVisibility) => void;
+}) {
+  if (!flags.hasActions) {
+    return null;
+  }
+  const busy = busyAction !== null;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 8,
+        marginTop: 14,
+        paddingTop: 14,
+        borderTop: `1px solid ${t.BORDER_SOLID}`,
+      }}
+    >
+      {flags.isCounterpartyPending && (
+        <>
+          <button type="button" disabled={busy} onClick={onConfirm} style={primaryBtn(t, busy)}>
+            {busyAction === 'confirm' ? 'Confirming…' : 'Confirm'}
+          </button>
+          <button type="button" disabled={busy} onClick={onDecline} style={ghostBtn(t, busy)}>
+            {busyAction === 'decline' ? 'Declining…' : 'Decline'}
+          </button>
+        </>
+      )}
+      {flags.canEnd && (
+        <button type="button" disabled={busy} onClick={onEnd} style={ghostBtn(t, busy)}>
+          {busyAction === 'end' ? 'Ending…' : 'End activity'}
+        </button>
+      )}
+      {flags.canSetVisibility && (
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto' }}>
+          <span style={{ fontSize: 12, color: t.MUTED }}>Visible to</span>
+          <select
+            aria-label="Who can see this activity"
+            value={visDraft}
+            disabled={busy}
+            onChange={(e) => onVisibility(e.target.value as RecurringActivityVisibility)}
+            style={{
+              padding: '6px 8px',
+              borderRadius: 8,
+              fontSize: 12,
+              color: t.TEXT,
+              background: t.INPUT_BG,
+              border: `1px solid ${t.BORDER_STRONG}`,
+              appearance: 'auto',
+            }}
+          >
+            {VISIBILITY_ORDER.map((v) => (
+              <option key={v} value={v} style={{ color: t.BG }}>
+                {VISIBILITY_LABEL[v]}
+              </option>
+            ))}
+          </select>
+        </label>
       )}
     </div>
   );

--- a/ctf/packages/web/components/recurring-activity/recurring-activity-shell.tsx
+++ b/ctf/packages/web/components/recurring-activity/recurring-activity-shell.tsx
@@ -23,6 +23,40 @@ import { RecurringActivityCreateForm, type CreateActivityInput } from './recurri
 
 type ActionKind = 'confirm' | 'decline' | 'end' | 'visibility';
 
+// Fetch and parse the activities + currencies payloads. Kept out of the component's loadData so its
+// response-shape branching does not inflate that callback's complexity.
+async function fetchRecurringActivityData(
+  signal?: AbortSignal,
+): Promise<{ activities: Activity[]; currencies: Currency[] }> {
+  const [activitiesRes, currenciesRes] = await Promise.all([
+    fetch('/api/recurring-activity', { cache: 'no-store', signal }),
+    fetch('/api/currencies', { cache: 'no-store', signal }),
+  ]);
+  if (!activitiesRes.ok) {
+    throw new Error('We could not load your ongoing activities. Try again in a moment.');
+  }
+  const activitiesData = (await activitiesRes.json()) as ActivitiesResponse;
+  const currenciesData = currenciesRes.ok
+    ? ((await currenciesRes.json()) as CurrenciesResponse)
+    : { ok: false as const };
+  return {
+    activities: activitiesData.activities ?? [],
+    currencies: currenciesData.currencies ?? [],
+  };
+}
+
+// An aborted load is expected teardown, not an error to surface; returns null in that case.
+function loadErrorMessage(e: unknown): string | null {
+  if ((e as Error).name === 'AbortError') {
+    return null;
+  }
+  return e instanceof Error ? e.message : 'We could not load your ongoing activities.';
+}
+
+function shouldClearLoading(signal: AbortSignal | undefined, background: boolean): boolean {
+  return !signal?.aborted && !background;
+}
+
 export function RecurringActivityShell() {
   const { theme } = useTheme();
   const t = getRecurringActivityTokens(theme);
@@ -43,29 +77,19 @@ export function RecurringActivityShell() {
     if (!background) setLoading(true);
     setError(null);
     try {
-      const [activitiesRes, currenciesRes] = await Promise.all([
-        fetch('/api/recurring-activity', { cache: 'no-store', signal }),
-        fetch('/api/currencies', { cache: 'no-store', signal }),
-      ]);
-      if (!activitiesRes.ok) {
-        throw new Error('We could not load your ongoing activities. Try again in a moment.');
-      }
-      const activitiesData = (await activitiesRes.json()) as ActivitiesResponse;
-      const currenciesData = currenciesRes.ok
-        ? ((await currenciesRes.json()) as CurrenciesResponse)
-        : { ok: false as const };
+      const data = await fetchRecurringActivityData(signal);
       if (signal?.aborted) {
         return;
       }
-      setActivities(activitiesData.activities ?? []);
-      setCurrencies(currenciesData.currencies ?? []);
+      setActivities(data.activities);
+      setCurrencies(data.currencies);
     } catch (e) {
-      if ((e as Error).name === 'AbortError') {
-        return;
+      const message = loadErrorMessage(e);
+      if (message) {
+        setError(message);
       }
-      setError(e instanceof Error ? e.message : 'We could not load your ongoing activities.');
     } finally {
-      if (!signal?.aborted && !background) {
+      if (shouldClearLoading(signal, background)) {
         setLoading(false);
       }
     }

--- a/ctf/packages/web/components/skills-hunt/sh-skills-picker.tsx
+++ b/ctf/packages/web/components/skills-hunt/sh-skills-picker.tsx
@@ -54,6 +54,18 @@ function useTaxonomy(): TaxonomyLoadState {
   return state;
 }
 
+// Read the grouped taxonomy out of the load state, defaulting to empty groupings whenever the
+// fetch is not yet ready (or failed). Keeps the picker's ternaries out of its render body.
+function readTaxonomy(taxonomy: TaxonomyLoadState): {
+  categories: Record<string, string[]>;
+  occupations: Record<string, string[]>;
+} {
+  if (taxonomy.status === "ready") {
+    return { categories: taxonomy.categories, occupations: taxonomy.occupations };
+  }
+  return { categories: {}, occupations: {} };
+}
+
 interface SkillsPickerProps {
   skills: string[];
   proposedSkills: string[];
@@ -144,15 +156,185 @@ function CategoryRow({ category, categorySkills, skills, isOpen, canAddMore, onO
   );
 }
 
+// Optional profession prefill — fills in a whole occupation's skills at once. Renders nothing
+// until the taxonomy is loaded and at least one occupation is known.
+function OccupationPrefill({ occupations, canAddMore, onAddOccupationSkills }: {
+  occupations: Record<string, string[]>;
+  canAddMore: boolean;
+  onAddOccupationSkills: (skillNames: string[]) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getSkillsHuntTokens(theme);
+  const occupationNames = Object.keys(occupations);
+  if (occupationNames.length === 0) return null;
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <label htmlFor="sh-occupation-prefill" style={{ fontSize: 11, color: t.SUBTLE, display: "block", marginBottom: 4 }}>
+        Know their profession? Add its skills <span style={{ color: t.FAINT }}>(optional — fills the skills in for you)</span>
+      </label>
+      <select
+        id="sh-occupation-prefill"
+        value=""
+        disabled={!canAddMore}
+        onChange={(e) => { const occ = e.target.value; if (occ && occupations[occ]) onAddOccupationSkills(occupations[occ]); }}
+        style={{ width: "100%", padding: "8px 12px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: t.TEXT, outline: "none", cursor: canAddMore ? "pointer" : "default", opacity: canAddMore ? 1 : 0.5 }}
+      >
+        <option value="">Select a profession…</option>
+        {occupationNames.map((occ) => (
+          <option key={occ} value={occ}>{occ}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// The loading / error status line for the taxonomy fetch. Renders nothing once the taxonomy
+// is ready (the accordion and search take over from there).
+function TaxonomyStatus({ taxonomy }: { taxonomy: TaxonomyLoadState }) {
+  const { theme } = useTheme();
+  const t = getSkillsHuntTokens(theme);
+  if (taxonomy.status === "loading") {
+    return <div style={{ fontSize: 12, color: t.MUTED, padding: "10px 0" }}>Loading skills…</div>;
+  }
+  if (taxonomy.status === "error") {
+    return <div style={{ fontSize: 12, color: "#F59E0B", padding: "6px 0", marginBottom: 4 }}>Could not load the skills list — add skills as free text below.</div>;
+  }
+  return null;
+}
+
+// Keyword search box — only shown once the taxonomy has categories to search across.
+function SkillSearch({ taxonomy, hasCategories, search, setSearch }: {
+  taxonomy: TaxonomyLoadState;
+  hasCategories: boolean;
+  search: string;
+  setSearch: (v: string) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getSkillsHuntTokens(theme);
+  if (taxonomy.status !== "ready" || !hasCategories) return null;
+  return (
+    <div style={{ position: "relative", marginBottom: 10 }}>
+      <Search size={14} style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: t.FAINT, pointerEvents: "none" }} />
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        aria-label="Search skills by keyword"
+        placeholder="Search skills by keyword…"
+        style={{ width: "100%", padding: "8px 32px 8px 34px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: t.TEXT, outline: "none", boxSizing: "border-box" }}
+      />
+      {search && (
+        <button type="button" aria-label="Clear skill search" onClick={() => setSearch("")}
+          style={{ position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", color: t.FAINT, cursor: "pointer", padding: 4, lineHeight: 1 }}>
+          <X size={13} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// When searching, a flat cross-sector result list replaces the accordion.
+function SearchResults({ taxonomy, hasCategories, query, search, matches, skills, canAddMore, onToggleSkill }: {
+  taxonomy: TaxonomyLoadState;
+  hasCategories: boolean;
+  query: string;
+  search: string;
+  matches: string[];
+  skills: string[];
+  canAddMore: boolean;
+  onToggleSkill: (s: string) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getSkillsHuntTokens(theme);
+  if (taxonomy.status !== "ready" || !hasCategories || !query) return null;
+  return (
+    <div style={{ border: "1px solid rgba(255,255,255,0.1)", borderRadius: 10, padding: "10px 14px", marginBottom: 10 }}>
+      {matches.length === 0 ? (
+        <div style={{ fontSize: 12, color: t.MUTED }}>No skills match “{search.trim()}”. Add it as a free-text skill below.</div>
+      ) : (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 7 }}>
+          {matches.map((s) => (
+            <SkillChip key={s} skill={s} selected={skills.includes(s)} canAddMore={canAddMore} onToggleSkill={onToggleSkill} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The sector accordion — shown when the taxonomy is ready and no keyword search is active.
+function CategoryAccordion({ taxonomy, hasCategories, query, categories, skills, openCategory, canAddMore, onOpenCategory, onToggleSkill }: {
+  taxonomy: TaxonomyLoadState;
+  hasCategories: boolean;
+  query: string;
+  categories: Record<string, string[]>;
+  skills: string[];
+  openCategory: string | null;
+  canAddMore: boolean;
+  onOpenCategory: (c: string | null) => void;
+  onToggleSkill: (s: string) => void;
+}) {
+  if (taxonomy.status !== "ready" || !hasCategories || query) return null;
+  return (
+    <div style={{ border: "1px solid rgba(255,255,255,0.1)", borderRadius: 10, overflow: "hidden", marginBottom: 10 }}>
+      {Object.entries(categories).map(([category, categorySkills]) => (
+        <CategoryRow key={category} category={category} categorySkills={categorySkills} skills={skills} isOpen={openCategory === category} canAddMore={canAddMore} onOpenCategory={onOpenCategory} onToggleSkill={onToggleSkill} />
+      ))}
+    </div>
+  );
+}
+
+// Free-text skill entry — proposed skills an admin can later promote into the taxonomy.
+// Only shown while there is still room under the 10-skill cap.
+function FreeTextAdder({ canAddMore, freeText, onFreeText, onAddProposed }: {
+  canAddMore: boolean;
+  freeText: string;
+  onFreeText: (v: string) => void;
+  onAddProposed: () => void;
+}) {
+  const { theme } = useTheme();
+  const t = getSkillsHuntTokens(theme);
+  if (!canAddMore) return null;
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: t.FAINT, marginBottom: 6 }}>Don&apos;t see what you need? Add free-text skills (comma or newline separated — each ≤ 40 chars):</div>
+      <div style={{ display: "flex", gap: 8 }}>
+        <input
+          value={freeText}
+          onChange={(e) => onFreeText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onAddProposed(); } }}
+          aria-label="Add free-text skills"
+          placeholder="e.g. Tie-dye, Beekeeping, Kintsugi…"
+          style={{ flex: 1, padding: "8px 12px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: t.TEXT, outline: "none" }}
+        />
+        <button type="button" onClick={onAddProposed} style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(251,191,36,0.1)", border: "1px solid rgba(251,191,36,0.25)", color: t.ACCENT, cursor: "pointer", fontSize: 12, fontWeight: 600 }}>Add</button>
+      </div>
+      <div style={{ fontSize: 11, color: t.FAINT, marginTop: 4 }}>Yellow chips = proposed skills — admin can promote them to the taxonomy later.</div>
+    </div>
+  );
+}
+
+// The cap notice (once 10 skills are reached) plus the running count.
+function FooterStatus({ canAddMore, allSkillCount }: {
+  canAddMore: boolean;
+  allSkillCount: number;
+}) {
+  const { theme } = useTheme();
+  const t = getSkillsHuntTokens(theme);
+  return (
+    <>
+      {!canAddMore && <div style={{ fontSize: 11, color: t.MUTED, padding: "6px 0" }}>Maximum 10 skills reached.</div>}
+      <div style={{ fontSize: 11, color: t.FAINT, marginTop: 6 }}>{allSkillCount}/10 skills added</div>
+    </>
+  );
+}
+
 export function SkillsPicker(props: SkillsPickerProps) {
   const { theme } = useTheme();
   const t = getSkillsHuntTokens(theme);
   const { skills, proposedSkills, freeText, openCategory, canAddMore, allSkillCount, onToggleSkill, onAddOccupationSkills, onRemoveProposed, onOpenCategory, onFreeText, onAddProposed } = props;
   const taxonomy = useTaxonomy();
-  const categories = taxonomy.status === "ready" ? taxonomy.categories : {};
-  const occupations = taxonomy.status === "ready" ? taxonomy.occupations : {};
+  const { categories, occupations } = readTaxonomy(taxonomy);
   const hasCategories = Object.keys(categories).length > 0;
-  const occupationNames = Object.keys(occupations);
 
   // Keyword search across every sector — a flat, de-duplicated skill list filtered
   // by substring. Local UI state only; it does not touch the form model.
@@ -174,96 +356,19 @@ export function SkillsPicker(props: SkillsPickerProps) {
 
       <SelectedChips skills={skills} proposedSkills={proposedSkills} onToggleSkill={onToggleSkill} onRemoveProposed={onRemoveProposed} />
 
-      {taxonomy.status === "ready" && occupationNames.length > 0 && (
-        <div style={{ marginBottom: 10 }}>
-          <label htmlFor="sh-occupation-prefill" style={{ fontSize: 11, color: t.SUBTLE, display: "block", marginBottom: 4 }}>
-            Know their profession? Add its skills <span style={{ color: t.FAINT }}>(optional — fills the skills in for you)</span>
-          </label>
-          <select
-            id="sh-occupation-prefill"
-            value=""
-            disabled={!canAddMore}
-            onChange={(e) => { const occ = e.target.value; if (occ && occupations[occ]) onAddOccupationSkills(occupations[occ]); }}
-            style={{ width: "100%", padding: "8px 12px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: t.TEXT, outline: "none", cursor: canAddMore ? "pointer" : "default", opacity: canAddMore ? 1 : 0.5 }}
-          >
-            <option value="">Select a profession…</option>
-            {occupationNames.map((occ) => (
-              <option key={occ} value={occ}>{occ}</option>
-            ))}
-          </select>
-        </div>
-      )}
+      <OccupationPrefill occupations={occupations} canAddMore={canAddMore} onAddOccupationSkills={onAddOccupationSkills} />
 
-      {taxonomy.status === "loading" && (
-        <div style={{ fontSize: 12, color: t.MUTED, padding: "10px 0" }}>Loading skills…</div>
-      )}
+      <TaxonomyStatus taxonomy={taxonomy} />
 
-      {taxonomy.status === "error" && (
-        <div style={{ fontSize: 12, color: "#F59E0B", padding: "6px 0", marginBottom: 4 }}>Could not load the skills list — add skills as free text below.</div>
-      )}
+      <SkillSearch taxonomy={taxonomy} hasCategories={hasCategories} search={search} setSearch={setSearch} />
 
-      {taxonomy.status === "ready" && hasCategories && (
-        <div style={{ position: "relative", marginBottom: 10 }}>
-          <Search size={14} style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: t.FAINT, pointerEvents: "none" }} />
-          <input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            aria-label="Search skills by keyword"
-            placeholder="Search skills by keyword…"
-            style={{ width: "100%", padding: "8px 32px 8px 34px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: t.TEXT, outline: "none", boxSizing: "border-box" }}
-          />
-          {search && (
-            <button type="button" aria-label="Clear skill search" onClick={() => setSearch("")}
-              style={{ position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", color: t.FAINT, cursor: "pointer", padding: 4, lineHeight: 1 }}>
-              <X size={13} />
-            </button>
-          )}
-        </div>
-      )}
+      <SearchResults taxonomy={taxonomy} hasCategories={hasCategories} query={query} search={search} matches={matches} skills={skills} canAddMore={canAddMore} onToggleSkill={onToggleSkill} />
 
-      {/* When searching, a flat cross-sector result list replaces the accordion. */}
-      {taxonomy.status === "ready" && hasCategories && query && (
-        <div style={{ border: "1px solid rgba(255,255,255,0.1)", borderRadius: 10, padding: "10px 14px", marginBottom: 10 }}>
-          {matches.length === 0 ? (
-            <div style={{ fontSize: 12, color: t.MUTED }}>No skills match “{search.trim()}”. Add it as a free-text skill below.</div>
-          ) : (
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 7 }}>
-              {matches.map((s) => (
-                <SkillChip key={s} skill={s} selected={skills.includes(s)} canAddMore={canAddMore} onToggleSkill={onToggleSkill} />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+      <CategoryAccordion taxonomy={taxonomy} hasCategories={hasCategories} query={query} categories={categories} skills={skills} openCategory={openCategory} canAddMore={canAddMore} onOpenCategory={onOpenCategory} onToggleSkill={onToggleSkill} />
 
-      {taxonomy.status === "ready" && hasCategories && !query && (
-        <div style={{ border: "1px solid rgba(255,255,255,0.1)", borderRadius: 10, overflow: "hidden", marginBottom: 10 }}>
-          {Object.entries(categories).map(([category, categorySkills]) => (
-            <CategoryRow key={category} category={category} categorySkills={categorySkills} skills={skills} isOpen={openCategory === category} canAddMore={canAddMore} onOpenCategory={onOpenCategory} onToggleSkill={onToggleSkill} />
-          ))}
-        </div>
-      )}
+      <FreeTextAdder canAddMore={canAddMore} freeText={freeText} onFreeText={onFreeText} onAddProposed={onAddProposed} />
 
-      {canAddMore && (
-        <div>
-          <div style={{ fontSize: 11, color: t.FAINT, marginBottom: 6 }}>Don&apos;t see what you need? Add free-text skills (comma or newline separated — each ≤ 40 chars):</div>
-          <div style={{ display: "flex", gap: 8 }}>
-            <input
-              value={freeText}
-              onChange={(e) => onFreeText(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onAddProposed(); } }}
-              aria-label="Add free-text skills"
-              placeholder="e.g. Tie-dye, Beekeeping, Kintsugi…"
-              style={{ flex: 1, padding: "8px 12px", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, fontSize: 13, color: t.TEXT, outline: "none" }}
-            />
-            <button type="button" onClick={onAddProposed} style={{ padding: "8px 14px", borderRadius: 8, background: "rgba(251,191,36,0.1)", border: "1px solid rgba(251,191,36,0.25)", color: t.ACCENT, cursor: "pointer", fontSize: 12, fontWeight: 600 }}>Add</button>
-          </div>
-          <div style={{ fontSize: 11, color: t.FAINT, marginTop: 4 }}>Yellow chips = proposed skills — admin can promote them to the taxonomy later.</div>
-        </div>
-      )}
-
-      {!canAddMore && <div style={{ fontSize: 11, color: t.MUTED, padding: "6px 0" }}>Maximum 10 skills reached.</div>}
-      <div style={{ fontSize: 11, color: t.FAINT, marginTop: 6 }}>{allSkillCount}/10 skills added</div>
+      <FooterStatus canAddMore={canAddMore} allSkillCount={allSkillCount} />
     </div>
   );
 }

--- a/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
+++ b/ctf/packages/web/components/skills-hunt/sh-use-nomination-form.ts
@@ -4,6 +4,26 @@ import { useState } from "react";
 import { MAX_SKILLS, type SkillsHuntRound } from "./sh-shared";
 import type { ScoutFormModel } from "./sh-scout-tab";
 
+// A nomination is ready to submit once there is an active round, a plausible full name,
+// at least one skill, and a country (the server enforces the same set).
+function isNominationReady(
+  activeRound: SkillsHuntRound | null,
+  fullName: string,
+  allSkillCount: number,
+  country: string,
+): boolean {
+  return (
+    activeRound !== null &&
+    fullName.trim().length >= 2 &&
+    allSkillCount > 0 &&
+    country.trim().length > 0
+  );
+}
+
+function nominationErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : "Failed to submit nomination.";
+}
+
 // Owns the nomination-form state, the submit/reset handlers, and assembly of the
 // ScoutFormModel passed to the Scout tab. Kept out of the shell to honor rule-116.
 export function useNominationForm(activeRound: SkillsHuntRound | null): {
@@ -59,11 +79,11 @@ export function useNominationForm(activeRound: SkillsHuntRound | null): {
 
   async function handleSubmit() {
     // Country is required (the server enforces it too); full name and at least one skill as before.
-    if (!activeRound || fullName.trim().length < 2 || allSkillCount === 0 || country.trim().length === 0) return;
+    if (!isNominationReady(activeRound, fullName, allSkillCount, country)) return;
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const res = await fetch(`/api/skills-hunt/rounds/${activeRound.id}/submissions`, {
+      const res = await fetch(`/api/skills-hunt/rounds/${activeRound!.id}/submissions`, {
         method: "POST",
         headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
         body: JSON.stringify({
@@ -84,7 +104,7 @@ export function useNominationForm(activeRound: SkillsHuntRound | null): {
       }
       setSubmitted(true);
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : "Failed to submit nomination.");
+      setSubmitError(nominationErrorMessage(e));
     } finally {
       setSubmitting(false);
     }

--- a/ctf/packages/web/components/skills-hunt/sha-moderation.tsx
+++ b/ctf/packages/web/components/skills-hunt/sha-moderation.tsx
@@ -9,6 +9,17 @@ import { SkillsHuntAdminTable } from "./sha-table";
 
 type RewardSummary = { totalCreditsPaid: number; rewardedSubmissionCount: number };
 
+// Confirm the mass action with the real count of affected pending submissions before firing —
+// a bulk accept pays each scout and a bulk reject can trip the rejection-rate guard, so neither
+// should run on a stray click.
+function bulkConfirmMessage(action: "accept" | "reject", count: number): string {
+  const verb = action === "accept" ? "Accept" : "Reject";
+  const consequence = action === "accept"
+    ? "Each accepted nomination pays the configured reward once."
+    : "This cannot be undone.";
+  return `${verb} ${count} selected submission${count === 1 ? "" : "s"}? ${consequence}`;
+}
+
 function RewardBanner({ round, summary }: { round: SkillsHuntRound | null; summary: RewardSummary | null }) {
   const { theme } = useTheme();
   const t = getSkillsHuntAdminTokens(theme);
@@ -123,14 +134,7 @@ export function SkillsHuntModeration({ rounds, activeRoundId, onRoundChange }: {
     const pendingIds = new Set(submissions.filter((s) => s.status === "pending").map((s) => s.id));
     const ids = Array.from(selected).filter((id) => pendingIds.has(id));
     if (ids.length === 0) return;
-    // Confirm the mass action with the real count of affected pending submissions before firing —
-    // a bulk accept pays each scout and a bulk reject can trip the rejection-rate guard, so neither
-    // should run on a stray click.
-    const verb = action === "accept" ? "Accept" : "Reject";
-    const consequence = action === "accept"
-      ? "Each accepted nomination pays the configured reward once."
-      : "This cannot be undone.";
-    if (!window.confirm(`${verb} ${ids.length} selected submission${ids.length === 1 ? "" : "s"}? ${consequence}`)) return;
+    if (!window.confirm(bulkConfirmMessage(action, ids.length))) return;
     const notes = action === "reject" ? promptRejectReason() : null;
     if (action === "reject" && notes === null) return;
     for (const id of ids) {

--- a/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
+++ b/ctf/packages/web/components/skills-hunt/skills-hunt-shell.tsx
@@ -47,6 +47,10 @@ interface ShellData {
   myFinds: SkillsHuntSubmission[];
 }
 
+function roundsLoadErrorMessage(e: unknown): string {
+  return e instanceof Error && e.message === "rounds" ? "Unable to load rounds." : "Something went wrong.";
+}
+
 function deriveShellState(args: {
   leaderboard: SkillsHuntLeaderboardItem[];
   serverCurrentUserEntry: SkillsHuntLeaderboardItem | null;
@@ -135,7 +139,7 @@ export function SkillsHuntShell({
         }
       } catch (e) {
         if (controller.signal.aborted) return;
-        setGlobalError(e instanceof Error && e.message === "rounds" ? "Unable to load rounds." : "Something went wrong.");
+        setGlobalError(roundsLoadErrorMessage(e));
       } finally {
         if (!controller.signal.aborted) setLoadingRounds(false);
       }

--- a/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
@@ -12,6 +12,7 @@ import {
   getSocketRelayTokens,
   requestTags,
   suggestTags,
+  type SocketRelayTokens,
   type SrChatCredentials,
   type SrDirectLine,
   type SrFulfillment,
@@ -40,10 +41,35 @@ function freshDraft(loc: MemberLocation): PostDraft {
   return { ...EMPTY_DRAFT, city: loc.city, state: loc.state, country: loc.country };
 }
 
+// Build an edit draft from an existing request (Edit re-opens the post in the Post tab).
+function draftFromRequest(request: SrRequest): PostDraft {
+  return {
+    title: request.title,
+    details: request.details,
+    tags: requestTags(request),
+    city: request.city ?? "",
+    state: request.state ?? "",
+    country: request.country ?? "",
+    isPublic: request.isPublic,
+    priceCurrency: request.priceCurrency ?? "FREE",
+    priceAmount: request.priceAmount != null ? String(request.priceAmount) : "",
+    requiresAmount: request.priceAmount != null,
+  };
+}
+
 async function getJson<T>(url: string): Promise<T | null> {
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) return null;
   return (await res.json()) as T;
+}
+
+// Read the items/total off a possibly-null list response, normalizing to empties. Kept as tiny
+// helpers so the loader below stays well within the rule-116 complexity limit.
+function itemsOf<T>(res: { items?: T[] } | null): T[] {
+  return res?.items ?? [];
+}
+function totalOf(res: { total?: number } | null): number {
+  return res?.total ?? 0;
 }
 
 // Page size for the main feed. The server scopes the feed to open (claimable) requests; "Load more"
@@ -68,12 +94,140 @@ async function loadSocketRelayData(): Promise<{
     getJson<SrFulfillmentsResponse>("/api/socket-relay/my-fulfillments"),
   ]);
   return {
-    requests: reqData?.items ?? [],
-    requestsTotal: reqData?.total ?? 0,
-    myRequests: myReqData?.items ?? [],
-    myRequestCount: myReqData?.total ?? 0,
-    fulfillments: fulData?.items ?? [],
+    requests: itemsOf(reqData),
+    requestsTotal: totalOf(reqData),
+    myRequests: itemsOf(myReqData),
+    myRequestCount: totalOf(myReqData),
+    fulfillments: itemsOf(fulData),
   };
+}
+
+// Best-effort load of the member's own directory location. A missing profile or a failed fetch resolves
+// to null so the caller can leave the default blank — it never blocks posting.
+async function fetchMemberLocation(signal: AbortSignal): Promise<MemberLocation | null> {
+  try {
+    const res = await fetch("/api/directory/profile", { signal });
+    if (!res.ok || signal.aborted) return null;
+    const data = (await res.json()) as { profile?: { city?: string | null; state?: string | null; country?: string | null } | null };
+    const p = data.profile;
+    if (!p || signal.aborted) return null;
+    return { city: p.city ?? "", state: p.state ?? "", country: p.country ?? "" };
+  } catch {
+    return null;
+  }
+}
+
+// Friendly, field-specific checks so a member is told exactly what to fix — never a raw
+// "invalid payload" from the server. Returns the error message, or null when the draft is postable.
+function validatePostDraft(draft: PostDraft): string | null {
+  if (!draft.title.trim()) return "Add a short title for your request.";
+  if (!draft.details.trim()) return "Add a few details about what you need or can give.";
+  if (draft.tags.length === 0) return "Add at least one tag (for example Food or Transport).";
+  if (draft.requiresAmount && !(Number(draft.priceAmount) > 0)) return "Enter an amount for the payment type you chose, or switch it to Free.";
+  return null;
+}
+
+// Normalize a trimmed text field to its value or null (a blank optional field is stored as null).
+function trimmedOrNull(value: string): string | null {
+  const v = value.trim();
+  return v ? v : null;
+}
+
+// Amount only for priced types (the form clears it for Free/Barter, so a blank amount becomes null).
+function parsePriceAmount(value: string): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function buildRequestBody(draft: PostDraft) {
+  return {
+    title: draft.title.trim(),
+    details: draft.details.trim(),
+    tags: draft.tags,
+    city: trimmedOrNull(draft.city),
+    state: trimmedOrNull(draft.state),
+    country: trimmedOrNull(draft.country),
+    isPublic: draft.isPublic,
+    // The chosen value type (default 'FREE'); amount only for priced types.
+    priceCurrency: draft.priceCurrency || null,
+    priceAmount: parsePriceAmount(draft.priceAmount),
+  };
+}
+
+// Create (POST) or update (PUT) a request. Throws with a friendly message on a non-OK response.
+async function saveDraft(draft: PostDraft, editingId: string | null): Promise<void> {
+  const url = editingId ? `/api/socket-relay/requests/${editingId}` : "/api/socket-relay/requests";
+  const res = await fetch(url, {
+    method: editingId ? "PUT" : "POST",
+    headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+    body: JSON.stringify(buildRequestBody(draft)),
+  });
+  if (!res.ok) {
+    const payload = (await res.json().catch(() => null)) as { message?: string } | null;
+    throw new Error(payload?.message ?? "Failed to save request.");
+  }
+}
+
+// POST with the CSRF header and no body; returns whether the server accepted it. Used by the re-post
+// and claim buttons, which only need to know success to trigger a refresh. A network failure returns
+// false so the caller simply skips the refresh (the next refresh reflects the latest state).
+async function postCsrf(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: "POST", headers: { "x-ctf-csrf": "1" } });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// Fetch Stream chat credentials for a fulfillment's Direct Line. Throws with a message on any non-OK
+// response (or a payload without credentials) so the caller can surface it.
+async function fetchChatCredentials(fulfillmentId: string): Promise<SrChatCredentials> {
+  const res = await fetch(`/api/socket-relay/fulfillments/${fulfillmentId}/chat`, {
+    method: "POST",
+    headers: { "x-ctf-csrf": "1" },
+  });
+  if (!res.ok) throw new Error("Failed to fetch chat credentials");
+  const data = (await res.json()) as SrChatCredentials;
+  if (!data.ok) throw new Error(data.message ?? "No chat credentials");
+  return data;
+}
+
+// Resolve (close / reopen) a fulfillment with the chosen outcome. Throws with a friendly message on a
+// non-OK response.
+async function closeFulfillment(fulfillmentId: string, outcome: SrResolveOutcome): Promise<void> {
+  const res = await fetch(`/api/socket-relay/fulfillments/${fulfillmentId}/close`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+    body: JSON.stringify({ outcome }),
+  });
+  if (!res.ok) {
+    const payload = (await res.json().catch(() => null)) as { message?: string } | null;
+    throw new Error(payload?.message ?? "Couldn't resolve this request. Please try again.");
+  }
+}
+
+// Whether a request row matches the active search term across its title/details/location.
+function matchesSearch(r: SrRequest, search: string): boolean {
+  const q = search.trim().toLowerCase();
+  if (!q) return true;
+  return `${r.title} ${r.details} ${r.city ?? ""} ${r.state ?? ""} ${r.country ?? ""}`.toLowerCase().includes(q);
+}
+
+// Whether a request row passes the current category/owner/search filter for the feed list.
+function matchesRequestFilter(r: SrRequest, category: string, userId: string | undefined, search: string): boolean {
+  if (category === "Mine") {
+    // Every row in myRequests is already the member's own; keep all statuses so they can always find,
+    // edit, and re-post their own posts.
+    if (r.ownerUserId !== userId) return false;
+  } else {
+    // Active feed: an expired post drops out for everyone EXCEPT its owner. The owner always sees
+    // their own posts — including expired ones (dimmed, with the Expired pill + Re-post) — so a post
+    // never silently disappears from the poster's own feed and re-posting is always one click away.
+    if (r.isExpired && r.ownerUserId !== userId) return false;
+    if (category !== "All" && !requestTags(r).some((tag) => tag.toLowerCase() === category.toLowerCase())) return false;
+  }
+  return matchesSearch(r, search);
 }
 
 type SocketRelayShellProps = {
@@ -82,7 +236,9 @@ type SocketRelayShellProps = {
   role?: string | null;
 };
 
-export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
+// All SocketRelay state, effects, and action handlers. Split out of the component so both the hook and
+// the component stay within the rule-116 line/complexity limits. Hook order is fixed and unconditional.
+function useSocketRelay() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [requests, setRequests] = useState<SrRequest[]>([]);
@@ -112,8 +268,6 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
-  const { theme } = useTheme();
-  const t = getSocketRelayTokens(theme);
 
   const fetchData = useCallback(async (showLoading = true) => {
     if (showLoading) setLoading(true);
@@ -162,104 +316,48 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
   useEffect(() => {
     const controller = new AbortController();
     void (async () => {
-      try {
-        const res = await fetch("/api/directory/profile", { signal: controller.signal });
-        if (!res.ok || controller.signal.aborted) return;
-        const data = (await res.json()) as { profile?: { city?: string | null; state?: string | null; country?: string | null } | null };
-        const p = data.profile;
-        if (!p || controller.signal.aborted) return;
-        const loc: MemberLocation = { city: p.city ?? "", state: p.state ?? "", country: p.country ?? "" };
-        setMyLocation(loc);
-        // Seed the current draft only if it is a pristine, untouched post (no title/details and no
-        // location typed). The content guard is what protects an in-progress compose or an open edit
-        // (both have a title), so this never clobbers real work regardless of the current tab.
-        setDraft((d) =>
-          !d.title && !d.details && !d.city && !d.state && !d.country
-            ? { ...d, city: loc.city, state: loc.state, country: loc.country }
-            : d,
-        );
-      } catch {
-        // Leave the default blank.
-      }
+      const loc = await fetchMemberLocation(controller.signal);
+      if (!loc || controller.signal.aborted) return;
+      setMyLocation(loc);
+      // Seed the current draft only if it is a pristine, untouched post (no title/details and no
+      // location typed). The content guard is what protects an in-progress compose or an open edit
+      // (both have a title), so this never clobbers real work regardless of the current tab.
+      setDraft((d) =>
+        !d.title && !d.details && !d.city && !d.state && !d.country
+          ? { ...d, city: loc.city, state: loc.state, country: loc.country }
+          : d,
+      );
     })();
     return () => controller.abort();
   }, []);
 
-  function startEdit(request: SrRequest) {
-    setDraft({
-      title: request.title,
-      details: request.details,
-      tags: requestTags(request),
-      city: request.city ?? "",
-      state: request.state ?? "",
-      country: request.country ?? "",
-      isPublic: request.isPublic,
-      priceCurrency: request.priceCurrency ?? "FREE",
-      priceAmount: request.priceAmount != null ? String(request.priceAmount) : "",
-      requiresAmount: request.priceAmount != null,
-    });
+  const startEdit = useCallback((request: SrRequest) => {
+    setDraft(draftFromRequest(request));
     setEditingId(request.id);
     setPostError(null);
     setPostSuccess(false);
     setTab("post");
-  }
+  }, []);
 
-  function cancelEdit() {
+  const cancelEdit = useCallback(() => {
     setDraft(freshDraft(myLocation));
     setEditingId(null);
     setPostError(null);
     setPostSuccess(false);
     setTab("feed");
-  }
+  }, [myLocation]);
 
-  async function handlePost() {
-    // Friendly, field-specific checks so a member is told exactly what to fix — never a raw
-    // "invalid payload" from the server.
-    if (!draft.title.trim()) {
-      setPostError("Add a short title for your request.");
-      return;
-    }
-    if (!draft.details.trim()) {
-      setPostError("Add a few details about what you need or can give.");
-      return;
-    }
-    if (draft.tags.length === 0) {
-      setPostError("Add at least one tag (for example Food or Transport).");
-      return;
-    }
-    if (draft.requiresAmount && !(Number(draft.priceAmount) > 0)) {
-      setPostError("Enter an amount for the payment type you chose, or switch it to Free.");
+  const handlePost = useCallback(async () => {
+    const validationError = validatePostDraft(draft);
+    if (validationError) {
+      setPostError(validationError);
       return;
     }
     setSubmitting(true);
     setPostError(null);
     setPostSuccess(false);
     try {
-      const url = editingId ? `/api/socket-relay/requests/${editingId}` : "/api/socket-relay/requests";
-      const res = await fetch(url, {
-        method: editingId ? "PUT" : "POST",
-        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
-        body: JSON.stringify({
-          title: draft.title.trim(),
-          details: draft.details.trim(),
-          tags: draft.tags,
-          city: draft.city.trim() ? draft.city.trim() : null,
-          state: draft.state.trim() ? draft.state.trim() : null,
-          country: draft.country.trim() ? draft.country.trim() : null,
-          isPublic: draft.isPublic,
-          // The chosen value type (default 'FREE'); amount only for priced types (the form clears it
-          // for Free/Barter, so a blank amount becomes null).
-          priceCurrency: draft.priceCurrency || null,
-          priceAmount: (() => {
-            const n = Number(draft.priceAmount);
-            return Number.isFinite(n) && n > 0 ? n : null;
-          })(),
-        }),
-      });
-      if (!res.ok) {
-        const payload = (await res.json().catch(() => null)) as { message?: string } | null;
-        throw new Error(payload?.message ?? "Failed to save request.");
-      }
+      await saveDraft(draft, editingId);
       setDraft(freshDraft(myLocation));
       setEditingId(null);
       setPostSuccess(true);
@@ -269,39 +367,27 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
     } finally {
       setSubmitting(false);
     }
-  }
+  }, [draft, editingId, myLocation, fetchData]);
 
   // Re-post an expired (or closed) request: re-opens it and resets the 28-day clock. Owner-only on the
   // server; here it is offered only on the member's own expired posts.
-  async function handleRepost(requestId: string) {
+  const handleRepost = useCallback(async (requestId: string) => {
     setSubmitting(true);
     try {
-      const res = await fetch(`/api/socket-relay/requests/${requestId}/repost`, {
-        method: "POST",
-        headers: { "x-ctf-csrf": "1" },
-      });
-      if (res.ok) await fetchData(false);
-    } catch {
-      // Refresh will reflect the latest state.
+      if (await postCsrf(`/api/socket-relay/requests/${requestId}/repost`)) await fetchData(false);
     } finally {
       setSubmitting(false);
     }
-  }
+  }, [fetchData]);
 
-  async function handleClaim(requestId: string) {
+  const handleClaim = useCallback(async (requestId: string) => {
     setSubmitting(true);
     try {
-      const res = await fetch(`/api/socket-relay/requests/${requestId}/fulfill`, {
-        method: "POST",
-        headers: { "x-ctf-csrf": "1" },
-      });
-      if (res.ok) await fetchData(false);
-    } catch {
-      // Refresh will reflect the latest state.
+      if (await postCsrf(`/api/socket-relay/requests/${requestId}/fulfill`)) await fetchData(false);
     } finally {
       setSubmitting(false);
     }
-  }
+  }, [fetchData]);
 
   // Select a Direct Line row. A pending request (no helper yet) has no chat to open — it just shows the
   // "waiting for a helper" pane — so only a fulfillment row fetches chat credentials.
@@ -315,14 +401,7 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
     }
     setChatLoading(true);
     try {
-      const res = await fetch(`/api/socket-relay/fulfillments/${line.fulfillment.id}/chat`, {
-        method: "POST",
-        headers: { "x-ctf-csrf": "1" },
-      });
-      if (!res.ok) throw new Error("Failed to fetch chat credentials");
-      const data = (await res.json()) as SrChatCredentials;
-      if (!data.ok) throw new Error(data.message ?? "No chat credentials");
-      setChatCredentials(data);
+      setChatCredentials(await fetchChatCredentials(line.fulfillment.id));
     } catch (e) {
       setChatError(e instanceof Error ? e.message : "Failed to load chat");
     } finally {
@@ -354,19 +433,11 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
 
   // Only the requester (the person who posted) can resolve; the route enforces this too. On success
   // we refresh and clear the selection so the resolved/reopened state is reflected.
-  async function handleResolve(fulfillmentId: string, outcome: SrResolveOutcome) {
+  const handleResolve = useCallback(async (fulfillmentId: string, outcome: SrResolveOutcome) => {
     setResolving(true);
     setChatError(null);
     try {
-      const res = await fetch(`/api/socket-relay/fulfillments/${fulfillmentId}/close`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
-        body: JSON.stringify({ outcome }),
-      });
-      if (!res.ok) {
-        const payload = (await res.json().catch(() => null)) as { message?: string } | null;
-        throw new Error(payload?.message ?? "Couldn't resolve this request. Please try again.");
-      }
+      await closeFulfillment(fulfillmentId, outcome);
       setSelectedLine(null);
       setChatCredentials(null);
       await fetchData(false);
@@ -377,82 +448,141 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
     } finally {
       setResolving(false);
     }
-  }
+  }, [fetchData]);
 
-  if (loading) return <SocketRelayLoading />;
-  if (error) {
-    return (
-      <div style={{ width: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
-        {error}
+  const updateDraft = useCallback((patch: Partial<PostDraft>) => setDraft((d) => ({ ...d, ...patch })), []);
+  const clearSelection = useCallback(() => {
+    setSelectedLine(null);
+    setChatCredentials(null);
+    setChatError(null);
+  }, []);
+
+  return {
+    loading, error, requests, requestsTotal, loadingMore, myRequests, fulfillments,
+    submitting, tab, category, search, draft, editingId, postError, postSuccess,
+    selectedLine, chatCredentials, chatLoading, chatError, resolving,
+    setTab, setCategory, setSearch,
+    fetchData, loadMore, startEdit, cancelEdit, handlePost, handleRepost, handleClaim,
+    handleSelectLine, handleResolve, updateDraft, clearSelection,
+  };
+}
+
+type SocketRelayHeaderProps = {
+  t: SocketRelayTokens;
+  openCount: number;
+  isAdmin?: boolean;
+  tab: Tab;
+  tabs: { key: Tab; label: string }[];
+  onTab: (tab: Tab) => void;
+  search: string;
+  onSearch: (value: string) => void;
+  categories: string[];
+  category: string;
+  onCategory: (category: string) => void;
+  onRefresh: () => void;
+};
+
+// Sticky header: title bar, tab switcher, and (on the feed tab) the search box + category chips.
+function SocketRelayHeader({ t, openCount, isAdmin, tab, tabs, onTab, search, onSearch, categories, category, onCategory, onRefresh }: SocketRelayHeaderProps) {
+  return (
+    <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+        <BackChevronButton accent={t.ACCENT} />
+        <Share2 size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
+        <span style={{ fontSize: 15, fontWeight: 700, color: t.TEXT, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>SocketRelay</span>
+        <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{openCount} open</Badge>
+        <PluginAdminButton href="/admin/socket-relay" isAdmin={isAdmin} accent={t.ACCENT} />
+        <RefreshButton onRefresh={onRefresh} title="Refresh" />
+        <MobileTopActions />
       </div>
-    );
-  }
+      <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
+        {tabs.map(({ key, label }) => (
+          <button key={key} onClick={() => onTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+        ))}
+      </div>
+      {tab === "feed" && (
+        <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
+          <input value={search} onChange={(e) => onSearch(e.target.value)} placeholder="Search requests…" style={{ width: "100%", padding: "8px 10px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }} />
+          <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
+            {categories.map((c) => (
+              <button key={c} onClick={() => onCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${t.ACCENT}14` : "transparent", border: `1px solid ${category === c ? t.ACCENT + "50" : t.BORDER_HI}`, color: category === c ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
-  // The "N open" badge uses the server-side total of open requests (not just the loaded page), so it
-  // stays honest when the board has more than one page. It counts every open post; a small number may
-  // be expired-open (hidden from non-owners in the feed), which is close enough for a header badge.
-  const openCount = requestsTotal;
-  // Only the default "All" feed paginates the board; "Mine" is already the member's own full set.
-  const hasMore = category !== "Mine" && requests.length < requestsTotal;
-  // "Mine" is a leading filter (only when signed in) so a member can always find their own posts — on a
-  // small phone screen especially — to edit or re-post them, instead of hunting through the whole feed.
-  const baseCategories = deriveCategories(requests, category === "Mine" ? "All" : category);
-  const categories = userId ? ["All", "Mine", ...baseCategories.filter((c) => c !== "All")] : baseCategories;
-  // "Mine" sources from `myRequests` (owner-scoped server-side, fetched at pageSize=100), NOT the global
-  // feed `requests` (only the 20 newest). Reading the global feed meant a member's own post fell out of
-  // "Mine" as soon as 20 newer posts existed board-wide — hiding their own posts and blocking Edit/Re-post.
-  const source = category === "Mine" ? myRequests : requests;
-  const visible = source.filter((r) => {
-    if (category === "Mine") {
-      // Every row in myRequests is already the member's own; keep all statuses so they can always find,
-      // edit, and re-post their own posts.
-      if (r.ownerUserId !== userId) return false;
-    } else {
-      // Active feed: an expired post drops out for everyone EXCEPT its owner. The owner always sees
-      // their own posts — including expired ones (dimmed, with the Expired pill + Re-post) — so a post
-      // never silently disappears from the poster's own feed and re-posting is always one click away.
-      if (r.isExpired && r.ownerUserId !== userId) return false;
-      if (category !== "All" && !requestTags(r).some((tag) => tag.toLowerCase() === category.toLowerCase())) return false;
-    }
-    if (search.trim()) {
-      const q = search.trim().toLowerCase();
-      if (!`${r.title} ${r.details} ${r.city ?? ""} ${r.state ?? ""} ${r.country ?? ""}`.toLowerCase().includes(q)) return false;
-    }
-    return true;
-  });
+type SocketRelayTabContentProps = {
+  tab: Tab;
+  requests: SrRequest[];
+  allRequests: SrRequest[];
+  userId?: string;
+  submitting: boolean;
+  search: string;
+  category: string;
+  hasMore: boolean;
+  loadingMore: boolean;
+  onLoadMore: () => void;
+  onClaim: (id: string) => void;
+  onPost: () => void;
+  onEdit: (request: SrRequest) => void;
+  onRepost: (id: string) => void;
+  draft: PostDraft;
+  editing: boolean;
+  onChange: (patch: Partial<PostDraft>) => void;
+  postError: string | null;
+  postSuccess: boolean;
+  onSubmit: () => void;
+  onCancelEdit: () => void;
+  directLines: SrDirectLine[];
+  selectedLine: SrDirectLine | null;
+  resolving: boolean;
+  onSelect: (line: SrDirectLine) => void;
+  onBack: () => void;
+  onResolve: (id: string, outcome: SrResolveOutcome) => void;
+  chatLoading: boolean;
+  chatError: string | null;
+  chatCredentials: SrChatCredentials | null;
+};
 
-  // The Direct Line list: active conversations plus your own still-open requests as pending
-  // placeholders. Cancelled/closed lines drop out — one row per request you're waiting on or talking through.
-  const directLines = buildDirectLines(fulfillments, myRequests);
-
-  const content = (
+// The body under the header: whichever tab is active. `requests` is the filtered feed list; suggestions
+// pull from `allRequests` (the full loaded set) so tag autocomplete is not limited to the visible rows.
+function SocketRelayTabContent(props: SocketRelayTabContentProps) {
+  const { tab, requests, allRequests, userId, submitting, search, category } = props;
+  const { hasMore, loadingMore, onLoadMore, onClaim, onPost, onEdit, onRepost } = props;
+  const { draft, editing, onChange, postError, postSuccess, onSubmit, onCancelEdit } = props;
+  const { directLines, selectedLine, resolving, onSelect, onBack, onResolve, chatLoading, chatError, chatCredentials } = props;
+  const filterActive = Boolean(search.trim()) || category !== "All";
+  return (
     <>
       {tab === "feed" && (
         <SocketRelayFeed
-          requests={visible}
+          requests={requests}
           currentUserId={userId}
           submitting={submitting}
-          filterActive={Boolean(search.trim()) || category !== "All"}
+          filterActive={filterActive}
           hasMore={hasMore}
           loadingMore={loadingMore}
-          onLoadMore={() => void loadMore()}
-          onClaim={(id) => void handleClaim(id)}
-          onPost={() => setTab("post")}
-          onEdit={startEdit}
-          onRepost={(id) => void handleRepost(id)}
+          onLoadMore={onLoadMore}
+          onClaim={onClaim}
+          onPost={onPost}
+          onEdit={onEdit}
+          onRepost={onRepost}
         />
       )}
       {tab === "post" && (
         <SocketRelayPost
           draft={draft}
-          editing={editingId !== null}
-          onChange={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+          editing={editing}
+          onChange={onChange}
           submitting={submitting}
           error={postError}
           success={postSuccess}
-          onSubmit={() => void handlePost()}
-          onCancelEdit={cancelEdit}
-          suggest={(prefix, exclude) => suggestTags(requests, prefix, exclude)}
+          onSubmit={onSubmit}
+          onCancelEdit={onCancelEdit}
+          suggest={(prefix, exclude) => suggestTags(allRequests, prefix, exclude)}
         />
       )}
       {tab === "chat" && (
@@ -461,9 +591,9 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
           selected={selectedLine}
           currentUserId={userId}
           resolving={resolving}
-          onSelect={(line) => void handleSelectLine(line)}
-          onBack={() => { setSelectedLine(null); setChatCredentials(null); setChatError(null); }}
-          onResolve={(id, outcome) => void handleResolve(id, outcome)}
+          onSelect={onSelect}
+          onBack={onBack}
+          onResolve={onResolve}
           chatLoading={chatLoading}
           chatError={chatError}
           chatCredentials={chatCredentials}
@@ -471,41 +601,94 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
       )}
     </>
   );
+}
 
-    const tabs: { key: Tab; label: string }[] = [
-      { key: "feed", label: "Feed" },
-      { key: "post", label: "Post" },
-      { key: "chat", label: "Direct Line" },
-    ];
+export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
+  const sr = useSocketRelay();
+  const { theme } = useTheme();
+  const t = getSocketRelayTokens(theme);
+
+  if (sr.loading) return <SocketRelayLoading />;
+  if (sr.error) {
     return (
-      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER}` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <BackChevronButton accent={t.ACCENT} />
-            <Share2 size={18} style={{ color: t.ACCENT, flexShrink: 0 }} />
-            <span style={{ fontSize: 15, fontWeight: 700, color: t.TEXT, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>SocketRelay</span>
-            <Badge style={{ background: `${t.ACCENT}20`, color: t.ACCENT, border: `1px solid ${t.ACCENT}35`, fontSize: 10, padding: "3px 8px", borderRadius: 20, flexShrink: 0 }}>{openCount} open</Badge>
-            <PluginAdminButton href="/admin/socket-relay" isAdmin={isAdmin} accent={t.ACCENT} />
-            <RefreshButton onRefresh={() => fetchData(false)} title="Refresh" />
-            <MobileTopActions />
-          </div>
-          <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
-            {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
-            ))}
-          </div>
-          {tab === "feed" && (
-            <div style={{ padding: "0 12px 10px", display: "flex", flexDirection: "column", gap: 8 }}>
-              <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search requests…" style={{ width: "100%", padding: "8px 10px", background: t.INPUT_BG, border: `1px solid ${t.BORDER}`, borderRadius: 8, fontSize: 13, color: t.SUBTLE, outline: "none", boxSizing: "border-box" }} />
-              <div style={{ display: "flex", gap: 6, overflowX: "auto" }}>
-                {categories.map((c) => (
-                  <button key={c} onClick={() => setCategory(c)} style={{ whiteSpace: "nowrap", padding: "5px 12px", borderRadius: 14, background: category === c ? `${t.ACCENT}14` : "transparent", border: `1px solid ${category === c ? t.ACCENT + "50" : t.BORDER_HI}`, color: category === c ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: 600, cursor: "pointer", flexShrink: 0 }}>{c}</button>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-        {content}
+      <div style={{ width: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Inter', system-ui, sans-serif", color: "#EF4444" }}>
+        {sr.error}
       </div>
     );
+  }
+
+  // The "N open" badge uses the server-side total of open requests (not just the loaded page), so it
+  // stays honest when the board has more than one page. It counts every open post; a small number may
+  // be expired-open (hidden from non-owners in the feed), which is close enough for a header badge.
+  const openCount = sr.requestsTotal;
+  // Only the default "All" feed paginates the board; "Mine" is already the member's own full set.
+  const hasMore = sr.category !== "Mine" && sr.requests.length < sr.requestsTotal;
+  // "Mine" is a leading filter (only when signed in) so a member can always find their own posts — on a
+  // small phone screen especially — to edit or re-post them, instead of hunting through the whole feed.
+  const baseCategories = deriveCategories(sr.requests, sr.category === "Mine" ? "All" : sr.category);
+  const categories = userId ? ["All", "Mine", ...baseCategories.filter((c) => c !== "All")] : baseCategories;
+  // "Mine" sources from `myRequests` (owner-scoped server-side, fetched at pageSize=100), NOT the global
+  // feed `requests` (only the 20 newest). Reading the global feed meant a member's own post fell out of
+  // "Mine" as soon as 20 newer posts existed board-wide — hiding their own posts and blocking Edit/Re-post.
+  const source = sr.category === "Mine" ? sr.myRequests : sr.requests;
+  const visible = source.filter((r) => matchesRequestFilter(r, sr.category, userId, sr.search));
+  // The Direct Line list: active conversations plus your own still-open requests as pending
+  // placeholders. Cancelled/closed lines drop out — one row per request you're waiting on or talking through.
+  const directLines = buildDirectLines(sr.fulfillments, sr.myRequests);
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: "feed", label: "Feed" },
+    { key: "post", label: "Post" },
+    { key: "chat", label: "Direct Line" },
+  ];
+  return (
+    <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TEXT }}>
+      <SocketRelayHeader
+        t={t}
+        openCount={openCount}
+        isAdmin={isAdmin}
+        tab={sr.tab}
+        tabs={tabs}
+        onTab={sr.setTab}
+        search={sr.search}
+        onSearch={sr.setSearch}
+        categories={categories}
+        category={sr.category}
+        onCategory={sr.setCategory}
+        onRefresh={() => sr.fetchData(false)}
+      />
+      <SocketRelayTabContent
+        tab={sr.tab}
+        requests={visible}
+        allRequests={sr.requests}
+        userId={userId}
+        submitting={sr.submitting}
+        search={sr.search}
+        category={sr.category}
+        hasMore={hasMore}
+        loadingMore={sr.loadingMore}
+        onLoadMore={() => void sr.loadMore()}
+        onClaim={(id) => void sr.handleClaim(id)}
+        onPost={() => sr.setTab("post")}
+        onEdit={sr.startEdit}
+        onRepost={(id) => void sr.handleRepost(id)}
+        draft={sr.draft}
+        editing={sr.editingId !== null}
+        onChange={sr.updateDraft}
+        postError={sr.postError}
+        postSuccess={sr.postSuccess}
+        onSubmit={() => void sr.handlePost()}
+        onCancelEdit={sr.cancelEdit}
+        directLines={directLines}
+        selectedLine={sr.selectedLine}
+        resolving={sr.resolving}
+        onSelect={(line) => void sr.handleSelectLine(line)}
+        onBack={sr.clearSelection}
+        onResolve={(id, outcome) => void sr.handleResolve(id, outcome)}
+        chatLoading={sr.chatLoading}
+        chatError={sr.chatError}
+        chatCredentials={sr.chatCredentials}
+      />
+    </div>
+  );
 }

--- a/ctf/packages/web/components/socket-relay/sr-feed.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-feed.tsx
@@ -6,7 +6,7 @@ import { MapPin, Share2 } from "lucide-react";
 import { FAINT, SUBTLE, requestTags, settlementLabel, srHandle, timeAgo, type SrRequest, type SrRequestStatus } from "./sr-shared";
 import { ShareLink } from "@/components/shared/share-link";
 import { useTheme } from '@/hooks/useTheme';
-import { getSocketRelayTokens } from './sr-shared';
+import { getSocketRelayTokens, type SocketRelayTokens } from './sr-shared';
 
 const editButtonStyle = { padding: "6px 14px", borderRadius: 8, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", color: "#9CA3AF", fontSize: 12, fontWeight: 600, cursor: "pointer" } as const;
 
@@ -69,6 +69,47 @@ function CardAction({
   );
 }
 
+// The badge row (tags, settlement, and status). Split from RequestCard so the several status-driven
+// ternaries live in their own scope instead of inflating the card's complexity.
+function CardBadges({
+  request: r,
+  t,
+  open,
+  expired,
+}: {
+  request: SrRequest;
+  t: SocketRelayTokens;
+  open: boolean;
+  expired: boolean;
+}) {
+  return (
+    <div style={{ display: "flex", gap: 8, marginBottom: 6, alignItems: "center", flexWrap: "wrap" }}>
+      {requestTags(r).map((tag) => (
+        <Badge key={tag} style={{ background: t.INPUT_BG, color: t.SUBTLE, border: "1px solid rgba(255,255,255,0.06)", fontSize: 11 }}>{tag}</Badge>
+      ))}
+      <Badge style={{ background: "rgba(34,197,94,0.10)", color: "#22C55E", border: "1px solid rgba(34,197,94,0.25)", fontSize: 11 }}>{settlementLabel(r.priceCurrency, r.priceAmount)}</Badge>
+      <Badge style={{ background: open ? "#22C55E20" : t.INPUT_BG, color: expired ? "#F59E0B" : open ? "#22C55E" : SUBTLE, border: `1px solid ${expired ? "#F59E0B40" : open ? "#22C55E40" : t.BORDER}`, fontSize: 11, textTransform: "capitalize" }}>{expired ? "expired" : r.status}</Badge>
+    </div>
+  );
+}
+
+// The meta row (handle, location, time, share). Split from RequestCard to keep the location guard out
+// of the card's complexity budget.
+function CardMeta({ request: r, t }: { request: SrRequest; t: SocketRelayTokens }) {
+  return (
+    <div style={{ display: "flex", gap: 12, fontSize: 12, color: SUBTLE, flexWrap: "wrap", alignItems: "center" }}>
+      <span style={{ color: t.ACCENT, fontWeight: 600 }}>{srHandle(r.ownerUsername, r.id)}</span>
+      {[r.city, r.state, r.country].some((v) => v && v.trim()) && (
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <MapPin size={11} /> {[r.city, r.state, r.country].map((v) => v?.trim()).filter(Boolean).join(", ")}
+        </span>
+      )}
+      <span>· {timeAgo(r.createdAtIso)}</span>
+      <ShareLink url={`/apps/socket-relay?request=${r.id}`} label="Share" title="Share this request" className="sr-share" />
+    </div>
+  );
+}
+
 function RequestCard({
   request,
   isOwn,
@@ -97,31 +138,65 @@ function RequestCard({
           <Share2 size={18} style={{ color: t.ACCENT }} />
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: "flex", gap: 8, marginBottom: 6, alignItems: "center", flexWrap: "wrap" }}>
-            {requestTags(r).map((tag) => (
-              <Badge key={tag} style={{ background: t.INPUT_BG, color: t.SUBTLE, border: "1px solid rgba(255,255,255,0.06)", fontSize: 11 }}>{tag}</Badge>
-            ))}
-            <Badge style={{ background: "rgba(34,197,94,0.10)", color: "#22C55E", border: "1px solid rgba(34,197,94,0.25)", fontSize: 11 }}>{settlementLabel(r.priceCurrency, r.priceAmount)}</Badge>
-            <Badge style={{ background: open ? "#22C55E20" : t.INPUT_BG, color: expired ? "#F59E0B" : open ? "#22C55E" : SUBTLE, border: `1px solid ${expired ? "#F59E0B40" : open ? "#22C55E40" : t.BORDER}`, fontSize: 11, textTransform: "capitalize" }}>{expired ? "expired" : r.status}</Badge>
-          </div>
+          <CardBadges request={r} t={t} open={open} expired={expired} />
           <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 4, lineHeight: 1.4 }}>{r.title}</div>
           {r.details && <div style={{ fontSize: 13, color: t.SUBTLE, marginBottom: 6, lineHeight: 1.5 }}>{r.details}</div>}
-          <div style={{ display: "flex", gap: 12, fontSize: 12, color: SUBTLE, flexWrap: "wrap", alignItems: "center" }}>
-            <span style={{ color: t.ACCENT, fontWeight: 600 }}>{srHandle(r.ownerUsername, r.id)}</span>
-            {[r.city, r.state, r.country].some((v) => v && v.trim()) && (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                <MapPin size={11} /> {[r.city, r.state, r.country].map((v) => v?.trim()).filter(Boolean).join(", ")}
-              </span>
-            )}
-            <span>· {timeAgo(r.createdAtIso)}</span>
-            <ShareLink url={`/apps/socket-relay?request=${r.id}`} label="Share" title="Share this request" className="sr-share" />
-          </div>
+          <CardMeta request={r} t={t} />
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-end", flexShrink: 0 }}>
           <CardAction status={r.status} expired={expired} isOwn={isOwn} submitting={submitting} onClaim={() => onClaim(r.id)} onEdit={() => onEdit(r)} onRepost={() => onRepost(r.id)} />
         </div>
       </div>
     </div>
+  );
+}
+
+// Shown when the feed has no cards: either the board is genuinely empty (with a Post Now shortcut) or a
+// search/filter matched nothing. Split out so its copy ternaries stay off the feed's complexity budget.
+function FeedEmptyState({
+  filterActive,
+  onPost,
+  t,
+}: {
+  filterActive: boolean;
+  onPost: () => void;
+  t: SocketRelayTokens;
+}) {
+  return (
+    <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+      <div style={{ width: 48, height: 48, borderRadius: "50%", border: `2px dashed ${t.ACCENT}4D`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Share2 size={20} style={{ color: `${t.ACCENT}66` }} />
+      </div>
+      <div style={{ fontSize: 15, fontWeight: 600, color: t.SUBTLE }}>{filterActive ? "No matches" : "No requests yet"}</div>
+      <div style={{ fontSize: 13, color: FAINT }}>{filterActive ? "No requests match your search or filter. Try clearing it." : "Be the first to post a need or offer to your community."}</div>
+      {!filterActive && (
+        <button onClick={onPost} style={{ padding: "10px 20px", borderRadius: 10, background: `${t.ACCENT}15`, border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
+          Post Now
+        </button>
+      )}
+    </div>
+  );
+}
+
+// The "Load more" button that pulls the next page of open requests. Split out so its disabled/label
+// ternaries stay off the feed's complexity budget.
+function LoadMoreButton({
+  loadingMore,
+  onLoadMore,
+  t,
+}: {
+  loadingMore: boolean;
+  onLoadMore: () => void;
+  t: SocketRelayTokens;
+}) {
+  return (
+    <button
+      onClick={onLoadMore}
+      disabled={loadingMore}
+      style={{ marginTop: 4, padding: "10px 20px", borderRadius: 10, background: "transparent", border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: loadingMore ? "not-allowed" : "pointer", alignSelf: "center" }}
+    >
+      {loadingMore ? "Loading…" : "Load more"}
+    </button>
   );
 }
 
@@ -159,31 +234,14 @@ export function SocketRelayFeed({
     <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "20px 24px" }}>
         {requests.length === 0 ? (
-          <div style={{ padding: "48px", textAlign: "center", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            <div style={{ width: 48, height: 48, borderRadius: "50%", border: `2px dashed ${t.ACCENT}4D`, display: "flex", alignItems: "center", justifyContent: "center" }}>
-              <Share2 size={20} style={{ color: `${t.ACCENT}66` }} />
-            </div>
-            <div style={{ fontSize: 15, fontWeight: 600, color: t.SUBTLE }}>{filterActive ? "No matches" : "No requests yet"}</div>
-            <div style={{ fontSize: 13, color: FAINT }}>{filterActive ? "No requests match your search or filter. Try clearing it." : "Be the first to post a need or offer to your community."}</div>
-            {!filterActive && (
-              <button onClick={onPost} style={{ padding: "10px 20px", borderRadius: 10, background: `${t.ACCENT}15`, border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
-                Post Now
-              </button>
-            )}
-          </div>
+          <FeedEmptyState filterActive={filterActive} onPost={onPost} t={t} />
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             {requests.map((r) => (
               <RequestCard key={r.id} request={r} isOwn={r.ownerUserId === currentUserId} submitting={submitting} onClaim={onClaim} onEdit={onEdit} onRepost={onRepost} />
             ))}
             {hasMore && onLoadMore && (
-              <button
-                onClick={onLoadMore}
-                disabled={loadingMore}
-                style={{ marginTop: 4, padding: "10px 20px", borderRadius: 10, background: "transparent", border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: loadingMore ? "not-allowed" : "pointer", alignSelf: "center" }}
-              >
-                {loadingMore ? "Loading…" : "Load more"}
-              </button>
+              <LoadMoreButton loadingMore={loadingMore} onLoadMore={onLoadMore} t={t} />
             )}
           </div>
         )}

--- a/ctf/packages/web/components/socket-relay/sr-post.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-post.tsx
@@ -8,7 +8,7 @@ import { CountrySelect, StateField } from "@/components/shared/location-select";
 import { FormField } from "@/components/shared/form-field";
 import type { Currency } from "lib/currency/types";
 import { useTheme } from '@/hooks/useTheme';
-import { getSocketRelayTokens } from './sr-shared';
+import { getSocketRelayTokens, type SocketRelayTokens } from './sr-shared';
 
 export type PostDraft = {
   title: string;
@@ -109,6 +109,26 @@ function TagEditor({
   );
 }
 
+// The primary submit button. Split from SocketRelayPost so its submitting/editing label ternaries live
+// in their own scope instead of inflating the form's complexity.
+function SubmitButton({
+  submitting,
+  editing,
+  t,
+  onSubmit,
+}: {
+  submitting: boolean;
+  editing: boolean;
+  t: SocketRelayTokens;
+  onSubmit: () => void;
+}) {
+  return (
+    <button onClick={onSubmit} disabled={submitting} style={{ padding: "14px", borderRadius: 12, background: submitting ? `${t.ACCENT}66` : t.ACCENT, border: "none", color: "#fff", fontSize: 15, fontWeight: 800, cursor: submitting ? "not-allowed" : "pointer" }}>
+      {submitting ? (editing ? "Saving…" : "Posting…") : editing ? "Save Changes" : "Post Request"}
+    </button>
+  );
+}
+
 export function SocketRelayPost({
   draft,
   editing,
@@ -183,9 +203,7 @@ export function SocketRelayPost({
         )}
         {error && <div role="alert" style={{ fontSize: 13, color: "#EF4444" }}>{error}</div>}
         {success && <div role="status" style={{ fontSize: 13, color: "#22C55E" }}>{editing ? "Saved! View it in the feed." : "Posted successfully! View it in the feed."}</div>}
-        <button onClick={onSubmit} disabled={submitting} style={{ padding: "14px", borderRadius: 12, background: submitting ? `${t.ACCENT}66` : t.ACCENT, border: "none", color: "#fff", fontSize: 15, fontWeight: 800, cursor: submitting ? "not-allowed" : "pointer" }}>
-          {submitting ? (editing ? "Saving…" : "Posting…") : editing ? "Save Changes" : "Post Request"}
-        </button>
+        <SubmitButton submitting={submitting} editing={editing} t={t} onSubmit={onSubmit} />
         {editing && (
           <button onClick={onCancelEdit} disabled={submitting} style={{ padding: "12px", borderRadius: 12, background: "transparent", border: "1px solid rgba(255,255,255,0.1)", color: t.SUBTLE, fontSize: 14, fontWeight: 600, cursor: "pointer" }}>
             Cancel Edit

--- a/ctf/packages/web/components/what-works/ww-admin-problems.tsx
+++ b/ctf/packages/web/components/what-works/ww-admin-problems.tsx
@@ -31,6 +31,105 @@ type Props = {
   onDelete: (problem: AdminProblem) => void;
 };
 
+type EditCardProps = {
+  t: WhatWorksTokens;
+  inputStyle: React.CSSProperties;
+  busy: boolean;
+  editEmoji: string;
+  setEditEmoji: (value: string) => void;
+  editTitle: string;
+  setEditTitle: (value: string) => void;
+  editContext: string;
+  setEditContext: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+};
+
+// Inline edit of an existing problem, rendered when its card is in edit mode. The draft fields are
+// seeded from the problem and saved through the same PATCH the deactivate toggle already uses.
+function ProblemEditCard({ t, inputStyle, busy, editEmoji, setEditEmoji, editTitle, setEditTitle, editContext, setEditContext, onSave, onCancel }: EditCardProps) {
+  const canSave = Boolean(editTitle.trim()) && !busy;
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.ACCENT}40` }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <input value={editEmoji} onChange={(event) => setEditEmoji(event.target.value)} placeholder="Emoji" aria-label="Edit emoji" style={{ ...inputStyle, width: 80, flexShrink: 0 }} />
+        <input value={editTitle} onChange={(event) => setEditTitle(event.target.value)} placeholder="Problem title" aria-label="Edit problem title" style={{ ...inputStyle, flex: 1, minWidth: 180 }} />
+      </div>
+      <textarea value={editContext} onChange={(event) => setEditContext(event.target.value)} placeholder="Short context shown under the title" aria-label="Edit problem context" rows={2} style={{ ...inputStyle, width: '100%', marginTop: 8, resize: 'vertical', boxSizing: 'border-box' }} />
+      <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+        <button type="button" disabled={!canSave} onClick={onSave} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: canSave ? 'pointer' : 'not-allowed', opacity: canSave ? 1 : 0.6 }}>
+          <Check size={13} /> {busy ? 'Saving…' : 'Save'}
+        </button>
+        <button type="button" disabled={busy} onClick={onCancel} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
+          <X size={13} /> Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type ViewCardProps = {
+  t: WhatWorksTokens;
+  problem: AdminProblem;
+  busy: boolean;
+  confirming: boolean;
+  onStartEdit: () => void;
+  onToggleActive: () => void;
+  onRequestDelete: () => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+};
+
+// Read-only problem card with its edit / activate / delete controls.
+function ProblemViewCard({ t, problem, busy, confirming, onStartEdit, onToggleActive, onRequestDelete, onConfirmDelete, onCancelDelete }: ViewCardProps) {
+  const busyCursor = busy ? 'not-allowed' : 'pointer';
+  const busyOpacity = busy ? 0.6 : 1;
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <span aria-hidden>{problem.emoji || '🧰'}</span>
+          <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{problem.title}</span>
+          {!problem.is_active ? (
+            <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(107,114,128,0.14)', color: t.SUBTLE, border: '1px solid rgba(107,114,128,0.3)' }}>inactive</span>
+          ) : null}
+        </div>
+        {problem.context ? <div style={{ fontSize: 12, color: t.MUTED, marginTop: 4 }}>{problem.context}</div> : null}
+        <div style={{ fontSize: 11, color: t.MUTED, marginTop: 4 }}>
+          {problem.approvedCount} approved · {problem.pendingCount} pending · {problem.productCount} total
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexShrink: 0, flexDirection: 'column', gap: 8 }}>
+        <button type="button" disabled={busy} onClick={onStartEdit} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+          <Pencil size={13} /> Edit
+        </button>
+        <button type="button" disabled={busy} onClick={onToggleActive} style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+          {problem.is_active ? 'Deactivate' : 'Activate'}
+        </button>
+        {confirming ? (
+          <>
+            <div style={{ fontSize: 11, color: t.MUTED, textAlign: 'right' }}>
+              Delete “{problem.title}” and its {problem.productCount} tool(s)? This cannot be undone.
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button type="button" disabled={busy} onClick={onConfirmDelete} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+                <Trash2 size={13} /> Confirm
+              </button>
+              <button type="button" onClick={onCancelDelete} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+                <X size={13} /> Cancel
+              </button>
+            </div>
+          </>
+        ) : (
+          <button type="button" disabled={busy} onClick={onRequestDelete} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+            <Trash2 size={13} /> Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function WhatWorksAdminProblems({ problems, busyId, creating, onCreate, onEdit, onToggleActive, onDelete }: Props) {
   const { theme } = useTheme();
   const t = getWhatWorksTokens(theme);
@@ -48,6 +147,8 @@ export function WhatWorksAdminProblems({ problems, busyId, creating, onCreate, o
 
   // Inline two-step delete confirmation (replaces window.confirm).
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+
+  const createDisabled = !title.trim() || creating;
 
   async function create(): Promise<void> {
     if (!title.trim() || creating) return;
@@ -84,7 +185,7 @@ export function WhatWorksAdminProblems({ problems, busyId, creating, onCreate, o
         </div>
         <textarea value={context} onChange={(event) => setContext(event.target.value)} placeholder="Short context shown under the title" aria-label="Problem context" rows={2} style={{ ...inputStyle, width: '100%', marginTop: 8, resize: 'vertical', boxSizing: 'border-box' }} />
         <div style={{ marginTop: 10 }}>
-          <button type="button" disabled={!title.trim() || creating} onClick={() => void create()} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '8px 14px', borderRadius: 8, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: !title.trim() || creating ? 'not-allowed' : 'pointer', opacity: !title.trim() || creating ? 0.6 : 1 }}>
+          <button type="button" disabled={createDisabled} onClick={() => void create()} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '8px 14px', borderRadius: 8, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: createDisabled ? 'not-allowed' : 'pointer', opacity: createDisabled ? 0.6 : 1 }}>
             <Plus size={13} /> {creating ? 'Adding…' : 'Add problem'}
           </button>
         </div>
@@ -97,69 +198,34 @@ export function WhatWorksAdminProblems({ problems, busyId, creating, onCreate, o
       ) : (
         problems.map((problem) => {
           const busy = busyId === problem.id;
-          if (editingId === problem.id) {
-            const canSave = Boolean(editTitle.trim()) && !busy;
-            return (
-              <div key={problem.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.ACCENT}40` }}>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                  <input value={editEmoji} onChange={(event) => setEditEmoji(event.target.value)} placeholder="Emoji" aria-label="Edit emoji" style={{ ...inputStyle, width: 80, flexShrink: 0 }} />
-                  <input value={editTitle} onChange={(event) => setEditTitle(event.target.value)} placeholder="Problem title" aria-label="Edit problem title" style={{ ...inputStyle, flex: 1, minWidth: 180 }} />
-                </div>
-                <textarea value={editContext} onChange={(event) => setEditContext(event.target.value)} placeholder="Short context shown under the title" aria-label="Edit problem context" rows={2} style={{ ...inputStyle, width: '100%', marginTop: 8, resize: 'vertical', boxSizing: 'border-box' }} />
-                <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
-                  <button type="button" disabled={!canSave} onClick={() => void saveEdit(problem)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: canSave ? 'pointer' : 'not-allowed', opacity: canSave ? 1 : 0.6 }}>
-                    <Check size={13} /> {busy ? 'Saving…' : 'Save'}
-                  </button>
-                  <button type="button" disabled={busy} onClick={() => setEditingId(null)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <X size={13} /> Cancel
-                  </button>
-                </div>
-              </div>
-            );
-          }
-          return (
-            <div key={problem.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
-              <div style={{ minWidth: 0 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                  <span aria-hidden>{problem.emoji || '🧰'}</span>
-                  <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{problem.title}</span>
-                  {!problem.is_active ? (
-                    <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(107,114,128,0.14)', color: t.SUBTLE, border: '1px solid rgba(107,114,128,0.3)' }}>inactive</span>
-                  ) : null}
-                </div>
-                {problem.context ? <div style={{ fontSize: 12, color: t.MUTED, marginTop: 4 }}>{problem.context}</div> : null}
-                <div style={{ fontSize: 11, color: t.MUTED, marginTop: 4 }}>
-                  {problem.approvedCount} approved · {problem.pendingCount} pending · {problem.productCount} total
-                </div>
-              </div>
-              <div style={{ display: 'flex', flexShrink: 0, flexDirection: 'column', gap: 8 }}>
-                <button type="button" disabled={busy} onClick={() => startEdit(problem)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                  <Pencil size={13} /> Edit
-                </button>
-                <button type="button" disabled={busy} onClick={() => onToggleActive(problem)} style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                  {problem.is_active ? 'Deactivate' : 'Activate'}
-                </button>
-                {confirmingDeleteId === problem.id ? (
-                  <>
-                    <div style={{ fontSize: 11, color: t.MUTED, textAlign: 'right' }}>
-                      Delete “{problem.title}” and its {problem.productCount} tool(s)? This cannot be undone.
-                    </div>
-                    <div style={{ display: 'flex', gap: 8 }}>
-                      <button type="button" disabled={busy} onClick={() => { setConfirmingDeleteId(null); onDelete(problem); }} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                        <Trash2 size={13} /> Confirm
-                      </button>
-                      <button type="button" onClick={() => setConfirmingDeleteId(null)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
-                        <X size={13} /> Cancel
-                      </button>
-                    </div>
-                  </>
-                ) : (
-                  <button type="button" disabled={busy} onClick={() => setConfirmingDeleteId(problem.id)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <Trash2 size={13} /> Delete
-                  </button>
-                )}
-              </div>
-            </div>
+          return editingId === problem.id ? (
+            <ProblemEditCard
+              key={problem.id}
+              t={t}
+              inputStyle={inputStyle}
+              busy={busy}
+              editEmoji={editEmoji}
+              setEditEmoji={setEditEmoji}
+              editTitle={editTitle}
+              setEditTitle={setEditTitle}
+              editContext={editContext}
+              setEditContext={setEditContext}
+              onSave={() => void saveEdit(problem)}
+              onCancel={() => setEditingId(null)}
+            />
+          ) : (
+            <ProblemViewCard
+              key={problem.id}
+              t={t}
+              problem={problem}
+              busy={busy}
+              confirming={confirmingDeleteId === problem.id}
+              onStartEdit={() => startEdit(problem)}
+              onToggleActive={() => onToggleActive(problem)}
+              onRequestDelete={() => setConfirmingDeleteId(problem.id)}
+              onConfirmDelete={() => { setConfirmingDeleteId(null); onDelete(problem); }}
+              onCancelDelete={() => setConfirmingDeleteId(null)}
+            />
           );
         })
       )}

--- a/ctf/packages/web/components/what-works/ww-admin-products.tsx
+++ b/ctf/packages/web/components/what-works/ww-admin-products.tsx
@@ -51,6 +51,200 @@ const STATUS_STYLE: Record<WhatWorksProductStatus, { bg: string; color: string; 
   rejected: { bg: 'rgba(239,68,68,0.12)', color: '#EF4444', border: 'rgba(239,68,68,0.3)' },
 };
 
+type ReviewActionsProps = {
+  t: WhatWorksTokens;
+  product: AdminProduct;
+  busy: boolean;
+  confirming: boolean;
+  onApprove: () => void;
+  onOpenReject: () => void;
+  onToggleEdit: () => void;
+  onRequestDelete: () => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+};
+
+// Approve / reject-open / edit-toggle / delete row for one suggestion card.
+function ProductReviewActions({ t, product, busy, confirming, onApprove, onOpenReject, onToggleEdit, onRequestDelete, onConfirmDelete, onCancelDelete }: ReviewActionsProps) {
+  const busyCursor = busy ? 'not-allowed' : 'pointer';
+  const busyOpacity = busy ? 0.6 : 1;
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginTop: 12 }}>
+      <span style={{ fontSize: 12, color: t.MUTED, marginRight: 'auto' }}>{product.verifiedCount} verified</span>
+      {product.status !== 'approved' ? (
+        <button type="button" disabled={busy} onClick={onApprove} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+          <CheckCircle size={13} /> Approve
+        </button>
+      ) : null}
+      {product.status !== 'rejected' ? (
+        <button type="button" disabled={busy} onClick={onOpenReject} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+          <XCircle size={13} /> {product.status === 'approved' ? 'Unpublish' : 'Reject'}
+        </button>
+      ) : null}
+      <button type="button" disabled={busy} onClick={onToggleEdit} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+        <Pencil size={13} /> Edit
+      </button>
+      {confirming ? (
+        <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 12, color: t.MUTED }}>Delete permanently?</span>
+          <button type="button" disabled={busy} onClick={onConfirmDelete} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+            <Trash2 size={13} /> Confirm
+          </button>
+          <button type="button" onClick={onCancelDelete} style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+            Cancel
+          </button>
+        </span>
+      ) : (
+        <button type="button" disabled={busy} onClick={onRequestDelete} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busyCursor, opacity: busyOpacity }}>
+          <Trash2 size={13} /> Delete
+        </button>
+      )}
+    </div>
+  );
+}
+
+type RejectFormProps = {
+  t: WhatWorksTokens;
+  product: AdminProduct;
+  busy: boolean;
+  reason: string;
+  setReason: (value: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+// Inline reject form. Replaces the old blocking window.prompt with a themable, testable textarea.
+function ProductRejectForm({ t, product, busy, reason, setReason, onCancel, onConfirm }: RejectFormProps) {
+  return (
+    <div style={{ marginTop: 12, padding: 12, borderRadius: 10, background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.25)' }}>
+      <label htmlFor={`reject-reason-${product.id}`} style={{ display: 'block', fontSize: 12, color: t.MUTED, marginBottom: 6 }}>
+        Reason (optional, shown only to admins)
+      </label>
+      <textarea
+        id={`reject-reason-${product.id}`}
+        value={reason}
+        onChange={(event) => setReason(event.target.value.slice(0, MAX_PRODUCT_NOTE_LENGTH))}
+        maxLength={MAX_PRODUCT_NOTE_LENGTH}
+        rows={3}
+        placeholder="Why is this being rejected?"
+        style={{ width: '100%', resize: 'vertical', padding: '8px 10px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontFamily: 'inherit' }}
+      />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
+        <span style={{ fontSize: 11, color: t.MUTED, marginRight: 'auto' }}>{reason.length}/{MAX_PRODUCT_NOTE_LENGTH}</span>
+        <button type="button" onClick={onCancel} style={{ padding: '6px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+          Cancel
+        </button>
+        <button type="button" disabled={busy} onClick={onConfirm} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
+          <XCircle size={13} /> {product.status === 'approved' ? 'Unpublish' : 'Reject'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type EditFormProps = {
+  t: WhatWorksTokens;
+  editInputStyle: React.CSSProperties;
+  busy: boolean;
+  draft: ProductEditDraft;
+  setDraft: React.Dispatch<React.SetStateAction<ProductEditDraft>>;
+  onCancel: () => void;
+  onSave: () => void;
+};
+
+// Inline edit of a tool's own details. The draft is seeded from the product and saved through the
+// same route's field-edit PATCH; status and verified count are unchanged.
+function ProductEditForm({ t, editInputStyle, busy, draft, setDraft, onCancel, onSave }: EditFormProps) {
+  const canSave = Boolean(draft.name.trim()) && Boolean(draft.purchaseUrl.trim()) && !busy;
+  return (
+    <div style={{ marginTop: 12, padding: 12, borderRadius: 10, background: `${t.ACCENT}08`, border: `1px solid ${t.ACCENT}35` }}>
+      <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 10 }}>Correct this tool&apos;s details. Its status and verified count are unchanged.</div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <input value={draft.emoji} onChange={(event) => setDraft((prev) => ({ ...prev, emoji: event.target.value.slice(0, MAX_EMOJI_LENGTH) }))} maxLength={MAX_EMOJI_LENGTH} placeholder="Emoji" aria-label="Edit emoji" style={{ ...editInputStyle, width: 80, flexShrink: 0 }} />
+        <input value={draft.name} onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value.slice(0, MAX_PRODUCT_NAME_LENGTH) }))} maxLength={MAX_PRODUCT_NAME_LENGTH} placeholder="Product name" aria-label="Edit product name" style={{ ...editInputStyle, flex: 1, minWidth: 180 }} />
+      </div>
+      <input value={draft.kind} onChange={(event) => setDraft((prev) => ({ ...prev, kind: event.target.value.slice(0, MAX_PRODUCT_KIND_LENGTH) }))} maxLength={MAX_PRODUCT_KIND_LENGTH} placeholder="Type (e.g. Headphones)" aria-label="Edit product type" style={{ ...editInputStyle, width: '100%', marginTop: 8, boxSizing: 'border-box' }} />
+      <input value={draft.purchaseUrl} onChange={(event) => setDraft((prev) => ({ ...prev, purchaseUrl: event.target.value.slice(0, MAX_PURCHASE_URL_LENGTH) }))} maxLength={MAX_PURCHASE_URL_LENGTH} placeholder="https://…" aria-label="Edit purchase link" inputMode="url" style={{ ...editInputStyle, width: '100%', marginTop: 8, boxSizing: 'border-box' }} />
+      <textarea value={draft.note} onChange={(event) => setDraft((prev) => ({ ...prev, note: event.target.value.slice(0, MAX_PRODUCT_NOTE_LENGTH) }))} maxLength={MAX_PRODUCT_NOTE_LENGTH} rows={2} placeholder="Why it works (optional)" aria-label="Edit note" style={{ ...editInputStyle, width: '100%', marginTop: 8, resize: 'vertical', boxSizing: 'border-box' }} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
+        <span style={{ fontSize: 11, color: t.MUTED, marginRight: 'auto' }}>{draft.note.length}/{MAX_PRODUCT_NOTE_LENGTH}</span>
+        <button type="button" onClick={onCancel} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+          <X size={13} /> Cancel
+        </button>
+        <button type="button" disabled={!canSave} onClick={onSave} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: canSave ? 'pointer' : 'not-allowed', opacity: canSave ? 1 : 0.6 }}>
+          <Check size={13} /> {busy ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type ProductCardProps = {
+  t: WhatWorksTokens;
+  editInputStyle: React.CSSProperties;
+  product: AdminProduct;
+  busy: boolean;
+  editingId: string | null;
+  rejectingId: string | null;
+  confirmingDeleteId: string | null;
+  reason: string;
+  setReason: (value: string) => void;
+  draft: ProductEditDraft;
+  setDraft: React.Dispatch<React.SetStateAction<ProductEditDraft>>;
+  onApprove: () => void;
+  onOpenReject: () => void;
+  onCloseReject: () => void;
+  onConfirmReject: () => void;
+  onToggleEdit: () => void;
+  onCancelEdit: () => void;
+  onSaveEdit: () => void;
+  onRequestDelete: () => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+};
+
+// One suggestion card: header, review actions, and the inline reject / edit forms.
+function ProductCard({ t, editInputStyle, product, busy, editingId, rejectingId, confirmingDeleteId, reason, setReason, draft, setDraft, onApprove, onOpenReject, onCloseReject, onConfirmReject, onToggleEdit, onCancelEdit, onSaveEdit, onRequestDelete, onConfirmDelete, onCancelDelete }: ProductCardProps) {
+  const status = STATUS_STYLE[product.status];
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <span aria-hidden>{product.emoji || '🧰'}</span>
+            <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{product.name}</span>
+            {product.kind ? <span style={{ fontSize: 12, color: t.MUTED }}>{product.kind}</span> : null}
+          </div>
+          <div style={{ fontSize: 12, color: t.MUTED, marginTop: 4 }}>Problem: {product.problemTitle}</div>
+          {product.note ? <div style={{ fontSize: 13, color: t.MUTED, fontStyle: 'italic', marginTop: 4 }}>“{product.note}”</div> : null}
+          <a href={product.purchaseUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'inline-block', marginTop: 4, fontSize: 12, color: t.ACCENT, textDecoration: 'underline', textUnderlineOffset: 4, wordBreak: 'break-all' }}>
+            {product.purchaseUrl}
+          </a>
+        </div>
+        <span style={{ flexShrink: 0, padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: status.bg, color: status.color, border: `1px solid ${status.border}` }}>{product.status}</span>
+      </div>
+      <ProductReviewActions
+        t={t}
+        product={product}
+        busy={busy}
+        confirming={confirmingDeleteId === product.id}
+        onApprove={onApprove}
+        onOpenReject={onOpenReject}
+        onToggleEdit={onToggleEdit}
+        onRequestDelete={onRequestDelete}
+        onConfirmDelete={onConfirmDelete}
+        onCancelDelete={onCancelDelete}
+      />
+      {rejectingId === product.id ? (
+        <ProductRejectForm t={t} product={product} busy={busy} reason={reason} setReason={setReason} onCancel={onCloseReject} onConfirm={onConfirmReject} />
+      ) : null}
+      {editingId === product.id ? (
+        <ProductEditForm t={t} editInputStyle={editInputStyle} busy={busy} draft={draft} setDraft={setDraft} onCancel={onCancelEdit} onSave={onSaveEdit} />
+      ) : null}
+    </div>
+  );
+}
+
 export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChangeFilter, onReview, onEdit, onDelete }: Props) {
   const { theme } = useTheme();
   const t = getWhatWorksTokens(theme);
@@ -133,107 +327,31 @@ export function WhatWorksAdminProducts({ products, busyId, statusFilter, onChang
       ) : (
         products.map((product) => {
           const busy = busyId === product.id;
-          const status = STATUS_STYLE[product.status];
           return (
-            <div key={product.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
-                <div style={{ minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                    <span aria-hidden>{product.emoji || '🧰'}</span>
-                    <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{product.name}</span>
-                    {product.kind ? <span style={{ fontSize: 12, color: t.MUTED }}>{product.kind}</span> : null}
-                  </div>
-                  <div style={{ fontSize: 12, color: t.MUTED, marginTop: 4 }}>Problem: {product.problemTitle}</div>
-                  {product.note ? <div style={{ fontSize: 13, color: t.MUTED, fontStyle: 'italic', marginTop: 4 }}>“{product.note}”</div> : null}
-                  <a href={product.purchaseUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'inline-block', marginTop: 4, fontSize: 12, color: t.ACCENT, textDecoration: 'underline', textUnderlineOffset: 4, wordBreak: 'break-all' }}>
-                    {product.purchaseUrl}
-                  </a>
-                </div>
-                <span style={{ flexShrink: 0, padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: status.bg, color: status.color, border: `1px solid ${status.border}` }}>{product.status}</span>
-              </div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginTop: 12 }}>
-                <span style={{ fontSize: 12, color: t.MUTED, marginRight: 'auto' }}>{product.verifiedCount} verified</span>
-                {product.status !== 'approved' ? (
-                  <button type="button" disabled={busy} onClick={() => onReview(product.id, 'approve')} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <CheckCircle size={13} /> Approve
-                  </button>
-                ) : null}
-                {product.status !== 'rejected' ? (
-                  <button type="button" disabled={busy} onClick={() => openReject(product.id)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <XCircle size={13} /> {product.status === 'approved' ? 'Unpublish' : 'Reject'}
-                  </button>
-                ) : null}
-                <button type="button" disabled={busy} onClick={() => (editingId === product.id ? setEditingId(null) : openEdit(product))} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                  <Pencil size={13} /> Edit
-                </button>
-                {confirmingDeleteId === product.id ? (
-                  <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ fontSize: 12, color: t.MUTED }}>Delete permanently?</span>
-                    <button type="button" disabled={busy} onClick={() => { setConfirmingDeleteId(null); onDelete(product.id); }} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                      <Trash2 size={13} /> Confirm
-                    </button>
-                    <button type="button" onClick={() => setConfirmingDeleteId(null)} style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
-                      Cancel
-                    </button>
-                  </span>
-                ) : (
-                  <button type="button" disabled={busy} onClick={() => setConfirmingDeleteId(product.id)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <Trash2 size={13} /> Delete
-                  </button>
-                )}
-              </div>
-              {rejectingId === product.id ? (
-                <div style={{ marginTop: 12, padding: 12, borderRadius: 10, background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.25)' }}>
-                  <label htmlFor={`reject-reason-${product.id}`} style={{ display: 'block', fontSize: 12, color: t.MUTED, marginBottom: 6 }}>
-                    Reason (optional, shown only to admins)
-                  </label>
-                  <textarea
-                    id={`reject-reason-${product.id}`}
-                    value={reason}
-                    onChange={(event) => setReason(event.target.value.slice(0, MAX_PRODUCT_NOTE_LENGTH))}
-                    maxLength={MAX_PRODUCT_NOTE_LENGTH}
-                    rows={3}
-                    placeholder="Why is this being rejected?"
-                    style={{ width: '100%', resize: 'vertical', padding: '8px 10px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, fontFamily: 'inherit' }}
-                  />
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
-                    <span style={{ fontSize: 11, color: t.MUTED, marginRight: 'auto' }}>{reason.length}/{MAX_PRODUCT_NOTE_LENGTH}</span>
-                    <button type="button" onClick={closeReject} style={{ padding: '6px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
-                      Cancel
-                    </button>
-                    <button type="button" disabled={busy} onClick={() => confirmReject(product.id)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                      <XCircle size={13} /> {product.status === 'approved' ? 'Unpublish' : 'Reject'}
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-              {editingId === product.id ? (
-                (() => {
-                  const canSave = Boolean(draft.name.trim()) && Boolean(draft.purchaseUrl.trim()) && !busy;
-                  return (
-                    <div style={{ marginTop: 12, padding: 12, borderRadius: 10, background: `${t.ACCENT}08`, border: `1px solid ${t.ACCENT}35` }}>
-                      <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 10 }}>Correct this tool&apos;s details. Its status and verified count are unchanged.</div>
-                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                        <input value={draft.emoji} onChange={(event) => setDraft((prev) => ({ ...prev, emoji: event.target.value.slice(0, MAX_EMOJI_LENGTH) }))} maxLength={MAX_EMOJI_LENGTH} placeholder="Emoji" aria-label="Edit emoji" style={{ ...editInputStyle, width: 80, flexShrink: 0 }} />
-                        <input value={draft.name} onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value.slice(0, MAX_PRODUCT_NAME_LENGTH) }))} maxLength={MAX_PRODUCT_NAME_LENGTH} placeholder="Product name" aria-label="Edit product name" style={{ ...editInputStyle, flex: 1, minWidth: 180 }} />
-                      </div>
-                      <input value={draft.kind} onChange={(event) => setDraft((prev) => ({ ...prev, kind: event.target.value.slice(0, MAX_PRODUCT_KIND_LENGTH) }))} maxLength={MAX_PRODUCT_KIND_LENGTH} placeholder="Type (e.g. Headphones)" aria-label="Edit product type" style={{ ...editInputStyle, width: '100%', marginTop: 8, boxSizing: 'border-box' }} />
-                      <input value={draft.purchaseUrl} onChange={(event) => setDraft((prev) => ({ ...prev, purchaseUrl: event.target.value.slice(0, MAX_PURCHASE_URL_LENGTH) }))} maxLength={MAX_PURCHASE_URL_LENGTH} placeholder="https://…" aria-label="Edit purchase link" inputMode="url" style={{ ...editInputStyle, width: '100%', marginTop: 8, boxSizing: 'border-box' }} />
-                      <textarea value={draft.note} onChange={(event) => setDraft((prev) => ({ ...prev, note: event.target.value.slice(0, MAX_PRODUCT_NOTE_LENGTH) }))} maxLength={MAX_PRODUCT_NOTE_LENGTH} rows={2} placeholder="Why it works (optional)" aria-label="Edit note" style={{ ...editInputStyle, width: '100%', marginTop: 8, resize: 'vertical', boxSizing: 'border-box' }} />
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
-                        <span style={{ fontSize: 11, color: t.MUTED, marginRight: 'auto' }}>{draft.note.length}/{MAX_PRODUCT_NOTE_LENGTH}</span>
-                        <button type="button" onClick={() => setEditingId(null)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
-                          <X size={13} /> Cancel
-                        </button>
-                        <button type="button" disabled={!canSave} onClick={() => saveEdit(product.id)} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderRadius: 8, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}35`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: canSave ? 'pointer' : 'not-allowed', opacity: canSave ? 1 : 0.6 }}>
-                          <Check size={13} /> {busy ? 'Saving…' : 'Save'}
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })()
-              ) : null}
-            </div>
+            <ProductCard
+              key={product.id}
+              t={t}
+              editInputStyle={editInputStyle}
+              product={product}
+              busy={busy}
+              editingId={editingId}
+              rejectingId={rejectingId}
+              confirmingDeleteId={confirmingDeleteId}
+              reason={reason}
+              setReason={setReason}
+              draft={draft}
+              setDraft={setDraft}
+              onApprove={() => onReview(product.id, 'approve')}
+              onOpenReject={() => openReject(product.id)}
+              onCloseReject={closeReject}
+              onConfirmReject={() => confirmReject(product.id)}
+              onToggleEdit={() => (editingId === product.id ? setEditingId(null) : openEdit(product))}
+              onCancelEdit={() => setEditingId(null)}
+              onSaveEdit={() => saveEdit(product.id)}
+              onRequestDelete={() => setConfirmingDeleteId(product.id)}
+              onConfirmDelete={() => { setConfirmingDeleteId(null); onDelete(product.id); }}
+              onCancelDelete={() => setConfirmingDeleteId(null)}
+            />
           );
         })
       )}

--- a/ctf/packages/web/components/what-works/ww-suggest-panel.tsx
+++ b/ctf/packages/web/components/what-works/ww-suggest-panel.tsx
@@ -34,61 +34,64 @@ function Field({ label, required, children }: { label: string; required?: boolea
   );
 }
 
-export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: Props) {
-  const { theme } = useTheme();
-  const t = getWhatWorksTokens(theme);
-  const inputStyle = makeInputStyle(t);
-  const [problemId, setProblemId] = useState('');
-  const [name, setName] = useState('');
-  const [link, setLink] = useState('');
-  const [why, setWhy] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [added, setAdded] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const ready = problemId.trim() && name.trim() && link.trim();
-
-  async function submit(): Promise<void> {
-    if (!ready || submitting) return;
-    setSubmitting(true);
-    setError(null);
-    const failure = await onSubmit({ problemId, name: name.trim(), purchaseUrl: link.trim(), note: why.trim() });
-    setSubmitting(false);
-    if (failure) {
-      setError(failure);
-      return;
-    }
-    setProblemId('');
-    setName('');
-    setLink('');
-    setWhy('');
-    setAdded(true);
-  }
-
-  if (added) {
-    return (
-      <div style={{ width: '100%', height: '100dvh', maxHeight: '100%', background: t.BG, fontFamily: "'Inter',system-ui", color: t.TITLE, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
-        <div style={{ maxWidth: 460, textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, padding: '0 32px' }}>
-          <div style={{ width: 72, height: 72, borderRadius: '50%', background: `${t.ACCENT}15`, border: `1px solid ${t.ACCENT}30`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <CheckCircle size={34} color={t.ACCENT} />
-          </div>
-          <div style={{ fontSize: 24, fontWeight: 800 }}>Suggestion submitted 🎉</div>
-          <div style={{ fontSize: 14, color: t.MUTED, lineHeight: 1.7 }}>A reviewer will check it before it joins the shared list. Each tool you add helps the next survivor find what works faster.</div>
-          <div style={{ display: 'flex', gap: 10 }}>
-            <button onClick={() => setAdded(false)} style={{ padding: '12px 24px', borderRadius: 10, background: t.ACCENT, border: 'none', color: '#0A0E06', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 7 }}>
-              <Plus size={15} /> Add another
+// Success confirmation shown after a suggestion is submitted for review.
+function SuggestSuccess({ t, onBack, onAddAnother }: { t: WhatWorksTokens; onBack?: () => void; onAddAnother: () => void }) {
+  return (
+    <div style={{ width: '100%', height: '100dvh', maxHeight: '100%', background: t.BG, fontFamily: "'Inter',system-ui", color: t.TITLE, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+      <div style={{ maxWidth: 460, textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, padding: '0 32px' }}>
+        <div style={{ width: 72, height: 72, borderRadius: '50%', background: `${t.ACCENT}15`, border: `1px solid ${t.ACCENT}30`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <CheckCircle size={34} color={t.ACCENT} />
+        </div>
+        <div style={{ fontSize: 24, fontWeight: 800 }}>Suggestion submitted 🎉</div>
+        <div style={{ fontSize: 14, color: t.MUTED, lineHeight: 1.7 }}>A reviewer will check it before it joins the shared list. Each tool you add helps the next survivor find what works faster.</div>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button onClick={onAddAnother} style={{ padding: '12px 24px', borderRadius: 10, background: t.ACCENT, border: 'none', color: '#0A0E06', fontSize: 14, fontWeight: 700, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+            <Plus size={15} /> Add another
+          </button>
+          {onBack ? (
+            <button onClick={onBack} style={{ padding: '12px 24px', borderRadius: 10, background: t.BORDER, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
+              Back to list
             </button>
-            {onBack ? (
-              <button onClick={onBack} style={{ padding: '12px 24px', borderRadius: 10, background: t.BORDER, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
-                Back to list
-              </button>
-            ) : null}
-          </div>
+          ) : null}
         </div>
       </div>
-    );
-  }
+    </div>
+  );
+}
 
+// Submit button — the shared "active" look is derived once from ready + submitting.
+function SuggestSubmitButton({ t, ready, submitting }: { t: WhatWorksTokens; ready: boolean; submitting: boolean }) {
+  const active = ready && !submitting;
+  return (
+    <button type="submit" disabled={!ready || submitting}
+      style={{ padding: '14px', borderRadius: 12, background: active ? t.ACCENT : t.BORDER, border: 'none', color: active ? '#0A0E06' : t.MUTED, fontSize: 15, fontWeight: 700, cursor: active ? 'pointer' : 'default', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
+      <Send size={16} /> {submitting ? 'Submitting…' : 'Submit for review'}
+    </button>
+  );
+}
+
+type SuggestFormProps = {
+  t: WhatWorksTokens;
+  inputStyle: CSSProperties;
+  problems: WhatWorksProblemOption[];
+  isFirst: boolean;
+  error: string | null;
+  problemId: string;
+  setProblemId: (value: string) => void;
+  name: string;
+  setName: (value: string) => void;
+  link: string;
+  setLink: (value: string) => void;
+  why: string;
+  setWhy: (value: string) => void;
+  ready: boolean;
+  submitting: boolean;
+  onSubmit: () => void;
+  onBack?: () => void;
+};
+
+// The suggest layout: header bar, the entry form, and the guidance panel.
+function SuggestForm({ t, inputStyle, problems, isFirst, error, problemId, setProblemId, name, setName, link, setLink, why, setWhy, ready, submitting, onSubmit, onBack }: SuggestFormProps) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', maxHeight: '100%', background: t.BG, fontFamily: "'Inter',system-ui", color: t.TITLE, overflow: 'hidden' }}>
       <div style={{ height: 56, borderBottom: `1px solid ${t.BORDER_SOLID}`, display: 'flex', alignItems: 'center', padding: '0 16px', gap: 12, background: t.HEADER, flexShrink: 0 }}>
@@ -124,7 +127,7 @@ export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: P
           ) : null}
 
           <form
-            onSubmit={(event) => { event.preventDefault(); void submit(); }}
+            onSubmit={(event) => { event.preventDefault(); onSubmit(); }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
           >
             <Field label="Problem it solves" required>
@@ -156,15 +159,70 @@ export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: P
               <textarea value={why} onChange={(event) => setWhy(event.target.value)} rows={3} placeholder="A short note from your experience — what it actually solved." style={{ ...inputStyle, padding: '11px 14px', background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 12, boxSizing: 'border-box', width: '100%', resize: 'none', lineHeight: 1.5 }} />
             </Field>
 
-            <button type="submit" disabled={!ready || submitting}
-              style={{ padding: '14px', borderRadius: 12, background: ready && !submitting ? t.ACCENT : t.BORDER, border: 'none', color: ready && !submitting ? '#0A0E06' : t.MUTED, fontSize: 15, fontWeight: 700, cursor: ready && !submitting ? 'pointer' : 'default', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
-              <Send size={16} /> {submitting ? 'Submitting…' : 'Submit for review'}
-            </button>
+            <SuggestSubmitButton t={t} ready={ready} submitting={submitting} />
           </form>
         </div>
 
         <WhatWorksSuggestGuidance />
       </div>
     </div>
+  );
+}
+
+export function WhatWorksSuggestPanel({ problems, isFirst, onSubmit, onBack }: Props) {
+  const { theme } = useTheme();
+  const t = getWhatWorksTokens(theme);
+  const inputStyle = makeInputStyle(t);
+  const [problemId, setProblemId] = useState('');
+  const [name, setName] = useState('');
+  const [link, setLink] = useState('');
+  const [why, setWhy] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [added, setAdded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const ready = Boolean(problemId.trim() && name.trim() && link.trim());
+
+  async function submit(): Promise<void> {
+    if (!ready || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const failure = await onSubmit({ problemId, name: name.trim(), purchaseUrl: link.trim(), note: why.trim() });
+    setSubmitting(false);
+    if (failure) {
+      setError(failure);
+      return;
+    }
+    setProblemId('');
+    setName('');
+    setLink('');
+    setWhy('');
+    setAdded(true);
+  }
+
+  if (added) {
+    return <SuggestSuccess t={t} onBack={onBack} onAddAnother={() => setAdded(false)} />;
+  }
+
+  return (
+    <SuggestForm
+      t={t}
+      inputStyle={inputStyle}
+      problems={problems}
+      isFirst={isFirst}
+      error={error}
+      problemId={problemId}
+      setProblemId={setProblemId}
+      name={name}
+      setName={setName}
+      link={link}
+      setLink={setLink}
+      why={why}
+      setWhy={setWhy}
+      ready={ready}
+      submitting={submitting}
+      onSubmit={() => void submit()}
+      onBack={onBack}
+    />
   );
 }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — web components).

## What

Rule-116 complexity/length cleanup across four plugins (13 components), grouped into one PR to keep the long tail moving. **Behavior-preserving** — rendered UI, state, effects, handlers, and network calls unchanged; hooks in stable, unconditional order; all `<label>`↔control associations preserved.

- **skills-hunt**: `sh-skills-picker` (22) → self-guarding child components; `sh-use-nomination-form`, `sha-moderation`, `skills-hunt-shell` → helpers
- **what-works**: `ww-admin-problems` (21), `ww-admin-products` (23), `ww-suggest-panel` (20) → card/form child components
- **socket-relay**: `socket-relay-shell` (362 lines / complexity 12) → `useSocketRelay` hook + header/tab child components; `sr-feed`, `sr-post` → card/button components
- **recurring-activity**: create-form, item, shell → helpers + `ItemActions`/`SubmitButton`

## Verification
- `pnpm --filter @ctf/web run typecheck` / repo `lint` — pass
- complexity rule + **`lint:a11y`** on all 13 files — pass
- `check-eof-format` — pass
- pre-push gate — pass

No schema/route/contract changes.

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_