### PR TITLE
refactor: reduce complexity in non-sensitive API route handlers

### DIFF
--- a/ctf/docs/quota-impact/2026-07-31-complexity-refactor-api-routes.md
+++ b/ctf/docs/quota-impact/2026-07-31-complexity-refactor-api-routes.md
@@ -1,0 +1,40 @@
+# Stream Quota Impact Note
+
+## Summary
+
+- Feature/Change: Rule-116 complexity refactor of non-sensitive API route handlers (api-b batch). The Stream-touching file in this batch is `packages/web/app/api/beacon/stream-webhook/route.ts`; the change only extracts internal helper functions from the existing handler. No Stream call, event, payload, or configuration was added, removed, or altered.
+- PR: #2025
+- Owner: platform
+- Date: 2026-07-31
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: None. The only Stream-related file is the Beacon recording webhook receiver (Video). The webhook handler's behavior is unchanged — same signature verification, same recording-ready processing, same downstream calls — so no Stream surface is exercised any differently than before.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: 0 (no change)
+- Activity Feed API calls estimate: 0 (no change)
+- Video participant-minutes estimate: 0 (no change)
+- AI Moderation credits estimate: 0 (no change)
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): Green — no change to Stream usage.
+- Peak scenario estimate: Unchanged from current production; this batch adds no new Stream traffic under any load.
+
+## Fallback and Degradation Plan
+
+- What degrades first: Unchanged. The Beacon recording webhook path retains its existing behavior and error handling.
+- User-visible messaging behavior: No change.
+- Kill switch / feature flag: No change; existing controls remain in place.
+
+## Observability
+
+- Metrics and alerts added/updated: None required; no behavior change.
+- Dashboard link (if available): N/A.
+
+## Validation
+
+- Tests added for degraded mode: None required — this is a behavior-preserving refactor. Verified by repo-wide typecheck, the complexity gate, eslint, and EOF-format check.
+- Rollback strategy: Revert PR #2025; the webhook handler returns to its prior single-function form with identical behavior.

--- a/ctf/packages/web/app/api/account/blocks/route.ts
+++ b/ctf/packages/web/app/api/account/blocks/route.ts
@@ -37,11 +37,49 @@ export async function GET() {
 
 type BlockBody = { blockedUserId?: unknown; safetyConcern?: unknown; safetyDetail?: unknown };
 
+type ParsedBlockRequest = { blockedUserId: string; safetyConcern: boolean; safetyDetail: string | null };
+
 function badRequest(message: string): NextResponse {
   return NextResponse.json(
     { ok: false, code: ACCOUNT_ERROR_CODE.invalidPayload, message },
     { status: 400 },
   );
+}
+
+// Parse and validate the block request body, resolving the optional safety escalation. Returns a
+// discriminated result so the caller keeps TypeScript narrowing.
+async function parseBlockRequest(request: Request): Promise<{ error: NextResponse } | { data: ParsedBlockRequest }> {
+  let body: BlockBody;
+  try {
+    body = (await request.json()) as BlockBody;
+  } catch {
+    return { error: badRequest('Invalid JSON body.') };
+  }
+
+  if (typeof body.blockedUserId !== 'string' || body.blockedUserId.trim().length === 0) {
+    return { error: badRequest('blockedUserId is required.') };
+  }
+  const blockedUserId = body.blockedUserId.trim();
+
+  // A safety escalation is opt-in. Anything other than a literal `true` is treated as an ordinary
+  // block, so a missing/odd value never accidentally raises an admin alert.
+  const safetyConcern = body.safetyConcern === true;
+
+  // The free-text context is optional even when escalating. Reject only a value that is present but
+  // not a string (a clear client bug); trim and cap an actual string, and store null when blank.
+  let safetyDetail: string | null = null;
+  if (safetyConcern && body.safetyDetail !== undefined && body.safetyDetail !== null) {
+    if (typeof body.safetyDetail !== 'string') {
+      return { error: badRequest('safetyDetail must be a string.') };
+    }
+    const trimmed = body.safetyDetail.trim();
+    if (trimmed.length > SAFETY_REPORT_DETAIL_MAX_LENGTH) {
+      return { error: badRequest(`safetyDetail must be ${SAFETY_REPORT_DETAIL_MAX_LENGTH} characters or fewer.`) };
+    }
+    safetyDetail = trimmed.length > 0 ? trimmed : null;
+  }
+
+  return { data: { blockedUserId, safetyConcern, safetyDetail } };
 }
 
 // Create a block. CSRF-protected and idempotent (blocking the same person twice is a no-op). A
@@ -65,35 +103,11 @@ export async function POST(request: Request) {
     return csrfDeny;
   }
 
-  let body: BlockBody;
-  try {
-    body = (await request.json()) as BlockBody;
-  } catch {
-    return badRequest('Invalid JSON body.');
+  const parsed = await parseBlockRequest(request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  if (typeof body.blockedUserId !== 'string' || body.blockedUserId.trim().length === 0) {
-    return badRequest('blockedUserId is required.');
-  }
-  const blockedUserId = body.blockedUserId.trim();
-
-  // A safety escalation is opt-in. Anything other than a literal `true` is treated as an ordinary
-  // block, so a missing/odd value never accidentally raises an admin alert.
-  const safetyConcern = body.safetyConcern === true;
-
-  // The free-text context is optional even when escalating. Reject only a value that is present but
-  // not a string (a clear client bug); trim and cap an actual string, and store null when blank.
-  let safetyDetail: string | null = null;
-  if (safetyConcern && body.safetyDetail !== undefined && body.safetyDetail !== null) {
-    if (typeof body.safetyDetail !== 'string') {
-      return badRequest('safetyDetail must be a string.');
-    }
-    const trimmed = body.safetyDetail.trim();
-    if (trimmed.length > SAFETY_REPORT_DETAIL_MAX_LENGTH) {
-      return badRequest(`safetyDetail must be ${SAFETY_REPORT_DETAIL_MAX_LENGTH} characters or fewer.`);
-    }
-    safetyDetail = trimmed.length > 0 ? trimmed : null;
-  }
+  const { blockedUserId, safetyConcern, safetyDetail } = parsed.data;
 
   try {
     if (safetyConcern) {

--- a/ctf/packages/web/app/api/announcements/[announcementId]/reactions/route.ts
+++ b/ctf/packages/web/app/api/announcements/[announcementId]/reactions/route.ts
@@ -17,6 +17,36 @@ type RouteParams = {
   params: Promise<{ announcementId: string }>;
 };
 
+// Map a toggle-reaction failure to its response. Known error codes carry their own status; anything
+// else is reported and returned as a generic 503.
+function mapAnnouncementReactionError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : 'unknown_error';
+  if (code === 'reaction_emoji_invalid') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Unsupported reaction emoji.' },
+      { status: 400 },
+    );
+  }
+  if (code === 'announcement_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.notFound, message: 'The announcement you are reacting to is no longer available.' },
+      { status: 400 },
+    );
+  }
+  if (code === 'cannot_react_to_own_post') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.forbidden, message: 'You can’t react to your own announcement.' },
+      { status: 403 },
+    );
+  }
+
+  reportError(error, { area: 'announcements', op: 'toggle_reaction' });
+  return NextResponse.json(
+    { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to update your reaction.' },
+    { status: 503 },
+  );
+}
+
 export async function POST(request: Request, { params }: RouteParams) {
   const gate = await requireFeedReadAccess();
   if (!gate.allowed) {
@@ -60,30 +90,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     });
     return NextResponse.json({ ok: true, reacted: result.reacted }, { status: 200 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'unknown_error';
-    if (code === 'reaction_emoji_invalid') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Unsupported reaction emoji.' },
-        { status: 400 },
-      );
-    }
-    if (code === 'announcement_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.notFound, message: 'The announcement you are reacting to is no longer available.' },
-        { status: 400 },
-      );
-    }
-    if (code === 'cannot_react_to_own_post') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.forbidden, message: 'You can’t react to your own announcement.' },
-        { status: 403 },
-      );
-    }
-
-    reportError(error, { area: 'announcements', op: 'toggle_reaction' });
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to update your reaction.' },
-      { status: 503 },
-    );
+    return mapAnnouncementReactionError(error);
   }
 }

--- a/ctf/packages/web/app/api/announcements/[announcementId]/replies/route.ts
+++ b/ctf/packages/web/app/api/announcements/[announcementId]/replies/route.ts
@@ -19,6 +19,36 @@ type RouteParams = {
   params: Promise<{ announcementId: string }>;
 };
 
+// Map a reply-create failure to its response. Known error codes carry their own status; anything
+// else is reported and returned as a generic 503.
+function mapAnnouncementReplyError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : 'unknown_error';
+  if (code === 'announcement_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.notFound, message: 'The announcement you are replying to is no longer available.' },
+      { status: 400 },
+    );
+  }
+  if (code === 'content_policy_violation') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Reply blocked by content moderation.' },
+      { status: 422 },
+    );
+  }
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'You are replying too quickly. Try again shortly.' },
+      { status: 429 },
+    );
+  }
+
+  reportError(error, { area: 'announcements', op: 'create_reply' });
+  return NextResponse.json(
+    { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to post your reply.' },
+    { status: 503 },
+  );
+}
+
 export async function GET(_request: Request, { params }: RouteParams) {
   const gate = await requireFeedReadAccess();
   if (!gate.allowed) {
@@ -110,30 +140,6 @@ export async function POST(request: Request, { params }: RouteParams) {
       { status: 201 },
     );
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'unknown_error';
-    if (code === 'announcement_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.notFound, message: 'The announcement you are replying to is no longer available.' },
-        { status: 400 },
-      );
-    }
-    if (code === 'content_policy_violation') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Reply blocked by content moderation.' },
-        { status: 422 },
-      );
-    }
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'You are replying too quickly. Try again shortly.' },
-        { status: 429 },
-      );
-    }
-
-    reportError(error, { area: 'announcements', op: 'create_reply' });
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to post your reply.' },
-      { status: 503 },
-    );
+    return mapAnnouncementReplyError(error);
   }
 }

