### PR TITLE
refactor: reduce complexity in foundation/trust-transport/lighthouse/skills-taxonomy/skills-hunt API routes

### DIFF
--- a/ctf/packages/web/app/api/foundation/admin/capacity-policy/route.ts
+++ b/ctf/packages/web/app/api/foundation/admin/capacity-policy/route.ts
@@ -23,6 +23,41 @@ export async function GET() {
   }
 }
 
+type CapacityPolicyPayload = {
+  maxActiveThreadsPerUser?: number;
+  maxMessagesPerMinute?: number;
+  maxSearchesPerMinute?: number;
+  maxQuoteTransitionsPerMinute?: number;
+  maxCallDurationMinutes?: number;
+  quotaState?: 'green' | 'yellow' | 'orange' | 'red';
+};
+
+type ValidatedCapacityPolicyPayload = {
+  maxActiveThreadsPerUser: number;
+  maxMessagesPerMinute: number;
+  maxSearchesPerMinute: number;
+  maxQuoteTransitionsPerMinute: number;
+  maxCallDurationMinutes: number;
+  quotaState: 'green' | 'yellow' | 'orange' | 'red';
+};
+
+// A full capacity policy requires every limit as an integer and a valid quota state; a partial or
+// mistyped body is rejected. Returns the validated payload, or null when the body is incomplete.
+function validateCapacityPolicyPayload(payload: CapacityPolicyPayload): ValidatedCapacityPolicyPayload | null {
+  if (
+    !Number.isInteger(payload.maxActiveThreadsPerUser)
+    || !Number.isInteger(payload.maxMessagesPerMinute)
+    || !Number.isInteger(payload.maxSearchesPerMinute)
+    || !Number.isInteger(payload.maxQuoteTransitionsPerMinute)
+    || !Number.isInteger(payload.maxCallDurationMinutes)
+    || (payload.quotaState !== 'green' && payload.quotaState !== 'yellow' && payload.quotaState !== 'orange' && payload.quotaState !== 'red')
+  ) {
+    return null;
+  }
+
+  return payload as ValidatedCapacityPolicyPayload;
+}
+
 export async function PUT(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -34,14 +69,7 @@ export async function PUT(request: Request) {
     return gate.response;
   }
 
-  let payload: {
-    maxActiveThreadsPerUser?: number;
-    maxMessagesPerMinute?: number;
-    maxSearchesPerMinute?: number;
-    maxQuoteTransitionsPerMinute?: number;
-    maxCallDurationMinutes?: number;
-    quotaState?: 'green' | 'yellow' | 'orange' | 'red';
-  } = {};
+  let payload: CapacityPolicyPayload = {};
   try {
     payload = await request.json();
   } catch {
@@ -51,28 +79,13 @@ export async function PUT(request: Request) {
     );
   }
 
-  if (
-    !Number.isInteger(payload.maxActiveThreadsPerUser)
-    || !Number.isInteger(payload.maxMessagesPerMinute)
-    || !Number.isInteger(payload.maxSearchesPerMinute)
-    || !Number.isInteger(payload.maxQuoteTransitionsPerMinute)
-    || !Number.isInteger(payload.maxCallDurationMinutes)
-    || (payload.quotaState !== 'green' && payload.quotaState !== 'yellow' && payload.quotaState !== 'orange' && payload.quotaState !== 'red')
-  ) {
+  const validatedPayload = validateCapacityPolicyPayload(payload);
+  if (!validatedPayload) {
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Full capacity policy payload is required.' },
       { status: 400 },
     );
   }
-
-  const validatedPayload = payload as {
-    maxActiveThreadsPerUser: number;
-    maxMessagesPerMinute: number;
-    maxSearchesPerMinute: number;
-    maxQuoteTransitionsPerMinute: number;
-    maxCallDurationMinutes: number;
-    quotaState: 'green' | 'yellow' | 'orange' | 'red';
-  };
 
   try {
     const policy = await updateCapacityPolicy({

--- a/ctf/packages/web/app/api/foundation/admin/rate-limits/evaluate/route.ts
+++ b/ctf/packages/web/app/api/foundation/admin/rate-limits/evaluate/route.ts
@@ -4,6 +4,21 @@ import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { evaluateRateLimitCommand, insertFoundationAudit } from 'lib/foundation/repository';
 import { reportError } from 'lib/observability/report';
 
+type EvaluatePayload = { userId?: string; commandName?: string; limit?: number; windowSeconds?: number };
+
+type NormalizedEvaluatePayload = { userId: string; commandName: string; limit: number; windowSeconds: number };
+
+// Normalize the request body: trim the identifiers and apply the default limit (20) and window (60s)
+// when a caller omits or mistypes them.
+function normalizeEvaluatePayload(payload: EvaluatePayload): NormalizedEvaluatePayload {
+  return {
+    userId: payload.userId?.trim() ?? '',
+    commandName: payload.commandName?.trim() ?? '',
+    limit: Number.isInteger(payload.limit) ? Number(payload.limit) : 20,
+    windowSeconds: Number.isInteger(payload.windowSeconds) ? Number(payload.windowSeconds) : 60,
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -15,7 +30,7 @@ export async function POST(request: Request) {
     return gate.response;
   }
 
-  let payload: { userId?: string; commandName?: string; limit?: number; windowSeconds?: number } = {};
+  let payload: EvaluatePayload = {};
   try {
     payload = await request.json();
   } catch {
@@ -25,10 +40,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const userId = payload.userId?.trim() ?? '';
-  const commandName = payload.commandName?.trim() ?? '';
-  const limit = Number.isInteger(payload.limit) ? Number(payload.limit) : 20;
-  const windowSeconds = Number.isInteger(payload.windowSeconds) ? Number(payload.windowSeconds) : 60;
+  const { userId, commandName, limit, windowSeconds } = normalizeEvaluatePayload(payload);
 
   if (!userId || !commandName) {
     return NextResponse.json(

--- a/ctf/packages/web/app/api/foundation/connections/instant-calls/[callId]/answer/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/instant-calls/[callId]/answer/route.ts
@@ -5,6 +5,47 @@ import { answerInstantCall } from 'lib/foundation/instant-call';
 import { insertFoundationAudit } from 'lib/foundation/repository';
 import { reportError } from 'lib/observability/report';
 
+// Map an answer-instant-call error to the matching HTTP response. Unknown errors are reported and
+// surfaced as a 503.
+function mapAnswerError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : '';
+  if (code === 'call_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callNotFound, message: 'Call not found or access denied.' },
+      { status: 404 },
+    );
+  }
+  if (code === 'not_callee') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callNotCallee, message: 'Only the person being called can answer.' },
+      { status: 403 },
+    );
+  }
+  if (code === 'not_ringing') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callNotRinging, message: 'This call is no longer ringing.' },
+      { status: 409 },
+    );
+  }
+  if (code === 'caller_insufficient_funds') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callInsufficientFunds, message: 'The caller does not have enough ServiceCredits — the call was not started.' },
+      { status: 402 },
+    );
+  }
+  if (code === 'billing_misconfigured') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callBillingMisconfigured, message: 'Paid calls are not set up for this call right now.' },
+      { status: 409 },
+    );
+  }
+  reportError(error, { area: 'foundation', op: 'connections_instant_call_answer' });
+  return NextResponse.json(
+    { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not answer the call.' },
+    { status: 503 },
+  );
+}
+
 // Answer a ringing instant 1:1 call (Foundation "Connect now", issue #808 tasks 3 and 4). Only the callee
 // may answer, and only while it is still ringing. Answering both moves the call into the in-call
 // ('answered') state AND takes the first per-block charge from the caller to the provider, inside
@@ -49,41 +90,6 @@ export async function POST(request: Request, context: { params: Promise<{ callId
 
     return NextResponse.json({ ok: true, call }, { status: 200 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-    if (code === 'call_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callNotFound, message: 'Call not found or access denied.' },
-        { status: 404 },
-      );
-    }
-    if (code === 'not_callee') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callNotCallee, message: 'Only the person being called can answer.' },
-        { status: 403 },
-      );
-    }
-    if (code === 'not_ringing') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callNotRinging, message: 'This call is no longer ringing.' },
-        { status: 409 },
-      );
-    }
-    if (code === 'caller_insufficient_funds') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callInsufficientFunds, message: 'The caller does not have enough ServiceCredits — the call was not started.' },
-        { status: 402 },
-      );
-    }
-    if (code === 'billing_misconfigured') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callBillingMisconfigured, message: 'Paid calls are not set up for this call right now.' },
-        { status: 409 },
-      );
-    }
-    reportError(error, { area: 'foundation', op: 'connections_instant_call_answer' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not answer the call.' },
-      { status: 503 },
-    );
+    return mapAnswerError(error);
   }
 }

--- a/ctf/packages/web/app/api/foundation/connections/instant-calls/[callId]/extend/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/instant-calls/[callId]/extend/route.ts
@@ -5,6 +5,53 @@ import { extendInstantCall } from 'lib/foundation/instant-call';
 import { insertFoundationAudit } from 'lib/foundation/repository';
 import { reportError } from 'lib/observability/report';
 
+// Map an extend-instant-call error to the matching HTTP response. Unknown errors are reported and
+// surfaced as a 503.
+function mapExtendError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : '';
+  if (code === 'call_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callNotFound, message: 'Call not found or access denied.' },
+      { status: 404 },
+    );
+  }
+  if (code === 'not_caller') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callNotCaller, message: 'Only the person who started the call can extend it.' },
+      { status: 403 },
+    );
+  }
+  if (code === 'not_active') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callNotActive, message: 'This call is not active.' },
+      { status: 409 },
+    );
+  }
+  if (code === 'block_cap_reached') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callBlockCapReached, message: 'You have reached the number of blocks you authorized for this call.' },
+      { status: 409 },
+    );
+  }
+  if (code === 'caller_insufficient_funds') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callInsufficientFunds, message: 'You do not have enough ServiceCredits — the call has ended.' },
+      { status: 402 },
+    );
+  }
+  if (code === 'billing_misconfigured') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callBillingMisconfigured, message: 'Paid calls are not set up for this call right now.' },
+      { status: 409 },
+    );
+  }
+  reportError(error, { area: 'foundation', op: 'connections_instant_call_extend' });
+  return NextResponse.json(
+    { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not extend the call.' },
+    { status: 503 },
+  );
+}
+
 // Extend an in-progress instant 1:1 call by one more paid block (Foundation "Connect now", issue #808
 // task 4). Caller-only: only the buyer who started the call can authorize another block. The call must be
 // active and still under the buyer-set block cap chosen at ring time. The next block is charged at the
@@ -51,47 +98,6 @@ export async function POST(request: Request, context: { params: Promise<{ callId
 
     return NextResponse.json({ ok: true, call }, { status: 200 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-    if (code === 'call_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callNotFound, message: 'Call not found or access denied.' },
-        { status: 404 },
-      );
-    }
-    if (code === 'not_caller') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callNotCaller, message: 'Only the person who started the call can extend it.' },
-        { status: 403 },
-      );
-    }
-    if (code === 'not_active') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callNotActive, message: 'This call is not active.' },
-        { status: 409 },
-      );
-    }
-    if (code === 'block_cap_reached') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callBlockCapReached, message: 'You have reached the number of blocks you authorized for this call.' },
-        { status: 409 },
-      );
-    }
-    if (code === 'caller_insufficient_funds') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callInsufficientFunds, message: 'You do not have enough ServiceCredits — the call has ended.' },
-        { status: 402 },
-      );
-    }
-    if (code === 'billing_misconfigured') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callBillingMisconfigured, message: 'Paid calls are not set up for this call right now.' },
-        { status: 409 },
-      );
-    }
-    reportError(error, { area: 'foundation', op: 'connections_instant_call_extend' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not extend the call.' },
-      { status: 503 },
-    );
+    return mapExtendError(error);
   }
 }

--- a/ctf/packages/web/app/api/foundation/connections/instant-calls/[callId]/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/instant-calls/[callId]/route.ts
@@ -7,7 +7,48 @@ import {
   getThreadChannelForCall,
 } from 'lib/foundation/instant-call';
 import type { FoundationInstantCallJoin } from 'lib/foundation/types';
+import type { AllowDecision } from 'lib/auth/server-authz';
 import { reportError } from 'lib/observability/report';
+
+type JoinCredentials = {
+  streamApiKey: string | null;
+  streamUserId: string | null;
+  streamToken: string | null;
+  streamChannelId: string;
+};
+
+// Resolve the participant-only Stream audio-join credentials for an answered call (same token path as
+// the Direct Line), plus the chat channel the audio room is anchored to.
+async function resolveJoinCredentials(auth: AllowDecision, callId: string): Promise<JoinCredentials> {
+  const channel = await getThreadChannelForCall({ callId, userId: auth.userId });
+  const credentials = await getInstantCallJoinCredentials({
+    userId: auth.userId,
+    displayName: auth.username ?? auth.userId,
+  });
+  return {
+    streamApiKey: credentials?.streamApiKey ?? null,
+    streamUserId: credentials?.streamUserId ?? null,
+    streamToken: credentials?.streamToken ?? null,
+    streamChannelId: channel.streamChannelId,
+  };
+}
+
+// Map an instant-call-state error to the matching HTTP response. Unknown errors are reported and
+// surfaced as a 503.
+function mapInstantCallStateError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : '';
+  if (code === 'call_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callNotFound, message: 'Call not found or access denied.' },
+      { status: 404 },
+    );
+  }
+  reportError(error, { area: 'foundation', op: 'connections_instant_call_state' });
+  return NextResponse.json(
+    { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not load the call.' },
+    { status: 503 },
+  );
+}
 
 // Poll the state of an instant 1:1 call the caller participates in (Foundation "Connect now", issue #808
 // task 3). Both the caller's "ringing…" surface and the callee's incoming-ring surface poll this to follow
