### PR TITLE
ci: make the complexity gate ignore inline eslint-disable directives

### DIFF
--- a/ctf/scripts/check-modularity-governance.sh
+++ b/ctf/scripts/check-modularity-governance.sh
@@ -60,8 +60,14 @@ fi
 echo "Checking ${#target_files[@]} changed file(s):"
 printf '  %s\n' "${target_files[@]}"
 
+# --no-inline-config: this gate runs eslint with ONLY the complexity + max-lines rules loaded, so an
+# `// eslint-disable-next-line <plugin>/<rule>` comment in a changed file (e.g. jsx-a11y/*, which lives
+# in the separate a11y-audit config, not the base lint config) would otherwise error as "Definition for
+# rule ... was not found" and fail the gate for an unrelated reason. Ignoring inline config also means a
+# function can't dodge this gate with `// eslint-disable complexity` — which is exactly what we want.
 if ESLINT_USE_FLAT_CONFIG=false pnpm exec eslint \
   --quiet \
+  --no-inline-config \
   --no-error-on-unmatched-pattern \
   --rule 'complexity:["error",10]' \
   --rule 'max-lines-per-function:["error",{"max":200,"skipBlankLines":true,"skipComments":true,"IIFEs":true}]' \


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (CI/infra change only).

## Why

The now-enforcing complexity gate (#2003) runs eslint with only the `complexity` + `max-lines-per-function` rules loaded. A changed file that contains an `// eslint-disable-next-line jsx-a11y/*` comment (jsx-a11y rules live in the separate `a11y-audit.config.mjs`, not the base lint config) makes that eslint run fail with `Definition for rule 'jsx-a11y/...' was not found` — failing the gate for an unrelated reason. This is already blocking a clean refactor PR (#2010, which only touches `beacon-viewer`/`share-link` a11y-disable comments).

## Fix

Add `--no-inline-config` to the gate's eslint invocation. It makes eslint ignore all inline `eslint-disable` directives, so:
- unknown-rule directives (jsx-a11y and friends) are harmless — no "rule not found",
- a function can't dodge this gate with `// eslint-disable complexity` either — which is the behavior we want.

Verified locally: a file with `// eslint-disable-next-line jsx-a11y/media-has-caption` errors under the old command and is clean with `--no-inline-config`.

## Review lane
CI enforcement fix. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_