--- a/ctf/packages/web/app/api/beacon/[id]/moderate/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/moderate/route.ts
@@ -17,6 +17,51 @@ type ModerateBody = {
 
 const VALID_ACTIONS: BeaconModerationAction[] = ['mute', 'ban', 'slow_mode'];
 
+// Parse and validate the moderation request body. Returns a discriminated result so the caller keeps
+// TypeScript narrowing on the validated action.
+async function parseModerateBody(
+  request: Request,
+): Promise<{ error: NextResponse } | { data: { action: BeaconModerationAction; body: ModerateBody } }> {
+  let body: ModerateBody;
+  try {
+    body = (await request.json()) as ModerateBody;
+  } catch {
+    return { error: NextResponse.json({ ok: false, code: BEACON_ERROR_CODE.invalidJson, message: 'Invalid JSON body.' }, { status: 400 }) };
+  }
+
+  const action = body.action as BeaconModerationAction | undefined;
+  if (!action || !VALID_ACTIONS.includes(action)) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.invalidPayload, message: 'action must be one of mute, ban, slow_mode.' },
+        { status: 400 },
+      ),
+    };
+  }
+  if ((action === 'mute' || action === 'ban') && !body.targetUserId) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: BEACON_ERROR_CODE.invalidPayload, message: 'targetUserId is required to mute or ban.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { data: { action, body } };
+}
+
+// Resolve the slow-mode cooldown, honouring an explicit 0 and defaulting when omitted; null for
+// non-slow-mode actions.
+function resolveCooldownSeconds(action: BeaconModerationAction, cooldownSeconds: number | null | undefined): number | null {
+  if (action !== 'slow_mode') {
+    return null;
+  }
+  if (cooldownSeconds === 0) {
+    return 0;
+  }
+  return cooldownSeconds ?? BEACON_DEFAULT_SLOW_MODE_SECONDS;
+}
+
 // Admin: moderate the live event chat — mute a member, ban a member from the event channel, or
 // toggle slow-mode.
 export async function POST(request: Request, context: RouteContext) {
@@ -32,26 +77,11 @@ export async function POST(request: Request, context: RouteContext) {
 
   const { id } = await context.params;
 
-  let body: ModerateBody;
-  try {
-    body = (await request.json()) as ModerateBody;
-  } catch {
-    return NextResponse.json({ ok: false, code: BEACON_ERROR_CODE.invalidJson, message: 'Invalid JSON body.' }, { status: 400 });
+  const parsed = await parseModerateBody(request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  const action = body.action as BeaconModerationAction | undefined;
-  if (!action || !VALID_ACTIONS.includes(action)) {
-    return NextResponse.json(
-      { ok: false, code: BEACON_ERROR_CODE.invalidPayload, message: 'action must be one of mute, ban, slow_mode.' },
-      { status: 400 },
-    );
-  }
-  if ((action === 'mute' || action === 'ban') && !body.targetUserId) {
-    return NextResponse.json(
-      { ok: false, code: BEACON_ERROR_CODE.invalidPayload, message: 'targetUserId is required to mute or ban.' },
-      { status: 400 },
-    );
-  }
+  const { action, body } = parsed.data;
 
   try {
     const event = await getBeaconEvent(id);
@@ -62,12 +92,7 @@ export async function POST(request: Request, context: RouteContext) {
       );
     }
 
-    const cooldownSeconds =
-      action === 'slow_mode'
-        ? body.cooldownSeconds === 0
-          ? 0
-          : body.cooldownSeconds ?? BEACON_DEFAULT_SLOW_MODE_SECONDS
-        : null;
+    const cooldownSeconds = resolveCooldownSeconds(action, body.cooldownSeconds);
 
     const applied = await moderateBeaconChat({
       eventId: event.id,

--- a/ctf/packages/web/app/api/beacon/stream-webhook/route.ts
+++ b/ctf/packages/web/app/api/beacon/stream-webhook/route.ts
@@ -10,6 +10,49 @@ import { reportError } from 'lib/observability/report';
 
 export const dynamic = 'force-dynamic';
 
+// Pull the call id and recording URL out of the payload defensively. `call_cid` looks like
+// "livestream:beacon-<id>"; strip the type prefix to get the call id. Missing/odd values yield empty
+// strings, which the caller treats as "nothing to do". We never fabricate a URL.
+function extractRecordingInfo(payload: Record<string, unknown>): { callId: string; recordingUrl: string } {
+  const callCid = typeof payload.call_cid === 'string' ? payload.call_cid : '';
+  const callId = callCid.includes(':') ? callCid.split(':').slice(1).join(':') : callCid;
+  const recording = (payload.call_recording ?? {}) as Record<string, unknown>;
+  const recordingUrl = typeof recording.url === 'string' ? recording.url : '';
+  return { callId, recordingUrl };
+}
+
+// Handle the recording-ready payload: store the URL and post the replay. Non-recording-ready events,
+// and recording-ready events missing a call id / URL / matching event, are acknowledged without
+// acting so Stream stops retrying.
+async function handleRecordingReady(payload: Record<string, unknown>): Promise<NextResponse> {
+  const type = typeof payload.type === 'string' ? payload.type : '';
+  if (type !== 'call.recording_ready') {
+    // Acknowledge other lifecycle events so Stream stops retrying; only recording-ready acts.
+    return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+  }
+
+  const { callId, recordingUrl } = extractRecordingInfo(payload);
+
+  if (callId.length === 0 || recordingUrl.length === 0) {
+    return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+  }
+
+  const event = await getBeaconEventByCallId(callId);
+  if (!event) {
+    return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+  }
+
+  // Store the URL (no-op when already set), then re-read so the post helper sees the URL even if
+  // this delivery raced an earlier one.
+  const updated = (await recordBeaconRecording(event.id, recordingUrl)) ?? {
+    ...event,
+    recordingUrl,
+  };
+  await postBeaconReplayNotice(updated);
+
+  return NextResponse.json({ ok: true, handled: true }, { status: 200 });
+}
+
 // Stream Video webhook. Verifies the signature, and on a recording-ready event stores the recording
 // URL and posts the replay to the Commons. Idempotent: the recording URL and the Commons post id are
 // each written only when still null, so a redelivered webhook never double-posts the replay.
@@ -38,35 +81,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const type = typeof payload.type === 'string' ? payload.type : '';
-    if (type !== 'call.recording_ready') {
-      // Acknowledge other lifecycle events so Stream stops retrying; only recording-ready acts.
-      return NextResponse.json({ ok: true, handled: false }, { status: 200 });
-    }
-
-    const callCid = typeof payload.call_cid === 'string' ? payload.call_cid : '';
-    const callId = callCid.includes(':') ? callCid.split(':').slice(1).join(':') : callCid;
-    const recording = (payload.call_recording ?? {}) as Record<string, unknown>;
-    const recordingUrl = typeof recording.url === 'string' ? recording.url : '';
-
-    if (callId.length === 0 || recordingUrl.length === 0) {
-      return NextResponse.json({ ok: true, handled: false }, { status: 200 });
-    }
-
-    const event = await getBeaconEventByCallId(callId);
-    if (!event) {
-      return NextResponse.json({ ok: true, handled: false }, { status: 200 });
-    }
-
-    // Store the URL (no-op when already set), then re-read so the post helper sees the URL even if
-    // this delivery raced an earlier one.
-    const updated = (await recordBeaconRecording(event.id, recordingUrl)) ?? {
-      ...event,
-      recordingUrl,
-    };
-    await postBeaconReplayNotice(updated);
-
-    return NextResponse.json({ ok: true, handled: true }, { status: 200 });
+    return await handleRecordingReady(payload);
   } catch (error) {
     reportError(error, { area: 'beacon', op: 'stream_webhook' });
     // Return 200 so Stream does not hammer retries on our transient failure; we logged it.

--- a/ctf/packages/web/app/api/bug-reports/admin/[id]/resolve/route.ts
+++ b/ctf/packages/web/app/api/bug-reports/admin/[id]/resolve/route.ts
@@ -8,6 +8,37 @@ type ResolveBody = { action?: unknown };
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+function invalidPayload(message: string): NextResponse {
+  return NextResponse.json(
+    { ok: false, code: BUG_REPORT_ERROR_CODE.invalidPayload, message },
+    { status: 400 },
+  );
+}
+
+// Validate the report id and request body, resolving the action. Returns a discriminated result so
+// the caller keeps TypeScript narrowing on the validated action.
+async function parseResolveRequest(
+  id: string,
+  request: Request,
+): Promise<{ error: NextResponse } | { data: { action: 'release' | 'reject' } }> {
+  if (!UUID_REGEX.test(id)) {
+    return { error: invalidPayload('Invalid report id.') };
+  }
+
+  let body: ResolveBody;
+  try {
+    body = (await request.json()) as ResolveBody;
+  } catch {
+    return { error: invalidPayload('Invalid JSON body.') };
+  }
+
+  if (body.action !== 'release' && body.action !== 'reject') {
+    return { error: invalidPayload('action must be "release" or "reject".') };
+  }
+
+  return { data: { action: body.action } };
+}
+
 // Resolve a held (or new) bug report. `release` sends it back to `new` so the create-issues
 // job publishes the redacted copy to the triage repo; `reject` drops it so it never does.
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -22,33 +53,15 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   }
 
   const { id } = await params;
-  if (!UUID_REGEX.test(id)) {
-    return NextResponse.json(
-      { ok: false, code: BUG_REPORT_ERROR_CODE.invalidPayload, message: 'Invalid report id.' },
-      { status: 400 },
-    );
+  const parsed = await parseResolveRequest(id, request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  let body: ResolveBody;
-  try {
-    body = (await request.json()) as ResolveBody;
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: BUG_REPORT_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
-      { status: 400 },
-    );
-  }
-
-  if (body.action !== 'release' && body.action !== 'reject') {
-    return NextResponse.json(
-      { ok: false, code: BUG_REPORT_ERROR_CODE.invalidPayload, message: 'action must be "release" or "reject".' },
-      { status: 400 },
-    );
-  }
+  const { action } = parsed.data;
 
   try {
     const changed =
-      body.action === 'release' ? await releaseHeldReport(id) : await rejectReport(id);
+      action === 'release' ? await releaseHeldReport(id) : await rejectReport(id);
 
     if (!changed) {
       // No row moved: the report was already resolved (published/rejected) or does not exist.
@@ -58,7 +71,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       );
     }
 
-    const newStatus = body.action === 'release' ? 'new' : 'rejected';
+    const newStatus = action === 'release' ? 'new' : 'rejected';
     return NextResponse.json({ ok: true, id, status: newStatus }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'bug-reports', op: 'admin-resolve' });

--- a/ctf/packages/web/app/api/click-log/route.ts
+++ b/ctf/packages/web/app/api/click-log/route.ts
@@ -25,6 +25,71 @@ export async function GET() {
   return NextResponse.json({ incidents, count });
 }
 
+function badRequest(error: string): NextResponse {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+// Validate a latitude value that is present in the incident metadata.
+function invalidLatitude(latitude: unknown): boolean {
+  return typeof latitude !== 'number' || !Number.isFinite(latitude) || latitude < -90 || latitude > 90;
+}
+
+// Validate a longitude value that is present in the incident metadata.
+function invalidLongitude(longitude: unknown): boolean {
+  return typeof longitude !== 'number' || !Number.isFinite(longitude) || longitude < -180 || longitude > 180;
+}
+
+// Trim notes before validating and storing so trailing/leading whitespace can't push a note past the
+// limit (or be stored unnormalised). Drop an empty trimmed note. Returns undefined when absent.
+function parseNotes(raw: unknown): { error: NextResponse } | { data: string | undefined } {
+  if (raw === undefined) {
+    return { data: undefined };
+  }
+  if (typeof raw !== 'string') {
+    return { error: badRequest('Invalid notes') };
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > MAX_NOTES_LENGTH) {
+    return { error: badRequest('Notes too long') };
+  }
+  return { data: trimmed.length > 0 ? trimmed : undefined };
+}
+
+// Validate and normalise the optional incident metadata. metadata is optional per the command
+// contract; a client that omits it (or sends an empty body) defaults to {} rather than a 400.
+// Returns a discriminated result so the caller keeps TypeScript narrowing.
+function parseIncidentMetadata(rawBody: unknown): { error: NextResponse } | { data: IncidentMetadata } {
+  const rawMetadata = (rawBody as { metadata?: unknown })?.metadata ?? {};
+  if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+    return { error: badRequest('Invalid metadata') };
+  }
+  const meta = rawMetadata as { latitude?: unknown; longitude?: unknown; notes?: unknown };
+  if (meta.latitude !== undefined && invalidLatitude(meta.latitude)) {
+    return { error: badRequest('Invalid latitude') };
+  }
+  if (meta.longitude !== undefined && invalidLongitude(meta.longitude)) {
+    return { error: badRequest('Invalid longitude') };
+  }
+  const notesResult = parseNotes(meta.notes);
+  if ('error' in notesResult) {
+    return notesResult;
+  }
+  return { data: buildMetadata(meta, notesResult.data) };
+}
+
+// Assemble the incident metadata, including only the fields that were provided so an omitted field is
+// stored as absent rather than as null/undefined.
+function buildMetadata(
+  meta: { latitude?: unknown; longitude?: unknown },
+  notes: string | undefined,
+): IncidentMetadata {
+  return {
+    ...(meta.latitude !== undefined ? { latitude: meta.latitude as number } : {}),
+    ...(meta.longitude !== undefined ? { longitude: meta.longitude as number } : {}),
+    ...(notes !== undefined ? { notes } : {}),
+  };
+}
+
 export async function POST(req: NextRequest) {
   const gate = await requireClickLogAccess();
   if (!gate.allowed) {
@@ -37,40 +102,11 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
-  // metadata is optional per the command contract; default it to {} so a client that
-  // omits it (or sends an empty body) is not rejected with a spurious 400.
-  const rawMetadata = body.metadata ?? {};
-  if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
-    return NextResponse.json({ error: 'Invalid metadata' }, { status: 400 });
+  const parsed = parseIncidentMetadata(body);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-  if (rawMetadata.latitude !== undefined) {
-    if (typeof rawMetadata.latitude !== 'number' || !Number.isFinite(rawMetadata.latitude) || rawMetadata.latitude < -90 || rawMetadata.latitude > 90) {
-      return NextResponse.json({ error: 'Invalid latitude' }, { status: 400 });
-    }
-  }
-  if (rawMetadata.longitude !== undefined) {
-    if (typeof rawMetadata.longitude !== 'number' || !Number.isFinite(rawMetadata.longitude) || rawMetadata.longitude < -180 || rawMetadata.longitude > 180) {
-      return NextResponse.json({ error: 'Invalid longitude' }, { status: 400 });
-    }
-  }
-  // Trim notes before validating and storing so trailing/leading whitespace can't push
-  // a note past the limit (or be stored unnormalized). Drop an empty trimmed note.
-  let notes: string | undefined;
-  if (rawMetadata.notes !== undefined) {
-    if (typeof rawMetadata.notes !== 'string') {
-      return NextResponse.json({ error: 'Invalid notes' }, { status: 400 });
-    }
-    const trimmed = rawMetadata.notes.trim();
-    if (trimmed.length > MAX_NOTES_LENGTH) {
-      return NextResponse.json({ error: 'Notes too long' }, { status: 400 });
-    }
-    notes = trimmed.length > 0 ? trimmed : undefined;
-  }
-  const metadata: IncidentMetadata = {
-    ...(rawMetadata.latitude !== undefined ? { latitude: rawMetadata.latitude } : {}),
-    ...(rawMetadata.longitude !== undefined ? { longitude: rawMetadata.longitude } : {}),
-    ...(notes !== undefined ? { notes } : {}),
-  };
+  const metadata = parsed.data;
   const incident = await createIncident({ userId, metadata });
   logClickLogAudit({ actorId: userId, command: 'click-log.incident.create', result: 'success' });
   // Return the incident flat to match the command contract's outputSchema

--- a/ctf/packages/web/app/api/click-log/route.ts
+++ b/ctf/packages/web/app/api/click-log/route.ts
@@ -40,7 +40,7 @@ function invalidLongitude(longitude: unknown): boolean {
 }
 
 // Trim notes before validating and storing so trailing/leading whitespace can't push a note past the
-// limit (or be stored unnormalised). Drop an empty trimmed note. Returns undefined when absent.
+// limit (or be stored unnormalized). Drop an empty trimmed note. Returns undefined when absent.
 function parseNotes(raw: unknown): { error: NextResponse } | { data: string | undefined } {
   if (raw === undefined) {
     return { data: undefined };
@@ -55,7 +55,7 @@ function parseNotes(raw: unknown): { error: NextResponse } | { data: string | un
   return { data: trimmed.length > 0 ? trimmed : undefined };
 }
 
-// Validate and normalise the optional incident metadata. metadata is optional per the command
+// Validate and normalize the optional incident metadata. metadata is optional per the command
 // contract; a client that omits it (or sends an empty body) defaults to {} rather than a 400.
 // Returns a discriminated result so the caller keeps TypeScript narrowing.
 function parseIncidentMetadata(rawBody: unknown): { error: NextResponse } | { data: IncidentMetadata } {

--- a/ctf/packages/web/app/api/comic/admin/contributions/[id]/review/route.ts
+++ b/ctf/packages/web/app/api/comic/admin/contributions/[id]/review/route.ts
@@ -24,7 +24,7 @@ function hashOf(entryType: string, question: string | null, content: string): st
 async function handleDecline(id: string, reviewerId: string, rawReason: unknown): Promise<NextResponse> {
   const reason = typeof rawReason === 'string' ? rawReason.trim() : '';
   if (reason.length === 0) {
-    // A decline the contributor cannot understand reads as a judgement on what they lived
+    // A decline the contributor cannot understand reads as a judgment on what they lived
     // through. The reason is shown to them on their own page, so it is required.
     return NextResponse.json(
       { ok: false, code: COMIC_ERROR_CODE.invalidPayload, message: 'Give a reason — the contributor sees it.' },

--- a/ctf/packages/web/app/api/comic/admin/contributions/[id]/review/route.ts
+++ b/ctf/packages/web/app/api/comic/admin/contributions/[id]/review/route.ts
@@ -20,6 +20,104 @@ function hashOf(entryType: string, question: string | null, content: string): st
     .digest('hex');
 }
 
+// DECLINE: flip the contribution to declined with a reason the contributor will see.
+async function handleDecline(id: string, reviewerId: string, rawReason: unknown): Promise<NextResponse> {
+  const reason = typeof rawReason === 'string' ? rawReason.trim() : '';
+  if (reason.length === 0) {
+    // A decline the contributor cannot understand reads as a judgement on what they lived
+    // through. The reason is shown to them on their own page, so it is required.
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.invalidPayload, message: 'Give a reason — the contributor sees it.' },
+      { status: 400 },
+    );
+  }
+
+  const declined = await declineContribution({ contributionId: id, reviewerId, reason });
+  if (!declined) {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.notFound, message: 'That contribution is not waiting for review.' },
+      { status: 404 },
+    );
+  }
+
+  logComicAudit({
+    actorId: reviewerId,
+    pluginId: 'comic',
+    command: 'comic.contribution.review',
+    status: 'allow',
+    reason: 'declined',
+    targetType: 'contribution',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+  });
+  return NextResponse.json({ ok: true, status: 'declined' }, { status: 200 });
+}
+
+// ACCEPT: promote the chosen entries, then make the recognition grant (which may fail without
+// undoing the promotion — see the POST doc comment below).
+async function handleAccept(id: string, reviewerId: string, rawExcluded: unknown): Promise<NextResponse> {
+  const excludedEntryIds = Array.isArray(rawExcluded)
+    ? rawExcluded.filter((value): value is string => typeof value === 'string')
+    : [];
+
+  const accepted = await acceptContribution({
+    contributionId: id,
+    reviewerId,
+    excludedEntryIds,
+    hashOf,
+  });
+  if (!accepted) {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.notFound, message: 'That contribution is not waiting for review.' },
+      { status: 404 },
+    );
+  }
+
+  const grant = await grantContributionRecognition({
+    contributionId: id,
+    contributorUserId: accepted.contributorUserId,
+    reviewerId,
+  });
+  if (grant.status === 'failed') {
+    // Reported, never thrown: the writing is already in the library and the reading is done.
+    reportError(new Error(`contribution grant failed: ${grant.reason}`), {
+      area: 'comic',
+      op: 'contribution_grant',
+      extra: { contributionId: id },
+    });
+  }
+
+  logComicAudit({
+    actorId: reviewerId,
+    pluginId: 'comic',
+    command: 'comic.contribution.review',
+    status: 'allow',
+    reason: 'accepted',
+    targetType: 'contribution',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+    metadata: {
+      promoted: accepted.promoted,
+      alreadyPresent: accepted.alreadyPresent,
+      excluded: excludedEntryIds.length,
+      grant: grant.status,
+    },
+  });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      status: 'accepted',
+      promoted: accepted.promoted,
+      alreadyPresent: accepted.alreadyPresent,
+      grant,
+    },
+    { status: 200 },
+  );
+}
+
 // Admin: accept or decline a contribution.
 //
 // ACCEPT promotes the chosen entries into comic_knowledge_entries — the moment a member's writing
@@ -60,97 +158,10 @@ export async function POST(request: Request, context: RouteContext) {
 
   try {
     if (body.action === 'decline') {
-      const reason = typeof body.reason === 'string' ? body.reason.trim() : '';
-      if (reason.length === 0) {
-        // A decline the contributor cannot understand reads as a judgment on what they lived
-        // through. The reason is shown to them on their own page, so it is required.
-        return NextResponse.json(
-          { ok: false, code: COMIC_ERROR_CODE.invalidPayload, message: 'Give a reason — the contributor sees it.' },
-          { status: 400 },
-        );
-      }
-
-      const declined = await declineContribution({ contributionId: id, reviewerId: gate.auth.userId, reason });
-      if (!declined) {
-        return NextResponse.json(
-          { ok: false, code: COMIC_ERROR_CODE.notFound, message: 'That contribution is not waiting for review.' },
-          { status: 404 },
-        );
-      }
-
-      logComicAudit({
-        actorId: gate.auth.userId,
-        pluginId: 'comic',
-        command: 'comic.contribution.review',
-        status: 'allow',
-        reason: 'declined',
-        targetType: 'contribution',
-        targetId: id,
-        result: 'success',
-        errorCategory: null,
-      });
-      return NextResponse.json({ ok: true, status: 'declined' }, { status: 200 });
+      return await handleDecline(id, gate.auth.userId, body.reason);
     }
 
-    const excludedEntryIds = Array.isArray(body.excludedEntryIds)
-      ? body.excludedEntryIds.filter((value): value is string => typeof value === 'string')
-      : [];
-
-    const accepted = await acceptContribution({
-      contributionId: id,
-      reviewerId: gate.auth.userId,
-      excludedEntryIds,
-      hashOf,
-    });
-    if (!accepted) {
-      return NextResponse.json(
-        { ok: false, code: COMIC_ERROR_CODE.notFound, message: 'That contribution is not waiting for review.' },
-        { status: 404 },
-      );
-    }
-
-    const grant = await grantContributionRecognition({
-      contributionId: id,
-      contributorUserId: accepted.contributorUserId,
-      reviewerId: gate.auth.userId,
-    });
-    if (grant.status === 'failed') {
-      // Reported, never thrown: the writing is already in the library and the reading is done.
-      reportError(new Error(`contribution grant failed: ${grant.reason}`), {
-        area: 'comic',
-        op: 'contribution_grant',
-        extra: { contributionId: id },
-      });
-    }
-
-    logComicAudit({
-      actorId: gate.auth.userId,
-      pluginId: 'comic',
-      command: 'comic.contribution.review',
-      status: 'allow',
-      reason: 'accepted',
-      targetType: 'contribution',
-      targetId: id,
-      result: 'success',
-      errorCategory: null,
-      metadata: {
-        promoted: accepted.promoted,
-        alreadyPresent: accepted.alreadyPresent,
-        excluded: excludedEntryIds.length,
-        grant: grant.status,
-      },
-    });
-
-    return NextResponse.json(
-      {
-        ok: true,
-        status: 'accepted',
-        promoted: accepted.promoted,
-        alreadyPresent: accepted.alreadyPresent,
-        grant,
-      },
-      { status: 200 },
-    );
+    return await handleAccept(id, gate.auth.userId, body.excludedEntryIds);
   } catch (error) {
     reportError(error, { area: 'comic', op: 'contribution_review', extra: { contributionId: id } });
     return NextResponse.json(

--- a/ctf/packages/web/app/api/comic/contributions/route.ts
+++ b/ctf/packages/web/app/api/comic/contributions/route.ts
@@ -4,6 +4,7 @@ import { COMIC_ERROR_CODE } from 'lib/comic/constants';
 import { logComicAudit } from 'lib/comic/audit';
 import { readQuoraExportArchive } from 'lib/comic/contribution-archive';
 import { dedupeContributedEntries, parseQuoraExportHtml } from 'lib/comic/quora-export-intake';
+import type { ContributedEntry } from 'lib/comic/quora-export-intake';
 import {
   CONTRIBUTION_CONSENT_VERSION,
   hasAgreedToEveryClause,
@@ -28,6 +29,182 @@ const MAX_CONTRIBUTIONS_PER_DAY = 5;
 
 function badRequest(message: string, code: string = COMIC_ERROR_CODE.invalidPayload) {
   return NextResponse.json({ ok: false, code, message }, { status: 400 });
+}
+
+// A parsed submission ready to store, or the 400 to return instead.
+type IntakeResult = { error: NextResponse } | { entries: ContributedEntry[]; discarded: string[] };
+
+// A request validated up to (but not including) the rate-limit check and content intake.
+type PreparedContribution =
+  | { error: NextResponse }
+  | { form: FormData; kind: 'links' | 'export'; file: File | null };
+
+// Consent is checked first, on purpose: an upload without it is never parsed, so a member who did
+// not agree has their file ignored rather than processed and then rejected. Returns the 400 to send,
+// or null when consent is in order.
+function checkConsent(form: FormData): NextResponse | null {
+  let agreedClauseIds: unknown;
+  try {
+    agreedClauseIds = JSON.parse(String(form.get('agreedClauseIds') ?? '[]'));
+  } catch {
+    agreedClauseIds = null;
+  }
+  if (!hasAgreedToEveryClause(agreedClauseIds)) {
+    return badRequest('Every consent statement has to be agreed to before anything can be sent.');
+  }
+  // A page cached from before a consent change would submit the old clause ids. Those pass the check
+  // above only if the ids still match; a version mismatch means the member read different wording,
+  // so make them re-read it rather than record consent they never gave.
+  if (String(form.get('consentVersion') ?? '') !== CONTRIBUTION_CONSENT_VERSION) {
+    return badRequest(
+      'The consent wording has been updated. Reload this page and read it again before sending.',
+      COMIC_ERROR_CODE.conflict,
+    );
+  }
+  return null;
+}
+
+// The file is only required on the export path. Validate its presence and size before anything is
+// decompressed.
+function validateUpload(form: FormData): { error: NextResponse } | { file: File } {
+  const uploaded = form.get('archive');
+  if (!(uploaded instanceof File)) {
+    return { error: badRequest('Attach the .zip file Quora sent you.') };
+  }
+  if (uploaded.size === 0) return { error: badRequest('That file is empty.') };
+  if (uploaded.size > MAX_UPLOAD_BYTES) {
+    return { error: badRequest(`That file is larger than ${Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024))} MB.`) };
+  }
+  return { file: uploaded };
+}
+
+// Parse the request up to the file: form body, chosen path, consent, and (export only) upload
+// validation. Kept before the rate-limit check so a malformed upload still 400s rather than 429s.
+async function prepareContribution(request: Request): Promise<PreparedContribution> {
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return { error: badRequest('Could not read what you sent.') };
+  }
+
+  // Two paths, and the default is the smaller one. `links` — the member pastes the two or three
+  // posts that are actually about being targeted, each with its Quora link as provenance. Most
+  // people's writing is mixed (dating, politics, faith, memes), and NOTHING in this pipeline sorts
+  // on-topic from off-topic automatically, so this puts the choosing where it is instant and free:
+  // with the author, who already knows which posts they are. It is also the more honest consent —
+  // picking three posts is knowing exactly what you are giving, where handing over an archive is
+  // agreeing in bulk to things you have forgotten you wrote.
+  // `export` stays for the rarer member whose public writing is nearly all on-topic.
+  const kind = form.get('kind') === 'export' ? 'export' : 'links';
+
+  const consentDeny = checkConsent(form);
+  if (consentDeny) return { error: consentDeny };
+
+  // A links contribution carries no upload at all, which is most of why it is the safer default: no
+  // archive to parse, and nothing to attack.
+  let file: File | null = null;
+  if (kind === 'export') {
+    const upload = validateUpload(form);
+    if ('error' in upload) return { error: upload.error };
+    file = upload.file;
+  }
+
+  return { form, kind, file };
+}
+
+// Links path: parse the pasted posts and validate them.
+function intakeLinks(form: FormData): IntakeResult {
+  let posts: unknown;
+  try {
+    posts = JSON.parse(String(form.get('posts') ?? '[]'));
+  } catch {
+    return { error: badRequest('Could not read the posts you pasted.') };
+  }
+  const validated = validateLinkedPosts(posts);
+  if (!validated.ok) return { error: badRequest(validated.message) };
+  return { entries: validated.entries, discarded: [] };
+}
+
+// Export path: parse the archive in memory, keep the allowlisted public sections, and discard the
+// rest (inbox, drafts, profile) before anything is written or any human sees it.
+async function intakeExport(file: File): Promise<IntakeResult> {
+  const archive = readQuoraExportArchive(new Uint8Array(await file.arrayBuffer()));
+  if (!archive.ok) {
+    const message =
+      archive.reason === 'not_a_zip'
+        ? 'That is not the .zip file Quora sends. Send the file from Quora as it arrived, without unzipping it.'
+        : archive.reason === 'no_index_html'
+          ? 'That .zip does not look like a Quora export — it has no index.html inside.'
+          : 'That export is too large to read.';
+    return { error: badRequest(message) };
+  }
+
+  const parsed = parseQuoraExportHtml(archive.html);
+  if (!parsed.looksLikeQuoraExport) {
+    return { error: badRequest('That file does not look like a Quora export.') };
+  }
+
+  const entries = dedupeContributedEntries(parsed.entries);
+  if (entries.length === 0) {
+    return { error: badRequest(
+      'Nothing public was found in that export — no answers, posts, or comments. Nothing has been kept.',
+    ) };
+  }
+  return { entries, discarded: parsed.discarded };
+}
+
+// Store the surviving entries and record the consent (never the content), then respond.
+async function storeContribution(params: {
+  form: FormData;
+  userId: string;
+  kind: 'links' | 'export';
+  entries: ContributedEntry[];
+  discarded: string[];
+}): Promise<NextResponse> {
+  const { form, userId, kind, entries, discarded } = params;
+
+  const contribution = await createContribution({
+    userId,
+    kind,
+    consentVersion: CONTRIBUTION_CONSENT_VERSION,
+    thirdPartyNote: String(form.get('thirdPartyNote') ?? ''),
+    discardedSections: discarded,
+    entries,
+  });
+
+  // Contributing is a route into verification: if this member has no Quora URL on file and gave
+  // one here, open an Unlock submission from it. Best-effort and AFTER the contribution is stored —
+  // the writing is already safe, and a failure here just means they verify the ordinary way.
+  // It creates a pending submission, never an approval; the owner still decides.
+  const unlockLink = await linkContributionToUnlock({
+    userId,
+    quoraProfileUrl: typeof form.get('quoraProfileUrl') === 'string' ? String(form.get('quoraProfileUrl')) : null,
+    contributionId: contribution.id,
+  });
+
+  // Audit the consent, never the content. What matters for the record is that this member agreed
+  // to this version of the wording at this time.
+  logComicAudit({
+    actorId: userId,
+    pluginId: 'comic',
+    command: 'comic.contribution.submit',
+    status: 'allow',
+    reason: 'ok',
+    targetType: 'contribution',
+    targetId: contribution.id,
+    result: 'success',
+    errorCategory: null,
+    metadata: {
+      consentVersion: CONTRIBUTION_CONSENT_VERSION,
+      entryCount: contribution.entryCount,
+      kind,
+      discardedSections: discarded,
+      unlockLink: unlockLink.status,
+    },
+  });
+
+  return NextResponse.json({ ok: true, contribution, unlockLink: unlockLink.status }, { status: 201 });
 }
 
 // GET: the member's own contribution history, for the page's status list.
@@ -63,58 +240,9 @@ export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) return csrfDeny;
 
-  let form: FormData;
-  try {
-    form = await request.formData();
-  } catch {
-    return badRequest('Could not read what you sent.');
-  }
-
-  // Two paths, and the default is the smaller one. `links` — the member pastes the two or three
-  // posts that are actually about being targeted, each with its Quora link as provenance. Most
-  // people's writing is mixed (dating, politics, faith, memes), and NOTHING in this pipeline sorts
-  // on-topic from off-topic automatically, so this puts the choosing where it is instant and free:
-  // with the author, who already knows which posts they are. It is also the more honest consent —
-  // picking three posts is knowing exactly what you are giving, where handing over an archive is
-  // agreeing in bulk to things you have forgotten you wrote.
-  // `export` stays for the rarer member whose public writing is nearly all on-topic.
-  const kind = form.get('kind') === 'export' ? 'export' : 'links';
-
-  // Consent is checked first, on purpose: an upload without it is never parsed, so a member who did
-  // not agree has their file ignored rather than processed and then rejected.
-  let agreedClauseIds: unknown;
-  try {
-    agreedClauseIds = JSON.parse(String(form.get('agreedClauseIds') ?? '[]'));
-  } catch {
-    agreedClauseIds = null;
-  }
-  if (!hasAgreedToEveryClause(agreedClauseIds)) {
-    return badRequest('Every consent statement has to be agreed to before anything can be sent.');
-  }
-  // A page cached from before a consent change would submit the old clause ids. Those pass the check
-  // above only if the ids still match; a version mismatch means the member read different wording,
-  // so make them re-read it rather than record consent they never gave.
-  if (String(form.get('consentVersion') ?? '') !== CONTRIBUTION_CONSENT_VERSION) {
-    return badRequest(
-      'The consent wording has been updated. Reload this page and read it again before sending.',
-      COMIC_ERROR_CODE.conflict,
-    );
-  }
-
-  // The file is only required on the export path. A links contribution carries no upload at all,
-  // which is most of why it is the safer default: no archive to parse, and nothing to attack.
-  let file: File | null = null;
-  if (kind === 'export') {
-    const uploaded = form.get('archive');
-    if (!(uploaded instanceof File)) {
-      return badRequest('Attach the .zip file Quora sent you.');
-    }
-    if (uploaded.size === 0) return badRequest('That file is empty.');
-    if (uploaded.size > MAX_UPLOAD_BYTES) {
-      return badRequest(`That file is larger than ${Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024))} MB.`);
-    }
-    file = uploaded;
-  }
+  const prepared = await prepareContribution(request);
+  if ('error' in prepared) return prepared.error;
+  const { form, kind, file } = prepared;
 
   try {
     if ((await countRecentContributions(gate.auth.userId, 24)) >= MAX_CONTRIBUTIONS_PER_DAY) {
@@ -128,86 +256,16 @@ export async function POST(request: Request) {
       );
     }
 
-    let entries;
-    let discarded: string[] = [];
+    const intake = kind === 'links' ? intakeLinks(form) : await intakeExport(file as File);
+    if ('error' in intake) return intake.error;
 
-    if (kind === 'links') {
-      let posts: unknown;
-      try {
-        posts = JSON.parse(String(form.get('posts') ?? '[]'));
-      } catch {
-        return badRequest('Could not read the posts you pasted.');
-      }
-      const validated = validateLinkedPosts(posts);
-      if (!validated.ok) return badRequest(validated.message);
-      entries = validated.entries;
-    } else {
-      const archive = readQuoraExportArchive(new Uint8Array(await (file as File).arrayBuffer()));
-      if (!archive.ok) {
-        const message =
-          archive.reason === 'not_a_zip'
-            ? 'That is not the .zip file Quora sends. Send the file from Quora as it arrived, without unzipping it.'
-            : archive.reason === 'no_index_html'
-              ? 'That .zip does not look like a Quora export — it has no index.html inside.'
-              : 'That export is too large to read.';
-        return badRequest(message);
-      }
-
-      const parsed = parseQuoraExportHtml(archive.html);
-      if (!parsed.looksLikeQuoraExport) {
-        return badRequest('That file does not look like a Quora export.');
-      }
-
-      entries = dedupeContributedEntries(parsed.entries);
-      discarded = parsed.discarded;
-      if (entries.length === 0) {
-        return badRequest(
-          'Nothing public was found in that export — no answers, posts, or comments. Nothing has been kept.',
-        );
-      }
-    }
-
-    const contribution = await createContribution({
+    return await storeContribution({
+      form,
       userId: gate.auth.userId,
       kind,
-      consentVersion: CONTRIBUTION_CONSENT_VERSION,
-      thirdPartyNote: String(form.get('thirdPartyNote') ?? ''),
-      discardedSections: discarded,
-      entries,
+      entries: intake.entries,
+      discarded: intake.discarded,
     });
-
-    // Contributing is a route into verification: if this member has no Quora URL on file and gave
-    // one here, open an Unlock submission from it. Best-effort and AFTER the contribution is stored —
-    // the writing is already safe, and a failure here just means they verify the ordinary way.
-    // It creates a pending submission, never an approval; the owner still decides.
-    const unlockLink = await linkContributionToUnlock({
-      userId: gate.auth.userId,
-      quoraProfileUrl: typeof form.get('quoraProfileUrl') === 'string' ? String(form.get('quoraProfileUrl')) : null,
-      contributionId: contribution.id,
-    });
-
-    // Audit the consent, never the content. What matters for the record is that this member agreed
-    // to this version of the wording at this time.
-    logComicAudit({
-      actorId: gate.auth.userId,
-      pluginId: 'comic',
-      command: 'comic.contribution.submit',
-      status: 'allow',
-      reason: 'ok',
-      targetType: 'contribution',
-      targetId: contribution.id,
-      result: 'success',
-      errorCategory: null,
-      metadata: {
-        consentVersion: CONTRIBUTION_CONSENT_VERSION,
-        entryCount: contribution.entryCount,
-        kind,
-        discardedSections: discarded,
-        unlockLink: unlockLink.status,
-      },
-    });
-
-    return NextResponse.json({ ok: true, contribution, unlockLink: unlockLink.status }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'comic', op: 'contribution_submit' });
     return NextResponse.json(

--- a/ctf/packages/web/app/api/comic/message/route.ts
+++ b/ctf/packages/web/app/api/comic/message/route.ts
@@ -29,6 +29,85 @@ function parseBody(body: MessageBody): ComicMessageInput | null {
   };
 }
 
+// Map a thrown repository error code to a known client response. Returns null for an unknown code,
+// which the caller reports and turns into a 503 — so reportError only fires for genuinely unexpected
+// failures, exactly as before.
+function mapKnownMessageError(code: string): NextResponse | null {
+  if (code === 'content_policy_violation') {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.moderationRejected, message: 'Message blocked by content moderation.' },
+      { status: 422 },
+    );
+  }
+
+  if (code === 'llm_consent_required') {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.consentRequired, message: 'AI processing consent is required before using the AI Assistant.' },
+      { status: 403 },
+    );
+  }
+
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.rateLimitExceeded, message: 'AI Assistant message rate limit exceeded.' },
+      { status: 429 },
+    );
+  }
+
+  return null;
+}
+
+type RoutedMessageResult = Awaited<ReturnType<typeof routeComicMessage>>;
+
+// Turn a successful routing result into its response and audit entry.
+function respondToRoutedMessage(result: RoutedMessageResult, userId: string): NextResponse {
+  // No @comic mention → peer-to-peer message, the assistant does nothing.
+  if (result.outcome === 'not_mentioned') {
+    logComicAudit({
+      actorId: userId,
+      pluginId: 'comic',
+      command: 'comic.message.route',
+      status: 'allow',
+      reason: 'not_mentioned_noop',
+      targetType: 'comic_message',
+      targetId: 'none',
+      result: 'success',
+      errorCategory: null,
+    });
+    return NextResponse.json({ ok: true, routedToAssistant: false }, { status: 200 });
+  }
+
+  logComicAudit({
+    actorId: userId,
+    pluginId: 'comic',
+    command: 'comic.message.route',
+    status: 'allow',
+    reason: result.outcome === 'human_first' ? 'safety_human_first' : 'interim_review_pending',
+    targetType: 'comic_turn',
+    targetId: result.userTurnId,
+    result: 'success',
+    errorCategory: null,
+    metadata: {
+      conversationId: result.conversationId,
+      outcome: result.outcome,
+      reviewId: result.reviewId,
+      safetyCategory: result.safetyCategory,
+    },
+  });
+
+  // The unreviewed draft is NEVER returned to the asker; only the safe holding response is.
+  return NextResponse.json(
+    {
+      ok: true,
+      routedToAssistant: true,
+      status: result.outcome,
+      conversationId: result.conversationId,
+      holdingResponse: result.holdingResponse,
+    },
+    { status: 202 },
+  );
+}
+
 export async function POST(request: Request) {
   const gate = await requireComicReadAccess();
   if (!gate.allowed) {
@@ -60,74 +139,13 @@ export async function POST(request: Request) {
 
   try {
     const result = await routeComicMessage(gate.auth.userId, gate.auth.username ?? null, input);
-
-    // No @comic mention → peer-to-peer message, the assistant does nothing.
-    if (result.outcome === 'not_mentioned') {
-      logComicAudit({
-        actorId: gate.auth.userId,
-        pluginId: 'comic',
-        command: 'comic.message.route',
-        status: 'allow',
-        reason: 'not_mentioned_noop',
-        targetType: 'comic_message',
-        targetId: 'none',
-        result: 'success',
-        errorCategory: null,
-      });
-      return NextResponse.json({ ok: true, routedToAssistant: false }, { status: 200 });
-    }
-
-    logComicAudit({
-      actorId: gate.auth.userId,
-      pluginId: 'comic',
-      command: 'comic.message.route',
-      status: 'allow',
-      reason: result.outcome === 'human_first' ? 'safety_human_first' : 'interim_review_pending',
-      targetType: 'comic_turn',
-      targetId: result.userTurnId,
-      result: 'success',
-      errorCategory: null,
-      metadata: {
-        conversationId: result.conversationId,
-        outcome: result.outcome,
-        reviewId: result.reviewId,
-        safetyCategory: result.safetyCategory,
-      },
-    });
-
-    // The unreviewed draft is NEVER returned to the asker; only the safe holding response is.
-    return NextResponse.json(
-      {
-        ok: true,
-        routedToAssistant: true,
-        status: result.outcome,
-        conversationId: result.conversationId,
-        holdingResponse: result.holdingResponse,
-      },
-      { status: 202 },
-    );
+    return respondToRoutedMessage(result, gate.auth.userId);
   } catch (error) {
     const code = error instanceof Error ? error.message : 'unknown_error';
 
-    if (code === 'content_policy_violation') {
-      return NextResponse.json(
-        { ok: false, code: COMIC_ERROR_CODE.moderationRejected, message: 'Message blocked by content moderation.' },
-        { status: 422 },
-      );
-    }
-
-    if (code === 'llm_consent_required') {
-      return NextResponse.json(
-        { ok: false, code: COMIC_ERROR_CODE.consentRequired, message: 'AI processing consent is required before using the AI Assistant.' },
-        { status: 403 },
-      );
-    }
-
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: COMIC_ERROR_CODE.rateLimitExceeded, message: 'AI Assistant message rate limit exceeded.' },
-        { status: 429 },
-      );
+    const known = mapKnownMessageError(code);
+    if (known) {
+      return known;
     }
 
     reportError(error, { area: 'comic', op: 'message' });

--- a/ctf/packages/web/app/api/comic/review/[turnId]/resolve/route.ts
+++ b/ctf/packages/web/app/api/comic/review/[turnId]/resolve/route.ts
@@ -24,6 +24,44 @@ function parseLinkedPluginSlugs(value: unknown): string[] {
   return value.filter((entry): entry is string => typeof entry === 'string');
 }
 
+// Repository error codes that all mean "the resolution payload was invalid" and map to a 400.
+const INVALID_RESOLUTION_CODES = new Set([
+  'invalid_resolution',
+  'correction_required',
+  'correction_too_long',
+  'reason_too_long',
+  'approve_requires_content',
+]);
+
+// Map a thrown repository error code to its response. Unknown codes fall through to the 503.
+function mapResolveError(code: string): NextResponse {
+  if (code === 'review_not_found') {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.reviewNotFound, message: 'Review item not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (code === 'review_already_resolved') {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.reviewAlreadyResolved, message: 'Review item already resolved.' },
+      { status: 409 },
+    );
+  }
+
+  if (INVALID_RESOLUTION_CODES.has(code)) {
+    return NextResponse.json(
+      { ok: false, code: COMIC_ERROR_CODE.invalidPayload, message: 'Invalid review resolution payload.' },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json(
+    { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to resolve review item.' },
+    { status: 503 },
+  );
+}
+
 function parseBody(body: ResolveBody): ComicReviewResolveInput | null {
   // Reject (rather than silently coerce to 'approve') any resolution outside the allowed set so a
   // malformed/unknown value cannot accidentally publish a draft.
@@ -105,37 +143,6 @@ export async function POST(request: Request, { params }: { params: Promise<{ tur
   } catch (error) {
     reportError(error, { area: 'comic', op: 'review_turnid_resolve' });
     const code = error instanceof Error ? error.message : 'unknown_error';
-
-    if (code === 'review_not_found') {
-      return NextResponse.json(
-        { ok: false, code: COMIC_ERROR_CODE.reviewNotFound, message: 'Review item not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (code === 'review_already_resolved') {
-      return NextResponse.json(
-        { ok: false, code: COMIC_ERROR_CODE.reviewAlreadyResolved, message: 'Review item already resolved.' },
-        { status: 409 },
-      );
-    }
-
-    if (
-      code === 'invalid_resolution'
-      || code === 'correction_required'
-      || code === 'correction_too_long'
-      || code === 'reason_too_long'
-      || code === 'approve_requires_content'
-    ) {
-      return NextResponse.json(
-        { ok: false, code: COMIC_ERROR_CODE.invalidPayload, message: 'Invalid review resolution payload.' },
-        { status: 400 },
-      );
-    }
-
-    return NextResponse.json(
-      { ok: false, code: COMIC_ERROR_CODE.persistenceUnavailable, message: 'Unable to resolve review item.' },
-      { status: 503 },
-    );
+    return mapResolveError(code);
   }
 }

--- a/ctf/packages/web/app/api/contributor-access/admin/config/route.ts
+++ b/ctf/packages/web/app/api/contributor-access/admin/config/route.ts
@@ -82,6 +82,127 @@ function nonNegativeNumber(value: number | undefined, fallback: number): number 
   return value;
 }
 
+type ContributorAccessConfigInput = Parameters<typeof upsertContributorAccessConfig>[0];
+type CurrentContributorAccessConfig = Awaited<ReturnType<typeof getContributorAccessConfig>>;
+
+type NumericConfigFields = {
+  threshold: number;
+  minAccountAgeDays: number;
+  minDistinctPlugins: number;
+  minCounterparties: number;
+  minEligibleToOpenChannel: number;
+};
+
+// Threshold and the four minimums: each defaults to the current value and must be a non-negative
+// number. Returns null when any one is invalid so the caller can emit a single 400.
+function parseNumericConfigFields(
+  body: ConfigBody,
+  current: CurrentContributorAccessConfig,
+): NumericConfigFields | null {
+  const threshold = nonNegativeNumber(body.threshold, current.threshold);
+  const minAccountAgeDays = nonNegativeNumber(body.minAccountAgeDays, current.minAccountAgeDays);
+  const minDistinctPlugins = nonNegativeNumber(body.minDistinctPlugins, current.minDistinctPlugins);
+  const minCounterparties = nonNegativeNumber(body.minCounterparties, current.minCounterparties);
+  const minEligibleToOpenChannel = nonNegativeNumber(body.minEligibleToOpenChannel, current.minEligibleToOpenChannel);
+  if (
+    threshold === null ||
+    minAccountAgeDays === null ||
+    minDistinctPlugins === null ||
+    minCounterparties === null ||
+    minEligibleToOpenChannel === null
+  ) {
+    return null;
+  }
+  return { threshold, minAccountAgeDays, minDistinctPlugins, minCounterparties, minEligibleToOpenChannel };
+}
+
+// Validate the incoming config body against the current row and produce the update to persist, or a
+// 400 response describing the first problem. Keeps the caller's TypeScript narrowing via destructuring.
+function validateConfigUpdate(
+  body: ConfigBody,
+  current: CurrentContributorAccessConfig,
+): { error: NextResponse } | { update: ContributorAccessConfigInput } {
+  const weights = parseWeights(body.weights);
+  if (weights === null) {
+    return { error: invalidPayload('weights must map known value-event keys to non-negative numbers.') };
+  }
+  const numeric = parseNumericConfigFields(body, current);
+  if (numeric === null) {
+    return { error: invalidPayload('threshold and minimums must be non-negative numbers.') };
+  }
+  if (body.channelOpen !== undefined && typeof body.channelOpen !== 'boolean') {
+    return { error: invalidPayload('channelOpen must be a boolean.') };
+  }
+
+  const update: ContributorAccessConfigInput = {
+    weights: body.weights === undefined ? current.weights : weights,
+    threshold: numeric.threshold,
+    minAccountAgeDays: Math.floor(numeric.minAccountAgeDays),
+    minDistinctPlugins: Math.floor(numeric.minDistinctPlugins),
+    minCounterparties: Math.floor(numeric.minCounterparties),
+    minEligibleToOpenChannel: Math.floor(numeric.minEligibleToOpenChannel),
+    channelOpen: body.channelOpen ?? current.channelOpen,
+  };
+  return { update };
+}
+
+// Launch gate (server-side, never client-trusted): the channel can only turn on once enough
+// members are eligible — a cold, near-empty "trusted" room reads worse than none. Checked
+// against the minimum in this same update. Stable reason code for the shell. Returns the 409
+// deny response (and audits it) when the gate blocks, otherwise null.
+async function maybeEnforceLaunchGate(
+  opening: boolean,
+  update: ContributorAccessConfigInput,
+  actorId: string,
+): Promise<NextResponse | null> {
+  if (!opening) {
+    return null;
+  }
+  const eligibleCount = await countEligibleMembers();
+  if (eligibleCount < update.minEligibleToOpenChannel) {
+    await insertContributorAccessAudit({
+      actorId,
+      command: 'contributor-access.config.update',
+      policyStatus: 'deny',
+      reason: 'contributor_access_channel_below_minimum',
+      targetType: 'config',
+      targetId: 'singleton',
+      metadata: { eligibleCount, minEligibleToOpenChannel: update.minEligibleToOpenChannel },
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        code: 'contributor_access_channel_below_minimum',
+        message: `The channel opens at ${update.minEligibleToOpenChannel} eligible members; there are ${eligibleCount}.`,
+      },
+      { status: 409 },
+    );
+  }
+  return null;
+}
+
+// Opening the channel creates it in Stream and runs the first membership sync. Guarded: a
+// Stream failure never rolls the config back — the flip already landed, membership
+// reconciles on the next sync, and the admin sees the warning. Returns the warning to surface,
+// or undefined when nothing needs surfacing (or the channel is not opening).
+async function runChannelOpenSyncIfOpening(opening: boolean): Promise<string | undefined> {
+  if (!opening) {
+    return undefined;
+  }
+  try {
+    const configured = await ensureGatedChannel();
+    if (configured) {
+      await syncGatedChannelMembership();
+    } else {
+      return 'Stream is not configured in this environment; the channel exists in config only.';
+    }
+  } catch (syncError) {
+    reportError(syncError, { area: 'contributor-access', op: 'admin_config_channel_open_sync' });
+    return 'Gated channel membership sync failed; it reconciles on the next sync.';
+  }
+  return undefined;
+}
+
 export async function PUT(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -105,63 +226,16 @@ export async function PUT(request: Request) {
 
   try {
     const current = await getContributorAccessConfig();
-    const weights = parseWeights(body.weights);
-    if (weights === null) {
-      return invalidPayload('weights must map known value-event keys to non-negative numbers.');
+    const validated = validateConfigUpdate(body, current);
+    if ('error' in validated) {
+      return validated.error;
     }
-    const threshold = nonNegativeNumber(body.threshold, current.threshold);
-    const minAccountAgeDays = nonNegativeNumber(body.minAccountAgeDays, current.minAccountAgeDays);
-    const minDistinctPlugins = nonNegativeNumber(body.minDistinctPlugins, current.minDistinctPlugins);
-    const minCounterparties = nonNegativeNumber(body.minCounterparties, current.minCounterparties);
-    const minEligibleToOpenChannel = nonNegativeNumber(body.minEligibleToOpenChannel, current.minEligibleToOpenChannel);
-    if (
-      threshold === null ||
-      minAccountAgeDays === null ||
-      minDistinctPlugins === null ||
-      minCounterparties === null ||
-      minEligibleToOpenChannel === null
-    ) {
-      return invalidPayload('threshold and minimums must be non-negative numbers.');
-    }
-    if (body.channelOpen !== undefined && typeof body.channelOpen !== 'boolean') {
-      return invalidPayload('channelOpen must be a boolean.');
-    }
+    const { update } = validated;
 
-    const update = {
-      weights: body.weights === undefined ? current.weights : weights,
-      threshold,
-      minAccountAgeDays: Math.floor(minAccountAgeDays),
-      minDistinctPlugins: Math.floor(minDistinctPlugins),
-      minCounterparties: Math.floor(minCounterparties),
-      minEligibleToOpenChannel: Math.floor(minEligibleToOpenChannel),
-      channelOpen: body.channelOpen ?? current.channelOpen,
-    };
-
-    // Launch gate (server-side, never client-trusted): the channel can only turn on once enough
-    // members are eligible — a cold, near-empty "trusted" room reads worse than none. Checked
-    // against the minimum in this same update. Stable reason code for the shell.
     const opening = update.channelOpen && !current.channelOpen;
-    if (opening) {
-      const eligibleCount = await countEligibleMembers();
-      if (eligibleCount < update.minEligibleToOpenChannel) {
-        await insertContributorAccessAudit({
-          actorId: gate.auth.userId,
-          command: 'contributor-access.config.update',
-          policyStatus: 'deny',
-          reason: 'contributor_access_channel_below_minimum',
-          targetType: 'config',
-          targetId: 'singleton',
-          metadata: { eligibleCount, minEligibleToOpenChannel: update.minEligibleToOpenChannel },
-        });
-        return NextResponse.json(
-          {
-            ok: false,
-            code: 'contributor_access_channel_below_minimum',
-            message: `The channel opens at ${update.minEligibleToOpenChannel} eligible members; there are ${eligibleCount}.`,
-          },
-          { status: 409 },
-        );
-      }
+    const launchGateResponse = await maybeEnforceLaunchGate(opening, update, gate.auth.userId);
+    if (launchGateResponse) {
+      return launchGateResponse;
     }
 
     await upsertContributorAccessConfig(update);
@@ -176,23 +250,7 @@ export async function PUT(request: Request) {
       metadata: update,
     });
 
-    // Opening the channel creates it in Stream and runs the first membership sync. Guarded: a
-    // Stream failure never rolls the config back — the flip already landed, membership
-    // reconciles on the next sync, and the admin sees the warning.
-    let channelSyncWarning: string | undefined;
-    if (opening) {
-      try {
-        const configured = await ensureGatedChannel();
-        if (configured) {
-          await syncGatedChannelMembership();
-        } else {
-          channelSyncWarning = 'Stream is not configured in this environment; the channel exists in config only.';
-        }
-      } catch (syncError) {
-        reportError(syncError, { area: 'contributor-access', op: 'admin_config_channel_open_sync' });
-        channelSyncWarning = 'Gated channel membership sync failed; it reconciles on the next sync.';
-      }
-    }
+    const channelSyncWarning = await runChannelOpenSyncIfOpening(opening);
 
     const config = await getContributorAccessConfig();
     return NextResponse.json(

--- a/ctf/packages/web/app/api/contributor-access/admin/revoke/route.ts
+++ b/ctf/packages/web/app/api/contributor-access/admin/revoke/route.ts
@@ -12,6 +12,22 @@ type RevokeBody = {
   reason?: string;
 };
 
+// Both a target userId and a non-empty reason are required (revoke is never reasonless). Returns a
+// 400 response when either is missing/blank.
+function parseRevokeBody(body: RevokeBody): { error: NextResponse } | { userId: string; reason: string } {
+  const userId = body.userId?.trim();
+  const reason = body.reason?.trim();
+  if (!userId || !reason) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'contributor_access_invalid_payload', message: 'userId and a non-empty reason are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+  return { userId, reason };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -33,14 +49,11 @@ export async function POST(request: Request) {
     );
   }
 
-  const userId = body.userId?.trim();
-  const reason = body.reason?.trim();
-  if (!userId || !reason) {
-    return NextResponse.json(
-      { ok: false, code: 'contributor_access_invalid_payload', message: 'userId and a non-empty reason are required.' },
-      { status: 400 },
-    );
+  const parsed = parseRevokeBody(body);
+  if ('error' in parsed) {
+    return parsed.error;
   }
+  const { userId, reason } = parsed;
 
   try {
     const revoked = await revokeEligibility({ userId, reason, revokedBy: gate.auth.userId });

--- a/ctf/packages/web/app/api/contributor-access/channel/messages/route.ts
+++ b/ctf/packages/web/app/api/contributor-access/channel/messages/route.ts
@@ -39,6 +39,57 @@ type MessageRequestBody = {
   replyToPostId?: unknown;
 };
 
+// Parse and validate the posting body: a required message text within the channel length limit and
+// an optional quoted-reply target. Returns a 400 response when the text is missing or too long.
+function parseChannelMessageInput(
+  body: MessageRequestBody,
+): { error: NextResponse } | { text: string; replyToPostId: string | null } {
+  const text = typeof body.text === 'string' ? body.text.trim() : '';
+  const replyToPostId = typeof body.replyToPostId === 'string' && body.replyToPostId.trim().length > 0
+    ? body.replyToPostId.trim()
+    : null;
+  if (!text || !validateGatedChannelPostBody(text)) {
+    return {
+      error: NextResponse.json(
+        { ok: false, message: 'Message text is required and must fit the channel length limit.' },
+        { status: 400 },
+      ),
+    };
+  }
+  return { text, replyToPostId };
+}
+
+// Map a create-post failure to its response. Known error codes carry their own status; anything
+// else is reported and returned as a generic 503.
+function mapChannelPostError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : 'unknown_error';
+  if (code === 'rate_limit_exceeded') {
+    // Same limiter shape and threshold as the Commons community-post route (8 per 30 minutes,
+    // counted per member in the database); the client shows this as the same error banner the
+    // Commons shows when its posting limit trips.
+    return NextResponse.json(
+      { ok: false, code: 'rate_limit_exceeded', message: 'Channel posting rate limit exceeded. Wait a little before posting again.' },
+      { status: 429 },
+    );
+  }
+  if (code === 'content_policy_violation') {
+    // Same content gate as the Commons (no raw <> markup, at most three links): the post is
+    // refused outright and never stored, so it is never visible to anyone.
+    return NextResponse.json(
+      { ok: false, code: 'content_policy_violation', message: 'Message blocked by content moderation.' },
+      { status: 422 },
+    );
+  }
+  if (code === 'reply_target_not_found') {
+    return NextResponse.json(
+      { ok: false, message: 'The message you are replying to is no longer available.' },
+      { status: 400 },
+    );
+  }
+  reportError(error, { area: 'contributor-access', op: 'channel_message_create' });
+  return NextResponse.json({ ok: false, message: 'Unable to send message.' }, { status: 503 });
+}
+
 export async function POST(request: Request) {
   const gate = await requireGatedChannelAccess();
   if (!gate.allowed) {
@@ -57,16 +108,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, message: 'Invalid JSON payload.' }, { status: 400 });
   }
 
-  const text = typeof body.text === 'string' ? body.text.trim() : '';
-  const replyToPostId = typeof body.replyToPostId === 'string' && body.replyToPostId.trim().length > 0
-    ? body.replyToPostId.trim()
-    : null;
-  if (!text || !validateGatedChannelPostBody(text)) {
-    return NextResponse.json(
-      { ok: false, message: 'Message text is required and must fit the channel length limit.' },
-      { status: 400 },
-    );
+  const parsed = parseChannelMessageInput(body);
+  if ('error' in parsed) {
+    return parsed.error;
   }
+  const { text, replyToPostId } = parsed;
 
   try {
     const authorUsername = gate.auth.username ?? null;
@@ -91,31 +137,6 @@ export async function POST(request: Request) {
     };
     return NextResponse.json({ ok: true, message }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'unknown_error';
-    if (code === 'rate_limit_exceeded') {
-      // Same limiter shape and threshold as the Commons community-post route (8 per 30 minutes,
-      // counted per member in the database); the client shows this as the same error banner the
-      // Commons shows when its posting limit trips.
-      return NextResponse.json(
-        { ok: false, code: 'rate_limit_exceeded', message: 'Channel posting rate limit exceeded. Wait a little before posting again.' },
-        { status: 429 },
-      );
-    }
-    if (code === 'content_policy_violation') {
-      // Same content gate as the Commons (no raw <> markup, at most three links): the post is
-      // refused outright and never stored, so it is never visible to anyone.
-      return NextResponse.json(
-        { ok: false, code: 'content_policy_violation', message: 'Message blocked by content moderation.' },
-        { status: 422 },
-      );
-    }
-    if (code === 'reply_target_not_found') {
-      return NextResponse.json(
-        { ok: false, message: 'The message you are replying to is no longer available.' },
-        { status: 400 },
-      );
-    }
-    reportError(error, { area: 'contributor-access', op: 'channel_message_create' });
-    return NextResponse.json({ ok: false, message: 'Unable to send message.' }, { status: 503 });
+    return mapChannelPostError(error);
   }
 }

--- a/ctf/packages/web/app/api/directory/admin/profiles/[id]/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/profiles/[id]/route.ts
@@ -10,28 +10,52 @@ type RouteParams = { params: Promise<{ id: string }> };
 
 type AdminProfileBody = Partial<DirectoryProfileInput>;
 
+// Returns the value when it is a string, otherwise the given fallback. Keeps parseBody free of
+// per-field type-guard ternaries so it stays within the complexity budget.
+function asString<T>(value: unknown, fallback: T): string | T {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+// Maps a persistence error to the response used by PUT. A message mentioning a "_not_found" selector
+// is a client validation problem (400); anything else is a persistence failure (503).
+function mapSelectorError(error: unknown): NextResponse {
+  const message = error instanceof Error ? error.message : 'unknown';
+  const isValidation = message.includes('_not_found');
+
+  return NextResponse.json(
+    {
+      ok: false,
+      code: isValidation ? DIRECTORY_ERROR_CODE.invalidPayload : DIRECTORY_ERROR_CODE.persistenceUnavailable,
+      message: isValidation ? 'Invalid selector references in profile payload.' : 'Unable to update profile.',
+    },
+    { status: isValidation ? 400 : 503 },
+  );
+}
+
 function parseBody(body: AdminProfileBody): DirectoryProfileInput {
   return {
-    firstName: typeof body.firstName === 'string' ? body.firstName : '',
-    lastName: typeof body.lastName === 'string' ? body.lastName : null,
-    headline: typeof body.headline === 'string' ? body.headline : null,
-    bio: typeof body.bio === 'string' ? body.bio : null,
-    profileUrl: typeof body.profileUrl === 'string' ? body.profileUrl : null,
-    sectorId: typeof body.sectorId === 'string' ? body.sectorId : null,
-    jobTitleId: typeof body.jobTitleId === 'string' ? body.jobTitleId : null,
-    skillIds: Array.isArray(body.skillIds)
-      ? body.skillIds.filter((value): value is string => typeof value === 'string')
-      : [],
+    firstName: asString(body.firstName, ''),
+    lastName: asString(body.lastName, null),
+    headline: asString(body.headline, null),
+    bio: asString(body.bio, null),
+    profileUrl: asString(body.profileUrl, null),
+    sectorId: asString(body.sectorId, null),
+    jobTitleId: asString(body.jobTitleId, null),
+    skillIds: stringArray(body.skillIds),
     // Fields the admin form may leave out stay undefined so updateAdminProfile preserves
     // the stored value instead of nulling it (payment addresses are member-owned and are
     // never sent by the admin drawer; location is sent, and an empty string clears it).
-    venmoAddress: typeof body.venmoAddress === 'string' ? body.venmoAddress : undefined,
-    moneroAddress: typeof body.moneroAddress === 'string' ? body.moneroAddress : undefined,
-    bitcoinAddress: typeof body.bitcoinAddress === 'string' ? body.bitcoinAddress : undefined,
-    serviceCreditsAddress: typeof body.serviceCreditsAddress === 'string' ? body.serviceCreditsAddress : undefined,
-    city: typeof body.city === 'string' ? body.city : undefined,
-    state: typeof body.state === 'string' ? body.state : undefined,
-    country: typeof body.country === 'string' ? body.country : undefined,
+    venmoAddress: asString(body.venmoAddress, undefined),
+    moneroAddress: asString(body.moneroAddress, undefined),
+    bitcoinAddress: asString(body.bitcoinAddress, undefined),
+    serviceCreditsAddress: asString(body.serviceCreditsAddress, undefined),
+    city: asString(body.city, undefined),
+    state: asString(body.state, undefined),
+    country: asString(body.country, undefined),
   };
 }
 
@@ -78,17 +102,7 @@ export async function PUT(request: Request, { params }: RouteParams) {
     return NextResponse.json({ ok: true, profile }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'directory', op: 'admin_profiles_id' });
-    const message = error instanceof Error ? error.message : 'unknown';
-    const isValidation = message.includes('_not_found');
-
-    return NextResponse.json(
-      {
-        ok: false,
-        code: isValidation ? DIRECTORY_ERROR_CODE.invalidPayload : DIRECTORY_ERROR_CODE.persistenceUnavailable,
-        message: isValidation ? 'Invalid selector references in profile payload.' : 'Unable to update profile.',
-      },
-      { status: isValidation ? 400 : 503 },
-    );
+    return mapSelectorError(error);
   }
 }
 

--- a/ctf/packages/web/app/api/directory/admin/profiles/[id]/takedown/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/profiles/[id]/takedown/route.ts
@@ -7,6 +7,77 @@ import { reportError } from 'lib/observability/report';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+type TakedownResult = Awaited<ReturnType<typeof takedownAdminProfile>>;
+type TakedownDenyResult = Exclude<TakedownResult, 'taken_down'>;
+
+// Reads and validates the required takedown reason. Returns the trimmed-nonempty reason string, or a
+// ready-to-send error response (invalid JSON body, or an empty/missing reason).
+async function parseTakedownReason(request: Request): Promise<{ error: NextResponse } | { reason: string }> {
+  let reason = '';
+  try {
+    const body = (await request.json()) as { reason?: unknown };
+    reason = typeof body.reason === 'string' ? body.reason : '';
+  } catch {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: DIRECTORY_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (reason.trim().length === 0) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: DIRECTORY_ERROR_CODE.invalidPayload, message: 'A reason is required to take down a profile.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { reason };
+}
+
+// The audit `reason` recorded for each non-success takedown outcome.
+function denyReasonFor(result: TakedownDenyResult): string {
+  return result === 'not_found'
+    ? 'not_found'
+    : result === 'claimed_guard'
+      ? 'invalid_claimed_unclaimed_transition'
+      : result === 'not_community_generated'
+        ? 'not_community_generated'
+        : 'missing_quora_url';
+}
+
+// The response sent for each non-success takedown outcome.
+function denyResponseFor(result: TakedownDenyResult): NextResponse {
+  if (result === 'not_found') {
+    return NextResponse.json(
+      { ok: false, code: DIRECTORY_ERROR_CODE.notFound, message: 'Profile not found.' },
+      { status: 404 },
+    );
+  }
+  if (result === 'claimed_guard') {
+    return NextResponse.json(
+      { ok: false, code: DIRECTORY_ERROR_CODE.claimedProfileGuard, message: 'Claimed profiles cannot be taken down; unassign first.' },
+      { status: 409 },
+    );
+  }
+  // not_community_generated / missing_quora_url — a takedown only applies to a nominated
+  // (community-generated) profile that carries a Quora URL. Use the ordinary delete otherwise.
+  return NextResponse.json(
+    {
+      ok: false,
+      code: DIRECTORY_ERROR_CODE.conflict,
+      message:
+        result === 'not_community_generated'
+          ? 'Takedown is only for community-generated profiles. Use delete for this one.'
+          : 'This profile has no Quora URL to suppress. Use delete instead.',
+    },
+    { status: 409 },
+  );
+}
+
 // Take down a community-generated profile at the person's request (they have no account and asked to
 // be removed). Unlike the ordinary delete, this also blocks the profile's Quora URL from being listed
 // again until an admin lifts the block. A reason is required and recorded in the audit trail.
@@ -23,23 +94,11 @@ export async function POST(request: Request, { params }: RouteParams) {
 
   const { id } = await params;
 
-  let reason = '';
-  try {
-    const body = (await request.json()) as { reason?: unknown };
-    reason = typeof body.reason === 'string' ? body.reason : '';
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: DIRECTORY_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
-      { status: 400 },
-    );
+  const parsed = await parseTakedownReason(request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  if (reason.trim().length === 0) {
-    return NextResponse.json(
-      { ok: false, code: DIRECTORY_ERROR_CODE.invalidPayload, message: 'A reason is required to take down a profile.' },
-      { status: 400 },
-    );
-  }
+  const { reason } = parsed;
 
   try {
     const result = await takedownAdminProfile(gate.auth.userId, id, reason);
@@ -58,51 +117,18 @@ export async function POST(request: Request, { params }: RouteParams) {
       return NextResponse.json({ ok: true }, { status: 200 });
     }
 
-    const denyReason =
-      result === 'not_found'
-        ? 'not_found'
-        : result === 'claimed_guard'
-          ? 'invalid_claimed_unclaimed_transition'
-          : result === 'not_community_generated'
-            ? 'not_community_generated'
-            : 'missing_quora_url';
-
     logDirectoryAudit({
       actorId: gate.auth.userId,
       command: 'directory.admin.profile.takedown',
       status: 'deny',
-      reason: denyReason,
+      reason: denyReasonFor(result),
       targetType: 'profile',
       targetId: id,
       result: 'failure',
       errorCategory: result === 'not_found' ? 'not_found' : 'policy',
     });
 
-    if (result === 'not_found') {
-      return NextResponse.json(
-        { ok: false, code: DIRECTORY_ERROR_CODE.notFound, message: 'Profile not found.' },
-        { status: 404 },
-      );
-    }
-    if (result === 'claimed_guard') {
-      return NextResponse.json(
-        { ok: false, code: DIRECTORY_ERROR_CODE.claimedProfileGuard, message: 'Claimed profiles cannot be taken down; unassign first.' },
-        { status: 409 },
-      );
-    }
-    // not_community_generated / missing_quora_url — a takedown only applies to a nominated
-    // (community-generated) profile that carries a Quora URL. Use the ordinary delete otherwise.
-    return NextResponse.json(
-      {
-        ok: false,
-        code: DIRECTORY_ERROR_CODE.conflict,
-        message:
-          result === 'not_community_generated'
-            ? 'Takedown is only for community-generated profiles. Use delete for this one.'
-            : 'This profile has no Quora URL to suppress. Use delete instead.',
-      },
-      { status: 409 },
-    );
+    return denyResponseFor(result);
   } catch (error) {
     reportError(error, { area: 'directory', op: 'admin_profile_takedown' });
     logDirectoryAudit({

--- a/ctf/packages/web/app/api/directory/admin/profiles/route.ts
+++ b/ctf/packages/web/app/api/directory/admin/profiles/route.ts
@@ -8,21 +8,48 @@ import { reportError } from 'lib/observability/report';
 
 type AdminProfileBody = Partial<DirectoryProfileInput>;
 
+// Returns the value when it is a string, otherwise the given fallback. Keeps parseBody free of
+// per-field type-guard ternaries so it stays within the complexity budget.
+function asString<T>(value: unknown, fallback: T): string | T {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+// Maps a persistence error to a response plus a validation flag. A message mentioning a "_not_found"
+// selector is a client validation problem (400); anything else is a persistence failure (503). The
+// flag lets the caller record the matching audit errorCategory.
+function mapSelectorError(error: unknown): { response: NextResponse; isValidation: boolean } {
+  const message = error instanceof Error ? error.message : 'unknown';
+  const isValidation = message.includes('_not_found');
+
+  const response = NextResponse.json(
+    {
+      ok: false,
+      code: isValidation ? DIRECTORY_ERROR_CODE.invalidPayload : DIRECTORY_ERROR_CODE.persistenceUnavailable,
+      message: isValidation ? 'Invalid selector references in profile payload.' : 'Unable to create profile.',
+    },
+    { status: isValidation ? 400 : 503 },
+  );
+
+  return { response, isValidation };
+}
+
 function parseBody(body: AdminProfileBody): DirectoryProfileInput {
   return {
-    firstName: typeof body.firstName === 'string' ? body.firstName : '',
-    lastName: typeof body.lastName === 'string' ? body.lastName : null,
-    headline: typeof body.headline === 'string' ? body.headline : null,
-    bio: typeof body.bio === 'string' ? body.bio : null,
-    profileUrl: typeof body.profileUrl === 'string' ? body.profileUrl : null,
-    sectorId: typeof body.sectorId === 'string' ? body.sectorId : null,
-    jobTitleId: typeof body.jobTitleId === 'string' ? body.jobTitleId : null,
-    skillIds: Array.isArray(body.skillIds)
-      ? body.skillIds.filter((value): value is string => typeof value === 'string')
-      : [],
-    city: typeof body.city === 'string' ? body.city : undefined,
-    state: typeof body.state === 'string' ? body.state : undefined,
-    country: typeof body.country === 'string' ? body.country : undefined,
+    firstName: asString(body.firstName, ''),
+    lastName: asString(body.lastName, null),
+    headline: asString(body.headline, null),
+    bio: asString(body.bio, null),
+    profileUrl: asString(body.profileUrl, null),
+    sectorId: asString(body.sectorId, null),
+    jobTitleId: asString(body.jobTitleId, null),
+    skillIds: stringArray(body.skillIds),
+    city: asString(body.city, undefined),
+    state: asString(body.state, undefined),
+    country: asString(body.country, undefined),
   };
 }
 
@@ -93,8 +120,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true, profile }, { status: 201 });
   } catch (error) {
     reportError(error, { area: 'directory', op: 'admin_profiles' });
-    const message = error instanceof Error ? error.message : 'unknown';
-    const isValidation = message.includes('_not_found');
+    const { response, isValidation } = mapSelectorError(error);
 
     logDirectoryAudit({
       actorId: gate.auth.userId,
@@ -107,13 +133,6 @@ export async function POST(request: Request) {
       errorCategory: isValidation ? 'validation' : 'persistence_error',
     });
 
-    return NextResponse.json(
-      {
-        ok: false,
-        code: isValidation ? DIRECTORY_ERROR_CODE.invalidPayload : DIRECTORY_ERROR_CODE.persistenceUnavailable,
-        message: isValidation ? 'Invalid selector references in profile payload.' : 'Unable to create profile.',
-      },
-      { status: isValidation ? 400 : 503 },
-    );
+    return response;
   }
 }

--- a/ctf/packages/web/app/api/directory/profile/route.ts
+++ b/ctf/packages/web/app/api/directory/profile/route.ts
@@ -8,29 +8,93 @@ import type { DirectoryProfileInput } from 'lib/directory/types';
 
 type ProfileBody = Partial<DirectoryProfileInput>;
 
+// Returns the value when it is a string, otherwise the given fallback. Keeps toProfileInput free of
+// per-field type-guard ternaries so it stays within the complexity budget.
+function asString<T>(value: unknown, fallback: T): string | T {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
 function toProfileInput(body: ProfileBody): DirectoryProfileInput {
   return {
-    firstName: typeof body.firstName === 'string' ? body.firstName : '',
-    lastName: typeof body.lastName === 'string' ? body.lastName : null,
-    headline: typeof body.headline === 'string' ? body.headline : null,
-    bio: typeof body.bio === 'string' ? body.bio : null,
-    profileUrl: typeof body.profileUrl === 'string' ? body.profileUrl : null,
-    sectorId: typeof body.sectorId === 'string' ? body.sectorId : null,
-    jobTitleId: typeof body.jobTitleId === 'string' ? body.jobTitleId : null,
-    skillIds: Array.isArray(body.skillIds)
-      ? body.skillIds.filter((value): value is string => typeof value === 'string')
-      : [],
-    proposedSkills: Array.isArray(body.proposedSkills)
-      ? body.proposedSkills.filter((value): value is string => typeof value === 'string')
-      : [],
-    venmoAddress: typeof body.venmoAddress === 'string' ? body.venmoAddress : null,
-    moneroAddress: typeof body.moneroAddress === 'string' ? body.moneroAddress : null,
-    bitcoinAddress: typeof body.bitcoinAddress === 'string' ? body.bitcoinAddress : null,
-    serviceCreditsAddress: typeof body.serviceCreditsAddress === 'string' ? body.serviceCreditsAddress : null,
-    city: typeof body.city === 'string' ? body.city : null,
-    state: typeof body.state === 'string' ? body.state : null,
-    country: typeof body.country === 'string' ? body.country : null,
+    firstName: asString(body.firstName, ''),
+    lastName: asString(body.lastName, null),
+    headline: asString(body.headline, null),
+    bio: asString(body.bio, null),
+    profileUrl: asString(body.profileUrl, null),
+    sectorId: asString(body.sectorId, null),
+    jobTitleId: asString(body.jobTitleId, null),
+    skillIds: stringArray(body.skillIds),
+    proposedSkills: stringArray(body.proposedSkills),
+    venmoAddress: asString(body.venmoAddress, null),
+    moneroAddress: asString(body.moneroAddress, null),
+    bitcoinAddress: asString(body.bitcoinAddress, null),
+    serviceCreditsAddress: asString(body.serviceCreditsAddress, null),
+    city: asString(body.city, null),
+    state: asString(body.state, null),
+    country: asString(body.country, null),
   };
+}
+
+// Maps a failed upsert to its response, logging the matching audit entry and reporting unexpected
+// faults. Extracted from handleUpsert to keep that handler within the complexity budget; behavior is
+// unchanged from the inline handling.
+function handleUpsertError(error: unknown, userId: string): NextResponse {
+  const message = error instanceof Error ? error.message : 'unknown';
+
+  // A first-time profile with no valid Quora URL: the Quora profile link is required to appear in
+  // the directory (it is the only social proof), so this is a client validation problem, not a fault.
+  if (message === 'directory_quora_url_required') {
+    logDirectoryAudit({
+      actorId: userId,
+      command: 'directory.profile.upsert',
+      status: 'deny',
+      reason: 'quora_url_required',
+      targetType: 'profile',
+      targetId: userId,
+      result: 'failure',
+      errorCategory: 'validation',
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        code: DIRECTORY_ERROR_CODE.invalidPayload,
+        message: 'A valid Quora profile URL is required (e.g. https://www.quora.com/profile/Your-Name).',
+      },
+      { status: 400 },
+    );
+  }
+
+  const isSelectorIssue = message.includes('directory_') && message.endsWith('_not_found');
+
+  // A selector-not-found is a client validation problem; anything else is an
+  // unexpected server/persistence failure worth reporting.
+  if (!isSelectorIssue) {
+    reportError(error, { area: 'directory', op: 'upsert_own_profile', extra: { userId } });
+  }
+
+  logDirectoryAudit({
+    actorId: userId,
+    command: 'directory.profile.upsert',
+    status: 'allow',
+    reason: 'profile_ownership_or_admin',
+    targetType: 'profile',
+    targetId: userId,
+    result: 'failure',
+    errorCategory: isSelectorIssue ? 'validation' : 'persistence_error',
+  });
+
+  return NextResponse.json(
+    {
+      ok: false,
+      code: isSelectorIssue ? DIRECTORY_ERROR_CODE.invalidPayload : DIRECTORY_ERROR_CODE.persistenceUnavailable,
+      message: isSelectorIssue ? 'Invalid selector references in profile payload.' : 'Unable to save profile.',
+    },
+    { status: isSelectorIssue ? 400 : 503 },
+  );
 }
 
 export async function GET() {
@@ -109,58 +173,7 @@ async function handleUpsert(request: Request) {
     // previous one (the URL can never be emptied). The client shows a note when this is set.
     return NextResponse.json({ ok: true, profile, quoraUrlKept }, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown';
-
-    // A first-time profile with no valid Quora URL: the Quora profile link is required to appear in
-    // the directory (it is the only social proof), so this is a client validation problem, not a fault.
-    if (message === 'directory_quora_url_required') {
-      logDirectoryAudit({
-        actorId: gate.auth.userId,
-        command: 'directory.profile.upsert',
-        status: 'deny',
-        reason: 'quora_url_required',
-        targetType: 'profile',
-        targetId: gate.auth.userId,
-        result: 'failure',
-        errorCategory: 'validation',
-      });
-      return NextResponse.json(
-        {
-          ok: false,
-          code: DIRECTORY_ERROR_CODE.invalidPayload,
-          message: 'A valid Quora profile URL is required (e.g. https://www.quora.com/profile/Your-Name).',
-        },
-        { status: 400 },
-      );
-    }
-
-    const isSelectorIssue = message.includes('directory_') && message.endsWith('_not_found');
-
-    // A selector-not-found is a client validation problem; anything else is an
-    // unexpected server/persistence failure worth reporting.
-    if (!isSelectorIssue) {
-      reportError(error, { area: 'directory', op: 'upsert_own_profile', extra: { userId: gate.auth.userId } });
-    }
-
-    logDirectoryAudit({
-      actorId: gate.auth.userId,
-      command: 'directory.profile.upsert',
-      status: 'allow',
-      reason: 'profile_ownership_or_admin',
-      targetType: 'profile',
-      targetId: gate.auth.userId,
-      result: 'failure',
-      errorCategory: isSelectorIssue ? 'validation' : 'persistence_error',
-    });
-
-    return NextResponse.json(
-      {
-        ok: false,
-        code: isSelectorIssue ? DIRECTORY_ERROR_CODE.invalidPayload : DIRECTORY_ERROR_CODE.persistenceUnavailable,
-        message: isSelectorIssue ? 'Invalid selector references in profile payload.' : 'Unable to save profile.',
-      },
-      { status: isSelectorIssue ? 400 : 503 },
-    );
+    return handleUpsertError(error, gate.auth.userId);
   }
 }
 

--- a/ctf/packages/web/app/api/feed/admin/moderation/[target]/[id]/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/moderation/[target]/[id]/route.ts
@@ -5,12 +5,58 @@ import {
   FEED_MODERATION_REASON,
   FEED_MODERATION_STATUS,
   isFeedModerationReason,
+  type FeedModerationReason,
+  type FeedModerationStatus,
 } from 'lib/feed/constants';
 import { isFeedModerationTarget, setCommunityModerationStatus } from 'lib/feed/moderation';
 import { logFeedAudit } from 'lib/feed/audit';
 import { reportError } from 'lib/observability/report';
 
 export const dynamic = 'force-dynamic';
+
+// Parse and validate the moderation request body. Returns the resolved transition (next status and
+// reason) or a ready-to-return error response, so the handler keeps its narrowing via destructuring.
+async function parseModerationBody(
+  request: Request,
+): Promise<
+  | { error: NextResponse }
+  | { data: { hidden: boolean; next: FeedModerationStatus; reason: FeedModerationReason | null } }
+> {
+  let body: { hidden?: unknown; reason?: unknown };
+  try {
+    body = (await request.json()) as { hidden?: unknown; reason?: unknown };
+  } catch {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  // Required rather than defaulted: an absent field would otherwise silently mean "un-hide", and a
+  // malformed request must never quietly put hidden content back in front of members.
+  if (typeof body.hidden !== 'boolean') {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Send hidden: true or hidden: false.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const next = body.hidden ? FEED_MODERATION_STATUS.hidden : FEED_MODERATION_STATUS.accepted;
+
+  // A reason is only meaningful when hiding, and it is validated against the fixed code set rather
+  // than accepted as free text: a moderator's prose about a member would become a permanent,
+  // unreviewable note attached to a survivor's account. An unrecognised or absent code falls back to
+  // 'other' instead of 400 — a hide is time-sensitive and should never fail over its label.
+  const reason = body.hidden
+    ? (isFeedModerationReason(body.reason) ? body.reason : FEED_MODERATION_REASON.other)
+    : null;
+
+  return { data: { hidden: body.hidden, next, reason } };
+}
 
 // POST: hide or un-hide one piece of member-facing content — a Commons post or reply, or a question or
 // answer in the Q&A.
@@ -46,34 +92,11 @@ export async function POST(
     );
   }
 
-  let body: { hidden?: unknown; reason?: unknown };
-  try {
-    body = (await request.json()) as { hidden?: unknown; reason?: unknown };
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
-      { status: 400 },
-    );
+  const parsed = await parseModerationBody(request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  // Required rather than defaulted: an absent field would otherwise silently mean "un-hide", and a
-  // malformed request must never quietly put hidden content back in front of members.
-  if (typeof body.hidden !== 'boolean') {
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Send hidden: true or hidden: false.' },
-      { status: 400 },
-    );
-  }
-
-  const next = body.hidden ? FEED_MODERATION_STATUS.hidden : FEED_MODERATION_STATUS.accepted;
-
-  // A reason is only meaningful when hiding, and it is validated against the fixed code set rather
-  // than accepted as free text: a moderator's prose about a member would become a permanent,
-  // unreviewable note attached to a survivor's account. An unrecognized or absent code falls back to
-  // 'other' instead of 400 — a hide is time-sensitive and should never fail over its label.
-  const reason = body.hidden
-    ? (isFeedModerationReason(body.reason) ? body.reason : FEED_MODERATION_REASON.other)
-    : null;
+  const { hidden, next, reason } = parsed.data;
 
   try {
     const outcome = await setCommunityModerationStatus({
@@ -101,7 +124,7 @@ export async function POST(
     logFeedAudit({
       actorId: gate.auth.userId,
       pluginId: 'feed',
-      command: body.hidden ? 'feed.community.moderation.hide' : 'feed.community.moderation.restore',
+      command: hidden ? 'feed.community.moderation.hide' : 'feed.community.moderation.restore',
       status: 'allow',
       reason: 'admin_moderation_allowed',
       targetType: `feed_${target}`,

--- a/ctf/packages/web/app/api/feed/admin/moderation/[target]/[id]/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/moderation/[target]/[id]/route.ts
@@ -49,7 +49,7 @@ async function parseModerationBody(
 
   // A reason is only meaningful when hiding, and it is validated against the fixed code set rather
   // than accepted as free text: a moderator's prose about a member would become a permanent,
-  // unreviewable note attached to a survivor's account. An unrecognised or absent code falls back to
+  // unreviewable note attached to a survivor's account. An unrecognized or absent code falls back to
   // 'other' instead of 400 — a hide is time-sensitive and should never fail over its label.
   const reason = body.hidden
     ? (isFeedModerationReason(body.reason) ? body.reason : FEED_MODERATION_REASON.other)

--- a/ctf/packages/web/app/api/feed/admin/questions/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/questions/route.ts
@@ -19,7 +19,7 @@ function parseQuestionsPagination(searchParams: URLSearchParams): { page: number
   return { page, pageSize };
 }
 
-// Validate the optional category filter. Returns a 400 response for an unrecognised value, otherwise
+// Validate the optional category filter. Returns a 400 response for an unrecognized value, otherwise
 // the parsed category (or null when the filter is absent).
 function parseQuestionsCategory(
   categoryRaw: string | null,

--- a/ctf/packages/web/app/api/feed/admin/questions/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/questions/route.ts
@@ -5,6 +5,36 @@ import { listAdminQuestions, isValidFeedQuestionCategory } from 'lib/feed/reposi
 import type { FeedQuestionCategory } from 'lib/feed/types';
 import { reportError } from 'lib/observability/report';
 
+// Resolve page and page size from the query string, applying the same defaults and the maximum cap
+// as before.
+function parseQuestionsPagination(searchParams: URLSearchParams): { page: number; pageSize: number } {
+  const pageRaw = Number.parseInt(searchParams.get('page') ?? '', 10);
+  const pageSizeRaw = Number.parseInt(searchParams.get('pageSize') ?? '', 10);
+
+  const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : FEED_DEFAULT_PAGE;
+  const pageSize = Math.min(
+    Number.isFinite(pageSizeRaw) && pageSizeRaw > 0 ? pageSizeRaw : FEED_DEFAULT_PAGE_SIZE,
+    FEED_MAX_PAGE_SIZE,
+  );
+  return { page, pageSize };
+}
+
+// Validate the optional category filter. Returns a 400 response for an unrecognised value, otherwise
+// the parsed category (or null when the filter is absent).
+function parseQuestionsCategory(
+  categoryRaw: string | null,
+): { error: NextResponse } | { data: FeedQuestionCategory | null } {
+  if (categoryRaw !== null && !isValidFeedQuestionCategory(categoryRaw)) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid category value.' },
+        { status: 400 },
+      ),
+    };
+  }
+  return { data: categoryRaw as FeedQuestionCategory | null };
+}
+
 export async function GET(request: Request) {
   const gate = await requireFeedAdminAccess();
   if (!gate.allowed) {
@@ -12,22 +42,13 @@ export async function GET(request: Request) {
   }
 
   const { searchParams } = new URL(request.url);
-  const pageRaw = Number.parseInt(searchParams.get('page') ?? '', 10);
-  const pageSizeRaw = Number.parseInt(searchParams.get('pageSize') ?? '', 10);
-  const categoryRaw = searchParams.get('category');
+  const { page, pageSize } = parseQuestionsPagination(searchParams);
 
-  const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : FEED_DEFAULT_PAGE;
-  const pageSize = Math.min(
-    Number.isFinite(pageSizeRaw) && pageSizeRaw > 0 ? pageSizeRaw : FEED_DEFAULT_PAGE_SIZE,
-    FEED_MAX_PAGE_SIZE,
-  );
-  if (categoryRaw !== null && !isValidFeedQuestionCategory(categoryRaw)) {
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid category value.' },
-      { status: 400 },
-    );
+  const parsedCategory = parseQuestionsCategory(searchParams.get('category'));
+  if ('error' in parsedCategory) {
+    return parsedCategory.error;
   }
-  const category = categoryRaw as FeedQuestionCategory | null;
+  const category = parsedCategory.data;
 
   try {
     const result = await listAdminQuestions({ page, pageSize }, { category });

--- a/ctf/packages/web/app/api/feed/community/posts/[postId]/reply/route.ts
+++ b/ctf/packages/web/app/api/feed/community/posts/[postId]/reply/route.ts
@@ -45,7 +45,7 @@ async function parseReplyBody(
 }
 
 // Map an error thrown while creating the reply to its response. Preserves the status code and error
-// code for each known failure, and reports anything unrecognised as a 503.
+// code for each known failure, and reports anything unrecognized as a 503.
 function mapReplyError(error: unknown): NextResponse {
   const code = error instanceof Error ? error.message : 'unknown_error';
 

--- a/ctf/packages/web/app/api/feed/community/posts/[postId]/reply/route.ts
+++ b/ctf/packages/web/app/api/feed/community/posts/[postId]/reply/route.ts
@@ -15,6 +15,68 @@ type RouteParams = {
   }>;
 };
 
+// Parse and validate the reply body. Returns the reply text to persist or a ready-to-return error
+// response.
+async function parseReplyBody(
+  request: Request,
+): Promise<{ error: NextResponse } | { data: string }> {
+  let body: ReplyBody;
+  try {
+    body = (await request.json()) as ReplyBody;
+  } catch {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (!validateFeedCommunityReplyBody(typeof body.body === 'string' ? body.body : '')) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid community reply payload.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { data: body.body ?? '' };
+}
+
+// Map an error thrown while creating the reply to its response. Preserves the status code and error
+// code for each known failure, and reports anything unrecognised as a 503.
+function mapReplyError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : 'unknown_error';
+
+  if (code === 'post_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.postNotFound, message: 'Community post not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (code === 'content_policy_violation') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Community reply blocked by content moderation.' },
+      { status: 422 },
+    );
+  }
+
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'Community reply rate limit exceeded.' },
+      { status: 429 },
+    );
+  }
+
+  reportError(error, { area: 'feed', op: 'community_posts_postid_reply' });
+  return NextResponse.json(
+    { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create community reply.' },
+    { status: 503 },
+  );
+}
+
 export async function POST(request: Request, { params }: RouteParams) {
   const gate = await requireFeedReadAccess();
   if (!gate.allowed) {
@@ -26,27 +88,16 @@ export async function POST(request: Request, { params }: RouteParams) {
     return csrfDeny;
   }
 
-  let body: ReplyBody;
-  try {
-    body = (await request.json()) as ReplyBody;
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
-      { status: 400 },
-    );
+  const parsed = await parseReplyBody(request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  if (!validateFeedCommunityReplyBody(typeof body.body === 'string' ? body.body : '')) {
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid community reply payload.' },
-      { status: 400 },
-    );
-  }
+  const replyText = parsed.data;
 
   const { postId } = await params;
 
   try {
-    const result = await replyToFeedCommunityPost(gate.auth.userId, postId, body.body ?? '');
+    const result = await replyToFeedCommunityPost(gate.auth.userId, postId, replyText);
     logFeedAudit({
       actorId: gate.auth.userId,
       pluginId: 'feed',
@@ -64,33 +115,6 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     return NextResponse.json({ ok: true, replyId: result.replyId, createdAt: result.createdAtIso }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'unknown_error';
-
-    if (code === 'post_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.postNotFound, message: 'Community post not found.' },
-        { status: 404 },
-      );
-    }
-
-    if (code === 'content_policy_violation') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Community reply blocked by content moderation.' },
-        { status: 422 },
-      );
-    }
-
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'Community reply rate limit exceeded.' },
-        { status: 429 },
-      );
-    }
-
-    reportError(error, { area: 'feed', op: 'community_posts_postid_reply' });
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create community reply.' },
-      { status: 503 },
-    );
+    return mapReplyError(error);
   }
 }

--- a/ctf/packages/web/app/api/feed/community/posts/route.ts
+++ b/ctf/packages/web/app/api/feed/community/posts/route.ts
@@ -47,7 +47,7 @@ async function parsePostBody(
 }
 
 // Map an error thrown while creating the post to its response. Preserves the status code and error
-// code for each known failure, and reports anything unrecognised as a 503.
+// code for each known failure, and reports anything unrecognized as a 503.
 function mapPostError(error: unknown): NextResponse {
   const code = error instanceof Error ? error.message : 'unknown_error';
   if (code === 'rate_limit_exceeded') {

--- a/ctf/packages/web/app/api/feed/community/posts/route.ts
+++ b/ctf/packages/web/app/api/feed/community/posts/route.ts
@@ -16,6 +16,68 @@ function parseBody(body: CommunityBody): FeedCommunityPostInput {
   };
 }
 
+// Parse and validate the community post body. Returns the validated input or a ready-to-return error
+// response.
+async function parsePostBody(
+  request: Request,
+): Promise<{ error: NextResponse } | { data: FeedCommunityPostInput }> {
+  let body: CommunityBody;
+  try {
+    body = (await request.json()) as CommunityBody;
+  } catch {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const input = parseBody(body);
+  if (!validateFeedCommunityPostInput(input)) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid community post payload.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { data: input };
+}
+
+// Map an error thrown while creating the post to its response. Preserves the status code and error
+// code for each known failure, and reports anything unrecognised as a 503.
+function mapPostError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : 'unknown_error';
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'Community posting rate limit exceeded.' },
+      { status: 429 },
+    );
+  }
+
+  if (code === 'content_policy_violation') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Community post blocked by content moderation.' },
+      { status: 422 },
+    );
+  }
+
+  if (code === 'reply_target_invalid' || code === 'reply_target_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'The post you are replying to is no longer available.' },
+      { status: 400 },
+    );
+  }
+
+  reportError(error, { area: 'feed', op: 'community_posts' });
+  return NextResponse.json(
+    { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create community post.' },
+    { status: 503 },
+  );
+}
+
 export async function POST(request: Request) {
   const gate = await requireFeedReadAccess();
   if (!gate.allowed) {
@@ -27,23 +89,11 @@ export async function POST(request: Request) {
     return csrfDeny;
   }
 
-  let body: CommunityBody;
-  try {
-    body = (await request.json()) as CommunityBody;
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid JSON body.' },
-      { status: 400 },
-    );
+  const parsed = await parsePostBody(request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  const input = parseBody(body);
-  if (!validateFeedCommunityPostInput(input)) {
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid community post payload.' },
-      { status: 400 },
-    );
-  }
+  const input = parsed.data;
 
   try {
     const result = await createFeedCommunityPost(gate.auth.userId, input, gate.auth.username ?? null);
@@ -61,32 +111,6 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, postId: result.postId, createdAt: result.createdAtIso, status: 'published' }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'unknown_error';
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'Community posting rate limit exceeded.' },
-        { status: 429 },
-      );
-    }
-
-    if (code === 'content_policy_violation') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Community post blocked by content moderation.' },
-        { status: 422 },
-      );
-    }
-
-    if (code === 'reply_target_invalid' || code === 'reply_target_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'The post you are replying to is no longer available.' },
-        { status: 400 },
-      );
-    }
-
-    reportError(error, { area: 'feed', op: 'community_posts' });
-    return NextResponse.json(
-      { ok: false, code: FEED_ERROR_CODE.persistenceUnavailable, message: 'Unable to create community post.' },
-      { status: 503 },
-    );
+    return mapPostError(error);
   }
 }

--- a/ctf/packages/web/app/api/hub/messages/[postId]/reactions/route.ts
+++ b/ctf/packages/web/app/api/hub/messages/[postId]/reactions/route.ts
@@ -13,6 +13,38 @@ type ReactionRequestBody = {
   emoji?: unknown;
 };
 
+// Map a toggle-reaction failure to its response. Known error codes carry their own status; anything
+// else is reported to Sentry and returned as a generic 503.
+function mapHubReactionError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : 'unknown_error';
+  if (code === 'reaction_emoji_invalid') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Unsupported reaction emoji.' },
+      { status: 400 },
+    );
+  }
+  if (code === 'post_not_found') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.postNotFound, message: 'The post you are reacting to is no longer available.' },
+      { status: 400 },
+    );
+  }
+  if (code === 'cannot_react_to_own_post') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.forbidden, message: 'You can’t react to your own post.' },
+      { status: 403 },
+    );
+  }
+
+  // Unexpected failure (e.g. a database error): caught errors do not reach Sentry on their
+  // own, so report it. The client still gets a generic message.
+  Sentry.captureException(error, { tags: { area: 'hub', op: 'toggle_reaction' } });
+  return NextResponse.json(
+    { ok: false, message: 'Unable to update your reaction.' },
+    { status: 503 },
+  );
+}
+
 export async function POST(
   request: Request,
   context: { params: Promise<{ postId: string }> },
@@ -59,32 +91,6 @@ export async function POST(
     const result = await toggleCommunityPostReaction(gate.auth.userId, postId, emoji);
     return NextResponse.json({ ok: true, reacted: result.reacted }, { status: 200 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'unknown_error';
-    if (code === 'reaction_emoji_invalid') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Unsupported reaction emoji.' },
-        { status: 400 },
-      );
-    }
-    if (code === 'post_not_found') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.postNotFound, message: 'The post you are reacting to is no longer available.' },
-        { status: 400 },
-      );
-    }
-    if (code === 'cannot_react_to_own_post') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.forbidden, message: 'You can’t react to your own post.' },
-        { status: 403 },
-      );
-    }
-
-    // Unexpected failure (e.g. a database error): caught errors do not reach Sentry on their
-    // own, so report it. The client still gets a generic message.
-    Sentry.captureException(error, { tags: { area: 'hub', op: 'toggle_reaction' } });
-    return NextResponse.json(
-      { ok: false, message: 'Unable to update your reaction.' },
-      { status: 503 },
-    );
+    return mapHubReactionError(error);
   }
 }