@@ -34,46 +75,24 @@ export async function GET(_request: Request, context: { params: Promise<{ callId
 
     // Only hand out audio-join credentials while the call is live (answered). A ringing/terminal call has
     // nothing to join, so the Stream fields stay null until it is answered.
-    let streamApiKey: string | null = null;
-    let streamUserId: string | null = null;
-    let streamToken: string | null = null;
-    let streamChannelId = '';
-    if (call.ringStatus === 'answered') {
-      const channel = await getThreadChannelForCall({ callId, userId: gate.auth.userId });
-      streamChannelId = channel.streamChannelId;
-      const credentials = await getInstantCallJoinCredentials({
-        userId: gate.auth.userId,
-        displayName: gate.auth.username ?? gate.auth.userId,
-      });
-      streamApiKey = credentials?.streamApiKey ?? null;
-      streamUserId = credentials?.streamUserId ?? null;
-      streamToken = credentials?.streamToken ?? null;
-    }
+    const credentials: JoinCredentials =
+      call.ringStatus === 'answered'
+        ? await resolveJoinCredentials(gate.auth, callId)
+        : { streamApiKey: null, streamUserId: null, streamToken: null, streamChannelId: '' };
 
     const payload: FoundationInstantCallJoin = {
       call,
       role,
-      streamApiKey,
-      streamUserId,
-      streamToken,
+      streamApiKey: credentials.streamApiKey,
+      streamUserId: credentials.streamUserId,
+      streamToken: credentials.streamToken,
       // The Stream Video call id the audio room joins (distinct from streamChannelId, the chat channel).
       // Surfaced flat so the client does not have to reach into `call` to find it (issue #987).
       streamCallId: call.streamCallId,
-      streamChannelId,
+      streamChannelId: credentials.streamChannelId,
     };
     return NextResponse.json({ ok: true, ...payload }, { status: 200 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-    if (code === 'call_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callNotFound, message: 'Call not found or access denied.' },
-        { status: 404 },
-      );
-    }
-    reportError(error, { area: 'foundation', op: 'connections_instant_call_state' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not load the call.' },
-      { status: 503 },
-    );
+    return mapInstantCallStateError(error);
   }
 }

--- a/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/calls/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/calls/route.ts
@@ -4,6 +4,71 @@ import { FOUNDATION_CALL_MODALITIES, FOUNDATION_ERROR_CODE } from 'lib/foundatio
 import { createCallSession, insertFoundationAudit } from 'lib/foundation/repository';
 import { reportError } from 'lib/observability/report';
 
+type CreateCallInput =
+  | { ok: true; modality: 'voice' | 'video'; requestedDurationMinutes?: number; idempotencyKey: string }
+  | { ok: false; response: NextResponse };
+
+// Parse and validate the create-call-session request body against the route's threadId. modality is
+// required and must be one of the supported values; idempotencyKey falls back to a deterministic key.
+async function readCreateCallInput(request: Request, threadId: string): Promise<CreateCallInput> {
+  let payload: { modality?: string; requestedDurationMinutes?: number; idempotencyKey?: string } = {};
+  try {
+    payload = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON payload.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const modality = payload.modality?.trim() ?? '';
+  if (!threadId || !FOUNDATION_CALL_MODALITIES.includes(modality as 'voice' | 'video')) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'threadId and modality (voice|video) are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    modality: modality as 'voice' | 'video',
+    requestedDurationMinutes: payload.requestedDurationMinutes,
+    idempotencyKey: payload.idempotencyKey?.trim() ?? `${threadId}:${modality}`,
+  };
+}
+
+// Map a create-call-session repository error to the matching HTTP response. Unknown errors are
+// reported and surfaced as a 503.
+function mapCreateCallError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : '';
+
+  if (code === 'thread_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found or access denied.' },
+      { status: 404 },
+    );
+  }
+
+  if (code === 'policy_denied') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Call session denied by capacity policy.' },
+      { status: 403 },
+    );
+  }
+
+  reportError(error, { area: 'foundation', op: 'connections_threads_threadid_calls' });
+  return NextResponse.json(
+    { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Call session unavailable.' },
+    { status: 503 },
+  );
+}
+
 export async function POST(request: Request, context: { params: Promise<{ threadId: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -17,22 +82,9 @@ export async function POST(request: Request, context: { params: Promise<{ thread
 
   const { threadId } = await context.params;
 
-  let payload: { modality?: string; requestedDurationMinutes?: number; idempotencyKey?: string } = {};
-  try {
-    payload = await request.json();
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON payload.' },
-      { status: 400 },
-    );
-  }
-
-  const modality = payload.modality?.trim() ?? '';
-  if (!threadId || !FOUNDATION_CALL_MODALITIES.includes(modality as 'voice' | 'video')) {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'threadId and modality (voice|video) are required.' },
-      { status: 400 },
-    );
+  const input = await readCreateCallInput(request, threadId);
+  if (!input.ok) {
+    return input.response;
   }
 
   try {
@@ -40,9 +92,9 @@ export async function POST(request: Request, context: { params: Promise<{ thread
       threadId,
       actorUserId: gate.auth.userId,
       actorDisplayName: gate.auth.username ?? gate.auth.userId,
-      modality: modality as 'voice' | 'video',
-      requestedDurationMinutes: payload.requestedDurationMinutes,
-      idempotencyKey: payload.idempotencyKey?.trim() ?? `${threadId}:${modality}`,
+      modality: input.modality,
+      requestedDurationMinutes: input.requestedDurationMinutes,
+      idempotencyKey: input.idempotencyKey,
     });
 
     await insertFoundationAudit({
@@ -52,31 +104,11 @@ export async function POST(request: Request, context: { params: Promise<{ thread
       reason: 'ok',
       targetType: 'thread',
       targetId: threadId,
-      metadata: { callSessionId: session.callSession.id, modality },
+      metadata: { callSessionId: session.callSession.id, modality: input.modality },
     });
 
     return NextResponse.json({ ok: true, ...session }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-
-    if (code === 'thread_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found or access denied.' },
-        { status: 404 },
-      );
-    }
-
-    if (code === 'policy_denied') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Call session denied by capacity policy.' },
-        { status: 403 },
-      );
-    }
-
-    reportError(error, { area: 'foundation', op: 'connections_threads_threadid_calls' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Call session unavailable.' },
-      { status: 503 },
-    );
+    return mapCreateCallError(error);
   }
 }

--- a/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/instant-call/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/instant-call/route.ts
@@ -9,6 +9,91 @@ type RingInput = {
   authorizedBlocks?: number;
 };
 
+type ParsedRingInput =
+  | { ok: true; authorizedBlocks?: number }
+  | { ok: false; response: NextResponse };
+
+// Parse the optional ring body. The body is optional; an absent authorizedBlocks falls back to the
+// default cap in ringInstantCall. When present, authorizedBlocks must be a number.
+async function readRingInput(request: Request): Promise<ParsedRingInput> {
+  let body: RingInput = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) {
+      body = JSON.parse(text) as RingInput;
+    }
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (body.authorizedBlocks !== undefined && typeof body.authorizedBlocks !== 'number') {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'authorizedBlocks must be a number.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, authorizedBlocks: body.authorizedBlocks };
+}
+
+// Map a ring-instant-call error to the matching HTTP response. Unknown errors are reported and
+// surfaced as a 503.
+function mapRingError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : '';
+
+  if (code === 'thread_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found or access denied.' },
+      { status: 404 },
+    );
+  }
+  if (code === 'invalid_authorized_blocks') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Choose a valid number of blocks to authorize.' },
+      { status: 400 },
+    );
+  }
+  if (code === 'billing_misconfigured') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callBillingMisconfigured, message: 'This provider is not set up for paid calls right now.' },
+      { status: 409 },
+    );
+  }
+  if (code === 'insufficient_balance') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.callInsufficientFunds, message: 'You do not have enough ServiceCredits to start this call.' },
+      { status: 402 },
+    );
+  }
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Too many call attempts. Wait a moment and try again.' },
+      { status: 429 },
+    );
+  }
+  if (code === 'callee_busy') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.calleeBusy, message: 'This person already has an incoming call. Try again shortly.' },
+      { status: 409 },
+    );
+  }
+
+  reportError(error, { area: 'foundation', op: 'connections_instant_call_ring' });
+  return NextResponse.json(
+    { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not start the call.' },
+    { status: 503 },
+  );
+}
+
 // Place an instant 1:1 call ring (Foundation "Connect now", issue #808 tasks 3 and 4). The caller is a
 // participant of an existing Direct Line thread; this rings the other participant (the provider). Audio
 // only for v1. The ring is in-app only — the callee learns about it by polling the incoming-call inbox.
@@ -34,31 +119,16 @@ export async function POST(request: Request, context: { params: Promise<{ thread
     );
   }
 
-  // The body is optional; an absent authorizedBlocks falls back to the default cap in ringInstantCall.
-  let body: RingInput = {};
-  try {
-    const text = await request.text();
-    if (text.trim().length > 0) {
-      body = JSON.parse(text) as RingInput;
-    }
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON.' },
-      { status: 400 },
-    );
-  }
-  if (body.authorizedBlocks !== undefined && typeof body.authorizedBlocks !== 'number') {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'authorizedBlocks must be a number.' },
-      { status: 400 },
-    );
+  const input = await readRingInput(request);
+  if (!input.ok) {
+    return input.response;
   }
 
   try {
     const call = await ringInstantCall({
       threadId,
       callerUserId: gate.auth.userId,
-      authorizedBlocks: body.authorizedBlocks,
+      authorizedBlocks: input.authorizedBlocks,
     });
 
     await insertFoundationAudit({
@@ -73,49 +143,6 @@ export async function POST(request: Request, context: { params: Promise<{ thread
 
     return NextResponse.json({ ok: true, call }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-
-    if (code === 'thread_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found or access denied.' },
-        { status: 404 },
-      );
-    }
-    if (code === 'invalid_authorized_blocks') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Choose a valid number of blocks to authorize.' },
-        { status: 400 },
-      );
-    }
-    if (code === 'billing_misconfigured') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callBillingMisconfigured, message: 'This provider is not set up for paid calls right now.' },
-        { status: 409 },
-      );
-    }
-    if (code === 'insufficient_balance') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.callInsufficientFunds, message: 'You do not have enough ServiceCredits to start this call.' },
-        { status: 402 },
-      );
-    }
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Too many call attempts. Wait a moment and try again.' },
-        { status: 429 },
-      );
-    }
-    if (code === 'callee_busy') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.calleeBusy, message: 'This person already has an incoming call. Try again shortly.' },
-        { status: 409 },
-      );
-    }
-
-    reportError(error, { area: 'foundation', op: 'connections_instant_call_ring' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not start the call.' },
-      { status: 503 },
-    );
+    return mapRingError(error);
   }
 }

--- a/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/messages/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/threads/[threadId]/messages/route.ts
@@ -4,6 +4,68 @@ import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { insertFoundationAudit, sendMessageToThread } from 'lib/foundation/repository';
 import { reportError } from 'lib/observability/report';
 
+type SendMessageInput =
+  | { ok: true; messageText: string; clientMessageId: string; attachments: unknown }
+  | { ok: false; response: NextResponse };
+
+// Parse and validate the send-message request body against the route's threadId. threadId, a
+// non-empty messageText, and a clientMessageId are all required.
+async function readSendMessageInput(request: Request, threadId: string): Promise<SendMessageInput> {
+  let payload: { messageText?: string; attachments?: unknown; clientMessageId?: string } = {};
+  try {
+    payload = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON payload.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const messageText = payload.messageText?.trim() ?? '';
+  const clientMessageId = payload.clientMessageId?.trim() ?? '';
+
+  if (!threadId || !messageText || !clientMessageId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'threadId, messageText, and clientMessageId are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, messageText, clientMessageId, attachments: payload.attachments };
+}
+
+// Map a send-message repository error to the matching HTTP response. Unknown errors are reported and
+// surfaced as a 503.
+function mapSendMessageError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : '';
+
+  if (code === 'thread_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found or access denied.' },
+      { status: 404 },
+    );
+  }
+
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Message rate limit exceeded.' },
+      { status: 429 },
+    );
+  }
+
+  reportError(error, { area: 'foundation', op: 'connections_threads_threadid_messages' });
+  return NextResponse.json(
+    { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Message send unavailable.' },
+    { status: 503 },
+  );
+}
+
 export async function POST(request: Request, context: { params: Promise<{ threadId: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -17,24 +79,9 @@ export async function POST(request: Request, context: { params: Promise<{ thread
 
   const { threadId } = await context.params;
 
-  let payload: { messageText?: string; attachments?: unknown; clientMessageId?: string } = {};
-  try {
-    payload = await request.json();
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON payload.' },
-      { status: 400 },
-    );
-  }
-
-  const messageText = payload.messageText?.trim() ?? '';
-  const clientMessageId = payload.clientMessageId?.trim() ?? '';
-
-  if (!threadId || !messageText || !clientMessageId) {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'threadId, messageText, and clientMessageId are required.' },
-      { status: 400 },
-    );
+  const input = await readSendMessageInput(request, threadId);
+  if (!input.ok) {
+    return input.response;
   }
 
   try {
@@ -42,9 +89,9 @@ export async function POST(request: Request, context: { params: Promise<{ thread
       threadId,
       actorUserId: gate.auth.userId,
       actorDisplayName: gate.auth.username ?? gate.auth.userId,
-      messageText,
-      attachments: payload.attachments,
-      clientMessageId,
+      messageText: input.messageText,
+      attachments: input.attachments,
+      clientMessageId: input.clientMessageId,
     });
 
     await insertFoundationAudit({
@@ -59,26 +106,6 @@ export async function POST(request: Request, context: { params: Promise<{ thread
 
     return NextResponse.json({ ok: true, message }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-
-    if (code === 'thread_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found or access denied.' },
-        { status: 404 },
-      );
-    }
-
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Message rate limit exceeded.' },
-        { status: 429 },
-      );
-    }
-
-    reportError(error, { area: 'foundation', op: 'connections_threads_threadid_messages' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Message send unavailable.' },
-      { status: 503 },
-    );
+    return mapSendMessageError(error);
   }
 }

--- a/ctf/packages/web/app/api/foundation/connections/threads/route.ts
+++ b/ctf/packages/web/app/api/foundation/connections/threads/route.ts
@@ -5,6 +5,77 @@ import { createConnectionThread, insertFoundationAudit } from 'lib/foundation/re
 import { notifySafe } from 'lib/notifications/repository';
 import { reportError } from 'lib/observability/report';
 
+type CreateThreadInput =
+  | { ok: true; providerId: string; idempotencyKey: string }
+  | { ok: false; response: NextResponse };
+
+// Parse and validate the create-thread request body. providerId is required; idempotencyKey falls
+// back to a deterministic per-provider key so the getOrCreate reuse path stays stable.
+async function readCreateThreadInput(request: Request): Promise<CreateThreadInput> {
+  let payload: { providerId?: string; idempotencyKey?: string } = {};
+  try {
+    payload = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON payload.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const providerId = payload.providerId?.trim();
+  if (!providerId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'providerId is required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    providerId,
+    idempotencyKey: payload.idempotencyKey?.trim() ?? `thread-${providerId}`,
+  };
+}
+
+// Map a create-thread repository error to the matching HTTP response. Unknown errors are reported and
+// surfaced as a 503.
+function mapCreateThreadError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : '';
+
+  if (code === 'provider_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.providerNotFound, message: 'Provider not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Thread create rate limit exceeded.' },
+      { status: 429 },
+    );
+  }
+
+  if (code === 'policy_denied') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Connection request denied by policy.' },
+      { status: 403 },
+    );
+  }
+
+  reportError(error, { area: 'foundation', op: 'connections_threads' });
+  return NextResponse.json(
+    { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Thread create unavailable.' },
+    { status: 503 },
+  );
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -16,30 +87,17 @@ export async function POST(request: Request) {
     return gate.response;
   }
 
-  let payload: { providerId?: string; idempotencyKey?: string } = {};
-  try {
-    payload = await request.json();
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'Invalid JSON payload.' },
-      { status: 400 },
-    );
-  }
-
-  const providerId = payload.providerId?.trim();
-  if (!providerId) {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'providerId is required.' },
-      { status: 400 },
-    );
+  const input = await readCreateThreadInput(request);
+  if (!input.ok) {
+    return input.response;
   }
 
   try {
     const thread = await createConnectionThread({
       actorUserId: gate.auth.userId,
       actorDisplayName: gate.auth.username ?? gate.auth.userId,
-      providerProfileId: providerId,
-      idempotencyKey: payload.idempotencyKey?.trim() ?? `thread-${providerId}`,
+      providerProfileId: input.providerId,
+      idempotencyKey: input.idempotencyKey,
     });
 
     await insertFoundationAudit({
@@ -49,7 +107,7 @@ export async function POST(request: Request) {
       reason: 'ok',
       targetType: 'thread',
       targetId: thread.thread.id,
-      metadata: { providerId, streamChannelId: thread.thread.streamChannelId },
+      metadata: { providerId: input.providerId, streamChannelId: thread.thread.streamChannelId },
     });
 
     // Notify the provider that someone started a connection with them — a durable record in the
@@ -79,33 +137,6 @@ export async function POST(request: Request) {
       { status: 201 },
     );
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-
-    if (code === 'provider_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.providerNotFound, message: 'Provider not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Thread create rate limit exceeded.' },
-        { status: 429 },
-      );
-    }
-
-    if (code === 'policy_denied') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Connection request denied by policy.' },
-        { status: 403 },
-      );
-    }
-
-    reportError(error, { area: 'foundation', op: 'connections_threads' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Thread create unavailable.' },
-      { status: 503 },
-    );
+    return mapCreateThreadError(error);
   }
 }

--- a/ctf/packages/web/app/api/foundation/provider/instant-call/route.ts
+++ b/ctf/packages/web/app/api/foundation/provider/instant-call/route.ts
@@ -27,11 +27,29 @@ export async function GET() {
 
 type InstantCallBody = { enabled?: unknown; rateCredits?: unknown; intervalMinutes?: unknown };
 
+type ValidatedInstantCallBody = { enabled: boolean; rateCredits: number | null; intervalMinutes: number };
+
 function badRequest(message: string): NextResponse {
   return NextResponse.json(
     { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message },
     { status: 400 },
   );
+}
+
+// Validate the instant-call body shape: enabled is required boolean, rateCredits is a number or null,
+// and intervalMinutes is a number. Returns a 400 response on the first shape error, otherwise the
+// narrowed body ready to persist (the repository still enforces the rate/interval value ranges).
+function validateInstantCallBody(body: InstantCallBody): NextResponse | ValidatedInstantCallBody {
+  if (typeof body.enabled !== 'boolean') {
+    return badRequest('enabled must be a boolean.');
+  }
+  if (body.rateCredits !== null && typeof body.rateCredits !== 'number') {
+    return badRequest('rateCredits must be a number or null.');
+  }
+  if (typeof body.intervalMinutes !== 'number') {
+    return badRequest('intervalMinutes must be a number.');
+  }
+  return { enabled: body.enabled, rateCredits: body.rateCredits, intervalMinutes: body.intervalMinutes };
 }
 
 // Save the member's instant-call settings. The repository validates the rate and interval and throws a
@@ -57,21 +75,16 @@ export async function PUT(request: Request) {
     return badRequest('Invalid JSON body.');
   }
 
-  if (typeof body.enabled !== 'boolean') {
-    return badRequest('enabled must be a boolean.');
-  }
-  if (body.rateCredits !== null && typeof body.rateCredits !== 'number') {
-    return badRequest('rateCredits must be a number or null.');
-  }
-  if (typeof body.intervalMinutes !== 'number') {
-    return badRequest('intervalMinutes must be a number.');
+  const validated = validateInstantCallBody(body);
+  if (validated instanceof NextResponse) {
+    return validated;
   }
 
   try {
     const instantCall = await setOwnInstantCallSettings(gate.auth.userId, {
-      enabled: body.enabled,
-      rateCredits: body.rateCredits,
-      intervalMinutes: body.intervalMinutes,
+      enabled: validated.enabled,
+      rateCredits: validated.rateCredits,
+      intervalMinutes: validated.intervalMinutes,
     });
     return NextResponse.json({ ok: true, instantCall }, { status: 200 });
   } catch (error) {

--- a/ctf/packages/web/app/api/foundation/push/subscribe/route.ts
+++ b/ctf/packages/web/app/api/foundation/push/subscribe/route.ts
@@ -6,6 +6,93 @@ import { saveWebPushSubscription } from 'lib/notifications/push';
 import { saveExpoPushSubscription } from 'lib/notifications/expo-push';
 import { reportError } from 'lib/observability/report';
 
+type PushSubscribePayload = {
+  kind?: unknown;
+  token?: unknown;
+  endpoint?: unknown;
+  keys?: { p256dh?: unknown; auth?: unknown };
+  userAgent?: unknown;
+};
+
+// Expo native push (Android): the body carries an Expo push token, no encryption keys. The token is the
+// device identity (stored as the endpoint). Audit metadata records only the kind, never the token.
+async function handleExpoSubscription(
+  payload: PushSubscribePayload,
+  userId: string,
+  userAgent: string | null,
+): Promise<NextResponse> {
+  const token = typeof payload.token === 'string' ? payload.token.trim() : '';
+  if (!token) {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A push token is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await saveExpoPushSubscription({ userId, token, userAgent });
+
+    await insertFoundationAudit({
+      actorId: userId,
+      command: 'foundation.push.subscribe',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'push_subscription',
+      targetId: userId,
+      metadata: { kind: 'expo' },
+    });
+
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (error) {
+    reportError(error, { area: 'foundation', op: 'push_subscribe' });
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not save your call alerts.' },
+      { status: 503 },
+    );
+  }
+}
+
+// Web Push (default): the body carries the browser's PushSubscription (endpoint + encryption keys).
+// The endpoint and keys are stored but never logged; audit metadata records only the kind.
+async function handleWebSubscription(
+  payload: PushSubscribePayload,
+  userId: string,
+  userAgent: string | null,
+): Promise<NextResponse> {
+  const endpoint = typeof payload.endpoint === 'string' ? payload.endpoint.trim() : '';
+  const p256dh = typeof payload.keys?.p256dh === 'string' ? payload.keys.p256dh : null;
+  const auth = typeof payload.keys?.auth === 'string' ? payload.keys.auth : null;
+
+  if (!endpoint || !p256dh || !auth) {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A complete push subscription is required.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await saveWebPushSubscription({ userId, endpoint, p256dh, auth, userAgent });
+
+    await insertFoundationAudit({
+      actorId: userId,
+      command: 'foundation.push.subscribe',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetType: 'push_subscription',
+      targetId: userId,
+      metadata: { kind: 'web' },
+    });
+
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (error) {
+    reportError(error, { area: 'foundation', op: 'push_subscribe' });
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not save your call alerts.' },
+      { status: 503 },
+    );
+  }
+}
+
 // Save the signed-in member's push subscription for one device. A provider who enabled "call alerts on
 // this device" sends their device subscription here so the Foundation instant-call ring can wake their
 // device. The member acts only on their own subscription.
@@ -31,13 +118,7 @@ export async function POST(request: Request) {
     return gate.response;
   }
 
-  let payload: {
-    kind?: unknown;
-    token?: unknown;
-    endpoint?: unknown;
-    keys?: { p256dh?: unknown; auth?: unknown };
-    userAgent?: unknown;
-  };
+  let payload: PushSubscribePayload;
   try {
     payload = await request.json();
   } catch {
@@ -50,70 +131,9 @@ export async function POST(request: Request) {
   const userAgent = typeof payload.userAgent === 'string' ? payload.userAgent.slice(0, 256) : null;
   const kind = payload.kind === 'expo' ? 'expo' : 'web';
 
-  // Expo native push (Android): the body carries an Expo push token, no encryption keys.
   if (kind === 'expo') {
-    const token = typeof payload.token === 'string' ? payload.token.trim() : '';
-    if (!token) {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A push token is required.' },
-        { status: 400 },
-      );
-    }
-
-    try {
-      await saveExpoPushSubscription({ userId: gate.auth.userId, token, userAgent });
-
-      await insertFoundationAudit({
-        actorId: gate.auth.userId,
-        command: 'foundation.push.subscribe',
-        policyStatus: 'allow',
-        reason: 'ok',
-        targetType: 'push_subscription',
-        targetId: gate.auth.userId,
-        metadata: { kind: 'expo' },
-      });
-
-      return NextResponse.json({ ok: true }, { status: 201 });
-    } catch (error) {
-      reportError(error, { area: 'foundation', op: 'push_subscribe' });
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not save your call alerts.' },
-        { status: 503 },
-      );
-    }
+    return handleExpoSubscription(payload, gate.auth.userId, userAgent);
   }
 
-  // Web Push (default): the body carries the browser's PushSubscription (endpoint + encryption keys).
-  const endpoint = typeof payload.endpoint === 'string' ? payload.endpoint.trim() : '';
-  const p256dh = typeof payload.keys?.p256dh === 'string' ? payload.keys.p256dh : null;
-  const auth = typeof payload.keys?.auth === 'string' ? payload.keys.auth : null;
-
-  if (!endpoint || !p256dh || !auth) {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A complete push subscription is required.' },
-      { status: 400 },
-    );
-  }
-
-  try {
-    await saveWebPushSubscription({ userId: gate.auth.userId, endpoint, p256dh, auth, userAgent });
-
-    await insertFoundationAudit({
-      actorId: gate.auth.userId,
-      command: 'foundation.push.subscribe',
-      policyStatus: 'allow',
-      reason: 'ok',
-      targetType: 'push_subscription',
-      targetId: gate.auth.userId,
-      metadata: { kind: 'web' },
-    });
-
-    return NextResponse.json({ ok: true }, { status: 201 });
-  } catch (error) {
-    reportError(error, { area: 'foundation', op: 'push_subscribe' });
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.persistenceUnavailable, message: 'Could not save your call alerts.' },
-      { status: 503 },
-    );
-  }
+  return handleWebSubscription(payload, gate.auth.userId, userAgent);
 }

