### PR TITLE
fix: use US spelling "realize" in the signal-vs-noise Commons notice

### DIFF
--- a/ctf/packages/web/lib/feed/commons-guidance.ts
+++ b/ctf/packages/web/lib/feed/commons-guidance.ts
@@ -140,7 +140,7 @@ const COMMONS_SIGNAL_BODY = [
   ),
   para('Here is the thinking behind that.'),
   para(
-    'Matthew was once asked by a Target on Quora, roughly: do you realise you are sometimes responding to',
+    'Matthew was once asked by a Target on Quora, roughly: do you realize you are sometimes responding to',
     'perps’ comments and posts? His answer, also roughly: yes — but I answered truthfully, so it does not',
     'matter that it was a perp, because a real Target will read the same answer and get value from it.',
   ),
@@ -223,7 +223,7 @@ export const COMMONS_GUIDANCE_BODY = COMMONS_NOTICES[0].body;
 // For a day cadence: the period is the interval index (whole days since the epoch divided by the
 // interval). It becomes due the first time a post is made inside a new interval — which means a notice
 // on a time cadence is delivered by the next post, not by a clock. A reminder nobody is present for is
-// worth nothing, so this is the intended behaviour and not a compromise; in a silent room, nothing is
+// worth nothing, so this is the intended behavior and not a compromise; in a silent room, nothing is
 // published until somebody shows up.
 export function dueMilestoneFor(
   notice: CommonsNotice,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

The recurring "Who I interact with is not a vouch" notice paraphrased Matthew's Quora question using the British spelling "realise". The owner's original wording used "realize", and the rest of the app's member-facing copy is US spelling. This was an unintentional slip introduced while paraphrasing.

- `ctf/packages/web/lib/feed/commons-guidance.ts`: `realise` → `realize` in the notice body.
- Same file: `behaviour` → `behavior` in a nearby code comment, for consistency.

## Already-published notice

No manual database edit is needed. `refreshPublishedGuidanceNotices` rewrites the body of an already-published guidance post from the source text on the next Commons post, so the corrected wording reaches the existing row on its own.

## Checks

- Typecheck passes (web, shared, mobile).
- `check-notice-formatting` passes — paragraph structure is unchanged.

I also scanned the rest of the web app for British spellings. The remaining hits are all code comments and identifiers (`normaliseAuthorizedBlocks`, "behaviour" in comments, "colour" in CSS comments) — nothing member-facing — so they are left alone here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_