### PR TITLE
ci: run the complexity gate against a dedicated minimal eslint config

### DIFF
--- a/ctf/scripts/check-modularity-governance.sh
+++ b/ctf/scripts/check-modularity-governance.sh
@@ -60,17 +60,20 @@ fi
 echo "Checking ${#target_files[@]} changed file(s):"
 printf '  %s\n' "${target_files[@]}"
 
-# --no-inline-config: this gate runs eslint with ONLY the complexity + max-lines rules loaded, so an
-# `// eslint-disable-next-line <plugin>/<rule>` comment in a changed file (e.g. jsx-a11y/*, which lives
-# in the separate a11y-audit config, not the base lint config) would otherwise error as "Definition for
-# rule ... was not found" and fail the gate for an unrelated reason. Ignoring inline config also means a
-# function can't dodge this gate with `// eslint-disable complexity` — which is exactly what we want.
+# This gate must enforce ONLY the two rule-116 limits (complexity, max function length) and nothing
+# else. It runs eslint against a dedicated minimal config (scripts/eslint.complexity.cjs) with
+# --no-eslintrc, so the project's full ruleset never runs here — otherwise a changed file's sanctioned
+# inline disables (e.g. an approved `@typescript-eslint/no-explicit-any`) would surface as gate failures,
+# and the base config's plugins would matter. --no-inline-config makes the gate ignore inline
+# eslint-disable comments entirely: a function can't dodge the limit with `// eslint-disable complexity`,
+# and a `// eslint-disable jsx-a11y/*` comment can't error as "rule not found" (that plugin isn't loaded
+# by this minimal config). The two rules live in the config file, not on the command line.
 if ESLINT_USE_FLAT_CONFIG=false pnpm exec eslint \
+  --no-eslintrc \
+  --config scripts/eslint.complexity.cjs \
   --quiet \
   --no-inline-config \
   --no-error-on-unmatched-pattern \
-  --rule 'complexity:["error",10]' \
-  --rule 'max-lines-per-function:["error",{"max":200,"skipBlankLines":true,"skipComments":true,"IIFEs":true}]' \
   "${target_files[@]}"; then
   echo "✅ Modularity/complexity governance check passed."
 else

--- a/ctf/scripts/eslint.complexity.cjs
+++ b/ctf/scripts/eslint.complexity.cjs
@@ -1,0 +1,21 @@
+// Minimal ESLint config used ONLY by the modularity/complexity gate
+// (check-modularity-governance.sh). It intentionally loads NO plugins and no
+// other rules — just the TypeScript parser (so .ts/.tsx parse) plus the two
+// rule-116 limits — so the gate enforces complexity and function length and
+// nothing else. Run via `eslint --no-eslintrc -c` so the project's full ruleset
+// (and its sanctioned inline disables, e.g. approved @typescript-eslint/no-explicit-any)
+// never affect this gate, and files with jsx-a11y disable comments don't error as
+// "rule not found".
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2023,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+  rules: {
+    complexity: ['error', 10],
+    'max-lines-per-function': ['error', { max: 200, skipBlankLines: true, skipComments: true, IIFEs: true }],
+  },
+};


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (CI/infra change only).

## Why

The gate ran eslint with the project's base eslintrc + two rule overrides, so it evaluated the *whole* ruleset on changed files. Combined with `--no-inline-config` (added in #2011 so jsx-a11y disable comments don't error as "rule not found"), a changed file's **sanctioned** inline disables — e.g. an approved `@typescript-eslint/no-explicit-any` — would surface as gate failures. That's a false-positive that would block legitimate refactors of any file carrying an approved disable.

## Fix

Run the gate against a dedicated minimal config — `scripts/eslint.complexity.cjs` (TypeScript parser + only `complexity` and `max-lines-per-function`) — with `--no-eslintrc`. The gate now enforces exactly the two rule-116 limits and nothing else. `--no-inline-config` stays so the limits can't be dodged inline and unknown-plugin disables remain harmless.

Verified locally: the full gate script fails on an over-complexity file and passes on a file whose only issue is a sanctioned `no-explicit-any` disable.

## Review lane
CI enforcement correctness fix. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_