### PR TITLE
refactor: reduce complexity in remaining web components and app pages

### DIFF
--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -1,6 +1,13 @@
-import { evaluatePluginAccess } from 'lib/auth/server-authz';
+import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
+import type { PluginDenyResponse } from 'lib/auth/deny-taxonomy';
 import { getHostedSignInUrl } from 'lib/auth/provider-env';
-import { canonicalizePluginSlug, getPluginBySlug, isAdminOnlyPlugin } from 'lib/plugins/repository';
+import {
+  canonicalizePluginSlug,
+  getPluginBySlug,
+  isAdminOnlyPlugin,
+  type PluginRegistryItem,
+} from 'lib/plugins/repository';
+import type { ReactNode } from 'react';
 import { getPublicVisitorShell } from '@/components/plugins/public-visitor-registry';
 import { ReviewsWidget } from '@/components/reviews/reviews-widget';
 import { BeaconShell } from '@/components/beacon/beacon-shell';
@@ -127,6 +134,114 @@ function GenericPluginView({
   );
 }
 
+type PluginShellContext = {
+  decision: AllowDecision;
+  plugin: PluginRegistryItem;
+  searchParams: {
+    track?: string;
+    status?: string;
+    startDate?: string;
+    cohortId?: string;
+  };
+};
+
+// Maps each plugin slug to the shell it renders once baseline access is allowed. Kept as a data
+// table so the route handler stays a simple lookup instead of a long branch chain; the props each
+// shell needs are read from the shared access context. `knowledge` and `weekly-performance`
+// redirect to their canonical routes instead of rendering a shell here. A slug with no entry falls
+// through to the generic plugin view.
+const PLUGIN_SHELL_RENDERERS: Record<string, (ctx: PluginShellContext) => ReactNode> = {
+  beacon: ({ decision }) => <BeaconShell isAdmin={decision.isAdmin} />,
+  'click-log': () => <ClickLogShell />,
+  'what-works': () => <WhatWorksShell />,
+  chyme: ({ decision }) => (
+    <ChymeShell
+      currentUser={{
+        userId: decision.userId,
+        username: decision.username,
+      }}
+    />
+  ),
+  directory: ({ decision }) => <DirectoryShell userId={decision.userId} isAdmin={decision.isAdmin} />,
+  workforce: ({ decision }) => <WorkforceShell isAdmin={decision.isAdmin} />,
+  'skills-hunt': ({ decision }) => (
+    <SkillsHuntShell
+      userId={decision.userId}
+      isAdmin={decision.isAdmin}
+      isModerator={decision.role === 'moderator'}
+    />
+  ),
+  'skills-taxonomy': () => <SkillsTaxonomyShell />,
+  foundation: ({ decision }) => <FoundationShell isAdmin={decision.isAdmin} />,
+  lighthouse: ({ decision }) => (
+    <LighthouseShell userId={decision.userId} username={decision.username} isAdmin={decision.isAdmin} />
+  ),
+  'socket-relay': ({ decision }) => (
+    <SocketRelayShell userId={decision.userId} isAdmin={decision.isAdmin} role={decision.role} />
+  ),
+  'trust-transport': ({ decision }) => <TrustTransportShell isAdmin={decision.isAdmin} />,
+  'peer-programming': ({ decision }) => <PeerProgrammingShell isAdmin={decision.isAdmin} />,
+  mood: () => <MoodShell />,
+  // The real page is the top-level /knowledge route — short enough to paste into an invitation post
+  // that is read outside the app. The launcher tile lands here and is sent on, so there is one page
+  // rather than two copies to keep in step.
+  knowledge: () => redirect('/knowledge'),
+  // Weekly Performance has no member view — the dashboard lives on the admin page only.
+  // Non-admins never reach this branch (the admin-only gate above 404s them).
+  'weekly-performance': () => redirect('/admin/weekly-performance'),
+  gdp: () => <GdpShell />,
+  'service-credits': ({ decision }) => <ServiceCreditsShell isAdmin={decision.isAdmin} />,
+  'level-up': ({ decision, searchParams }) => (
+    <LevelUpShell userId={decision.userId} isAdmin={decision.isAdmin} query={searchParams} />
+  ),
+};
+
+// A denied request either browses the plugin's public landing (anonymous or not-yet-verified) or
+// sees the informative access-denied view (other 403s). Extracted so the route handler stays flat.
+function renderAccessDenied(decision: PluginDenyResponse, plugin: PluginRegistryItem): ReactNode {
+  // Two cases see the plugin's public visitor view rather than a denial wall:
+  //  - an anonymous visitor (no session) denied with AUTH_UNAUTHORIZED, and
+  //  - a signed-in but not-yet-verified member denied with `unlock_required`.
+  // Both can browse the plugin's marketing/landing content the same way; the
+  // not-yet-verified member is nudged from there toward the Unlock flow, and the
+  // Hub general channel remains their support surface. Other 403s (e.g. a missing
+  // username or a role requirement) keep the informative access-denied view.
+  if (decision.code === 'AUTH_UNAUTHORIZED' || decision.reason === 'unlock_required') {
+    const PublicVisitorShell = getPublicVisitorShell(plugin.slug);
+    const signInUrl = getHostedSignInUrl() ?? '/sign-in';
+    // A signed-in-but-not-yet-verified member (denied with `unlock_required`)
+    // is already authenticated, so the public shell's "Sign In / Join Free"
+    // CTAs are wrong for them; pass a verifyUrl so the shell shows a single
+    // "Finish verifying" action pointing at the Unlock flow instead. An
+    // anonymous visitor (AUTH_UNAUTHORIZED) gets no verifyUrl and sees the
+    // normal sign-in / sign-up CTAs.
+    const verifyUrl = decision.reason === 'unlock_required' ? '/plugin/unlock' : undefined;
+    // The back-to-/apps control lives inside each public shell's own header
+    // row (PublicShellBackLink), so no wrapping frame is needed here.
+    return (
+      <>
+        <PublicVisitorShell
+          pluginSlug={plugin.slug}
+          pluginName={plugin.name}
+          signInUrl={signInUrl}
+          verifyUrl={verifyUrl}
+        />
+        {/* Corner reviews widget — shown on every public (signed-out) plugin page. */}
+        <ReviewsWidget />
+      </>
+    );
+  }
+
+  return (
+    <AccessDeniedView
+      status={decision.status}
+      code={decision.code}
+      reason={decision.reason}
+      requestedPluginSlug={plugin.slug}
+    />
+  );
+}
+
 export default async function PluginRoutePage({ params, searchParams }: PluginRoutePageProps) {
   const resolvedParams = await params;
   const resolvedSearchParams = await searchParams;
@@ -158,135 +273,16 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (!decision.allowed) {
-    // Two cases see the plugin's public visitor view rather than a denial wall:
-    //  - an anonymous visitor (no session) denied with AUTH_UNAUTHORIZED, and
-    //  - a signed-in but not-yet-verified member denied with `unlock_required`.
-    // Both can browse the plugin's marketing/landing content the same way; the
-    // not-yet-verified member is nudged from there toward the Unlock flow, and the
-    // Hub general channel remains their support surface. Other 403s (e.g. a missing
-    // username or a role requirement) keep the informative access-denied view.
-    if (decision.code === 'AUTH_UNAUTHORIZED' || decision.reason === 'unlock_required') {
-      const PublicVisitorShell = getPublicVisitorShell(selectedPlugin.slug);
-      const signInUrl = getHostedSignInUrl() ?? '/sign-in';
-      // A signed-in-but-not-yet-verified member (denied with `unlock_required`)
-      // is already authenticated, so the public shell's "Sign In / Join Free"
-      // CTAs are wrong for them; pass a verifyUrl so the shell shows a single
-      // "Finish verifying" action pointing at the Unlock flow instead. An
-      // anonymous visitor (AUTH_UNAUTHORIZED) gets no verifyUrl and sees the
-      // normal sign-in / sign-up CTAs.
-      const verifyUrl = decision.reason === 'unlock_required' ? '/plugin/unlock' : undefined;
-      // The back-to-/apps control lives inside each public shell's own header
-      // row (PublicShellBackLink), so no wrapping frame is needed here.
-      return (
-        <>
-          <PublicVisitorShell
-            pluginSlug={selectedPlugin.slug}
-            pluginName={selectedPlugin.name}
-            signInUrl={signInUrl}
-            verifyUrl={verifyUrl}
-          />
-          {/* Corner reviews widget — shown on every public (signed-out) plugin page. */}
-          <ReviewsWidget />
-        </>
-      );
-    }
-
-    return (
-      <AccessDeniedView
-        status={decision.status}
-        code={decision.code}
-        reason={decision.reason}
-        requestedPluginSlug={selectedPlugin.slug}
-      />
-    );
+    return renderAccessDenied(decision, selectedPlugin);
   }
 
-  if (selectedPlugin.slug === 'beacon') {
-    return <BeaconShell isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'click-log') {
-    return <ClickLogShell />;
-  }
-
-  if (selectedPlugin.slug === 'what-works') {
-    return <WhatWorksShell />;
-  }
-
-  if (selectedPlugin.slug === 'chyme') {
-    return (
-      <ChymeShell
-        currentUser={{
-          userId: decision.userId,
-          username: decision.username,
-        }}
-      />
-    );
-  }
-
-  if (selectedPlugin.slug === 'directory') {
-    return <DirectoryShell userId={decision.userId} isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'workforce') {
-    return <WorkforceShell isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'skills-hunt') {
-    return <SkillsHuntShell userId={decision.userId} isAdmin={decision.isAdmin} isModerator={decision.role === 'moderator'} />;
-  }
-
-  if (selectedPlugin.slug === 'skills-taxonomy') {
-    return <SkillsTaxonomyShell />;
-  }
-
-  if (selectedPlugin.slug === 'foundation') {
-    return <FoundationShell isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'lighthouse') {
-    return <LighthouseShell userId={decision.userId} username={decision.username} isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'socket-relay') {
-    return <SocketRelayShell userId={decision.userId} isAdmin={decision.isAdmin} role={decision.role} />;
-  }
-
-  if (selectedPlugin.slug === 'trust-transport') {
-    return <TrustTransportShell isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'peer-programming') {
-    return <PeerProgrammingShell isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'mood') {
-    return <MoodShell />;
-  }
-
-  if (selectedPlugin.slug === 'knowledge') {
-    // The real page is the top-level /knowledge route — short enough to paste into an invitation post
-    // that is read outside the app. The launcher tile lands here and is sent on, so there is one page
-    // rather than two copies to keep in step.
-    redirect('/knowledge');
-  }
-
-  if (selectedPlugin.slug === 'weekly-performance') {
-    // Weekly Performance has no member view — the dashboard lives on the admin page only.
-    // Non-admins never reach this branch (the admin-only gate above 404s them).
-    redirect('/admin/weekly-performance');
-  }
-
-  if (selectedPlugin.slug === 'gdp') {
-    return <GdpShell />;
-  }
-
-  if (selectedPlugin.slug === 'service-credits') {
-    return <ServiceCreditsShell isAdmin={decision.isAdmin} />;
-  }
-
-  if (selectedPlugin.slug === 'level-up') {
-    return <LevelUpShell userId={decision.userId} isAdmin={decision.isAdmin} query={resolvedSearchParams} />;
+  const renderShell = PLUGIN_SHELL_RENDERERS[selectedPlugin.slug];
+  if (renderShell) {
+    return renderShell({
+      decision,
+      plugin: selectedPlugin,
+      searchParams: resolvedSearchParams,
+    });
   }
 
   return (

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -1,13 +1,6 @@
-import { evaluatePluginAccess, type AllowDecision } from 'lib/auth/server-authz';
-import type { PluginDenyResponse } from 'lib/auth/deny-taxonomy';
+import { evaluatePluginAccess } from 'lib/auth/server-authz';
 import { getHostedSignInUrl } from 'lib/auth/provider-env';
-import {
-  canonicalizePluginSlug,
-  getPluginBySlug,
-  isAdminOnlyPlugin,
-  type PluginRegistryItem,
-} from 'lib/plugins/repository';
-import type { ReactNode } from 'react';
+import { canonicalizePluginSlug, getPluginBySlug, isAdminOnlyPlugin } from 'lib/plugins/repository';
 import { getPublicVisitorShell } from '@/components/plugins/public-visitor-registry';
 import { ReviewsWidget } from '@/components/reviews/reviews-widget';
 import { BeaconShell } from '@/components/beacon/beacon-shell';
@@ -134,114 +127,6 @@ function GenericPluginView({
   );
 }
 
-type PluginShellContext = {
-  decision: AllowDecision;
-  plugin: PluginRegistryItem;
-  searchParams: {
-    track?: string;
-    status?: string;
-    startDate?: string;
-    cohortId?: string;
-  };
-};
-
-// Maps each plugin slug to the shell it renders once baseline access is allowed. Kept as a data
-// table so the route handler stays a simple lookup instead of a long branch chain; the props each
-// shell needs are read from the shared access context. `knowledge` and `weekly-performance`
-// redirect to their canonical routes instead of rendering a shell here. A slug with no entry falls
-// through to the generic plugin view.
-const PLUGIN_SHELL_RENDERERS: Record<string, (ctx: PluginShellContext) => ReactNode> = {
-  beacon: ({ decision }) => <BeaconShell isAdmin={decision.isAdmin} />,
-  'click-log': () => <ClickLogShell />,
-  'what-works': () => <WhatWorksShell />,
-  chyme: ({ decision }) => (
-    <ChymeShell
-      currentUser={{
-        userId: decision.userId,
-        username: decision.username,
-      }}
-    />
-  ),
-  directory: ({ decision }) => <DirectoryShell userId={decision.userId} isAdmin={decision.isAdmin} />,
-  workforce: ({ decision }) => <WorkforceShell isAdmin={decision.isAdmin} />,
-  'skills-hunt': ({ decision }) => (
-    <SkillsHuntShell
-      userId={decision.userId}
-      isAdmin={decision.isAdmin}
-      isModerator={decision.role === 'moderator'}
-    />
-  ),
-  'skills-taxonomy': () => <SkillsTaxonomyShell />,
-  foundation: ({ decision }) => <FoundationShell isAdmin={decision.isAdmin} />,
-  lighthouse: ({ decision }) => (
-    <LighthouseShell userId={decision.userId} username={decision.username} isAdmin={decision.isAdmin} />
-  ),
-  'socket-relay': ({ decision }) => (
-    <SocketRelayShell userId={decision.userId} isAdmin={decision.isAdmin} role={decision.role} />
-  ),
-  'trust-transport': ({ decision }) => <TrustTransportShell isAdmin={decision.isAdmin} />,
-  'peer-programming': ({ decision }) => <PeerProgrammingShell isAdmin={decision.isAdmin} />,
-  mood: () => <MoodShell />,
-  // The real page is the top-level /knowledge route — short enough to paste into an invitation post
-  // that is read outside the app. The launcher tile lands here and is sent on, so there is one page
-  // rather than two copies to keep in step.
-  knowledge: () => redirect('/knowledge'),
-  // Weekly Performance has no member view — the dashboard lives on the admin page only.
-  // Non-admins never reach this branch (the admin-only gate above 404s them).
-  'weekly-performance': () => redirect('/admin/weekly-performance'),
-  gdp: () => <GdpShell />,
-  'service-credits': ({ decision }) => <ServiceCreditsShell isAdmin={decision.isAdmin} />,
-  'level-up': ({ decision, searchParams }) => (
-    <LevelUpShell userId={decision.userId} isAdmin={decision.isAdmin} query={searchParams} />
-  ),
-};
-
-// A denied request either browses the plugin's public landing (anonymous or not-yet-verified) or
-// sees the informative access-denied view (other 403s). Extracted so the route handler stays flat.
-function renderAccessDenied(decision: PluginDenyResponse, plugin: PluginRegistryItem): ReactNode {
-  // Two cases see the plugin's public visitor view rather than a denial wall:
-  //  - an anonymous visitor (no session) denied with AUTH_UNAUTHORIZED, and
-  //  - a signed-in but not-yet-verified member denied with `unlock_required`.
-  // Both can browse the plugin's marketing/landing content the same way; the
-  // not-yet-verified member is nudged from there toward the Unlock flow, and the
-  // Hub general channel remains their support surface. Other 403s (e.g. a missing
-  // username or a role requirement) keep the informative access-denied view.
-  if (decision.code === 'AUTH_UNAUTHORIZED' || decision.reason === 'unlock_required') {
-    const PublicVisitorShell = getPublicVisitorShell(plugin.slug);
-    const signInUrl = getHostedSignInUrl() ?? '/sign-in';
-    // A signed-in-but-not-yet-verified member (denied with `unlock_required`)
-    // is already authenticated, so the public shell's "Sign In / Join Free"
-    // CTAs are wrong for them; pass a verifyUrl so the shell shows a single
-    // "Finish verifying" action pointing at the Unlock flow instead. An
-    // anonymous visitor (AUTH_UNAUTHORIZED) gets no verifyUrl and sees the
-    // normal sign-in / sign-up CTAs.
-    const verifyUrl = decision.reason === 'unlock_required' ? '/plugin/unlock' : undefined;
-    // The back-to-/apps control lives inside each public shell's own header
-    // row (PublicShellBackLink), so no wrapping frame is needed here.
-    return (
-      <>
-        <PublicVisitorShell
-          pluginSlug={plugin.slug}
-          pluginName={plugin.name}
-          signInUrl={signInUrl}
-          verifyUrl={verifyUrl}
-        />
-        {/* Corner reviews widget — shown on every public (signed-out) plugin page. */}
-        <ReviewsWidget />
-      </>
-    );
-  }
-
-  return (
-    <AccessDeniedView
-      status={decision.status}
-      code={decision.code}
-      reason={decision.reason}
-      requestedPluginSlug={plugin.slug}
-    />
-  );
-}
-
 export default async function PluginRoutePage({ params, searchParams }: PluginRoutePageProps) {
   const resolvedParams = await params;
   const resolvedSearchParams = await searchParams;
@@ -273,16 +158,135 @@ export default async function PluginRoutePage({ params, searchParams }: PluginRo
   }
 
   if (!decision.allowed) {
-    return renderAccessDenied(decision, selectedPlugin);
+    // Two cases see the plugin's public visitor view rather than a denial wall:
+    //  - an anonymous visitor (no session) denied with AUTH_UNAUTHORIZED, and
+    //  - a signed-in but not-yet-verified member denied with `unlock_required`.
+    // Both can browse the plugin's marketing/landing content the same way; the
+    // not-yet-verified member is nudged from there toward the Unlock flow, and the
+    // Hub general channel remains their support surface. Other 403s (e.g. a missing
+    // username or a role requirement) keep the informative access-denied view.
+    if (decision.code === 'AUTH_UNAUTHORIZED' || decision.reason === 'unlock_required') {
+      const PublicVisitorShell = getPublicVisitorShell(selectedPlugin.slug);
+      const signInUrl = getHostedSignInUrl() ?? '/sign-in';
+      // A signed-in-but-not-yet-verified member (denied with `unlock_required`)
+      // is already authenticated, so the public shell's "Sign In / Join Free"
+      // CTAs are wrong for them; pass a verifyUrl so the shell shows a single
+      // "Finish verifying" action pointing at the Unlock flow instead. An
+      // anonymous visitor (AUTH_UNAUTHORIZED) gets no verifyUrl and sees the
+      // normal sign-in / sign-up CTAs.
+      const verifyUrl = decision.reason === 'unlock_required' ? '/plugin/unlock' : undefined;
+      // The back-to-/apps control lives inside each public shell's own header
+      // row (PublicShellBackLink), so no wrapping frame is needed here.
+      return (
+        <>
+          <PublicVisitorShell
+            pluginSlug={selectedPlugin.slug}
+            pluginName={selectedPlugin.name}
+            signInUrl={signInUrl}
+            verifyUrl={verifyUrl}
+          />
+          {/* Corner reviews widget — shown on every public (signed-out) plugin page. */}
+          <ReviewsWidget />
+        </>
+      );
+    }
+
+    return (
+      <AccessDeniedView
+        status={decision.status}
+        code={decision.code}
+        reason={decision.reason}
+        requestedPluginSlug={selectedPlugin.slug}
+      />
+    );
   }
 
-  const renderShell = PLUGIN_SHELL_RENDERERS[selectedPlugin.slug];
-  if (renderShell) {
-    return renderShell({
-      decision,
-      plugin: selectedPlugin,
-      searchParams: resolvedSearchParams,
-    });
+  if (selectedPlugin.slug === 'beacon') {
+    return <BeaconShell isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'click-log') {
+    return <ClickLogShell />;
+  }
+
+  if (selectedPlugin.slug === 'what-works') {
+    return <WhatWorksShell />;
+  }
+
+  if (selectedPlugin.slug === 'chyme') {
+    return (
+      <ChymeShell
+        currentUser={{
+          userId: decision.userId,
+          username: decision.username,
+        }}
+      />
+    );
+  }
+
+  if (selectedPlugin.slug === 'directory') {
+    return <DirectoryShell userId={decision.userId} isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'workforce') {
+    return <WorkforceShell isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'skills-hunt') {
+    return <SkillsHuntShell userId={decision.userId} isAdmin={decision.isAdmin} isModerator={decision.role === 'moderator'} />;
+  }
+
+  if (selectedPlugin.slug === 'skills-taxonomy') {
+    return <SkillsTaxonomyShell />;
+  }
+
+  if (selectedPlugin.slug === 'foundation') {
+    return <FoundationShell isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'lighthouse') {
+    return <LighthouseShell userId={decision.userId} username={decision.username} isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'socket-relay') {
+    return <SocketRelayShell userId={decision.userId} isAdmin={decision.isAdmin} role={decision.role} />;
+  }
+
+  if (selectedPlugin.slug === 'trust-transport') {
+    return <TrustTransportShell isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'peer-programming') {
+    return <PeerProgrammingShell isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'mood') {
+    return <MoodShell />;
+  }
+
+  if (selectedPlugin.slug === 'knowledge') {
+    // The real page is the top-level /knowledge route — short enough to paste into an invitation post
+    // that is read outside the app. The launcher tile lands here and is sent on, so there is one page
+    // rather than two copies to keep in step.
+    redirect('/knowledge');
+  }
+
+  if (selectedPlugin.slug === 'weekly-performance') {
+    // Weekly Performance has no member view — the dashboard lives on the admin page only.
+    // Non-admins never reach this branch (the admin-only gate above 404s them).
+    redirect('/admin/weekly-performance');
+  }
+
+  if (selectedPlugin.slug === 'gdp') {
+    return <GdpShell />;
+  }
+
+  if (selectedPlugin.slug === 'service-credits') {
+    return <ServiceCreditsShell isAdmin={decision.isAdmin} />;
+  }
+
+  if (selectedPlugin.slug === 'level-up') {
+    return <LevelUpShell userId={decision.userId} isAdmin={decision.isAdmin} query={resolvedSearchParams} />;
   }
 
   return (

--- a/ctf/packages/web/app/page.tsx
+++ b/ctf/packages/web/app/page.tsx
@@ -2,9 +2,10 @@ import { redirect } from 'next/navigation';
 import { CommunityShell, type ShellVerification } from '../components/community-shell/community-shell';
 import type { ShellCurrentUser } from '../components/community-shell/shell-types';
 import type { TrustUserExtension } from '../lib/trust/types';
-import { resolveRequestIdentity } from '../lib/auth/request-identity';
+import { resolveRequestIdentity, type RequestIdentity } from '../lib/auth/request-identity';
 import { getUnlockAccessTier, isUnlockEarlyCommonsEnabled } from '../lib/unlock/access';
 import { getUnlockStatusForUser } from '../lib/unlock/repository';
+import type { UnlockAccessTier } from '../lib/unlock/types';
 import { getGdpShellStats } from '../lib/gdp/repository';
 import { listPluginRegistry, filterPluginsForViewer } from '../lib/plugins/repository';
 import { getTrustUserExtension } from '../lib/trust/repository';
@@ -33,6 +34,86 @@ function buildFallbackTrust(userId: string): TrustUserExtension {
   };
 }
 
+// Reduce a resolved request identity to the two fields the hub branches on.
+// A guest (unauthenticated) resolves to a null userId and non-admin.
+function resolveIdentityFields(identity: RequestIdentity | null): {
+  userId: string | null;
+  isAdmin: boolean;
+} {
+  const userId = identity?.isAuthenticated ? identity.userId : null;
+  const isAdmin = identity?.isAdmin ?? false;
+  return { userId, isAdmin };
+}
+
+// A/B experiment: a not-yet-verified member in the early-Commons treatment bucket lands on the
+// Commons (the Hub) instead of being redirected to the Unlock screen, so they can ask for help —
+// e.g. trouble finding their Quora URL. Only evaluated for users who would otherwise be redirected,
+// and defaults to false (control), so production routing is unchanged until the rollout is enabled.
+async function resolveEarlyCommons(
+  userId: string | null,
+  tier: UnlockAccessTier | null,
+): Promise<boolean> {
+  if (!userId) {
+    return false;
+  }
+  if (tier === 'approved_full' || tier === 'locked_support_only') {
+    return false;
+  }
+  return isUnlockEarlyCommonsEnabled(userId).catch(() => false);
+}
+
+// Unlock is the single source of truth for who reaches the Hub. Everyone else is redirected into
+// the Unlock flow. Admins and approved_full/locked_support_only members reach the Hub; an
+// early-Commons treatment member is also allowed to stay.
+function shouldRedirectToUnlock(params: {
+  userId: string | null;
+  isAdmin: boolean;
+  tier: UnlockAccessTier | null;
+  earlyCommons: boolean;
+}): boolean {
+  const { userId, isAdmin, tier, earlyCommons } = params;
+  return (
+    Boolean(userId) &&
+    !isAdmin &&
+    tier !== 'approved_full' &&
+    tier !== 'locked_support_only' &&
+    !earlyCommons
+  );
+}
+
+// Early-Commons treatment members land on the Commons instead of the Unlock screen, so without a
+// prompt here they have no idea verification is still required. Give them a persistent verify prompt
+// in the shell to submit their Quora URL. Scoped to the treatment bucket only: submitting moves a
+// member to `pending_readonly`, and only a treatment member stays on the Commons afterward (a
+// support-only member would be redirected to /plugin/unlock), so we do not prompt support-only
+// members here and create that trap.
+async function resolveVerification(
+  earlyCommons: boolean,
+  userId: string | null,
+): Promise<ShellVerification | null> {
+  if (!earlyCommons || !userId) {
+    return null;
+  }
+  const unlockStatus = await getUnlockStatusForUser(userId).catch(() => null);
+  if (!unlockStatus) {
+    return null;
+  }
+  return {
+    hasSubmission: unlockStatus.hasSubmission,
+    reviewStatus: unlockStatus.reviewStatus,
+  };
+}
+
+async function resolveTrust(
+  userId: string | null,
+  fallbackUserId: string,
+): Promise<TrustUserExtension> {
+  if (!userId) {
+    return buildFallbackTrust(fallbackUserId);
+  }
+  return getTrustUserExtension(userId).catch(() => buildFallbackTrust(userId));
+}
+
 export default async function HomePage() {
   const pluginsPromise = listPluginRegistry();
   const shellStatsPromise = getGdpShellStats().catch(() => ({ memberCount: null, gdpValueUsd: null }));
@@ -44,8 +125,7 @@ export default async function HomePage() {
     identityPromise,
   ]);
 
-  const userId = identity?.isAuthenticated ? identity.userId : null;
-  const isAdmin = identity?.isAdmin ?? false;
+  const { userId, isAdmin } = resolveIdentityFields(identity);
 
   // Operator-only plugins (e.g. Weekly Performance) must not appear in the member hub's app list.
   // The /apps launcher and /api/plugins already apply this filter; the home hub did not, so an
@@ -62,35 +142,13 @@ export default async function HomePage() {
   // landing page (handled at the plugin route), not a denial wall. Nothing is hidden here.
   const tier = userId ? await getUnlockAccessTier(userId).catch(() => null) : null;
 
-  // A/B experiment: a not-yet-verified member in the early-Commons treatment bucket lands on the
-  // Commons (this Hub) instead of being redirected to the Unlock screen, so they can ask for help —
-  // e.g. trouble finding their Quora URL. Only evaluated for users who would otherwise be redirected,
-  // and defaults to false (control), so production routing is unchanged until the rollout is enabled.
-  const earlyCommons =
-    userId && tier !== 'approved_full' && tier !== 'locked_support_only'
-      ? await isUnlockEarlyCommonsEnabled(userId).catch(() => false)
-      : false;
+  const earlyCommons = await resolveEarlyCommons(userId, tier);
 
-  if (userId && !isAdmin && tier !== 'approved_full' && tier !== 'locked_support_only' && !earlyCommons) {
+  if (shouldRedirectToUnlock({ userId, isAdmin, tier, earlyCommons })) {
     redirect('/plugin/unlock');
   }
 
-  // Early-Commons treatment members land on the Commons instead of the Unlock screen, so without a
-  // prompt here they have no idea verification is still required. Give them a persistent verify prompt
-  // in the shell to submit their Quora URL. Scoped to the treatment bucket only: submitting moves a
-  // member to `pending_readonly`, and only a treatment member stays on the Commons afterward (a
-  // support-only member would be redirected to /plugin/unlock), so we do not prompt support-only
-  // members here and create that trap.
-  let verification: ShellVerification | null = null;
-  if (earlyCommons && userId) {
-    const unlockStatus = await getUnlockStatusForUser(userId).catch(() => null);
-    if (unlockStatus) {
-      verification = {
-        hasSubmission: unlockStatus.hasSubmission,
-        reviewStatus: unlockStatus.reviewStatus,
-      };
-    }
-  }
+  const verification = await resolveVerification(earlyCommons, userId);
 
   const isAuthenticated = Boolean(userId);
 
@@ -98,9 +156,7 @@ export default async function HomePage() {
     ? buildShellUser(userId, identity?.username ?? null)
     : buildShellUser('guest', null);
 
-  const trust = userId
-    ? await getTrustUserExtension(userId).catch(() => buildFallbackTrust(userId))
-    : buildFallbackTrust(currentUser.userId);
+  const trust = await resolveTrust(userId, currentUser.userId);
 
   // Send "Sign In" straight to Clerk's hosted Account Portal. Falls back to the
   // in-app `/sign-in` catch-all (which itself forwards to the portal) only when

--- a/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
+++ b/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
@@ -17,6 +17,40 @@ type ConfirmProps = {
   onConfirm: () => Promise<void>;
 };
 
+// The confirm/cancel button row. Kept as its own component so the ready/submitting style branches
+// live outside the main component's decision count.
+function ConfirmDeleteActions({
+  ready, submitting, brand, border, onConfirm, onCancel,
+}: {
+  ready: boolean;
+  submitting: boolean;
+  brand: string;
+  border: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 10 }}>
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={!ready}
+        style={{ flex: 1, padding: '13px', borderRadius: 11, background: ready ? 'rgba(239,68,68,0.14)' : 'rgba(255,255,255,0.04)', border: `1px solid ${ready ? 'rgba(239,68,68,0.45)' : border}`, color: ready ? '#EF4444' : '#374151', fontSize: 14, fontWeight: 700, cursor: ready ? 'pointer' : 'not-allowed', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
+      >
+        {submitting ? <><Loader2 size={15} className="account-data-spin" /> Deleting…</> : <><Trash2 size={15} /> Delete permanently</>}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={submitting}
+        style={{ padding: '13px 22px', borderRadius: 11, background: `${brand}12`, border: `1px solid ${brand}30`, color: brand, fontSize: 14, fontWeight: 600, cursor: submitting ? 'not-allowed' : 'pointer' }}
+      >
+        Keep my data
+      </button>
+    </div>
+  );
+}
+
 // Full-account deletion confirmation. Requires the user to type the exact phrase
 // ("delete my account") before the delete button is enabled — an intentional gesture, matching
 // AccountDataConfirmDelete.tsx / MobileAccountDataConfirmDelete.tsx. On success it shows the
@@ -128,24 +162,14 @@ export function AccountDataConfirmDelete({ serviceCount, onCancel, onConfirm }: 
           ) : null}
 
           {/* Actions */}
-          <div style={{ display: 'flex', gap: 10 }}>
-            <button
-              type="button"
-              onClick={handleConfirm}
-              disabled={!ready}
-              style={{ flex: 1, padding: '13px', borderRadius: 11, background: ready ? 'rgba(239,68,68,0.14)' : 'rgba(255,255,255,0.04)', border: `1px solid ${ready ? 'rgba(239,68,68,0.45)' : BORDER}`, color: ready ? '#EF4444' : '#374151', fontSize: 14, fontWeight: 700, cursor: ready ? 'pointer' : 'not-allowed', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
-            >
-              {status === 'submitting' ? <><Loader2 size={15} className="account-data-spin" /> Deleting…</> : <><Trash2 size={15} /> Delete permanently</>}
-            </button>
-            <button
-              type="button"
-              onClick={onCancel}
-              disabled={status === 'submitting'}
-              style={{ padding: '13px 22px', borderRadius: 11, background: `${BRAND}12`, border: `1px solid ${BRAND}30`, color: BRAND, fontSize: 14, fontWeight: 600, cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}
-            >
-              Keep my data
-            </button>
-          </div>
+          <ConfirmDeleteActions
+            ready={ready}
+            submitting={status === 'submitting'}
+            brand={BRAND}
+            border={BORDER}
+            onConfirm={handleConfirm}
+            onCancel={onCancel}
+          />
         </div>
       </div>
     </div>

--- a/ctf/packages/web/components/account-data/account-data-mobile.tsx
+++ b/ctf/packages/web/components/account-data/account-data-mobile.tsx
@@ -118,29 +118,19 @@ function ExportButton({ service, isExporting, tokens, onExportService }: {
   );
 }
 
-function MobileDataView({
-  remaining, retained, pendingSlug, rowError, exportingKey, onDeleteService, onExportService, onExportAll, tokens,
-}: {
-  remaining: AccountService[];
-  retained: AccountService[];
-  pendingSlug: string | null;
+// "Download all my data" action plus its error/help line. Kept as its own component so the
+// export-in-flight and error style branches live outside MobileDataView's decision count.
+function ExportAllSection({ rowError, exportingKey, onExportAll, tokens }: {
   rowError: { slug: string; message: string } | null;
   exportingKey: string | null;
-  onDeleteService: (service: AccountService) => void;
-  onExportService: (service: AccountService) => void;
   onExportAll: () => void;
   tokens: AccountDataTokens;
 }) {
-  const { BRAND, SURFACE, BORDER, TEXT, SUBTLE } = tokens;
+  const { BRAND } = tokens;
   const exportingAll = exportingKey === 'full-account';
   const fullExportError = rowError?.slug === 'full-account' ? rowError.message : null;
   return (
     <>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 10, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 12 }}>
-        <Info size={13} color={BRAND} style={{ flexShrink: 0, marginTop: 1 }} />
-        <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.5 }}>Deleting from a service is permanent. Some audit records are retained for platform integrity.</div>
-      </div>
-
       {/* Take your data with you (issue #1264): one action downloads every service's data as a
           single JSON file. The per-service download sits on each card below. */}
       <button
@@ -157,6 +147,32 @@ function MobileDataView({
       ) : (
         <div style={{ fontSize: 11, color: '#4B5563', lineHeight: 1.4, marginBottom: 10 }}>One JSON file with your own rows from every service. Money ledgers and audit records are retained by design and not included.</div>
       )}
+    </>
+  );
+}
+
+function MobileDataView({
+  remaining, retained, pendingSlug, rowError, exportingKey, onDeleteService, onExportService, onExportAll, tokens,
+}: {
+  remaining: AccountService[];
+  retained: AccountService[];
+  pendingSlug: string | null;
+  rowError: { slug: string; message: string } | null;
+  exportingKey: string | null;
+  onDeleteService: (service: AccountService) => void;
+  onExportService: (service: AccountService) => void;
+  onExportAll: () => void;
+  tokens: AccountDataTokens;
+}) {
+  const { BRAND, SURFACE, BORDER, TEXT, SUBTLE } = tokens;
+  return (
+    <>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 10, background: `${BRAND}06`, border: `1px solid ${BRAND}18`, marginBottom: 12 }}>
+        <Info size={13} color={BRAND} style={{ flexShrink: 0, marginTop: 1 }} />
+        <div style={{ fontSize: 12, color: '#9CA3AF', lineHeight: 1.5 }}>Deleting from a service is permanent. Some audit records are retained for platform integrity.</div>
+      </div>
+
+      <ExportAllSection rowError={rowError} exportingKey={exportingKey} onExportAll={onExportAll} tokens={tokens} />
 
       <div style={{ fontSize: 12, fontWeight: 700, color: SUBTLE, textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 10 }}>Personal data — {remaining.length} {remaining.length === 1 ? 'service' : 'services'}</div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginBottom: 24 }}>

--- a/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
+++ b/ctf/packages/web/components/beacon/beacon-admin-shell.tsx
@@ -68,9 +68,213 @@ async function adminMutate<T = unknown>(url: string, method: 'POST' | 'DELETE', 
   }
 }
 
-export function BeaconAdminShell() {
+// The broadcast panel for the selected event: go-live / end, RTMP ingest, the in-browser host
+// stage, and (while live) chat moderation. Renders nothing unless an event is selected and not yet
+// ended, so the caller can render it unconditionally.
+function BroadcastSection({
+  activeEvent,
+  ingest,
+  host,
+  chat,
+  copied,
+  moderateTarget,
+  broadcastSectionRef,
+  onGoLive,
+  onEndEvent,
+  onModerate,
+  onCopy,
+  onModerateTargetChange,
+}: {
+  activeEvent: BeaconEvent | null;
+  ingest: IngestResponse | null;
+  host: BeaconHostCredentials | null;
+  chat: ChatCredentials | null;
+  copied: string | null;
+  moderateTarget: string;
+  broadcastSectionRef: React.RefObject<HTMLElement | null>;
+  onGoLive: (eventId: string) => void;
+  onEndEvent: (eventId: string) => void;
+  onModerate: (eventId: string, action: 'mute' | 'ban' | 'slow_mode', extra?: { targetUserId?: string; cooldownSeconds?: number }) => void;
+  onCopy: (label: string, value: string) => void;
+  onModerateTargetChange: (value: string) => void;
+}) {
   const { theme } = useTheme();
   const t = getBeaconTokens(theme);
+  if (!activeEvent || activeEvent.status === 'ended') {
+    return null;
+  }
+  return (
+    <section ref={broadcastSectionRef} style={cardStyle(t)}>
+      <h2 style={cardTitleStyle}>Broadcast: {activeEvent.title}</h2>
+      {activeEvent.status === 'draft' ? (
+        <button type="button" onClick={() => onGoLive(activeEvent.id)} style={primaryButtonStyle(t)}>Go live</button>
+      ) : (
+        <button type="button" onClick={() => onEndEvent(activeEvent.id)} style={{ ...primaryButtonStyle(t), background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.35)', color: '#F87171' }}>End broadcast</button>
+      )}
+
+      {ingest ? (
+        <div style={{ marginTop: 18 }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Phone demo — push to this RTMP target from a broadcaster app</div>
+          <CopyRow label="RTMP URL" value={ingest.rtmpIngestUrl} copied={copied === 'RTMP URL'} onCopy={() => onCopy('RTMP URL', ingest.rtmpIngestUrl)} />
+          <CopyRow label="Stream key" value={ingest.streamKey} copied={copied === 'Stream key'} onCopy={() => onCopy('Stream key', ingest.streamKey)} masked />
+        </div>
+      ) : null}
+
+      {host ? (
+        <div style={{ marginTop: 18 }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Computer demo — share a screen or window from this browser</div>
+          <BeaconHostStage credentials={host} eventId={activeEvent.id} />
+        </div>
+      ) : null}
+
+      {activeEvent.status === 'live' ? (
+        <div style={{ marginTop: 18 }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Moderate the chat</div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <input value={moderateTarget} onChange={(event) => onModerateTargetChange(event.target.value)} placeholder="member user id" style={{ ...inputStyle(t), marginBottom: 0, maxWidth: 240 }} />
+            <button type="button" onClick={() => moderateTarget && void onModerate(activeEvent.id, 'mute', { targetUserId: moderateTarget })} style={chipButtonStyle(t)}>Mute</button>
+            <button type="button" onClick={() => moderateTarget && void onModerate(activeEvent.id, 'ban', { targetUserId: moderateTarget })} style={chipButtonStyle(t)}>Ban</button>
+            <button type="button" onClick={() => void onModerate(activeEvent.id, 'slow_mode', { cooldownSeconds: 10 })} style={chipButtonStyle(t)}>Slow-mode 10s</button>
+            <button type="button" onClick={() => void onModerate(activeEvent.id, 'slow_mode', { cooldownSeconds: 0 })} style={chipButtonStyle(t)}>Slow-mode off</button>
+          </div>
+          {chat ? (
+            <div style={{ marginTop: 14, height: 360, borderRadius: 12, border: `1px solid ${t.BORDER_SOLID}`, overflow: 'hidden' }}>
+              <StreamChatPanel
+                streamApiKey={chat.streamApiKey}
+                streamToken={chat.streamToken}
+                streamUserId={chat.streamUserId}
+                streamChannelId={chat.streamChannelId}
+                channelType={chat.streamChannelType}
+                accentColor={t.ACCENT}
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+// One event row in the history list, with Replay / Open / two-step Delete controls.
+function EventHistoryRow({
+  event,
+  confirmDeleteId,
+  deletingId,
+  onOpen,
+  onDelete,
+  onArmDelete,
+  onCancelDelete,
+}: {
+  event: BeaconEvent;
+  confirmDeleteId: string | null;
+  deletingId: string | null;
+  onOpen: (eventId: string) => void;
+  onDelete: (eventId: string) => void;
+  onArmDelete: (eventId: string) => void;
+  onCancelDelete: () => void;
+}) {
+  const { theme } = useTheme();
+  const t = getBeaconTokens(theme);
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, padding: '10px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{event.title}</div>
+        <div style={{ fontSize: 12, color: t.SUBTLE }}>
+          {event.status}
+          {event.recordingUrl ? ' · recording ready' : ''}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        {event.recordingUrl ? (
+          <a href={event.recordingUrl} target="_blank" rel="noreferrer" style={chipButtonStyle(t)}>Replay</a>
+        ) : null}
+        {event.status !== 'ended' ? (
+          <button type="button" onClick={() => onOpen(event.id)} style={chipButtonStyle(t)}>Open</button>
+        ) : null}
+        {/* Delete is offered for drafts only. A draft was never broadcast — nobody saw
+            it, it has no recording, and it does not appear in the member view — so
+            removing a mistyped one destroys nothing. A live or ended event is public
+            history and is never deletable from here. */}
+        {event.status === 'draft' ? (
+          confirmDeleteId === event.id ? (
+            <>
+              <button
+                type="button"
+                onClick={() => onDelete(event.id)}
+                disabled={deletingId === event.id}
+                style={dangerButtonStyle(t)}
+              >
+                {deletingId === event.id ? 'Deleting…' : 'Confirm delete'}
+              </button>
+              <button type="button" onClick={onCancelDelete} style={chipButtonStyle(t)}>Cancel</button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onArmDelete(event.id)}
+              aria-label={`Delete the draft "${event.title}"`}
+              style={chipButtonStyle(t)}
+            >
+              Delete
+            </button>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function EventHistorySection({
+  loading,
+  events,
+  confirmDeleteId,
+  deletingId,
+  onOpen,
+  onDelete,
+  onArmDelete,
+  onCancelDelete,
+}: {
+  loading: boolean;
+  events: BeaconEvent[];
+  confirmDeleteId: string | null;
+  deletingId: string | null;
+  onOpen: (eventId: string) => void;
+  onDelete: (eventId: string) => void;
+  onArmDelete: (eventId: string) => void;
+  onCancelDelete: () => void;
+}) {
+  const { theme } = useTheme();
+  const t = getBeaconTokens(theme);
+  return (
+    <section style={cardStyle(t)}>
+      <h2 style={cardTitleStyle}>Event history</h2>
+      {loading ? (
+        <div style={{ color: t.SUBTLE, fontSize: 14 }}>Loading…</div>
+      ) : events.length === 0 ? (
+        <div style={{ color: t.SUBTLE, fontSize: 14 }}>No events yet. Create one above.</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {events.map((event) => (
+            <EventHistoryRow
+              key={event.id}
+              event={event}
+              confirmDeleteId={confirmDeleteId}
+              deletingId={deletingId}
+              onOpen={onOpen}
+              onDelete={onDelete}
+              onArmDelete={onArmDelete}
+              onCancelDelete={onCancelDelete}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// All Beacon admin state, data loading, and mutations. Split out of the component so the render
+// stays small; the component below only reads this hook and draws the sections.
+function useBeaconAdmin() {
   const [events, setEvents] = useState<BeaconEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -250,6 +454,28 @@ export function BeaconAdminShell() {
     });
   }, []);
 
+  return {
+    events, loading, error, notice,
+    title, setTitle, description, setDescription, creating,
+    setActiveEventId, ingest, host, chat, copied,
+    moderateTarget, setModerateTarget, confirmDeleteId, setConfirmDeleteId, deletingId,
+    broadcastSectionRef, activeEvent,
+    createEvent, deleteDraft, goLive, endEvent, moderate, copy,
+  };
+}
+
+export function BeaconAdminShell() {
+  const { theme } = useTheme();
+  const t = getBeaconTokens(theme);
+  const {
+    events, loading, error, notice,
+    title, setTitle, description, setDescription, creating,
+    setActiveEventId, ingest, host, chat, copied,
+    moderateTarget, setModerateTarget, confirmDeleteId, setConfirmDeleteId, deletingId,
+    broadcastSectionRef, activeEvent,
+    createEvent, deleteDraft, goLive, endEvent, moderate, copy,
+  } = useBeaconAdmin();
+
   return (
     <main
       style={{
@@ -281,115 +507,31 @@ export function BeaconAdminShell() {
           </button>
         </section>
 
-        {activeEvent && activeEvent.status !== 'ended' ? (
-          <section ref={broadcastSectionRef} style={cardStyle(t)}>
-            <h2 style={cardTitleStyle}>Broadcast: {activeEvent.title}</h2>
-            {activeEvent.status === 'draft' ? (
-              <button type="button" onClick={() => void goLive(activeEvent.id)} style={primaryButtonStyle(t)}>Go live</button>
-            ) : (
-              <button type="button" onClick={() => void endEvent(activeEvent.id)} style={{ ...primaryButtonStyle(t), background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.35)', color: '#F87171' }}>End broadcast</button>
-            )}
+        <BroadcastSection
+          activeEvent={activeEvent}
+          ingest={ingest}
+          host={host}
+          chat={chat}
+          copied={copied}
+          moderateTarget={moderateTarget}
+          broadcastSectionRef={broadcastSectionRef}
+          onGoLive={(eventId) => void goLive(eventId)}
+          onEndEvent={(eventId) => void endEvent(eventId)}
+          onModerate={(eventId, action, extra) => void moderate(eventId, action, extra)}
+          onCopy={copy}
+          onModerateTargetChange={setModerateTarget}
+        />
 
-            {ingest ? (
-              <div style={{ marginTop: 18 }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Phone demo — push to this RTMP target from a broadcaster app</div>
-                <CopyRow label="RTMP URL" value={ingest.rtmpIngestUrl} copied={copied === 'RTMP URL'} onCopy={() => copy('RTMP URL', ingest.rtmpIngestUrl)} />
-                <CopyRow label="Stream key" value={ingest.streamKey} copied={copied === 'Stream key'} onCopy={() => copy('Stream key', ingest.streamKey)} masked />
-              </div>
-            ) : null}
-
-            {host ? (
-              <div style={{ marginTop: 18 }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Computer demo — share a screen or window from this browser</div>
-                <BeaconHostStage credentials={host} eventId={activeEvent.id} />
-              </div>
-            ) : null}
-
-            {activeEvent.status === 'live' ? (
-              <div style={{ marginTop: 18 }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Moderate the chat</div>
-                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
-                  <input value={moderateTarget} onChange={(event) => setModerateTarget(event.target.value)} placeholder="member user id" style={{ ...inputStyle(t), marginBottom: 0, maxWidth: 240 }} />
-                  <button type="button" onClick={() => moderateTarget && void moderate(activeEvent.id, 'mute', { targetUserId: moderateTarget })} style={chipButtonStyle(t)}>Mute</button>
-                  <button type="button" onClick={() => moderateTarget && void moderate(activeEvent.id, 'ban', { targetUserId: moderateTarget })} style={chipButtonStyle(t)}>Ban</button>
-                  <button type="button" onClick={() => void moderate(activeEvent.id, 'slow_mode', { cooldownSeconds: 10 })} style={chipButtonStyle(t)}>Slow-mode 10s</button>
-                  <button type="button" onClick={() => void moderate(activeEvent.id, 'slow_mode', { cooldownSeconds: 0 })} style={chipButtonStyle(t)}>Slow-mode off</button>
-                </div>
-                {chat ? (
-                  <div style={{ marginTop: 14, height: 360, borderRadius: 12, border: `1px solid ${t.BORDER_SOLID}`, overflow: 'hidden' }}>
-                    <StreamChatPanel
-                      streamApiKey={chat.streamApiKey}
-                      streamToken={chat.streamToken}
-                      streamUserId={chat.streamUserId}
-                      streamChannelId={chat.streamChannelId}
-                      channelType={chat.streamChannelType}
-                      accentColor={t.ACCENT}
-                    />
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
-          </section>
-        ) : null}
-
-        <section style={cardStyle(t)}>
-          <h2 style={cardTitleStyle}>Event history</h2>
-          {loading ? (
-            <div style={{ color: t.SUBTLE, fontSize: 14 }}>Loading…</div>
-          ) : events.length === 0 ? (
-            <div style={{ color: t.SUBTLE, fontSize: 14 }}>No events yet. Create one above.</div>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {events.map((event) => (
-                <div key={event.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, padding: '10px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-                  <div style={{ minWidth: 0 }}>
-                    <div style={{ fontSize: 14, fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{event.title}</div>
-                    <div style={{ fontSize: 12, color: t.SUBTLE }}>
-                      {event.status}
-                      {event.recordingUrl ? ' · recording ready' : ''}
-                    </div>
-                  </div>
-                  <div style={{ display: 'flex', gap: 8 }}>
-                    {event.recordingUrl ? (
-                      <a href={event.recordingUrl} target="_blank" rel="noreferrer" style={chipButtonStyle(t)}>Replay</a>
-                    ) : null}
-                    {event.status !== 'ended' ? (
-                      <button type="button" onClick={() => setActiveEventId(event.id)} style={chipButtonStyle(t)}>Open</button>
-                    ) : null}
-                    {/* Delete is offered for drafts only. A draft was never broadcast — nobody saw
-                        it, it has no recording, and it does not appear in the member view — so
-                        removing a mistyped one destroys nothing. A live or ended event is public
-                        history and is never deletable from here. */}
-                    {event.status === 'draft' ? (
-                      confirmDeleteId === event.id ? (
-                        <>
-                          <button
-                            type="button"
-                            onClick={() => deleteDraft(event.id)}
-                            disabled={deletingId === event.id}
-                            style={dangerButtonStyle(t)}
-                          >
-                            {deletingId === event.id ? 'Deleting…' : 'Confirm delete'}
-                          </button>
-                          <button type="button" onClick={() => setConfirmDeleteId(null)} style={chipButtonStyle(t)}>Cancel</button>
-                        </>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={() => setConfirmDeleteId(event.id)}
-                          aria-label={`Delete the draft "${event.title}"`}
-                          style={chipButtonStyle(t)}
-                        >
-                          Delete
-                        </button>
-                      )
-                    ) : null}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
+        <EventHistorySection
+          loading={loading}
+          events={events}
+          confirmDeleteId={confirmDeleteId}
+          deletingId={deletingId}
+          onOpen={setActiveEventId}
+          onDelete={deleteDraft}
+          onArmDelete={setConfirmDeleteId}
+          onCancelDelete={() => setConfirmDeleteId(null)}
+        />
       </div>
     </main>
   );

--- a/ctf/packages/web/components/beacon/beacon-viewer.tsx
+++ b/ctf/packages/web/components/beacon/beacon-viewer.tsx
@@ -37,6 +37,131 @@ type ChatCredentials = {
   streamToken: string;
 };
 
+// Derive the view state from the polled /current response. Kept out of the component so its chain of
+// optional lookups does not add branches to the render function.
+function deriveBeaconView(current: CurrentResponse | null): {
+  liveEvent: BeaconEventLike | null;
+  hlsUrl: string | null;
+  replay: BeaconEventLike | null;
+} {
+  const liveEvent = current?.event && current.event.status === 'live' ? current.event : null;
+  const hlsUrl = liveEvent ? current?.hlsPlaybackUrl ?? null : null;
+  const replay = current?.replay ?? null;
+  return { liveEvent, hlsUrl, replay };
+}
+
+// The live layout: player on the left, chat (member) or sign-in prompt (anonymous) on the right.
+function BeaconLiveView({
+  liveEvent,
+  hlsUrl,
+  videoRef,
+  isMember,
+  chat,
+  chatError,
+  signInUrl,
+}: {
+  liveEvent: BeaconEventLike;
+  hlsUrl: string | null;
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  isMember: boolean;
+  chat: ChatCredentials | null;
+  chatError: string | null;
+  signInUrl: string;
+}) {
+  const { theme } = useTheme();
+  const t = getBeaconTokens(theme);
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 16 }}>
+      <div style={{ display: 'grid', gap: 16, gridTemplateColumns: '1fr', alignItems: 'start' }} className="beacon-live-grid">
+        <section>
+          <div
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(245,158,11,0.14)',
+              border: `1px solid ${BEACON_COLOR}55`,
+              color: BEACON_COLOR,
+              borderRadius: 999,
+              padding: '4px 12px',
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: '0.04em',
+              marginBottom: 12,
+            }}
+          >
+            <span style={{ width: 8, height: 8, borderRadius: '50%', background: BEACON_COLOR, display: 'inline-block' }} />
+            LIVE AND PUBLIC
+          </div>
+          <h2 style={{ fontSize: 20, fontWeight: 700, margin: '0 0 6px' }}>{liveEvent.title}</h2>
+          {liveEvent.description ? (
+            <p style={{ color: t.SUBTLE, fontSize: 14, margin: '0 0 12px' }}>{liveEvent.description}</p>
+          ) : null}
+          <div style={{ borderRadius: 12, overflow: 'hidden', background: '#000', border: `1px solid ${t.BORDER_SOLID}`, aspectRatio: '16 / 9' }}>
+            {hlsUrl ? (
+              <video ref={videoRef} controls autoPlay playsInline muted style={{ width: '100%', height: '100%' }} />
+            ) : (
+              <div style={{ ...centeredStyle(t), height: '100%' }}>The broadcast is starting…</div>
+            )}
+          </div>
+          <p style={{ color: t.SUBTLE, fontSize: 12, marginTop: 10 }}>
+            This broadcast and its chat are public. The event is recorded; the replay is posted to the Commons.
+          </p>
+        </section>
+
+        <aside style={{ ...panelStyle(t), padding: 0, minHeight: 420, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          <div style={{ padding: '12px 16px', borderBottom: `1px solid ${t.BORDER_SOLID}`, fontWeight: 700, fontSize: 14 }}>Live chat</div>
+          {isMember ? (
+            chat ? (
+              <div style={{ flex: 1, minHeight: 0 }}>
+                <StreamChatPanel
+                  streamApiKey={chat.streamApiKey}
+                  streamToken={chat.streamToken}
+                  streamUserId={chat.streamUserId}
+                  streamChannelId={chat.streamChannelId}
+                  channelType={chat.streamChannelType}
+                  accentColor={t.ACCENT}
+                />
+              </div>
+            ) : (
+              <div style={{ ...centeredStyle(t), flex: 1 }}>{chatError ?? 'Connecting to chat…'}</div>
+            )
+          ) : (
+            <div style={{ ...centeredStyle(t), flex: 1, flexDirection: 'column', gap: 12, padding: 24, textAlign: 'center' }}>
+              <Lock size={28} style={{ color: t.SUBTLE }} />
+              <div style={{ fontSize: 14, color: t.SUBTLE }}>Sign in to chat and react. Anyone can watch — chatting is for members.</div>
+              <a href={signInUrl} style={ctaStyle(t)}>Sign in to chat</a>
+            </div>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+// The calm idle layout shown when nothing is live: a "no live event" card plus the last replay.
+function BeaconIdleView({ replay }: { replay: BeaconEventLike | null }) {
+  const { theme } = useTheme();
+  const t = getBeaconTokens(theme);
+  return (
+    <div style={{ ...panelStyle(t), textAlign: 'center', padding: '48px 24px' }}>
+      <Radio size={40} style={{ color: t.SUBTLE, display: 'block', margin: '0 auto 12px' }} />
+      <div style={{ fontSize: 16, fontWeight: 600 }}>No live event right now</div>
+      <p style={{ color: t.SUBTLE, fontSize: 14, marginTop: 6 }}>When Farah goes live, it will appear here.</p>
+      {replay?.recordingUrl ? (
+        <div style={{ marginTop: 20, textAlign: 'left' }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Last replay</div>
+          <div style={{ borderRadius: 12, overflow: 'hidden', background: '#000', border: `1px solid ${t.BORDER_SOLID}`, aspectRatio: '16 / 9' }}>
+            {/* eslint-disable-next-line jsx-a11y/media-has-caption -- known gap (WCAG 1.2.2): recorded broadcasts have no captions track yet; a captions pipeline is tracked in issue #1432. */}
+            <video controls playsInline src={replay.recordingUrl} style={{ width: '100%', height: '100%' }} />
+          </div>
+          <div style={{ fontSize: 14, fontWeight: 600, marginTop: 8 }}>{replay.title}</div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function BeaconViewer({ signInUrl, isMember }: { signInUrl: string; isMember: boolean }) {
   const { theme } = useTheme();
   const t = getBeaconTokens(theme);
@@ -67,9 +192,7 @@ export function BeaconViewer({ signInUrl, isMember }: { signInUrl: string; isMem
     return () => clearInterval(timer);
   }, [loadCurrent]);
 
-  const liveEvent = current?.event && current.event.status === 'live' ? current.event : null;
-  const hlsUrl = liveEvent ? current?.hlsPlaybackUrl ?? null : null;
-  const replay = current?.replay ?? null;
+  const { liveEvent, hlsUrl, replay } = deriveBeaconView(current);
 
   // Attach the HLS source. Safari/iOS play HLS (application/vnd.apple.mpegurl) natively, so we set the
   // source directly. Every other browser (Chrome/Firefox/Edge) cannot play HLS natively, so we attach
@@ -167,87 +290,17 @@ export function BeaconViewer({ signInUrl, isMember }: { signInUrl: string; isMem
       {loading ? (
         <div style={panelStyle(t)}>Loading…</div>
       ) : liveEvent ? (
-        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 16 }}>
-          <div style={{ display: 'grid', gap: 16, gridTemplateColumns: '1fr', alignItems: 'start' }} className="beacon-live-grid">
-            <section>
-              <div
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 8,
-                  background: 'rgba(245,158,11,0.14)',
-                  border: `1px solid ${BEACON_COLOR}55`,
-                  color: BEACON_COLOR,
-                  borderRadius: 999,
-                  padding: '4px 12px',
-                  fontSize: 12,
-                  fontWeight: 700,
-                  letterSpacing: '0.04em',
-                  marginBottom: 12,
-                }}
-              >
-                <span style={{ width: 8, height: 8, borderRadius: '50%', background: BEACON_COLOR, display: 'inline-block' }} />
-                LIVE AND PUBLIC
-              </div>
-              <h2 style={{ fontSize: 20, fontWeight: 700, margin: '0 0 6px' }}>{liveEvent.title}</h2>
-              {liveEvent.description ? (
-                <p style={{ color: t.SUBTLE, fontSize: 14, margin: '0 0 12px' }}>{liveEvent.description}</p>
-              ) : null}
-              <div style={{ borderRadius: 12, overflow: 'hidden', background: '#000', border: `1px solid ${t.BORDER_SOLID}`, aspectRatio: '16 / 9' }}>
-                {hlsUrl ? (
-                  <video ref={videoRef} controls autoPlay playsInline muted style={{ width: '100%', height: '100%' }} />
-                ) : (
-                  <div style={{ ...centeredStyle(t), height: '100%' }}>The broadcast is starting…</div>
-                )}
-              </div>
-              <p style={{ color: t.SUBTLE, fontSize: 12, marginTop: 10 }}>
-                This broadcast and its chat are public. The event is recorded; the replay is posted to the Commons.
-              </p>
-            </section>
-
-            <aside style={{ ...panelStyle(t), padding: 0, minHeight: 420, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-              <div style={{ padding: '12px 16px', borderBottom: `1px solid ${t.BORDER_SOLID}`, fontWeight: 700, fontSize: 14 }}>Live chat</div>
-              {isMember ? (
-                chat ? (
-                  <div style={{ flex: 1, minHeight: 0 }}>
-                    <StreamChatPanel
-                      streamApiKey={chat.streamApiKey}
-                      streamToken={chat.streamToken}
-                      streamUserId={chat.streamUserId}
-                      streamChannelId={chat.streamChannelId}
-                      channelType={chat.streamChannelType}
-                      accentColor={t.ACCENT}
-                    />
-                  </div>
-                ) : (
-                  <div style={{ ...centeredStyle(t), flex: 1 }}>{chatError ?? 'Connecting to chat…'}</div>
-                )
-              ) : (
-                <div style={{ ...centeredStyle(t), flex: 1, flexDirection: 'column', gap: 12, padding: 24, textAlign: 'center' }}>
-                  <Lock size={28} style={{ color: t.SUBTLE }} />
-                  <div style={{ fontSize: 14, color: t.SUBTLE }}>Sign in to chat and react. Anyone can watch — chatting is for members.</div>
-                  <a href={signInUrl} style={ctaStyle(t)}>Sign in to chat</a>
-                </div>
-              )}
-            </aside>
-          </div>
-        </div>
+        <BeaconLiveView
+          liveEvent={liveEvent}
+          hlsUrl={hlsUrl}
+          videoRef={videoRef}
+          isMember={isMember}
+          chat={chat}
+          chatError={chatError}
+          signInUrl={signInUrl}
+        />
       ) : (
-        <div style={{ ...panelStyle(t), textAlign: 'center', padding: '48px 24px' }}>
-          <Radio size={40} style={{ color: t.SUBTLE, display: 'block', margin: '0 auto 12px' }} />
-          <div style={{ fontSize: 16, fontWeight: 600 }}>No live event right now</div>
-          <p style={{ color: t.SUBTLE, fontSize: 14, marginTop: 6 }}>When Farah goes live, it will appear here.</p>
-          {replay?.recordingUrl ? (
-            <div style={{ marginTop: 20, textAlign: 'left' }}>
-              <div style={{ fontSize: 13, fontWeight: 700, color: t.SUBTLE, marginBottom: 8 }}>Last replay</div>
-              <div style={{ borderRadius: 12, overflow: 'hidden', background: '#000', border: `1px solid ${t.BORDER_SOLID}`, aspectRatio: '16 / 9' }}>
-                {/* eslint-disable-next-line jsx-a11y/media-has-caption -- known gap (WCAG 1.2.2): recorded broadcasts have no captions track yet; a captions pipeline is tracked in issue #1432. */}
-                <video controls playsInline src={replay.recordingUrl} style={{ width: '100%', height: '100%' }} />
-              </div>
-              <div style={{ fontSize: 14, fontWeight: 600, marginTop: 8 }}>{replay.title}</div>
-            </div>
-          ) : null}
-        </div>
+        <BeaconIdleView replay={replay} />
       )}
 
     </main>

--- a/ctf/packages/web/components/blocks/block-member-button.tsx
+++ b/ctf/packages/web/components/blocks/block-member-button.tsx
@@ -9,6 +9,9 @@ import { SAFETY_REPORT_DETAIL_MAX_LENGTH } from 'lib/safety/constants';
 
 type Status = 'idle' | 'confirming' | 'submitting' | 'done' | 'error';
 
+// The three chrome tokens the block dialog and its sections need.
+type BlockDialogTokens = { BORDER: string; TEXT: string; SUBTLE: string };
+
 type BlockMemberButtonProps = {
   // The user id of the member to block.
   targetUserId: string;
@@ -20,6 +23,202 @@ type BlockMemberButtonProps = {
   // Optional style override for the trigger button, so a surface can match its own layout.
   style?: CSSProperties;
 };
+
+// The optional, clearly-secondary safety escalation inside the dialog. An ordinary block reaches no
+// one; only checking this box sends a report to the admins so they can act. Kept module-scope so its
+// conditional styles stay out of the dialog's complexity count.
+function BlockMemberSafetySection({
+  safetyConcern,
+  safetyDetail,
+  disabled,
+  tokens,
+  onToggleConcern,
+  onDetailChange,
+}: {
+  safetyConcern: boolean;
+  safetyDetail: string;
+  disabled: boolean;
+  tokens: BlockDialogTokens;
+  onToggleConcern: (value: boolean) => void;
+  onDetailChange: (value: string) => void;
+}) {
+  const { BORDER, SUBTLE, TEXT } = tokens;
+  return (
+    <div style={{ borderRadius: 12, background: 'rgba(245,158,11,0.05)', border: '1px solid rgba(245,158,11,0.22)', padding: '12px 14px', marginBottom: 18 }}>
+      <label style={{ display: 'flex', gap: 10, alignItems: 'flex-start', cursor: disabled ? 'not-allowed' : 'pointer' }}>
+        <input
+          type="checkbox"
+          aria-label="Report this person to the admins as a safety concern"
+          checked={safetyConcern}
+          disabled={disabled}
+          onChange={(e) => onToggleConcern(e.target.checked)}
+          style={{ marginTop: 2, width: 16, height: 16, accentColor: '#F59E0B', flexShrink: 0, cursor: disabled ? 'not-allowed' : 'pointer' }}
+        />
+        <span style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, fontWeight: 700, color: '#F59E0B' }}>
+            <AlertTriangle size={14} /> Report this person to the admins as a safety concern
+          </span>
+          <span style={{ fontSize: 12.5, color: '#9CA3AF', lineHeight: 1.55 }}>
+            Only check this if you believe they are a suspected predator or human trafficker.
+            An ordinary block does not notify anyone — this sends a private report to the admins
+            so they can review and act.
+          </span>
+        </span>
+      </label>
+
+      {safetyConcern ? (
+        <div style={{ marginTop: 12 }}>
+          <label htmlFor="safety-detail" style={{ display: 'block', fontSize: 12.5, color: SUBTLE, marginBottom: 6 }}>
+            Anything the admins should know (optional)
+          </label>
+          <textarea
+            id="safety-detail"
+            value={safetyDetail}
+            disabled={disabled}
+            onChange={(e) => onDetailChange(e.target.value)}
+            maxLength={SAFETY_REPORT_DETAIL_MAX_LENGTH}
+            rows={3}
+            placeholder="A short note that would help the admins (optional)"
+            style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical', minHeight: 64, padding: '9px 11px', borderRadius: 9, background: 'rgba(255,255,255,0.03)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontFamily: 'inherit', lineHeight: 1.5 }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// The confirm / cancel action row. Its button copy and disabled/loading affordances all depend on the
+// submitting state and whether a safety report is going out, so it lives here to keep those ternaries
+// out of the dialog's complexity count.
+function BlockMemberActions({
+  submitting,
+  safetyConcern,
+  tokens,
+  onConfirm,
+  onCancel,
+}: {
+  submitting: boolean;
+  safetyConcern: boolean;
+  tokens: Pick<BlockDialogTokens, 'BORDER' | 'SUBTLE'>;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const { BORDER, SUBTLE } = tokens;
+  return (
+    <div style={{ display: 'flex', gap: 10 }}>
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={submitting}
+        style={{ flex: 1, padding: '12px', borderRadius: 11, background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.45)', color: '#EF4444', fontSize: 14, fontWeight: 700, cursor: submitting ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
+      >
+        {submitting
+          ? <><Loader2 size={15} className="blocks-spin" /> {safetyConcern ? 'Blocking and reporting…' : 'Blocking…'}</>
+          : <><Ban size={15} /> {safetyConcern ? 'Block and report' : 'Block member'}</>}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={submitting}
+        style={{ padding: '12px 20px', borderRadius: 11, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 14, fontWeight: 600, cursor: submitting ? 'not-allowed' : 'pointer' }}
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+// The confirm dialog itself. Renders nothing while idle; otherwise the modal with the plain-language
+// explanation, the optional safety escalation, any error, and the action row. Kept module-scope so its
+// conditional bits stay out of the button's complexity count.
+function BlockMemberDialog({
+  status,
+  label,
+  safetyConcern,
+  safetyDetail,
+  errorMessage,
+  tokens,
+  onClose,
+  onConfirm,
+  onToggleConcern,
+  onDetailChange,
+}: {
+  status: Status;
+  label: string;
+  safetyConcern: boolean;
+  safetyDetail: string;
+  errorMessage: string | null;
+  tokens: BlockDialogTokens;
+  onClose: () => void;
+  onConfirm: () => void;
+  onToggleConcern: (value: boolean) => void;
+  onDetailChange: (value: string) => void;
+}) {
+  if (status === 'idle') return null;
+  const { BORDER, TEXT, SUBTLE } = tokens;
+  const submitting = status === 'submitting';
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Block this member"
+      style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(9,11,15,0.78)', fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16, overflowY: 'auto' }}
+    >
+      <div style={{ width: '100%', maxWidth: 460, borderRadius: 22, background: '#0D0F14', border: '1px solid rgba(239,68,68,0.3)', boxShadow: '0 28px 72px rgba(0,0,0,0.65)', overflow: 'hidden' }}>
+        <div style={{ padding: '22px 24px 16px', display: 'flex', alignItems: 'flex-start', gap: 12, borderBottom: '1px solid rgba(239,68,68,0.12)' }}>
+          <div style={{ width: 44, height: 44, borderRadius: 12, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <Ban size={20} color="#EF4444" />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 17, fontWeight: 800, color: TEXT }}>Block {label}?</div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            aria-label="Cancel"
+            style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: submitting ? 'not-allowed' : 'pointer', color: SUBTLE, flexShrink: 0 }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div style={{ padding: '20px 24px' }}>
+          <p style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.6, margin: '0 0 16px' }}>
+            They won&apos;t be able to see or contact you, and they won&apos;t be told. This is private
+            — no one is notified. You can unblock them later from your blocked members list.
+          </p>
+
+          {/* Optional, clearly-secondary safety escalation. An ordinary block reaches no one; only
+              checking this box sends a report to the admins so they can act. */}
+          <BlockMemberSafetySection
+            safetyConcern={safetyConcern}
+            safetyDetail={safetyDetail}
+            disabled={submitting}
+            tokens={{ BORDER, TEXT, SUBTLE }}
+            onToggleConcern={onToggleConcern}
+            onDetailChange={onDetailChange}
+          />
+
+          {status === 'error' && errorMessage ? (
+            <div style={{ padding: '10px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.3)', color: '#F87171', fontSize: 13, marginBottom: 16, lineHeight: 1.5 }}>
+              {errorMessage}
+            </div>
+          ) : null}
+
+          <BlockMemberActions
+            submitting={submitting}
+            safetyConcern={safetyConcern}
+            tokens={{ BORDER, SUBTLE }}
+            onConfirm={onConfirm}
+            onCancel={onClose}
+          />
+        </div>
+      </div>
+      <style>{'@keyframes blocks-spin{to{transform:rotate(360deg)}}.blocks-spin{animation:blocks-spin 0.8s linear infinite}'}</style>
+    </div>
+  );
+}
 
 // Reusable "Block member" action. Any surface that shows another member can drop this in: it owns
 // the confirm dialog, the POST, and the loading / error / done states. The dialog states plainly
@@ -62,6 +261,9 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
     }
   }
 
+  // Closing is blocked mid-submit so a member can't dismiss the dialog while the block is in flight.
+  const closeDialog = () => { if (status !== 'submitting') setStatus('idle'); };
+
   // Once blocked, the trigger becomes a calm, non-actionable confirmation rather than disappearing,
   // so the member gets clear feedback that the block took effect. When a safety report also went out,
   // the label says so, so the member knows the admins were notified.
@@ -94,112 +296,18 @@ export function BlockMemberButton({ targetUserId, displayName, onBlocked, style 
         <Ban size={15} /> Block member
       </button>
 
-      {status !== 'idle' ? (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-label="Block this member"
-          style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(9,11,15,0.78)', fontFamily: "'Inter', system-ui, sans-serif", color: TEXT, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16, overflowY: 'auto' }}
-        >
-          <div style={{ width: '100%', maxWidth: 460, borderRadius: 22, background: '#0D0F14', border: '1px solid rgba(239,68,68,0.3)', boxShadow: '0 28px 72px rgba(0,0,0,0.65)', overflow: 'hidden' }}>
-            <div style={{ padding: '22px 24px 16px', display: 'flex', alignItems: 'flex-start', gap: 12, borderBottom: '1px solid rgba(239,68,68,0.12)' }}>
-              <div style={{ width: 44, height: 44, borderRadius: 12, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-                <Ban size={20} color="#EF4444" />
-              </div>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontSize: 17, fontWeight: 800, color: TEXT }}>Block {label}?</div>
-              </div>
-              <button
-                type="button"
-                onClick={() => { if (status !== 'submitting') setStatus('idle'); }}
-                disabled={status === 'submitting'}
-                aria-label="Cancel"
-                style={{ width: 30, height: 30, borderRadius: 8, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: status === 'submitting' ? 'not-allowed' : 'pointer', color: SUBTLE, flexShrink: 0 }}
-              >
-                <X size={14} />
-              </button>
-            </div>
-
-            <div style={{ padding: '20px 24px' }}>
-              <p style={{ fontSize: 14, color: '#9CA3AF', lineHeight: 1.6, margin: '0 0 16px' }}>
-                They won&apos;t be able to see or contact you, and they won&apos;t be told. This is private
-                — no one is notified. You can unblock them later from your blocked members list.
-              </p>
-
-              {/* Optional, clearly-secondary safety escalation. An ordinary block reaches no one; only
-                  checking this box sends a report to the admins so they can act. */}
-              <div style={{ borderRadius: 12, background: 'rgba(245,158,11,0.05)', border: '1px solid rgba(245,158,11,0.22)', padding: '12px 14px', marginBottom: 18 }}>
-                <label style={{ display: 'flex', gap: 10, alignItems: 'flex-start', cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}>
-                  <input
-                    type="checkbox"
-                    aria-label="Report this person to the admins as a safety concern"
-                    checked={safetyConcern}
-                    disabled={status === 'submitting'}
-                    onChange={(e) => setSafetyConcern(e.target.checked)}
-                    style={{ marginTop: 2, width: 16, height: 16, accentColor: '#F59E0B', flexShrink: 0, cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}
-                  />
-                  <span style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, fontWeight: 700, color: '#F59E0B' }}>
-                      <AlertTriangle size={14} /> Report this person to the admins as a safety concern
-                    </span>
-                    <span style={{ fontSize: 12.5, color: '#9CA3AF', lineHeight: 1.55 }}>
-                      Only check this if you believe they are a suspected predator or human trafficker.
-                      An ordinary block does not notify anyone — this sends a private report to the admins
-                      so they can review and act.
-                    </span>
-                  </span>
-                </label>
-
-                {safetyConcern ? (
-                  <div style={{ marginTop: 12 }}>
-                    <label htmlFor="safety-detail" style={{ display: 'block', fontSize: 12.5, color: SUBTLE, marginBottom: 6 }}>
-                      Anything the admins should know (optional)
-                    </label>
-                    <textarea
-                      id="safety-detail"
-                      value={safetyDetail}
-                      disabled={status === 'submitting'}
-                      onChange={(e) => setSafetyDetail(e.target.value)}
-                      maxLength={SAFETY_REPORT_DETAIL_MAX_LENGTH}
-                      rows={3}
-                      placeholder="A short note that would help the admins (optional)"
-                      style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical', minHeight: 64, padding: '9px 11px', borderRadius: 9, background: 'rgba(255,255,255,0.03)', border: `1px solid ${BORDER}`, color: TEXT, fontSize: 13, fontFamily: 'inherit', lineHeight: 1.5 }}
-                    />
-                  </div>
-                ) : null}
-              </div>
-
-              {status === 'error' && errorMessage ? (
-                <div style={{ padding: '10px 12px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.3)', color: '#F87171', fontSize: 13, marginBottom: 16, lineHeight: 1.5 }}>
-                  {errorMessage}
-                </div>
-              ) : null}
-
-              <div style={{ display: 'flex', gap: 10 }}>
-                <button
-                  type="button"
-                  onClick={handleConfirm}
-                  disabled={status === 'submitting'}
-                  style={{ flex: 1, padding: '12px', borderRadius: 11, background: 'rgba(239,68,68,0.14)', border: '1px solid rgba(239,68,68,0.45)', color: '#EF4444', fontSize: 14, fontWeight: 700, cursor: status === 'submitting' ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7 }}
-                >
-                  {status === 'submitting'
-                    ? <><Loader2 size={15} className="blocks-spin" /> {safetyConcern ? 'Blocking and reporting…' : 'Blocking…'}</>
-                    : <><Ban size={15} /> {safetyConcern ? 'Block and report' : 'Block member'}</>}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { if (status !== 'submitting') setStatus('idle'); }}
-                  disabled={status === 'submitting'}
-                  style={{ padding: '12px 20px', borderRadius: 11, background: 'rgba(255,255,255,0.04)', border: `1px solid ${BORDER}`, color: SUBTLE, fontSize: 14, fontWeight: 600, cursor: status === 'submitting' ? 'not-allowed' : 'pointer' }}
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          </div>
-          <style>{'@keyframes blocks-spin{to{transform:rotate(360deg)}}.blocks-spin{animation:blocks-spin 0.8s linear infinite}'}</style>
-        </div>
-      ) : null}
+      <BlockMemberDialog
+        status={status}
+        label={label}
+        safetyConcern={safetyConcern}
+        safetyDetail={safetyDetail}
+        errorMessage={errorMessage}
+        tokens={{ BORDER, TEXT, SUBTLE }}
+        onClose={closeDialog}
+        onConfirm={handleConfirm}
+        onToggleConcern={setSafetyConcern}
+        onDetailChange={setSafetyDetail}
+      />
     </>
   );
 }

--- a/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
+++ b/ctf/packages/web/components/bug-reports/bug-reports-admin-shell.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { Bug, ExternalLink } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
-import { getBugReportsTokens } from './bug-reports-shared';
+import { getBugReportsTokens, type BugReportsTokens } from './bug-reports-shared';
 import type { BugReportStatus, BugReportRiskLevel } from 'lib/bug-reports/constants';
 import type { BugReportRiskFlag } from 'lib/bug-reports/sanitize';
 
@@ -92,6 +92,120 @@ function StatBlock({ label, value, accent }: { label: string; value: number; acc
     <div style={{ flex: 1, minWidth: 120, padding: '10px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
       <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? t.TITLE }}>{value}</div>
       <div style={{ fontSize: 11, color: t.MUTED, marginTop: 2 }}>{label}</div>
+    </div>
+  );
+}
+
+// The risk-flag chips shown on a held/flagged report. Renders nothing when there are no flags.
+function RiskFlags({ flags }: { flags: BugReportRiskFlag[] }) {
+  if (flags.length === 0) return null;
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
+      {flags.map((flag) => (
+        <span
+          key={flag}
+          style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 600, background: 'rgba(245,158,11,0.1)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}
+        >
+          {RISK_FLAG_LABEL[flag] ?? flag}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// The metadata footer: page, app version, and a link to the triage issue when one exists.
+function ReportFooter({ report, t }: { report: AdminBugReport; t: BugReportsTokens }) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 16px', marginTop: 10, fontSize: 12, color: t.MUTED }}>
+      {report.pageUrl ? <span>Page: {report.pageUrl}</span> : null}
+      {report.appVersion ? <span>App: {report.appVersion}</span> : null}
+      {report.issueUrl ? (
+        <Link
+          href={report.issueUrl}
+          target="_blank"
+          rel="noreferrer"
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: t.ACCENT, textDecoration: 'none' }}
+        >
+          <ExternalLink size={12} /> Triage issue #{report.issueNumber ?? '?'}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+// The release/reject action row. Renders nothing when the report is in a terminal state.
+function ReportActions({ report, busy, t, onResolve }: {
+  report: AdminBugReport;
+  busy: boolean;
+  t: BugReportsTokens;
+  onResolve: (id: string, action: 'release' | 'reject') => void;
+}) {
+  // A held report can be released to triage; a new one is already queued for the drain,
+  // so it only offers reject. Release on a new report would 409 (the update only matches
+  // held_for_review), so the button is hidden there.
+  const canRelease = report.status === 'held_for_review';
+  const canReject = report.status === 'held_for_review' || report.status === 'new';
+  if (!canRelease && !canReject) return null;
+  const cursor = busy ? 'not-allowed' : 'pointer';
+  const opacity = busy ? 0.6 : 1;
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 12 }}>
+      {canRelease ? (
+        <button
+          type="button"
+          onClick={() => void onResolve(report.id, 'release')}
+          disabled={busy}
+          style={{ padding: '7px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor, opacity }}
+        >
+          Release to triage
+        </button>
+      ) : null}
+      {canReject ? (
+        <button
+          type="button"
+          onClick={() => void onResolve(report.id, 'reject')}
+          disabled={busy}
+          style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor, opacity }}
+        >
+          Reject
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+// One report card: metadata row, redacted message/context, risk flags, footer, and actions.
+function AdminReportCard({ report, busy, t, onResolve }: {
+  report: AdminBugReport;
+  busy: boolean;
+  t: BugReportsTokens;
+  onResolve: (id: string, action: 'release' | 'reject') => void;
+}) {
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <StatusPill status={report.status} />
+        <span style={{ fontSize: 12, color: t.MUTED }}>{formatWhen(report.createdAt)}</span>
+        <span style={{ fontSize: 12, color: t.MUTED }}>· From: {report.reporterHandle}</span>
+        {report.pluginSlug ? <span style={{ fontSize: 12, color: t.MUTED }}>· {report.pluginSlug}</span> : null}
+      </div>
+
+      <p style={{ whiteSpace: 'pre-wrap', fontSize: 13, color: t.TITLE, margin: 0 }}>
+        {report.redactedMessage || '(no message)'}
+      </p>
+
+      {report.redactedContext ? (
+        <p style={{ whiteSpace: 'pre-wrap', fontSize: 13, color: t.MUTED, marginTop: 8, marginBottom: 0 }}>
+          <span style={{ color: t.TITLE, fontWeight: 600 }}>What they were trying to do: </span>
+          {report.redactedContext}
+        </p>
+      ) : null}
+
+      <RiskFlags flags={report.riskFlags} />
+
+      <ReportFooter report={report} t={t} />
+
+      <ReportActions report={report} busy={busy} t={t} onResolve={onResolve} />
     </div>
   );
 }
@@ -200,88 +314,15 @@ export function BugReportsAdminShell() {
           </div>
         ) : null}
 
-        {items.map((report) => {
-          // A held report can be released to triage; a new one is already queued for the drain,
-          // so it only offers reject. Release on a new report would 409 (the update only matches
-          // held_for_review), so the button is hidden there.
-          const canRelease = report.status === 'held_for_review';
-          const canReject = report.status === 'held_for_review' || report.status === 'new';
-          const busy = busyId === report.id;
-          return (
-            <div key={report.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                <StatusPill status={report.status} />
-                <span style={{ fontSize: 12, color: t.MUTED }}>{formatWhen(report.createdAt)}</span>
-                <span style={{ fontSize: 12, color: t.MUTED }}>· From: {report.reporterHandle}</span>
-                {report.pluginSlug ? <span style={{ fontSize: 12, color: t.MUTED }}>· {report.pluginSlug}</span> : null}
-              </div>
-
-              <p style={{ whiteSpace: 'pre-wrap', fontSize: 13, color: t.TITLE, margin: 0 }}>
-                {report.redactedMessage || '(no message)'}
-              </p>
-
-              {report.redactedContext ? (
-                <p style={{ whiteSpace: 'pre-wrap', fontSize: 13, color: t.MUTED, marginTop: 8, marginBottom: 0 }}>
-                  <span style={{ color: t.TITLE, fontWeight: 600 }}>What they were trying to do: </span>
-                  {report.redactedContext}
-                </p>
-              ) : null}
-
-              {report.riskFlags.length > 0 ? (
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
-                  {report.riskFlags.map((flag) => (
-                    <span
-                      key={flag}
-                      style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 600, background: 'rgba(245,158,11,0.1)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}
-                    >
-                      {RISK_FLAG_LABEL[flag] ?? flag}
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 16px', marginTop: 10, fontSize: 12, color: t.MUTED }}>
-                {report.pageUrl ? <span>Page: {report.pageUrl}</span> : null}
-                {report.appVersion ? <span>App: {report.appVersion}</span> : null}
-                {report.issueUrl ? (
-                  <Link
-                    href={report.issueUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: t.ACCENT, textDecoration: 'none' }}
-                  >
-                    <ExternalLink size={12} /> Triage issue #{report.issueNumber ?? '?'}
-                  </Link>
-                ) : null}
-              </div>
-
-              {canRelease || canReject ? (
-                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 12 }}>
-                  {canRelease ? (
-                    <button
-                      type="button"
-                      onClick={() => void resolve(report.id, 'release')}
-                      disabled={busy}
-                      style={{ padding: '7px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
-                    >
-                      Release to triage
-                    </button>
-                  ) : null}
-                  {canReject ? (
-                    <button
-                      type="button"
-                      onClick={() => void resolve(report.id, 'reject')}
-                      disabled={busy}
-                      style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
-                    >
-                      Reject
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
+        {items.map((report) => (
+          <AdminReportCard
+            key={report.id}
+            report={report}
+            busy={busyId === report.id}
+            t={t}
+            onResolve={resolve}
+          />
+        ))}
       </div>
     </div>
   );

--- a/ctf/packages/web/components/click-log/click-log-log-panel.tsx
+++ b/ctf/packages/web/components/click-log/click-log-log-panel.tsx
@@ -3,7 +3,94 @@
 import { AlertTriangle, MapPin } from "lucide-react";
 import { MAX_NOTES_LENGTH } from "../../lib/click-log/constants";
 import { useTheme } from "@/hooks/useTheme";
-import { getClickLogTokens } from "./click-log-shared";
+import { getClickLogTokens, type ClickLogTokens } from "./click-log-shared";
+
+type GeoStatus = "idle" | "locating" | "error";
+
+// The "Add location" button. Its background/border/color and the disabled/loading affordances all
+// depend on locationAdded and the geolocation status, so it lives here as its own component to keep
+// those ternaries out of the panel's complexity count.
+function ClickLogLocationButton({
+  locationAdded,
+  geoStatus,
+  tokens,
+  onAddLocation,
+}: {
+  locationAdded: boolean;
+  geoStatus: GeoStatus;
+  tokens: ClickLogTokens;
+  onAddLocation: () => void;
+}) {
+  const t = tokens;
+  const locating = geoStatus === "locating";
+  const locationLabel = locationAdded ? "Location added" : locating ? "Locating…" : "Add location";
+  return (
+    <button
+      onClick={onAddLocation}
+      disabled={locating}
+      style={{ display: "flex", alignItems: "center", gap: 5, padding: "7px 12px", borderRadius: 8, background: locationAdded ? `${t.ACCENT}18` : t.INPUT_BG, border: `1px solid ${locationAdded ? t.ACCENT + "40" : t.BORDER_SOLID}`, color: locationAdded ? t.ACCENT : t.MUTED, fontSize: 12, cursor: locating ? "not-allowed" : "pointer", opacity: locating ? 0.7 : 1 }}
+    >
+      <MapPin size={12} /> {locationLabel}
+    </button>
+  );
+}
+
+// The optional note form revealed under the log button. Extracted so its several conditional style
+// values stay out of the panel's complexity count.
+function ClickLogNoteForm({
+  note,
+  submitting,
+  locationAdded,
+  geoStatus,
+  geoError,
+  tokens,
+  onNoteChange,
+  onAddLocation,
+  onSubmit,
+  onCancel,
+}: {
+  note: string;
+  submitting: boolean;
+  locationAdded: boolean;
+  geoStatus: GeoStatus;
+  geoError: string | null;
+  tokens: ClickLogTokens;
+  onNoteChange: (value: string) => void;
+  onAddLocation: () => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  const t = tokens;
+  return (
+    <div style={{ width: "100%", maxWidth: 480, padding: "16px", borderRadius: 14, background: t.SURFACE, border: `1px solid ${t.ACCENT}30` }}>
+      <div style={{ fontSize: 13, fontWeight: 600, color: t.TITLE, marginBottom: 8 }}>Add a note (optional)</div>
+      <textarea
+        value={note}
+        onChange={(e) => onNoteChange(e.target.value)}
+        rows={3}
+        maxLength={MAX_NOTES_LENGTH}
+        placeholder="Describe what happened…"
+        style={{ width: "100%", padding: "10px 12px", background: t.BG, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, fontSize: 13, color: t.TITLE, outline: "none", resize: "vertical", fontFamily: "inherit", boxSizing: "border-box" }}
+      />
+      <div style={{ display: "flex", gap: 8, marginTop: 10, alignItems: "center" }}>
+        <ClickLogLocationButton
+          locationAdded={locationAdded}
+          geoStatus={geoStatus}
+          tokens={t}
+          onAddLocation={onAddLocation}
+        />
+        <div style={{ flex: 1 }} />
+        <button onClick={onCancel} style={{ padding: "7px 14px", borderRadius: 8, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, cursor: "pointer" }}>Cancel</button>
+        <button onClick={onSubmit} disabled={submitting} style={{ padding: "7px 18px", borderRadius: 8, background: t.ACCENT, border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: submitting ? "not-allowed" : "pointer", opacity: submitting ? 0.7 : 1 }}>Submit</button>
+      </div>
+      {geoStatus === "error" && (
+        <div style={{ marginTop: 8, fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
+          {geoError ?? "Couldn't get your location — check location permissions and try again."}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function ClickLogLogPanel({
   logged,
@@ -24,7 +111,7 @@ export function ClickLogLogPanel({
   note: string;
   submitting: boolean;
   locationAdded: boolean;
-  geoStatus: "idle" | "locating" | "error";
+  geoStatus: GeoStatus;
   geoError: string | null;
   onToggleForm: () => void;
   onNoteChange: (value: string) => void;
@@ -49,34 +136,18 @@ export function ClickLogLogPanel({
       </div>
 
       {showForm && (
-        <div style={{ width: "100%", maxWidth: 480, padding: "16px", borderRadius: 14, background: t.SURFACE, border: `1px solid ${t.ACCENT}30` }}>
-          <div style={{ fontSize: 13, fontWeight: 600, color: t.TITLE, marginBottom: 8 }}>Add a note (optional)</div>
-          <textarea
-            value={note}
-            onChange={(e) => onNoteChange(e.target.value)}
-            rows={3}
-            maxLength={MAX_NOTES_LENGTH}
-            placeholder="Describe what happened…"
-            style={{ width: "100%", padding: "10px 12px", background: t.BG, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, fontSize: 13, color: t.TITLE, outline: "none", resize: "vertical", fontFamily: "inherit", boxSizing: "border-box" }}
-          />
-          <div style={{ display: "flex", gap: 8, marginTop: 10, alignItems: "center" }}>
-            <button
-              onClick={onAddLocation}
-              disabled={geoStatus === "locating"}
-              style={{ display: "flex", alignItems: "center", gap: 5, padding: "7px 12px", borderRadius: 8, background: locationAdded ? `${t.ACCENT}18` : t.INPUT_BG, border: `1px solid ${locationAdded ? t.ACCENT + "40" : t.BORDER_SOLID}`, color: locationAdded ? t.ACCENT : t.MUTED, fontSize: 12, cursor: geoStatus === "locating" ? "not-allowed" : "pointer", opacity: geoStatus === "locating" ? 0.7 : 1 }}
-            >
-              <MapPin size={12} /> {locationAdded ? "Location added" : geoStatus === "locating" ? "Locating…" : "Add location"}
-            </button>
-            <div style={{ flex: 1 }} />
-            <button onClick={onCancel} style={{ padding: "7px 14px", borderRadius: 8, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, cursor: "pointer" }}>Cancel</button>
-            <button onClick={onSubmit} disabled={submitting} style={{ padding: "7px 18px", borderRadius: 8, background: t.ACCENT, border: "none", color: "#fff", fontSize: 12, fontWeight: 700, cursor: submitting ? "not-allowed" : "pointer", opacity: submitting ? 0.7 : 1 }}>Submit</button>
-          </div>
-          {geoStatus === "error" && (
-            <div style={{ marginTop: 8, fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
-              {geoError ?? "Couldn't get your location — check location permissions and try again."}
-            </div>
-          )}
-        </div>
+        <ClickLogNoteForm
+          note={note}
+          submitting={submitting}
+          locationAdded={locationAdded}
+          geoStatus={geoStatus}
+          geoError={geoError}
+          tokens={t}
+          onNoteChange={onNoteChange}
+          onAddLocation={onAddLocation}
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+        />
       )}
     </div>
   );

--- a/ctf/packages/web/components/feed-announcements/commons-moderation-admin-shell.tsx
+++ b/ctf/packages/web/components/feed-announcements/commons-moderation-admin-shell.tsx
@@ -28,6 +28,59 @@ import { getFeedAnnouncementsTokens, type FeedAnnouncementsTokens } from './feed
 
 const CSRF_HEADERS = { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' };
 
+type TabKey = 'all' | 'hidden' | 'authors' | 'flagged';
+
+type ModerationQueuePayload = {
+  ok?: boolean;
+  rows?: FeedModerationQueueRow[];
+  hidden?: { posts: number; replies: number };
+  authors?: FeedModerationAuthorSummary[];
+  message?: string;
+};
+
+// Build the query suffix for the moderation queue fetch. Kept out of the component so the two
+// optional filters do not add branches to the render function.
+function buildModerationQuerySuffix(onlyHidden: boolean, authorUserId?: string | null): string {
+  const query = new URLSearchParams();
+  if (onlyHidden) query.set('hidden', '1');
+  if (authorUserId) query.set('author', authorUserId);
+  const qs = query.toString();
+  return qs ? `?${qs}` : '';
+}
+
+// Pick the notice line for a hide/restore. `changed === false` means the row was already in the
+// requested state, so nothing actually moved.
+function moderationNotice(
+  changed: boolean | undefined,
+  nextHidden: boolean,
+  hiddenMsg: string,
+  shownMsg: string,
+): string {
+  if (changed === false) return 'Already in that state — nothing changed.';
+  return nextHidden ? hiddenMsg : shownMsg;
+}
+
+// Shared hide/restore POST. Same endpoint shape for Commons rows and flagged answers; the caller
+// supplies the URL and applies its own default message so the wording stays per-surface.
+async function postModeration(
+  url: string,
+  nextHidden: boolean,
+  reason: FeedModerationReason,
+): Promise<{ ok: boolean; changed?: boolean; message?: string }> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: CSRF_HEADERS,
+    body: JSON.stringify(nextHidden ? { hidden: true, reason } : { hidden: false }),
+  });
+  const data = (await res.json().catch(() => null)) as
+    | { ok?: boolean; changed?: boolean; message?: string }
+    | null;
+  if (!res.ok || !data?.ok) {
+    return { ok: false, message: data?.message };
+  }
+  return { ok: true, changed: data.changed };
+}
+
 function StatBlock({ label, value, accent }: { label: string; value: number; accent?: string }) {
   const { theme } = useTheme();
   const t = getFeedAnnouncementsTokens(theme);
@@ -52,6 +105,325 @@ function tabStyle(t: FeedAnnouncementsTokens, active: boolean) {
   } as const;
 }
 
+function HiddenStats({ hidden }: { hidden: { posts: number; replies: number } }) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 16 }}>
+      <StatBlock label="Hidden posts" value={hidden.posts} accent={hidden.posts > 0 ? '#F59E0B' : undefined} />
+      <StatBlock label="Hidden replies" value={hidden.replies} accent={hidden.replies > 0 ? '#F59E0B' : undefined} />
+    </div>
+  );
+}
+
+function ModerationTabs({
+  tab,
+  focusAuthor,
+  pendingFlagged,
+  onSwitch,
+}: {
+  tab: TabKey;
+  focusAuthor: FeedModerationAuthorSummary | null;
+  pendingFlagged: number;
+  onSwitch: (next: TabKey) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  const recentActive = tab === 'all' && !focusAuthor;
+  return (
+    <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
+      <button type="button" onClick={() => onSwitch('all')} aria-pressed={recentActive} style={tabStyle(t, recentActive)}>
+        Recent
+      </button>
+      <button type="button" onClick={() => onSwitch('hidden')} aria-pressed={tab === 'hidden'} style={tabStyle(t, tab === 'hidden')}>
+        Hidden only
+      </button>
+      <button type="button" onClick={() => onSwitch('authors')} aria-pressed={tab === 'authors'} style={tabStyle(t, tab === 'authors')}>
+        By member
+      </button>
+      <button type="button" onClick={() => onSwitch('flagged')} aria-pressed={tab === 'flagged'} style={tabStyle(t, tab === 'flagged')}>
+        Flagged answers{pendingFlagged > 0 ? ` (${pendingFlagged})` : ''}
+      </button>
+    </div>
+  );
+}
+
+// The reason applied to the next hide. One picker for the whole list rather than one per row:
+// a sweep of off-topic posts is the same judgement repeated, and asking for it on every card
+// would be twenty identical clicks. Restoring ignores this.
+function ReasonPicker({ reason, onChange }: { reason: FeedModerationReason; onChange: (r: FeedModerationReason) => void }) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
+      <label htmlFor="ctf-moderation-reason" style={{ fontSize: 12.5, color: t.MUTED }}>
+        Hide reason
+      </label>
+      <select
+        id="ctf-moderation-reason"
+        value={reason}
+        onChange={(e) => onChange(e.target.value as FeedModerationReason)}
+        style={{ padding: '6px 10px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13 }}
+      >
+        {FEED_MODERATION_REASONS.map((code) => (
+          <option key={code} value={code}>{FEED_MODERATION_REASON_LABEL[code]}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function FocusAuthorHeader({ author, onBack }: { author: FeedModerationAuthorSummary; onBack: () => void }) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 16, padding: '10px 14px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <span style={{ fontSize: 13, color: t.TITLE }}>
+        Everything from {author.authorUsername ? `@${author.authorUsername}` : author.authorUserId}
+        {' — '}
+        {author.postCount} post{author.postCount === 1 ? '' : 's'}, {author.replyCount} repl{author.replyCount === 1 ? 'y' : 'ies'}
+        {author.hiddenCount > 0 ? `, ${author.hiddenCount} already hidden` : ''}
+      </span>
+      <button type="button" onClick={onBack} style={{ padding: '4px 10px', borderRadius: 8, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, fontWeight: 600, cursor: 'pointer' }}>
+        Back to members
+      </button>
+    </div>
+  );
+}
+
+// The hide/restore button shared by Commons rows and flagged answers. Restore is green, hide is
+// amber; the label differs per surface but the shape is identical.
+function HideToggleButton({
+  isHidden,
+  busy,
+  hideLabel,
+  onClick,
+}: {
+  isHidden: boolean;
+  busy: boolean;
+  hideLabel: string;
+  onClick: () => void;
+}) {
+  const colors = isHidden
+    ? { bg: 'rgba(34,197,94,0.12)', border: 'rgba(34,197,94,0.3)', color: '#22C55E' }
+    : { bg: 'rgba(245,158,11,0.12)', border: 'rgba(245,158,11,0.3)', color: '#F59E0B' };
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onClick={onClick}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8,
+        background: colors.bg,
+        border: `1px solid ${colors.border}`,
+        color: colors.color,
+        fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1,
+      }}
+    >
+      {isHidden ? <Eye size={13} /> : <EyeOff size={13} />}
+      {busy ? 'Saving…' : isHidden ? 'Put back' : hideLabel}
+    </button>
+  );
+}
+
+function FlaggedAnswerCard({
+  row,
+  busy,
+  onToggle,
+}: {
+  row: FeedFlaggedAnswerRow;
+  busy: boolean;
+  onToggle: (row: FeedFlaggedAnswerRow, nextHidden: boolean) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  const isHidden = row.moderationStatus === 'hidden';
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${isHidden ? 'rgba(245,158,11,0.35)' : t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
+        <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(239,68,68,0.12)', color: '#EF4444', border: '1px solid rgba(239,68,68,0.3)' }}>
+          <Flag size={10} style={{ verticalAlign: '-1px', marginRight: 3 }} />
+          {row.flaggedCount} flag{row.flaggedCount === 1 ? '' : 's'}
+        </span>
+        {row.notHelpfulCount > 0 ? (
+          <span style={{ fontSize: 11.5, color: t.MUTED }}>{row.notHelpfulCount} marked not helpful</span>
+        ) : null}
+        <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: `${t.ACCENT}1f`, color: t.ACCENT, border: `1px solid ${t.ACCENT}4d` }}>
+          {row.answerType === 'llm' ? 'Assistant' : 'Member'}
+        </span>
+        {isHidden ? (
+          <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
+            Hidden{row.moderationReason ? ` · ${FEED_MODERATION_REASON_LABEL[row.moderationReason]}` : ''}
+          </span>
+        ) : null}
+      </div>
+
+      <div style={{ fontSize: 12.5, color: t.MUTED, marginBottom: 6 }}>
+        Asked: {row.questionBody}
+      </div>
+      <div style={{ fontSize: 14, lineHeight: 1.6, color: t.TITLE, whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginBottom: 10 }}>
+        {row.answerBody}
+      </div>
+
+      <HideToggleButton isHidden={isHidden} busy={busy} hideLabel="Hide answer" onClick={() => onToggle(row, !isHidden)} />
+    </div>
+  );
+}
+
+function FlaggedTab({
+  flagged,
+  busyId,
+  onToggle,
+}: {
+  flagged: FeedFlaggedAnswerRow[];
+  busyId: string | null;
+  onToggle: (row: FeedFlaggedAnswerRow, nextHidden: boolean) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  if (flagged.length === 0) {
+    return (
+      <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+        No answers have been flagged.
+      </div>
+    );
+  }
+  return (
+    <>
+      <p style={{ fontSize: 12.5, color: t.MUTED, marginTop: 0, marginBottom: 12 }}>
+        Answers members flagged, most-flagged first. Until now these went nowhere — the count was
+        being collected and no screen showed it. Hiding an answer leaves the question up, so the
+        member who asked still has their question and can get a better answer.
+      </p>
+      {flagged.map((row) => (
+        <FlaggedAnswerCard key={row.answerId} row={row} busy={busyId === row.answerId} onToggle={onToggle} />
+      ))}
+    </>
+  );
+}
+
+function AuthorRow({ author, onOpen }: { author: FeedModerationAuthorSummary; onOpen: (a: FeedModerationAuthorSummary) => void }) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  const a = author;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(a)}
+      style={{ display: 'block', width: '100%', textAlign: 'left', marginBottom: 10, padding: '12px 14px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, cursor: 'pointer' }}
+    >
+      <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 4, wordBreak: 'break-all' }}>
+        {a.authorUsername ? `@${a.authorUsername}` : a.authorUserId}
+      </div>
+      <div style={{ fontSize: 12, color: t.MUTED }}>
+        {a.postCount} post{a.postCount === 1 ? '' : 's'} · {a.replyCount} repl{a.replyCount === 1 ? 'y' : 'ies'}
+        {a.hiddenCount > 0 ? ` · ${a.hiddenCount} hidden` : ''}
+        {' · first '}{new Date(a.firstPostedAtIso).toLocaleDateString()}
+        {' · last '}{new Date(a.lastPostedAtIso).toLocaleDateString()}
+      </div>
+    </button>
+  );
+}
+
+function AuthorsTab({ authors, onOpen }: { authors: FeedModerationAuthorSummary[]; onOpen: (a: FeedModerationAuthorSummary) => void }) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  if (authors.length === 0) {
+    return (
+      <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+        Nobody has posted in the Commons yet.
+      </div>
+    );
+  }
+  return (
+    <>
+      <p style={{ fontSize: 12.5, color: t.MUTED, marginTop: 0, marginBottom: 12 }}>
+        Ordered by how much each member has posted. Someone who wandered off topic once looks
+        different here from an account that has never been on topic — open a member to read
+        everything they have written before deciding.
+      </p>
+      {authors.map((a) => (
+        <AuthorRow key={a.authorUserId} author={a} onOpen={onOpen} />
+      ))}
+    </>
+  );
+}
+
+function QueueRowCard({
+  row,
+  busy,
+  onToggle,
+}: {
+  row: FeedModerationQueueRow;
+  busy: boolean;
+  onToggle: (row: FeedModerationQueueRow, nextHidden: boolean) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  const isHidden = row.moderationStatus === 'hidden';
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${isHidden ? 'rgba(245,158,11,0.35)' : t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
+        <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: `${t.ACCENT}1f`, color: t.ACCENT, border: `1px solid ${t.ACCENT}4d` }}>
+          {row.target === 'reply' ? 'Reply' : 'Post'}
+        </span>
+        {isHidden ? (
+          <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
+            {/* The reason rides on the Hidden pill, so a later pass can tell an off-topic
+                sweep apart from an abuse removal without opening the audit log. */}
+            Hidden{row.moderationReason ? ` · ${FEED_MODERATION_REASON_LABEL[row.moderationReason]}` : ''}
+          </span>
+        ) : null}
+        <span style={{ fontSize: 12, color: t.MUTED }}>
+          {row.authorUsername ? `@${row.authorUsername}` : row.authorUserId}
+          {' · '}
+          {new Date(row.createdAtIso).toLocaleString()}
+        </span>
+      </div>
+
+      <div style={{ fontSize: 14, lineHeight: 1.6, color: t.TITLE, whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginBottom: 10 }}>
+        {row.body}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <HideToggleButton isHidden={isHidden} busy={busy} hideLabel="Hide" onClick={() => onToggle(row, !isHidden)} />
+        {row.target === 'reply' && row.postId ? (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 12, color: t.MUTED }}>
+            <MessageSquare size={12} /> on post {row.postId.slice(0, 8)}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function QueueTab({
+  rows,
+  tab,
+  busyId,
+  onToggle,
+}: {
+  rows: FeedModerationQueueRow[];
+  tab: TabKey;
+  busyId: string | null;
+  onToggle: (row: FeedModerationQueueRow, nextHidden: boolean) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  if (rows.length === 0) {
+    return (
+      <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+        {tab === 'hidden' ? 'Nothing is hidden.' : 'No Commons posts yet.'}
+      </div>
+    );
+  }
+  return (
+    <>
+      {rows.map((row) => (
+        <QueueRowCard key={`${row.target}-${row.id}`} row={row} busy={busyId === row.id} onToggle={onToggle} />
+      ))}
+    </>
+  );
+}
+
 export function CommonsModerationAdminShell({
   rows: initialRows,
   hidden: initialHidden,
@@ -70,7 +442,7 @@ export function CommonsModerationAdminShell({
   const [rows, setRows] = useState(initialRows);
   const [hidden, setHidden] = useState(initialHidden);
   const [authors, setAuthors] = useState(initialAuthors);
-  const [tab, setTab] = useState<'all' | 'hidden' | 'authors' | 'flagged'>('all');
+  const [tab, setTab] = useState<TabKey>('all');
   const [flagged, setFlagged] = useState(initialFlagged);
   const [pendingFlagged, setPendingFlagged] = useState(initialPendingFlagged);
   const [focusAuthor, setFocusAuthor] = useState<FeedModerationAuthorSummary | null>(null);
@@ -82,36 +454,30 @@ export function CommonsModerationAdminShell({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
+  // Apply a queue payload to state. Only replace the roster when the response carried one — a
+  // single-author request returns an empty array by design, and overwriting with it would blank
+  // the roster you came from.
+  const applyQueueData = useCallback((data: ModerationQueuePayload) => {
+    if (Array.isArray(data.rows)) setRows(data.rows);
+    if (data.hidden) setHidden(data.hidden);
+    if (Array.isArray(data.authors) && data.authors.length > 0) setAuthors(data.authors);
+  }, []);
+
   const reload = useCallback(async (onlyHidden: boolean, authorUserId?: string | null) => {
     setError(null);
-    const query = new URLSearchParams();
-    if (onlyHidden) query.set('hidden', '1');
-    if (authorUserId) query.set('author', authorUserId);
-    const suffix = query.toString() ? `?${query.toString()}` : '';
+    const suffix = buildModerationQuerySuffix(onlyHidden, authorUserId);
     try {
       const res = await fetch(`/api/feed/admin/moderation${suffix}`, { cache: 'no-store' });
-      const data = (await res.json().catch(() => null)) as
-        | {
-          ok?: boolean;
-          rows?: FeedModerationQueueRow[];
-          hidden?: { posts: number; replies: number };
-          authors?: FeedModerationAuthorSummary[];
-          message?: string;
-        }
-        | null;
+      const data = (await res.json().catch(() => null)) as ModerationQueuePayload | null;
       if (res.ok && data?.ok && Array.isArray(data.rows)) {
-        setRows(data.rows);
-        if (data.hidden) setHidden(data.hidden);
-        // Only replace the roster when the response carried one — a single-author request returns an
-        // empty array by design, and overwriting with it would blank the roster you came from.
-        if (Array.isArray(data.authors) && data.authors.length > 0) setAuthors(data.authors);
+        applyQueueData(data);
       } else {
         setError(data?.message ?? 'Could not load the moderation queue.');
       }
     } catch {
       setError('Could not load the moderation queue.');
     }
-  }, []);
+  }, [applyQueueData]);
 
   const reloadFlagged = useCallback(async () => {
     setError(null);
@@ -131,7 +497,7 @@ export function CommonsModerationAdminShell({
     }
   }, []);
 
-  function switchTab(next: 'all' | 'hidden' | 'authors' | 'flagged') {
+  function switchTab(next: TabKey) {
     setTab(next);
     setFocusAuthor(null);
     if (next === 'flagged') void reloadFlagged();
@@ -147,25 +513,12 @@ export function CommonsModerationAdminShell({
     setError(null);
     setNotice(null);
     try {
-      const res = await fetch(`/api/feed/admin/moderation/answer/${row.answerId}`, {
-        method: 'POST',
-        headers: CSRF_HEADERS,
-        body: JSON.stringify(nextHidden ? { hidden: true, reason } : { hidden: false }),
-      });
-      const data = (await res.json().catch(() => null)) as
-        | { ok?: boolean; changed?: boolean; message?: string }
-        | null;
-      if (!res.ok || !data?.ok) {
-        setError(data?.message ?? 'Could not change that answer.');
+      const result = await postModeration(`/api/feed/admin/moderation/answer/${row.answerId}`, nextHidden, reason);
+      if (!result.ok) {
+        setError(result.message ?? 'Could not change that answer.');
         return;
       }
-      setNotice(
-        data.changed === false
-          ? 'Already in that state — nothing changed.'
-          : nextHidden
-            ? 'Answer hidden. The question stays up.'
-            : 'Answer is visible again.',
-      );
+      setNotice(moderationNotice(result.changed, nextHidden, 'Answer hidden. The question stays up.', 'Answer is visible again.'));
       await reloadFlagged();
     } catch {
       setError('Could not change that answer.');
@@ -190,25 +543,17 @@ export function CommonsModerationAdminShell({
     setError(null);
     setNotice(null);
     try {
-      const res = await fetch(`/api/feed/admin/moderation/${row.target}/${row.id}`, {
-        method: 'POST',
-        headers: CSRF_HEADERS,
-        body: JSON.stringify(nextHidden ? { hidden: true, reason } : { hidden: false }),
-      });
-      const data = (await res.json().catch(() => null)) as
-        | { ok?: boolean; changed?: boolean; moderationStatus?: string; message?: string }
-        | null;
-      if (!res.ok || !data?.ok) {
-        setError(data?.message ?? 'Could not change that post.');
+      const result = await postModeration(`/api/feed/admin/moderation/${row.target}/${row.id}`, nextHidden, reason);
+      if (!result.ok) {
+        setError(result.message ?? 'Could not change that post.');
         return;
       }
-      setNotice(
-        data.changed === false
-          ? 'Already in that state — nothing changed.'
-          : nextHidden
-            ? 'Hidden from the Commons. It is not deleted — you can put it back.'
-            : 'Back in the Commons.',
-      );
+      setNotice(moderationNotice(
+        result.changed,
+        nextHidden,
+        'Hidden from the Commons. It is not deleted — you can put it back.',
+        'Back in the Commons.',
+      ));
       await reload(tab === 'hidden', focusAuthor?.authorUserId ?? null);
     } catch {
       setError('Could not change that post.');
@@ -226,10 +571,7 @@ export function CommonsModerationAdminShell({
         actions={<PluginUserShellButton href="/" accent={t.ACCENT} label="Commons" />}
       />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 16 }}>
-          <StatBlock label="Hidden posts" value={hidden.posts} accent={hidden.posts > 0 ? '#F59E0B' : undefined} />
-          <StatBlock label="Hidden replies" value={hidden.replies} accent={hidden.replies > 0 ? '#F59E0B' : undefined} />
-        </div>
+        <HiddenStats hidden={hidden} />
 
         <p style={{ fontSize: 13, lineHeight: 1.6, color: t.MUTED, marginTop: 0, marginBottom: 16 }}>
           Hiding takes a post out of the Commons for everyone. It is <strong>not</strong> deletion — the
@@ -237,55 +579,11 @@ export function CommonsModerationAdminShell({
           should be able to rewrite a member&apos;s post and leave their name on it.
         </p>
 
-        <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
-          <button type="button" onClick={() => switchTab('all')} aria-pressed={tab === 'all' && !focusAuthor} style={tabStyle(t, tab === 'all' && !focusAuthor)}>
-            Recent
-          </button>
-          <button type="button" onClick={() => switchTab('hidden')} aria-pressed={tab === 'hidden'} style={tabStyle(t, tab === 'hidden')}>
-            Hidden only
-          </button>
-          <button type="button" onClick={() => switchTab('authors')} aria-pressed={tab === 'authors'} style={tabStyle(t, tab === 'authors')}>
-            By member
-          </button>
-          <button type="button" onClick={() => switchTab('flagged')} aria-pressed={tab === 'flagged'} style={tabStyle(t, tab === 'flagged')}>
-            Flagged answers{pendingFlagged > 0 ? ` (${pendingFlagged})` : ''}
-          </button>
-        </div>
+        <ModerationTabs tab={tab} focusAuthor={focusAuthor} pendingFlagged={pendingFlagged} onSwitch={switchTab} />
 
-        {/* The reason applied to the next hide. One picker for the whole list rather than one per row:
-            a sweep of off-topic posts is the same judgement repeated, and asking for it on every card
-            would be twenty identical clicks. Restoring ignores this. */}
-        {tab !== 'authors' ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
-            <label htmlFor="ctf-moderation-reason" style={{ fontSize: 12.5, color: t.MUTED }}>
-              Hide reason
-            </label>
-            <select
-              id="ctf-moderation-reason"
-              value={reason}
-              onChange={(e) => setReason(e.target.value as FeedModerationReason)}
-              style={{ padding: '6px 10px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13 }}
-            >
-              {FEED_MODERATION_REASONS.map((code) => (
-                <option key={code} value={code}>{FEED_MODERATION_REASON_LABEL[code]}</option>
-              ))}
-            </select>
-          </div>
-        ) : null}
+        {tab !== 'authors' ? <ReasonPicker reason={reason} onChange={setReason} /> : null}
 
-        {focusAuthor ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 16, padding: '10px 14px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-            <span style={{ fontSize: 13, color: t.TITLE }}>
-              Everything from {focusAuthor.authorUsername ? `@${focusAuthor.authorUsername}` : focusAuthor.authorUserId}
-              {' — '}
-              {focusAuthor.postCount} post{focusAuthor.postCount === 1 ? '' : 's'}, {focusAuthor.replyCount} repl{focusAuthor.replyCount === 1 ? 'y' : 'ies'}
-              {focusAuthor.hiddenCount > 0 ? `, ${focusAuthor.hiddenCount} already hidden` : ''}
-            </span>
-            <button type="button" onClick={() => switchTab('authors')} style={{ padding: '4px 10px', borderRadius: 8, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, fontWeight: 600, cursor: 'pointer' }}>
-              Back to members
-            </button>
-          </div>
-        ) : null}
+        {focusAuthor ? <FocusAuthorHeader author={focusAuthor} onBack={() => switchTab('authors')} /> : null}
 
         {error ? (
           <div role="alert" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>{error}</div>
@@ -295,156 +593,11 @@ export function CommonsModerationAdminShell({
         ) : null}
 
         {tab === 'flagged' ? (
-          flagged.length === 0 ? (
-            <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              No answers have been flagged.
-            </div>
-          ) : (
-            <>
-              <p style={{ fontSize: 12.5, color: t.MUTED, marginTop: 0, marginBottom: 12 }}>
-                Answers members flagged, most-flagged first. Until now these went nowhere — the count was
-                being collected and no screen showed it. Hiding an answer leaves the question up, so the
-                member who asked still has their question and can get a better answer.
-              </p>
-              {flagged.map((row) => {
-                const isHidden = row.moderationStatus === 'hidden';
-                const busy = busyId === row.answerId;
-                return (
-                  <div key={row.answerId} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${isHidden ? 'rgba(245,158,11,0.35)' : t.BORDER_SOLID}` }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
-                      <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(239,68,68,0.12)', color: '#EF4444', border: '1px solid rgba(239,68,68,0.3)' }}>
-                        <Flag size={10} style={{ verticalAlign: '-1px', marginRight: 3 }} />
-                        {row.flaggedCount} flag{row.flaggedCount === 1 ? '' : 's'}
-                      </span>
-                      {row.notHelpfulCount > 0 ? (
-                        <span style={{ fontSize: 11.5, color: t.MUTED }}>{row.notHelpfulCount} marked not helpful</span>
-                      ) : null}
-                      <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: `${t.ACCENT}1f`, color: t.ACCENT, border: `1px solid ${t.ACCENT}4d` }}>
-                        {row.answerType === 'llm' ? 'Assistant' : 'Member'}
-                      </span>
-                      {isHidden ? (
-                        <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
-                          Hidden{row.moderationReason ? ` · ${FEED_MODERATION_REASON_LABEL[row.moderationReason]}` : ''}
-                        </span>
-                      ) : null}
-                    </div>
-
-                    <div style={{ fontSize: 12.5, color: t.MUTED, marginBottom: 6 }}>
-                      Asked: {row.questionBody}
-                    </div>
-                    <div style={{ fontSize: 14, lineHeight: 1.6, color: t.TITLE, whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginBottom: 10 }}>
-                      {row.answerBody}
-                    </div>
-
-                    <button
-                      type="button"
-                      disabled={busy}
-                      onClick={() => void setAnswerHidden(row, !isHidden)}
-                      style={{
-                        display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8,
-                        background: isHidden ? 'rgba(34,197,94,0.12)' : 'rgba(245,158,11,0.12)',
-                        border: `1px solid ${isHidden ? 'rgba(34,197,94,0.3)' : 'rgba(245,158,11,0.3)'}`,
-                        color: isHidden ? '#22C55E' : '#F59E0B',
-                        fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1,
-                      }}
-                    >
-                      {isHidden ? <Eye size={13} /> : <EyeOff size={13} />}
-                      {busy ? 'Saving…' : isHidden ? 'Put back' : 'Hide answer'}
-                    </button>
-                  </div>
-                );
-              })}
-            </>
-          )
+          <FlaggedTab flagged={flagged} busyId={busyId} onToggle={setAnswerHidden} />
         ) : tab === 'authors' ? (
-          authors.length === 0 ? (
-            <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              Nobody has posted in the Commons yet.
-            </div>
-          ) : (
-            <>
-              <p style={{ fontSize: 12.5, color: t.MUTED, marginTop: 0, marginBottom: 12 }}>
-                Ordered by how much each member has posted. Someone who wandered off topic once looks
-                different here from an account that has never been on topic — open a member to read
-                everything they have written before deciding.
-              </p>
-              {authors.map((a) => (
-                <button
-                  key={a.authorUserId}
-                  type="button"
-                  onClick={() => openAuthor(a)}
-                  style={{ display: 'block', width: '100%', textAlign: 'left', marginBottom: 10, padding: '12px 14px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, cursor: 'pointer' }}
-                >
-                  <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 4, wordBreak: 'break-all' }}>
-                    {a.authorUsername ? `@${a.authorUsername}` : a.authorUserId}
-                  </div>
-                  <div style={{ fontSize: 12, color: t.MUTED }}>
-                    {a.postCount} post{a.postCount === 1 ? '' : 's'} · {a.replyCount} repl{a.replyCount === 1 ? 'y' : 'ies'}
-                    {a.hiddenCount > 0 ? ` · ${a.hiddenCount} hidden` : ''}
-                    {' · first '}{new Date(a.firstPostedAtIso).toLocaleDateString()}
-                    {' · last '}{new Date(a.lastPostedAtIso).toLocaleDateString()}
-                  </div>
-                </button>
-              ))}
-            </>
-          )
-        ) : rows.length === 0 ? (
-          <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-            {tab === 'hidden' ? 'Nothing is hidden.' : 'No Commons posts yet.'}
-          </div>
+          <AuthorsTab authors={authors} onOpen={openAuthor} />
         ) : (
-          rows.map((row) => {
-            const isHidden = row.moderationStatus === 'hidden';
-            const busy = busyId === row.id;
-            return (
-              <div key={`${row.target}-${row.id}`} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${isHidden ? 'rgba(245,158,11,0.35)' : t.BORDER_SOLID}` }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
-                  <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: `${t.ACCENT}1f`, color: t.ACCENT, border: `1px solid ${t.ACCENT}4d` }}>
-                    {row.target === 'reply' ? 'Reply' : 'Post'}
-                  </span>
-                  {isHidden ? (
-                    <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
-                      {/* The reason rides on the Hidden pill, so a later pass can tell an off-topic
-                          sweep apart from an abuse removal without opening the audit log. */}
-                      Hidden{row.moderationReason ? ` · ${FEED_MODERATION_REASON_LABEL[row.moderationReason]}` : ''}
-                    </span>
-                  ) : null}
-                  <span style={{ fontSize: 12, color: t.MUTED }}>
-                    {row.authorUsername ? `@${row.authorUsername}` : row.authorUserId}
-                    {' · '}
-                    {new Date(row.createdAtIso).toLocaleString()}
-                  </span>
-                </div>
-
-                <div style={{ fontSize: 14, lineHeight: 1.6, color: t.TITLE, whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginBottom: 10 }}>
-                  {row.body}
-                </div>
-
-                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                  <button
-                    type="button"
-                    disabled={busy}
-                    onClick={() => void setHiddenState(row, !isHidden)}
-                    style={{
-                      display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8,
-                      background: isHidden ? 'rgba(34,197,94,0.12)' : 'rgba(245,158,11,0.12)',
-                      border: `1px solid ${isHidden ? 'rgba(34,197,94,0.3)' : 'rgba(245,158,11,0.3)'}`,
-                      color: isHidden ? '#22C55E' : '#F59E0B',
-                      fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1,
-                    }}
-                  >
-                    {isHidden ? <Eye size={13} /> : <EyeOff size={13} />}
-                    {busy ? 'Saving…' : isHidden ? 'Put back' : 'Hide'}
-                  </button>
-                  {row.target === 'reply' && row.postId ? (
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 12, color: t.MUTED }}>
-                      <MessageSquare size={12} /> on post {row.postId.slice(0, 8)}
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-            );
-          })
+          <QueueTab rows={rows} tab={tab} busyId={busyId} onToggle={setHiddenState} />
         )}
       </div>
     </div>

--- a/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
+++ b/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
@@ -65,6 +65,171 @@ async function adminMutate(url: string, method: 'POST' | 'PUT', body?: unknown):
   }
 }
 
+// One action button in an announcement row (Edit / Publish / Archive). The busy-dependent cursor and
+// opacity live here so the row itself does not repeat them per button.
+function ActionButton({
+  busy,
+  onClick,
+  icon,
+  label,
+  bg,
+  border,
+  color,
+}: {
+  busy: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  bg: string;
+  border: string;
+  color: string;
+}) {
+  return (
+    <button type="button" disabled={busy} onClick={onClick} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: bg, border: `1px solid ${border}`, color, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
+      {icon} {label}
+    </button>
+  );
+}
+
+// The optional "link up to N plugins" picker inside the create/edit form. Best-effort options come
+// from the parent; the server re-validates the chosen slug on submit.
+function LinkedPluginsPicker({
+  linkedPluginSlugs,
+  pluginOptions,
+  max,
+  nameForSlug,
+  onAdd,
+  onRemove,
+}: {
+  linkedPluginSlugs: string[];
+  pluginOptions: PluginOption[];
+  max: number;
+  nameForSlug: (slug: string) => string;
+  onAdd: (slug: string) => void;
+  onRemove: (slug: string) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: t.MUTED }}>
+        <Link2 size={14} /> Link plugins (optional, up to {max})
+      </span>
+      {linkedPluginSlugs.length > 0 ? (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {linkedPluginSlugs.map((slug) => (
+            <span key={slug} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 6px 4px 10px', borderRadius: 999, background: `${t.ACCENT}1f`, border: `1px solid ${t.ACCENT}4d`, color: t.ACCENT, fontSize: 13, fontWeight: 600 }}>
+              {nameForSlug(slug)}
+              <button type="button" aria-label={`Remove ${nameForSlug(slug)}`} onClick={() => onRemove(slug)} style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 18, height: 18, borderRadius: 999, background: 'transparent', border: 'none', color: t.ACCENT, cursor: 'pointer', padding: 0 }}>
+                <X size={13} />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {linkedPluginSlugs.length < max ? (
+        <select
+          value=""
+          onChange={(e) => { onAdd(e.target.value); e.currentTarget.value = ''; }}
+          style={{ ...fieldStyle(t) }}
+        >
+          <option value="">{linkedPluginSlugs.length === 0 ? 'No linked plugin' : 'Add another plugin…'}</option>
+          {pluginOptions.filter((p) => !linkedPluginSlugs.includes(p.slug)).map((p) => (
+            <option key={p.slug} value={p.slug}>{p.name}</option>
+          ))}
+        </select>
+      ) : (
+        <span style={{ fontSize: 12, color: t.MUTED }}>Maximum of {max} linked plugins reached.</span>
+      )}
+      {linkedPluginSlugs.length > 0 ? (
+        <span style={{ fontSize: 12, color: t.MUTED }}>Readers will see an “Open {nameForSlug(linkedPluginSlugs[0])}” link{linkedPluginSlugs.length > 1 ? ` and ${linkedPluginSlugs.length - 1} more` : ''}.</span>
+      ) : null}
+    </div>
+  );
+}
+
+// The submit / cancel row for the create/edit form.
+function AnnouncementFormActions({
+  busy,
+  editingId,
+  onSubmit,
+  onCancel,
+}: {
+  busy: boolean;
+  editingId: string | null;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      <button type="button" disabled={busy} onClick={onSubmit} style={{ padding: '10px 16px', borderRadius: 10, background: busy ? `${t.ACCENT}66` : t.ACCENT, border: 'none', color: '#fff', fontSize: 14, fontWeight: 800, cursor: busy ? 'not-allowed' : 'pointer' }}>
+        {busy ? 'Working…' : editingId ? 'Save changes' : 'Create draft'}
+      </button>
+      {editingId ? (
+        <button type="button" disabled={busy} onClick={onCancel} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '10px 16px', borderRadius: 10, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 14, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer' }}>
+          <X size={14} /> Cancel
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+// One announcement row in the list, with its status pill, linked-plugin links, and status-driven
+// actions.
+function AnnouncementCard({
+  a,
+  busy,
+  nameForSlug,
+  onEdit,
+  onPublish,
+  onArchive,
+}: {
+  a: Announcement;
+  busy: boolean;
+  nameForSlug: (slug: string) => string;
+  onEdit: (a: Announcement) => void;
+  onPublish: (a: Announcement) => void;
+  onArchive: (a: Announcement) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getFeedAnnouncementsTokens(theme);
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 14, fontWeight: 600, flex: 1 }}>{a.title}</span>
+        <Pill label={a.status} color={STATUS_COLOR[a.status] ?? t.MUTED} />
+      </div>
+      <div style={{ fontSize: 12, color: t.MUTED, marginBottom: a.linkedPluginSlugs.length > 0 ? 6 : (a.status === 'archived' ? 0 : 8) }}>{a.body}</div>
+      {a.linkedPluginSlugs.length > 0 ? (
+        <div style={{ display: 'inline-flex', flexWrap: 'wrap', alignItems: 'center', gap: 5, fontSize: 12, color: t.ACCENT, marginBottom: a.status === 'archived' ? 0 : 8 }}>
+          <Link2 size={12} /> Links to{' '}
+          {a.linkedPluginSlugs.map((slug, index) => (
+            <span key={slug}>
+              <a href={`/apps/${slug}`} style={{ color: t.ACCENT, textDecoration: 'underline' }}>
+                {nameForSlug(slug)}
+              </a>
+              {index < a.linkedPluginSlugs.length - 1 ? ', ' : ''}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        {a.status === 'draft' ? (
+          <ActionButton busy={busy} onClick={() => onEdit(a)} icon={<Pencil size={13} />} label="Edit" bg={`${t.ACCENT}1f`} border={`${t.ACCENT}4d`} color={t.ACCENT} />
+        ) : null}
+        {a.status === 'draft' ? (
+          <ActionButton busy={busy} onClick={() => onPublish(a)} icon={<Send size={13} />} label="Publish" bg="rgba(34,197,94,0.12)" border="rgba(34,197,94,0.3)" color="#22C55E" />
+        ) : null}
+        {a.status === 'published' ? (
+          <ActionButton busy={busy} onClick={() => onArchive(a)} icon={<Archive size={13} />} label="Archive" bg="rgba(107,114,128,0.12)" border="rgba(107,114,128,0.3)" color="#9CA3AF" />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function FeedAnnouncementsAdminShell({
   config,
   announcements,
@@ -214,93 +379,30 @@ export function FeedAnnouncementsAdminShell({
           {/* Optional: link up to 3 plugins. Each linked plugin adds an "Open <Plugin>" link to the
               published announcement so a reader can jump straight to that app. More than 3 is
               information overload, so the picker stops at 3 (the server enforces the same cap). */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 }}>
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: t.MUTED }}>
-              <Link2 size={14} /> Link plugins (optional, up to {MAX_LINKED_PLUGINS})
-            </span>
-            {draft.linkedPluginSlugs.length > 0 ? (
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                {draft.linkedPluginSlugs.map((slug) => (
-                  <span key={slug} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 6px 4px 10px', borderRadius: 999, background: `${t.ACCENT}1f`, border: `1px solid ${t.ACCENT}4d`, color: t.ACCENT, fontSize: 13, fontWeight: 600 }}>
-                    {nameForSlug(slug)}
-                    <button type="button" aria-label={`Remove ${nameForSlug(slug)}`} onClick={() => removeLinkedPlugin(slug)} style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 18, height: 18, borderRadius: 999, background: 'transparent', border: 'none', color: t.ACCENT, cursor: 'pointer', padding: 0 }}>
-                      <X size={13} />
-                    </button>
-                  </span>
-                ))}
-              </div>
-            ) : null}
-            {draft.linkedPluginSlugs.length < MAX_LINKED_PLUGINS ? (
-              <select
-                value=""
-                onChange={(e) => { addLinkedPlugin(e.target.value); e.currentTarget.value = ''; }}
-                style={{ ...fieldStyle(t) }}
-              >
-                <option value="">{draft.linkedPluginSlugs.length === 0 ? 'No linked plugin' : 'Add another plugin…'}</option>
-                {pluginOptions.filter((p) => !draft.linkedPluginSlugs.includes(p.slug)).map((p) => (
-                  <option key={p.slug} value={p.slug}>{p.name}</option>
-                ))}
-              </select>
-            ) : (
-              <span style={{ fontSize: 12, color: t.MUTED }}>Maximum of {MAX_LINKED_PLUGINS} linked plugins reached.</span>
-            )}
-            {draft.linkedPluginSlugs.length > 0 ? (
-              <span style={{ fontSize: 12, color: t.MUTED }}>Readers will see an “Open {nameForSlug(draft.linkedPluginSlugs[0])}” link{draft.linkedPluginSlugs.length > 1 ? ` and ${draft.linkedPluginSlugs.length - 1} more` : ''}.</span>
-            ) : null}
-          </div>
-          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-            <button type="button" disabled={busy} onClick={() => void submitDraft()} style={{ padding: '10px 16px', borderRadius: 10, background: busy ? `${t.ACCENT}66` : t.ACCENT, border: 'none', color: '#fff', fontSize: 14, fontWeight: 800, cursor: busy ? 'not-allowed' : 'pointer' }}>
-              {busy ? 'Working…' : editingId ? 'Save changes' : 'Create draft'}
-            </button>
-            {editingId ? (
-              <button type="button" disabled={busy} onClick={cancelEdit} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '10px 16px', borderRadius: 10, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 14, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer' }}>
-                <X size={14} /> Cancel
-              </button>
-            ) : null}
-          </div>
+          <LinkedPluginsPicker
+            linkedPluginSlugs={draft.linkedPluginSlugs}
+            pluginOptions={pluginOptions}
+            max={MAX_LINKED_PLUGINS}
+            nameForSlug={nameForSlug}
+            onAdd={addLinkedPlugin}
+            onRemove={removeLinkedPlugin}
+          />
+          <AnnouncementFormActions busy={busy} editingId={editingId} onSubmit={() => void submitDraft()} onCancel={cancelEdit} />
         </div>
 
         {announcements.length === 0 ? (
           <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>No announcements yet.</div>
         ) : (
           announcements.map((a) => (
-            <div key={a.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4, flexWrap: 'wrap' }}>
-                <span style={{ fontSize: 14, fontWeight: 600, flex: 1 }}>{a.title}</span>
-                <Pill label={a.status} color={STATUS_COLOR[a.status] ?? t.MUTED} />
-              </div>
-              <div style={{ fontSize: 12, color: t.MUTED, marginBottom: a.linkedPluginSlugs.length > 0 ? 6 : (a.status === 'archived' ? 0 : 8) }}>{a.body}</div>
-              {a.linkedPluginSlugs.length > 0 ? (
-                <div style={{ display: 'inline-flex', flexWrap: 'wrap', alignItems: 'center', gap: 5, fontSize: 12, color: t.ACCENT, marginBottom: a.status === 'archived' ? 0 : 8 }}>
-                  <Link2 size={12} /> Links to{' '}
-                  {a.linkedPluginSlugs.map((slug, index) => (
-                    <span key={slug}>
-                      <a href={`/apps/${slug}`} style={{ color: t.ACCENT, textDecoration: 'underline' }}>
-                        {nameForSlug(slug)}
-                      </a>
-                      {index < a.linkedPluginSlugs.length - 1 ? ', ' : ''}
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                {a.status === 'draft' ? (
-                  <button type="button" disabled={busy} onClick={() => startEdit(a)} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: `${t.ACCENT}1f`, border: `1px solid ${t.ACCENT}4d`, color: t.ACCENT, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <Pencil size={13} /> Edit
-                  </button>
-                ) : null}
-                {a.status === 'draft' ? (
-                  <button type="button" disabled={busy} onClick={() => void act(() => adminMutate(`/api/feed/admin/announcements/${a.id}/publish`, 'POST', {}), 'Published.')} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <Send size={13} /> Publish
-                  </button>
-                ) : null}
-                {a.status === 'published' ? (
-                  <button type="button" disabled={busy} onClick={() => void act(() => adminMutate(`/api/feed/admin/announcements/${a.id}/archive`, 'POST', {}), 'Archived.')} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8, background: 'rgba(107,114,128,0.12)', border: '1px solid rgba(107,114,128,0.3)', color: '#9CA3AF', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}>
-                    <Archive size={13} /> Archive
-                  </button>
-                ) : null}
-              </div>
-            </div>
+            <AnnouncementCard
+              key={a.id}
+              a={a}
+              busy={busy}
+              nameForSlug={nameForSlug}
+              onEdit={startEdit}
+              onPublish={(item) => void act(() => adminMutate(`/api/feed/admin/announcements/${item.id}/publish`, 'POST', {}), 'Published.')}
+              onArchive={(item) => void act(() => adminMutate(`/api/feed/admin/announcements/${item.id}/archive`, 'POST', {}), 'Archived.')}
+            />
           ))
         )}
       </div>

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -65,6 +65,51 @@ function deriveIsEstimate(rawMetrics: unknown): boolean {
   );
 }
 
+// True only when the caller passed a signal that has already been aborted. Pulled out so each
+// abort guard stays a single decision point instead of repeating the optional-chain check.
+function isAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
+type ParsedGdpReport = {
+  report: GdpReportPayload | null;
+  isEstimate: boolean;
+  metricRows: GdpMetricRow[];
+};
+
+// Read the report, the estimate flag, and the raw metric rows out of the /api/gdp/report/current
+// payload in one place, so fetchReport just stores the result.
+function parseGdpReportResponse(data: { report?: GdpReportPayload | null }): ParsedGdpReport {
+  const report = data.report ?? null;
+  return {
+    report,
+    isEstimate: deriveIsEstimate(data.report?.metrics),
+    metricRows: Array.isArray(data.report?.metrics) ? data.report.metrics : [],
+  };
+}
+
+// Shape the /api/gdp/countries payload into the panel's rows. Reconciles the located countries with
+// the "Location not set" bucket so their shares are a % of the same member roster the hero shows.
+function buildGdpCountries(data: {
+  countries?: Array<{ country: string; members: number }>;
+  unspecified?: number;
+  totalMembers?: number;
+}): GdpCountry[] {
+  const rows = data.countries ?? [];
+  const located = rows.reduce((sum, r) => sum + r.members, 0);
+  // total is the full member roster; shares are a % of it, so the located countries plus the
+  // "Location not set" bucket reconcile to the same member count the hero shows.
+  const total = data.totalMembers ?? located;
+  // The route owns this bucket (it already floors it at 0 and omits it when the roster read
+  // fails), so read it as sent rather than deriving a second copy here from total - located.
+  const unspecified = data.unspecified ?? 0;
+  const mapped: GdpCountry[] = rows.map((r) => ({ country: r.country, members: r.members, share: total > 0 ? (r.members / total) * 100 : 0 }));
+  if (unspecified > 0) {
+    mapped.push({ country: "Location not set", members: unspecified, share: total > 0 ? (unspecified / total) * 100 : 0, unspecified: true });
+  }
+  return mapped;
+}
+
 export default function GdpShell() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -87,15 +132,16 @@ export default function GdpShell() {
       const res = await fetch("/api/gdp/report/current", { signal });
       if (!res.ok) throw new Error("Failed to load GDP report");
       const data = (await res.json()) as { report?: GdpReportPayload | null };
-      if (signal?.aborted) return;
-      setReport(data.report ?? null);
-      setIsEstimate(deriveIsEstimate(data.report?.metrics));
-      setMetricRows(Array.isArray(data.report?.metrics) ? data.report.metrics : []);
+      if (isAborted(signal)) return;
+      const parsed = parseGdpReportResponse(data);
+      setReport(parsed.report);
+      setIsEstimate(parsed.isEstimate);
+      setMetricRows(parsed.metricRows);
     } catch (e: unknown) {
-      if (signal?.aborted) return;
+      if (isAborted(signal)) return;
       setError(e instanceof Error ? e.message : "Failed to load GDP data.");
     } finally {
-      if (initial && !signal?.aborted) setLoading(false);
+      if (initial && !isAborted(signal)) setLoading(false);
     }
   }, []);
 
@@ -104,22 +150,10 @@ export default function GdpShell() {
   const fetchCountries = useCallback(async (signal?: AbortSignal) => {
     try {
       const res = await fetch("/api/gdp/countries", { signal });
-      if (!res.ok || signal?.aborted) return;
+      if (!res.ok || isAborted(signal)) return;
       const data = (await res.json()) as { countries?: Array<{ country: string; members: number }>; unspecified?: number; totalMembers?: number };
-      const rows = data.countries ?? [];
-      const located = rows.reduce((sum, r) => sum + r.members, 0);
-      // total is the full member roster; shares are a % of it, so the located countries plus the
-      // "Location not set" bucket reconcile to the same member count the hero shows.
-      const total = data.totalMembers ?? located;
-      // The route owns this bucket (it already floors it at 0 and omits it when the roster read
-      // fails), so read it as sent rather than deriving a second copy here from total - located.
-      const unspecified = data.unspecified ?? 0;
-      if (signal?.aborted) return;
-      const mapped: GdpCountry[] = rows.map((r) => ({ country: r.country, members: r.members, share: total > 0 ? (r.members / total) * 100 : 0 }));
-      if (unspecified > 0) {
-        mapped.push({ country: "Location not set", members: unspecified, share: total > 0 ? (unspecified / total) * 100 : 0, unspecified: true });
-      }
-      setCountries(mapped);
+      if (isAborted(signal)) return;
+      setCountries(buildGdpCountries(data));
     } catch {
       // Leave the panel empty.
     }

--- a/ctf/packages/web/components/level-up/lu-achievements.tsx
+++ b/ctf/packages/web/components/level-up/lu-achievements.tsx
@@ -69,6 +69,21 @@ function EmptyAchievements() {
   );
 }
 
+function BadgeFooter({ achievement }: { achievement: Achievement }) {
+  const { theme } = useTheme();
+  const t = getLevelUpTokens(theme);
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {achievement.creditReward > 0 ? (
+        <span style={{ fontSize: 11, color: achievement.earned ? t.ACCENT : t.TEXT_SUBTLE, fontWeight: 600 }}>+{achievement.creditReward} SC</span>
+      ) : <span />}
+      {achievement.earned && achievement.earnedAtIso && (
+        <span style={{ fontSize: 10, color: t.FAINT }}>{formatDate(achievement.earnedAtIso)}</span>
+      )}
+    </div>
+  );
+}
+
 function BadgeTile({ achievement }: { achievement: Achievement }) {
   const { theme } = useTheme();
   const t = getLevelUpTokens(theme);
@@ -86,14 +101,7 @@ function BadgeTile({ achievement }: { achievement: Achievement }) {
       {achievement.description && (
         <div style={{ fontSize: 11, color: t.TEXT_SUBTLE, lineHeight: 1.5, marginBottom: 8 }}>{achievement.description}</div>
       )}
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        {achievement.creditReward > 0 ? (
-          <span style={{ fontSize: 11, color: achievement.earned ? t.ACCENT : t.TEXT_SUBTLE, fontWeight: 600 }}>+{achievement.creditReward} SC</span>
-        ) : <span />}
-        {achievement.earned && achievement.earnedAtIso && (
-          <span style={{ fontSize: 10, color: t.FAINT }}>{formatDate(achievement.earnedAtIso)}</span>
-        )}
-      </div>
+      <BadgeFooter achievement={achievement} />
     </div>
   );
 }

--- a/ctf/packages/web/components/level-up/lu-admin-shell.tsx
+++ b/ctf/packages/web/components/level-up/lu-admin-shell.tsx
@@ -68,19 +68,461 @@ function formatQueueTime(iso: string): string {
   return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 }
 
-export function LevelUpAdminShell({
-  kpis,
-  openDisputes,
-  pendingValidations,
-  pendingProposals,
+const alertBoxStyle: React.CSSProperties = { marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 };
+const noticeBoxStyle: React.CSSProperties = { marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13 };
+
+function DisputesSection({ openDisputes, t }: { openDisputes: AdminDispute[]; t: LevelUpTokens }) {
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 12 }}>
+        Open disputes {openDisputes.length > 0 ? `(${openDisputes.length})` : ''}
+      </h2>
+      {openDisputes.length === 0 ? (
+        <div style={{ padding: '20px 16px', textAlign: 'center', color: t.MUTED, fontSize: 13, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+          No open disputes.
+        </div>
+      ) : (
+        openDisputes.map((dispute) => (
+          <div key={dispute.id} style={{ marginBottom: 10, padding: '12px 14px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{dispute.title}</span>
+              <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>{formatQueueTime(dispute.createdAtIso)}</span>
+            </div>
+            <p style={{ fontSize: 13, color: '#D1D5DB', margin: '6px 0 0', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>{dispute.description}</p>
+            <div style={{ fontSize: 12, color: t.MUTED, marginTop: 6 }}>
+              Opened by {dispute.openedByName ?? `member ${dispute.openedByUserId.slice(0, 6)}`}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function ValidationsSection({ pendingValidations, t }: { pendingValidations: AdminValidation[]; t: LevelUpTokens }) {
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 12 }}>
+        Pending milestone validations {pendingValidations.length > 0 ? `(${pendingValidations.length})` : ''}
+      </h2>
+      {pendingValidations.length === 0 ? (
+        <div style={{ padding: '20px 16px', textAlign: 'center', color: t.MUTED, fontSize: 13, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+          No pending validations.
+        </div>
+      ) : (
+        pendingValidations.map((validation) => (
+          <div key={validation.id} style={{ marginBottom: 10, padding: '12px 14px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 13, fontWeight: 700, color: t.TITLE }}>Milestone {validation.milestoneId.slice(0, 8)}</span>
+              <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>{formatQueueTime(validation.createdAtIso)}</span>
+            </div>
+            {validation.validationNote ? (
+              <p style={{ fontSize: 13, color: '#D1D5DB', margin: '6px 0 0', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>{validation.validationNote}</p>
+            ) : null}
+            <div style={{ fontSize: 12, color: t.MUTED, marginTop: 6 }}>Enrollment {validation.enrollmentId.slice(0, 8)}</div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function ProposalCard({
+  proposal,
+  proposalTerms,
+  setProposalTerms,
+  busyProposalId,
+  onApprove,
+  onDismiss,
+  t,
 }: {
-  kpis: AdminKpis;
-  openDisputes: AdminDispute[];
-  pendingValidations: AdminValidation[];
-  pendingProposals: AdminProposal[];
+  proposal: AdminProposal;
+  proposalTerms: Record<string, ProposalTermMonths>;
+  setProposalTerms: React.Dispatch<React.SetStateAction<Record<string, ProposalTermMonths>>>;
+  busyProposalId: string | null;
+  onApprove: (proposal: AdminProposal) => void;
+  onDismiss: (proposal: AdminProposal) => void;
+  t: LevelUpTokens;
 }) {
-  const { theme } = useTheme();
-  const t = getLevelUpTokens(theme);
+  const term = proposalTerms[proposal.id] ?? 3;
+  const busy = busyProposalId === proposal.id;
+  return (
+    <div style={{ marginBottom: 10, padding: '12px 14px', borderRadius: 10, background: t.BG, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>#{proposal.rank} · {proposal.occupation}</span>
+        <Pill>{proposal.sector}</Pill>
+        <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>gap {Math.round(proposal.gap)}</span>
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginTop: 10 }}>
+        <label style={{ fontSize: 12, color: t.MUTED }}>
+          Term:{' '}
+          <select
+            value={term}
+            disabled={busy}
+            onChange={(event) => setProposalTerms((prev) => ({ ...prev, [proposal.id]: Number(event.target.value) as ProposalTermMonths }))}
+            style={{ borderRadius: 6, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, padding: '5px 8px', fontSize: 12 }}
+          >
+            {PROPOSAL_TERM_MONTHS.map((months) => (
+              <option key={months} value={months}>{months} month{months === 1 ? '' : 's'}</option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={() => onApprove(proposal)}
+          disabled={busy}
+          style={{ marginLeft: 'auto', padding: '7px 14px', borderRadius: 7, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 12, fontWeight: 700, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+        >
+          {busy ? 'Working…' : 'Approve & open'}
+        </button>
+        <button
+          type="button"
+          onClick={() => onDismiss(proposal)}
+          disabled={busy}
+          style={{ padding: '7px 14px', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ProposalsSection({
+  proposals,
+  proposalTerms,
+  setProposalTerms,
+  busyProposalId,
+  autoRunning,
+  autoError,
+  autoNotice,
+  proposalError,
+  proposalNotice,
+  onRefresh,
+  onApprove,
+  onDismiss,
+  t,
+}: {
+  proposals: AdminProposal[];
+  proposalTerms: Record<string, ProposalTermMonths>;
+  setProposalTerms: React.Dispatch<React.SetStateAction<Record<string, ProposalTermMonths>>>;
+  busyProposalId: string | null;
+  autoRunning: boolean;
+  autoError: string | null;
+  autoNotice: string | null;
+  proposalError: string | null;
+  proposalNotice: string | null;
+  onRefresh: () => void;
+  onApprove: (proposal: AdminProposal) => void;
+  onDismiss: (proposal: AdminProposal) => void;
+  t: LevelUpTokens;
+}) {
+  return (
+    <div style={{ marginBottom: 24, padding: '16px 18px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 6 }}>
+        <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, margin: 0 }}>
+          Cohort proposals from Workforce gaps {proposals.length > 0 ? `(${proposals.length})` : ''}
+        </h2>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={autoRunning}
+          style={{ marginLeft: 'auto', padding: '8px 16px', borderRadius: 8, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: autoRunning ? 'not-allowed' : 'pointer', opacity: autoRunning ? 0.6 : 1 }}
+        >
+          {autoRunning ? 'Refreshing…' : 'Refresh proposals'}
+        </button>
+      </div>
+      <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, marginBottom: 14 }}>
+        The gaps are re-read on a cadence into a ranked, sector-diverse queue. Approve a proposal to
+        open a cohort — you choose the term — or dismiss it. Approving never opens two cohorts for the
+        same occupation; refreshing supersedes proposals whose gap has closed.
+      </p>
+      {autoError ? <div role="alert" style={alertBoxStyle}>{autoError}</div> : null}
+      {autoNotice ? <div style={noticeBoxStyle}>{autoNotice}</div> : null}
+      {proposalError ? <div role="alert" style={alertBoxStyle}>{proposalError}</div> : null}
+      {proposalNotice ? <div style={noticeBoxStyle}>{proposalNotice}</div> : null}
+      {proposals.length === 0 ? (
+        <div style={{ padding: '20px 16px', textAlign: 'center', color: t.MUTED, fontSize: 13, borderRadius: 10, background: t.BG, border: `1px solid ${t.BORDER_SOLID}` }}>
+          No pending proposals. Use “Refresh proposals” to re-read the current Workforce gaps.
+        </div>
+      ) : (
+        proposals.map((proposal) => (
+          <ProposalCard
+            key={proposal.id}
+            proposal={proposal}
+            proposalTerms={proposalTerms}
+            setProposalTerms={setProposalTerms}
+            busyProposalId={busyProposalId}
+            onApprove={onApprove}
+            onDismiss={onDismiss}
+            t={t}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function CohortsSection({ cohorts, cohortsError, t }: { cohorts: AdminCohort[] | null; cohortsError: string | null; t: LevelUpTokens }) {
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 12 }}>Cohorts</h2>
+      {cohortsError ? <div role="alert" style={alertBoxStyle}>{cohortsError}</div> : null}
+      {cohorts === null ? (
+        <div style={{ fontSize: 13, color: t.MUTED }}>Loading cohorts…</div>
+      ) : cohorts.length === 0 ? (
+        <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+          No cohorts yet. Trainers create cohorts from the plugin shell.
+        </div>
+      ) : (
+        cohorts.map((cohort) => (
+          <div key={cohort.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+              <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{cohort.title}</span>
+              <Pill>{cohort.track}</Pill>
+              <Pill>{cohort.status}</Pill>
+              {cohort.autoCreated ? <Pill>auto</Pill> : null}
+              {cohort.needsTrainer ? (
+                <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#FBBF24', border: '1px solid rgba(245,158,11,0.4)' }}>
+                  needs trainer
+                </span>
+              ) : null}
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 24px', fontSize: 12, color: t.MUTED }}>
+              <span>Seats: {cohort.seatsAvailable} of {cohort.seats} open</span>
+              <span>Required deposit: {cohort.requiredCredits} credits</span>
+              <span>Trainer split: {cohort.trainerSplitPercent}%</span>
+              <span>Completion bonus: {cohort.completionBonusCredits} credits</span>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function GrantFields({
+  targetUserId,
+  setTargetUserId,
+  amountText,
+  setAmountText,
+  reason,
+  setReason,
+  governanceTicketId,
+  setGovernanceTicketId,
+  confirming,
+  submitting,
+  t,
+}: {
+  targetUserId: string;
+  setTargetUserId: (v: string) => void;
+  amountText: string;
+  setAmountText: (v: string) => void;
+  reason: string;
+  setReason: (v: string) => void;
+  governanceTicketId: string;
+  setGovernanceTicketId: (v: string) => void;
+  confirming: boolean;
+  submitting: boolean;
+  t: LevelUpTokens;
+}) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12 }}>
+      <label style={{ display: 'block', fontSize: 12 }}>
+        <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Member user ID</span>
+        <input
+          style={inputStyle(t)}
+          value={targetUserId}
+          onChange={(event) => setTargetUserId(event.target.value)}
+          disabled={confirming || submitting}
+          placeholder="user_…"
+        />
+      </label>
+      <label style={{ display: 'block', fontSize: 12 }}>
+        <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Amount to grant (greater than zero)</span>
+        <input
+          style={inputStyle(t)}
+          value={amountText}
+          onChange={(event) => setAmountText(event.target.value)}
+          disabled={confirming || submitting}
+          inputMode="decimal"
+          min={0}
+          placeholder="e.g. 25"
+        />
+      </label>
+      <label style={{ display: 'block', fontSize: 12, gridColumn: '1 / -1' }}>
+        <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Reason</span>
+        <input
+          style={inputStyle(t)}
+          value={reason}
+          onChange={(event) => setReason(event.target.value)}
+          disabled={confirming || submitting}
+          placeholder="Why this adjustment is being made"
+        />
+      </label>
+      <label style={{ display: 'block', fontSize: 12, gridColumn: '1 / -1' }}>
+        <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Governance ticket ID</span>
+        <input
+          style={inputStyle(t)}
+          value={governanceTicketId}
+          onChange={(event) => setGovernanceTicketId(event.target.value)}
+          disabled={confirming || submitting}
+          placeholder="e.g. GOV-1234"
+        />
+      </label>
+    </div>
+  );
+}
+
+function ConfirmPanel({
+  magnitude,
+  targetUserId,
+  reason,
+  governanceTicketId,
+  submitting,
+  onSubmit,
+  onCancel,
+  t,
+}: {
+  magnitude: number;
+  targetUserId: string;
+  reason: string;
+  governanceTicketId: string;
+  submitting: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+  t: LevelUpTokens;
+}) {
+  return (
+    <div style={{ marginTop: 14, padding: '14px 16px', borderRadius: 12, background: 'rgba(245,158,11,0.1)', border: '1px solid rgba(245,158,11,0.4)' }}>
+      <p style={{ fontSize: 13, fontWeight: 600, color: '#FBBF24', marginBottom: 4 }}>
+        Confirm: this will add {magnitude} ServiceCredits to member {targetUserId.trim()}.
+      </p>
+      <p style={{ fontSize: 12, color: 'rgba(251,191,36,0.85)', marginBottom: 12 }}>
+        Reason: {reason.trim()} · Governance ticket: {governanceTicketId.trim()}
+      </p>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={submitting}
+          style={{ padding: '8px 16px', borderRadius: 8, background: '#F59E0B', border: '1px solid #F59E0B', color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: submitting ? 'not-allowed' : 'pointer', opacity: submitting ? 0.6 : 1 }}
+        >
+          {submitting ? 'Applying…' : `Yes, grant ${magnitude} credits`}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={submitting}
+          style={{ padding: '8px 16px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: submitting ? 'not-allowed' : 'pointer', opacity: submitting ? 0.6 : 1 }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ReviewButton({ submitting, formReady, onClick, t }: { submitting: boolean; formReady: boolean; onClick: () => void; t: LevelUpTokens }) {
+  const blocked = submitting || !formReady;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={blocked}
+      style={{ marginTop: 14, padding: '9px 18px', borderRadius: 8, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: blocked ? 'not-allowed' : 'pointer', opacity: blocked ? 0.6 : 1 }}
+    >
+      Review grant
+    </button>
+  );
+}
+
+function GrantForm({
+  targetUserId,
+  setTargetUserId,
+  amountText,
+  setAmountText,
+  reason,
+  setReason,
+  governanceTicketId,
+  setGovernanceTicketId,
+  confirming,
+  submitting,
+  formError,
+  notice,
+  formReady,
+  magnitude,
+  beginConfirm,
+  cancelConfirm,
+  submitAdjustment,
+  t,
+}: {
+  targetUserId: string;
+  setTargetUserId: (v: string) => void;
+  amountText: string;
+  setAmountText: (v: string) => void;
+  reason: string;
+  setReason: (v: string) => void;
+  governanceTicketId: string;
+  setGovernanceTicketId: (v: string) => void;
+  confirming: boolean;
+  submitting: boolean;
+  formError: string | null;
+  notice: string | null;
+  formReady: boolean;
+  magnitude: number;
+  beginConfirm: () => void;
+  cancelConfirm: () => void;
+  submitAdjustment: () => void;
+  t: LevelUpTokens;
+}) {
+  return (
+    <div style={{ padding: '16px 18px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 6 }}>Grant member ServiceCredits</h2>
+      <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, marginBottom: 14 }}>
+        LevelUp only ever grants ServiceCredits to a member — it never removes them. Enter an
+        amount greater than zero. Every grant is recorded against a governance ticket and is
+        written to the audit log.
+      </p>
+
+      {formError ? <div role="alert" style={alertBoxStyle}>{formError}</div> : null}
+      {notice ? <div style={noticeBoxStyle}>{notice}</div> : null}
+
+      <GrantFields
+        targetUserId={targetUserId}
+        setTargetUserId={setTargetUserId}
+        amountText={amountText}
+        setAmountText={setAmountText}
+        reason={reason}
+        setReason={setReason}
+        governanceTicketId={governanceTicketId}
+        setGovernanceTicketId={setGovernanceTicketId}
+        confirming={confirming}
+        submitting={submitting}
+        t={t}
+      />
+
+      {confirming ? (
+        <ConfirmPanel
+          magnitude={magnitude}
+          targetUserId={targetUserId}
+          reason={reason}
+          governanceTicketId={governanceTicketId}
+          submitting={submitting}
+          onSubmit={submitAdjustment}
+          onCancel={cancelConfirm}
+          t={t}
+        />
+      ) : (
+        <ReviewButton submitting={submitting} formReady={formReady} onClick={beginConfirm} t={t} />
+      )}
+    </div>
+  );
+}
+
+// All state, derived values, and mutation handlers for the admin shell. Kept as a hook so the
+// component itself stays a thin render of the extracted section components.
+function useLevelUpAdminController(pendingProposals: AdminProposal[]) {
   const [cohorts, setCohorts] = useState<AdminCohort[] | null>(null);
   const [cohortsError, setCohortsError] = useState<string | null>(null);
 
@@ -260,6 +702,88 @@ export function LevelUpAdminShell({
     [loadProposals],
   );
 
+  return {
+    cohorts,
+    cohortsError,
+    proposals,
+    proposalTerms,
+    setProposalTerms,
+    busyProposalId,
+    proposalNotice,
+    proposalError,
+    targetUserId,
+    setTargetUserId,
+    amountText,
+    setAmountText,
+    reason,
+    setReason,
+    governanceTicketId,
+    setGovernanceTicketId,
+    confirming,
+    submitting,
+    formError,
+    notice,
+    autoRunning,
+    autoNotice,
+    autoError,
+    formReady,
+    magnitude,
+    beginConfirm,
+    cancelConfirm,
+    submitAdjustment,
+    refreshProposals,
+    approveProposal,
+    dismissProposal,
+  };
+}
+
+export function LevelUpAdminShell({
+  kpis,
+  openDisputes,
+  pendingValidations,
+  pendingProposals,
+}: {
+  kpis: AdminKpis;
+  openDisputes: AdminDispute[];
+  pendingValidations: AdminValidation[];
+  pendingProposals: AdminProposal[];
+}) {
+  const { theme } = useTheme();
+  const t = getLevelUpTokens(theme);
+  const {
+    cohorts,
+    cohortsError,
+    proposals,
+    proposalTerms,
+    setProposalTerms,
+    busyProposalId,
+    proposalNotice,
+    proposalError,
+    targetUserId,
+    setTargetUserId,
+    amountText,
+    setAmountText,
+    reason,
+    setReason,
+    governanceTicketId,
+    setGovernanceTicketId,
+    confirming,
+    submitting,
+    formError,
+    notice,
+    autoRunning,
+    autoNotice,
+    autoError,
+    formReady,
+    magnitude,
+    beginConfirm,
+    cancelConfirm,
+    submitAdjustment,
+    refreshProposals,
+    approveProposal,
+    dismissProposal,
+  } = useLevelUpAdminController(pendingProposals);
+
   return (
     <div
       style={{
@@ -285,289 +809,52 @@ export function LevelUpAdminShell({
 
         {/* Review queue: open disputes. Read-only list so the admin-landing dot leads somewhere that
             shows what is new; resolving a dispute stays in the existing dispute flow. */}
-        <div style={{ marginBottom: 24 }}>
-          <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 12 }}>
-            Open disputes {openDisputes.length > 0 ? `(${openDisputes.length})` : ''}
-          </h2>
-          {openDisputes.length === 0 ? (
-            <div style={{ padding: '20px 16px', textAlign: 'center', color: t.MUTED, fontSize: 13, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              No open disputes.
-            </div>
-          ) : (
-            openDisputes.map((dispute) => (
-              <div key={dispute.id} style={{ marginBottom: 10, padding: '12px 14px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
-                  <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{dispute.title}</span>
-                  <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>{formatQueueTime(dispute.createdAtIso)}</span>
-                </div>
-                <p style={{ fontSize: 13, color: '#D1D5DB', margin: '6px 0 0', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>{dispute.description}</p>
-                <div style={{ fontSize: 12, color: t.MUTED, marginTop: 6 }}>
-                  Opened by {dispute.openedByName ?? `member ${dispute.openedByUserId.slice(0, 6)}`}
-                </div>
-              </div>
-            ))
-          )}
-        </div>
+        <DisputesSection openDisputes={openDisputes} t={t} />
 
         {/* Review queue: pending milestone validations. */}
-        <div style={{ marginBottom: 24 }}>
-          <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 12 }}>
-            Pending milestone validations {pendingValidations.length > 0 ? `(${pendingValidations.length})` : ''}
-          </h2>
-          {pendingValidations.length === 0 ? (
-            <div style={{ padding: '20px 16px', textAlign: 'center', color: t.MUTED, fontSize: 13, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              No pending validations.
-            </div>
-          ) : (
-            pendingValidations.map((validation) => (
-              <div key={validation.id} style={{ marginBottom: 10, padding: '12px 14px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
-                  <span style={{ fontSize: 13, fontWeight: 700, color: t.TITLE }}>Milestone {validation.milestoneId.slice(0, 8)}</span>
-                  <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>{formatQueueTime(validation.createdAtIso)}</span>
-                </div>
-                {validation.validationNote ? (
-                  <p style={{ fontSize: 13, color: '#D1D5DB', margin: '6px 0 0', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>{validation.validationNote}</p>
-                ) : null}
-                <div style={{ fontSize: 12, color: t.MUTED, marginTop: 6 }}>Enrollment {validation.enrollmentId.slice(0, 8)}</div>
-              </div>
-            ))
-          )}
-        </div>
+        <ValidationsSection pendingValidations={pendingValidations} t={t} />
 
         {/* Cohort proposals from Workforce gaps (issue #904) */}
-        <div style={{ marginBottom: 24, padding: '16px 18px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 6 }}>
-            <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, margin: 0 }}>
-              Cohort proposals from Workforce gaps {proposals.length > 0 ? `(${proposals.length})` : ''}
-            </h2>
-            <button
-              type="button"
-              onClick={refreshProposals}
-              disabled={autoRunning}
-              style={{ marginLeft: 'auto', padding: '8px 16px', borderRadius: 8, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: autoRunning ? 'not-allowed' : 'pointer', opacity: autoRunning ? 0.6 : 1 }}
-            >
-              {autoRunning ? 'Refreshing…' : 'Refresh proposals'}
-            </button>
-          </div>
-          <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, marginBottom: 14 }}>
-            The gaps are re-read on a cadence into a ranked, sector-diverse queue. Approve a proposal to
-            open a cohort — you choose the term — or dismiss it. Approving never opens two cohorts for the
-            same occupation; refreshing supersedes proposals whose gap has closed.
-          </p>
-          {autoError ? (
-            <div role="alert" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>
-              {autoError}
-            </div>
-          ) : null}
-          {autoNotice ? (
-            <div style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13 }}>
-              {autoNotice}
-            </div>
-          ) : null}
-          {proposalError ? (
-            <div role="alert" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>
-              {proposalError}
-            </div>
-          ) : null}
-          {proposalNotice ? (
-            <div style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13 }}>
-              {proposalNotice}
-            </div>
-          ) : null}
-          {proposals.length === 0 ? (
-            <div style={{ padding: '20px 16px', textAlign: 'center', color: t.MUTED, fontSize: 13, borderRadius: 10, background: t.BG, border: `1px solid ${t.BORDER_SOLID}` }}>
-              No pending proposals. Use “Refresh proposals” to re-read the current Workforce gaps.
-            </div>
-          ) : (
-            proposals.map((proposal) => {
-              const term = proposalTerms[proposal.id] ?? 3;
-              const busy = busyProposalId === proposal.id;
-              return (
-                <div key={proposal.id} style={{ marginBottom: 10, padding: '12px 14px', borderRadius: 10, background: t.BG, border: `1px solid ${t.BORDER_SOLID}` }}>
-                  <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
-                    <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>#{proposal.rank} · {proposal.occupation}</span>
-                    <Pill>{proposal.sector}</Pill>
-                    <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>gap {Math.round(proposal.gap)}</span>
-                  </div>
-                  <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginTop: 10 }}>
-                    <label style={{ fontSize: 12, color: t.MUTED }}>
-                      Term:{' '}
-                      <select
-                        value={term}
-                        disabled={busy}
-                        onChange={(event) => setProposalTerms((prev) => ({ ...prev, [proposal.id]: Number(event.target.value) as ProposalTermMonths }))}
-                        style={{ borderRadius: 6, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, padding: '5px 8px', fontSize: 12 }}
-                      >
-                        {PROPOSAL_TERM_MONTHS.map((months) => (
-                          <option key={months} value={months}>{months} month{months === 1 ? '' : 's'}</option>
-                        ))}
-                      </select>
-                    </label>
-                    <button
-                      type="button"
-                      onClick={() => void approveProposal(proposal)}
-                      disabled={busy}
-                      style={{ marginLeft: 'auto', padding: '7px 14px', borderRadius: 7, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 12, fontWeight: 700, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
-                    >
-                      {busy ? 'Working…' : 'Approve & open'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void dismissProposal(proposal)}
-                      disabled={busy}
-                      style={{ padding: '7px 14px', borderRadius: 7, background: 'transparent', border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 12, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
-                    >
-                      Dismiss
-                    </button>
-                  </div>
-                </div>
-              );
-            })
-          )}
-        </div>
+        <ProposalsSection
+          proposals={proposals}
+          proposalTerms={proposalTerms}
+          setProposalTerms={setProposalTerms}
+          busyProposalId={busyProposalId}
+          autoRunning={autoRunning}
+          autoError={autoError}
+          autoNotice={autoNotice}
+          proposalError={proposalError}
+          proposalNotice={proposalNotice}
+          onRefresh={refreshProposals}
+          onApprove={(proposal) => void approveProposal(proposal)}
+          onDismiss={(proposal) => void dismissProposal(proposal)}
+          t={t}
+        />
 
         {/* Cohorts */}
-        <div style={{ marginBottom: 24 }}>
-          <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 12 }}>Cohorts</h2>
-          {cohortsError ? (
-            <div role="alert" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>
-              {cohortsError}
-            </div>
-          ) : null}
-          {cohorts === null ? (
-            <div style={{ fontSize: 13, color: t.MUTED }}>Loading cohorts…</div>
-          ) : cohorts.length === 0 ? (
-            <div style={{ padding: '32px 16px', textAlign: 'center', color: t.MUTED, fontSize: 14, borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-              No cohorts yet. Trainers create cohorts from the plugin shell.
-            </div>
-          ) : (
-            cohorts.map((cohort) => (
-              <div key={cohort.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                  <span style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>{cohort.title}</span>
-                  <Pill>{cohort.track}</Pill>
-                  <Pill>{cohort.status}</Pill>
-                  {cohort.autoCreated ? <Pill>auto</Pill> : null}
-                  {cohort.needsTrainer ? (
-                    <span style={{ padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#FBBF24', border: '1px solid rgba(245,158,11,0.4)' }}>
-                      needs trainer
-                    </span>
-                  ) : null}
-                </div>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 24px', fontSize: 12, color: t.MUTED }}>
-                  <span>Seats: {cohort.seatsAvailable} of {cohort.seats} open</span>
-                  <span>Required deposit: {cohort.requiredCredits} credits</span>
-                  <span>Trainer split: {cohort.trainerSplitPercent}%</span>
-                  <span>Completion bonus: {cohort.completionBonusCredits} credits</span>
-                </div>
-              </div>
-            ))
-          )}
-        </div>
+        <CohortsSection cohorts={cohorts} cohortsError={cohortsError} t={t} />
 
         {/* ServiceCredits grant (grant-only — never removes credits) */}
-        <div style={{ padding: '16px 18px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
-          <h2 style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, marginBottom: 6 }}>Grant member ServiceCredits</h2>
-          <p style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, marginBottom: 14 }}>
-            LevelUp only ever grants ServiceCredits to a member — it never removes them. Enter an
-            amount greater than zero. Every grant is recorded against a governance ticket and is
-            written to the audit log.
-          </p>
-
-          {formError ? (
-            <div role="alert" style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#EF4444', fontSize: 13 }}>
-              {formError}
-            </div>
-          ) : null}
-          {notice ? (
-            <div style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13 }}>
-              {notice}
-            </div>
-          ) : null}
-
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12 }}>
-            <label style={{ display: 'block', fontSize: 12 }}>
-              <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Member user ID</span>
-              <input
-                style={inputStyle(t)}
-                value={targetUserId}
-                onChange={(event) => setTargetUserId(event.target.value)}
-                disabled={confirming || submitting}
-                placeholder="user_…"
-              />
-            </label>
-            <label style={{ display: 'block', fontSize: 12 }}>
-              <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Amount to grant (greater than zero)</span>
-              <input
-                style={inputStyle(t)}
-                value={amountText}
-                onChange={(event) => setAmountText(event.target.value)}
-                disabled={confirming || submitting}
-                inputMode="decimal"
-                min={0}
-                placeholder="e.g. 25"
-              />
-            </label>
-            <label style={{ display: 'block', fontSize: 12, gridColumn: '1 / -1' }}>
-              <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Reason</span>
-              <input
-                style={inputStyle(t)}
-                value={reason}
-                onChange={(event) => setReason(event.target.value)}
-                disabled={confirming || submitting}
-                placeholder="Why this adjustment is being made"
-              />
-            </label>
-            <label style={{ display: 'block', fontSize: 12, gridColumn: '1 / -1' }}>
-              <span style={{ display: 'block', fontSize: 11, fontWeight: 600, color: t.MUTED, marginBottom: 6 }}>Governance ticket ID</span>
-              <input
-                style={inputStyle(t)}
-                value={governanceTicketId}
-                onChange={(event) => setGovernanceTicketId(event.target.value)}
-                disabled={confirming || submitting}
-                placeholder="e.g. GOV-1234"
-              />
-            </label>
-          </div>
-
-          {confirming ? (
-            <div style={{ marginTop: 14, padding: '14px 16px', borderRadius: 12, background: 'rgba(245,158,11,0.1)', border: '1px solid rgba(245,158,11,0.4)' }}>
-              <p style={{ fontSize: 13, fontWeight: 600, color: '#FBBF24', marginBottom: 4 }}>
-                Confirm: this will add {magnitude} ServiceCredits to member {targetUserId.trim()}.
-              </p>
-              <p style={{ fontSize: 12, color: 'rgba(251,191,36,0.85)', marginBottom: 12 }}>
-                Reason: {reason.trim()} · Governance ticket: {governanceTicketId.trim()}
-              </p>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                <button
-                  type="button"
-                  onClick={submitAdjustment}
-                  disabled={submitting}
-                  style={{ padding: '8px 16px', borderRadius: 8, background: '#F59E0B', border: '1px solid #F59E0B', color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: submitting ? 'not-allowed' : 'pointer', opacity: submitting ? 0.6 : 1 }}
-                >
-                  {submitting ? 'Applying…' : `Yes, grant ${magnitude} credits`}
-                </button>
-                <button
-                  type="button"
-                  onClick={cancelConfirm}
-                  disabled={submitting}
-                  style={{ padding: '8px 16px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: submitting ? 'not-allowed' : 'pointer', opacity: submitting ? 0.6 : 1 }}
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={beginConfirm}
-              disabled={submitting || !formReady}
-              style={{ marginTop: 14, padding: '9px 18px', borderRadius: 8, background: t.ACCENT, border: `1px solid ${t.ACCENT}`, color: '#0F1117', fontSize: 13, fontWeight: 700, cursor: submitting || !formReady ? 'not-allowed' : 'pointer', opacity: submitting || !formReady ? 0.6 : 1 }}
-            >
-              Review grant
-            </button>
-          )}
-        </div>
+        <GrantForm
+          targetUserId={targetUserId}
+          setTargetUserId={setTargetUserId}
+          amountText={amountText}
+          setAmountText={setAmountText}
+          reason={reason}
+          setReason={setReason}
+          governanceTicketId={governanceTicketId}
+          setGovernanceTicketId={setGovernanceTicketId}
+          confirming={confirming}
+          submitting={submitting}
+          formError={formError}
+          notice={notice}
+          formReady={formReady}
+          magnitude={magnitude}
+          beginConfirm={beginConfirm}
+          cancelConfirm={cancelConfirm}
+          submitAdjustment={submitAdjustment}
+          t={t}
+        />
 
       </div>
     </div>

--- a/ctf/packages/web/components/mood/mood-shell.tsx
+++ b/ctf/packages/web/components/mood/mood-shell.tsx
@@ -13,6 +13,20 @@ import { MoodCheckin } from "./mood-checkin";
 import { MoodCommunity } from "./mood-community";
 import { MoodCrisisRail } from "./mood-crisis-rail";
 
+// True only when the caller passed a signal that has already been aborted. Pulled out so the
+// abort guards below stay single decision points instead of repeating the optional-chain check.
+function isAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
+// Fetch the eligibility payload for a pseudonymous client. Throws on a non-OK response so the
+// caller's catch can surface the error message.
+async function fetchMoodEligibility(id: string, signal?: AbortSignal): Promise<MoodEligibility> {
+  const res = await fetch(`/api/mood/eligibility?clientId=${encodeURIComponent(id)}`, { signal, cache: "no-store" });
+  if (!res.ok) throw new Error("Failed to check eligibility.");
+  return (await res.json()) as MoodEligibility;
+}
+
 export default function MoodShell() {
   const [tab, setTab] = useState<Tab>("checkin");
   const [loading, setLoading] = useState(true);
@@ -32,14 +46,12 @@ export default function MoodShell() {
   const loadEligibility = useCallback(async (id: string, initial = false, signal?: AbortSignal) => {
     if (initial) setLoading(true);
     try {
-      const res = await fetch(`/api/mood/eligibility?clientId=${encodeURIComponent(id)}`, { signal, cache: "no-store" });
-      if (!res.ok) throw new Error("Failed to check eligibility.");
-      const data = (await res.json()) as MoodEligibility;
-      if (!signal?.aborted) setEligibility(data);
+      const data = await fetchMoodEligibility(id, signal);
+      if (!isAborted(signal)) setEligibility(data);
     } catch (e) {
-      if (!signal?.aborted) setError(e instanceof Error ? e.message : "Failed to load mood data.");
+      if (!isAborted(signal)) setError(e instanceof Error ? e.message : "Failed to load mood data.");
     } finally {
-      if (initial && !signal?.aborted) setLoading(false);
+      if (initial && !isAborted(signal)) setLoading(false);
     }
   }, []);
 

--- a/ctf/packages/web/components/mutual-time/mutual-time-admin.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-admin.tsx
@@ -16,6 +16,71 @@ import {
   formatResultDateTime,
 } from './mutual-time-shared';
 
+type Tokens = ReturnType<typeof getMutualTimeTokens>;
+
+const chipStyleFor = (t: Tokens): React.CSSProperties => ({ padding: '6px 12px', borderRadius: 6, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 12, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 5 });
+
+function ClosedResult({ ev, t, tz }: { ev: MutualTimeEvent; t: Tokens; tz: string }) {
+  return (
+    <>
+      {ev.effectiveState === 'closed' && ev.resultSlotStartIso && (
+        <span style={{ fontSize: 12, color: t.SUBTLE, alignSelf: 'center' }}>
+          ✓ {formatResultDateTime(ev.resultSlotStartIso, tz)} · {ev.resultCanMakeIt} can make it
+        </span>
+      )}
+      {ev.effectiveState === 'closed' && !ev.resultSlotStartIso && (
+        <span style={{ fontSize: 12, color: t.SUBTLE, alignSelf: 'center' }}>No time chosen (no votes)</span>
+      )}
+    </>
+  );
+}
+
+function EventActions({ ev, t, tz, isCopied, isClosing, onCopy, onClose }: { ev: MutualTimeEvent; t: Tokens; tz: string; isCopied: boolean; isClosing: boolean; onCopy: (slug: string) => void; onClose: (id: string) => void }) {
+  const chipStyle = chipStyleFor(t);
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+      <button onClick={() => onCopy(ev.slug)} style={{ ...chipStyle, color: isCopied ? t.ACCENT : t.TITLE, border: `1px solid ${isCopied ? t.ACCENT : t.BORDER_SOLID}` }}>
+        {isCopied ? <Check size={12} /> : <Copy size={12} />}
+        {isCopied ? 'Copied' : 'Copy link'}
+      </button>
+      <a href={`/mutual-time/${ev.slug}`} target="_blank" rel="noreferrer" style={chipStyle}>
+        <Link2 size={12} /> View
+      </a>
+      {ev.effectiveState !== 'closed' && (
+        <button onClick={() => onClose(ev.id)} disabled={isClosing} style={{ ...chipStyle, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.30)', color: isClosing ? t.SUBTLE : '#F87171' }}>
+          {isClosing ? 'Closing…' : 'Close and choose the time'}
+        </button>
+      )}
+      <ClosedResult ev={ev} t={t} tz={tz} />
+    </div>
+  );
+}
+
+function EventRow({ ev, t, tz, copiedSlug, closingId, onCopy, onClose }: { ev: MutualTimeEvent; t: Tokens; tz: string; copiedSlug: string | null; closingId: string | null; onCopy: (slug: string) => void; onClose: (id: string) => void }) {
+  const isScheduled = ev.effectiveState === 'scheduled';
+  const isCopied = copiedSlug === ev.slug;
+  const isClosing = closingId === ev.id;
+  const active = ev.effectiveState !== 'closed' && !isScheduled;
+  const statusText = ev.effectiveState === 'closed' ? 'closed' : isScheduled ? 'scheduled' : 'open';
+  return (
+    <div style={{ padding: '12px 14px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 600 }}>{ev.title || 'Untitled event'}</div>
+          <div style={{ fontSize: 12, color: t.SUBTLE, marginTop: 2 }}>
+            {ev.voterCount} voter{ev.voterCount === 1 ? '' : 's'} · {meetingPluginName(ev.meetingPlugin)}
+          </div>
+        </div>
+        <div style={{ flexShrink: 0, padding: '3px 10px', borderRadius: 999, background: active ? `${t.ACCENT}14` : t.SURFACE, border: `1px solid ${active ? `${t.ACCENT}44` : t.BORDER_SOLID}`, fontSize: 11, fontWeight: 700, color: active ? t.ACCENT : t.SUBTLE }}>
+          {statusText}
+        </div>
+      </div>
+
+      <EventActions ev={ev} t={t} tz={tz} isCopied={isCopied} isClosing={isClosing} onCopy={onCopy} onClose={onClose} />
+    </div>
+  );
+}
+
 // Admin dashboard for Mutual Time (spec #1780): create an event (one shareable link) and manage the
 // list of events you created — copy the link, open it, close a survey and choose the winning time.
 // Admin-only surface (gated by the page). No credits anywhere.
@@ -120,7 +185,6 @@ export function MutualTimeAdmin() {
   const card: React.CSSProperties = { marginTop: 20, borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: 20 };
   const labelStyle: React.CSSProperties = { display: 'block', fontSize: 12, fontWeight: 600, color: t.SUBTLE, margin: '10px 0 4px' };
   const inputStyle: React.CSSProperties = { width: '100%', boxSizing: 'border-box', background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, padding: '10px 12px', color: t.TITLE, fontSize: 14, fontFamily: 'inherit' };
-  const chipStyle: React.CSSProperties = { padding: '6px 12px', borderRadius: 6, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 12, fontWeight: 600, cursor: 'pointer', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 5 };
 
   return (
     <div style={{ background: t.BG, minHeight: '100vh', color: t.TITLE }}>
@@ -193,51 +257,9 @@ export function MutualTimeAdmin() {
             <div style={{ color: t.SUBTLE, fontSize: 14 }}>No events yet. Create one above and share its link.</div>
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {events.map((ev) => {
-                const isOpen = ev.effectiveState !== 'closed';
-                const isScheduled = ev.effectiveState === 'scheduled';
-                const isCopied = copiedSlug === ev.slug;
-                const isClosing = closingId === ev.id;
-                const statusText = ev.effectiveState === 'closed' ? 'closed' : isScheduled ? 'scheduled' : 'open';
-                return (
-                  <div key={ev.id} style={{ padding: '12px 14px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, display: 'flex', flexDirection: 'column', gap: 8 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
-                      <div>
-                        <div style={{ fontSize: 14, fontWeight: 600 }}>{ev.title || 'Untitled event'}</div>
-                        <div style={{ fontSize: 12, color: t.SUBTLE, marginTop: 2 }}>
-                          {ev.voterCount} voter{ev.voterCount === 1 ? '' : 's'} · {meetingPluginName(ev.meetingPlugin)}
-                        </div>
-                      </div>
-                      <div style={{ flexShrink: 0, padding: '3px 10px', borderRadius: 999, background: isOpen && !isScheduled ? `${t.ACCENT}14` : t.SURFACE, border: `1px solid ${isOpen && !isScheduled ? `${t.ACCENT}44` : t.BORDER_SOLID}`, fontSize: 11, fontWeight: 700, color: isOpen && !isScheduled ? t.ACCENT : t.SUBTLE }}>
-                        {statusText}
-                      </div>
-                    </div>
-
-                    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
-                      <button onClick={() => handleCopy(ev.slug)} style={{ ...chipStyle, color: isCopied ? t.ACCENT : t.TITLE, border: `1px solid ${isCopied ? t.ACCENT : t.BORDER_SOLID}` }}>
-                        {isCopied ? <Check size={12} /> : <Copy size={12} />}
-                        {isCopied ? 'Copied' : 'Copy link'}
-                      </button>
-                      <a href={`/mutual-time/${ev.slug}`} target="_blank" rel="noreferrer" style={chipStyle}>
-                        <Link2 size={12} /> View
-                      </a>
-                      {ev.effectiveState !== 'closed' && (
-                        <button onClick={() => handleClose(ev.id)} disabled={isClosing} style={{ ...chipStyle, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.30)', color: isClosing ? t.SUBTLE : '#F87171' }}>
-                          {isClosing ? 'Closing…' : 'Close and choose the time'}
-                        </button>
-                      )}
-                      {ev.effectiveState === 'closed' && ev.resultSlotStartIso && (
-                        <span style={{ fontSize: 12, color: t.SUBTLE, alignSelf: 'center' }}>
-                          ✓ {formatResultDateTime(ev.resultSlotStartIso, tz)} · {ev.resultCanMakeIt} can make it
-                        </span>
-                      )}
-                      {ev.effectiveState === 'closed' && !ev.resultSlotStartIso && (
-                        <span style={{ fontSize: 12, color: t.SUBTLE, alignSelf: 'center' }}>No time chosen (no votes)</span>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
+              {events.map((ev) => (
+                <EventRow key={ev.id} ev={ev} t={t} tz={tz} copiedSlug={copiedSlug} closingId={closingId} onCopy={handleCopy} onClose={handleClose} />
+              ))}
             </div>
           )}
         </section>

--- a/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
@@ -186,6 +186,88 @@ function GateView({ isSignedIn, signInUrl, verifyUrl, closesLabel, t }: { isSign
   );
 }
 
+function TimeZoneRow({ tz, showTz, setShowTz, setTz, t }: { tz: string; showTz: boolean; setShowTz: (v: boolean) => void; setTz: (v: string) => void; t: Tokens }) {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <button onClick={() => setShowTz(!showTz)} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, background: 'transparent', border: 'none', cursor: 'pointer', color: t.SUBTLE, fontSize: 13, fontWeight: 500, padding: 0 }}>
+        <Globe size={13} /> Times shown in {timeZoneLabel(tz)}
+        <ChevronDown size={12} style={{ transform: showTz ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }} />
+      </button>
+      {showTz && (
+        <div style={{ marginTop: 8 }}>
+          <select value={tz} onChange={(e) => setTz(e.target.value)} style={{ background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, color: t.TITLE, fontSize: 13, padding: '8px 10px', maxWidth: 320, width: '100%' }}>
+            {listTimeZones().map((z) => (
+              <option key={z} value={z}>{z.replace(/_/g, ' ')}</option>
+            ))}
+          </select>
+          <div style={{ fontSize: 11, color: t.SUBTLE, marginTop: 4 }}>Traveling or using a VPN? Pick the timezone you&apos;re actually in.</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type VotePeriod = { label: string; order: number; slots: string[] };
+
+function SlotGrid({ periods, picks, atMax, toggle, tz, t }: { periods: VotePeriod[]; picks: string[]; atMax: boolean; toggle: (iso: string) => void; tz: string; t: Tokens }) {
+  return (
+    <div style={{ borderRadius: 14, border: `1px solid ${t.BORDER_SOLID}`, background: t.HEADER, marginBottom: 16, overflow: 'hidden' }}>
+      {periods.length === 0 ? (
+        <div style={{ padding: 14, color: t.SUBTLE, fontSize: 13 }}>No times on this day.</div>
+      ) : (
+        periods.map((period) => (
+          <div key={period.order} style={{ padding: '10px 14px', borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.05em' }}>{period.label}</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              {period.slots.map((iso) => {
+                const isSel = picks.includes(iso);
+                const isDis = !isSel && atMax;
+                return (
+                  <button key={iso} onClick={() => !isDis && toggle(iso)} style={{ padding: '5px 10px', borderRadius: 6, background: isSel ? `${t.ACCENT}22` : t.SURFACE, border: `1px solid ${isSel ? t.ACCENT : t.BORDER_SOLID}`, color: isSel ? t.ACCENT : isDis ? t.SUBTLE : t.TITLE, fontSize: 12, fontWeight: isSel ? 700 : 400, cursor: isDis ? 'not-allowed' : 'pointer', opacity: isDis ? 0.4 : 1, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                    {isSel && <Check size={11} />}
+                    {formatSlotTime(iso, tz)}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function PicksSummary({ picks, tz, toggle, t }: { picks: string[]; tz: string; toggle: (iso: string) => void; t: Tokens }) {
+  if (picks.length === 0) return null;
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Your picks</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {[...picks].sort().map((iso) => (
+          <div key={iso} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 10px', borderRadius: 6, background: `${t.ACCENT}12`, border: `1px solid ${t.ACCENT}40`, fontSize: 13, color: t.TITLE }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <Clock size={12} style={{ color: t.ACCENT }} /> {formatSlotDate(iso, tz)} · {formatSlotRange(iso, tz)}
+            </span>
+            <button onClick={() => toggle(iso)} style={{ background: 'transparent', border: 'none', color: t.SUBTLE, cursor: 'pointer', fontSize: 11, fontWeight: 600 }}>remove</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SaveBar({ saving, picks, save, t }: { saving: boolean; picks: string[]; save: () => void; t: Tokens }) {
+  return (
+    <button
+      onClick={save}
+      disabled={saving}
+      style={{ padding: '10px 20px', borderRadius: 10, background: `${t.ACCENT}22`, border: `1px solid ${t.ACCENT}`, color: t.ACCENT, fontSize: 14, fontWeight: 700, cursor: saving ? 'not-allowed' : 'pointer' }}
+    >
+      {saving ? 'Saving…' : picks.length === 0 ? 'Clear my picks' : 'Save my picks'}
+    </button>
+  );
+}
+
 function VoteView({
   event,
   tz,
@@ -305,22 +387,7 @@ function VoteView({
 
       <div style={{ borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: 20, marginTop: 4 }}>
         {/* Timezone row */}
-        <div style={{ marginBottom: 18 }}>
-          <button onClick={() => setShowTz(!showTz)} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, background: 'transparent', border: 'none', cursor: 'pointer', color: t.SUBTLE, fontSize: 13, fontWeight: 500, padding: 0 }}>
-            <Globe size={13} /> Times shown in {timeZoneLabel(tz)}
-            <ChevronDown size={12} style={{ transform: showTz ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }} />
-          </button>
-          {showTz && (
-            <div style={{ marginTop: 8 }}>
-              <select value={tz} onChange={(e) => setTz(e.target.value)} style={{ background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, color: t.TITLE, fontSize: 13, padding: '8px 10px', maxWidth: 320, width: '100%' }}>
-                {listTimeZones().map((z) => (
-                  <option key={z} value={z}>{z.replace(/_/g, ' ')}</option>
-                ))}
-              </select>
-              <div style={{ fontSize: 11, color: t.SUBTLE, marginTop: 4 }}>Traveling or using a VPN? Pick the timezone you&apos;re actually in.</div>
-            </div>
-          )}
-        </div>
+        <TimeZoneRow tz={tz} showTz={showTz} setShowTz={setShowTz} setTz={setTz} t={t} />
 
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
           <span style={{ fontSize: 13, fontWeight: 600, color: t.TITLE }}>Pick up to {MUTUAL_TIME_MAX_PICKS} one-hour windows you&apos;re free</span>
@@ -342,56 +409,14 @@ function VoteView({
         </div>
 
         {/* Slot grid */}
-        <div style={{ borderRadius: 14, border: `1px solid ${t.BORDER_SOLID}`, background: t.HEADER, marginBottom: 16, overflow: 'hidden' }}>
-          {periods.length === 0 ? (
-            <div style={{ padding: 14, color: t.SUBTLE, fontSize: 13 }}>No times on this day.</div>
-          ) : (
-            periods.map((period) => (
-              <div key={period.order} style={{ padding: '10px 14px', borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
-                <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.05em' }}>{period.label}</div>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                  {period.slots.map((iso) => {
-                    const isSel = picks.includes(iso);
-                    const isDis = !isSel && atMax;
-                    return (
-                      <button key={iso} onClick={() => !isDis && toggle(iso)} style={{ padding: '5px 10px', borderRadius: 6, background: isSel ? `${t.ACCENT}22` : t.SURFACE, border: `1px solid ${isSel ? t.ACCENT : t.BORDER_SOLID}`, color: isSel ? t.ACCENT : isDis ? t.SUBTLE : t.TITLE, fontSize: 12, fontWeight: isSel ? 700 : 400, cursor: isDis ? 'not-allowed' : 'pointer', opacity: isDis ? 0.4 : 1, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                        {isSel && <Check size={11} />}
-                        {formatSlotTime(iso, tz)}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ))
-          )}
-        </div>
+        <SlotGrid periods={periods} picks={picks} atMax={atMax} toggle={toggle} tz={tz} t={t} />
 
         {/* Picks summary */}
-        {picks.length > 0 && (
-          <div style={{ marginBottom: 12 }}>
-            <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Your picks</div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              {[...picks].sort().map((iso) => (
-                <div key={iso} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 10px', borderRadius: 6, background: `${t.ACCENT}12`, border: `1px solid ${t.ACCENT}40`, fontSize: 13, color: t.TITLE }}>
-                  <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                    <Clock size={12} style={{ color: t.ACCENT }} /> {formatSlotDate(iso, tz)} · {formatSlotRange(iso, tz)}
-                  </span>
-                  <button onClick={() => toggle(iso)} style={{ background: 'transparent', border: 'none', color: t.SUBTLE, cursor: 'pointer', fontSize: 11, fontWeight: 600 }}>remove</button>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <PicksSummary picks={picks} tz={tz} toggle={toggle} t={t} />
 
         {error && <div style={{ marginBottom: 10, fontSize: 13, color: '#F87171' }}>{error}</div>}
 
-        <button
-          onClick={save}
-          disabled={saving}
-          style={{ padding: '10px 20px', borderRadius: 10, background: `${t.ACCENT}22`, border: `1px solid ${t.ACCENT}`, color: t.ACCENT, fontSize: 14, fontWeight: 700, cursor: saving ? 'not-allowed' : 'pointer' }}
-        >
-          {saving ? 'Saving…' : picks.length === 0 ? 'Clear my picks' : 'Save my picks'}
-        </button>
+        <SaveBar saving={saving} picks={picks} save={save} t={t} />
       </div>
     </>
   );

--- a/ctf/packages/web/components/safety/safety-admin-shell.tsx
+++ b/ctf/packages/web/components/safety/safety-admin-shell.tsx
@@ -83,6 +83,110 @@ function StatBlock({ label, value, accent }: { label: string; value: number; acc
   );
 }
 
+// The review / dismiss buttons for an open report. The busy-dependent cursor and opacity live here
+// so the card does not repeat them per button.
+function SafetyReviewActions({
+  busy,
+  onReviewed,
+  onDismissed,
+}: {
+  busy: boolean;
+  onReviewed: () => void;
+  onDismissed: () => void;
+}) {
+  const { theme } = useTheme();
+  const t = getSafetyTokens(theme);
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 12 }}>
+      <button
+        type="button"
+        onClick={onReviewed}
+        disabled={busy}
+        style={{ padding: '7px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+      >
+        Mark reviewed
+      </button>
+      <button
+        type="button"
+        onClick={onDismissed}
+        disabled={busy}
+        style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+// One report row in the admin queue. A repeat offender (another open report about the same reported
+// member) gets an amber border and a flag.
+function SafetyReportCard({
+  report,
+  busy,
+  onReview,
+}: {
+  report: AdminSafetyReport;
+  busy: boolean;
+  onReview: (id: string, action: 'reviewed' | 'dismissed') => void;
+}) {
+  const { theme } = useTheme();
+  const t = getSafetyTokens(theme);
+  const canAct = report.status === 'open';
+  // A repeat offender: at least one OTHER open report about the same reported member
+  // (openReportsAboutReported excludes this row, so > 0 means more than one open report).
+  const isRepeat = report.openReportsAboutReported > 0;
+  return (
+    <div style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${isRepeat ? 'rgba(245,158,11,0.4)' : t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <StatusPill status={report.status} />
+        <span style={{ fontSize: 12, color: t.MUTED }}>{formatWhen(report.createdAtIso)}</span>
+        {isRepeat ? (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
+            <AlertTriangle size={12} /> {report.openReportsAboutReported} other open report{report.openReportsAboutReported === 1 ? '' : 's'} about this member
+          </span>
+        ) : null}
+      </div>
+
+      <div style={{ fontSize: 13, color: t.TITLE, lineHeight: 1.7 }}>
+        <span style={{ color: t.MUTED }}>Reported member: </span>
+        <span style={{ fontWeight: 700 }}>{report.reportedDisplayName}</span>
+        <span style={{ color: t.MUTED }}> ({report.reportedUserId})</span>
+      </div>
+      <div style={{ fontSize: 13, color: t.TITLE, lineHeight: 1.7 }}>
+        <span style={{ color: t.MUTED }}>Reported by: </span>
+        <span style={{ fontWeight: 600 }}>{report.reporterDisplayName}</span>
+        <span style={{ color: t.MUTED }}> ({report.reporterUserId})</span>
+      </div>
+
+      {report.detail ? (
+        <p style={{ whiteSpace: 'pre-wrap', fontSize: 13, color: t.TITLE, marginTop: 8, marginBottom: 0 }}>
+          <span style={{ color: t.MUTED, fontWeight: 600 }}>What the reporter said: </span>
+          {report.detail}
+        </p>
+      ) : (
+        <p style={{ fontSize: 13, color: t.MUTED, marginTop: 8, marginBottom: 0, fontStyle: 'italic' }}>
+          No additional detail was provided.
+        </p>
+      )}
+
+      {report.status !== 'open' && report.reviewedAtIso ? (
+        <div style={{ fontSize: 12, color: t.MUTED, marginTop: 10 }}>
+          {STATUS_LABEL[report.status]} {formatWhen(report.reviewedAtIso)}
+          {report.reviewedByUserId ? ` by ${report.reviewedByUserId}` : ''}
+        </div>
+      ) : null}
+
+      {canAct ? (
+        <SafetyReviewActions
+          busy={busy}
+          onReviewed={() => onReview(report.id, 'reviewed')}
+          onDismissed={() => onReview(report.id, 'dismissed')}
+        />
+      ) : null}
+    </div>
+  );
+}
+
 // Admin safety-report queue (issue #809, task 3). The only path by which a member block reaches the
 // admin: a member who blocked someone and flagged it as a suspected predator / human trafficker. The
 // owner reviews these so they can ban globally (the global ban itself is task 5 — this surface is
@@ -194,76 +298,14 @@ export function SafetyAdminShell() {
           </div>
         ) : null}
 
-        {reports.map((report) => {
-          const busy = busyId === report.id;
-          const canAct = report.status === 'open';
-          // A repeat offender: at least one OTHER open report about the same reported member
-          // (openReportsAboutReported excludes this row, so > 0 means more than one open report).
-          const isRepeat = report.openReportsAboutReported > 0;
-          return (
-            <div key={report.id} style={{ marginBottom: 12, padding: '14px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${isRepeat ? 'rgba(245,158,11,0.4)' : t.BORDER_SOLID}` }}>
-              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                <StatusPill status={report.status} />
-                <span style={{ fontSize: 12, color: t.MUTED }}>{formatWhen(report.createdAtIso)}</span>
-                {isRepeat ? (
-                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: 'rgba(245,158,11,0.12)', color: '#F59E0B', border: '1px solid rgba(245,158,11,0.3)' }}>
-                    <AlertTriangle size={12} /> {report.openReportsAboutReported} other open report{report.openReportsAboutReported === 1 ? '' : 's'} about this member
-                  </span>
-                ) : null}
-              </div>
-
-              <div style={{ fontSize: 13, color: t.TITLE, lineHeight: 1.7 }}>
-                <span style={{ color: t.MUTED }}>Reported member: </span>
-                <span style={{ fontWeight: 700 }}>{report.reportedDisplayName}</span>
-                <span style={{ color: t.MUTED }}> ({report.reportedUserId})</span>
-              </div>
-              <div style={{ fontSize: 13, color: t.TITLE, lineHeight: 1.7 }}>
-                <span style={{ color: t.MUTED }}>Reported by: </span>
-                <span style={{ fontWeight: 600 }}>{report.reporterDisplayName}</span>
-                <span style={{ color: t.MUTED }}> ({report.reporterUserId})</span>
-              </div>
-
-              {report.detail ? (
-                <p style={{ whiteSpace: 'pre-wrap', fontSize: 13, color: t.TITLE, marginTop: 8, marginBottom: 0 }}>
-                  <span style={{ color: t.MUTED, fontWeight: 600 }}>What the reporter said: </span>
-                  {report.detail}
-                </p>
-              ) : (
-                <p style={{ fontSize: 13, color: t.MUTED, marginTop: 8, marginBottom: 0, fontStyle: 'italic' }}>
-                  No additional detail was provided.
-                </p>
-              )}
-
-              {report.status !== 'open' && report.reviewedAtIso ? (
-                <div style={{ fontSize: 12, color: t.MUTED, marginTop: 10 }}>
-                  {STATUS_LABEL[report.status]} {formatWhen(report.reviewedAtIso)}
-                  {report.reviewedByUserId ? ` by ${report.reviewedByUserId}` : ''}
-                </div>
-              ) : null}
-
-              {canAct ? (
-                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 12 }}>
-                  <button
-                    type="button"
-                    onClick={() => void review(report.id, 'reviewed')}
-                    disabled={busy}
-                    style={{ padding: '7px 12px', borderRadius: 8, background: 'rgba(34,197,94,0.12)', border: '1px solid rgba(34,197,94,0.3)', color: '#22C55E', fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
-                  >
-                    Mark reviewed
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void review(report.id, 'dismissed')}
-                    disabled={busy}
-                    style={{ padding: '7px 12px', borderRadius: 8, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED, fontSize: 13, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
-                  >
-                    Dismiss
-                  </button>
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
+        {reports.map((report) => (
+          <SafetyReportCard
+            key={report.id}
+            report={report}
+            busy={busyId === report.id}
+            onReview={(id, action) => void review(id, action)}
+          />
+        ))}
       </div>
     </div>
   );

--- a/ctf/packages/web/components/shared/share-link.tsx
+++ b/ctf/packages/web/components/shared/share-link.tsx
@@ -52,6 +52,112 @@ async function writeToClipboard(text: string): Promise<boolean> {
   }
 }
 
+// Decide which way the popup opens from the trigger. Vertically: open below when there isn't room
+// above (~190px covers title + URL field + two rows + padding), otherwise above. Horizontally:
+// right-align when growing rightward would cross the viewport's right edge (which forces the page into
+// horizontal scroll on a phone), otherwise grow rightward from the left edge. Kept module-scope so the
+// several ?./??/?: it needs stay out of the effect's complexity count.
+function computePopupPosition(rect: DOMRect | undefined): {
+  placement: "top" | "bottom";
+  align: "left" | "right";
+} {
+  const POPUP_HEIGHT = 190;
+  const POPUP_WIDTH = 280;
+  const triggerTop = rect?.top ?? POPUP_HEIGHT + 1;
+  const triggerLeft = rect?.left ?? 0;
+  return {
+    placement: triggerTop < POPUP_HEIGHT + 16 ? "bottom" : "top",
+    align: triggerLeft + POPUP_WIDTH > window.innerWidth - 16 ? "right" : "left",
+  };
+}
+
+// The share popover: the selectable URL field plus the "Copy link" and "Open in new tab" actions.
+// Kept module-scope so its placement/copy-state ternaries stay out of the ShareLink complexity count.
+function ShareLinkPopup({
+  dialogId,
+  title,
+  placement,
+  align,
+  absolute,
+  copied,
+  copyFailed,
+  urlRef,
+  onCopy,
+  onOpenNewTab,
+}: {
+  dialogId: string;
+  title: string;
+  placement: "top" | "bottom";
+  align: "left" | "right";
+  absolute: string;
+  copied: boolean;
+  copyFailed: boolean;
+  urlRef: React.RefObject<HTMLInputElement | null>;
+  onCopy: () => void;
+  onOpenNewTab: () => void;
+}) {
+  const itemStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    width: "100%",
+    padding: "8px 10px",
+    background: "transparent",
+    border: "none",
+    borderRadius: 8,
+    color: "var(--ctf-text, #E8EAF0)",
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+    textAlign: "left",
+  };
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- stopPropagation only prevents the outside-click-close from firing on the popover's own content; it is event management, not a user action. The popover's controls are focusable buttons.
+    <div
+      id={dialogId}
+      role="dialog"
+      aria-label={title}
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: "absolute",
+        ...(placement === "top"
+          ? { bottom: "calc(100% + 8px)" }
+          : { top: "calc(100% + 8px)" }),
+        ...(align === "right" ? { right: 0 } : { left: 0 }),
+        zIndex: 50,
+        width: 280,
+        maxWidth: "80vw",
+        padding: 12,
+        background: "var(--ctf-panel, #161B27)",
+        border: "1px solid var(--ctf-border, #1E2A3A)",
+        borderRadius: 12,
+        boxShadow: "0 12px 28px rgba(0,0,0,0.45)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div style={{ fontSize: 12, fontWeight: 700, color: "var(--ctf-text-secondary, #9CA3AF)" }}>{title}</div>
+      <input
+        ref={urlRef}
+        readOnly
+        value={absolute}
+        aria-label="Link URL"
+        onFocus={(e) => e.currentTarget.select()}
+        style={{ width: "100%", padding: "8px 10px", background: "var(--ctf-surface, rgba(255,255,255,0.04))", border: "1px solid var(--ctf-border, rgba(255,255,255,0.08))", borderRadius: 8, fontSize: 12, color: "var(--ctf-text, #E8EAF0)", outline: "none", boxSizing: "border-box" }}
+      />
+      <button type="button" onClick={onCopy} style={itemStyle}>
+        {copied ? <Check size={15} /> : <Copy size={15} />}
+        <span aria-live="polite">{copied ? "Copied!" : copyFailed ? "Copy failed — copy the link above" : "Copy link"}</span>
+      </button>
+      <button type="button" onClick={onOpenNewTab} style={itemStyle}>
+        <ExternalLink size={15} />
+        <span>Open in new tab</span>
+      </button>
+    </div>
+  );
+}
+
 export function ShareLink({
   url,
   label = "Share",
@@ -96,17 +202,12 @@ export function ShareLink({
 
   useEffect(() => {
     if (!open) return;
-    // Decide which way to open: if there isn't room for the popup above the trigger, open below.
-    // ~190px covers the popup (title + URL field + two rows + padding).
-    const POPUP_HEIGHT = 190;
-    const POPUP_WIDTH = 280;
+    // Decide which way the popup opens (see computePopupPosition) so it isn't clipped by the header
+    // or pushed off the right edge into horizontal scroll.
     const rect = triggerRef.current?.getBoundingClientRect();
-    const triggerTop = rect?.top ?? POPUP_HEIGHT + 1;
-    setPlacement(triggerTop < POPUP_HEIGHT + 16 ? "bottom" : "top");
-    // And which way to grow: right-align the popup when growing rightward would cross the viewport's
-    // right edge (which forces the page into horizontal scroll on a phone).
-    const triggerLeft = rect?.left ?? 0;
-    setAlign(triggerLeft + POPUP_WIDTH > window.innerWidth - 16 ? "right" : "left");
+    const position = computePopupPosition(rect);
+    setPlacement(position.placement);
+    setAlign(position.align);
     // Focus the URL field so a keyboard/AT user lands on the link itself.
     urlRef.current?.focus();
     urlRef.current?.select();
@@ -145,22 +246,6 @@ export function ShareLink({
     setOpen(false);
   }
 
-  const itemStyle: React.CSSProperties = {
-    display: "flex",
-    alignItems: "center",
-    gap: 8,
-    width: "100%",
-    padding: "8px 10px",
-    background: "transparent",
-    border: "none",
-    borderRadius: 8,
-    color: "var(--ctf-text, #E8EAF0)",
-    fontSize: 13,
-    fontWeight: 600,
-    cursor: "pointer",
-    textAlign: "left",
-  };
-
   return (
     <div ref={rootRef} style={{ position: "relative", display: children ? "block" : "inline-flex" }}>
       <button
@@ -190,49 +275,18 @@ export function ShareLink({
       </button>
 
       {open ? (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- stopPropagation only prevents the outside-click-close from firing on the popover's own content; it is event management, not a user action. The popover's controls are focusable buttons.
-        <div
-          id={dialogId}
-          role="dialog"
-          aria-label={title}
-          onClick={(e) => e.stopPropagation()}
-          style={{
-            position: "absolute",
-            ...(placement === "top"
-              ? { bottom: "calc(100% + 8px)" }
-              : { top: "calc(100% + 8px)" }),
-            ...(align === "right" ? { right: 0 } : { left: 0 }),
-            zIndex: 50,
-            width: 280,
-            maxWidth: "80vw",
-            padding: 12,
-            background: "var(--ctf-panel, #161B27)",
-            border: "1px solid var(--ctf-border, #1E2A3A)",
-            borderRadius: 12,
-            boxShadow: "0 12px 28px rgba(0,0,0,0.45)",
-            display: "flex",
-            flexDirection: "column",
-            gap: 8,
-          }}
-        >
-          <div style={{ fontSize: 12, fontWeight: 700, color: "var(--ctf-text-secondary, #9CA3AF)" }}>{title}</div>
-          <input
-            ref={urlRef}
-            readOnly
-            value={absolute}
-            aria-label="Link URL"
-            onFocus={(e) => e.currentTarget.select()}
-            style={{ width: "100%", padding: "8px 10px", background: "var(--ctf-surface, rgba(255,255,255,0.04))", border: "1px solid var(--ctf-border, rgba(255,255,255,0.08))", borderRadius: 8, fontSize: 12, color: "var(--ctf-text, #E8EAF0)", outline: "none", boxSizing: "border-box" }}
-          />
-          <button type="button" onClick={() => void onCopy()} style={itemStyle}>
-            {copied ? <Check size={15} /> : <Copy size={15} />}
-            <span aria-live="polite">{copied ? "Copied!" : copyFailed ? "Copy failed — copy the link above" : "Copy link"}</span>
-          </button>
-          <button type="button" onClick={onOpenNewTab} style={itemStyle}>
-            <ExternalLink size={15} />
-            <span>Open in new tab</span>
-          </button>
-        </div>
+        <ShareLinkPopup
+          dialogId={dialogId}
+          title={title}
+          placement={placement}
+          align={align}
+          absolute={absolute}
+          copied={copied}
+          copyFailed={copyFailed}
+          urlRef={urlRef}
+          onCopy={() => void onCopy()}
+          onOpenNewTab={onOpenNewTab}
+        />
       ) : null}
     </div>
   );

--- a/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
+++ b/ctf/packages/web/components/skills-taxonomy/skills-taxonomy-browser.tsx
@@ -6,12 +6,106 @@ import { BackChevronButton } from "@/lib/nav/back-history";
 import { useTheme } from "@/hooks/useTheme";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
-import { getSkillsTaxonomyTokens, type StSector } from "./st-shared";
+import {
+  getSkillsTaxonomyTokens,
+  type SkillsTaxonomyTokens,
+  type StJobTitle,
+  type StSector,
+  type StSkill,
+} from "./st-shared";
 import { SkillsTaxonomySectorsColumn } from "./st-sectors-column";
 import { SkillsTaxonomyTitlesColumn } from "./st-titles-column";
 import { SkillsTaxonomySkillsDetail } from "./st-skills-detail";
 import { SkillsTaxonomyEmptyState } from "./st-empty-state";
 import { SkillsTaxonomyLoading } from "./st-loading";
+
+type StMobileView = "sectors" | "titles" | "skills";
+
+// The drill-down "back" bar shown above the body on phones. It renders nothing at the top level
+// (sectors), and otherwise a button that steps one level back up the hierarchy. Kept module-scope so
+// the level-to-target/label ternaries live here rather than inflating the browser's complexity.
+function SkillsTaxonomyMobileBackBar({
+  mobileView,
+  tokens,
+  onBack,
+}: {
+  mobileView: StMobileView;
+  tokens: SkillsTaxonomyTokens;
+  onBack: (view: StMobileView) => void;
+}) {
+  if (mobileView === "sectors") return null;
+  const backTarget: StMobileView = mobileView === "skills" ? "titles" : "sectors";
+  const backLabel = mobileView === "skills" ? "Job titles" : "Sectors";
+  const t = tokens;
+  return (
+    <div style={{ padding: "0 12px 10px" }}>
+      <button type="button" onClick={() => onBack(backTarget)} style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", padding: "8px 12px", borderRadius: 8, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, color: t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
+        <ChevronLeft size={14} /> {backLabel}
+      </button>
+    </div>
+  );
+}
+
+// The drill-down body: the error state, or one of the three hierarchy columns for the current level.
+// Kept module-scope so the level switch lives here rather than inflating the browser's complexity.
+function SkillsTaxonomyBody({
+  error,
+  mobileView,
+  sectors,
+  selectedSector,
+  selectedSectorId,
+  selectedJobTitle,
+  selectedJobTitleId,
+  visibleSkills,
+  search,
+  onSelectSector,
+  onSelectJobTitle,
+  onSearch,
+}: {
+  error: string | null;
+  mobileView: StMobileView;
+  sectors: StSector[];
+  selectedSector: StSector | null;
+  selectedSectorId: string | null;
+  selectedJobTitle: StJobTitle | null;
+  selectedJobTitleId: string | null;
+  visibleSkills: StSkill[];
+  search: string;
+  onSelectSector: (id: string) => void;
+  onSelectJobTitle: (id: string) => void;
+  onSearch: (value: string) => void;
+}) {
+  if (error) {
+    return <div style={{ padding: 24, color: "#F87171", fontSize: 14 }}>{error}</div>;
+  }
+  if (mobileView === "sectors") {
+    return (
+      <SkillsTaxonomySectorsColumn
+        sectors={sectors}
+        selectedSectorId={selectedSectorId}
+        onSelect={onSelectSector}
+      />
+    );
+  }
+  if (mobileView === "titles") {
+    return (
+      <SkillsTaxonomyTitlesColumn
+        sector={selectedSector}
+        selectedJobTitleId={selectedJobTitleId}
+        onSelect={onSelectJobTitle}
+      />
+    );
+  }
+  return (
+    <SkillsTaxonomySkillsDetail
+      sector={selectedSector}
+      jobTitle={selectedJobTitle}
+      skills={visibleSkills}
+      search={search}
+      onSearch={onSearch}
+    />
+  );
+}
 
 export function SkillsTaxonomyBrowser() {
   const [sectors, setSectors] = useState<StSector[]>([]);
@@ -22,7 +116,7 @@ export function SkillsTaxonomyBrowser() {
   const [error, setError] = useState<string | null>(null);
   const { theme } = useTheme();
   const t = getSkillsTaxonomyTokens(theme);
-  const [mobileView, setMobileView] = useState<"sectors" | "titles" | "skills">("sectors");
+  const [mobileView, setMobileView] = useState<StMobileView>("sectors");
 
   // Shared by the initial-load effect and the refresh button; a refresh (initial=false) re-pulls
   // the hierarchy without flashing the full-screen loading state and keeps the current selection.
@@ -60,49 +154,32 @@ export function SkillsTaxonomyBrowser() {
   // Phones can't fit three columns side by side, so the hierarchy becomes a
   // drill-down: sectors → job titles → skills, one level at a time with a
   // back button. The column components go full-width on small screens.
-    const backTarget = mobileView === "skills" ? "titles" : "sectors";
-    const backLabel = mobileView === "skills" ? "Job titles" : "Sectors";
-    return (
-      <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
-        <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
-            <BackChevronButton accent={t.ACCENT} />
-            {/* Title shrinks and truncates so the trailing controls stay on screen */}
-            <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>Skills Taxonomy</span>
-            <RefreshButton onRefresh={() => load()} title="Refresh" />
-            <MobileTopActions />
-          </div>
-          {mobileView !== "sectors" && (
-            <div style={{ padding: "0 12px 10px" }}>
-              <button type="button" onClick={() => setMobileView(backTarget)} style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", padding: "8px 12px", borderRadius: 8, background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, color: t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>
-                <ChevronLeft size={14} /> {backLabel}
-              </button>
-            </div>
-          )}
+  return (
+    <div style={{ minHeight: "100vh", background: t.BG, fontFamily: "'Inter', system-ui, sans-serif", color: t.TITLE }}>
+      <div style={{ position: "sticky", top: 0, zIndex: 20, background: t.HEADER, borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
+          <BackChevronButton accent={t.ACCENT} />
+          {/* Title shrinks and truncates so the trailing controls stay on screen */}
+          <span style={{ fontSize: 15, fontWeight: 700, color: t.TITLE, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>Skills Taxonomy</span>
+          <RefreshButton onRefresh={() => load()} title="Refresh" />
+          <MobileTopActions />
         </div>
-        {error ? (
-          <div style={{ padding: 24, color: "#F87171", fontSize: 14 }}>{error}</div>
-        ) : mobileView === "sectors" ? (
-          <SkillsTaxonomySectorsColumn
-            sectors={sectors}
-            selectedSectorId={selectedSectorId}
-            onSelect={(id) => { setSelectedSectorId(id); setSelectedJobTitleId(null); setSearch(""); setMobileView("titles"); }}
-          />
-        ) : mobileView === "titles" ? (
-          <SkillsTaxonomyTitlesColumn
-            sector={selectedSector}
-            selectedJobTitleId={selectedJobTitleId}
-            onSelect={(id) => { setSelectedJobTitleId(id); setSearch(""); setMobileView("skills"); }}
-          />
-        ) : (
-          <SkillsTaxonomySkillsDetail
-            sector={selectedSector}
-            jobTitle={selectedJobTitle}
-            skills={visibleSkills}
-            search={search}
-            onSearch={setSearch}
-          />
-        )}
+        <SkillsTaxonomyMobileBackBar mobileView={mobileView} tokens={t} onBack={setMobileView} />
       </div>
-    );
+      <SkillsTaxonomyBody
+        error={error}
+        mobileView={mobileView}
+        sectors={sectors}
+        selectedSector={selectedSector}
+        selectedSectorId={selectedSectorId}
+        selectedJobTitle={selectedJobTitle}
+        selectedJobTitleId={selectedJobTitleId}
+        visibleSkills={visibleSkills}
+        search={search}
+        onSelectSector={(id) => { setSelectedSectorId(id); setSelectedJobTitleId(null); setSearch(""); setMobileView("titles"); }}
+        onSelectJobTitle={(id) => { setSelectedJobTitleId(id); setSearch(""); setMobileView("skills"); }}
+        onSearch={setSearch}
+      />
+    </div>
+  );
 }

--- a/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
+++ b/ctf/packages/web/components/weekly-performance/weekly-performance-shell.tsx
@@ -35,6 +35,10 @@ function priorWeekStart(weeks: WpWeek[], selected: string | null): string | null
   return sorted[index + 1].weekStartDate;
 }
 
+function readCurrentWeekStart(currentData: CurrentWeekResponse | null): string | null {
+  return currentData?.currentWeek?.weekStartDate ?? null;
+}
+
 async function fetchShellData(): Promise<ShellData> {
   const [weeksRes, currentRes] = await Promise.all([
     fetch("/api/weekly-performance/weeks", { cache: "no-store" }),
@@ -43,7 +47,7 @@ async function fetchShellData(): Promise<ShellData> {
   if (!weeksRes.ok) throw new Error("Failed to load weeks.");
   const weeksData = (await weeksRes.json()) as WeeksResponse;
   const currentData = currentRes.ok ? ((await currentRes.json()) as CurrentWeekResponse) : null;
-  const currentWeekStart = currentData?.currentWeek?.weekStartDate ?? null;
+  const currentWeekStart = readCurrentWeekStart(currentData);
   return {
     weeks: weeksData.weeks,
     activeUsers: currentData?.activeUsersLast7Days ?? null,

--- a/ctf/packages/web/components/workforce/workforce-admin-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-admin-shell.tsx
@@ -65,6 +65,14 @@ function NumberField({
   );
 }
 
+// Pick the most specific error text the server returned, falling back to a status-based message.
+function resolveErrorMessage(
+  data: { message?: string; reason?: string; code?: string } | null,
+  status: number,
+): string {
+  return data?.message ?? data?.reason ?? data?.code ?? `Request failed (${status}).`;
+}
+
 async function adminMutate(
   url: string,
   method: 'PUT',
@@ -80,7 +88,7 @@ async function adminMutate(
       | { message?: string; reason?: string; code?: string; config?: WorkforceConfig }
       | null;
     if (res.ok) return { ok: true, config: data?.config };
-    return { ok: false, message: data?.message ?? data?.reason ?? data?.code ?? `Request failed (${res.status}).` };
+    return { ok: false, message: resolveErrorMessage(data, res.status) };
   } catch {
     return { ok: false, message: 'Network error. Try again.' };
   }

--- a/ctf/packages/web/components/workforce/workforce-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-shell.tsx
@@ -156,6 +156,62 @@ function WorkforceWarningBanner({ message }: { message: string }) {
   );
 }
 
+// Empty only when there is genuinely nothing to track: no taxonomy sectors/occupations and nobody
+// in the Directory. Demand alone (population model) is enough to render the dashboard.
+function isDashboardEmptyData(dashboard: WorkforceDashboard): boolean {
+  return dashboard.sectorsTotal === 0 && dashboard.occupationsTotal === 0 && dashboard.totalMembers === 0;
+}
+
+function WorkforceSkillSection({
+  activeView,
+  skillItems,
+}: {
+  activeView: SidebarView;
+  skillItems: WorkforceGroupedReportItem[];
+}) {
+  const showDistribution = (activeView === 'overview' || activeView === 'skill-level') && skillItems.length > 0;
+  return (
+    <>
+      {showDistribution ? <WorkforceSkillDistribution skillItems={skillItems} /> : null}
+
+      {/* Skill-level drilldown: expand a level to see the matched members (the V2 drilldown). */}
+      {activeView === 'skill-level' ? (
+        <div style={{ marginTop: 16 }}>
+          <WorkforceBucketDrilldown kind="skill-level" title="Members by skill level" items={skillItems} />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function WorkforceSectorSection({
+  activeView,
+  sectorItems,
+  occupationItems,
+}: {
+  activeView: SidebarView;
+  sectorItems: WorkforceGroupedReportItem[];
+  occupationItems: WorkforceOccupationGapItem[];
+}) {
+  const showTraining = activeView === 'overview' || activeView === 'sector';
+  return (
+    <>
+      {/* Overview keeps the aggregate sector bars; the Sectors view uses the expandable drilldown so
+          members are reachable. */}
+      {activeView === 'overview' ? <WorkforceSectorGaps sectorItems={sectorItems} /> : null}
+      {activeView === 'sector' ? (
+        <WorkforceBucketDrilldown kind="sector" title="Members by sector" items={sectorItems} />
+      ) : null}
+
+      {showTraining ? (
+        <div style={{ marginTop: 16 }}>
+          <WorkforceTrainingGaps occupationItems={occupationItems} />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
 function WorkforceDashboardContent({
   t,
   dashboard,
@@ -173,12 +229,7 @@ function WorkforceDashboardContent({
   activeView: SidebarView;
   warning: string | null;
 }) {
-  // Empty only when there is genuinely nothing to track: no taxonomy sectors/occupations and nobody
-  // in the Directory. Demand alone (population model) is enough to render the dashboard.
-  const isEmpty = !dashboard
-    || (dashboard.sectorsTotal === 0 && dashboard.occupationsTotal === 0 && dashboard.totalMembers === 0);
-
-  if (isEmpty) {
+  if (!dashboard || isDashboardEmptyData(dashboard)) {
     return <WorkforceEmptyState t={t} />;
   }
 
@@ -188,32 +239,88 @@ function WorkforceDashboardContent({
         {warning ? <WorkforceWarningBanner message={warning} /> : null}
         <WorkforceHeroStats dashboard={dashboard} />
 
-        {(activeView === 'overview' || activeView === 'skill-level') && skillItems.length > 0 ? (
-          <WorkforceSkillDistribution skillItems={skillItems} />
-        ) : null}
+        <WorkforceSkillSection activeView={activeView} skillItems={skillItems} />
 
-        {/* Skill-level drilldown: expand a level to see the matched members (the V2 drilldown). */}
-        {activeView === 'skill-level' ? (
-          <div style={{ marginTop: 16 }}>
-            <WorkforceBucketDrilldown kind="skill-level" title="Members by skill level" items={skillItems} />
-          </div>
-        ) : null}
-
-        {/* Overview keeps the aggregate sector bars; the Sectors view uses the expandable drilldown so
-            members are reachable. */}
-        {activeView === 'overview' ? <WorkforceSectorGaps sectorItems={sectorItems} /> : null}
-        {activeView === 'sector' ? (
-          <WorkforceBucketDrilldown kind="sector" title="Members by sector" items={sectorItems} />
-        ) : null}
-
-        {(activeView === 'overview' || activeView === 'sector') ? (
-          <div style={{ marginTop: 16 }}>
-            <WorkforceTrainingGaps occupationItems={occupationItems} />
-          </div>
-        ) : null}
+        <WorkforceSectorSection
+          activeView={activeView}
+          sectorItems={sectorItems}
+          occupationItems={occupationItems}
+        />
       </div>
     </ScrollArea>
   );
+}
+
+function isAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
+// A 401/403 on ANY endpoint means the session is no longer valid (e.g. it expired after the page
+// loaded). Callers surface a re-auth prompt rather than a soft "couldn't load" warning.
+function anyAuthFailure(responses: Response[]): boolean {
+  return responses.some((r) => r.status === 401 || r.status === 403);
+}
+
+async function readItems<T>(res: Response): Promise<T[]> {
+  if (!res.ok) return [];
+  const json = (await res.json()) as { items?: T[] };
+  return json.items ?? [];
+}
+
+// A 404 on the profile is normal (the member has not claimed a Directory profile); any other
+// non-OK profile status yields null too, and is noted separately in failedSectionsMessage.
+async function readProfile(res: Response): Promise<WorkforceProfile | null> {
+  if (!res.ok) return null;
+  const json = (await res.json()) as { profile?: WorkforceProfile };
+  return json.profile ?? null;
+}
+
+// Surface a non-blocking notice if a secondary panel failed to load, instead of silently showing it
+// empty (which reads as "no data").
+function failedSectionsMessage(
+  sectorRes: Response,
+  skillRes: Response,
+  occRes: Response,
+  profileRes: Response,
+): string | null {
+  const failed: string[] = [];
+  if (!sectorRes.ok) failed.push('sector gaps');
+  if (!skillRes.ok) failed.push('skill levels');
+  if (!occRes.ok) failed.push('training gaps');
+  if (!profileRes.ok && profileRes.status !== 404) failed.push('your profile');
+  return failed.length > 0 ? `Some sections could not be loaded: ${failed.join(', ')}.` : null;
+}
+
+async function loadWorkforceData(
+  signal?: AbortSignal,
+): Promise<{ data: WorkforceData; warning: string | null }> {
+  const [dashRes, sectorRes, skillRes, occRes, profileRes] = await Promise.all([
+    fetch('/api/workforce/dashboard', { signal }),
+    fetch('/api/workforce/reports/sector/all', { signal }),
+    fetch('/api/workforce/reports/skill-level/all', { signal }),
+    fetch('/api/workforce/reports/occupations?limit=10', { signal }),
+    fetch('/api/workforce/profile', { signal }),
+  ]);
+
+  if (anyAuthFailure([dashRes, sectorRes, skillRes, occRes, profileRes])) {
+    throw new Error('Your session has expired. Please sign in again.');
+  }
+
+  // The dashboard is the core of the page; if it fails there is nothing meaningful to show, so
+  // surface the error state rather than silently falling through to the empty state.
+  if (!dashRes.ok) {
+    throw new Error(`Dashboard request failed (${dashRes.status}).`);
+  }
+
+  const dashJson = (await dashRes.json()) as { dashboard?: WorkforceDashboard };
+  const data: WorkforceData = {
+    dashboard: dashJson.dashboard ?? null,
+    sectorItems: await readItems<WorkforceGroupedReportItem>(sectorRes),
+    skillItems: await readItems<WorkforceGroupedReportItem>(skillRes),
+    occupationItems: await readItems<WorkforceOccupationGapItem>(occRes),
+    profile: await readProfile(profileRes),
+  };
+  return { data, warning: failedSectionsMessage(sectorRes, skillRes, occRes, profileRes) };
 }
 
 export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
@@ -238,67 +345,15 @@ export function WorkforceShell({ isAdmin }: { isAdmin?: boolean }) {
     setError(null);
     setWarning(null);
     try {
-      const [dashRes, sectorRes, skillRes, occRes, profileRes] = await Promise.all([
-        fetch('/api/workforce/dashboard', { signal }),
-        fetch('/api/workforce/reports/sector/all', { signal }),
-        fetch('/api/workforce/reports/skill-level/all', { signal }),
-        fetch('/api/workforce/reports/occupations?limit=10', { signal }),
-        fetch('/api/workforce/profile', { signal }),
-      ]);
-
-      if (signal?.aborted) return;
-
-      // A 401/403 on ANY endpoint means the session is no longer valid (e.g. it expired after the
-      // page loaded). Surface a re-auth prompt via the error state rather than a soft "couldn't load"
-      // warning, so a user who lost their session is told to sign in again instead of being left on a
-      // half-rendered dashboard.
-      if ([dashRes, sectorRes, skillRes, occRes, profileRes].some((r) => r.status === 401 || r.status === 403)) {
-        throw new Error('Your session has expired. Please sign in again.');
-      }
-
-      // The dashboard is the core of the page; if it fails there is nothing meaningful to show, so
-      // surface the error state rather than silently falling through to the empty state.
-      if (!dashRes.ok) {
-        throw new Error(`Dashboard request failed (${dashRes.status}).`);
-      }
-
-      const dashJson = (await dashRes.json()) as { dashboard?: WorkforceDashboard };
-      const sectorJson = sectorRes.ok
-        ? ((await sectorRes.json()) as { items?: WorkforceGroupedReportItem[] })
-        : null;
-      const skillJson = skillRes.ok
-        ? ((await skillRes.json()) as { items?: WorkforceGroupedReportItem[] })
-        : null;
-      const occJson = occRes.ok
-        ? ((await occRes.json()) as { items?: WorkforceOccupationGapItem[] })
-        : null;
-      // A 404 on the profile is normal (the member has not claimed a Directory profile); any other
-      // non-OK profile status is a real failure worth noting.
-      const profileJson = profileRes.ok
-        ? ((await profileRes.json()) as { profile?: WorkforceProfile })
-        : null;
-
-      // Surface a non-blocking notice if a secondary panel failed to load, instead of silently
-      // showing it empty (which reads as "no data").
-      const failed: string[] = [];
-      if (!sectorRes.ok) failed.push('sector gaps');
-      if (!skillRes.ok) failed.push('skill levels');
-      if (!occRes.ok) failed.push('training gaps');
-      if (!profileRes.ok && profileRes.status !== 404) failed.push('your profile');
-
-      setData({
-        dashboard: dashJson?.dashboard ?? null,
-        sectorItems: sectorJson?.items ?? [],
-        skillItems: skillJson?.items ?? [],
-        occupationItems: occJson?.items ?? [],
-        profile: profileJson?.profile ?? null,
-      });
-      setWarning(failed.length > 0 ? `Some sections could not be loaded: ${failed.join(', ')}.` : null);
+      const { data: loaded, warning: warn } = await loadWorkforceData(signal);
+      if (isAborted(signal)) return;
+      setData(loaded);
+      setWarning(warn);
     } catch (e: unknown) {
-      if (signal?.aborted) return;
+      if (isAborted(signal)) return;
       setError(e instanceof Error ? e.message : 'Failed to load workforce data.');
     } finally {
-      if (!signal?.aborted && initial) {
+      if (!isAborted(signal) && initial) {
         setLoading(false);
       }
     }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — web components/pages).

## What

Rule-116 complexity/length cleanup for the remaining flagged web components (~24 files) plus two app pages — this finishes the web **component** layer. **Behavior-preserving** — rendered UI, state, effects, handlers, and network calls unchanged; hooks in stable, unconditional order; all `<label>`↔control associations preserved.

Highlights:
- `level-up/lu-admin-shell` (471 lines / complexity 39) → `useLevelUpAdminController` hook + section components
- `feed-announcements/commons-moderation-admin-shell` (372 lines / 20) → shared moderation helpers + tab/card components
- `beacon/beacon-admin-shell` (286 lines) → `useBeaconAdmin` hook; `beacon-viewer` → live/idle view components
- `workforce` shell/admin, `weekly-performance`, `mutual-time` admin/public, `safety-admin`, `bug-reports` admin, `account-data`, `gdp`, `mood`, `skills-taxonomy`, `click-log`, `blocks`, `shared/share-link`
- `app/page.tsx` (HomePage 22) and `app/apps/[pluginSlug]/page.tsx` (30 → data-driven renderer map)

## Verification
- `pnpm --filter @ctf/web run typecheck` / repo `lint` — pass
- complexity rule + **`lint:a11y`** (across all components/app) — pass
- `check-eof-format` — pass
- pre-push gate — pass

No schema/route/contract changes.

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_