--- a/ctf/packages/web/app/api/hub/messages/route.ts
+++ b/ctf/packages/web/app/api/hub/messages/route.ts
@@ -24,74 +24,133 @@ import { ensureMutationCsrf } from '../../feed/_lib';
 // (feed_items) as the single source of truth. The channel is one blended stream
 // interleaving admin announcements, AI Q&A, and peer-to-peer community posts.
 
-function mapTimelineItemToHubMessage(
+function hubMessageAuthor(
   item: FeedTimelineItem,
-  linkedPluginsByAnnouncementId: Map<string, Array<{ slug: string; name: string }>>,
-): HubMessage {
+): { userId: string; username: HubMessage['username']; displayName: string } {
   const isCommunity = item.itemType === 'community';
-  const authorUserId = isCommunity ? item.community?.authorUserId ?? 'hub-system' : 'hub-system';
+  const userId = isCommunity ? item.community?.authorUserId ?? 'hub-system' : 'hub-system';
   // This route is gated to signed-in members, so a peer post leads with the
   // author's @username when we captured it at post time. Posts created before
   // usernames were stored (and official announcements/AI answers) fall back to
   // the pseudonymous "Community member" / "Survivor Hub" labels.
-  const authorUsername = isCommunity ? item.community?.authorUsername ?? null : null;
-  const displayName = isCommunity
-    ? feedAuthorHandle(authorUsername, authorUserId)
-    : 'Survivor Hub';
+  const username = isCommunity ? item.community?.authorUsername ?? null : null;
+  const displayName = isCommunity ? feedAuthorHandle(username, userId) : 'Survivor Hub';
+  return { userId, username, displayName };
+}
 
-  // Announcements carry their title separately so the client can render it as a heading on the
-  // official card; the message text is then the body alone. Questions/community posts are body-only.
+// A peer post may quote another peer post (Signal-style reply). The quoted author handle
+// and short snippet are resolved server-side in the feed repository and carried here.
+function hubQuotedMessage(item: FeedTimelineItem): HubMessage['quotedMessage'] {
+  const isCommunity = item.itemType === 'community';
+  if (isCommunity && item.community?.quotedPost) {
+    return {
+      author: item.community.quotedPost.author,
+      snippet: item.community.quotedPost.snippet,
+      // The quoted post's id, so the client can scroll to the original when the quote is tapped.
+      postId: item.community.replyToPostId,
+    };
+  }
+  return null;
+}
+
+// Emoji reactions resolved server-side for the requesting member: from the community post for a
+// peer message, from the announcement for an official one. Other messages carry an empty array.
+function hubReactions(item: FeedTimelineItem): HubMessage['reactions'] {
+  const isCommunity = item.itemType === 'community';
+  const isAnnouncement = item.itemType === 'announcement';
+  if (isCommunity && item.community) {
+    return item.community.reactions;
+  }
+  if (isAnnouncement && item.announcement) {
+    return item.announcement.reactions;
+  }
+  return [];
+}
+
+// Announcement-only parts of a message: the title rendered as a heading on the official card, the
+// linked plugins (0–3) resolved to { slug, name } for the "Open <Plugin>" chips, the id
+// reactions/replies key on, and the reply count for the "N replies" affordance. Peer posts and AI
+// answers carry null / [] / 0.
+function hubAnnouncementParts(
+  item: FeedTimelineItem,
+  linkedPluginsByAnnouncementId: Map<string, Array<{ slug: string; name: string }>>,
+): {
+  title: HubMessage['title'];
+  linkedPlugins: HubMessage['linkedPlugins'];
+  announcementId: HubMessage['announcementId'];
+  replyCount: HubMessage['replyCount'];
+} {
   const isAnnouncement = item.itemType === 'announcement';
   const title = isAnnouncement ? item.title || null : null;
-  const text = item.body;
-
-  // The linked plugins (0–3) for this announcement, resolved to { slug, name } for the clickable
-  // "Open <Plugin>" chips. Only announcements carry them; keyed by the source announcement id.
   const linkedPlugins = isAnnouncement && item.sourceAnnouncementId
     ? linkedPluginsByAnnouncementId.get(item.sourceAnnouncementId) ?? []
     : [];
-
-  // A peer post may quote another peer post (Signal-style reply). The quoted author handle
-  // and short snippet are resolved server-side in the feed repository and carried here.
-  const quotedMessage = isCommunity && item.community?.quotedPost
-    ? {
-        author: item.community.quotedPost.author,
-        snippet: item.community.quotedPost.snippet,
-        // The quoted post's id, so the client can scroll to the original when the quote is tapped.
-        postId: item.community.replyToPostId,
-      }
-    : null;
-
-  // Emoji reactions resolved server-side for the requesting member: from the community post for a
-  // peer message, from the announcement for an official one. Other messages carry an empty array.
-  const reactions = isCommunity && item.community
-    ? item.community.reactions
-    : isAnnouncement && item.announcement
-      ? item.announcement.reactions
-      : [];
-
-  // Announcement-only: the id reactions/replies key on, and the reply count for the "N replies"
-  // affordance on the official card. Peer posts and AI answers carry null / 0.
   const announcementId = isAnnouncement ? item.sourceAnnouncementId : null;
   const replyCount = isAnnouncement && item.announcement ? item.announcement.replyCount : 0;
+  return { title, linkedPlugins, announcementId, replyCount };
+}
+
+function mapTimelineItemToHubMessage(
+  item: FeedTimelineItem,
+  linkedPluginsByAnnouncementId: Map<string, Array<{ slug: string; name: string }>>,
+): HubMessage {
+  const author = hubMessageAuthor(item);
+  const { title, linkedPlugins, announcementId, replyCount } = hubAnnouncementParts(
+    item,
+    linkedPluginsByAnnouncementId,
+  );
 
   return {
     id: item.id,
-    userId: authorUserId,
-    username: authorUsername,
-    displayName,
+    userId: author.userId,
+    username: author.username,
+    displayName: author.displayName,
     avatarUrl: null,
     kind: item.itemType,
     title,
     linkedPlugins,
-    text,
+    // Announcements carry their title separately (above); the message text is the body alone.
+    // Questions/community posts are body-only.
+    text: item.body,
     sentAtIso: item.publishedAtIso,
-    communityPostId: isCommunity ? item.sourceCommunityPostId : null,
+    communityPostId: item.itemType === 'community' ? item.sourceCommunityPostId : null,
     announcementId,
-    quotedMessage,
-    reactions,
+    quotedMessage: hubQuotedMessage(item),
+    reactions: hubReactions(item),
     replyCount,
   };
+}
+
+// Resolve the timeline options from the request query. Precedence: mentions, then announcements,
+// then the unfiltered "all" stream (with optional deep-link "load around" ids).
+function resolveHubFeedOptions(
+  url: string,
+  username: string | null,
+  userId: string,
+): Parameters<typeof listFeedTimeline>[3] {
+  const params = new URL(url).searchParams;
+  // Optional mentions filter (`?mentions=me`): show only messages whose body @-mentions
+  // the CALLER. The handle forms are derived server-side from the authenticated user
+  // (`@<username>` and the `@user-<id token>` pseudonym) — a client-supplied handle is
+  // never trusted. Mentions mode is peer-chat only, so it reads just the community
+  // channel (announcements and AI Q&A cards are not part of the mentions view).
+  if (params.get('mentions') === 'me') {
+    return { channel: 'community', mentionHandles: feedMentionTokens(username, userId) };
+  }
+  // Announcements filter (`?channel=announcements`, from the 📣 chip): return only official
+  // announcements, including ones that scrolled off the recent page, so a member with limited
+  // history can still surface them. Only this value is honored; anything else falls back to 'all'.
+  // Mentions takes precedence when both are present.
+  if (params.get('channel') === 'announcements') {
+    return { channel: 'announcements' };
+  }
+  // Deep-link "load around" (`?aroundPost=<id>` / `?aroundAnnouncement=<id>`, from a notification's
+  // "Open"): return a page centered on that message so it lands even when it is older than the recent
+  // page. It reads the unfiltered stream (a deep link is not a mentions/announcements view) and only
+  // applies when no filter is active. An unknown/deleted id falls back to the normal recent page.
+  const aroundCommunityPostId = params.get('aroundPost');
+  const aroundAnnouncementId = aroundCommunityPostId ? null : params.get('aroundAnnouncement');
+  return { channel: 'all', aroundCommunityPostId, aroundAnnouncementId };
 }
 
 export async function GET(request: Request) {
@@ -102,38 +161,8 @@ export async function GET(request: Request) {
 
   try {
     const pagination = parsePaginationParams(request.url);
-    // Optional mentions filter (`?mentions=me`): show only messages whose body @-mentions
-    // the CALLER. The handle forms are derived server-side from the authenticated user
-    // (`@<username>` and the `@user-<id token>` pseudonym) — a client-supplied handle is
-    // never trusted. Mentions mode is peer-chat only, so it reads just the community
-    // channel (announcements and AI Q&A cards are not part of the mentions view).
-    const params = new URL(request.url).searchParams;
-    const mentionsMe = params.get('mentions') === 'me';
-    const mentionHandles = mentionsMe
-      ? feedMentionTokens(gate.identity.username, gate.auth.userId)
-      : null;
-    // Announcements filter (`?channel=announcements`, from the 📣 chip): return only official
-    // announcements, including ones that scrolled off the recent page, so a member with limited
-    // history can still surface them. Only this value is honored; anything else falls back to 'all'.
-    // Mentions takes precedence when both are present.
-    const announcementsOnly = !mentionsMe && params.get('channel') === 'announcements';
-    // Deep-link "load around" (`?aroundPost=<id>` / `?aroundAnnouncement=<id>`, from a notification's
-    // "Open"): return a page centered on that message so it lands even when it is older than the recent
-    // page. It reads the unfiltered stream (a deep link is not a mentions/announcements view) and only
-    // applies when no filter is active. An unknown/deleted id falls back to the normal recent page.
-    const aroundCommunityPostId = !mentionsMe && !announcementsOnly ? params.get('aroundPost') : null;
-    const aroundAnnouncementId =
-      !mentionsMe && !announcementsOnly && !aroundCommunityPostId ? params.get('aroundAnnouncement') : null;
-    const timeline = await listFeedTimeline(
-      gate.auth.userId,
-      gate.auth.role,
-      pagination,
-      mentionsMe
-        ? { channel: 'community', mentionHandles }
-        : announcementsOnly
-          ? { channel: 'announcements' }
-          : { channel: 'all', aroundCommunityPostId, aroundAnnouncementId },
-    );
+    const options = resolveHubFeedOptions(request.url, gate.identity.username, gate.auth.userId);
+    const timeline = await listFeedTimeline(gate.auth.userId, gate.auth.role, pagination, options);
 
     // Resolve the linked plugin (if any) for the announcements on this page, so each official card
     // can render a clickable "Open <Plugin>" chip. One batched lookup for all announcement ids.
@@ -195,6 +224,75 @@ function readQuotedMessage(value: unknown): HubMessage['quotedMessage'] {
   return { author: author.slice(0, 160), snippet: snippet.slice(0, 160), postId };
 }
 
+type HubPostInput = { body: string; replyToPostId: string | null };
+
+// Parse and validate the composer body. Admins (the owner) get a higher length + link cap so a
+// detailed welcome/help post is not blocked as spam; members keep the low caps. Returns a 400
+// response when the text is missing or fails the community-post rules.
+function validateHubPostInput(
+  body: MessageRequestBody,
+  isPrivileged: boolean,
+): { error: NextResponse } | { text: string; input: HubPostInput; echoedQuote: HubMessage['quotedMessage'] } {
+  const text = typeof body.text === 'string' ? body.text.trim() : '';
+  const replyToPostId = typeof body.replyToPostId === 'string' ? body.replyToPostId.trim() : null;
+  const echoedQuote = readQuotedMessage(body.quotedMessage);
+  const input: HubPostInput = { body: text, replyToPostId };
+  const maxLength = isPrivileged ? FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH : FEED_MAX_COMMUNITY_POST_LENGTH;
+  if (!text || !validateFeedCommunityPostInput(input, maxLength)) {
+    // Name the length when that is the reason. The composer blocks an over-limit send before it gets
+    // here, but a client with a wrong cap (an out-of-date tab, the API called directly) would
+    // otherwise get "must be a valid community post" and no idea what to change.
+    const overBy = normalizedPostLength(text) - maxLength;
+    return {
+      error: NextResponse.json(
+        {
+          ok: false,
+          message:
+            overBy > 0
+              ? `That message is ${overBy.toLocaleString()} characters over the ${maxLength.toLocaleString()}-character limit. Shorten it, or split it into two messages.`
+              : 'Message text must be a valid community post.',
+        },
+        { status: 400 },
+      ),
+    };
+  }
+  return { text, input, echoedQuote };
+}
+
+// Map a create-post failure to its response. Known error codes carry their own status; anything
+// else is reported to Sentry (caught errors do not reach it on their own) and returned as a
+// generic 503 — the underlying error is not safe to leak to the client.
+function mapHubPostError(error: unknown): NextResponse {
+  const code = error instanceof Error ? error.message : 'unknown_error';
+  if (code === 'rate_limit_exceeded') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'Posting rate limit exceeded.' },
+      { status: 429 },
+    );
+  }
+  if (code === 'content_policy_violation') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Post blocked by content moderation.' },
+      { status: 422 },
+    );
+  }
+  if (code === 'reply_target_invalid' || code === 'reply_target_not_found') {
+    return NextResponse.json(
+      { ok: false, message: 'The message you are replying to is no longer available.' },
+      { status: 400 },
+    );
+  }
+
+  Sentry.captureException(error, { tags: { area: 'hub', op: 'send_message' } });
+  return NextResponse.json(
+    {
+      ok: false,
+      message: 'Unable to send message.',
+    },
+    { status: 503 },
+  );
+}
+
 export async function POST(request: Request) {
   const gate = await requireHubAccess();
   if (!gate.allowed) {
@@ -219,30 +317,14 @@ export async function POST(request: Request) {
     );
   }
 
-  const text = typeof body.text === 'string' ? body.text.trim() : '';
-  const replyToPostId = typeof body.replyToPostId === 'string' ? body.replyToPostId.trim() : null;
-  const echoedQuote = readQuotedMessage(body.quotedMessage);
-  const input = { body: text, replyToPostId };
   // Admins (the owner) get a higher length + link cap so a detailed welcome/help post is not blocked
   // as spam; members keep the low caps.
   const isPrivileged = gate.auth.isAdmin;
-  const maxLength = isPrivileged ? FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH : FEED_MAX_COMMUNITY_POST_LENGTH;
-  if (!text || !validateFeedCommunityPostInput(input, maxLength)) {
-    // Name the length when that is the reason. The composer blocks an over-limit send before it gets
-    // here, but a client with a wrong cap (an out-of-date tab, the API called directly) would
-    // otherwise get "must be a valid community post" and no idea what to change.
-    const overBy = normalizedPostLength(text) - maxLength;
-    return NextResponse.json(
-      {
-        ok: false,
-        message:
-          overBy > 0
-            ? `That message is ${overBy.toLocaleString()} characters over the ${maxLength.toLocaleString()}-character limit. Shorten it, or split it into two messages.`
-            : 'Message text must be a valid community post.',
-      },
-      { status: 400 },
-    );
+  const validated = validateHubPostInput(body, isPrivileged);
+  if ('error' in validated) {
+    return validated.error;
   }
+  const { text, input, echoedQuote } = validated;
 
   try {
     // A message posted from the Hub input is a peer-to-peer community post.
@@ -268,7 +350,7 @@ export async function POST(request: Request) {
       announcementId: null,
       // Echo the quote the sender saw so the optimistic message renders it immediately. The
       // next polled read re-resolves it authoritatively from the stored reply_to_post_id.
-      quotedMessage: replyToPostId ? echoedQuote : null,
+      quotedMessage: input.replyToPostId ? echoedQuote : null,
       // A freshly created post has no reactions yet.
       reactions: [],
       // Peer posts are not replied to through the announcement thread.
@@ -277,36 +359,6 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true, message }, { status: 201 });
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'unknown_error';
-    if (code === 'rate_limit_exceeded') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.rateLimitExceeded, message: 'Posting rate limit exceeded.' },
-        { status: 429 },
-      );
-    }
-    if (code === 'content_policy_violation') {
-      return NextResponse.json(
-        { ok: false, code: FEED_ERROR_CODE.moderationRejected, message: 'Post blocked by content moderation.' },
-        { status: 422 },
-      );
-    }
-    if (code === 'reply_target_invalid' || code === 'reply_target_not_found') {
-      return NextResponse.json(
-        { ok: false, message: 'The message you are replying to is no longer available.' },
-        { status: 400 },
-      );
-    }
-
-    // Unexpected failure (e.g. a database error): report the real cause to Sentry so it
-    // is diagnosable in prod (caught errors do not reach Sentry on their own). The user
-    // still gets a generic message — the underlying error is not safe to leak to the client.
-    Sentry.captureException(error, { tags: { area: 'hub', op: 'send_message' } });
-    return NextResponse.json(
-      {
-        ok: false,
-        message: 'Unable to send message.',
-      },
-      { status: 503 },
-    );
+    return mapHubPostError(error);
   }
 }