--- a/ctf/packages/web/app/api/foundation/quotes/[quoteRequestId]/state/route.ts
+++ b/ctf/packages/web/app/api/foundation/quotes/[quoteRequestId]/state/route.ts
@@ -5,6 +5,92 @@ import { insertFoundationAudit, updateQuoteRequestState } from 'lib/foundation/r
 import type { FoundationQuoteState } from 'lib/foundation/types';
 import { reportError } from 'lib/observability/report';
 
+type StatePayload = {
+  transitionTo?: string;
+  transitionReason?: string;
+  idempotencyKey?: string;
+  quotedAmount?: unknown;
+  quotedCurrency?: unknown;
+};
+
+type ParsedStatePayload = { transitionTo: string; quotedAmount: number; quotedCurrency: string };
+
+// Read the request fields we validate: the trimmed transition target, the quoted amount (NaN when not a
+// number), and the trimmed quoted currency ('' when absent).
+function parseStatePayload(payload: StatePayload): ParsedStatePayload {
+  return {
+    transitionTo: payload.transitionTo?.trim() ?? '',
+    quotedAmount: typeof payload.quotedAmount === 'number' ? payload.quotedAmount : NaN,
+    quotedCurrency: typeof payload.quotedCurrency === 'string' ? payload.quotedCurrency.trim() : '',
+  };
+}
+
+// Validate the transition request. quoteRequestId and a known transitionTo are always required. On the
+// 'provider_responded' transition the provider attaches a price: a finite quotedAmount >= 0 and a
+// non-empty quotedCurrency (a code from the shared currency catalog). Only the provider may do this;
+// that ownership check is enforced in the repository. Returns a 400 response on the first shape error,
+// otherwise null.
+function validateStatePayload(quoteRequestId: string, parsed: ParsedStatePayload): NextResponse | null {
+  if (!quoteRequestId || !FOUNDATION_QUOTE_STATES.includes(parsed.transitionTo as FoundationQuoteState)) {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'quoteRequestId and valid transitionTo are required.' },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.transitionTo === 'provider_responded') {
+    if (!Number.isFinite(parsed.quotedAmount) || parsed.quotedAmount < 0 || parsed.quotedCurrency.length === 0) {
+      return NextResponse.json(
+        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A valid quotedAmount and quotedCurrency are required to respond with a price.' },
+        { status: 400 },
+      );
+    }
+  }
+
+  return null;
+}
+
+// Use the caller-supplied idempotency key when present; otherwise fall back to the deterministic key.
+function resolveIdempotencyKey(provided: string | undefined, fallback: string): string {
+  return provided?.trim() ?? fallback;
+}
+
+// Map a known repository error code to its member-facing response; returns null for anything unknown so
+// the caller can report it and answer 503.
+function mapQuoteStateError(error: unknown): NextResponse | null {
+  const code = error instanceof Error ? error.message : '';
+
+  if (code === 'quote_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.quoteNotFound, message: 'Quote request not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (code === 'invalid_payload') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A valid quotedAmount and quotedCurrency are required to respond with a price.' },
+      { status: 400 },
+    );
+  }
+
+  if (code === 'invalid_quote_transition') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.invalidQuoteTransition, message: 'Invalid quote lifecycle transition.' },
+      { status: 409 },
+    );
+  }
+
+  if (code === 'policy_denied') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Quote transition denied by policy.' },
+      { status: 403 },
+    );
+  }
+
+  return null;
+}
+
 export async function POST(request: Request, context: { params: Promise<{ quoteRequestId: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -18,13 +104,7 @@ export async function POST(request: Request, context: { params: Promise<{ quoteR
 
   const { quoteRequestId } = await context.params;
 
-  let payload: {
-    transitionTo?: string;
-    transitionReason?: string;
-    idempotencyKey?: string;
-    quotedAmount?: unknown;
-    quotedCurrency?: unknown;
-  } = {};
+  let payload: StatePayload = {};
   try {
     payload = await request.json();
   } catch {
@@ -34,27 +114,14 @@ export async function POST(request: Request, context: { params: Promise<{ quoteR
     );
   }
 
-  const transitionTo = payload.transitionTo?.trim() ?? '';
-  if (!quoteRequestId || !FOUNDATION_QUOTE_STATES.includes(transitionTo as FoundationQuoteState)) {
-    return NextResponse.json(
-      { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'quoteRequestId and valid transitionTo are required.' },
-      { status: 400 },
-    );
+  const parsed = parseStatePayload(payload);
+  const validationError = validateStatePayload(quoteRequestId, parsed);
+  if (validationError) {
+    return validationError;
   }
 
-  // On the 'provider_responded' transition the provider attaches a price: a finite quotedAmount >= 0 and
-  // a non-empty quotedCurrency (a code from the shared currency catalog). Only the provider may do this;
-  // that ownership check is enforced in the repository. Validate the shape here before persisting.
-  const quotedAmount = typeof payload.quotedAmount === 'number' ? payload.quotedAmount : NaN;
-  const quotedCurrency = typeof payload.quotedCurrency === 'string' ? payload.quotedCurrency.trim() : '';
-  if (transitionTo === 'provider_responded') {
-    if (!Number.isFinite(quotedAmount) || quotedAmount < 0 || quotedCurrency.length === 0) {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A valid quotedAmount and quotedCurrency are required to respond with a price.' },
-        { status: 400 },
-      );
-    }
-  }
+  const { transitionTo, quotedAmount, quotedCurrency } = parsed;
+  const priced = transitionTo === 'provider_responded';
 
   try {
     const result = await updateQuoteRequestState({
@@ -62,9 +129,9 @@ export async function POST(request: Request, context: { params: Promise<{ quoteR
       actorUserId: gate.auth.userId,
       targetState: transitionTo as FoundationQuoteState,
       transitionReason: payload.transitionReason,
-      quotedAmount: transitionTo === 'provider_responded' ? quotedAmount : null,
-      quotedCurrency: transitionTo === 'provider_responded' ? quotedCurrency : null,
-      idempotencyKey: payload.idempotencyKey?.trim() ?? `${quoteRequestId}:${transitionTo}`,
+      quotedAmount: priced ? quotedAmount : null,
+      quotedCurrency: priced ? quotedCurrency : null,
+      idempotencyKey: resolveIdempotencyKey(payload.idempotencyKey, `${quoteRequestId}:${transitionTo}`),
     });
 
     await insertFoundationAudit({
@@ -79,34 +146,9 @@ export async function POST(request: Request, context: { params: Promise<{ quoteR
 
     return NextResponse.json({ ok: true, ...result }, { status: 200 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-
-    if (code === 'quote_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.quoteNotFound, message: 'Quote request not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (code === 'invalid_payload') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'A valid quotedAmount and quotedCurrency are required to respond with a price.' },
-        { status: 400 },
-      );
-    }
-
-    if (code === 'invalid_quote_transition') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.invalidQuoteTransition, message: 'Invalid quote lifecycle transition.' },
-        { status: 409 },
-      );
-    }
-
-    if (code === 'policy_denied') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Quote transition denied by policy.' },
-        { status: 403 },
-      );
+    const mapped = mapQuoteStateError(error);
+    if (mapped) {
+      return mapped;
     }
 
     reportError(error, { area: 'foundation', op: 'quotes_quoterequestid_state' });

--- a/ctf/packages/web/app/api/foundation/quotes/route.ts
+++ b/ctf/packages/web/app/api/foundation/quotes/route.ts
@@ -4,6 +4,47 @@ import { FOUNDATION_ERROR_CODE } from 'lib/foundation/constants';
 import { createQuoteRequest, insertFoundationAudit } from 'lib/foundation/repository';
 import { reportError } from 'lib/observability/report';
 
+type CreateQuotePayload = { threadId?: string; serviceType?: string; requestDetails?: unknown; idempotencyKey?: string };
+
+// Trim an optional string field to a plain string ('' when absent).
+function trimmed(value: string | undefined): string {
+  return value?.trim() ?? '';
+}
+
+// Use the caller-supplied idempotency key when present; otherwise fall back to the deterministic key.
+function resolveIdempotencyKey(provided: string | undefined, fallback: string): string {
+  return provided?.trim() ?? fallback;
+}
+
+// Map a known repository error code to its member-facing response; returns null for anything unknown so
+// the caller can report it and answer 503.
+function mapCreateQuoteError(error: unknown): NextResponse | null {
+  const code = error instanceof Error ? error.message : '';
+
+  if (code === 'thread_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (code === 'policy_denied') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Quote create denied by policy.' },
+      { status: 403 },
+    );
+  }
+
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Quote create rate limit exceeded.' },
+      { status: 429 },
+    );
+  }
+
+  return null;
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -15,7 +56,7 @@ export async function POST(request: Request) {
     return gate.response;
   }
 
-  let payload: { threadId?: string; serviceType?: string; requestDetails?: unknown; idempotencyKey?: string } = {};
+  let payload: CreateQuotePayload = {};
   try {
     payload = await request.json();
   } catch {
@@ -25,8 +66,8 @@ export async function POST(request: Request) {
     );
   }
 
-  const threadId = payload.threadId?.trim() ?? '';
-  const serviceType = payload.serviceType?.trim() ?? '';
+  const threadId = trimmed(payload.threadId);
+  const serviceType = trimmed(payload.serviceType);
   if (!threadId || !serviceType) {
     return NextResponse.json(
       { ok: false, code: FOUNDATION_ERROR_CODE.invalidPayload, message: 'threadId and serviceType are required.' },
@@ -40,7 +81,7 @@ export async function POST(request: Request) {
       actorUserId: gate.auth.userId,
       serviceType,
       requestDetails: payload.requestDetails,
-      idempotencyKey: payload.idempotencyKey?.trim() ?? `${threadId}:${serviceType}`,
+      idempotencyKey: resolveIdempotencyKey(payload.idempotencyKey, `${threadId}:${serviceType}`),
     });
 
     await insertFoundationAudit({
@@ -55,27 +96,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, quote }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : '';
-
-    if (code === 'thread_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.threadNotFound, message: 'Thread not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (code === 'policy_denied') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.policyDenied, message: 'Quote create denied by policy.' },
-        { status: 403 },
-      );
-    }
-
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FOUNDATION_ERROR_CODE.rateLimitExceeded, message: 'Quote create rate limit exceeded.' },
-        { status: 429 },
-      );
+    const mapped = mapCreateQuoteError(error);
+    if (mapped) {
+      return mapped;
     }
 
     reportError(error, { area: 'foundation', op: 'quotes' });

--- a/ctf/packages/web/app/api/lighthouse/admin/properties/[propertyId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/admin/properties/[propertyId]/route.ts
@@ -11,25 +11,41 @@ type RouteParams = {
 
 type PropertyBody = Partial<LighthousePropertyInput>;
 
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asStringOr(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
 function parsePropertyInput(body: PropertyBody): LighthousePropertyInput {
   return {
-    title: typeof body.title === 'string' ? body.title : '',
-    description: typeof body.description === 'string' ? body.description : '',
-    propertyType: typeof body.propertyType === 'string' ? body.propertyType : null,
-    addressLine: typeof body.addressLine === 'string' ? body.addressLine : null,
-    city: typeof body.city === 'string' ? body.city : null,
-    state: typeof body.state === 'string' ? body.state : null,
-    country: typeof body.country === 'string' ? body.country : null,
-    zipCode: typeof body.zipCode === 'string' ? body.zipCode : null,
-    bedrooms: typeof body.bedrooms === 'number' ? body.bedrooms : null,
-    bathrooms: typeof body.bathrooms === 'number' ? body.bathrooms : null,
-    monthlyRent: typeof body.monthlyRent === 'number' ? body.monthlyRent : null,
-    availableFromIso: typeof body.availableFromIso === 'string' ? body.availableFromIso : null,
+    title: asStringOr(body.title, ''),
+    description: asStringOr(body.description, ''),
+    propertyType: asString(body.propertyType),
+    addressLine: asString(body.addressLine),
+    city: asString(body.city),
+    state: asString(body.state),
+    country: asString(body.country),
+    zipCode: asString(body.zipCode),
+    bedrooms: asNumber(body.bedrooms),
+    bathrooms: asNumber(body.bathrooms),
+    monthlyRent: asNumber(body.monthlyRent),
+    availableFromIso: asString(body.availableFromIso),
     amenities: body.amenities,
     houseRules: body.houseRules,
     photos: body.photos,
-    airbnbProfileUrl: typeof body.airbnbProfileUrl === 'string' ? body.airbnbProfileUrl : null,
-    isActive: typeof body.isActive === 'boolean' ? body.isActive : true,
+    airbnbProfileUrl: asString(body.airbnbProfileUrl),
+    isActive: asBoolean(body.isActive, true),
   };
 }
 

--- a/ctf/packages/web/app/api/lighthouse/blocks/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/blocks/route.ts
@@ -9,83 +9,48 @@ type CreateBlockBody = {
   reason?: string;
 };
 
+// Maps a repository error code (thrown as an Error message) to the exact status/body it produced
+// before. Keeping this as a lookup table preserves each response 1:1 while avoiding a long if-chain.
+const LIGHTHOUSE_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  profile_not_found: { code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.', status: 404 },
+  property_not_found: { code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.', status: 404 },
+  match_not_found: { code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.', status: 404 },
+  block_not_found: { code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.', status: 404 },
+  not_owner: { code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.', status: 403 },
+  policy_denied: { code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.', status: 403 },
+  blocked_pair: { code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.', status: 403 },
+  self_block: { code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.', status: 403 },
+  duplicate_match: { code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.', status: 409 },
+  'invalid payload': { code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
-
-  if (code === 'profile_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'property_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'match_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'block_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'not_owner') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'policy_denied') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'blocked_pair') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'self_block') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'duplicate_match') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'invalid payload') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.' },
-      { status: 400 },
-    );
+  const mapped = LIGHTHOUSE_ERROR_RESPONSES[code];
+  if (mapped) {
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   return NextResponse.json(
     { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: fallbackMessage },
     { status: 503 },
   );
+}
+
+// A policy denial raised by the repository (self_block, policy_denied) must also be audited.
+async function auditBlockCreateDeny(actorId: string, error: unknown, blockedUserId: string): Promise<void> {
+  const code = error instanceof Error ? error.message : '';
+  if (code === 'self_block' || code === 'policy_denied') {
+    await insertLighthouseAudit({
+      actorId,
+      command: 'lighthouse.block.create',
+      policyStatus: 'deny',
+      reason: code,
+      targetType: 'block',
+      targetId: blockedUserId,
+      metadata: { blockedUserId },
+    });
+  }
 }
 
 export async function GET() {
@@ -165,19 +130,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true, block }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'lighthouse', op: 'blocks' });
-    // A policy denial raised by the repository (self_block, policy_denied) must also be audited.
-    const code = error instanceof Error ? error.message : '';
-    if (code === 'self_block' || code === 'policy_denied') {
-      await insertLighthouseAudit({
-        actorId: gate.auth.userId,
-        command: 'lighthouse.block.create',
-        policyStatus: 'deny',
-        reason: code,
-        targetType: 'block',
-        targetId: blockedUserId,
-        metadata: { blockedUserId },
-      });
-    }
+    await auditBlockCreateDeny(gate.auth.userId, error, blockedUserId);
     return lighthouseErrorResponse(error, 'Block create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/matches/[matchId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/[matchId]/route.ts
@@ -11,83 +11,42 @@ type RouteParams = {
 
 type MatchBody = Partial<LighthouseMatchUpdateInput>;
 
+// Maps a repository error code (thrown as an Error message) to the exact status/body it produced
+// before. Keeping this as a lookup table preserves each response 1:1 while avoiding a long if-chain.
+const LIGHTHOUSE_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  profile_not_found: { code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.', status: 404 },
+  property_not_found: { code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.', status: 404 },
+  match_not_found: { code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.', status: 404 },
+  block_not_found: { code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.', status: 404 },
+  not_owner: { code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.', status: 403 },
+  policy_denied: { code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.', status: 403 },
+  blocked_pair: { code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.', status: 403 },
+  self_block: { code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.', status: 403 },
+  duplicate_match: { code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.', status: 409 },
+  'invalid payload': { code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
-
-  if (code === 'profile_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'property_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'match_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'block_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'not_owner') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'policy_denied') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'blocked_pair') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'self_block') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'duplicate_match') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'invalid payload') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.' },
-      { status: 400 },
-    );
+  const mapped = LIGHTHOUSE_ERROR_RESPONSES[code];
+  if (mapped) {
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   return NextResponse.json(
     { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: fallbackMessage },
     { status: 503 },
   );
+}
+
+function parseMatchUpdateInput(body: MatchBody): LighthouseMatchUpdateInput {
+  return {
+    status:
+      body.status === 'accepted' || body.status === 'rejected' || body.status === 'cancelled' || body.status === 'completed'
+        ? body.status
+        : 'pending',
+    hostResponse: typeof body.hostResponse === 'string' ? body.hostResponse : null,
+  };
 }
 
 export async function PUT(request: Request, { params }: RouteParams) {
@@ -111,12 +70,7 @@ export async function PUT(request: Request, { params }: RouteParams) {
     );
   }
 
-  const input: LighthouseMatchUpdateInput = {
-    status: body.status === 'accepted' || body.status === 'rejected' || body.status === 'cancelled' || body.status === 'completed'
-      ? body.status
-      : 'pending',
-    hostResponse: typeof body.hostResponse === 'string' ? body.hostResponse : null,
-  };
+  const input = parseMatchUpdateInput(body);
 
   if (!validateMatchUpdateInput(input)) {
     return NextResponse.json(

--- a/ctf/packages/web/app/api/lighthouse/matches/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/matches/route.ts
@@ -13,83 +13,89 @@ import { reportError } from 'lib/observability/report';
 
 type MatchBody = Partial<LighthouseMatchCreateInput> & { idempotencyKey?: string };
 
+type CreatedMatchResult = Awaited<ReturnType<typeof createMatchRequest>>;
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asStringOr(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+// Maps a repository error code (thrown as an Error message) to the exact status/body it produced
+// before. Keeping this as a lookup table preserves each response 1:1 while avoiding a long if-chain.
+const LIGHTHOUSE_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  profile_not_found: { code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.', status: 404 },
+  property_not_found: { code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.', status: 404 },
+  match_not_found: { code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.', status: 404 },
+  block_not_found: { code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.', status: 404 },
+  not_owner: { code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.', status: 403 },
+  policy_denied: { code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.', status: 403 },
+  blocked_pair: { code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.', status: 403 },
+  self_block: { code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.', status: 403 },
+  duplicate_match: { code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.', status: 409 },
+  'invalid payload': { code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
-
-  if (code === 'profile_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'property_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'match_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'block_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'not_owner') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'policy_denied') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'blocked_pair') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'self_block') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'duplicate_match') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'invalid payload') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.' },
-      { status: 400 },
-    );
+  const mapped = LIGHTHOUSE_ERROR_RESPONSES[code];
+  if (mapped) {
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   return NextResponse.json(
     { ok: false, code: LIGHTHOUSE_ERROR_CODE.persistenceUnavailable, message: fallbackMessage },
     { status: 503 },
   );
+}
+
+function parseMatchCreateInput(body: MatchBody): LighthouseMatchCreateInput {
+  return {
+    propertyId: asStringOr(body.propertyId, ''),
+    message: asString(body.message),
+    desiredMoveInDateIso: asString(body.desiredMoveInDateIso),
+  };
+}
+
+function resolveIdempotencyKey(body: MatchBody, userId: string, propertyId: string): string {
+  const provided = typeof body.idempotencyKey === 'string' ? body.idempotencyKey.trim() : '';
+  return provided.length > 0 ? provided : `${userId}:${propertyId}`;
+}
+
+// Notify the host that a seeker requested a stay on their listing — best-effort, deduped on the
+// match id. The repository rejects a request on one's own listing, so the host is never the actor.
+async function notifyHostOfMatch(created: CreatedMatchResult, actorUserId: string): Promise<void> {
+  if (created.match.hostUserId && created.match.hostUserId !== actorUserId) {
+    await notifySafe({
+      userId: created.match.hostUserId,
+      sourcePlugin: 'lighthouse',
+      notificationType: 'lighthouse.match.requested',
+      category: 'safety',
+      summary: 'Someone requested a stay on your LightHouse listing.',
+      linkPath: '/apps/lighthouse',
+      targetRef: created.match.id,
+    });
+  }
+}
+
+// The seeker-role check, blocked-pair check, and duplicate check all live in the repository and
+// raise these codes. The audit contract marks lighthouse.match.request.create as allow_or_deny,
+// so a policy denial must emit a deny audit event, not only the success path.
+async function auditMatchCreateDeny(actorId: string, error: unknown, propertyId: string): Promise<void> {
+  const code = error instanceof Error ? error.message : '';
+  if (code === 'policy_denied' || code === 'blocked_pair' || code === 'duplicate_match' || code === 'not_owner') {
+    await insertLighthouseAudit({
+      actorId,
+      command: 'lighthouse.match.request.create',
+      policyStatus: 'deny',
+      reason: code,
+      targetType: 'match',
+      targetId: propertyId,
+      metadata: { propertyId },
+    });
+  }
 }
 
 export async function GET() {
@@ -128,11 +134,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const input: LighthouseMatchCreateInput = {
-    propertyId: typeof body.propertyId === 'string' ? body.propertyId : '',
-    message: typeof body.message === 'string' ? body.message : null,
-    desiredMoveInDateIso: typeof body.desiredMoveInDateIso === 'string' ? body.desiredMoveInDateIso : null,
-  };
+  const input = parseMatchCreateInput(body);
 
   if (!validateMatchCreateInput(input)) {
     return NextResponse.json(
@@ -148,9 +150,7 @@ export async function POST(request: Request) {
       propertyId: input.propertyId,
       message: input.message,
       desiredMoveInDateIso: input.desiredMoveInDateIso,
-      idempotencyKey: typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim().length > 0
-        ? body.idempotencyKey.trim()
-        : `${gate.auth.userId}:${input.propertyId}`,
+      idempotencyKey: resolveIdempotencyKey(body, gate.auth.userId, input.propertyId),
     });
 
     await insertLighthouseAudit({
@@ -163,38 +163,12 @@ export async function POST(request: Request) {
       metadata: { propertyId: created.match.propertyId },
     });
 
-    // Notify the host that a seeker requested a stay on their listing — best-effort, deduped on the
-    // match id. The repository rejects a request on one's own listing, so the host is never the actor.
-    if (created.match.hostUserId && created.match.hostUserId !== gate.auth.userId) {
-      await notifySafe({
-        userId: created.match.hostUserId,
-        sourcePlugin: 'lighthouse',
-        notificationType: 'lighthouse.match.requested',
-        category: 'safety',
-        summary: 'Someone requested a stay on your LightHouse listing.',
-        linkPath: '/apps/lighthouse',
-        targetRef: created.match.id,
-      });
-    }
+    await notifyHostOfMatch(created, gate.auth.userId);
 
     return NextResponse.json({ ok: true, ...created }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'lighthouse', op: 'matches' });
-    // The seeker-role check, blocked-pair check, and duplicate check all live in the repository and
-    // raise these codes. The audit contract marks lighthouse.match.request.create as allow_or_deny,
-    // so a policy denial must emit a deny audit event, not only the success path.
-    const code = error instanceof Error ? error.message : '';
-    if (code === 'policy_denied' || code === 'blocked_pair' || code === 'duplicate_match' || code === 'not_owner') {
-      await insertLighthouseAudit({
-        actorId: gate.auth.userId,
-        command: 'lighthouse.match.request.create',
-        policyStatus: 'deny',
-        reason: code,
-        targetType: 'match',
-        targetId: input.propertyId,
-        metadata: { propertyId: input.propertyId },
-      });
-    }
+    await auditMatchCreateDeny(gate.auth.userId, error, input.propertyId);
     return lighthouseErrorResponse(error, 'Match create unavailable.');
   }
 }

--- a/ctf/packages/web/app/api/lighthouse/profile/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/profile/route.ts
@@ -13,93 +13,54 @@ import { reportError } from 'lib/observability/report';
 
 type ProfileBody = Partial<LighthouseProfileInput>;
 
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
 function parseProfileInput(body: ProfileBody): LighthouseProfileInput {
   return {
     profileType: body.profileType === 'host' ? 'host' : 'seeker',
-    bio: typeof body.bio === 'string' ? body.bio : null,
-    phoneNumber: typeof body.phoneNumber === 'string' ? body.phoneNumber : null,
-    signalUrl: typeof body.signalUrl === 'string' ? body.signalUrl : null,
-    isActive: typeof body.isActive === 'boolean' ? body.isActive : true,
-    hasProperty: typeof body.hasProperty === 'boolean' ? body.hasProperty : false,
-    housingNeeds: typeof body.housingNeeds === 'string' ? body.housingNeeds : null,
-    desiredMoveInDateIso: typeof body.desiredMoveInDateIso === 'string' ? body.desiredMoveInDateIso : null,
-    budgetMin: typeof body.budgetMin === 'number' ? body.budgetMin : null,
-    budgetMax: typeof body.budgetMax === 'number' ? body.budgetMax : null,
-    desiredCountry: typeof body.desiredCountry === 'string' ? body.desiredCountry : null,
+    bio: asString(body.bio),
+    phoneNumber: asString(body.phoneNumber),
+    signalUrl: asString(body.signalUrl),
+    isActive: asBoolean(body.isActive, true),
+    hasProperty: asBoolean(body.hasProperty, false),
+    housingNeeds: asString(body.housingNeeds),
+    desiredMoveInDateIso: asString(body.desiredMoveInDateIso),
+    budgetMin: asNumber(body.budgetMin),
+    budgetMax: asNumber(body.budgetMax),
+    desiredCountry: asString(body.desiredCountry),
   };
 }
 
+// Maps a repository error code (thrown as an Error message) to the exact status/body it produced
+// before. Keeping this as a lookup table preserves each response 1:1 while avoiding a long if-chain.
+const LIGHTHOUSE_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  profile_not_found: { code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.', status: 404 },
+  property_not_found: { code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.', status: 404 },
+  match_not_found: { code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.', status: 404 },
+  block_not_found: { code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.', status: 404 },
+  not_owner: { code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.', status: 403 },
+  policy_denied: { code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.', status: 403 },
+  blocked_pair: { code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.', status: 403 },
+  self_block: { code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.', status: 403 },
+  duplicate_match: { code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.', status: 409 },
+  'invalid payload': { code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
-
-  if (code === 'profile_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'property_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'match_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'block_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'not_owner') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'policy_denied') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'blocked_pair') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'self_block') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'duplicate_match') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'invalid payload') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.' },
-      { status: 400 },
-    );
+  const mapped = LIGHTHOUSE_ERROR_RESPONSES[code];
+  if (mapped) {
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   return NextResponse.json(

--- a/ctf/packages/web/app/api/lighthouse/properties/[propertyId]/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/properties/[propertyId]/route.ts
@@ -17,103 +17,72 @@ type RouteParams = {
 
 type PropertyBody = Partial<LighthousePropertyInput>;
 
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asStringOr(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function asStringArray(value: unknown): string[] | null {
+  return Array.isArray(value)
+    ? value.filter((code): code is string => typeof code === 'string')
+    : null;
+}
+
 function parsePropertyInput(body: PropertyBody): LighthousePropertyInput {
   return {
-    title: typeof body.title === 'string' ? body.title : '',
-    description: typeof body.description === 'string' ? body.description : '',
-    propertyType: typeof body.propertyType === 'string' ? body.propertyType : null,
-    addressLine: typeof body.addressLine === 'string' ? body.addressLine : null,
-    city: typeof body.city === 'string' ? body.city : null,
-    state: typeof body.state === 'string' ? body.state : null,
-    country: typeof body.country === 'string' ? body.country : null,
-    zipCode: typeof body.zipCode === 'string' ? body.zipCode : null,
-    bedrooms: typeof body.bedrooms === 'number' ? body.bedrooms : null,
-    bathrooms: typeof body.bathrooms === 'number' ? body.bathrooms : null,
-    monthlyRent: typeof body.monthlyRent === 'number' ? body.monthlyRent : null,
-    rentCurrency: typeof body.rentCurrency === 'string' ? body.rentCurrency : null,
-    acceptedCurrencies: Array.isArray(body.acceptedCurrencies)
-      ? body.acceptedCurrencies.filter((code): code is string => typeof code === 'string')
-      : null,
-    availableFromIso: typeof body.availableFromIso === 'string' ? body.availableFromIso : null,
+    title: asStringOr(body.title, ''),
+    description: asStringOr(body.description, ''),
+    propertyType: asString(body.propertyType),
+    addressLine: asString(body.addressLine),
+    city: asString(body.city),
+    state: asString(body.state),
+    country: asString(body.country),
+    zipCode: asString(body.zipCode),
+    bedrooms: asNumber(body.bedrooms),
+    bathrooms: asNumber(body.bathrooms),
+    monthlyRent: asNumber(body.monthlyRent),
+    rentCurrency: asString(body.rentCurrency),
+    acceptedCurrencies: asStringArray(body.acceptedCurrencies),
+    availableFromIso: asString(body.availableFromIso),
     amenities: body.amenities,
     houseRules: body.houseRules,
     photos: body.photos,
-    airbnbProfileUrl: typeof body.airbnbProfileUrl === 'string' ? body.airbnbProfileUrl : null,
-    isActive: typeof body.isActive === 'boolean' ? body.isActive : true,
+    airbnbProfileUrl: asString(body.airbnbProfileUrl),
+    isActive: asBoolean(body.isActive, true),
   };
 }
 
+// Maps a repository error code (thrown as an Error message) to the exact status/body it produced
+// before. Keeping this as a lookup table preserves each response 1:1 while avoiding a long if-chain.
+const LIGHTHOUSE_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  profile_not_found: { code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.', status: 404 },
+  property_not_found: { code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.', status: 404 },
+  match_not_found: { code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.', status: 404 },
+  block_not_found: { code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.', status: 404 },
+  not_owner: { code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.', status: 403 },
+  policy_denied: { code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.', status: 403 },
+  blocked_pair: { code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.', status: 403 },
+  self_block: { code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.', status: 403 },
+  duplicate_match: { code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.', status: 409 },
+  'invalid payload': { code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
-
-  if (code === 'profile_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'property_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'match_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'block_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'not_owner') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'policy_denied') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'blocked_pair') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'self_block') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'duplicate_match') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'invalid payload') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.' },
-      { status: 400 },
-    );
+  const mapped = LIGHTHOUSE_ERROR_RESPONSES[code];
+  if (mapped) {
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   return NextResponse.json(

--- a/ctf/packages/web/app/api/lighthouse/properties/route.ts
+++ b/ctf/packages/web/app/api/lighthouse/properties/route.ts
@@ -25,103 +25,72 @@ function parseOnlyActive(value: string | null): boolean {
   return !(value === 'false' || value === '0');
 }
 
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asStringOr(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function asStringArray(value: unknown): string[] | null {
+  return Array.isArray(value)
+    ? value.filter((code): code is string => typeof code === 'string')
+    : null;
+}
+
 function parsePropertyInput(body: PropertyBody): LighthousePropertyInput {
   return {
-    title: typeof body.title === 'string' ? body.title : '',
-    description: typeof body.description === 'string' ? body.description : '',
-    propertyType: typeof body.propertyType === 'string' ? body.propertyType : null,
-    addressLine: typeof body.addressLine === 'string' ? body.addressLine : null,
-    city: typeof body.city === 'string' ? body.city : null,
-    state: typeof body.state === 'string' ? body.state : null,
-    country: typeof body.country === 'string' ? body.country : null,
-    zipCode: typeof body.zipCode === 'string' ? body.zipCode : null,
-    bedrooms: typeof body.bedrooms === 'number' ? body.bedrooms : null,
-    bathrooms: typeof body.bathrooms === 'number' ? body.bathrooms : null,
-    monthlyRent: typeof body.monthlyRent === 'number' ? body.monthlyRent : null,
-    rentCurrency: typeof body.rentCurrency === 'string' ? body.rentCurrency : null,
-    acceptedCurrencies: Array.isArray(body.acceptedCurrencies)
-      ? body.acceptedCurrencies.filter((code): code is string => typeof code === 'string')
-      : null,
-    availableFromIso: typeof body.availableFromIso === 'string' ? body.availableFromIso : null,
+    title: asStringOr(body.title, ''),
+    description: asStringOr(body.description, ''),
+    propertyType: asString(body.propertyType),
+    addressLine: asString(body.addressLine),
+    city: asString(body.city),
+    state: asString(body.state),
+    country: asString(body.country),
+    zipCode: asString(body.zipCode),
+    bedrooms: asNumber(body.bedrooms),
+    bathrooms: asNumber(body.bathrooms),
+    monthlyRent: asNumber(body.monthlyRent),
+    rentCurrency: asString(body.rentCurrency),
+    acceptedCurrencies: asStringArray(body.acceptedCurrencies),
+    availableFromIso: asString(body.availableFromIso),
     amenities: body.amenities,
     houseRules: body.houseRules,
     photos: body.photos,
-    airbnbProfileUrl: typeof body.airbnbProfileUrl === 'string' ? body.airbnbProfileUrl : null,
-    isActive: typeof body.isActive === 'boolean' ? body.isActive : true,
+    airbnbProfileUrl: asString(body.airbnbProfileUrl),
+    isActive: asBoolean(body.isActive, true),
   };
 }
 
+// Maps a repository error code (thrown as an Error message) to the exact status/body it produced
+// before. Keeping this as a lookup table preserves each response 1:1 while avoiding a long if-chain.
+const LIGHTHOUSE_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  profile_not_found: { code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.', status: 404 },
+  property_not_found: { code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.', status: 404 },
+  match_not_found: { code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.', status: 404 },
+  block_not_found: { code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.', status: 404 },
+  not_owner: { code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.', status: 403 },
+  policy_denied: { code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.', status: 403 },
+  blocked_pair: { code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.', status: 403 },
+  self_block: { code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.', status: 403 },
+  duplicate_match: { code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.', status: 409 },
+  'invalid payload': { code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 function lighthouseErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
-
-  if (code === 'profile_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.profileNotFound, message: 'Lighthouse profile not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'property_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.propertyNotFound, message: 'Lighthouse property not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'match_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.matchNotFound, message: 'Lighthouse match not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'block_not_found') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockNotFound, message: 'Lighthouse block not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'not_owner') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.notOwner, message: 'Operation requires ownership.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'policy_denied') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'blocked_pair') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.blockedPair, message: 'Match blocked by pair policy.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'self_block') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.selfBlock, message: 'Cannot block your own user account.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'duplicate_match') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.duplicateMatch, message: 'Active match request already exists.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'invalid payload') {
-    return NextResponse.json(
-      { ok: false, code: LIGHTHOUSE_ERROR_CODE.invalidPayload, message: 'Invalid payload.' },
-      { status: 400 },
-    );
+  const mapped = LIGHTHOUSE_ERROR_RESPONSES[code];
+  if (mapped) {
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   return NextResponse.json(

--- a/ctf/packages/web/app/api/skills-hunt/admin/reports/[reportId]/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/reports/[reportId]/route.ts
@@ -5,6 +5,29 @@ import { resolveReport, type ResolveReportInput } from 'lib/skills-hunt/moderati
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
 import { reportError } from 'lib/observability/report';
 
+type ResolveReportBodyResult =
+  | { ok: true; status: ResolveReportInput['status']; resolutionNotes: string | null }
+  | { ok: false; message: string };
+
+// Validate the report-resolution body: status must be one of the three allowed
+// values, resolutionNotes must be a string, null, or absent (normalised to null).
+function validateResolveReportBody(body: Partial<ResolveReportInput>): ResolveReportBodyResult {
+  if (body.status !== 'dismissed' && body.status !== 'archived' && body.status !== 'removed') {
+    return { ok: false, message: 'status must be dismissed | archived | removed' };
+  }
+
+  // resolutionNotes must be string, null, or absent. Anything else is malformed.
+  if (
+    body.resolutionNotes !== undefined
+    && body.resolutionNotes !== null
+    && typeof body.resolutionNotes !== 'string'
+  ) {
+    return { ok: false, message: 'resolutionNotes must be a string or null' };
+  }
+
+  return { ok: true, status: body.status, resolutionNotes: body.resolutionNotes ?? null };
+}
+
 export async function PATCH(request: Request, { params }: { params: Promise<{ reportId: string }> }) {
   const gate = await requireSkillsHuntAdminAccess();
   if (!gate.allowed) {
@@ -28,31 +51,19 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ re
     );
   }
 
-  if (body.status !== 'dismissed' && body.status !== 'archived' && body.status !== 'removed') {
+  const parsed = validateResolveReportBody(body);
+  if (!parsed.ok) {
     return NextResponse.json(
-      { ok: false, code: SKILLS_HUNT_ERROR_CODE.invalidPayload, message: 'status must be dismissed | archived | removed' },
+      { ok: false, code: SKILLS_HUNT_ERROR_CODE.invalidPayload, message: parsed.message },
       { status: 400 },
     );
   }
-
-  // resolutionNotes must be string, null, or absent. Anything else is malformed.
-  if (
-    body.resolutionNotes !== undefined
-    && body.resolutionNotes !== null
-    && typeof body.resolutionNotes !== 'string'
-  ) {
-    return NextResponse.json(
-      { ok: false, code: SKILLS_HUNT_ERROR_CODE.invalidPayload, message: 'resolutionNotes must be a string or null' },
-      { status: 400 },
-    );
-  }
-  const resolutionNotes: string | null = body.resolutionNotes ?? null;
 
   try {
     const report = await withDbTransaction((client) =>
       resolveReport(client, gate.auth.userId, reportId, {
-        status: body.status as ResolveReportInput['status'],
-        resolutionNotes,
+        status: parsed.status,
+        resolutionNotes: parsed.resolutionNotes,
       }),
     );
     if (!report) {

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/missions/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/missions/route.ts
@@ -10,6 +10,72 @@ import {
 import { SKILLS_HUNT_ERROR_CODE } from 'lib/skills-hunt/constants';
 import { reportError } from 'lib/observability/report';
 
+const VALID_GOAL_TYPES = ['count_total_accepted', 'count_skills_in_sector', 'count_rare_skill_finds', 'count_distinct_sectors'] as const;
+const VALID_MISSION_STATUSES = ['draft', 'active', 'locked', 'archived'] as const;
+
+type MissionBodyResult =
+  | { ok: true; input: MissionCreateInput }
+  | { ok: false; message: string };
+
+// Runtime narrowing: every field touched by createMission gets checked before
+// construction. Malformed types fail-fast with 400. Checks are grouped across a
+// few helpers to keep each within complexity limits; each pushes to `errors`.
+function validateMissionCoreFields(body: Record<string, unknown>, errors: string[]): void {
+  if (typeof body.title !== 'string') errors.push('title must be a string');
+  if (typeof body.goalTarget !== 'number') errors.push('goalTarget must be a number');
+  if (typeof body.goalType !== 'string' || !VALID_GOAL_TYPES.includes(body.goalType as typeof VALID_GOAL_TYPES[number])) {
+    errors.push('goalType must be one of ' + VALID_GOAL_TYPES.join(' | '));
+  }
+  if (body.goalMetadata !== undefined && (typeof body.goalMetadata !== 'object' || body.goalMetadata === null || Array.isArray(body.goalMetadata))) {
+    errors.push('goalMetadata must be an object');
+  }
+}
+
+function validateMissionScoreFields(body: Record<string, unknown>, errors: string[]): void {
+  if (body.bonusPoints !== undefined && typeof body.bonusPoints !== 'number') {
+    errors.push('bonusPoints must be a number');
+  }
+  if (body.displayOrder !== undefined && typeof body.displayOrder !== 'number') {
+    errors.push('displayOrder must be a number');
+  }
+  if (body.status !== undefined && (typeof body.status !== 'string' || !VALID_MISSION_STATUSES.includes(body.status as typeof VALID_MISSION_STATUSES[number]))) {
+    errors.push('status must be one of ' + VALID_MISSION_STATUSES.join(' | '));
+  }
+}
+
+function validateMissionCopyFields(body: Record<string, unknown>, errors: string[]): void {
+  if (body.description !== undefined && body.description !== null && typeof body.description !== 'string') {
+    errors.push('description must be a string or null');
+  }
+  if (body.colorHex !== undefined && body.colorHex !== null && typeof body.colorHex !== 'string') {
+    errors.push('colorHex must be a string or null');
+  }
+}
+
+function parseMissionBody(roundId: string, body: Record<string, unknown>): MissionBodyResult {
+  const errors: string[] = [];
+  validateMissionCoreFields(body, errors);
+  validateMissionScoreFields(body, errors);
+  validateMissionCopyFields(body, errors);
+  if (errors.length) {
+    return { ok: false, message: errors.join('; ') };
+  }
+
+  const input: MissionCreateInput = {
+    roundId,
+    title: body.title as string,
+    description: (body.description as string | null | undefined) ?? null,
+    goalType: body.goalType as MissionCreateInput['goalType'],
+    goalTarget: body.goalTarget as number,
+    goalMetadata: (body.goalMetadata as Record<string, unknown> | undefined) ?? {},
+    bonusPoints: (body.bonusPoints as number | undefined) ?? 0,
+    colorHex: (body.colorHex as string | null | undefined) ?? null,
+    status: (body.status as MissionCreateInput['status'] | undefined) ?? 'active',
+    displayOrder: (body.displayOrder as number | undefined) ?? 0,
+  };
+  return { ok: true, input };
+}
+
 export async function GET(_request: Request, { params }: { params: Promise<{ roundId: string }> }) {
   const gate = await requireSkillsHuntAdminAccess();
   if (!gate.allowed) {
@@ -56,53 +122,14 @@ export async function POST(request: Request, { params }: { params: Promise<{ rou
     );
   }
 
-  // Runtime narrowing: every field touched by createMission gets checked
-  // before construction. Malformed types fail-fast with 400.
-  const errors: string[] = [];
-  if (typeof body.title !== 'string') errors.push('title must be a string');
-  if (typeof body.goalTarget !== 'number') errors.push('goalTarget must be a number');
-  const validGoalTypes = ['count_total_accepted', 'count_skills_in_sector', 'count_rare_skill_finds', 'count_distinct_sectors'] as const;
-  if (typeof body.goalType !== 'string' || !validGoalTypes.includes(body.goalType as typeof validGoalTypes[number])) {
-    errors.push('goalType must be one of ' + validGoalTypes.join(' | '));
-  }
-  if (body.description !== undefined && body.description !== null && typeof body.description !== 'string') {
-    errors.push('description must be a string or null');
-  }
-  if (body.goalMetadata !== undefined && (typeof body.goalMetadata !== 'object' || body.goalMetadata === null || Array.isArray(body.goalMetadata))) {
-    errors.push('goalMetadata must be an object');
-  }
-  if (body.bonusPoints !== undefined && typeof body.bonusPoints !== 'number') {
-    errors.push('bonusPoints must be a number');
-  }
-  if (body.colorHex !== undefined && body.colorHex !== null && typeof body.colorHex !== 'string') {
-    errors.push('colorHex must be a string or null');
-  }
-  const validStatuses = ['draft', 'active', 'locked', 'archived'] as const;
-  if (body.status !== undefined && (typeof body.status !== 'string' || !validStatuses.includes(body.status as typeof validStatuses[number]))) {
-    errors.push('status must be one of ' + validStatuses.join(' | '));
-  }
-  if (body.displayOrder !== undefined && typeof body.displayOrder !== 'number') {
-    errors.push('displayOrder must be a number');
-  }
-  if (errors.length) {
+  const parsed = parseMissionBody(roundId, body);
+  if (!parsed.ok) {
     return NextResponse.json(
-      { ok: false, code: SKILLS_HUNT_ERROR_CODE.invalidPayload, message: errors.join('; ') },
+      { ok: false, code: SKILLS_HUNT_ERROR_CODE.invalidPayload, message: parsed.message },
       { status: 400 },
     );
   }
-
-  const input: MissionCreateInput = {
-    roundId,
-    title: body.title as string,
-    description: (body.description as string | null | undefined) ?? null,
-    goalType: body.goalType as MissionCreateInput['goalType'],
-    goalTarget: body.goalTarget as number,
-    goalMetadata: (body.goalMetadata as Record<string, unknown> | undefined) ?? {},
-    bonusPoints: (body.bonusPoints as number | undefined) ?? 0,
-    colorHex: (body.colorHex as string | null | undefined) ?? null,
-    status: (body.status as MissionCreateInput['status'] | undefined) ?? 'active',
-    displayOrder: (body.displayOrder as number | undefined) ?? 0,
-  };
+  const input = parsed.input;
 
   const validation = validateMissionCreateInput(input);
   if (validation) {

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/[roundId]/route.ts
@@ -7,34 +7,47 @@ import { reportError } from 'lib/observability/report';
 
 type RoundBody = Partial<SkillsHuntRoundInput>;
 
+// description is tri-state: absent preserves the current value, an explicit
+// string sets it, anything else clears it to null.
+function mergeRoundDescription(existing: SkillsHuntRound, body: RoundBody): string | null {
+  return body.description === undefined
+    ? existing.description
+    : typeof body.description === 'string'
+      ? body.description
+      : null;
+}
+
+function mergeRoundStatus(existing: SkillsHuntRound, body: RoundBody): SkillsHuntRoundInput['status'] {
+  return body.status === 'draft' || body.status === 'active' || body.status === 'closed' || body.status === 'archived'
+    ? body.status
+    : existing.status;
+}
+
+// rewardPerUserRoundCap is tri-state like description: absent preserves, a
+// number sets it, anything else clears it to null.
+function mergeRoundRewardCap(existing: SkillsHuntRound, body: RoundBody): number | null {
+  return body.rewardPerUserRoundCap === undefined
+    ? existing.rewardPerUserRoundCap
+    : typeof body.rewardPerUserRoundCap === 'number'
+      ? body.rewardPerUserRoundCap
+      : null;
+}
+
 // round.update is a partial update: every field is optional in the contract, so
 // a body that omits a field must preserve the round's existing value rather than
 // silently reset it to a default. Merge each present field over the current round.
 function mergeRoundInput(existing: SkillsHuntRound, body: RoundBody): SkillsHuntRoundInput {
   return {
     name: typeof body.name === 'string' ? body.name : existing.name,
-    description:
-      body.description === undefined
-        ? existing.description
-        : typeof body.description === 'string'
-          ? body.description
-          : null,
-    status:
-      body.status === 'draft' || body.status === 'active' || body.status === 'closed' || body.status === 'archived'
-        ? body.status
-        : existing.status,
+    description: mergeRoundDescription(existing, body),
+    status: mergeRoundStatus(existing, body),
     startsAtIso: typeof body.startsAtIso === 'string' ? body.startsAtIso : existing.startsAtIso,
     endsAtIso: typeof body.endsAtIso === 'string' ? body.endsAtIso : existing.endsAtIso,
     scoringConfig:
       body.scoringConfig && typeof body.scoringConfig === 'object' ? body.scoringConfig : existing.scoringConfig,
     rewardCreditsPerAccept:
       typeof body.rewardCreditsPerAccept === 'number' ? body.rewardCreditsPerAccept : existing.rewardCreditsPerAccept,
-    rewardPerUserRoundCap:
-      body.rewardPerUserRoundCap === undefined
-        ? existing.rewardPerUserRoundCap
-        : typeof body.rewardPerUserRoundCap === 'number'
-          ? body.rewardPerUserRoundCap
-          : null,
+    rewardPerUserRoundCap: mergeRoundRewardCap(existing, body),
   };
 }
 

--- a/ctf/packages/web/app/api/skills-hunt/admin/rounds/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/rounds/route.ts
@@ -7,11 +7,15 @@ import { reportError } from 'lib/observability/report';
 
 type RoundBody = Partial<SkillsHuntRoundInput>;
 
+function normalizeRoundStatus(status: SkillsHuntRoundInput['status'] | undefined): SkillsHuntRoundInput['status'] {
+  return status === 'active' || status === 'closed' || status === 'archived' ? status : 'draft';
+}
+
 function toRoundInput(body: RoundBody): SkillsHuntRoundInput {
   return {
     name: typeof body.name === 'string' ? body.name : '',
     description: typeof body.description === 'string' ? body.description : null,
-    status: body.status === 'active' || body.status === 'closed' || body.status === 'archived' ? body.status : 'draft',
+    status: normalizeRoundStatus(body.status),
     startsAtIso: typeof body.startsAtIso === 'string' ? body.startsAtIso : new Date().toISOString(),
     endsAtIso: typeof body.endsAtIso === 'string' ? body.endsAtIso : new Date(Date.now() + 86400000).toISOString(),
     scoringConfig: body.scoringConfig && typeof body.scoringConfig === 'object' ? body.scoringConfig : {},

--- a/ctf/packages/web/app/api/skills-hunt/admin/submissions/[submissionId]/generate-directory-profile/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/admin/submissions/[submissionId]/generate-directory-profile/route.ts
@@ -8,6 +8,30 @@ type GenerateBody = {
   invitedByUsername?: string;
 };
 
+// Map a thrown repository error message to the HTTP response shape. Unknown
+// messages fall through to a 503 persistence-unavailable response.
+function mapGenerateProfileError(message: string): { status: number; code: string; responseMessage: string } {
+  if (message === 'skills_hunt_profile_already_generated') {
+    return {
+      status: 409,
+      code: SKILLS_HUNT_ERROR_CODE.profileAlreadyGenerated,
+      responseMessage: 'Directory profile was already generated for this submission.',
+    };
+  }
+  if (message === 'skills_hunt_submission_not_found') {
+    return {
+      status: 404,
+      code: SKILLS_HUNT_ERROR_CODE.submissionNotFound,
+      responseMessage: 'Accepted submission not found.',
+    };
+  }
+  return {
+    status: 503,
+    code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable,
+    responseMessage: 'Unable to generate directory profile projection.',
+  };
+}
+
 export async function POST(request: Request, { params }: { params: Promise<{ submissionId: string }> }) {
   const gate = await requireSkillsHuntModeratorAccess();
   if (!gate.allowed) {
@@ -59,20 +83,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ sub
   } catch (error) {
     reportError(error, { area: 'skills-hunt', op: 'admin_submissions_submissionid_generate_directory_profile' });
     const message = error instanceof Error ? error.message : 'unknown';
-
-    let status = 503;
-    let code: string = SKILLS_HUNT_ERROR_CODE.persistenceUnavailable;
-    let responseMessage = 'Unable to generate directory profile projection.';
-
-    if (message === 'skills_hunt_profile_already_generated') {
-      status = 409;
-      code = SKILLS_HUNT_ERROR_CODE.profileAlreadyGenerated;
-      responseMessage = 'Directory profile was already generated for this submission.';
-    } else if (message === 'skills_hunt_submission_not_found') {
-      status = 404;
-      code = SKILLS_HUNT_ERROR_CODE.submissionNotFound;
-      responseMessage = 'Accepted submission not found.';
-    }
+    const { status, code, responseMessage } = mapGenerateProfileError(message);
 
     return NextResponse.json({ ok: false, code, message: responseMessage }, { status });
   }

--- a/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/submissions/route.ts
+++ b/ctf/packages/web/app/api/skills-hunt/rounds/[roundId]/submissions/route.ts
@@ -25,6 +25,62 @@ function formatRetryApprox(resetAtIso: string | null): string {
   return ` You can submit again in about ${days} day${days === 1 ? '' : 's'}.`;
 }
 
+// Map a thrown createSubmission error message to the HTTP response shape.
+// Unknown messages fall through to a 503 persistence-unavailable response.
+function mapSubmissionCreateError(message: string): { status: number; code: string; responseMessage: string } {
+  if (message === 'skills_hunt_round_not_found') {
+    return { status: 404, code: SKILLS_HUNT_ERROR_CODE.roundNotFound, responseMessage: 'Round not found.' };
+  }
+  if (message === 'skills_hunt_round_not_active') {
+    return { status: 409, code: SKILLS_HUNT_ERROR_CODE.roundNotActive, responseMessage: 'Round is not currently active.' };
+  }
+  if (message.startsWith('skills_hunt_submission_limit_exceeded')) {
+    const sep = message.indexOf(':');
+    const resetAtIso = sep >= 0 ? message.slice(sep + 1) : null;
+    return {
+      status: 429,
+      code: SKILLS_HUNT_ERROR_CODE.submissionLimitExceeded,
+      responseMessage: `You've reached the weekly nomination limit.${formatRetryApprox(resetAtIso)}`,
+    };
+  }
+  if (message === 'skills_hunt_pre_approval_required') {
+    return {
+      status: 403,
+      code: SKILLS_HUNT_ERROR_CODE.preApprovalRequired,
+      responseMessage: 'Your recent submissions need admin pre-approval before you can submit again.',
+    };
+  }
+  if (message === 'skills_hunt_rejection_guard_violation') {
+    return {
+      status: 429,
+      code: SKILLS_HUNT_ERROR_CODE.rejectionGuardViolation,
+      responseMessage: 'Submission blocked by rejection-rate guardrail.',
+    };
+  }
+  if (message === 'skills_hunt_duplicate_submission') {
+    return {
+      status: 409,
+      code: SKILLS_HUNT_ERROR_CODE.duplicateSubmission,
+      responseMessage: 'Duplicate submission signature for this round.',
+    };
+  }
+  if (message === 'skills_hunt_invalid_quora_url') {
+    return { status: 400, code: SKILLS_HUNT_ERROR_CODE.invalidPayload, responseMessage: 'Invalid Quora profile URL.' };
+  }
+  if (message === 'skills_hunt_url_dead') {
+    return {
+      status: 400,
+      code: SKILLS_HUNT_ERROR_CODE.urlValidationFailed,
+      responseMessage: 'This Quora profile URL appears to be removed or unreachable. Please verify and try again.',
+    };
+  }
+  return {
+    status: 503,
+    code: SKILLS_HUNT_ERROR_CODE.persistenceUnavailable,
+    responseMessage: 'Unable to create submission.',
+  };
+}
+
 function toSubmissionInput(roundId: string, body: SubmissionBody): SkillsHuntSubmissionInput {
   return {
     roundId,
@@ -128,46 +184,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ rou
   } catch (error) {
     reportError(error, { area: 'skills-hunt', op: 'rounds_roundid_submissions' });
     const message = error instanceof Error ? error.message : 'unknown';
-
-    let status = 503;
-    let code: string = SKILLS_HUNT_ERROR_CODE.persistenceUnavailable;
-    let responseMessage = 'Unable to create submission.';
-
-    if (message === 'skills_hunt_round_not_found') {
-      status = 404;
-      code = SKILLS_HUNT_ERROR_CODE.roundNotFound;
-      responseMessage = 'Round not found.';
-    } else if (message === 'skills_hunt_round_not_active') {
-      status = 409;
-      code = SKILLS_HUNT_ERROR_CODE.roundNotActive;
-      responseMessage = 'Round is not currently active.';
-    } else if (message.startsWith('skills_hunt_submission_limit_exceeded')) {
-      status = 429;
-      code = SKILLS_HUNT_ERROR_CODE.submissionLimitExceeded;
-      const sep = message.indexOf(':');
-      const resetAtIso = sep >= 0 ? message.slice(sep + 1) : null;
-      responseMessage = `You've reached the weekly nomination limit.${formatRetryApprox(resetAtIso)}`;
-    } else if (message === 'skills_hunt_pre_approval_required') {
-      status = 403;
-      code = SKILLS_HUNT_ERROR_CODE.preApprovalRequired;
-      responseMessage = 'Your recent submissions need admin pre-approval before you can submit again.';
-    } else if (message === 'skills_hunt_rejection_guard_violation') {
-      status = 429;
-      code = SKILLS_HUNT_ERROR_CODE.rejectionGuardViolation;
-      responseMessage = 'Submission blocked by rejection-rate guardrail.';
-    } else if (message === 'skills_hunt_duplicate_submission') {
-      status = 409;
-      code = SKILLS_HUNT_ERROR_CODE.duplicateSubmission;
-      responseMessage = 'Duplicate submission signature for this round.';
-    } else if (message === 'skills_hunt_invalid_quora_url') {
-      status = 400;
-      code = SKILLS_HUNT_ERROR_CODE.invalidPayload;
-      responseMessage = 'Invalid Quora profile URL.';
-    } else if (message === 'skills_hunt_url_dead') {
-      status = 400;
-      code = SKILLS_HUNT_ERROR_CODE.urlValidationFailed;
-      responseMessage = 'This Quora profile URL appears to be removed or unreachable. Please verify and try again.';
-    }
+    const { status, code, responseMessage } = mapSubmissionCreateError(message);
 
     logSkillsHuntAudit({
       actorId: gate.auth.userId,

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/dependency-impact/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/dependency-impact/route.ts
@@ -10,6 +10,49 @@ import { reportError } from 'lib/observability/report';
 // both, but the operation is recorded in the audit targetContext per contract.
 const VALID_OPERATIONS = new Set(['delete', 'deactivate']);
 
+type DependencyImpactTarget = {
+  targetType: string;
+  targetId: string;
+  operation: string;
+};
+
+// Shared failure path for the preview read: reports the error, records the
+// audit outcome, and maps a missing target to 404 / everything else to 503.
+function handleDependencyImpactFailure(
+  error: unknown,
+  actorId: string,
+  target: DependencyImpactTarget,
+): NextResponse {
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_dependency_impact' });
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+  const notFound = errorMessage.endsWith('_not_found');
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.dependency-impact.preview',
+    actorId,
+    // A missing target is a denial-of-operation (invalid_target), not an
+    // allowed-but-failed read, so the audit reflects a deny decision.
+    status: notFound ? 'deny' : 'allow',
+    reason: notFound ? 'invalid_target' : 'admin_or_taxonomy_admin',
+    target,
+    result: 'failure',
+    errorCategory: notFound ? 'not_found' : 'persistence_error',
+  });
+
+  if (notFound) {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Taxonomy target not found.' },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to preview dependency impact.' },
+    { status: 503 },
+  );
+}
+
 export async function GET(request: Request) {
   const gate = await requireTaxonomyAdminAccess();
   if (!gate.allowed) {
@@ -20,6 +63,7 @@ export async function GET(request: Request) {
   const targetType = url.searchParams.get('targetType') ?? '';
   const targetId = url.searchParams.get('targetId') ?? '';
   const operation = url.searchParams.get('operation') ?? '';
+  const target: DependencyImpactTarget = { targetType, targetId, operation };
 
   if (!validateDependencyPreviewInput(targetType, targetId) || !VALID_OPERATIONS.has(operation)) {
     return NextResponse.json(
@@ -41,48 +85,13 @@ export async function GET(request: Request) {
       actorId: gate.auth.userId,
       status: 'allow',
       reason: 'admin_or_taxonomy_admin',
-      target: {
-        targetType,
-        targetId,
-        operation,
-      },
+      target,
       result: 'success',
       errorCategory: null,
     });
 
     return NextResponse.json(impact, { status: 200 });
   } catch (error) {
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_dependency_impact' });
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-    const notFound = errorMessage.endsWith('_not_found');
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.dependency-impact.preview',
-      actorId: gate.auth.userId,
-      // A missing target is a denial-of-operation (invalid_target), not an
-      // allowed-but-failed read, so the audit reflects a deny decision.
-      status: notFound ? 'deny' : 'allow',
-      reason: notFound ? 'invalid_target' : 'admin_or_taxonomy_admin',
-      target: {
-        targetType,
-        targetId,
-        operation,
-      },
-      result: 'failure',
-      errorCategory: notFound ? 'not_found' : 'persistence_error',
-    });
-
-    if (notFound) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Taxonomy target not found.' },
-        { status: 404 },
-      );
-    }
-
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to preview dependency impact.' },
-      { status: 503 },
-    );
+    return handleDependencyImpactFailure(error, gate.auth.userId, target);
   }
 }

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/[id]/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/[id]/route.ts
@@ -22,6 +22,119 @@ type DeleteBody = {
   reason?: unknown;
 };
 
+type DeleteFailureKind = 'not_found' | 'conflict' | 'error';
+
+// Maps a repository delete error message to a coarse outcome. `notFoundCode` is
+// the entity-specific "not found" message the repository throws.
+function classifyDeleteFailure(errorMessage: string, notFoundCode: string): DeleteFailureKind {
+  if (errorMessage === notFoundCode) {
+    return 'not_found';
+  }
+
+  if (errorMessage === 'unresolved_downstream_dependencies' || errorMessage === 'destructive_threshold_exceeded') {
+    return 'conflict';
+  }
+
+  return 'error';
+}
+
+// Resolves the delete reason from the query string, falling back to the JSON
+// body when the query parameter is absent.
+async function resolveDeleteReason(request: Request): Promise<string> {
+  let reason = new URL(request.url).searchParams.get('reason') ?? '';
+  if (!reason) {
+    try {
+      const body = (await request.json()) as DeleteBody;
+      reason = typeof body.reason === 'string' ? body.reason : '';
+    } catch {
+      reason = '';
+    }
+  }
+
+  return reason;
+}
+
+function buildJobTitleUpdateInput(id: string, body: JobTitleUpdateBody) {
+  return {
+    id,
+    sectorId: typeof body.sectorId === 'string' ? body.sectorId : undefined,
+    name: typeof body.name === 'string' ? body.name : undefined,
+    displayOrder: typeof body.displayOrder === 'number' ? body.displayOrder : undefined,
+    isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
+  };
+}
+
+// Shared failure path for job title updates: records the audit outcome and maps
+// a missing parent sector to 404 / everything else to 503.
+function handleJobTitleUpdateFailure(error: unknown, actorId: string, id: string): NextResponse {
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+  const notFound = errorMessage === 'sector_not_found';
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.job-title.update',
+    actorId,
+    status: notFound ? 'deny' : 'allow',
+    reason: notFound ? 'invalid_parent_sector' : 'admin_or_taxonomy_admin',
+    target: { jobTitleId: id },
+    result: 'failure',
+    errorCategory: notFound ? 'not_found' : 'persistence_error',
+  });
+
+  if (notFound) {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent sector not found.' },
+      { status: 404 },
+    );
+  }
+
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_job_titles_id' });
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update job title.' },
+    { status: 503 },
+  );
+}
+
+// Shared failure path for job title deletion: records the audit outcome and maps
+// a missing target to 404 / dependency safeguards to 409 / everything else to 503.
+function handleJobTitleDeleteFailure(error: unknown, actorId: string, id: string): NextResponse {
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+  const kind = classifyDeleteFailure(errorMessage, 'job_title_not_found');
+  const errorCategory =
+    kind === 'conflict' ? 'dependency_conflict' : kind === 'not_found' ? 'not_found' : 'persistence_error';
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.job-title.delete',
+    actorId,
+    status: kind === 'error' ? 'allow' : 'deny',
+    reason: kind === 'error' ? 'admin_or_taxonomy_admin' : errorMessage,
+    target: { jobTitleId: id },
+    result: 'failure',
+    errorCategory,
+  });
+
+  if (kind === 'not_found') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Job title not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (kind === 'conflict') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.conflict, message: 'Job title delete blocked by dependency safeguards.' },
+      { status: 409 },
+    );
+  }
+
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_job_titles_id' });
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete job title.' },
+    { status: 503 },
+  );
+}
+
 export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
   const gate = await requireTaxonomyAdminAccess();
   if (!gate.allowed) {
@@ -72,13 +185,7 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
     );
   }
 
-  const input = {
-    id,
-    sectorId: typeof body.sectorId === 'string' ? body.sectorId : undefined,
-    name: typeof body.name === 'string' ? body.name : undefined,
-    displayOrder: typeof body.displayOrder === 'number' ? body.displayOrder : undefined,
-    isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
-  };
+  const input = buildJobTitleUpdateInput(id, body);
 
   if (!validateJobTitleUpdateInput(input)) {
     return NextResponse.json(
@@ -109,32 +216,7 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
 
     return NextResponse.json({ ok: true, jobTitle }, { status: 200 });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-    const notFound = errorMessage === 'sector_not_found';
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.job-title.update',
-      actorId: gate.auth.userId,
-      status: notFound ? 'deny' : 'allow',
-      reason: notFound ? 'invalid_parent_sector' : 'admin_or_taxonomy_admin',
-      target: { jobTitleId: id },
-      result: 'failure',
-      errorCategory: notFound ? 'not_found' : 'persistence_error',
-    });
-
-    if (notFound) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent sector not found.' },
-        { status: 404 },
-      );
-    }
-
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_job_titles_id' });
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update job title.' },
-      { status: 503 },
-    );
+    return handleJobTitleUpdateFailure(error, gate.auth.userId, id);
   }
 }
 
@@ -151,15 +233,7 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
 
   const { id } = await context.params;
 
-  let reason = new URL(request.url).searchParams.get('reason') ?? '';
-  if (!reason) {
-    try {
-      const body = (await request.json()) as DeleteBody;
-      reason = typeof body.reason === 'string' ? body.reason : '';
-    } catch {
-      reason = '';
-    }
-  }
+  const reason = await resolveDeleteReason(request);
 
   if (!validateDeleteInput('job-title', id, reason)) {
     return NextResponse.json(
@@ -184,39 +258,6 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
 
     return NextResponse.json({ ok: true, jobTitleId: id, deleted: true, deletedAt: deleted.deletedAtIso }, { status: 200 });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-    const conflict = errorMessage === 'unresolved_downstream_dependencies' || errorMessage === 'destructive_threshold_exceeded';
-    const notFound = errorMessage === 'job_title_not_found';
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.job-title.delete',
-      actorId: gate.auth.userId,
-      status: conflict || notFound ? 'deny' : 'allow',
-      reason: conflict ? errorMessage : notFound ? 'job_title_not_found' : 'admin_or_taxonomy_admin',
-      target: { jobTitleId: id },
-      result: 'failure',
-      errorCategory: conflict ? 'dependency_conflict' : notFound ? 'not_found' : 'persistence_error',
-    });
-
-    if (notFound) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Job title not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (conflict) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.conflict, message: 'Job title delete blocked by dependency safeguards.' },
-        { status: 409 },
-      );
-    }
-
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_job_titles_id' });
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete job title.' },
-      { status: 503 },
-    );
+    return handleJobTitleDeleteFailure(error, gate.auth.userId, id);
   }
 }

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/job-titles/route.ts
@@ -18,6 +18,36 @@ function parseIncludeInactive(url: string): boolean {
   return new URL(url).searchParams.get('includeInactive') !== 'false';
 }
 
+// Shared failure path for job title creation: records the audit outcome and
+// maps a missing parent sector to 404 / everything else to 503.
+function handleJobTitleCreateFailure(error: unknown, actorId: string, sectorId: string): NextResponse {
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.job-title.create',
+    actorId,
+    status: 'allow',
+    reason: 'admin_or_taxonomy_admin',
+    target: { sectorId },
+    result: 'failure',
+    errorCategory: errorMessage === 'sector_not_found' ? 'not_found' : 'persistence_error',
+  });
+
+  if (errorMessage === 'sector_not_found') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent sector not found.' },
+      { status: 404 },
+    );
+  }
+
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_job_titles' });
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to create job title.' },
+    { status: 503 },
+  );
+}
+
 export async function GET(request: Request) {
   const gate = await requireTaxonomyAdminAccess();
   if (!gate.allowed) {
@@ -109,30 +139,6 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, jobTitle }, { status: 201 });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.job-title.create',
-      actorId: gate.auth.userId,
-      status: 'allow',
-      reason: 'admin_or_taxonomy_admin',
-      target: { sectorId: input.sectorId },
-      result: 'failure',
-      errorCategory: errorMessage === 'sector_not_found' ? 'not_found' : 'persistence_error',
-    });
-
-    if (errorMessage === 'sector_not_found') {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent sector not found.' },
-        { status: 404 },
-      );
-    }
-
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_job_titles' });
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to create job title.' },
-      { status: 503 },
-    );
+    return handleJobTitleCreateFailure(error, gate.auth.userId, input.sectorId);
   }
 }

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/sectors/[id]/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/sectors/[id]/route.ts
@@ -22,6 +22,88 @@ type DeleteBody = {
   reason?: unknown;
 };
 
+type DeleteFailureKind = 'not_found' | 'conflict' | 'error';
+
+// Maps a repository delete error message to a coarse outcome. `notFoundCode` is
+// the entity-specific "not found" message the repository throws.
+function classifyDeleteFailure(errorMessage: string, notFoundCode: string): DeleteFailureKind {
+  if (errorMessage === notFoundCode) {
+    return 'not_found';
+  }
+
+  if (errorMessage === 'unresolved_downstream_dependencies' || errorMessage === 'destructive_threshold_exceeded') {
+    return 'conflict';
+  }
+
+  return 'error';
+}
+
+// Resolves the delete reason from the query string, falling back to the JSON
+// body when the query parameter is absent.
+async function resolveDeleteReason(request: Request): Promise<string> {
+  let reason = new URL(request.url).searchParams.get('reason') ?? '';
+  if (!reason) {
+    try {
+      const body = (await request.json()) as DeleteBody;
+      reason = typeof body.reason === 'string' ? body.reason : '';
+    } catch {
+      reason = '';
+    }
+  }
+
+  return reason;
+}
+
+function buildSectorUpdateInput(id: string, body: SectorUpdateBody) {
+  return {
+    id,
+    name: typeof body.name === 'string' ? body.name : undefined,
+    displayOrder: typeof body.displayOrder === 'number' ? body.displayOrder : undefined,
+    workforceShare: typeof body.workforceShare === 'number' || body.workforceShare === null ? body.workforceShare : undefined,
+    isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
+  };
+}
+
+// Shared failure path for sector deletion: records the audit outcome and maps a
+// missing target to 404 / dependency safeguards to 409 / everything else to 503.
+function handleSectorDeleteFailure(error: unknown, actorId: string, id: string): NextResponse {
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+  const kind = classifyDeleteFailure(errorMessage, 'sector_not_found');
+  const errorCategory =
+    kind === 'conflict' ? 'dependency_conflict' : kind === 'not_found' ? 'not_found' : 'persistence_error';
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.sector.delete',
+    actorId,
+    status: kind === 'error' ? 'allow' : 'deny',
+    reason: kind === 'error' ? 'admin_or_taxonomy_admin' : errorMessage,
+    target: { sectorId: id },
+    result: 'failure',
+    errorCategory,
+  });
+
+  if (kind === 'not_found') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Sector not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (kind === 'conflict') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.conflict, message: 'Sector delete blocked by dependency safeguards.' },
+      { status: 409 },
+    );
+  }
+
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_sectors_id' });
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete sector.' },
+    { status: 503 },
+  );
+}
+
 export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
   const gate = await requireTaxonomyAdminAccess();
   if (!gate.allowed) {
@@ -72,13 +154,7 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
     );
   }
 
-  const input = {
-    id,
-    name: typeof body.name === 'string' ? body.name : undefined,
-    displayOrder: typeof body.displayOrder === 'number' ? body.displayOrder : undefined,
-    workforceShare: typeof body.workforceShare === 'number' || body.workforceShare === null ? body.workforceShare : undefined,
-    isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
-  };
+  const input = buildSectorUpdateInput(id, body);
 
   if (!validateSectorUpdateInput(input)) {
     return NextResponse.json(
@@ -141,15 +217,7 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
 
   const { id } = await context.params;
 
-  let reason = new URL(request.url).searchParams.get('reason') ?? '';
-  if (!reason) {
-    try {
-      const body = (await request.json()) as DeleteBody;
-      reason = typeof body.reason === 'string' ? body.reason : '';
-    } catch {
-      reason = '';
-    }
-  }
+  const reason = await resolveDeleteReason(request);
 
   if (!validateDeleteInput('sector', id, reason)) {
     return NextResponse.json(
@@ -174,39 +242,6 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
 
     return NextResponse.json({ ok: true, sectorId: id, deleted: true, deletedAt: deleted.deletedAtIso }, { status: 200 });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-    const conflict = errorMessage === 'unresolved_downstream_dependencies' || errorMessage === 'destructive_threshold_exceeded';
-    const notFound = errorMessage === 'sector_not_found';
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.sector.delete',
-      actorId: gate.auth.userId,
-      status: conflict || notFound ? 'deny' : 'allow',
-      reason: conflict ? errorMessage : notFound ? 'sector_not_found' : 'admin_or_taxonomy_admin',
-      target: { sectorId: id },
-      result: 'failure',
-      errorCategory: conflict ? 'dependency_conflict' : notFound ? 'not_found' : 'persistence_error',
-    });
-
-    if (notFound) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Sector not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (conflict) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.conflict, message: 'Sector delete blocked by dependency safeguards.' },
-        { status: 409 },
-      );
-    }
-
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_sectors_id' });
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete sector.' },
-      { status: 503 },
-    );
+    return handleSectorDeleteFailure(error, gate.auth.userId, id);
   }
 }

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/skills/[id]/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/skills/[id]/route.ts
@@ -23,6 +23,120 @@ type DeleteBody = {
   reason?: unknown;
 };
 
+type DeleteFailureKind = 'not_found' | 'conflict' | 'error';
+
+// Maps a repository delete error message to a coarse outcome. `notFoundCode` is
+// the entity-specific "not found" message the repository throws.
+function classifyDeleteFailure(errorMessage: string, notFoundCode: string): DeleteFailureKind {
+  if (errorMessage === notFoundCode) {
+    return 'not_found';
+  }
+
+  if (errorMessage === 'unresolved_downstream_dependencies' || errorMessage === 'destructive_threshold_exceeded') {
+    return 'conflict';
+  }
+
+  return 'error';
+}
+
+// Resolves the delete reason from the query string, falling back to the JSON
+// body when the query parameter is absent.
+async function resolveDeleteReason(request: Request): Promise<string> {
+  let reason = new URL(request.url).searchParams.get('reason') ?? '';
+  if (!reason) {
+    try {
+      const body = (await request.json()) as DeleteBody;
+      reason = typeof body.reason === 'string' ? body.reason : '';
+    } catch {
+      reason = '';
+    }
+  }
+
+  return reason;
+}
+
+function buildSkillUpdateInput(id: string, body: SkillUpdateBody) {
+  return {
+    id,
+    jobTitleId: typeof body.jobTitleId === 'string' ? body.jobTitleId : undefined,
+    name: typeof body.name === 'string' ? body.name : undefined,
+    displayOrder: typeof body.displayOrder === 'number' ? body.displayOrder : undefined,
+    aliases: Array.isArray(body.aliases) ? body.aliases.filter((entry): entry is string => typeof entry === 'string') : undefined,
+    isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
+  };
+}
+
+// Shared failure path for skill updates: records the audit outcome and maps a
+// missing parent job title to 404 / everything else to 503.
+function handleSkillUpdateFailure(error: unknown, actorId: string, id: string): NextResponse {
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+  const notFound = errorMessage === 'job_title_not_found';
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.skill.update',
+    actorId,
+    status: notFound ? 'deny' : 'allow',
+    reason: notFound ? 'invalid_parent_job_title' : 'admin_or_taxonomy_admin',
+    target: { skillId: id },
+    result: 'failure',
+    errorCategory: notFound ? 'not_found' : 'persistence_error',
+  });
+
+  if (notFound) {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent job title not found.' },
+      { status: 404 },
+    );
+  }
+
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_skills_id' });
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update skill.' },
+    { status: 503 },
+  );
+}
+
+// Shared failure path for skill deletion: records the audit outcome and maps a
+// missing target to 404 / dependency safeguards to 409 / everything else to 503.
+function handleSkillDeleteFailure(error: unknown, actorId: string, id: string): NextResponse {
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+  const kind = classifyDeleteFailure(errorMessage, 'skill_not_found');
+  const errorCategory =
+    kind === 'conflict' ? 'dependency_conflict' : kind === 'not_found' ? 'not_found' : 'persistence_error';
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.skill.delete',
+    actorId,
+    status: kind === 'error' ? 'allow' : 'deny',
+    reason: kind === 'error' ? 'admin_or_taxonomy_admin' : errorMessage,
+    target: { skillId: id },
+    result: 'failure',
+    errorCategory,
+  });
+
+  if (kind === 'not_found') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Skill not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (kind === 'conflict') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.conflict, message: 'Skill delete blocked by dependency safeguards.' },
+      { status: 409 },
+    );
+  }
+
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_skills_id' });
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete skill.' },
+    { status: 503 },
+  );
+}
+
 export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
   const gate = await requireTaxonomyAdminAccess();
   if (!gate.allowed) {
@@ -73,14 +187,7 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
     );
   }
 
-  const input = {
-    id,
-    jobTitleId: typeof body.jobTitleId === 'string' ? body.jobTitleId : undefined,
-    name: typeof body.name === 'string' ? body.name : undefined,
-    displayOrder: typeof body.displayOrder === 'number' ? body.displayOrder : undefined,
-    aliases: Array.isArray(body.aliases) ? body.aliases.filter((entry): entry is string => typeof entry === 'string') : undefined,
-    isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
-  };
+  const input = buildSkillUpdateInput(id, body);
 
   if (!validateSkillUpdateInput(input)) {
     return NextResponse.json(
@@ -111,32 +218,7 @@ export async function PUT(request: Request, context: { params: Promise<{ id: str
 
     return NextResponse.json({ ok: true, skill }, { status: 200 });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-    const notFound = errorMessage === 'job_title_not_found';
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.skill.update',
-      actorId: gate.auth.userId,
-      status: notFound ? 'deny' : 'allow',
-      reason: notFound ? 'invalid_parent_job_title' : 'admin_or_taxonomy_admin',
-      target: { skillId: id },
-      result: 'failure',
-      errorCategory: notFound ? 'not_found' : 'persistence_error',
-    });
-
-    if (notFound) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent job title not found.' },
-        { status: 404 },
-      );
-    }
-
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_skills_id' });
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to update skill.' },
-      { status: 503 },
-    );
+    return handleSkillUpdateFailure(error, gate.auth.userId, id);
   }
 }
 
@@ -153,15 +235,7 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
 
   const { id } = await context.params;
 
-  let reason = new URL(request.url).searchParams.get('reason') ?? '';
-  if (!reason) {
-    try {
-      const body = (await request.json()) as DeleteBody;
-      reason = typeof body.reason === 'string' ? body.reason : '';
-    } catch {
-      reason = '';
-    }
-  }
+  const reason = await resolveDeleteReason(request);
 
   if (!validateDeleteInput('skill', id, reason)) {
     return NextResponse.json(
@@ -186,39 +260,6 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
 
     return NextResponse.json({ ok: true, skillId: id, deleted: true, deletedAt: deleted.deletedAtIso }, { status: 200 });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-    const conflict = errorMessage === 'unresolved_downstream_dependencies' || errorMessage === 'destructive_threshold_exceeded';
-    const notFound = errorMessage === 'skill_not_found';
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.skill.delete',
-      actorId: gate.auth.userId,
-      status: conflict || notFound ? 'deny' : 'allow',
-      reason: conflict ? errorMessage : notFound ? 'skill_not_found' : 'admin_or_taxonomy_admin',
-      target: { skillId: id },
-      result: 'failure',
-      errorCategory: conflict ? 'dependency_conflict' : notFound ? 'not_found' : 'persistence_error',
-    });
-
-    if (notFound) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Skill not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (conflict) {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.conflict, message: 'Skill delete blocked by dependency safeguards.' },
-        { status: 409 },
-      );
-    }
-
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_skills_id' });
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to delete skill.' },
-      { status: 503 },
-    );
+    return handleSkillDeleteFailure(error, gate.auth.userId, id);
   }
 }

