### PR TITLE
fix: make the Expo Android quota guard actually read build usage

### DIFF
--- a/ctf/scripts/check-expo-build-quota.mjs
+++ b/ctf/scripts/check-expo-build-quota.mjs
@@ -28,7 +28,8 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const quotaPath = resolve(here, '../packages/mobile/expo-free-tier-quota.json');
+const mobileDir = resolve(here, '../packages/mobile');
+const quotaPath = resolve(mobileDir, 'expo-free-tier-quota.json');
 
 const mode = (process.argv[2] || 'scheduled').toLowerCase();
 
@@ -70,11 +71,19 @@ function countThisMonth() {
   try {
     raw = execFileSync(
       'eas',
-      ['build:list', '--platform', 'android', '--limit', '100', '--json', '--non-interactive'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      // 50 is the highest --limit the EAS CLI accepts. That is far more than the
+      // 15-builds-per-month cap, so the current month is always fully covered.
+      ['build:list', '--platform', 'android', '--limit', '50', '--json', '--non-interactive'],
+      // Run inside the Expo app directory. The workflows call this script from the
+      // repo root, and there is no app config there, so `eas build:list` would exit
+      // with "EAS project not configured" and the guard would fail open.
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], cwd: mobileDir },
     );
   } catch (err) {
-    return { error: err.message };
+    // Include the CLI's own output; err.message alone only repeats the command,
+    // which hides why the read failed. The EAS CLI puts some failures on stdout.
+    const detail = [err?.stdout, err?.stderr].map((s) => String(s || '').trim()).filter(Boolean).join(' ');
+    return { error: detail ? `${err.message} ${detail}` : err.message };
   }
 
   let builds;


### PR DESCRIPTION
Opened automatically for the failed scheduled Android test build: https://github.com/chargingthefuture/chargingthefuture/actions/runs/30626050339

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — this changes a CI helper script only, no app surface.

## What failed

EAS refused the build. From the run log:

> This account has used its Android builds from the Free plan this month, which will reset in 12 hours (on Sat Aug 01 2026).

The monthly allotment itself is not something a code change can extend. What a code change *can* fix is the guard step that exists to skip the run in exactly this case and did not do it. `Check Expo build quota` logged:

> [expo-build-quota] Could not read EAS build usage (Command failed: eas build:list ...). Falling back to the cron frequency cap and proceeding.

`ctf/scripts/check-expo-build-quota.mjs` falls open when it cannot read usage, so the run went ahead and hit the hard limit at EAS instead of skipping cleanly.

## Why the read failed

Reproduced both causes directly:

1. `--limit 100` is rejected by the EAS CLI — `--limit must be between 1 and 50`.
2. All three Expo workflows run the script from the repo root, where there is no Expo app config, so the CLI exits with `EAS project not configured`.

Either one alone breaks the read, so this guard has never actually enforced the quota.

## The change

One file, `ctf/scripts/check-expo-build-quota.mjs`:

- `--limit 100` becomes `--limit 50`, the CLI maximum. Still well above the 15-builds-per-month cap, so the current calendar month is fully covered.
- The `eas build:list` call now runs with `cwd` set to `ctf/packages/mobile`, so it resolves the Expo project regardless of where a workflow invokes the script. Fixing it in the script covers all three callers (`expo-android-scheduled-build.yml`, `expo-preview.yml`, `expo-android-release.yml`), which all run from the repo root.
- The fall-open message now includes the CLI's own output. Before, it only repeated the command, which hid the reason.

No product code, no schema, no routes, no contracts, no delivery-status change, so no feature inventory update applies.

## Verification

Run from the repo root, as the workflows do:

- `report` mode: `This month: 15 Android build(s) used. Limits — hard cap 15, automated budget 12 ...` — matches what EAS reported when it refused the build.
- `scheduled` mode: `build_allowed=false`, `Skipping build: 15 Android build(s) already used this month, which meets the automated-build budget (12, reserving 3 for releases).`

So with this change the run would have skipped cleanly and stayed green instead of failing.

- `pnpm --dir ctf --filter @ctf/mobile run typecheck` — passed
- `pnpm --dir ctf --filter @ctf/mobile run lint` — passed
- `ctf/scripts/check-eof-format.sh` — passed

## What this does not do

The build allotment for this month stays used up; the next scheduled run before the month rolls over will skip instead of build. The Monday cycle after the reset builds normally.