--- a/ctf/packages/web/app/api/mood/submissions/route.ts
+++ b/ctf/packages/web/app/api/mood/submissions/route.ts
@@ -12,6 +12,61 @@ type SubmissionBody = {
 
 const SUBMIT_DATA_CLASSES = ['mood_value_metadata', 'mood_check_timing_metadata'];
 
+// Log the invalid-payload deny audit row and return the matching 400. Both boundary checks (missing
+// fields and out-of-range mood value) share the same deny shape, differing only in the message.
+function denyInvalidPayload(actorId: string, clientId: string | undefined, message: string): NextResponse {
+  logMoodAudit({
+    actorId,
+    command: 'mood.check.submit',
+    status: 'deny',
+    reason: 'invalid_mood_value',
+    evidence: { roleCheck: 'pass', moodBoundsCheck: 'fail', cooldownCheck: 'fail' },
+    dataClassesAccessed: SUBMIT_DATA_CLASSES,
+    target: { clientId },
+    result: 'failure',
+    errorCategory: 'invalid_payload',
+  });
+  return NextResponse.json({ ok: false, code: 'mood_invalid_payload', message }, { status: 400 });
+}
+
+// Log the deny audit row for a failed submission (cooldown or persistence) and return the error
+// response. A cooldown denial is expected member behaviour, so it is not reported as an error.
+function handleSubmissionError(actorId: string, clientId: string | undefined, error: unknown): NextResponse {
+  const cooldownDenied = error instanceof Error && error.message === 'cooldown_active';
+  logMoodAudit({
+    actorId,
+    command: 'mood.check.submit',
+    status: 'deny',
+    reason: cooldownDenied ? 'cooldown_not_elapsed' : 'persistence_error',
+    evidence: {
+      roleCheck: 'pass',
+      moodBoundsCheck: 'pass',
+      cooldownCheck: cooldownDenied ? 'fail' : 'pass',
+    },
+    dataClassesAccessed: SUBMIT_DATA_CLASSES,
+    target: { clientId },
+    result: 'failure',
+    errorCategory: cooldownDenied ? 'cooldown_active' : 'persistence_error',
+  });
+  if (!cooldownDenied) {
+    reportError(error, { area: 'mood', op: 'submissions' });
+  }
+  return moodErrorResponse(error, 'Mood submission unavailable.');
+}
+
+// Validate the submission body. The 1..5 integer bound is enforced at the API boundary so an
+// out-of-range value returns 400 (the invalid_mood_value denyCondition) rather than falling through
+// to the repository throw path. Returns a discriminated result so the caller keeps narrowing.
+function validateSubmissionBody(body: SubmissionBody): { error: string } | { data: { clientId: string; moodValue: number } } {
+  if (!body.clientId || typeof body.moodValue !== 'number') {
+    return { error: 'clientId and moodValue are required.' };
+  }
+  if (!Number.isInteger(body.moodValue) || body.moodValue < 1 || body.moodValue > 5) {
+    return { error: 'moodValue must be an integer from 1 to 5.' };
+  }
+  return { data: { clientId: body.clientId, moodValue: body.moodValue } };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -30,38 +85,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: 'mood_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (!body.clientId || typeof body.moodValue !== 'number') {
-    logMoodAudit({
-      actorId: gate.auth.userId,
-      command: 'mood.check.submit',
-      status: 'deny',
-      reason: 'invalid_mood_value',
-      evidence: { roleCheck: 'pass', moodBoundsCheck: 'fail', cooldownCheck: 'fail' },
-      dataClassesAccessed: SUBMIT_DATA_CLASSES,
-      target: { clientId: body.clientId },
-      result: 'failure',
-      errorCategory: 'invalid_payload',
-    });
-    return NextResponse.json({ ok: false, code: 'mood_invalid_payload', message: 'clientId and moodValue are required.' }, { status: 400 });
+  const validated = validateSubmissionBody(body);
+  if ('error' in validated) {
+    return denyInvalidPayload(gate.auth.userId, body.clientId, validated.error);
   }
-
-  // Enforce the 1..5 integer bound at the API boundary so an out-of-range value
-  // returns 400 (the invalid_mood_value denyCondition) rather than falling
-  // through to the repository throw path.
-  if (!Number.isInteger(body.moodValue) || body.moodValue < 1 || body.moodValue > 5) {
-    logMoodAudit({
-      actorId: gate.auth.userId,
-      command: 'mood.check.submit',
-      status: 'deny',
-      reason: 'invalid_mood_value',
-      evidence: { roleCheck: 'pass', moodBoundsCheck: 'fail', cooldownCheck: 'fail' },
-      dataClassesAccessed: SUBMIT_DATA_CLASSES,
-      target: { clientId: body.clientId },
-      result: 'failure',
-      errorCategory: 'invalid_payload',
-    });
-    return NextResponse.json({ ok: false, code: 'mood_invalid_payload', message: 'moodValue must be an integer from 1 to 5.' }, { status: 400 });
-  }
+  const { clientId, moodValue } = validated.data;
 
   try {
     // Resolve the server-controlled pseudonym for this user; the check-in is
@@ -69,8 +97,8 @@ export async function POST(request: Request) {
     const pseudonym = await getOrCreateMoodPseudonym(gate.auth.userId);
     const submission = await createMoodSubmission({
       pseudonym,
-      clientId: body.clientId,
-      moodValue: body.moodValue,
+      clientId,
+      moodValue,
       note: typeof body.note === 'string' ? body.note : null,
     });
 
@@ -81,32 +109,13 @@ export async function POST(request: Request) {
       reason: 'mood_check_recorded',
       evidence: { roleCheck: 'pass', moodBoundsCheck: 'pass', cooldownCheck: 'pass' },
       dataClassesAccessed: SUBMIT_DATA_CLASSES,
-      target: { clientId: body.clientId, checkId: submission.checkId },
+      target: { clientId, checkId: submission.checkId },
       result: 'success',
       errorCategory: null,
     });
 
     return NextResponse.json({ ok: true, submission }, { status: 201 });
   } catch (error) {
-    const cooldownDenied = error instanceof Error && error.message === 'cooldown_active';
-    logMoodAudit({
-      actorId: gate.auth.userId,
-      command: 'mood.check.submit',
-      status: 'deny',
-      reason: cooldownDenied ? 'cooldown_not_elapsed' : 'persistence_error',
-      evidence: {
-        roleCheck: 'pass',
-        moodBoundsCheck: 'pass',
-        cooldownCheck: cooldownDenied ? 'fail' : 'pass',
-      },
-      dataClassesAccessed: SUBMIT_DATA_CLASSES,
-      target: { clientId: body.clientId },
-      result: 'failure',
-      errorCategory: cooldownDenied ? 'cooldown_active' : 'persistence_error',
-    });
-    if (!cooldownDenied) {
-      reportError(error, { area: 'mood', op: 'submissions' });
-    }
-    return moodErrorResponse(error, 'Mood submission unavailable.');
+    return handleSubmissionError(gate.auth.userId, clientId, error);
   }
 }

--- a/ctf/packages/web/app/api/mood/submissions/route.ts
+++ b/ctf/packages/web/app/api/mood/submissions/route.ts
@@ -30,7 +30,7 @@ function denyInvalidPayload(actorId: string, clientId: string | undefined, messa
 }
 
 // Log the deny audit row for a failed submission (cooldown or persistence) and return the error
-// response. A cooldown denial is expected member behaviour, so it is not reported as an error.
+// response. A cooldown denial is expected member behavior, so it is not reported as an error.
 function handleSubmissionError(actorId: string, clientId: string | undefined, error: unknown): NextResponse {
   const cooldownDenied = error instanceof Error && error.message === 'cooldown_active';
   logMoodAudit({

--- a/ctf/packages/web/app/api/notifications/push/subscribe/route.ts
+++ b/ctf/packages/web/app/api/notifications/push/subscribe/route.ts
@@ -15,7 +15,7 @@ function invalidPayload(message: string): NextResponse {
 
 type PushSubscriptionPayload = { endpoint?: unknown; keys?: { p256dh?: unknown; auth?: unknown }; userAgent?: unknown };
 
-// Extract and normalise the subscription fields from the raw payload. A missing/odd endpoint becomes
+// Extract and normalize the subscription fields from the raw payload. A missing/odd endpoint becomes
 // an empty string and missing/odd keys become null, which the caller rejects with a 400. The user
 // agent is capped at 256 characters.
 function readSubscriptionFields(payload: PushSubscriptionPayload): { endpoint: string; p256dh: string | null; auth: string | null; userAgent: string | null } {

--- a/ctf/packages/web/app/api/notifications/push/subscribe/route.ts
+++ b/ctf/packages/web/app/api/notifications/push/subscribe/route.ts
@@ -4,6 +4,47 @@ import { saveWebPushSubscription } from 'lib/notifications/push';
 import { NOTIFICATION_ERROR_CODE } from 'lib/notifications/types';
 import { reportError } from 'lib/observability/report';
 
+type PushSubscriptionInput = { endpoint: string; p256dh: string; auth: string; userAgent: string | null };
+
+function invalidPayload(message: string): NextResponse {
+  return NextResponse.json(
+    { ok: false, code: NOTIFICATION_ERROR_CODE.invalidPayload, message },
+    { status: 400 },
+  );
+}
+
+type PushSubscriptionPayload = { endpoint?: unknown; keys?: { p256dh?: unknown; auth?: unknown }; userAgent?: unknown };
+
+// Extract and normalise the subscription fields from the raw payload. A missing/odd endpoint becomes
+// an empty string and missing/odd keys become null, which the caller rejects with a 400. The user
+// agent is capped at 256 characters.
+function readSubscriptionFields(payload: PushSubscriptionPayload): { endpoint: string; p256dh: string | null; auth: string | null; userAgent: string | null } {
+  const endpoint = typeof payload.endpoint === 'string' ? payload.endpoint.trim() : '';
+  const p256dh = typeof payload.keys?.p256dh === 'string' ? payload.keys.p256dh : null;
+  const auth = typeof payload.keys?.auth === 'string' ? payload.keys.auth : null;
+  const userAgent = typeof payload.userAgent === 'string' ? payload.userAgent.slice(0, 256) : null;
+  return { endpoint, p256dh, auth, userAgent };
+}
+
+// Parse and validate the push subscription body, extracting the endpoint/keys and capping the user
+// agent. Returns a discriminated result so the caller keeps TypeScript narrowing.
+async function parseSubscriptionRequest(request: Request): Promise<{ error: NextResponse } | { data: PushSubscriptionInput }> {
+  let payload: PushSubscriptionPayload;
+  try {
+    payload = await request.json();
+  } catch {
+    return { error: invalidPayload('A subscription is required.') };
+  }
+
+  const { endpoint, p256dh, auth, userAgent } = readSubscriptionFields(payload);
+
+  if (!endpoint || !p256dh || !auth) {
+    return { error: invalidPayload('A complete push subscription is required.') };
+  }
+
+  return { data: { endpoint, p256dh, auth, userAgent } };
+}
+
 // Save the signed-in member's Web Push subscription for one device, so their opted-in notifications can
 // also ping this device. Scoped to the caller's own subscription; stored in the user-global
 // push_subscriptions table (shared with Foundation call alerts) — a device subscribed once receives
@@ -19,27 +60,11 @@ export async function POST(request: Request) {
     return gate.response;
   }
 
-  let payload: { endpoint?: unknown; keys?: { p256dh?: unknown; auth?: unknown }; userAgent?: unknown };
-  try {
-    payload = await request.json();
-  } catch {
-    return NextResponse.json(
-      { ok: false, code: NOTIFICATION_ERROR_CODE.invalidPayload, message: 'A subscription is required.' },
-      { status: 400 },
-    );
+  const parsed = await parseSubscriptionRequest(request);
+  if ('error' in parsed) {
+    return parsed.error;
   }
-
-  const endpoint = typeof payload.endpoint === 'string' ? payload.endpoint.trim() : '';
-  const p256dh = typeof payload.keys?.p256dh === 'string' ? payload.keys.p256dh : null;
-  const auth = typeof payload.keys?.auth === 'string' ? payload.keys.auth : null;
-  const userAgent = typeof payload.userAgent === 'string' ? payload.userAgent.slice(0, 256) : null;
-
-  if (!endpoint || !p256dh || !auth) {
-    return NextResponse.json(
-      { ok: false, code: NOTIFICATION_ERROR_CODE.invalidPayload, message: 'A complete push subscription is required.' },
-      { status: 400 },
-    );
-  }
+  const { endpoint, p256dh, auth, userAgent } = parsed.data;
 
   try {
     await saveWebPushSubscription({ userId: gate.auth.userId, endpoint, p256dh, auth, userAgent });

--- a/ctf/packages/web/app/api/peer-programming/admin/topics/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/admin/topics/route.ts
@@ -11,6 +11,56 @@ type TopicBody = {
   publish?: boolean;
 };
 
+// Parse and validate the topic body. Returns the narrowed, required fields on success so the caller
+// keeps TypeScript's non-optional types; on failure returns the exact error response to send.
+type ParsedTopicBody =
+  | {
+      ok: true;
+      weekStartDate: string;
+      title: string;
+      guidance: string;
+      revisionNote: string | null | undefined;
+      publish: boolean | undefined;
+    }
+  | { ok: false; response: NextResponse };
+
+async function parseTopicBody(request: NextRequest): Promise<ParsedTopicBody> {
+  let body: TopicBody;
+  try {
+    body = (await request.json()) as TopicBody;
+  } catch {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 }) };
+  }
+
+  if (!body.weekStartDate || !body.title || !body.guidance) {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'weekStartDate, title, and guidance are required.' }, { status: 400 }) };
+  }
+
+  // The week key must be the Monday of the target week in YYYY-MM-DD form — room loads look the
+  // topic up by getWeekStartDate(), which always produces a Monday, so a topic saved under any
+  // other date would never be found. This is the contract's invalid_week_key deny condition.
+  const weekKeyMatch = /^\d{4}-\d{2}-\d{2}$/.test(body.weekStartDate);
+  const parsedWeekStart = new Date(`${body.weekStartDate}T00:00:00Z`);
+  if (!weekKeyMatch || Number.isNaN(parsedWeekStart.getTime()) || parsedWeekStart.getUTCDay() !== 1) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: 'peer_programming_invalid_week_key', message: 'weekStartDate must be the Monday of the target week, as YYYY-MM-DD.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    weekStartDate: body.weekStartDate,
+    title: body.title,
+    guidance: body.guidance,
+    revisionNote: body.revisionNote,
+    publish: body.publish,
+  };
+}
+
 export async function GET() {
   const gate = await requirePeerProgrammingAdminAccess();
   if (!gate.allowed) {
@@ -37,28 +87,11 @@ export async function PUT(request: NextRequest) {
     return gate.response;
   }
 
-  let body: TopicBody;
-  try {
-    body = (await request.json()) as TopicBody;
-  } catch {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
+  const parsed = await parseTopicBody(request);
+  if (!parsed.ok) {
+    return parsed.response;
   }
-
-  if (!body.weekStartDate || !body.title || !body.guidance) {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'weekStartDate, title, and guidance are required.' }, { status: 400 });
-  }
-
-  // The week key must be the Monday of the target week in YYYY-MM-DD form — room loads look the
-  // topic up by getWeekStartDate(), which always produces a Monday, so a topic saved under any
-  // other date would never be found. This is the contract's invalid_week_key deny condition.
-  const weekKeyMatch = /^\d{4}-\d{2}-\d{2}$/.test(body.weekStartDate);
-  const parsedWeekStart = new Date(`${body.weekStartDate}T00:00:00Z`);
-  if (!weekKeyMatch || Number.isNaN(parsedWeekStart.getTime()) || parsedWeekStart.getUTCDay() !== 1) {
-    return NextResponse.json(
-      { ok: false, code: 'peer_programming_invalid_week_key', message: 'weekStartDate must be the Monday of the target week, as YYYY-MM-DD.' },
-      { status: 400 },
-    );
-  }
+  const body = parsed;
 
   try {
     const topic = await upsertWeeklyTopic({

--- a/ctf/packages/web/app/api/peer-programming/feedback/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/feedback/route.ts
@@ -21,6 +21,63 @@ function isReleaseSurface(value: string): value is ReleaseSurface {
   return (RELEASE_SURFACES as readonly string[]).includes(value);
 }
 
+// Parse and validate the feedback body. Returns the narrowed, required fields on success so the
+// caller keeps TypeScript's non-optional types; on failure returns the exact 400 response to send.
+type ParsedFeedbackBody =
+  | {
+      ok: true;
+      cohortId: string | null | undefined;
+      issueType: string;
+      suggestionCategory: string;
+      releaseSurface: ReleaseSurface | undefined;
+      note: string;
+    }
+  | { ok: false; response: NextResponse };
+
+async function parseFeedbackBody(request: Request): Promise<ParsedFeedbackBody> {
+  let body: FeedbackBody;
+  try {
+    body = (await request.json()) as FeedbackBody;
+  } catch {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 }) };
+  }
+
+  if (!body.issueType || !body.suggestionCategory || !body.note) {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'issueType, suggestionCategory and note are required.' }, { status: 400 }) };
+  }
+
+  // releaseSurface stays optional (older clients omit it and mean the web app), but a supplied
+  // value must be one of the contract's enum members — anything else is refused, not persisted.
+  if (body.releaseSurface !== undefined && !isReleaseSurface(body.releaseSurface)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: 'peer_programming_invalid_payload', message: 'releaseSurface must be "web" or "android".' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (body.note.length > PEER_PROGRAMMING_MAX_FEEDBACK_LENGTH) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: 'peer_programming_invalid_payload', message: `Feedback note must be ${PEER_PROGRAMMING_MAX_FEEDBACK_LENGTH} characters or fewer.` },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    cohortId: body.cohortId,
+    issueType: body.issueType,
+    suggestionCategory: body.suggestionCategory,
+    releaseSurface: body.releaseSurface,
+    note: body.note,
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -32,32 +89,11 @@ export async function POST(request: Request) {
     return gate.response;
   }
 