--- a/ctf/packages/web/app/api/skills-taxonomy/admin/skills/route.ts
+++ b/ctf/packages/web/app/api/skills-taxonomy/admin/skills/route.ts
@@ -19,6 +19,36 @@ function parseIncludeInactive(url: string): boolean {
   return new URL(url).searchParams.get('includeInactive') !== 'false';
 }
 
+// Shared failure path for skill creation: records the audit outcome and maps a
+// missing parent job title to 404 / everything else to 503.
+function handleSkillCreateFailure(error: unknown, actorId: string, jobTitleId: string): NextResponse {
+  const errorMessage = error instanceof Error ? error.message : 'unknown_error';
+
+  logSkillsTaxonomyAudit({
+    pluginId: 'skills-taxonomy',
+    command: 'skills-taxonomy.skill.create',
+    actorId,
+    status: 'allow',
+    reason: 'admin_or_taxonomy_admin',
+    target: { jobTitleId },
+    result: 'failure',
+    errorCategory: errorMessage === 'job_title_not_found' ? 'not_found' : 'persistence_error',
+  });
+
+  if (errorMessage === 'job_title_not_found') {
+    return NextResponse.json(
+      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent job title not found.' },
+      { status: 404 },
+    );
+  }
+
+  reportError(error, { area: 'skills-taxonomy', op: 'admin_skills' });
+  return NextResponse.json(
+    { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to create skill.' },
+    { status: 503 },
+  );
+}
+
 export async function GET(request: Request) {
   const gate = await requireTaxonomyAdminAccess();
   if (!gate.allowed) {
@@ -111,30 +141,6 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, skill }, { status: 201 });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'unknown_error';
-
-    logSkillsTaxonomyAudit({
-      pluginId: 'skills-taxonomy',
-      command: 'skills-taxonomy.skill.create',
-      actorId: gate.auth.userId,
-      status: 'allow',
-      reason: 'admin_or_taxonomy_admin',
-      target: { jobTitleId: input.jobTitleId },
-      result: 'failure',
-      errorCategory: errorMessage === 'job_title_not_found' ? 'not_found' : 'persistence_error',
-    });
-
-    if (errorMessage === 'job_title_not_found') {
-      return NextResponse.json(
-        { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.notFound, message: 'Parent job title not found.' },
-        { status: 404 },
-      );
-    }
-
-    reportError(error, { area: 'skills-taxonomy', op: 'admin_skills' });
-    return NextResponse.json(
-      { ok: false, code: SKILLS_TAXONOMY_ERROR_CODE.persistenceUnavailable, message: 'Unable to create skill.' },
-      { status: 503 },
-    );
+    return handleSkillCreateFailure(error, gate.auth.userId, input.jobTitleId);
   }
 }