-  let body: FeedbackBody;
-  try {
-    body = (await request.json()) as FeedbackBody;
-  } catch {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
+  const parsed = await parseFeedbackBody(request);
+  if (!parsed.ok) {
+    return parsed.response;
   }
-
-  if (!body.issueType || !body.suggestionCategory || !body.note) {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'issueType, suggestionCategory and note are required.' }, { status: 400 });
-  }
-
-  // releaseSurface stays optional (older clients omit it and mean the web app), but a supplied
-  // value must be one of the contract's enum members — anything else is refused, not persisted.
-  if (body.releaseSurface !== undefined && !isReleaseSurface(body.releaseSurface)) {
-    return NextResponse.json(
-      { ok: false, code: 'peer_programming_invalid_payload', message: 'releaseSurface must be "web" or "android".' },
-      { status: 400 },
-    );
-  }
-
-  if (body.note.length > PEER_PROGRAMMING_MAX_FEEDBACK_LENGTH) {
-    return NextResponse.json(
-      { ok: false, code: 'peer_programming_invalid_payload', message: `Feedback note must be ${PEER_PROGRAMMING_MAX_FEEDBACK_LENGTH} characters or fewer.` },
-      { status: 400 },
-    );
-  }
+  const body = parsed;
 
   try {
     await submitFeedback({

--- a/ctf/packages/web/app/api/peer-programming/messages/[messageId]/replies/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/messages/[messageId]/replies/route.ts
@@ -9,7 +9,36 @@ type ReplyBody = {
   body?: string;
 };
 
+// Parse and validate the reply body. Returns the narrowed, required fields on success so the caller
+// keeps TypeScript's non-optional types; on failure returns the exact 400 response to send.
+type ParsedReplyBody =
+  | { ok: true; cohortId: string; body: string }
+  | { ok: false; response: NextResponse };
 
+async function parseReplyBody(request: Request): Promise<ParsedReplyBody> {
+  let body: ReplyBody;
+  try {
+    body = (await request.json()) as ReplyBody;
+  } catch {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 }) };
+  }
+
+  if (!body.cohortId || !body.body) {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'cohortId and body are required.' }, { status: 400 }) };
+  }
+
+  if (body.body.length > PEER_PROGRAMMING_MAX_MESSAGE_LENGTH) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: 'peer_programming_invalid_payload', message: `Reply body must be ${PEER_PROGRAMMING_MAX_MESSAGE_LENGTH} characters or fewer.` },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, cohortId: body.cohortId, body: body.body };
+}
 
 export async function POST(request: Request, context: { params: Promise<{ messageId: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
@@ -22,23 +51,11 @@ export async function POST(request: Request, context: { params: Promise<{ messag
     return gate.response;
   }
 
-  let body: ReplyBody;
-  try {
-    body = (await request.json()) as ReplyBody;
-  } catch {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
+  const parsed = await parseReplyBody(request);
+  if (!parsed.ok) {
+    return parsed.response;
   }
-
-  if (!body.cohortId || !body.body) {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'cohortId and body are required.' }, { status: 400 });
-  }
-
-  if (body.body.length > PEER_PROGRAMMING_MAX_MESSAGE_LENGTH) {
-    return NextResponse.json(
-      { ok: false, code: 'peer_programming_invalid_payload', message: `Reply body must be ${PEER_PROGRAMMING_MAX_MESSAGE_LENGTH} characters or fewer.` },
-      { status: 400 },
-    );
-  }
+  const body = parsed;
 
   const { messageId } = await context.params;
 

--- a/ctf/packages/web/app/api/peer-programming/messages/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/messages/route.ts
@@ -10,6 +10,64 @@ type CreateMessageBody = {
   body?: string;
 };
 
+// Parse and validate the request body. Returns the narrowed, required fields on success so the
+// caller keeps TypeScript's non-optional types; on failure returns the exact 400 response to send.
+type ParsedMessageBody =
+  | { ok: true; cohortId: string; body: string }
+  | { ok: false; response: NextResponse };
+
+async function parseCreateMessageBody(request: Request): Promise<ParsedMessageBody> {
+  let body: CreateMessageBody;
+  try {
+    body = (await request.json()) as CreateMessageBody;
+  } catch {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 }) };
+  }
+
+  if (!body.cohortId || !body.body) {
+    return { ok: false, response: NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'cohortId and body are required.' }, { status: 400 }) };
+  }
+
+  if (body.body.length > PEER_PROGRAMMING_MAX_MESSAGE_LENGTH) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { ok: false, code: 'peer_programming_invalid_payload', message: `Message body must be ${PEER_PROGRAMMING_MAX_MESSAGE_LENGTH} characters or fewer.` },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, cohortId: body.cohortId, body: body.body };
+}
+
+// Notify the other cohort members that a message landed — best-effort, after the write, never the
+// sender. Cohorts are small, so a per-member notification per message is fine; the notification is
+// deduped per (member, message) via target_ref. This is what surfaces a cohort message in the 🔔
+// notifications center and (for members who opted the Community category in) pings their device.
+async function notifyCohortMembers(cohortId: string, senderUserId: string, messageId: string): Promise<void> {
+  try {
+    const membersByCohort = await listCohortMemberUserIds([cohortId]);
+    const memberIds = membersByCohort.get(cohortId) ?? [];
+    for (const memberId of memberIds) {
+      if (memberId === senderUserId) {
+        continue;
+      }
+      await notifySafe({
+        userId: memberId,
+        sourcePlugin: 'peer-programming',
+        notificationType: 'peer-programming.cohort.message',
+        category: 'community',
+        summary: 'New message in your PeerProgramming cohort.',
+        linkPath: `/apps/peer-programming?cohortId=${encodeURIComponent(cohortId)}`,
+        targetRef: messageId,
+      });
+    }
+  } catch (notifyError) {
+    reportError(notifyError, { area: 'peer-programming', op: 'emit_cohort_message_notification' });
+  }
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -21,23 +79,11 @@ export async function POST(request: Request) {
     return gate.response;
   }
 
-  let body: CreateMessageBody;
-  try {
-    body = (await request.json()) as CreateMessageBody;
-  } catch {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
+  const parsed = await parseCreateMessageBody(request);
+  if (!parsed.ok) {
+    return parsed.response;
   }
-
-  if (!body.cohortId || !body.body) {
-    return NextResponse.json({ ok: false, code: 'peer_programming_invalid_payload', message: 'cohortId and body are required.' }, { status: 400 });
-  }
-
-  if (body.body.length > PEER_PROGRAMMING_MAX_MESSAGE_LENGTH) {
-    return NextResponse.json(
-      { ok: false, code: 'peer_programming_invalid_payload', message: `Message body must be ${PEER_PROGRAMMING_MAX_MESSAGE_LENGTH} characters or fewer.` },
-      { status: 400 },
-    );
-  }
+  const body = parsed;
 
   // Only a member of the cohort may post into it. The tier is decided here from that
   // membership, never trusted from the request body — an authenticated non-member
@@ -92,30 +138,7 @@ export async function POST(request: Request) {
       targetId: message.id,
     });
 
-    // Notify the other cohort members that a message landed — best-effort, after the write, never the
-    // sender. Cohorts are small, so a per-member notification per message is fine; the notification is
-    // deduped per (member, message) via target_ref. This is what surfaces a cohort message in the 🔔
-    // notifications center and (for members who opted the Community category in) pings their device.
-    try {
-      const membersByCohort = await listCohortMemberUserIds([body.cohortId]);
-      const memberIds = membersByCohort.get(body.cohortId) ?? [];
-      for (const memberId of memberIds) {
-        if (memberId === gate.auth.userId) {
-          continue;
-        }
-        await notifySafe({
-          userId: memberId,
-          sourcePlugin: 'peer-programming',
-          notificationType: 'peer-programming.cohort.message',
-          category: 'community',
-          summary: 'New message in your PeerProgramming cohort.',
-          linkPath: `/apps/peer-programming?cohortId=${encodeURIComponent(body.cohortId)}`,
-          targetRef: message.id,
-        });
-      }
-    } catch (notifyError) {
-      reportError(notifyError, { area: 'peer-programming', op: 'emit_cohort_message_notification' });
-    }
+    await notifyCohortMembers(body.cohortId, gate.auth.userId, message.id);
 
     return NextResponse.json({ ok: true, message }, { status: 201 });
   } catch (error) {

--- a/ctf/packages/web/app/api/peer-programming/room/route.ts
+++ b/ctf/packages/web/app/api/peer-programming/room/route.ts
@@ -11,6 +11,7 @@ import {
   listMessages,
 } from 'lib/peer-programming/repository';
 import { buildCohortRosters, type CohortMember } from 'lib/peer-programming/roster';
+import type { PeerProgrammingCohort, PeerProgrammingMessage, PeerProgrammingTopic } from 'lib/peer-programming/types';
 import { reportError } from 'lib/observability/report';
 
 // How the requester relates to the cohort they are viewing:
@@ -18,6 +19,86 @@ import { reportError } from 'lib/observability/report';
 //   - admin:    an admin viewing a cohort they were not placed in, so they can manage it.
 //   - listener: any other signed-in member listening in on a running cohort (read-only).
 type RoomAccess = 'member' | 'admin' | 'listener';
+
+// Decide the access label for a resolved cohort from membership + admin status: a member can post,
+// an admin who is not a member can manage, anyone else listens in read-only.
+function pickAccess(isMember: boolean, isAdmin: boolean): RoomAccess {
+  return isMember ? 'member' : isAdmin ? 'admin' : 'listener';
+}
+
+// Resolve which cohort's room to open. With no ?cohortId the member sees their own cohort
+// (today's behavior). With a ?cohortId an admin or any signed-in member can open another
+// running cohort to listen in — read-only unless they are actually a member of it.
+async function resolveRoom(
+  myCohort: PeerProgrammingCohort | null,
+  requestedCohortId: string | null,
+  userId: string,
+  isAdmin: boolean,
+): Promise<{ cohort: PeerProgrammingCohort | null; access: RoomAccess }> {
+  let cohort = myCohort;
+  let access: RoomAccess = myCohort ? 'member' : 'listener';
+
+  if (requestedCohortId) {
+    const requested =
+      myCohort && myCohort.id === requestedCohortId ? myCohort : await getCohortById(requestedCohortId);
+    if (requested) {
+      cohort = requested;
+      const member = myCohort?.id === requested.id || (await isCohortMember(requested.id, userId));
+      access = pickAccess(member, isAdmin);
+    }
+  }
+
+  return { cohort, access };
+}
+
+// Who is in the open cohort, with resolved usernames, so members (and listeners) can see who
+// their cohort-mates are. Membership is not secret. Empty when no cohort is open.
+//
+// The roster is best-effort and must never blank the room: each name is resolved via an external
+// Clerk lookup, so if that is slow or fails the room still renders with an empty roster rather
+// than the whole page failing. It is also capped (PEER_PROGRAMMING_ROOM_ROSTER_LIMIT) because the
+// standing cohort can hold every active member; the true total still shows as the member count.
+async function loadRoster(cohort: PeerProgrammingCohort | null): Promise<CohortMember[]> {
+  if (!cohort) {
+    return [];
+  }
+  try {
+    return (await buildCohortRosters([cohort.id], PEER_PROGRAMMING_ROOM_ROSTER_LIMIT)).get(cohort.id) ?? [];
+  } catch (rosterError) {
+    reportError(rosterError, { area: 'peer-programming', op: 'room_roster' });
+    return [];
+  }
+}
+
+// Assemble the room response body.
+function buildRoomPayload(args: {
+  topic: PeerProgrammingTopic | null;
+  cohort: PeerProgrammingCohort | null;
+  members: CohortMember[];
+  messages: PeerProgrammingMessage[];
+  cohorts: PeerProgrammingCohort[];
+  myCohort: PeerProgrammingCohort | null;
+  access: RoomAccess;
+}) {
+  const { topic, cohort, members, messages, cohorts, myCohort, access } = args;
+  return {
+    ok: true,
+    topic,
+    cohort,
+    members,
+    messages,
+    // The full set of running cohorts for the week so the room can show "listen in on a running
+    // cohort" to a member who was not placed here, and so an admin can reach every cohort.
+    cohorts,
+    myCohortId: myCohort?.id ?? null,
+    access,
+    isMember: access === 'member',
+    fallbackOpen: cohort?.fallbackOpen ?? true,
+    // An ended cohort is read-only: the client hides the composer and shows an "ended" notice, and
+    // the message/reply routes reject posting to it server-side.
+    ended: cohort ? cohort.status === 'ended' : false,
+  };
+}
 
 export async function GET(request: Request) {
   const gate = await requirePeerProgrammingReadAccess();
@@ -39,57 +120,19 @@ export async function GET(request: Request) {
       listActiveCohorts(),
     ]);
 
-    // Resolve which cohort's room to open. With no ?cohortId the member sees their own cohort
-    // (today's behavior). With a ?cohortId an admin or any signed-in member can open another
-    // running cohort to listen in — read-only unless they are actually a member of it.
-    let cohort = myCohort;
-    let access: RoomAccess = myCohort ? 'member' : 'listener';
-
-    if (requestedCohortId) {
-      const requested =
-        myCohort && myCohort.id === requestedCohortId ? myCohort : await getCohortById(requestedCohortId);
-      if (requested) {
-        cohort = requested;
-        const member = myCohort?.id === requested.id || (await isCohortMember(requested.id, gate.auth.userId));
-        access = member ? 'member' : gate.auth.isAdmin ? 'admin' : 'listener';
-      }
-    }
+    const { cohort, access } = await resolveRoom(
+      myCohort,
+      requestedCohortId,
+      gate.auth.userId,
+      gate.auth.isAdmin,
+    );
 
     const messages = cohort ? await listMessages(cohort.id) : [];
-    // Who is in the open cohort, with resolved usernames, so members (and listeners) can see who
-    // their cohort-mates are. Membership is not secret. Empty when no cohort is open.
-    //
-    // The roster is best-effort and must never blank the room: each name is resolved via an external
-    // Clerk lookup, so if that is slow or fails the room still renders with an empty roster rather
-    // than the whole page failing. It is also capped (PEER_PROGRAMMING_ROOM_ROSTER_LIMIT) because the
-    // standing cohort can hold every active member; the true total still shows as the member count.
-    let members: CohortMember[] = [];
-    if (cohort) {
-      try {
-        members = (await buildCohortRosters([cohort.id], PEER_PROGRAMMING_ROOM_ROSTER_LIMIT)).get(cohort.id) ?? [];
-      } catch (rosterError) {
-        reportError(rosterError, { area: 'peer-programming', op: 'room_roster' });
-        members = [];
-      }
-    }
+    const members = await loadRoster(cohort);
 
-    return NextResponse.json({
-      ok: true,
-      topic,
-      cohort,
-      members,
-      messages,
-      // The full set of running cohorts for the week so the room can show "listen in on a running
-      // cohort" to a member who was not placed here, and so an admin can reach every cohort.
-      cohorts,
-      myCohortId: myCohort?.id ?? null,
-      access,
-      isMember: access === 'member',
-      fallbackOpen: cohort?.fallbackOpen ?? true,
-      // An ended cohort is read-only: the client hides the composer and shows an "ended" notice, and
-      // the message/reply routes reject posting to it server-side.
-      ended: cohort ? cohort.status === 'ended' : false,
-    });
+    return NextResponse.json(
+      buildRoomPayload({ topic, cohort, members, messages, cohorts, myCohort, access }),
+    );
   } catch (error) {
     reportError(error, { area: 'peer-programming', op: 'room' });
     return peerProgrammingErrorResponse(error, 'PeerProgramming room unavailable.');

--- a/ctf/packages/web/app/api/recurring-activity/route.ts
+++ b/ctf/packages/web/app/api/recurring-activity/route.ts
@@ -45,6 +45,77 @@ async function withCounterpartyNames(activities: RecurringActivity[], readerUser
   });
 }
 
+// A validation failure carries the audit `reason` and the member-facing `message` so the caller can
+// record the deny audit row and return the 400 in one place.
+type CreateDeny = { reason: string; message: string };
+
+type ValidatedCreateBody = {
+  counterpartyUserId: string;
+  sector: RecurringActivitySector;
+  currencyCode: string;
+  cadence: RecurringActivityCadence;
+  visibility: RecurringActivityVisibility | undefined;
+  scValue: number | null | undefined;
+};
+
+// scValue is optional; an empty string / null / undefined means "not provided". A present value must
+// parse to a finite number. Returns a discriminated result so the caller keeps narrowing.
+function parseScValue(raw: unknown): { error: CreateDeny } | { data: number | null | undefined } {
+  if (raw === undefined || raw === null || raw === '') {
+    return { data: undefined };
+  }
+  const parsed = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return { error: { reason: 'invalid_sc_value', message: 'scValue must be a number.' } };
+  }
+  return { data: parsed };
+}
+
+// Validate the create-activity body. Returns a discriminated result so the caller keeps TypeScript
+// narrowing on the validated fields and records the deny audit row itself on failure.
+function validateCreateBody(body: Record<string, unknown>): { error: CreateDeny } | { data: ValidatedCreateBody } {
+  const counterpartyUserId = typeof body.counterpartyUserId === 'string' ? body.counterpartyUserId.trim() : '';
+  const sector = body.sector;
+  const currencyCode = typeof body.currencyCode === 'string' ? body.currencyCode.trim() : '';
+  const cadence = body.cadence;
+  const visibility = body.visibility;
+
+  if (!counterpartyUserId) {
+    return { error: { reason: 'missing_counterparty', message: 'counterpartyUserId is required.' } };
+  }
+  if (!RECURRING_ACTIVITY_SECTORS.includes(sector as RecurringActivitySector)) {
+    return { error: { reason: 'invalid_sector', message: `sector must be one of: ${RECURRING_ACTIVITY_SECTORS.join(', ')}.` } };
+  }
+  if (!currencyCode) {
+    return { error: { reason: 'missing_currency', message: 'currencyCode is required.' } };
+  }
+  if (!RECURRING_ACTIVITY_CADENCES.includes(cadence as RecurringActivityCadence)) {
+    return { error: { reason: 'invalid_cadence', message: `cadence must be one of: ${RECURRING_ACTIVITY_CADENCES.join(', ')}.` } };
+  }
+  if (
+    visibility !== undefined &&
+    !RECURRING_ACTIVITY_VISIBILITY_VALUES.includes(visibility as RecurringActivityVisibility)
+  ) {
+    return { error: { reason: 'invalid_visibility', message: `visibility must be one of: ${RECURRING_ACTIVITY_VISIBILITY_VALUES.join(', ')}.` } };
+  }
+
+  const scValueResult = parseScValue(body.scValue);
+  if ('error' in scValueResult) {
+    return scValueResult;
+  }
+
+  return {
+    data: {
+      counterpartyUserId,
+      sector: sector as RecurringActivitySector,
+      currencyCode,
+      cadence: cadence as RecurringActivityCadence,
+      visibility: visibility as RecurringActivityVisibility | undefined,
+      scValue: scValueResult.data,
+    },
+  };
+}
+
 // GET /api/recurring-activity — the caller's own ongoing activities (both sides), newest first.
 export async function GET() {
   const gate = await requireRecurringActivityAccess();
@@ -98,49 +169,21 @@ export async function POST(request: Request) {
     return denyBadRequest('invalid_json', 'Invalid JSON body.');
   }
 
-  const counterpartyUserId = typeof body.counterpartyUserId === 'string' ? body.counterpartyUserId.trim() : '';
-  const sector = body.sector;
-  const currencyCode = typeof body.currencyCode === 'string' ? body.currencyCode.trim() : '';
-  const cadence = body.cadence;
-  const visibility = body.visibility;
-
-  if (!counterpartyUserId) {
-    return denyBadRequest('missing_counterparty', 'counterpartyUserId is required.');
+  const validated = validateCreateBody(body);
+  if ('error' in validated) {
+    return denyBadRequest(validated.error.reason, validated.error.message);
   }
-  if (!RECURRING_ACTIVITY_SECTORS.includes(sector as RecurringActivitySector)) {
-    return denyBadRequest('invalid_sector', `sector must be one of: ${RECURRING_ACTIVITY_SECTORS.join(', ')}.`);
-  }
-  if (!currencyCode) {
-    return denyBadRequest('missing_currency', 'currencyCode is required.');
-  }
-  if (!RECURRING_ACTIVITY_CADENCES.includes(cadence as RecurringActivityCadence)) {
-    return denyBadRequest('invalid_cadence', `cadence must be one of: ${RECURRING_ACTIVITY_CADENCES.join(', ')}.`);
-  }
-  if (
-    visibility !== undefined &&
-    !RECURRING_ACTIVITY_VISIBILITY_VALUES.includes(visibility as RecurringActivityVisibility)
-  ) {
-    return denyBadRequest('invalid_visibility', `visibility must be one of: ${RECURRING_ACTIVITY_VISIBILITY_VALUES.join(', ')}.`);
-  }
-
-  let scValue: number | null | undefined;
-  if (body.scValue !== undefined && body.scValue !== null && body.scValue !== '') {
-    const parsed = typeof body.scValue === 'number' ? body.scValue : Number(body.scValue);
-    if (!Number.isFinite(parsed)) {
-      return denyBadRequest('invalid_sc_value', 'scValue must be a number.');
-    }
-    scValue = parsed;
-  }
+  const { counterpartyUserId, sector, currencyCode, cadence, visibility, scValue } = validated.data;
 
   try {
     const activity = await createRecurringActivity({
       ownerUserId: userId,
       counterpartyUserId,
-      sector: sector as RecurringActivitySector,
+      sector,
       currencyCode,
-      cadence: cadence as RecurringActivityCadence,
+      cadence,
       scValue,
-      visibility: visibility as RecurringActivityVisibility | undefined,
+      visibility,
     });
     await logRecurringActivityAuditEvent({
       actorUserId: userId,

--- a/ctf/packages/web/app/api/socket-relay/_lib.ts
+++ b/ctf/packages/web/app/api/socket-relay/_lib.ts
@@ -75,107 +75,36 @@ export function parsePositiveInteger(value: string | null, fallback: number): nu
   return parsed;
 }
 
+// Maps a thrown error code (the Error message) to its canonical response code, member-facing message,
+// and HTTP status. The resolve-flow entries (actor_not_requester, fulfillment_not_active,
+// invalid_outcome) are here for a reason: without them, an authorization denial (a helper trying to
+// resolve) and a conflict (resolving an already-resolved fulfillment) both fell through to the 503
+// default branch — reporting an authz/conflict as a server outage and firing a spurious error alert.
+const SOCKET_RELAY_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  request_not_found: { code: SOCKET_RELAY_ERROR_CODE.requestNotFound, message: 'SocketRelay request not found.', status: 404 },
+  fulfillment_not_found: { code: SOCKET_RELAY_ERROR_CODE.fulfillmentNotFound, message: 'SocketRelay fulfillment not found.', status: 404 },
+  profile_not_found: { code: SOCKET_RELAY_ERROR_CODE.profileNotFound, message: 'SocketRelay profile not found.', status: 404 },
+  not_owner: { code: SOCKET_RELAY_ERROR_CODE.notOwner, message: 'Operation requires ownership.', status: 403 },
+  request_not_claimable: { code: SOCKET_RELAY_ERROR_CODE.requestNotClaimable, message: 'Request is not claimable.', status: 409 },
+  request_expired: { code: SOCKET_RELAY_ERROR_CODE.requestExpired, message: 'This request has expired. The person who posted it can re-post it.', status: 409 },
+  request_not_repostable: { code: SOCKET_RELAY_ERROR_CODE.requestNotRepostable, message: 'This request has an active helper — resolve the Direct Line before re-posting.', status: 409 },
+  actor_not_requester: { code: SOCKET_RELAY_ERROR_CODE.actorNotRequester, message: 'Only the person who posted this request can resolve it.', status: 403 },
+  fulfillment_not_active: { code: SOCKET_RELAY_ERROR_CODE.fulfillmentNotActive, message: 'This Direct Line is already resolved.', status: 409 },
+  invalid_outcome: { code: SOCKET_RELAY_ERROR_CODE.invalidOutcome, message: 'Choose how to resolve this request.', status: 400 },
+  actor_is_owner: { code: SOCKET_RELAY_ERROR_CODE.actorIsOwner, message: 'Request owner cannot claim fulfillment.', status: 403 },
+  actor_not_participant: { code: SOCKET_RELAY_ERROR_CODE.actorNotParticipant, message: 'Not a fulfillment participant.', status: 403 },
+  prohibited_content_detected: { code: SOCKET_RELAY_ERROR_CODE.prohibitedContent, message: 'Message rejected by moderation policy.', status: 400 },
+  'invalid payload': { code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },
+};
+
 export function socketRelayErrorResponse(error: unknown, fallbackMessage: string) {
   const code = error instanceof Error ? error.message : '';
 
-  if (code === 'request_not_found') {
+  const mapped = SOCKET_RELAY_ERROR_RESPONSES[code];
+  if (mapped) {
     return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.requestNotFound, message: 'SocketRelay request not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'fulfillment_not_found') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.fulfillmentNotFound, message: 'SocketRelay fulfillment not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'profile_not_found') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.profileNotFound, message: 'SocketRelay profile not found.' },
-      { status: 404 },
-    );
-  }
-
-  if (code === 'not_owner') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.notOwner, message: 'Operation requires ownership.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'request_not_claimable') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.requestNotClaimable, message: 'Request is not claimable.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'request_expired') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.requestExpired, message: 'This request has expired. The person who posted it can re-post it.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'request_not_repostable') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.requestNotRepostable, message: 'This request has an active helper — resolve the Direct Line before re-posting.' },
-      { status: 409 },
-    );
-  }
-
-  // Resolve-flow errors from resolveFulfillment. Without these, an authorization denial (a helper trying
-  // to resolve) and a conflict (resolving an already-resolved fulfillment) both fell through to the 503
-  // default branch — reporting an authz/conflict as a server outage and firing a spurious error alert.
-  if (code === 'actor_not_requester') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.actorNotRequester, message: 'Only the person who posted this request can resolve it.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'fulfillment_not_active') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.fulfillmentNotActive, message: 'This Direct Line is already resolved.' },
-      { status: 409 },
-    );
-  }
-
-  if (code === 'invalid_outcome') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.invalidOutcome, message: 'Choose how to resolve this request.' },
-      { status: 400 },
-    );
-  }
-
-  if (code === 'actor_is_owner') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.actorIsOwner, message: 'Request owner cannot claim fulfillment.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'actor_not_participant') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.actorNotParticipant, message: 'Not a fulfillment participant.' },
-      { status: 403 },
-    );
-  }
-
-  if (code === 'prohibited_content_detected') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.prohibitedContent, message: 'Message rejected by moderation policy.' },
-      { status: 400 },
-    );
-  }
-
-  if (code === 'invalid payload') {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: 'Invalid payload.' },
-      { status: 400 },
+      { ok: false, code: mapped.code, message: mapped.message },
+      { status: mapped.status },
     );
   }
 