--- a/ctf/packages/web/app/api/trust-transport/_lib.ts
+++ b/ctf/packages/web/app/api/trust-transport/_lib.ts
@@ -75,54 +75,39 @@ export function parsePositiveInteger(value: string | null, fallback: number): nu
   return parsed;
 }
 
+// A non-empty trimmed idempotency key is kept as-is; anything else falls back to the caller's key.
+export function resolveIdempotencyKey(value: unknown, fallbackKey: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallbackKey;
+}
+
+// Maps a repository error message to its member-facing response shape. Keeping this as a lookup keeps
+// trustTransportErrorResponse a single table read instead of a long branch chain.
+type TrustTransportErrorResponse = { code: string; message: string; status: number };
+
+const TRUST_TRANSPORT_ERROR_RESPONSES: Record<string, TrustTransportErrorResponse> = {
+  invalid_mode: { code: TRUST_TRANSPORT_ERROR_CODE.invalidMode, message: 'Mode is invalid.', status: 400 },
+  request_not_found: { code: TRUST_TRANSPORT_ERROR_CODE.requestNotFound, message: 'Request not found.', status: 404 },
+  offer_not_found: { code: TRUST_TRANSPORT_ERROR_CODE.offerNotFound, message: 'Offer not found.', status: 404 },
+  trip_not_found: { code: TRUST_TRANSPORT_ERROR_CODE.tripNotFound, message: 'Trip not found.', status: 404 },
+  incident_not_found: { code: TRUST_TRANSPORT_ERROR_CODE.incidentNotFound, message: 'Incident not found.', status: 404 },
+  invalid_transition: { code: TRUST_TRANSPORT_ERROR_CODE.invalidTransition, message: 'Invalid status transition.', status: 409 },
+  completion_requires_confirmation: {
+    code: TRUST_TRANSPORT_ERROR_CODE.completionRequiresConfirmation,
+    message: 'Both the requester and the provider must confirm before a trip can be marked complete.',
+    status: 409,
+  },
+  policy_denied: { code: TRUST_TRANSPORT_ERROR_CODE.policyDenied, message: 'Operation denied by policy.', status: 403 },
+  insufficient_balance: { code: TRUST_TRANSPORT_ERROR_CODE.insufficientBalance, message: 'Insufficient available balance.', status: 409 },
+  account_restricted: { code: TRUST_TRANSPORT_ERROR_CODE.accountRestricted, message: 'Account is restricted.', status: 403 },
+  invalid_payload: { code: TRUST_TRANSPORT_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 export function trustTransportErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
 
-  if (code === 'invalid_mode') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.invalidMode, message: 'Mode is invalid.' }, { status: 400 });
-  }
-
-  if (code === 'request_not_found') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.requestNotFound, message: 'Request not found.' }, { status: 404 });
-  }
-
-  if (code === 'offer_not_found') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.offerNotFound, message: 'Offer not found.' }, { status: 404 });
-  }
-
-  if (code === 'trip_not_found') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.tripNotFound, message: 'Trip not found.' }, { status: 404 });
-  }
-
-  if (code === 'incident_not_found') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.incidentNotFound, message: 'Incident not found.' }, { status: 404 });
-  }
-
-  if (code === 'invalid_transition') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.invalidTransition, message: 'Invalid status transition.' }, { status: 409 });
-  }
-
-  if (code === 'completion_requires_confirmation') {
-    return NextResponse.json(
-      { ok: false, code: TRUST_TRANSPORT_ERROR_CODE.completionRequiresConfirmation, message: 'Both the requester and the provider must confirm before a trip can be marked complete.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'policy_denied') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.policyDenied, message: 'Operation denied by policy.' }, { status: 403 });
-  }
-
-  if (code === 'insufficient_balance') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.insufficientBalance, message: 'Insufficient available balance.' }, { status: 409 });
-  }
-
-  if (code === 'account_restricted') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.accountRestricted, message: 'Account is restricted.' }, { status: 403 });
-  }
-
-  if (code === 'invalid_payload') {
-    return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.invalidPayload, message: 'Invalid payload.' }, { status: 400 });
+  const mapped = TRUST_TRANSPORT_ERROR_RESPONSES[code];
+  if (mapped) {
+    return NextResponse.json({ ok: false, code: mapped.code, message: mapped.message }, { status: mapped.status });
   }
 
   reportError(error, { area: 'trust-transport', op: 'unknown' });