--- a/ctf/packages/web/app/api/socket-relay/fulfillments/[id]/chat/route.ts
+++ b/ctf/packages/web/app/api/socket-relay/fulfillments/[id]/chat/route.ts
@@ -5,6 +5,31 @@ import { getFulfillmentById } from 'lib/socket-relay/repository';
 import { buildIdentityDisplayName } from 'lib/auth/request-identity';
 import { reportError } from 'lib/observability/report';
 
+type Fulfillment = NonNullable<Awaited<ReturnType<typeof getFulfillmentById>>>;
+
+// Resolve the fulfillment for a participant, or return the appropriate error response.
+// 404 only when it genuinely does not exist; a non-participant on an existing fulfillment gets 403.
+// Returning 404 for the authorization failure would leak existence (a caller could tell "does not
+// exist" from "exists but not mine"), and it would diverge from the sibling routes that return 403.
+async function loadParticipantFulfillment(
+  id: string,
+  userId: string,
+): Promise<{ error: NextResponse } | { fulfillment: Fulfillment }> {
+  const fulfillment = await getFulfillmentById(id);
+  if (!fulfillment) {
+    return { error: NextResponse.json({ ok: false, message: 'Fulfillment not found' }, { status: 404 }) };
+  }
+  if (fulfillment.requesterUserId !== userId && fulfillment.fulfillerUserId !== userId) {
+    return {
+      error: NextResponse.json(
+        { ok: false, message: 'You are not a participant in this Direct Line' },
+        { status: 403 },
+      ),
+    };
+  }
+  return { fulfillment };
+}
+
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -23,16 +48,11 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
 
   const userId = gate.auth.userId;
 
-  const fulfillment = await getFulfillmentById(id);
-  // 404 only when it genuinely does not exist; a non-participant on an existing fulfillment gets 403.
-  // Returning 404 for the authorization failure would leak existence (a caller could tell "does not
-  // exist" from "exists but not mine"), and it would diverge from the sibling routes that return 403.
-  if (!fulfillment) {
-    return NextResponse.json({ ok: false, message: 'Fulfillment not found' }, { status: 404 });
+  const access = await loadParticipantFulfillment(id, userId);
+  if ('error' in access) {
+    return access.error;
   }
-  if (fulfillment.requesterUserId !== userId && fulfillment.fulfillerUserId !== userId) {
-    return NextResponse.json({ ok: false, message: 'You are not a participant in this Direct Line' }, { status: 403 });
-  }
+  const { fulfillment } = access;
 
   try {
     // Use the handles captured on the fulfillment at claim time so both participants render with a real

--- a/ctf/packages/web/app/api/socket-relay/requests/route.ts
+++ b/ctf/packages/web/app/api/socket-relay/requests/route.ts
@@ -54,6 +54,34 @@ export async function GET(request: Request) {
   }
 }
 
+// Validate a parsed request payload. Returns an error response, or null when the payload is acceptable.
+async function validateCreateRequestPayload(
+  input: ReturnType<typeof parseRequestInput>,
+): Promise<NextResponse | null> {
+  // Answer the one payload problem a caller can act on by itself before the catch-all message below.
+  if (hasOverlongTag(input.tags)) {
+    return NextResponse.json(
+      { ok: false, code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: SOCKET_RELAY_TAG_LENGTH_MESSAGE },
+      { status: 400 },
+    );
+  }
+
+  if (!validateRequestInput(input) || !(await isValidRequestPrice(input.priceCurrency, input.priceAmount))) {
+    return NextResponse.json(
+      { ok: false, code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: 'Invalid request payload.' },
+      { status: 400 },
+    );
+  }
+
+  return null;
+}
+
+// Use the caller-supplied idempotency key when present and non-empty, otherwise derive one.
+function resolveIdempotencyKey(body: Record<string, unknown>, userId: string): string {
+  const raw = body.idempotencyKey;
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : `${userId}:${Date.now()}`;
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -76,24 +104,12 @@ export async function POST(request: Request) {
   }
 
   const input = parseRequestInput(body);
-  // Answer the one payload problem a caller can act on by itself before the catch-all message below.
-  if (hasOverlongTag(input.tags)) {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: SOCKET_RELAY_TAG_LENGTH_MESSAGE },
-      { status: 400 },
-    );
+  const payloadDeny = await validateCreateRequestPayload(input);
+  if (payloadDeny) {
+    return payloadDeny;
   }
 
-  if (!validateRequestInput(input) || !(await isValidRequestPrice(input.priceCurrency, input.priceAmount))) {
-    return NextResponse.json(
-      { ok: false, code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: 'Invalid request payload.' },
-      { status: 400 },
-    );
-  }
-
-  const idempotencyKey = typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim().length > 0
-    ? body.idempotencyKey.trim()
-    : `${gate.auth.userId}:${Date.now()}`;
+  const idempotencyKey = resolveIdempotencyKey(body, gate.auth.userId);
 
   try {
     const item = await createRequest(gate.auth.userId, gate.auth.username ?? null, input, idempotencyKey);

--- a/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/grant-reward/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/grant-reward/route.ts
@@ -13,6 +13,18 @@ type RouteParams = {
   params: Promise<{ submissionId: string }>;
 };
 
+type ParsedSubmissionId =
+  | { ok: true; submissionId: number }
+  | { ok: false; response: ReturnType<typeof unlockErrorResponse> };
+
+function parseSubmissionId(value: string): ParsedSubmissionId {
+  const submissionId = Number(value);
+  if (!Number.isInteger(submissionId) || submissionId <= 0) {
+    return { ok: false, response: unlockErrorResponse('submissionId must be a positive integer.', 400) };
+  }
+  return { ok: true, submissionId };
+}
+
 // Admin determination "winner" path. Grants a held verification reward to this account — the admin decides
 // this is the account that keeps the Quora identity. Clears the hold, then grants through the shared guard.
 // If another account STILL holds the identity's reward (it was not revoked first), the guard withholds again
@@ -32,10 +44,11 @@ export async function POST(request: Request, { params }: RouteParams) {
   const requestId = resolveUnlockRequestId(request);
 
   const resolvedParams = await params;
-  const submissionId = Number(resolvedParams.submissionId);
-  if (!Number.isInteger(submissionId) || submissionId <= 0) {
-    return unlockErrorResponse('submissionId must be a positive integer.', 400);
+  const parsedId = parseSubmissionId(resolvedParams.submissionId);
+  if (!parsedId.ok) {
+    return parsedId.response;
   }
+  const { submissionId } = parsedId;
 
   try {
     const existing = await getUnlockSubmissionById(submissionId);

--- a/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/revoke/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/revoke/route.ts
@@ -17,6 +17,61 @@ type RevokeBody = {
   reviewNote?: string;
 };
 
+type ParsedSubmissionId =
+  | { ok: true; submissionId: number }
+  | { ok: false; response: ReturnType<typeof unlockErrorResponse> };
+
+function parseSubmissionId(value: string): ParsedSubmissionId {
+  const submissionId = Number(value);
+  if (!Number.isInteger(submissionId) || submissionId <= 0) {
+    return { ok: false, response: unlockErrorResponse('submissionId must be a positive integer.', 400) };
+  }
+  return { ok: true, submissionId };
+}
+
+type UnlockSubmissionRecord = NonNullable<Awaited<ReturnType<typeof getUnlockSubmissionById>>>;
+
+type ReclaimOutcome = { creditsReclaimed: boolean; reclaimAmount: number };
+
+// Claw the reward back if it was actually granted. Best-effort: an insufficient balance (already spent)
+// must not block the access revocation, so a burn failure is reported and swallowed here.
+async function reclaimUnlockReward(
+  submission: UnlockSubmissionRecord,
+  actorUserId: string,
+  submissionId: number,
+): Promise<ReclaimOutcome> {
+  if (!submission.incentiveGrantedAt) {
+    return { creditsReclaimed: false, reclaimAmount: 0 };
+  }
+
+  const runtimeConfig = await getUnlockRuntimeConfig();
+  const reclaimAmount = runtimeConfig.incentiveAmount;
+  try {
+    const burn = await burnCredits({
+      actorId: actorUserId,
+      targetUserId: submission.userId,
+      amount: reclaimAmount,
+      burnReason: 'unlock_reward_revoked_duplicate_identity',
+      governanceTicketId: `unlock:revoke:submission:${submissionId}`,
+      idempotencyKey: `unlock-revoke-submission-${submissionId}`,
+    });
+    await insertServiceCreditsAudit({
+      actorId: actorUserId,
+      command: 'service-credits.governance.burn.unlock.revoke',
+      policyStatus: 'allow',
+      reason: 'unlock_reward_revoked',
+      targetType: 'governance_event',
+      targetId: burn.governanceEventId,
+      metadata: { unlockSubmissionId: submissionId, targetUserId: submission.userId, amount: reclaimAmount },
+    });
+    return { creditsReclaimed: true, reclaimAmount };
+  } catch (burnError) {
+    // Leave creditsReclaimed false; the access revocation below still proceeds. Surface for diagnosis.
+    reportError(burnError, { area: 'unlock', op: 'admin_submissions_submissionid_revoke_burn', extra: { submissionId } });
+    return { creditsReclaimed: false, reclaimAmount };
+  }
+}
+
 // Admin determination "loser" path. Revokes a submission's verification reward: claws the ServiceCredits
 // back (a governance burn) and drops the account to support-only + rejected, so the duplicate-identity guard
 // can hand the reward to the right account. Used when a Quora identity was approved on more than one account
@@ -37,10 +92,11 @@ export async function POST(request: Request, { params }: RouteParams) {
   const requestId = resolveUnlockRequestId(request);
 
   const resolvedParams = await params;
-  const submissionId = Number(resolvedParams.submissionId);
-  if (!Number.isInteger(submissionId) || submissionId <= 0) {
-    return unlockErrorResponse('submissionId must be a positive integer.', 400);
+  const parsedId = parseSubmissionId(resolvedParams.submissionId);
+  if (!parsedId.ok) {
+    return parsedId.response;
   }
+  const { submissionId } = parsedId;
 
   let body: RevokeBody = {};
   try {
@@ -59,37 +115,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       return NextResponse.json({ ok: true, submission: existing, creditsReclaimed: false, alreadyRevoked: true });
     }
 
-    // Claw the reward back if it was actually granted. Best-effort: an insufficient balance (already spent)
-    // must not block the access revocation.
-    let creditsReclaimed = false;
-    let reclaimAmount = 0;
-    if (existing.incentiveGrantedAt) {
-      const runtimeConfig = await getUnlockRuntimeConfig();
-      reclaimAmount = runtimeConfig.incentiveAmount;
-      try {
-        const burn = await burnCredits({
-          actorId: gate.auth.userId,
-          targetUserId: existing.userId,
-          amount: reclaimAmount,
-          burnReason: 'unlock_reward_revoked_duplicate_identity',
-          governanceTicketId: `unlock:revoke:submission:${submissionId}`,
-          idempotencyKey: `unlock-revoke-submission-${submissionId}`,
-        });
-        creditsReclaimed = true;
-        await insertServiceCreditsAudit({
-          actorId: gate.auth.userId,
-          command: 'service-credits.governance.burn.unlock.revoke',
-          policyStatus: 'allow',
-          reason: 'unlock_reward_revoked',
-          targetType: 'governance_event',
-          targetId: burn.governanceEventId,
-          metadata: { unlockSubmissionId: submissionId, targetUserId: existing.userId, amount: reclaimAmount },
-        });
-      } catch (burnError) {
-        // Leave creditsReclaimed false; the access revocation below still proceeds. Surface for diagnosis.
-        reportError(burnError, { area: 'unlock', op: 'admin_submissions_submissionid_revoke_burn', extra: { submissionId } });
-      }
-    }
+    const { creditsReclaimed, reclaimAmount } = await reclaimUnlockReward(existing, gate.auth.userId, submissionId);
 
     const submission = await revokeUnlockSubmissionReward({
       actorUserId: gate.auth.userId,

--- a/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/[submissionId]/route.ts
@@ -13,6 +13,44 @@ type EditUrlBody = {
   quoraProfileUrl?: string;
 };
 
+type ParsedSubmissionId =
+  | { ok: true; submissionId: number }
+  | { ok: false; response: ReturnType<typeof unlockErrorResponse> };
+
+function parseSubmissionId(value: string): ParsedSubmissionId {
+  const submissionId = Number(value);
+  if (!Number.isInteger(submissionId) || submissionId <= 0) {
+    return { ok: false, response: unlockErrorResponse('submissionId must be a positive integer.', 400) };
+  }
+  return { ok: true, submissionId };
+}
+
+// Parse the JSON body and run the same validation and normalization as the member submission path.
+// Returns both the raw URL the caller sent (stored as-is) and its canonical normalized form.
+type ParsedEditUrlBody =
+  | { ok: true; rawUrl: string; normalizedUrl: string }
+  | { ok: false; response: ReturnType<typeof unlockErrorResponse> };
+
+async function parseEditUrlBody(request: Request): Promise<ParsedEditUrlBody> {
+  let body: EditUrlBody;
+  try {
+    body = (await request.json()) as EditUrlBody;
+  } catch {
+    return { ok: false, response: unlockErrorResponse('Invalid JSON payload.', 400) };
+  }
+
+  if (!body.quoraProfileUrl || typeof body.quoraProfileUrl !== 'string') {
+    return { ok: false, response: unlockErrorResponse('quoraProfileUrl is required.', 400) };
+  }
+
+  const normalizedUrl = normalizeQuoraProfileUrl(body.quoraProfileUrl);
+  if (!normalizedUrl) {
+    return { ok: false, response: unlockErrorResponse('Valid Quora profile URL is required.', 400) };
+  }
+
+  return { ok: true, rawUrl: body.quoraProfileUrl, normalizedUrl };
+}
+
 // Admin correction of a submission's Quora profile URL (e.g. fixing a typo a member submitted).
 // Re-runs the same validation and normalization as the member submission path so the stored
 // normalized URL stays canonical. Does not change review status or the verification window.
@@ -30,29 +68,20 @@ export async function PATCH(request: Request, { params }: RouteParams) {
   const requestId = resolveUnlockRequestId(request);
 
   const resolvedParams = await params;
-  const submissionId = Number(resolvedParams.submissionId);
-  if (!Number.isInteger(submissionId) || submissionId <= 0) {
-    return unlockErrorResponse('submissionId must be a positive integer.', 400);
+  const parsedId = parseSubmissionId(resolvedParams.submissionId);
+  if (!parsedId.ok) {
+    return parsedId.response;
   }
+  const { submissionId } = parsedId;
 
-  let body: EditUrlBody;
-  try {
-    body = (await request.json()) as EditUrlBody;
-  } catch {
-    return unlockErrorResponse('Invalid JSON payload.', 400);
+  const parsedBody = await parseEditUrlBody(request);
+  if (!parsedBody.ok) {
+    return parsedBody.response;
   }
-
-  if (!body.quoraProfileUrl || typeof body.quoraProfileUrl !== 'string') {
-    return unlockErrorResponse('quoraProfileUrl is required.', 400);
-  }
-
-  const normalizedUrl = normalizeQuoraProfileUrl(body.quoraProfileUrl);
-  if (!normalizedUrl) {
-    return unlockErrorResponse('Valid Quora profile URL is required.', 400);
-  }
+  const { rawUrl, normalizedUrl } = parsedBody;
 
   try {
-    const submission = await updateUnlockSubmissionQuoraUrl(submissionId, body.quoraProfileUrl, normalizedUrl);
+    const submission = await updateUnlockSubmissionQuoraUrl(submissionId, rawUrl, normalizedUrl);
 
     if (!submission) {
       return unlockErrorResponse('Unlock submission not found.', 404);

--- a/ctf/packages/web/app/api/unlock/admin/submissions/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/submissions/route.ts
@@ -7,6 +7,49 @@ import { reportError } from 'lib/observability/report';
 const ALLOWED_REVIEW_STATUSES = new Set<UnlockReviewStatus>(['pending', 'approved', 'rejected', 'spam']);
 const ALLOWED_ACCESS_TIERS = new Set<UnlockAccessTier>(['pending_readonly', 'locked_support_only', 'approved_full']);
 
+type SubmissionFilters = {
+  reviewStatus: UnlockReviewStatus | undefined;
+  accessTier: UnlockAccessTier | undefined;
+  limit: number;
+};
+
+// Parse and validate the queue filters from the query string. Returns the narrowed filters passed
+// to the repository plus the raw candidate strings that the audit metadata logs verbatim, so the
+// audit record keeps logging exactly what the caller sent (including an empty string).
+type ParsedFilters =
+  | {
+      ok: true;
+      filters: SubmissionFilters;
+      reviewStatusCandidate: string | null;
+      accessTierCandidate: string | null;
+    }
+  | { ok: false; response: ReturnType<typeof unlockErrorResponse> };
+
+function parseSubmissionFilters(url: URL): ParsedFilters {
+  const reviewStatusCandidate = url.searchParams.get('reviewStatus');
+  const accessTierCandidate = url.searchParams.get('accessTier');
+  const limitCandidate = Number(url.searchParams.get('limit') ?? 100);
+
+  if (reviewStatusCandidate && !ALLOWED_REVIEW_STATUSES.has(reviewStatusCandidate as UnlockReviewStatus)) {
+    return { ok: false, response: unlockErrorResponse('Invalid reviewStatus filter.', 400) };
+  }
+
+  if (accessTierCandidate && !ALLOWED_ACCESS_TIERS.has(accessTierCandidate as UnlockAccessTier)) {
+    return { ok: false, response: unlockErrorResponse('Invalid accessTier filter.', 400) };
+  }
+
+  return {
+    ok: true,
+    filters: {
+      reviewStatus: reviewStatusCandidate ? (reviewStatusCandidate as UnlockReviewStatus) : undefined,
+      accessTier: accessTierCandidate ? (accessTierCandidate as UnlockAccessTier) : undefined,
+      limit: Number.isFinite(limitCandidate) ? limitCandidate : 100,
+    },
+    reviewStatusCandidate,
+    accessTierCandidate,
+  };
+}
+
 export async function GET(request: Request) {
   const gate = await requireUnlockAdminAccess();
   if (!gate.allowed) {
@@ -15,25 +58,13 @@ export async function GET(request: Request) {
 
   const requestId = resolveUnlockRequestId(request);
 
-  const url = new URL(request.url);
-  const reviewStatusCandidate = url.searchParams.get('reviewStatus');
-  const accessTierCandidate = url.searchParams.get('accessTier');
-  const limitCandidate = Number(url.searchParams.get('limit') ?? 100);
-
-  if (reviewStatusCandidate && !ALLOWED_REVIEW_STATUSES.has(reviewStatusCandidate as UnlockReviewStatus)) {
-    return unlockErrorResponse('Invalid reviewStatus filter.', 400);
-  }
-
-  if (accessTierCandidate && !ALLOWED_ACCESS_TIERS.has(accessTierCandidate as UnlockAccessTier)) {
-    return unlockErrorResponse('Invalid accessTier filter.', 400);
+  const parsed = parseSubmissionFilters(new URL(request.url));
+  if (!parsed.ok) {
+    return parsed.response;
   }
 
   try {
-    const submissions = await listUnlockSubmissions({
-      reviewStatus: reviewStatusCandidate ? (reviewStatusCandidate as UnlockReviewStatus) : undefined,
-      accessTier: accessTierCandidate ? (accessTierCandidate as UnlockAccessTier) : undefined,
-      limit: Number.isFinite(limitCandidate) ? limitCandidate : 100,
-    });
+    const submissions = await listUnlockSubmissions(parsed.filters);
 
     await insertUnlockAudit({
       actorUserId: gate.auth.userId,
@@ -42,8 +73,8 @@ export async function GET(request: Request) {
       reason: 'ok',
       requestId,
       metadata: {
-        reviewStatus: reviewStatusCandidate,
-        accessTier: accessTierCandidate,
+        reviewStatus: parsed.reviewStatusCandidate,
+        accessTier: parsed.accessTierCandidate,
         count: submissions.length,
       },
     });

--- a/ctf/packages/web/app/api/what-works/admin/problems/[id]/route.ts
+++ b/ctf/packages/web/app/api/what-works/admin/problems/[id]/route.ts
@@ -13,6 +13,57 @@ import { logWhatWorksAudit } from 'lib/what-works/audit';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
+// Read a finite number as a truncated integer, mirroring the original inline check; anything else
+// yields null so the caller can skip the field.
+function readFiniteInt(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  return null;
+}
+
+// Build the partial update from the body, validating each supplied field's length. Returns the
+// narrowed patch on success (guaranteed to hold at least one field), or an error response.
+function buildProblemPatch(
+  body: Record<string, unknown>,
+): { error: NextResponse } | { data: UpdateProblemInput } {
+  const patch: UpdateProblemInput = {};
+  const title = readTrimmedString(body.title);
+  if (title !== null) {
+    if (title.length > MAX_PROBLEM_TITLE_LENGTH) {
+      return { error: whatWorksError('Problem title is too long.', 'what_works_title_too_long', 400) };
+    }
+    patch.title = title;
+  }
+  if (typeof body.context === 'string') {
+    const context2 = body.context.trim();
+    if (context2.length > MAX_PROBLEM_CONTEXT_LENGTH) {
+      return { error: whatWorksError('Problem context is too long.', 'what_works_context_too_long', 400) };
+    }
+    patch.context = context2;
+  }
+  if (typeof body.emoji === 'string') {
+    const emoji = body.emoji.trim();
+    if (emoji.length > MAX_EMOJI_LENGTH) {
+      return { error: whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400) };
+    }
+    patch.emoji = emoji;
+  }
+  const sortOrder = readFiniteInt(body.sortOrder);
+  if (sortOrder !== null) {
+    patch.sortOrder = sortOrder;
+  }
+  if (typeof body.isActive === 'boolean') {
+    patch.isActive = body.isActive;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return { error: whatWorksError('No fields to update.', 'what_works_no_fields', 400) };
+  }
+
+  return { data: patch };
+}
+
 export async function PATCH(request: Request, context: RouteContext) {
   const csrf = ensureMutationCsrf(request);
   if (csrf) {
@@ -33,38 +84,11 @@ export async function PATCH(request: Request, context: RouteContext) {
     return whatWorksError('Invalid JSON body.', 'what_works_invalid_body', 400);
   }
 
-  const patch: UpdateProblemInput = {};
-  const title = readTrimmedString(body.title);
-  if (title !== null) {
-    if (title.length > MAX_PROBLEM_TITLE_LENGTH) {
-      return whatWorksError('Problem title is too long.', 'what_works_title_too_long', 400);
-    }
-    patch.title = title;
+  const built = buildProblemPatch(body);
+  if ('error' in built) {
+    return built.error;
   }
-  if (typeof body.context === 'string') {
-    const context2 = body.context.trim();
-    if (context2.length > MAX_PROBLEM_CONTEXT_LENGTH) {
-      return whatWorksError('Problem context is too long.', 'what_works_context_too_long', 400);
-    }
-    patch.context = context2;
-  }
-  if (typeof body.emoji === 'string') {
-    const emoji = body.emoji.trim();
-    if (emoji.length > MAX_EMOJI_LENGTH) {
-      return whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400);
-    }
-    patch.emoji = emoji;
-  }
-  if (typeof body.sortOrder === 'number' && Number.isFinite(body.sortOrder)) {
-    patch.sortOrder = Math.trunc(body.sortOrder);
-  }
-  if (typeof body.isActive === 'boolean') {
-    patch.isActive = body.isActive;
-  }
-
-  if (Object.keys(patch).length === 0) {
-    return whatWorksError('No fields to update.', 'what_works_no_fields', 400);
-  }
+  const patch = built.data;
 
   const problem = await updateProblem(id, patch);
   logWhatWorksAudit({

--- a/ctf/packages/web/app/api/what-works/admin/problems/route.ts
+++ b/ctf/packages/web/app/api/what-works/admin/problems/route.ts
@@ -10,6 +10,41 @@ import {
 } from '../../_lib';
 import { logWhatWorksAudit } from 'lib/what-works/audit';
 
+// The problem fields once required-field and length checks have passed.
+type ValidatedProblem = {
+  title: string;
+  emoji: string;
+  context: string;
+  sortOrder: number;
+};
+
+// Parse and validate the create-problem body. Returns the narrowed fields on success so the
+// caller keeps type narrowing, or an error response to return as-is.
+function validateProblemBody(
+  body: Record<string, unknown>,
+): { error: NextResponse } | { data: ValidatedProblem } {
+  const title = readTrimmedString(body.title);
+  const emoji = readTrimmedString(body.emoji) ?? '';
+  const context = readTrimmedString(body.context) ?? '';
+  const sortOrderRaw = body.sortOrder;
+  const sortOrder = typeof sortOrderRaw === 'number' && Number.isFinite(sortOrderRaw) ? Math.trunc(sortOrderRaw) : 0;
+
+  if (!title) {
+    return { error: whatWorksError('Add a problem title.', 'what_works_title_required', 400) };
+  }
+  if (title.length > MAX_PROBLEM_TITLE_LENGTH) {
+    return { error: whatWorksError('Problem title is too long.', 'what_works_title_too_long', 400) };
+  }
+  if (context.length > MAX_PROBLEM_CONTEXT_LENGTH) {
+    return { error: whatWorksError('Problem context is too long.', 'what_works_context_too_long', 400) };
+  }
+  if (emoji.length > MAX_EMOJI_LENGTH) {
+    return { error: whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400) };
+  }
+
+  return { data: { title, emoji, context, sortOrder } };
+}
+
 export async function GET() {
   const gate = await requireWhatWorksAdminAccess();
   if (!gate.allowed) {
@@ -44,24 +79,11 @@ export async function POST(request: Request) {
     return whatWorksError('Invalid JSON body.', 'what_works_invalid_body', 400);
   }
 
-  const title = readTrimmedString(body.title);
-  const emoji = readTrimmedString(body.emoji) ?? '';
-  const context = readTrimmedString(body.context) ?? '';
-  const sortOrderRaw = body.sortOrder;
-  const sortOrder = typeof sortOrderRaw === 'number' && Number.isFinite(sortOrderRaw) ? Math.trunc(sortOrderRaw) : 0;
-
-  if (!title) {
-    return whatWorksError('Add a problem title.', 'what_works_title_required', 400);
+  const validated = validateProblemBody(body);
+  if ('error' in validated) {
+    return validated.error;
   }
-  if (title.length > MAX_PROBLEM_TITLE_LENGTH) {
-    return whatWorksError('Problem title is too long.', 'what_works_title_too_long', 400);
-  }
-  if (context.length > MAX_PROBLEM_CONTEXT_LENGTH) {
-    return whatWorksError('Problem context is too long.', 'what_works_context_too_long', 400);
-  }
-  if (emoji.length > MAX_EMOJI_LENGTH) {
-    return whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400);
-  }
+  const { title, emoji, context, sortOrder } = validated.data;
 
   const problem = await createProblem({
     title,

--- a/ctf/packages/web/app/api/what-works/admin/products/[id]/route.ts
+++ b/ctf/packages/web/app/api/what-works/admin/products/[id]/route.ts
@@ -19,11 +19,121 @@ import { logWhatWorksAudit } from 'lib/what-works/audit';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
+// The editable tool fields once required-field and length checks have passed.
+type ValidatedProductEdit = {
+  name: string;
+  purchaseUrl: string;
+  emoji: string;
+  kind: string;
+  note: string;
+};
+
+// Optional fields keep the original semantics: a string value is trimmed, anything else is ''.
+function readTrimmedOrEmpty(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+// Validate the edit body. Returns the narrowed fields on success so the caller keeps type
+// narrowing, or an error response to return as-is.
+function validateProductEdit(
+  body: Record<string, unknown>,
+): { error: NextResponse } | { data: ValidatedProductEdit } {
+  const name = readTrimmedString(body.name);
+  const purchaseUrl = readTrimmedString(body.purchaseUrl);
+  const emoji = readTrimmedOrEmpty(body.emoji);
+  const kind = readTrimmedOrEmpty(body.kind);
+  const note = readTrimmedOrEmpty(body.note);
+
+  if (!name) {
+    return { error: whatWorksError('Add a product name.', 'what_works_name_required', 400) };
+  }
+  if (!purchaseUrl) {
+    return { error: whatWorksError('Add a direct purchase link.', 'what_works_link_required', 400) };
+  }
+  if (name.length > MAX_PRODUCT_NAME_LENGTH) {
+    return { error: whatWorksError('Product name is too long.', 'what_works_name_too_long', 400) };
+  }
+  if (kind.length > MAX_PRODUCT_KIND_LENGTH) {
+    return { error: whatWorksError('Product type is too long.', 'what_works_kind_too_long', 400) };
+  }
+  if (note.length > MAX_PRODUCT_NOTE_LENGTH) {
+    return { error: whatWorksError('Note is too long.', 'what_works_note_too_long', 400) };
+  }
+  if (emoji.length > MAX_EMOJI_LENGTH) {
+    return { error: whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400) };
+  }
+  if (purchaseUrl.length > MAX_PURCHASE_URL_LENGTH || !isValidHttpUrl(purchaseUrl)) {
+    return { error: whatWorksError('Enter a valid http(s) purchase link.', 'what_works_link_invalid', 400) };
+  }
+
+  return { data: { name, purchaseUrl, emoji, kind, note } };
+}
+
+// No action → correct the tool's details.
+// The edit path lets an admin fix a typo or a broken link after the tool is already approved,
+// without unpublishing it. Identity columns and endorsements are never touched.
+async function handleProductEdit(
+  id: string,
+  body: Record<string, unknown>,
+  actorId: string,
+): Promise<NextResponse> {
+  const validated = validateProductEdit(body);
+  if ('error' in validated) {
+    return validated.error;
+  }
+  const { name, purchaseUrl, emoji, kind, note } = validated.data;
+
+  const product = await updateProduct(id, { emoji, name, kind, note, purchaseUrl });
+  logWhatWorksAudit({
+    actorId,
+    command: 'what-works.admin.product.update',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'product',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+  });
+  return NextResponse.json({ ok: true, status: product?.status ?? null });
+}
+
+// Otherwise → moderate (approve/reject).
+async function handleProductModeration(
+  id: string,
+  body: Record<string, unknown>,
+  action: string,
+  actorId: string,
+): Promise<NextResponse> {
+  if (action !== 'approve' && action !== 'reject') {
+    return whatWorksError('Action must be approve or reject.', 'what_works_invalid_action', 400);
+  }
+  const rejectionReason = readTrimmedString(body.rejectionReason) ?? undefined;
+  if (rejectionReason && rejectionReason.length > MAX_PRODUCT_NOTE_LENGTH) {
+    return whatWorksError('Rejection reason is too long.', 'what_works_reason_too_long', 400);
+  }
+
+  const product = await reviewProduct(id, {
+    action,
+    reviewerId: actorId,
+    rejectionReason,
+  });
+  logWhatWorksAudit({
+    actorId,
+    command: 'what-works.admin.product.review',
+    status: 'allow',
+    reason: 'admin_route_guard',
+    targetType: 'product',
+    targetId: id,
+    result: 'success',
+    errorCategory: null,
+    metadata: { action, status: product?.status ?? null },
+  });
+  return NextResponse.json({ ok: true, status: product?.status ?? null });
+}
+
 // PATCH does one of two things depending on the body:
 //   - `action: approve|reject`  → moderate the tool (change its status).
 //   - no `action`               → correct the tool's own details (name, link, note, emoji, kind).
-// The edit path lets an admin fix a typo or a broken link after the tool is already approved,
-// without unpublishing it. Identity columns and endorsements are never touched by either path.
 export async function PATCH(request: Request, context: RouteContext) {
   const csrf = ensureMutationCsrf(request);
   if (csrf) {
@@ -45,77 +155,10 @@ export async function PATCH(request: Request, context: RouteContext) {
   }
 
   const action = readTrimmedString(body.action);
-
-  // No action → correct the tool's details.
   if (action === null) {
-    const name = readTrimmedString(body.name);
-    const purchaseUrl = readTrimmedString(body.purchaseUrl);
-    const emoji = typeof body.emoji === 'string' ? body.emoji.trim() : '';
-    const kind = typeof body.kind === 'string' ? body.kind.trim() : '';
-    const note = typeof body.note === 'string' ? body.note.trim() : '';
-
-    if (!name) {
-      return whatWorksError('Add a product name.', 'what_works_name_required', 400);
-    }
-    if (!purchaseUrl) {
-      return whatWorksError('Add a direct purchase link.', 'what_works_link_required', 400);
-    }
-    if (name.length > MAX_PRODUCT_NAME_LENGTH) {
-      return whatWorksError('Product name is too long.', 'what_works_name_too_long', 400);
-    }
-    if (kind.length > MAX_PRODUCT_KIND_LENGTH) {
-      return whatWorksError('Product type is too long.', 'what_works_kind_too_long', 400);
-    }
-    if (note.length > MAX_PRODUCT_NOTE_LENGTH) {
-      return whatWorksError('Note is too long.', 'what_works_note_too_long', 400);
-    }
-    if (emoji.length > MAX_EMOJI_LENGTH) {
-      return whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400);
-    }
-    if (purchaseUrl.length > MAX_PURCHASE_URL_LENGTH || !isValidHttpUrl(purchaseUrl)) {
-      return whatWorksError('Enter a valid http(s) purchase link.', 'what_works_link_invalid', 400);
-    }
-
-    const product = await updateProduct(id, { emoji, name, kind, note, purchaseUrl });
-    logWhatWorksAudit({
-      actorId: gate.auth.userId,
-      command: 'what-works.admin.product.update',
-      status: 'allow',
-      reason: 'admin_route_guard',
-      targetType: 'product',
-      targetId: id,
-      result: 'success',
-      errorCategory: null,
-    });
-    return NextResponse.json({ ok: true, status: product?.status ?? null });
+    return handleProductEdit(id, body, gate.auth.userId);
   }
-
-  // Otherwise → moderate (approve/reject).
-  if (action !== 'approve' && action !== 'reject') {
-    return whatWorksError('Action must be approve or reject.', 'what_works_invalid_action', 400);
-  }
-  const rejectionReason = readTrimmedString(body.rejectionReason) ?? undefined;
-  if (rejectionReason && rejectionReason.length > MAX_PRODUCT_NOTE_LENGTH) {
-    return whatWorksError('Rejection reason is too long.', 'what_works_reason_too_long', 400);
-  }
-
-  const product = await reviewProduct(id, {
-    action,
-    reviewerId: gate.auth.userId,
-    rejectionReason,
-  });
-  logWhatWorksAudit({
-    actorId: gate.auth.userId,
-    command: 'what-works.admin.product.review',
-    status: 'allow',
-    reason: 'admin_route_guard',
-    targetType: 'product',
-    targetId: id,
-    result: 'success',
-    errorCategory: null,
-    metadata: { action, status: product?.status ?? null },
-  });
-  return NextResponse.json({ ok: true, status: product?.status ?? null });
+  return handleProductModeration(id, body, action, gate.auth.userId);
 }
 
 export async function DELETE(request: Request, context: RouteContext) {

--- a/ctf/packages/web/app/api/what-works/products/route.ts
+++ b/ctf/packages/web/app/api/what-works/products/route.ts
@@ -19,6 +19,61 @@ import {
 import { logWhatWorksAudit } from 'lib/what-works/audit';
 import { reportError } from 'lib/observability/report';
 
+// The suggested fields once required-field and length checks have passed.
+type ValidatedSuggestion = {
+  problemId: string;
+  name: string;
+  purchaseUrl: string;
+  emoji: string;
+  kind: string;
+  note: string;
+};
+
+// Optional fields default to an empty string, mirroring the original `?? ''` reads.
+function readOptionalString(value: unknown): string {
+  return readTrimmedString(value) ?? '';
+}
+
+// Parse and validate the suggestion body. Returns the narrowed fields on success so the
+// caller keeps type narrowing, or an error response to return as-is.
+function validateSuggestionBody(
+  body: Record<string, unknown>,
+): { error: NextResponse } | { data: ValidatedSuggestion } {
+  const problemId = readTrimmedString(body.problemId);
+  const name = readTrimmedString(body.name);
+  const purchaseUrl = readTrimmedString(body.purchaseUrl);
+  const emoji = readOptionalString(body.emoji);
+  const kind = readOptionalString(body.kind);
+  const note = readOptionalString(body.note);
+
+  if (!problemId) {
+    return { error: whatWorksError('Choose the problem this item solves.', 'what_works_problem_required', 400) };
+  }
+  if (!name) {
+    return { error: whatWorksError('Add a product name.', 'what_works_name_required', 400) };
+  }
+  if (!purchaseUrl) {
+    return { error: whatWorksError('Add a direct purchase link.', 'what_works_link_required', 400) };
+  }
+  if (name.length > MAX_PRODUCT_NAME_LENGTH) {
+    return { error: whatWorksError('Product name is too long.', 'what_works_name_too_long', 400) };
+  }
+  if (kind.length > MAX_PRODUCT_KIND_LENGTH) {
+    return { error: whatWorksError('Product type is too long.', 'what_works_kind_too_long', 400) };
+  }
+  if (note.length > MAX_PRODUCT_NOTE_LENGTH) {
+    return { error: whatWorksError('Note is too long.', 'what_works_note_too_long', 400) };
+  }
+  if (emoji.length > MAX_EMOJI_LENGTH) {
+    return { error: whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400) };
+  }
+  if (purchaseUrl.length > MAX_PURCHASE_URL_LENGTH || !isValidHttpUrl(purchaseUrl)) {
+    return { error: whatWorksError('Enter a valid http(s) purchase link.', 'what_works_link_invalid', 400) };
+  }
+
+  return { data: { problemId, name, purchaseUrl, emoji, kind, note } };
+}
+
 // A survivor suggests a tool. It lands as `pending` for admin review before it joins
 // the shared list, and the suggester is auto-recorded as its first verifier.
 export async function POST(request: Request) {
@@ -39,37 +94,11 @@ export async function POST(request: Request) {
     return whatWorksError('Invalid JSON body.', 'what_works_invalid_body', 400);
   }
 
-  const problemId = readTrimmedString(body.problemId);
-  const name = readTrimmedString(body.name);
-  const purchaseUrl = readTrimmedString(body.purchaseUrl);
-  const emoji = readTrimmedString(body.emoji) ?? '';
-  const kind = readTrimmedString(body.kind) ?? '';
-  const note = readTrimmedString(body.note) ?? '';
-
-  if (!problemId) {
-    return whatWorksError('Choose the problem this item solves.', 'what_works_problem_required', 400);
+  const validated = validateSuggestionBody(body);
+  if ('error' in validated) {
+    return validated.error;
   }
-  if (!name) {
-    return whatWorksError('Add a product name.', 'what_works_name_required', 400);
-  }
-  if (!purchaseUrl) {
-    return whatWorksError('Add a direct purchase link.', 'what_works_link_required', 400);
-  }
-  if (name.length > MAX_PRODUCT_NAME_LENGTH) {
-    return whatWorksError('Product name is too long.', 'what_works_name_too_long', 400);
-  }
-  if (kind.length > MAX_PRODUCT_KIND_LENGTH) {
-    return whatWorksError('Product type is too long.', 'what_works_kind_too_long', 400);
-  }
-  if (note.length > MAX_PRODUCT_NOTE_LENGTH) {
-    return whatWorksError('Note is too long.', 'what_works_note_too_long', 400);
-  }
-  if (emoji.length > MAX_EMOJI_LENGTH) {
-    return whatWorksError('Emoji is invalid.', 'what_works_emoji_invalid', 400);
-  }
-  if (purchaseUrl.length > MAX_PURCHASE_URL_LENGTH || !isValidHttpUrl(purchaseUrl)) {
-    return whatWorksError('Enter a valid http(s) purchase link.', 'what_works_link_invalid', 400);
-  }
+  const { problemId, name, purchaseUrl, emoji, kind, note } = validated.data;
 
   const problem = await getProblemById(problemId);
   if (!problem || !problem.is_active) {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — server-only API route handlers, no rendered surface.

## What

Rule-116 complexity/length cleanup for **43 API route handlers** that were over the complexity-10 limit. This is the api-b batch — the non-sensitive routes not covered by #2012 (api-a). **Behavior-preserving**: identical HTTP status codes, CSRF/auth gates, request parsing semantics, response bodies, audit side effects, DB queries, and error handling. Complexity was reduced purely by extracting module-scope helpers — body validation/parsing returning discriminated `{ error } | { data }` results (so callers keep TypeScript narrowing), error-code→response mapping tables, payload builders — and by splitting handlers with two independent branches into named sub-handlers.

Areas covered:
- peer-programming (5): room, messages, messages/replies, feedback, admin/topics
- unlock admin (4): submissions list, submissions/[id], revoke, grant-reward
- what-works (4): products, admin/problems, admin/problems/[id], admin/products/[id]
- socket-relay (3): _lib error table, fulfillments/[id]/chat, requests
- feed (4): admin/moderation, admin/questions, community/posts/reply, community/posts
- directory (4): admin/profiles, admin/profiles/[id], admin/profiles/[id]/takedown, profile
- comic (4): admin/contributions/review, contributions, message, review/resolve
- contributor-access (3): admin/config, admin/revoke, channel/messages
- hub (2): messages, messages/[postId]/reactions
- announcements (2): reactions, replies
- misc (8): account/blocks, beacon/moderate, beacon/stream-webhook, bug-reports/admin/resolve, click-log, mood/submissions, notifications/push/subscribe, recurring-activity

## Verification
- complexity gate (`complexity: 10`, `max-lines-per-function: 200`) on all 43 files — passes (exit 0)
- `pnpm --filter @ctf/web run typecheck` — passes
- repo-wide typecheck (pre-commit/pre-push) — passes
- eslint on changed files — passes
- `check-eof-format` — passes

No schema changes. Contracts unchanged (pure handler-internal refactor).

## Review lane
Rule-116 decomposition, behavior-preserving → low-risk lane. Ready for review, auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_