--- a/ctf/packages/web/app/api/trust-transport/admin/accounts/[userId]/restrict/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/admin/accounts/[userId]/restrict/route.ts
@@ -24,6 +24,7 @@ export async function POST(request: Request, { params }: RouteProps) {
   try {
     body = (await request.json()) as Record<string, unknown>;
   } catch {
+    // Body is optional here; a missing or malformed JSON body leaves the empty defaults in place.
   }
 
   const reason = typeof body.reason === 'string' ? body.reason : null;

--- a/ctf/packages/web/app/api/trust-transport/admin/incidents/[incidentId]/resolve/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/admin/incidents/[incidentId]/resolve/route.ts
@@ -24,6 +24,7 @@ export async function POST(request: Request, { params }: RouteProps) {
   try {
     body = (await request.json()) as Record<string, unknown>;
   } catch {
+    // Body is optional here; a missing or malformed JSON body leaves the empty defaults in place.
   }
 
   const resolutionNotes = typeof body.resolutionNotes === 'string' ? body.resolutionNotes : null;

--- a/ctf/packages/web/app/api/trust-transport/offers/[offerId]/accept/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/offers/[offerId]/accept/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { ensureMutationCsrf, requireTrustTransportReadAccess, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
+import { ensureMutationCsrf, requireTrustTransportReadAccess, resolveIdempotencyKey, trustTransportErrorResponse } from 'lib/trust-transport/_lib';
 import { TRUST_TRANSPORT_ERROR_CODE } from 'lib/trust-transport/constants';
 import { acceptOffer, insertTrustTransportAudit } from 'lib/trust-transport/repository';
 import { notifySafe } from 'lib/notifications/repository';
@@ -40,9 +40,7 @@ export async function POST(request: Request, { params }: RouteProps) {
     );
   }
 
-  const idempotencyKey = typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim().length > 0
-    ? body.idempotencyKey.trim()
-    : `${gate.auth.userId}:${Date.now()}`;
+  const idempotencyKey = resolveIdempotencyKey(body.idempotencyKey, `${gate.auth.userId}:${Date.now()}`);
 
   try {
     const result = await acceptOffer(requestId, offerId, gate.auth.userId, idempotencyKey);

--- a/ctf/packages/web/app/api/trust-transport/orders/[orderId]/cancel/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/orders/[orderId]/cancel/route.ts
@@ -22,6 +22,7 @@ export async function POST(request: Request, { params }: RouteProps) {
   try {
     body = (await request.json()) as Record<string, unknown>;
   } catch {
+    // Body is optional here; a missing or malformed JSON body leaves the empty defaults in place.
   }
 
   const reason = typeof body.reason === 'string' ? body.reason : null;

--- a/ctf/packages/web/app/api/trust-transport/requests/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/requests/route.ts
@@ -18,30 +18,38 @@ function parsePriceAmount(value: unknown): number | null {
   return null;
 }
 
-function parseRequestInput(body: Record<string, unknown>): TrustTransportRequestInput {
-  const modeValue = typeof body.mode === 'string' ? body.mode : 'ride';
-  const mode = (TRUST_TRANSPORT_MODES as readonly string[]).includes(modeValue)
+function parseMode(value: unknown): TrustTransportMode {
+  const modeValue = typeof value === 'string' ? value : 'ride';
+  return (TRUST_TRANSPORT_MODES as readonly string[]).includes(modeValue)
     ? (modeValue as TrustTransportMode)
     : 'ride';
+}
 
-  // Settlement value type (issue #420): a non-empty code names how the ride is settled; absent means
-  // none chosen. Amount is kept only as a positive finite number, so amount-less types carry no amount.
-  const priceCurrency =
-    typeof body.priceCurrency === 'string' && body.priceCurrency.trim().length > 0
-      ? body.priceCurrency.trim()
-      : null;
-  const priceAmount = parsePriceAmount(body.priceAmount);
+function stringOrDefault(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
 
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+// Settlement value type (issue #420): a non-empty code names how the ride is settled; absent means
+// none chosen. Amount is kept only as a positive finite number, so amount-less types carry no amount.
+function parsePriceCurrency(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseRequestInput(body: Record<string, unknown>): TrustTransportRequestInput {
   return {
-    mode,
-    title: typeof body.title === 'string' ? body.title : '',
-    details: typeof body.details === 'string' ? body.details : '',
-    pickupCity: typeof body.pickupCity === 'string' ? body.pickupCity : null,
-    dropoffCity: typeof body.dropoffCity === 'string' ? body.dropoffCity : null,
-    pickupGeoRedacted: typeof body.pickupGeoRedacted === 'string' ? body.pickupGeoRedacted : null,
-    dropoffGeoRedacted: typeof body.dropoffGeoRedacted === 'string' ? body.dropoffGeoRedacted : null,
-    priceCurrency,
-    priceAmount,
+    mode: parseMode(body.mode),
+    title: stringOrDefault(body.title, ''),
+    details: stringOrDefault(body.details, ''),
+    pickupCity: optionalString(body.pickupCity),
+    dropoffCity: optionalString(body.dropoffCity),
+    pickupGeoRedacted: optionalString(body.pickupGeoRedacted),
+    dropoffGeoRedacted: optionalString(body.dropoffGeoRedacted),
+    priceCurrency: parsePriceCurrency(body.priceCurrency),
+    priceAmount: parsePriceAmount(body.priceAmount),
   };
 }
 

--- a/ctf/packages/web/app/api/trust-transport/service-credits/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/service-credits/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { requireTrustTransportReadAccess, ensureMutationCsrf } from 'lib/trust-transport/_lib';
+import { requireTrustTransportReadAccess, ensureMutationCsrf, resolveIdempotencyKey } from 'lib/trust-transport/_lib';
 import { createTransfer } from 'lib/service-credits/repository';
 import { insertTrustTransportAudit } from 'lib/trust-transport/repository';
 import { TRUST_TRANSPORT_ERROR_CODE } from 'lib/trust-transport/constants';
@@ -11,6 +11,18 @@ type TrustTransportServiceCreditsSendInput = {
   message?: string;
   idempotencyKey?: string;
 };
+
+// A transfer amount must be a positive finite number; booleans, strings, and null never qualify.
+function isValidTransferAmount(amount: unknown): amount is number {
+  return typeof amount === 'number' && Number.isFinite(amount) && amount > 0;
+}
+
+// A non-empty message marks the transfer with the message reason code; otherwise the plain reason.
+function transferReasonCode(message: unknown): string {
+  return typeof message === 'string' && message.trim().length > 0
+    ? 'trust-transport.transfer.message'
+    : 'trust-transport.transfer';
+}
 
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -30,7 +42,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.invalidPayload, message: 'Invalid JSON.' }, { status: 400 });
   }
 
-  if (!input.toUserId || typeof input.amount !== 'number' || !Number.isFinite(input.amount) || input.amount <= 0) {
+  if (!input.toUserId || !isValidTransferAmount(input.amount)) {
     return NextResponse.json({ ok: false, code: TRUST_TRANSPORT_ERROR_CODE.invalidPayload, message: 'Invalid payload.' }, { status: 400 });
   }
 
@@ -41,10 +53,10 @@ export async function POST(request: Request) {
   }
 
   try {
-    const idempotencyKey =
-      typeof input.idempotencyKey === 'string' && input.idempotencyKey.trim().length > 0
-        ? input.idempotencyKey.trim()
-        : `trust-transport-${gate.auth.userId}-${Date.now()}`;
+    const idempotencyKey = resolveIdempotencyKey(
+      input.idempotencyKey,
+      `trust-transport-${gate.auth.userId}-${Date.now()}`,
+    );
 
     const tx = await createTransfer({
       senderUserId: gate.auth.userId,
@@ -52,7 +64,7 @@ export async function POST(request: Request) {
       amount: input.amount,
       idempotencyKey,
       originPlugin: 'trust-transport',
-      reasonCode: input.message && input.message.trim().length > 0 ? 'trust-transport.transfer.message' : 'trust-transport.transfer',
+      reasonCode: transferReasonCode(input.message),
     });
 
     // Cross-user credit transfers are a financial mutation inside this plugin; record an audit event so

--- a/ctf/packages/web/app/api/trust-transport/trips/[tripId]/emergency-stop/route.ts
+++ b/ctf/packages/web/app/api/trust-transport/trips/[tripId]/emergency-stop/route.ts
@@ -22,6 +22,7 @@ export async function POST(request: Request, { params }: RouteProps) {
   try {
     body = (await request.json()) as Record<string, unknown>;
   } catch {
+    // Body is optional here; a missing or malformed JSON body leaves the empty defaults in place.
   }
 
   const notes = typeof body.notes === 'string' ? body.notes : null;


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (backend API route handlers only).

## What

Rule-116 complexity/length cleanup for 40 API route handlers across five areas. **Behavior-preserving** — identical HTTP status codes, CSRF/auth gates, request parsing, response bodies, audit side effects, DB queries, and error handling. Reduced complexity purely by extracting module-scope helpers (input validation/parsing, error-code→response mapping tables, payload builders).

- foundation (13 routes: connections/threads/instant-calls, admin, provider, push, quotes)
- trust-transport (8: requests, service-credits read, offers/orders/trips, admin) + `_lib` error-table
- lighthouse (7: profile, properties, matches, blocks, admin)
- skills-taxonomy (6: admin sectors/job-titles/skills/dependency-impact)
- skills-hunt (6: rounds, submissions, admin reports/rounds/missions)

## Verification
- `pnpm --filter @ctf/web run typecheck` / repo `lint` — pass
- complexity gate check on changed files (`--no-inline-config`) — pass
- `check-eof-format` — pass
- pre-push gate — pass

No schema changes. Contracts unchanged (pure handler-internal refactor).

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_