### PR TITLE
refactor: reduce complexity in service-credits, deletion, and clerk-webhook surfaces

### DIFF
--- a/ctf/packages/web/app/api/chyme/service-credits/route.ts
+++ b/ctf/packages/web/app/api/chyme/service-credits/route.ts
@@ -4,6 +4,46 @@ import { sendServiceCredits } from 'lib/chyme/repository';
 import { CHYME_MAX_TIP_AMOUNT } from 'lib/chyme/constants';
 import { reportError } from 'lib/observability/report';
 
+type TipBody = { toUserId: string; amount: number; message?: string; idempotencyKey?: unknown };
+
+// A stable client-supplied nonce makes a retried tip idempotent; namespace it under the sender so one
+// member's nonce can never collide with another's. Absent a nonce the repository mints a per-request UUID.
+function buildTipIdempotencyKey(senderUserId: string, rawKey: unknown): string | undefined {
+  const clientNonce =
+    typeof rawKey === 'string' && rawKey.trim().length > 0 ? rawKey.trim() : null;
+  return clientNonce ? `chyme-${senderUserId}-${clientNonce}` : undefined;
+}
+
+// Validate a parsed tip payload and derive the namespaced idempotency key. Pure (no I/O) so the route
+// body stays under the complexity limit; every guard, message, and status code is unchanged from the
+// inline version.
+function validateTipRequest(
+  body: TipBody,
+  senderUserId: string,
+): { error: NextResponse } | { data: { toUserId: string; amount: number; message?: string; idempotencyKey: string | undefined } } {
+  if (!body.toUserId || typeof body.amount !== 'number' || !Number.isFinite(body.amount) || body.amount <= 0) {
+    return { error: NextResponse.json({ ok: false, message: 'Invalid payload.' }, { status: 400 }) };
+  }
+
+  // Reject a self-tip: round-tripping credits to yourself has no purpose and invites fee/accounting abuse.
+  if (body.toUserId === senderUserId) {
+    return { error: NextResponse.json({ ok: false, message: 'You cannot tip yourself.' }, { status: 400 }) };
+  }
+
+  // Cap the amount at the route so an unbounded value never reaches the transfer primitive.
+  if (body.amount > CHYME_MAX_TIP_AMOUNT) {
+    return {
+      error: NextResponse.json(
+        { ok: false, message: `Amount exceeds the maximum tip of ${CHYME_MAX_TIP_AMOUNT}.` },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const idempotencyKey = buildTipIdempotencyKey(senderUserId, body.idempotencyKey);
+  return { data: { toUserId: body.toUserId, amount: body.amount, message: body.message, idempotencyKey } };
+}
+
 export async function POST(request: Request) {
   const gate = await requireChymeAccess();
   if (!gate.allowed) {
@@ -15,40 +55,21 @@ export async function POST(request: Request) {
     return csrfDeny;
   }
 
-  let body: { toUserId: string; amount: number; message?: string; idempotencyKey?: unknown };
+  let body: TipBody;
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ ok: false, message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (!body.toUserId || typeof body.amount !== 'number' || !Number.isFinite(body.amount) || body.amount <= 0) {
-    return NextResponse.json({ ok: false, message: 'Invalid payload.' }, { status: 400 });
+  const validated = validateTipRequest(body, gate.identity.userId);
+  if ('error' in validated) {
+    return validated.error;
   }
-
-  // Reject a self-tip: round-tripping credits to yourself has no purpose and invites fee/accounting abuse.
-  if (body.toUserId === gate.identity.userId) {
-    return NextResponse.json({ ok: false, message: 'You cannot tip yourself.' }, { status: 400 });
-  }
-
-  // Cap the amount at the route so an unbounded value never reaches the transfer primitive.
-  if (body.amount > CHYME_MAX_TIP_AMOUNT) {
-    return NextResponse.json(
-      { ok: false, message: `Amount exceeds the maximum tip of ${CHYME_MAX_TIP_AMOUNT}.` },
-      { status: 400 },
-    );
-  }
-
-  // A stable client-supplied nonce makes a retried tip idempotent; namespace it under the sender so one
-  // member's nonce can never collide with another's. Absent a nonce the repository mints a per-request UUID.
-  const clientNonce =
-    typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim().length > 0
-      ? body.idempotencyKey.trim()
-      : null;
-  const idempotencyKey = clientNonce ? `chyme-${gate.identity.userId}-${clientNonce}` : undefined;
+  const { toUserId, amount, message, idempotencyKey } = validated.data;
 
   try {
-    const tx = await sendServiceCredits(gate.identity.userId, body.toUserId, body.amount, body.message, idempotencyKey);
+    const tx = await sendServiceCredits(gate.identity.userId, toUserId, amount, message, idempotencyKey);
     return NextResponse.json({ ok: true, transaction: tx }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'chyme', op: 'service_credits' });

--- a/ctf/packages/web/app/api/internal/account/delete/route.ts
+++ b/ctf/packages/web/app/api/internal/account/delete/route.ts
@@ -26,10 +26,11 @@ function isAuthorized(request: Request, secret: string): boolean {
   return request.headers.get('authorization') === `Bearer ${secret}`;
 }
 
-export async function POST(request: Request) {
-  // Distinguish "not configured" (503 — secret missing in the app runtime) from "wrong/no secret"
-  // (403) so the workflow's error message can point at the right fix. This is the ONLY presence check;
-  // isAuthorized below assumes a configured secret and only verifies the supplied token.
+// Presence + Bearer gate. Distinguish "not configured" (503 — secret missing in the app runtime) from
+// "wrong/no secret" (403) so the workflow's error message can point at the right fix. This is the ONLY
+// presence check; isAuthorized assumes a configured secret and only verifies the supplied token.
+// Returns a ready error response, or null when the caller is authorized.
+function authorizeRequest(request: Request): NextResponse | null {
   const secret = process.env.ACCOUNT_DELETE_SECRET?.trim() ?? '';
   if (secret.length === 0) {
     return NextResponse.json(
@@ -43,7 +44,15 @@ export async function POST(request: Request) {
       { status: 403 },
     );
   }
+  return null;
+}
 
+type ParsedDeleteRequest = { userId: string; deleteClerk: boolean; target: 'demo' | 'public'; targetLabel: string };
+
+// Parse + validate the request body and derive the deletion target. Returns a ready error response
+// (missing userId) or the validated inputs; status code and code string are unchanged from the inline
+// version.
+async function parseDeleteRequest(request: Request): Promise<{ error: NextResponse } | { data: ParsedDeleteRequest }> {
   let body: { userId?: unknown; deleteClerk?: unknown; target?: unknown };
   try {
     body = (await request.json()) as { userId?: unknown; deleteClerk?: unknown; target?: unknown };
@@ -52,10 +61,12 @@ export async function POST(request: Request) {
   }
   const userId = typeof body.userId === 'string' ? body.userId.trim() : '';
   if (userId.length === 0) {
-    return NextResponse.json(
-      { ok: false, code: 'account_delete_bad_request', message: 'userId is required.' },
-      { status: 400 },
-    );
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'account_delete_bad_request', message: 'userId is required.' },
+        { status: 400 },
+      ),
+    };
   }
   // Default true: a duplicate account should be fully gone (data + Clerk identity) in one run. Pass
   // `{ "deleteClerk": false }` to delete only the database data and keep the Clerk account.
@@ -70,6 +81,45 @@ export async function POST(request: Request) {
   const target = body.target === 'demo' ? 'demo' : 'public';
   const targetLabel = target === 'demo' ? 'demo' : 'production';
 
+  return { data: { userId, deleteClerk, target, targetLabel } };
+}
+
+// Optionally delete the Clerk identity after the DB deletion has already succeeded. Runs only when
+// requested; a Clerk failure is surfaced (clerkError) without failing the request so the operator can
+// retry just the Clerk side (e.g. the user was already removed there).
+async function deleteClerkAccountIfRequested(
+  userId: string,
+  deleteClerk: boolean,
+): Promise<{ clerkDeleted: boolean; clerkError: string | null }> {
+  if (!deleteClerk) {
+    return { clerkDeleted: false, clerkError: null };
+  }
+  const secretKey = getClerkSecretKey();
+  if (!secretKey) {
+    return { clerkDeleted: false, clerkError: 'clerk_secret_not_configured' };
+  }
+  try {
+    await createClerkClient({ secretKey }).users.deleteUser(userId);
+    return { clerkDeleted: true, clerkError: null };
+  } catch (error) {
+    // The DB deletion already succeeded; surface the Clerk failure without failing the request
+    // so the operator can retry just the Clerk side (e.g. the user was already removed there).
+    return { clerkDeleted: false, clerkError: error instanceof Error ? error.message : 'clerk_delete_failed' };
+  }
+}
+
+export async function POST(request: Request) {
+  const authError = authorizeRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  const parsed = await parseDeleteRequest(request);
+  if ('error' in parsed) {
+    return parsed.error;
+  }
+  const { userId, deleteClerk, target, targetLabel } = parsed.data;
+
   // Track which step is running so a failure response can say whether the ServiceCredits reclaim
   // request or the data deletion threw — the generic 503 alone was undiagnosable from the Actions log.
   let step = 'reclaim_request';
@@ -80,23 +130,7 @@ export async function POST(request: Request) {
       return deleteAllAccountData(userId, reclaim.requestedAtIso);
     });
 
-    let clerkDeleted = false;
-    let clerkError: string | null = null;
-    if (deleteClerk) {
-      const secretKey = getClerkSecretKey();
-      if (!secretKey) {
-        clerkError = 'clerk_secret_not_configured';
-      } else {
-        try {
-          await createClerkClient({ secretKey }).users.deleteUser(userId);
-          clerkDeleted = true;
-        } catch (error) {
-          // The DB deletion already succeeded; surface the Clerk failure without failing the request
-          // so the operator can retry just the Clerk side (e.g. the user was already removed there).
-          clerkError = error instanceof Error ? error.message : 'clerk_delete_failed';
-        }
-      }
-    }
+    const { clerkDeleted, clerkError } = await deleteClerkAccountIfRequested(userId, deleteClerk);
 
     logChymeAudit({
       pluginId: 'chyme',

--- a/ctf/packages/web/app/api/internal/service-credits/accounts/[accountId]/deletion-reclaims/[deletionRequestId]/execute/route.ts
+++ b/ctf/packages/web/app/api/internal/service-credits/accounts/[accountId]/deletion-reclaims/[deletionRequestId]/execute/route.ts
@@ -22,10 +22,11 @@ function isAuthorized(request: Request, configuredToken: string): boolean {
   return providedToken.length > 0 && providedToken === configuredToken;
 }
 
-export async function POST(request: Request, context: ReclaimParams) {
-  // Distinguish "not configured" (503 — token missing in the app runtime) from "wrong/no token" (403)
-  // so the calling service can tell a misconfigured deployment from a bad credential, matching the
-  // account/delete route. This is the only presence check; isAuthorized only verifies the token.
+// Presence + token gate. Distinguish "not configured" (503 — token missing in the app runtime) from
+// "wrong/no token" (403) so the calling service can tell a misconfigured deployment from a bad
+// credential, matching the account/delete route. This is the only presence check; isAuthorized only
+// verifies the token. Returns a ready error response, or null when the caller is authorized.
+function authorizeReclaimRequest(request: Request): NextResponse | null {
   const configuredToken = process.env.SERVICE_CREDITS_INTERNAL_TOKEN?.trim() ?? '';
   if (configuredToken.length === 0) {
     return NextResponse.json(
@@ -39,20 +40,61 @@ export async function POST(request: Request, context: ReclaimParams) {
       { status: 403 },
     );
   }
+  return null;
+}
 
+// The five fields required by executeDeletionReclaim, narrowed to non-optional strings once the
+// payload guard has passed — mirrors the narrowing the inline `if (!body.x || ...)` guard produced.
+type ValidatedReclaimBody = ReclaimBody & {
+  treasuryUserId: string;
+  requestedAt: string;
+  idempotencyKey: string;
+  requestId: string;
+  traceId: string;
+};
+
+// Parse + validate the reclaim body. Returns a ready error response (invalid JSON, or a missing
+// required field) or the validated body. Status codes and code strings are unchanged from the inline
+// version.
+async function parseReclaimBody(request: Request): Promise<{ error: NextResponse } | { data: ValidatedReclaimBody }> {
   let body: ReclaimBody;
   try {
     body = (await request.json()) as ReclaimBody;
   } catch {
-    return NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
+    return { error: NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 }) };
   }
 
   if (!body.treasuryUserId || !body.requestedAt || !body.idempotencyKey || !body.requestId || !body.traceId) {
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_invalid_payload', message: 'treasuryUserId, requestedAt, idempotencyKey, requestId, and traceId are required.' },
-      { status: 400 },
-    );
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'service_credits_invalid_payload', message: 'treasuryUserId, requestedAt, idempotencyKey, requestId, and traceId are required.' },
+        { status: 400 },
+      ),
+    };
   }
+
+  return {
+    data: {
+      treasuryUserId: body.treasuryUserId,
+      requestedAt: body.requestedAt,
+      idempotencyKey: body.idempotencyKey,
+      requestId: body.requestId,
+      traceId: body.traceId,
+    },
+  };
+}
+
+export async function POST(request: Request, context: ReclaimParams) {
+  const authError = authorizeReclaimRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  const parsed = await parseReclaimBody(request);
+  if ('error' in parsed) {
+    return parsed.error;
+  }
+  const body = parsed.data;
 
   const { accountId, deletionRequestId } = await context.params;
 

--- a/ctf/packages/web/app/api/service-credits/_lib.ts
+++ b/ctf/packages/web/app/api/service-credits/_lib.ts
@@ -47,49 +47,38 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
   return null;
 }
 
+// Known ServiceCredits error messages that map straight to a JSON response with no side effect.
+// One error.message can match at most one entry, so table lookup preserves the original if-chain's
+// behavior exactly (these branches never called reportError before returning).
+const SERVICE_CREDITS_SIMPLE_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
+  insufficient_balance: { code: 'service_credits_insufficient_balance', message: 'Insufficient balance.', status: 409 },
+  invalid_payload: { code: 'service_credits_invalid_payload', message: 'Invalid ServiceCredits payload.', status: 400 },
+  transfer_conflict: { code: 'service_credits_transfer_conflict', message: 'Unable to resolve idempotent transfer state.', status: 409 },
+  not_found: { code: 'service_credits_not_found', message: 'Requested resource was not found.', status: 404 },
+  invalid_state: { code: 'service_credits_invalid_state', message: 'Resource is not in a valid state for this command.', status: 409 },
+  reclaim_window_not_elapsed: { code: 'service_credits_reclaim_window_not_elapsed', message: 'Deletion reclaim window has not elapsed.', status: 409 },
+  active_escrow_holds: { code: 'service_credits_active_escrow_holds', message: 'Deletion reclaim blocked by active escrow holds.', status: 409 },
+};
+
+// External-ledger error messages. These branches DID call reportError before returning a 503, so the
+// lookup path below reports the error just as the original if-chain did.
+const SERVICE_CREDITS_LEDGER_ERROR_RESPONSES: Record<string, { code: string; message: string }> = {
+  external_ledger_not_configured: { code: 'service_credits_external_ledger_not_configured', message: 'Formance ledger is not configured for ServiceCredits.' },
+  external_ledger_unavailable: { code: 'service_credits_external_ledger_unavailable', message: 'Formance ledger rejected or failed the command.' },
+};
+
 export function serviceCreditsErrorResponse(error: unknown, fallbackMessage: string): NextResponse {
-  if (error instanceof Error && error.message === 'insufficient_balance') {
-    return NextResponse.json({ ok: false, code: 'service_credits_insufficient_balance', message: 'Insufficient balance.' }, { status: 409 });
-  }
+  if (error instanceof Error) {
+    const simple = SERVICE_CREDITS_SIMPLE_ERROR_RESPONSES[error.message];
+    if (simple) {
+      return NextResponse.json({ ok: false, code: simple.code, message: simple.message }, { status: simple.status });
+    }
 
-  if (error instanceof Error && error.message === 'invalid_payload') {
-    return NextResponse.json({ ok: false, code: 'service_credits_invalid_payload', message: 'Invalid ServiceCredits payload.' }, { status: 400 });
-  }
-
-  if (error instanceof Error && error.message === 'transfer_conflict') {
-    return NextResponse.json({ ok: false, code: 'service_credits_transfer_conflict', message: 'Unable to resolve idempotent transfer state.' }, { status: 409 });
-  }
-
-  if (error instanceof Error && error.message === 'not_found') {
-    return NextResponse.json({ ok: false, code: 'service_credits_not_found', message: 'Requested resource was not found.' }, { status: 404 });
-  }
-
-  if (error instanceof Error && error.message === 'invalid_state') {
-    return NextResponse.json({ ok: false, code: 'service_credits_invalid_state', message: 'Resource is not in a valid state for this command.' }, { status: 409 });
-  }
-
-  if (error instanceof Error && error.message === 'reclaim_window_not_elapsed') {
-    return NextResponse.json({ ok: false, code: 'service_credits_reclaim_window_not_elapsed', message: 'Deletion reclaim window has not elapsed.' }, { status: 409 });
-  }
-
-  if (error instanceof Error && error.message === 'active_escrow_holds') {
-    return NextResponse.json({ ok: false, code: 'service_credits_active_escrow_holds', message: 'Deletion reclaim blocked by active escrow holds.' }, { status: 409 });
-  }
-
-  if (error instanceof Error && error.message === 'external_ledger_not_configured') {
-    reportError(error, { area: 'service-credits', op: 'unknown' });
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_external_ledger_not_configured', message: 'Formance ledger is not configured for ServiceCredits.' },
-      { status: 503 },
-    );
-  }
-
-  if (error instanceof Error && error.message === 'external_ledger_unavailable') {
-    reportError(error, { area: 'service-credits', op: 'unknown' });
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_external_ledger_unavailable', message: 'Formance ledger rejected or failed the command.' },
-      { status: 503 },
-    );
+    const ledger = SERVICE_CREDITS_LEDGER_ERROR_RESPONSES[error.message];
+    if (ledger) {
+      reportError(error, { area: 'service-credits', op: 'unknown' });
+      return NextResponse.json({ ok: false, code: ledger.code, message: ledger.message }, { status: 503 });
+    }
   }
 
   reportError(error, { area: 'service-credits', op: 'unknown' });

--- a/ctf/packages/web/app/api/service-credits/admin/disputes/adjustments/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/disputes/adjustments/route.ts
@@ -12,6 +12,48 @@ type DisputeAdjustmentBody = {
   idempotencyKey?: string;
 };
 
+type DisputeAdjustmentInput = {
+  disputeCaseId: string;
+  sourceUserId: string;
+  destinationUserId: string;
+  amount: number;
+  adjustmentReason: string;
+  idempotencyKey: string;
+};
+
+function validateDisputeAdjustmentBody(
+  body: DisputeAdjustmentBody,
+): { error: NextResponse } | { data: DisputeAdjustmentInput } {
+  if (
+    !body.disputeCaseId
+    || !body.sourceUserId
+    || !body.destinationUserId
+    || typeof body.amount !== 'number'
+    || !(body.amount > 0)
+    || !Number.isFinite(body.amount)
+    || !body.adjustmentReason
+    || !body.idempotencyKey
+  ) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'service_credits_invalid_payload', message: 'disputeCaseId, sourceUserId, destinationUserId, amount, adjustmentReason, and idempotencyKey are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    data: {
+      disputeCaseId: body.disputeCaseId,
+      sourceUserId: body.sourceUserId,
+      destinationUserId: body.destinationUserId,
+      amount: body.amount,
+      adjustmentReason: body.adjustmentReason,
+      idempotencyKey: body.idempotencyKey,
+    },
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -30,31 +72,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (
-    !body.disputeCaseId
-    || !body.sourceUserId
-    || !body.destinationUserId
-    || typeof body.amount !== 'number'
-    || !(body.amount > 0)
-    || !Number.isFinite(body.amount)
-    || !body.adjustmentReason
-    || !body.idempotencyKey
-  ) {
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_invalid_payload', message: 'disputeCaseId, sourceUserId, destinationUserId, amount, adjustmentReason, and idempotencyKey are required.' },
-      { status: 400 },
-    );
+  const validation = validateDisputeAdjustmentBody(body);
+  if ('error' in validation) {
+    return validation.error;
   }
+  const input = validation.data;
 
   try {
     const adjustment = await applyDisputeAdjustment({
       actorId: gate.auth.userId,
-      disputeCaseId: body.disputeCaseId,
-      sourceUserId: body.sourceUserId,
-      destinationUserId: body.destinationUserId,
-      amount: body.amount,
-      adjustmentReason: body.adjustmentReason,
-      idempotencyKey: body.idempotencyKey,
+      disputeCaseId: input.disputeCaseId,
+      sourceUserId: input.sourceUserId,
+      destinationUserId: input.destinationUserId,
+      amount: input.amount,
+      adjustmentReason: input.adjustmentReason,
+      idempotencyKey: input.idempotencyKey,
     });
 
     await insertServiceCreditsAudit({
@@ -65,9 +97,9 @@ export async function POST(request: Request) {
       targetType: 'dispute_adjustment',
       targetId: adjustment.adjustmentId,
       metadata: {
-        disputeCaseId: body.disputeCaseId,
+        disputeCaseId: input.disputeCaseId,
         transferId: adjustment.transferId,
-        amount: body.amount,
+        amount: input.amount,
       },
     });
 

--- a/ctf/packages/web/app/api/service-credits/admin/governance/burns/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/governance/burns/route.ts
@@ -11,6 +11,35 @@ type BurnBody = {
   idempotencyKey?: string;
 };
 
+type BurnInput = {
+  targetUserId: string;
+  amount: number;
+  burnReason: string;
+  governanceTicketId: string;
+  idempotencyKey: string;
+};
+
+function validateBurnBody(body: BurnBody): { error: NextResponse } | { data: BurnInput } {
+  if (!body.targetUserId || typeof body.amount !== 'number' || !(body.amount > 0) || !Number.isFinite(body.amount) || !body.burnReason || !body.governanceTicketId || !body.idempotencyKey) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'service_credits_invalid_payload', message: 'targetUserId, amount, burnReason, governanceTicketId, and idempotencyKey are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    data: {
+      targetUserId: body.targetUserId,
+      amount: body.amount,
+      burnReason: body.burnReason,
+      governanceTicketId: body.governanceTicketId,
+      idempotencyKey: body.idempotencyKey,
+    },
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -29,21 +58,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (!body.targetUserId || typeof body.amount !== 'number' || !(body.amount > 0) || !Number.isFinite(body.amount) || !body.burnReason || !body.governanceTicketId || !body.idempotencyKey) {
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_invalid_payload', message: 'targetUserId, amount, burnReason, governanceTicketId, and idempotencyKey are required.' },
-      { status: 400 },
-    );
+  const validation = validateBurnBody(body);
+  if ('error' in validation) {
+    return validation.error;
   }
+  const input = validation.data;
 
   try {
     const burn = await burnCredits({
       actorId: gate.auth.userId,
-      targetUserId: body.targetUserId,
-      amount: body.amount,
-      burnReason: body.burnReason,
-      governanceTicketId: body.governanceTicketId,
-      idempotencyKey: body.idempotencyKey,
+      targetUserId: input.targetUserId,
+      amount: input.amount,
+      burnReason: input.burnReason,
+      governanceTicketId: input.governanceTicketId,
+      idempotencyKey: input.idempotencyKey,
     });
 
     await insertServiceCreditsAudit({
@@ -53,7 +81,7 @@ export async function POST(request: Request) {
       reason: 'ok',
       targetType: 'governance_event',
       targetId: burn.governanceEventId,
-      metadata: { targetUserId: body.targetUserId, amount: body.amount, governanceTicketId: body.governanceTicketId },
+      metadata: { targetUserId: input.targetUserId, amount: input.amount, governanceTicketId: input.governanceTicketId },
     });
 
     return NextResponse.json({ ok: true, burn }, { status: 201 });

--- a/ctf/packages/web/app/api/service-credits/admin/governance/mint-grants/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/governance/mint-grants/route.ts
@@ -11,6 +11,35 @@ type MintBody = {
   idempotencyKey?: string;
 };
 
+type MintInput = {
+  targetUserId: string;
+  amount: number;
+  grantReason: string;
+  governanceTicketId: string;
+  idempotencyKey: string;
+};
+
+function validateMintBody(body: MintBody): { error: NextResponse } | { data: MintInput } {
+  if (!body.targetUserId || typeof body.amount !== 'number' || !(body.amount > 0) || !Number.isFinite(body.amount) || !body.grantReason || !body.governanceTicketId || !body.idempotencyKey) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'service_credits_invalid_payload', message: 'targetUserId, amount, grantReason, governanceTicketId, and idempotencyKey are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    data: {
+      targetUserId: body.targetUserId,
+      amount: body.amount,
+      grantReason: body.grantReason,
+      governanceTicketId: body.governanceTicketId,
+      idempotencyKey: body.idempotencyKey,
+    },
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -29,21 +58,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (!body.targetUserId || typeof body.amount !== 'number' || !(body.amount > 0) || !Number.isFinite(body.amount) || !body.grantReason || !body.governanceTicketId || !body.idempotencyKey) {
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_invalid_payload', message: 'targetUserId, amount, grantReason, governanceTicketId, and idempotencyKey are required.' },
-      { status: 400 },
-    );
+  const validation = validateMintBody(body);
+  if ('error' in validation) {
+    return validation.error;
   }
+  const input = validation.data;
 
   try {
     const grant = await mintGrant({
       actorId: gate.auth.userId,
-      targetUserId: body.targetUserId,
-      amount: body.amount,
-      grantReason: body.grantReason,
-      governanceTicketId: body.governanceTicketId,
-      idempotencyKey: body.idempotencyKey,
+      targetUserId: input.targetUserId,
+      amount: input.amount,
+      grantReason: input.grantReason,
+      governanceTicketId: input.governanceTicketId,
+      idempotencyKey: input.idempotencyKey,
     });
 
     await insertServiceCreditsAudit({
@@ -56,7 +84,7 @@ export async function POST(request: Request) {
       // Record the governing command-contract version so compliance review can tell which mint rules
       // applied. The audit-trail table has no version column, so it rides in metadata. Keep in step
       // with the governance.mint.grant version in SERVICE_CREDITS_PLUGIN_COMMAND_CONTRACTS.yaml.
-      metadata: { commandVersion: '1.1.0', targetUserId: body.targetUserId, amount: body.amount, governanceTicketId: body.governanceTicketId },
+      metadata: { commandVersion: '1.1.0', targetUserId: input.targetUserId, amount: input.amount, governanceTicketId: input.governanceTicketId },
     });
 
     return NextResponse.json({ ok: true, grant }, { status: 201 });

--- a/ctf/packages/web/app/api/service-credits/admin/treasury/fees/collect/route.ts
+++ b/ctf/packages/web/app/api/service-credits/admin/treasury/fees/collect/route.ts
@@ -12,6 +12,48 @@ type TreasuryFeeBody = {
   idempotencyKey?: string;
 };
 
+type TreasuryFeeInput = {
+  sourceUserId: string;
+  treasuryUserId: string;
+  amount: number;
+  feeReasonCode: string;
+  originPlugin: string;
+  idempotencyKey: string;
+};
+
+function validateTreasuryFeeBody(
+  body: TreasuryFeeBody,
+): { error: NextResponse } | { data: TreasuryFeeInput } {
+  if (
+    !body.sourceUserId
+    || !body.treasuryUserId
+    || typeof body.amount !== 'number'
+    || !(body.amount > 0)
+    || !Number.isFinite(body.amount)
+    || !body.feeReasonCode
+    || !body.originPlugin
+    || !body.idempotencyKey
+  ) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'service_credits_invalid_payload', message: 'sourceUserId, treasuryUserId, amount, feeReasonCode, originPlugin, and idempotencyKey are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    data: {
+      sourceUserId: body.sourceUserId,
+      treasuryUserId: body.treasuryUserId,
+      amount: body.amount,
+      feeReasonCode: body.feeReasonCode,
+      originPlugin: body.originPlugin,
+      idempotencyKey: body.idempotencyKey,
+    },
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -30,31 +72,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (
-    !body.sourceUserId
-    || !body.treasuryUserId
-    || typeof body.amount !== 'number'
-    || !(body.amount > 0)
-    || !Number.isFinite(body.amount)
-    || !body.feeReasonCode
-    || !body.originPlugin
-    || !body.idempotencyKey
-  ) {
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_invalid_payload', message: 'sourceUserId, treasuryUserId, amount, feeReasonCode, originPlugin, and idempotencyKey are required.' },
-      { status: 400 },
-    );
+  const validation = validateTreasuryFeeBody(body);
+  if ('error' in validation) {
+    return validation.error;
   }
+  const input = validation.data;
 
   try {
     const collection = await collectTreasuryFee({
       actorId: gate.auth.userId,
-      sourceUserId: body.sourceUserId,
-      treasuryUserId: body.treasuryUserId,
-      amount: body.amount,
-      feeReasonCode: body.feeReasonCode,
-      originPlugin: body.originPlugin,
-      idempotencyKey: body.idempotencyKey,
+      sourceUserId: input.sourceUserId,
+      treasuryUserId: input.treasuryUserId,
+      amount: input.amount,
+      feeReasonCode: input.feeReasonCode,
+      originPlugin: input.originPlugin,
+      idempotencyKey: input.idempotencyKey,
     });
 
     await insertServiceCreditsAudit({
@@ -65,9 +97,9 @@ export async function POST(request: Request) {
       targetType: 'treasury_event',
       targetId: collection.treasuryEventId,
       metadata: {
-        amount: body.amount,
-        sourceUserId: body.sourceUserId,
-        treasuryUserId: body.treasuryUserId,
+        amount: input.amount,
+        sourceUserId: input.sourceUserId,
+        treasuryUserId: input.treasuryUserId,
         transferId: collection.transferId,
       },
     });

--- a/ctf/packages/web/app/api/service-credits/escrows/route.ts
+++ b/ctf/packages/web/app/api/service-credits/escrows/route.ts
@@ -12,6 +12,47 @@ type EscrowHoldBody = {
   idempotencyKey?: string;
 };
 
+type ParsedEscrowHoldRequest = {
+  escrowId: string | undefined;
+  sourceUserId: string;
+  amount: number;
+  originPlugin: string;
+  releasePolicy: string;
+  idempotencyKey: string;
+};
+
+// Validate/normalize the escrow-hold body. Returns the parsed request on success or a ready 400
+// response on failure. Preserves the original validation checks verbatim.
+function parseEscrowHoldBody(body: EscrowHoldBody): { error: NextResponse } | { data: ParsedEscrowHoldRequest } {
+  if (
+    !body.sourceUserId
+    || typeof body.amount !== 'number'
+    || !(body.amount > 0)
+    || !Number.isFinite(body.amount)
+    || !body.originPlugin
+    || !body.releasePolicy
+    || !body.idempotencyKey
+  ) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'service_credits_invalid_payload', message: 'sourceUserId, amount, originPlugin, releasePolicy, and idempotencyKey are required.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    data: {
+      escrowId: typeof body.escrowId === 'string' ? body.escrowId : undefined,
+      sourceUserId: body.sourceUserId,
+      amount: body.amount,
+      originPlugin: body.originPlugin,
+      releasePolicy: body.releasePolicy,
+      idempotencyKey: body.idempotencyKey,
+    },
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -30,30 +71,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (
-    !body.sourceUserId
-    || typeof body.amount !== 'number'
-    || !(body.amount > 0)
-    || !Number.isFinite(body.amount)
-    || !body.originPlugin
-    || !body.releasePolicy
-    || !body.idempotencyKey
-  ) {
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_invalid_payload', message: 'sourceUserId, amount, originPlugin, releasePolicy, and idempotencyKey are required.' },
-      { status: 400 },
-    );
+  const parsed = parseEscrowHoldBody(body);
+  if ('error' in parsed) {
+    return parsed.error;
   }
 
   try {
     const escrow = await createEscrowHold({
       actorId: gate.auth.userId,
-      escrowId: typeof body.escrowId === 'string' ? body.escrowId : undefined,
-      sourceUserId: body.sourceUserId,
-      amount: body.amount,
-      originPlugin: body.originPlugin,
-      releasePolicy: body.releasePolicy,
-      idempotencyKey: body.idempotencyKey,
+      escrowId: parsed.data.escrowId,
+      sourceUserId: parsed.data.sourceUserId,
+      amount: parsed.data.amount,
+      originPlugin: parsed.data.originPlugin,
+      releasePolicy: parsed.data.releasePolicy,
+      idempotencyKey: parsed.data.idempotencyKey,
     });
 
     await insertServiceCreditsAudit({
@@ -63,7 +94,7 @@ export async function POST(request: Request) {
       reason: 'ok',
       targetType: 'escrow',
       targetId: escrow.escrowId,
-      metadata: { heldAmount: escrow.heldAmount, holdStatus: escrow.holdStatus, originPlugin: body.originPlugin },
+      metadata: { heldAmount: escrow.heldAmount, holdStatus: escrow.holdStatus, originPlugin: parsed.data.originPlugin },
     });
 
     return NextResponse.json({ ok: true, escrow }, { status: 201 });

--- a/ctf/packages/web/app/api/service-credits/transfers/route.ts
+++ b/ctf/packages/web/app/api/service-credits/transfers/route.ts
@@ -18,6 +18,77 @@ type TransferBody = {
   rail?: 'balance' | 'mutual_credit';
 };
 
+type ParsedTransferRequest = {
+  recipientUserId: string;
+  amount: number;
+  idempotencyKey: string;
+  originPlugin: string;
+  reasonCode: string | undefined;
+  rail: 'mutual_credit' | undefined;
+};
+
+// Validate the required transfer fields (and the optional rail enum). Returns the narrowed core
+// values on success, or a ready 400 response on failure. Checks are kept verbatim and in order.
+function validateTransferFields(
+  body: TransferBody,
+): { error: NextResponse } | { recipientUserId: string; amount: number; idempotencyKey: string } {
+  if (!body.recipientUserId || typeof body.amount !== 'number' || !(body.amount > 0) || !Number.isFinite(body.amount) || !body.idempotencyKey) {
+    return { error: NextResponse.json({ ok: false, code: 'service_credits_invalid_payload', message: 'recipientUserId, amount and idempotencyKey are required.' }, { status: 400 }) };
+  }
+
+  if (body.rail !== undefined && body.rail !== 'balance' && body.rail !== 'mutual_credit') {
+    return { error: NextResponse.json({ ok: false, code: 'service_credits_invalid_payload', message: 'rail must be "balance" or "mutual_credit".' }, { status: 400 }) };
+  }
+
+  return { recipientUserId: body.recipientUserId, amount: body.amount, idempotencyKey: body.idempotencyKey };
+}
+
+// Resolve and validate the origin plugin. Returns the resolved slug or a ready 400 response.
+function resolveTransferOriginPlugin(body: TransferBody): { error: NextResponse } | { originPlugin: string } {
+  // The access policy for transfer.create denies invalid_origin_plugin / disallowed_cross_plugin_path.
+  // Enforce that here: when originPlugin is supplied it must name a real plugin, so an arbitrary string
+  // can never be stored as the cross-plugin path. Omitting it means a direct send from this app.
+  const originPlugin =
+    typeof body.originPlugin === 'string' && body.originPlugin.trim().length > 0
+      ? body.originPlugin.trim()
+      : DEFAULT_ORIGIN_PLUGIN;
+  if (!isRegisteredPluginSlug(originPlugin)) {
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'service_credits_invalid_origin_plugin', message: 'originPlugin must be a registered plugin.' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { originPlugin };
+}
+
+// Validate/normalize the transfer body. Returns the parsed request on success or a ready 400
+// response on failure. Preserves the original validation order and every check verbatim.
+function parseTransferBody(body: TransferBody): { error: NextResponse } | { data: ParsedTransferRequest } {
+  const fields = validateTransferFields(body);
+  if ('error' in fields) {
+    return { error: fields.error };
+  }
+
+  const origin = resolveTransferOriginPlugin(body);
+  if ('error' in origin) {
+    return { error: origin.error };
+  }
+
+  return {
+    data: {
+      recipientUserId: fields.recipientUserId,
+      amount: fields.amount,
+      idempotencyKey: fields.idempotencyKey,
+      originPlugin: origin.originPlugin,
+      reasonCode: typeof body.reasonCode === 'string' ? body.reasonCode : undefined,
+      rail: body.rail === 'mutual_credit' ? 'mutual_credit' : undefined,
+    },
+  };
+}
+
 export async function POST(request: Request) {
   const csrfDeny = ensureMutationCsrf(request);
   if (csrfDeny) {
@@ -36,37 +107,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: 'service_credits_invalid_json', message: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  if (!body.recipientUserId || typeof body.amount !== 'number' || !(body.amount > 0) || !Number.isFinite(body.amount) || !body.idempotencyKey) {
-    return NextResponse.json({ ok: false, code: 'service_credits_invalid_payload', message: 'recipientUserId, amount and idempotencyKey are required.' }, { status: 400 });
-  }
-
-  if (body.rail !== undefined && body.rail !== 'balance' && body.rail !== 'mutual_credit') {
-    return NextResponse.json({ ok: false, code: 'service_credits_invalid_payload', message: 'rail must be "balance" or "mutual_credit".' }, { status: 400 });
-  }
-
-  // The access policy for transfer.create denies invalid_origin_plugin / disallowed_cross_plugin_path.
-  // Enforce that here: when originPlugin is supplied it must name a real plugin, so an arbitrary string
-  // can never be stored as the cross-plugin path. Omitting it means a direct send from this app.
-  const originPlugin =
-    typeof body.originPlugin === 'string' && body.originPlugin.trim().length > 0
-      ? body.originPlugin.trim()
-      : DEFAULT_ORIGIN_PLUGIN;
-  if (!isRegisteredPluginSlug(originPlugin)) {
-    return NextResponse.json(
-      { ok: false, code: 'service_credits_invalid_origin_plugin', message: 'originPlugin must be a registered plugin.' },
-      { status: 400 },
-    );
+  const parsed = parseTransferBody(body);
+  if ('error' in parsed) {
+    return parsed.error;
   }
 
   try {
     const transfer = await createTransfer({
       senderUserId: gate.auth.userId,
-      recipientUserId: body.recipientUserId,
-      amount: body.amount,
-      idempotencyKey: body.idempotencyKey,
-      originPlugin,
-      reasonCode: typeof body.reasonCode === 'string' ? body.reasonCode : undefined,
-      rail: body.rail === 'mutual_credit' ? 'mutual_credit' : undefined,
+      recipientUserId: parsed.data.recipientUserId,
+      amount: parsed.data.amount,
+      idempotencyKey: parsed.data.idempotencyKey,
+      originPlugin: parsed.data.originPlugin,
+      reasonCode: parsed.data.reasonCode,
+      rail: parsed.data.rail,
     });
 
     await insertServiceCreditsAudit({

--- a/ctf/packages/web/app/api/webhooks/clerk/route.ts
+++ b/ctf/packages/web/app/api/webhooks/clerk/route.ts
@@ -60,13 +60,22 @@ function verifySvixSignature(
 
 type ClerkWebhookEvent = { type?: string; data?: { id?: unknown } };
 
-export async function POST(request: Request) {
-  const signingSecret = process.env.CLERK_WEBHOOK_SIGNING_SECRET;
+// Configuration presence + full svix verification for an incoming delivery, in the original order:
+// require the signing secret (503 inert), read the raw body (never parse before verifying), require
+// the three svix headers, enforce the timestamp tolerance, then verify the signature. Returns a ready
+// error response or the verified raw body. Each status code and code string is unchanged from the
+// inline version.
+async function verifyWebhookDelivery(
+  request: Request,
+  signingSecret: string | undefined,
+): Promise<{ error: NextResponse } | { rawBody: string }> {
   if (!signingSecret || signingSecret.trim().length === 0) {
-    return NextResponse.json(
-      { ok: false, code: 'clerk_webhook_not_configured', message: 'CLERK_WEBHOOK_SIGNING_SECRET is not set in the app runtime.' },
-      { status: 503 },
-    );
+    return {
+      error: NextResponse.json(
+        { ok: false, code: 'clerk_webhook_not_configured', message: 'CLERK_WEBHOOK_SIGNING_SECRET is not set in the app runtime.' },
+        { status: 503 },
+      ),
+    };
   }
 
   const svixId = request.headers.get('svix-id');
@@ -76,17 +85,27 @@ export async function POST(request: Request) {
   const rawBody = await request.text();
 
   if (!svixId || !svixTimestamp || !svixSignature) {
-    return NextResponse.json({ ok: false, code: 'missing_signature_headers' }, { status: 400 });
+    return { error: NextResponse.json({ ok: false, code: 'missing_signature_headers' }, { status: 400 }) };
   }
 
   const timestampSeconds = Number(svixTimestamp);
   if (!Number.isFinite(timestampSeconds) || Math.abs(Date.now() / 1000 - timestampSeconds) > TIMESTAMP_TOLERANCE_SECONDS) {
-    return NextResponse.json({ ok: false, code: 'timestamp_out_of_tolerance' }, { status: 400 });
+    return { error: NextResponse.json({ ok: false, code: 'timestamp_out_of_tolerance' }, { status: 400 }) };
   }
 
   if (!verifySvixSignature(signingSecret, svixId, svixTimestamp, svixSignature, rawBody)) {
-    return NextResponse.json({ ok: false, code: 'invalid_signature' }, { status: 401 });
+    return { error: NextResponse.json({ ok: false, code: 'invalid_signature' }, { status: 401 }) };
   }
+
+  return { rawBody };
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyWebhookDelivery(request, process.env.CLERK_WEBHOOK_SIGNING_SECRET);
+  if ('error' in verification) {
+    return verification.error;
+  }
+  const { rawBody } = verification;
 
   let event: ClerkWebhookEvent;
   try {

--- a/ctf/packages/web/components/service-credits/sc-shared.ts
+++ b/ctf/packages/web/components/service-credits/sc-shared.ts
@@ -34,36 +34,46 @@ export type LedgerEntry = {
   createdAt: string;
 };
 
+export type LedgerDescription = { label: string; direction: "in" | "out" | "neutral" };
+
+// Reference-keyed labels for the "credit" entry type (default: "Credit grant").
+const CREDIT_LABELS_BY_REFERENCE: Record<string, string> = {
+  transfer: "Received credits",
+  treasury_fee: "Fee received",
+  dispute_adjustment: "Dispute resolution credit",
+};
+
+// Reference-keyed labels for the "debit" entry type (default: "Credits removed").
+const DEBIT_LABELS_BY_REFERENCE: Record<string, string> = {
+  treasury_fee: "Treasury fee",
+  dispute_adjustment: "Dispute resolution debit",
+};
+
+// Fixed descriptions for entry types that do not depend on referenceType.
+const FIXED_LEDGER_DESCRIPTIONS: Record<string, LedgerDescription> = {
+  escrow_hold: { label: "Held in escrow", direction: "out" },
+  escrow_release: { label: "Escrow released", direction: "neutral" },
+  escrow_refund: { label: "Escrow refunded", direction: "in" },
+  initial_allocation: { label: "Welcome allocation", direction: "in" },
+  skills_hunt_award: { label: "SkillsHunt award", direction: "in" },
+};
+
 // Plain-language label + direction for a ledger row. Direction drives the +/- sign and color:
 // "in" credits the member, "out" debits, "neutral" for escrow moves that net within the member's own
 // wallet (held/released) where a signed amount would mislead. Keeps wording newcomer-friendly.
 export function describeLedgerEntry(
   entryType: string,
   referenceType: string,
-): { label: string; direction: "in" | "out" | "neutral" } {
-  switch (entryType) {
-    case "credit":
-      if (referenceType === "transfer") return { label: "Received credits", direction: "in" };
-      if (referenceType === "treasury_fee") return { label: "Fee received", direction: "in" };
-      if (referenceType === "dispute_adjustment") return { label: "Dispute resolution credit", direction: "in" };
-      return { label: "Credit grant", direction: "in" };
-    case "debit":
-      if (referenceType === "treasury_fee") return { label: "Treasury fee", direction: "out" };
-      if (referenceType === "dispute_adjustment") return { label: "Dispute resolution debit", direction: "out" };
-      return { label: "Credits removed", direction: "out" };
-    case "escrow_hold":
-      return { label: "Held in escrow", direction: "out" };
-    case "escrow_release":
-      return { label: "Escrow released", direction: "neutral" };
-    case "escrow_refund":
-      return { label: "Escrow refunded", direction: "in" };
-    case "initial_allocation":
-      return { label: "Welcome allocation", direction: "in" };
-    case "skills_hunt_award":
-      return { label: "SkillsHunt award", direction: "in" };
-    default:
-      return { label: entryType.replace(/_/g, " "), direction: "neutral" };
+): LedgerDescription {
+  if (entryType === "credit") {
+    return { label: CREDIT_LABELS_BY_REFERENCE[referenceType] ?? "Credit grant", direction: "in" };
   }
+  if (entryType === "debit") {
+    return { label: DEBIT_LABELS_BY_REFERENCE[referenceType] ?? "Credits removed", direction: "out" };
+  }
+  const fixed = FIXED_LEDGER_DESCRIPTIONS[entryType];
+  if (fixed) return fixed;
+  return { label: entryType.replace(/_/g, " "), direction: "neutral" };
 }
 
 // Public circulation metrics returned by GET /api/service-credits/circulation. Aggregate,

--- a/ctf/packages/web/components/service-credits/sca-credit-limits-panel.tsx
+++ b/ctf/packages/web/components/service-credits/sca-credit-limits-panel.tsx
@@ -10,7 +10,82 @@ import { useState } from 'react';
 import { Field, ConfirmAction, Feedback } from './sca-fields';
 import { scAdminMutate, type CreditLimitResponse, type CreditLimitLookup, type CreditLimitLookupResponse } from './sca-shared';
 import { useTheme } from '@/hooks/useTheme';
-import { getServiceCreditsTokens } from './sc-shared';
+import { getServiceCreditsTokens, type ServiceCreditsTokens } from './sc-shared';
+
+// The set-limit action is ready once a member ID and a finite, non-negative limit are supplied.
+function isCreditLimitReady(targetUserId: string, creditLimit: string, limit: number): boolean {
+  return Boolean(targetUserId.trim()) && creditLimit.length > 0 && Number.isFinite(limit) && limit >= 0;
+}
+
+// Read-only look-up trigger. Disabled while a member ID is missing or a look-up is in flight.
+function LookUpButton({
+  disabled,
+  lookingUp,
+  onLookUp,
+  t,
+}: {
+  disabled: boolean;
+  lookingUp: boolean;
+  onLookUp: () => void;
+  t: ServiceCreditsTokens;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onLookUp}
+      style={{
+        display: 'inline-flex',
+        alignSelf: 'flex-start',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 8,
+        border: `1px solid ${t.BORDER_SOLID}`,
+        background: t.BG,
+        color: t.TITLE,
+        padding: '9px 16px',
+        fontSize: 13,
+        fontWeight: 600,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {lookingUp ? 'Looking up…' : 'Look up'}
+    </button>
+  );
+}
+
+// Read-only card showing a member's current mutual-credit limit, its source, and freeze state.
+function CreditLimitLookupCard({ lookup, t }: { lookup: CreditLimitLookup; t: ServiceCreditsTokens }) {
+  return (
+    <dl
+      style={{
+        display: 'grid',
+        gap: '4px 24px',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+        borderRadius: 10,
+        border: `1px solid ${t.BORDER_SOLID}`,
+        background: t.BG,
+        padding: 12,
+        fontSize: 13,
+        margin: 0,
+      }}
+    >
+      <div>
+        <dt style={{ color: t.MUTED }}>Mutual-credit limit</dt>
+        <dd style={{ fontWeight: 700, color: t.TITLE, margin: 0 }}>{lookup.creditLimit}</dd>
+      </div>
+      <div>
+        <dt style={{ color: t.MUTED }}>Source</dt>
+        <dd style={{ fontWeight: 700, color: t.TITLE, margin: 0 }}>{lookup.isDefault ? 'Policy default' : 'Per-account'}</dd>
+      </div>
+      <div>
+        <dt style={{ color: t.MUTED }}>Frozen</dt>
+        <dd style={{ fontWeight: 700, color: t.TITLE, margin: 0 }}>{lookup.frozen ? 'Yes' : 'No'}</dd>
+      </div>
+    </dl>
+  );
+}
 
 export function ServiceCreditsCreditLimitsPanel() {
   const { theme } = useTheme();
@@ -24,7 +99,8 @@ export function ServiceCreditsCreditLimitsPanel() {
   const [lookup, setLookup] = useState<CreditLimitLookup | null>(null);
 
   const limit = Number(creditLimit);
-  const ready = targetUserId.trim() && creditLimit.length > 0 && Number.isFinite(limit) && limit >= 0;
+  const ready = isCreditLimitReady(targetUserId, creditLimit, limit);
+  const lookupDisabled = !targetUserId.trim() || lookingUp;
 
   async function lookUp() {
     const id = targetUserId.trim();
@@ -96,56 +172,8 @@ export function ServiceCreditsCreditLimitsPanel() {
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-        <button
-          type="button"
-          disabled={!targetUserId.trim() || lookingUp}
-          onClick={() => void lookUp()}
-          style={{
-            display: 'inline-flex',
-            alignSelf: 'flex-start',
-            alignItems: 'center',
-            justifyContent: 'center',
-            borderRadius: 8,
-            border: `1px solid ${t.BORDER_SOLID}`,
-            background: t.BG,
-            color: t.TITLE,
-            padding: '9px 16px',
-            fontSize: 13,
-            fontWeight: 600,
-            cursor: !targetUserId.trim() || lookingUp ? 'not-allowed' : 'pointer',
-            opacity: !targetUserId.trim() || lookingUp ? 0.5 : 1,
-          }}
-        >
-          {lookingUp ? 'Looking up…' : 'Look up'}
-        </button>
-        {lookup ? (
-          <dl
-            style={{
-              display: 'grid',
-              gap: '4px 24px',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-              borderRadius: 10,
-              border: `1px solid ${t.BORDER_SOLID}`,
-              background: t.BG,
-              padding: 12,
-              fontSize: 13,
-              margin: 0,
-            }}
-          >
-            <div>
-              <dt style={{ color: t.MUTED }}>Mutual-credit limit</dt>
-              <dd style={{ fontWeight: 700, color: t.TITLE, margin: 0 }}>{lookup.creditLimit}</dd>
-            </div>
-            <div>
-              <dt style={{ color: t.MUTED }}>Source</dt>
-              <dd style={{ fontWeight: 700, color: t.TITLE, margin: 0 }}>{lookup.isDefault ? 'Policy default' : 'Per-account'}</dd>
-            </div>
-            <div>
-              <dt style={{ color: t.MUTED }}>Frozen</dt>
-              <dd style={{ fontWeight: 700, color: t.TITLE, margin: 0 }}>{lookup.frozen ? 'Yes' : 'No'}</dd>
-            </div>
-          </dl>
-        ) : null}
+        <LookUpButton disabled={lookupDisabled} lookingUp={lookingUp} onLookUp={() => void lookUp()} t={t} />
+        {lookup ? <CreditLimitLookupCard lookup={lookup} t={t} /> : null}
         <p style={{ fontSize: 11, color: t.MUTED, margin: 0, lineHeight: 1.5 }}>
           Every member gets the same flat limit by default. Override per account only when needed; set to 0 to revoke.
         </p>

--- a/ctf/packages/web/components/service-credits/sca-disputes-panel.tsx
+++ b/ctf/packages/web/components/service-credits/sca-disputes-panel.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Field, ConfirmAction, Feedback } from './sca-fields';
 import { scAdminMutate, newIdempotencyKey, type DisputeAdjustmentResponse } from './sca-shared';
 import { useTheme } from '@/hooks/useTheme';
-import { getServiceCreditsTokens } from './sc-shared';
+import { getServiceCreditsTokens, type ServiceCreditsTokens } from './sc-shared';
 
 // One open dispute in the review list (mirrors ServiceCreditsAdminDispute from the repository).
 type OpenDispute = {
@@ -26,6 +26,101 @@ function formatDisputeTime(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return '';
   return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+// The adjustment is ready once both members, a finite positive amount, and a reason are supplied.
+function isDisputeReady(
+  disputeCaseId: string,
+  sourceUserId: string,
+  destinationUserId: string,
+  value: number,
+  reason: string,
+): boolean {
+  return (
+    Boolean(disputeCaseId.trim()) &&
+    Boolean(sourceUserId.trim()) &&
+    Boolean(destinationUserId.trim()) &&
+    Number.isFinite(value) &&
+    value > 0 &&
+    Boolean(reason.trim())
+  );
+}
+
+// One row in the open-disputes review list. "Resolve" pre-fills the form's case ID.
+function OpenDisputeRow({
+  dispute,
+  onResolve,
+  t,
+}: {
+  dispute: OpenDispute;
+  onResolve: (id: string) => void;
+  t: ServiceCreditsTokens;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 8,
+        padding: '10px 12px',
+        borderRadius: 10,
+        background: t.BG,
+        border: `1px solid ${t.BORDER_SOLID}`,
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, color: t.TITLE, fontWeight: 600 }}>{dispute.reason}</div>
+        <div style={{ fontSize: 11, color: t.MUTED, marginTop: 2 }}>
+          Opened by {dispute.openedByName ?? `member ${dispute.openedByUserId.slice(0, 6)}`} · {formatDisputeTime(dispute.createdAtIso)}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => onResolve(dispute.id)}
+        style={{
+          padding: '6px 12px',
+          borderRadius: 8,
+          fontSize: 12,
+          fontWeight: 700,
+          cursor: 'pointer',
+          background: `${t.ACCENT}1F`,
+          color: t.ACCENT,
+          border: `1px solid ${t.ACCENT}40`,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        Resolve
+      </button>
+    </div>
+  );
+}
+
+// Open-disputes review list: a dispute with no adjustment yet. "Resolve" pre-fills the form's
+// case ID (the operator still supplies source/destination/amount). Drives the admin dot.
+function OpenDisputesList({
+  openDisputes,
+  onResolve,
+  t,
+}: {
+  openDisputes: OpenDispute[];
+  onResolve: (id: string) => void;
+  t: ServiceCreditsTokens;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>
+        Open disputes {openDisputes.length > 0 ? `(${openDisputes.length})` : ''}
+      </h3>
+      {openDisputes.length === 0 ? (
+        <p style={{ fontSize: 13, color: t.MUTED, margin: 0 }}>No open disputes.</p>
+      ) : (
+        openDisputes.map((dispute) => (
+          <OpenDisputeRow key={dispute.id} dispute={dispute} onResolve={onResolve} t={t} />
+        ))
+      )}
+    </div>
+  );
 }
 
 export function ServiceCreditsDisputesPanel() {
@@ -58,8 +153,7 @@ export function ServiceCreditsDisputesPanel() {
   }, [loadOpenDisputes]);
 
   const value = Number(amount);
-  const ready =
-    disputeCaseId.trim() && sourceUserId.trim() && destinationUserId.trim() && Number.isFinite(value) && value > 0 && reason.trim();
+  const ready = isDisputeReady(disputeCaseId, sourceUserId, destinationUserId, value, reason);
 
   async function submit() {
     setBusy(true);
@@ -109,56 +203,7 @@ export function ServiceCreditsDisputesPanel() {
         </p>
       </header>
 
-      {/* Open-disputes review list: a dispute with no adjustment yet. "Resolve" pre-fills the form's
-          case ID (the operator still supplies source/destination/amount). Drives the admin dot. */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>
-          Open disputes {openDisputes.length > 0 ? `(${openDisputes.length})` : ''}
-        </h3>
-        {openDisputes.length === 0 ? (
-          <p style={{ fontSize: 13, color: t.MUTED, margin: 0 }}>No open disputes.</p>
-        ) : (
-          openDisputes.map((dispute) => (
-            <div
-              key={dispute.id}
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                alignItems: 'center',
-                gap: 8,
-                padding: '10px 12px',
-                borderRadius: 10,
-                background: t.BG,
-                border: `1px solid ${t.BORDER_SOLID}`,
-              }}
-            >
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontSize: 13, color: t.TITLE, fontWeight: 600 }}>{dispute.reason}</div>
-                <div style={{ fontSize: 11, color: t.MUTED, marginTop: 2 }}>
-                  Opened by {dispute.openedByName ?? `member ${dispute.openedByUserId.slice(0, 6)}`} · {formatDisputeTime(dispute.createdAtIso)}
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => setDisputeCaseId(dispute.id)}
-                style={{
-                  padding: '6px 12px',
-                  borderRadius: 8,
-                  fontSize: 12,
-                  fontWeight: 700,
-                  cursor: 'pointer',
-                  background: `${t.ACCENT}1F`,
-                  color: t.ACCENT,
-                  border: `1px solid ${t.ACCENT}40`,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                Resolve
-              </button>
-            </div>
-          ))
-        )}
-      </div>
+      <OpenDisputesList openDisputes={openDisputes} onResolve={setDisputeCaseId} t={t} />
 
       <Feedback error={error} notice={notice} />
 

--- a/ctf/packages/web/components/service-credits/sca-fields.tsx
+++ b/ctf/packages/web/components/service-credits/sca-fields.tsx
@@ -6,7 +6,7 @@
 // Dark admin design system (rule 131): ServiceCredits accent is #A855F7.
 import { useState, type ReactNode } from 'react';
 import { useTheme } from '@/hooks/useTheme';
-import { getServiceCreditsTokens } from './sc-shared';
+import { getServiceCreditsTokens, type ServiceCreditsTokens } from './sc-shared';
 
 export function Field({
   label,
@@ -51,55 +51,64 @@ export function Field({
   );
 }
 
-// A two-step commit: the primary button arms a plain-language summary of exactly what
-// will change; the operator must press "Confirm" to fire the mutation. Used for every
-// state-changing action in the ServiceCredits admin (money core — no silent commits).
-export function ConfirmAction({
+// The un-armed primary button. Pressing it arms the confirm prompt. A "danger" tone renders
+// the red destructive styling (used for burns); the default tone uses the ServiceCredits accent.
+function ArmButton({
   label,
-  summary,
   busy,
   disabled,
-  onConfirm,
-  tone = 'default',
+  tone,
+  onArm,
+  t,
 }: {
   label: string;
-  summary: ReactNode;
   busy: boolean;
   disabled?: boolean;
-  onConfirm: () => void;
-  tone?: 'default' | 'danger';
+  tone: 'default' | 'danger';
+  onArm: () => void;
+  t: ServiceCreditsTokens;
 }) {
-  const { theme } = useTheme();
-  const t = getServiceCreditsTokens(theme);
-  const [armed, setArmed] = useState(false);
+  const blocked = disabled || busy;
+  const isDanger = tone === 'danger';
+  return (
+    <button
+      type="button"
+      disabled={blocked}
+      onClick={onArm}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 8,
+        padding: '9px 16px',
+        fontSize: 13,
+        fontWeight: 700,
+        cursor: blocked ? 'not-allowed' : 'pointer',
+        opacity: blocked ? 0.5 : 1,
+        background: isDanger ? 'rgba(239,68,68,0.1)' : t.ACCENT,
+        border: isDanger ? '1px solid rgba(239,68,68,0.4)' : `1px solid ${t.ACCENT}`,
+        color: isDanger ? '#FCA5A5' : '#FFFFFF',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
 
-  if (!armed) {
-    const isDanger = tone === 'danger';
-    return (
-      <button
-        type="button"
-        disabled={disabled || busy}
-        onClick={() => setArmed(true)}
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          borderRadius: 8,
-          padding: '9px 16px',
-          fontSize: 13,
-          fontWeight: 700,
-          cursor: disabled || busy ? 'not-allowed' : 'pointer',
-          opacity: disabled || busy ? 0.5 : 1,
-          background: isDanger ? 'rgba(239,68,68,0.1)' : t.ACCENT,
-          border: isDanger ? '1px solid rgba(239,68,68,0.4)' : `1px solid ${t.ACCENT}`,
-          color: isDanger ? '#FCA5A5' : '#FFFFFF',
-        }}
-      >
-        {label}
-      </button>
-    );
-  }
-
+// The armed state: a plain-language summary of exactly what will change plus Confirm / Cancel.
+function ConfirmPrompt({
+  summary,
+  busy,
+  onConfirm,
+  onCancel,
+  t,
+}: {
+  summary: ReactNode;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  t: ServiceCreditsTokens;
+}) {
   return (
     <div
       style={{
@@ -138,7 +147,7 @@ export function ConfirmAction({
         <button
           type="button"
           disabled={busy}
-          onClick={() => setArmed(false)}
+          onClick={onCancel}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
@@ -158,6 +167,39 @@ export function ConfirmAction({
         </button>
       </div>
     </div>
+  );
+}
+
+// A two-step commit: the primary button arms a plain-language summary of exactly what
+// will change; the operator must press "Confirm" to fire the mutation. Used for every
+// state-changing action in the ServiceCredits admin (money core — no silent commits).
+export function ConfirmAction({
+  label,
+  summary,
+  busy,
+  disabled,
+  onConfirm,
+  tone = 'default',
+}: {
+  label: string;
+  summary: ReactNode;
+  busy: boolean;
+  disabled?: boolean;
+  onConfirm: () => void;
+  tone?: 'default' | 'danger';
+}) {
+  const { theme } = useTheme();
+  const t = getServiceCreditsTokens(theme);
+  const [armed, setArmed] = useState(false);
+
+  if (!armed) {
+    return (
+      <ArmButton label={label} busy={busy} disabled={disabled} tone={tone} onArm={() => setArmed(true)} t={t} />
+    );
+  }
+
+  return (
+    <ConfirmPrompt summary={summary} busy={busy} onConfirm={onConfirm} onCancel={() => setArmed(false)} t={t} />
   );
 }
 

--- a/ctf/packages/web/components/service-credits/sca-governance-panel.tsx
+++ b/ctf/packages/web/components/service-credits/sca-governance-panel.tsx
@@ -10,7 +10,7 @@ import { useState } from 'react';
 import { Field, ConfirmAction, Feedback } from './sca-fields';
 import { scAdminMutate, newIdempotencyKey, type BurnResponse, type MintGrantResponse } from './sca-shared';
 import { useTheme } from '@/hooks/useTheme';
-import { getServiceCreditsTokens } from './sc-shared';
+import { getServiceCreditsTokens, type ServiceCreditsTokens } from './sc-shared';
 
 function useGovernanceForm() {
   const [targetUserId, setTargetUserId] = useState('');
@@ -24,6 +24,76 @@ function useGovernanceForm() {
     setTicket('');
   };
   return { targetUserId, setTargetUserId, amount, setAmount, reason, setReason, ticket, setTicket, reset };
+}
+
+type GovernanceForm = ReturnType<typeof useGovernanceForm>;
+
+// A mint or a burn is ready once a member, a finite positive amount, a reason, and a ticket exist.
+function isGovernanceReady(targetUserId: string, amount: number, reason: string, ticket: string): boolean {
+  return Boolean(targetUserId.trim()) && Number.isFinite(amount) && amount > 0 && Boolean(reason.trim()) && Boolean(ticket.trim());
+}
+
+// One side of the governance panel (mint or burn). The verb/preposition/balance-effect props keep
+// each side's confirm summary and copy exactly as shipped while sharing a single field layout.
+function GovernanceSubForm({
+  title,
+  form,
+  amount,
+  ready,
+  busy,
+  tone,
+  confirmLabel,
+  reasonPlaceholder,
+  verb,
+  preposition,
+  balanceEffect,
+  showFeedback,
+  error,
+  notice,
+  onConfirm,
+  t,
+}: {
+  title: string;
+  form: GovernanceForm;
+  amount: number;
+  ready: boolean;
+  busy: boolean;
+  tone: 'default' | 'danger';
+  confirmLabel: string;
+  reasonPlaceholder: string;
+  verb: string;
+  preposition: string;
+  balanceEffect: string;
+  showFeedback: boolean;
+  error: string | null;
+  notice: string | null;
+  onConfirm: () => void;
+  t: ServiceCreditsTokens;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>{title}</h3>
+      <Field label="Member user ID" value={form.targetUserId} onChange={form.setTargetUserId} placeholder="user_…" />
+      <Field label="Amount (credits)" type="number" value={form.amount} onChange={form.setAmount} placeholder="0" />
+      <Field label="Governance ticket ID" value={form.ticket} onChange={form.setTicket} placeholder="GOV-…" />
+      <Field label="Reason" value={form.reason} onChange={form.setReason} placeholder={reasonPlaceholder} />
+      <ConfirmAction
+        label={confirmLabel}
+        tone={tone}
+        busy={busy}
+        disabled={!ready}
+        onConfirm={onConfirm}
+        summary={
+          <>
+            {verb} <strong>{ready ? amount : 0}</strong> credits {preposition} member{' '}
+            <strong>{form.targetUserId.trim() || '—'}</strong> under ticket{' '}
+            <strong>{form.ticket.trim() || '—'}</strong>. This {balanceEffect} their balance and cannot be undone here.
+          </>
+        }
+      />
+      {showFeedback ? <Feedback error={error} notice={notice} /> : null}
+    </div>
+  );
 }
 
 export function ServiceCreditsGovernancePanel() {
@@ -42,8 +112,8 @@ export function ServiceCreditsGovernancePanel() {
 
   const mintAmount = Number(mint.amount);
   const burnAmount = Number(burn.amount);
-  const mintReady = mint.targetUserId.trim() && Number.isFinite(mintAmount) && mintAmount > 0 && mint.reason.trim() && mint.ticket.trim();
-  const burnReady = burn.targetUserId.trim() && Number.isFinite(burnAmount) && burnAmount > 0 && burn.reason.trim() && burn.ticket.trim();
+  const mintReady = isGovernanceReady(mint.targetUserId, mintAmount, mint.reason, mint.ticket);
+  const burnReady = isGovernanceReady(burn.targetUserId, burnAmount, burn.reason, burn.ticket);
 
   async function submitMint() {
     setBusy('mint');
@@ -109,50 +179,43 @@ export function ServiceCreditsGovernancePanel() {
       </header>
 
       <div style={{ display: 'grid', gap: 20, gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))' }}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>Mint grant</h3>
-          <Field label="Member user ID" value={mint.targetUserId} onChange={mint.setTargetUserId} placeholder="user_…" />
-          <Field label="Amount (credits)" type="number" value={mint.amount} onChange={mint.setAmount} placeholder="0" />
-          <Field label="Governance ticket ID" value={mint.ticket} onChange={mint.setTicket} placeholder="GOV-…" />
-          <Field label="Reason" value={mint.reason} onChange={mint.setReason} placeholder="Why this grant is issued" />
-          <ConfirmAction
-            label="Mint grant"
-            busy={busy === 'mint'}
-            disabled={!mintReady}
-            onConfirm={() => void submitMint()}
-            summary={
-              <>
-                Mint <strong>{mintReady ? mintAmount : 0}</strong> credits to member{' '}
-                <strong>{mint.targetUserId.trim() || '—'}</strong> under ticket{' '}
-                <strong>{mint.ticket.trim() || '—'}</strong>. This increases their balance and cannot be undone here.
-              </>
-            }
-          />
-          {lastAction === 'mint' ? <Feedback error={error} notice={notice} /> : null}
-        </div>
+        <GovernanceSubForm
+          title="Mint grant"
+          form={mint}
+          amount={mintAmount}
+          ready={mintReady}
+          busy={busy === 'mint'}
+          tone="default"
+          confirmLabel="Mint grant"
+          reasonPlaceholder="Why this grant is issued"
+          verb="Mint"
+          preposition="to"
+          balanceEffect="increases"
+          showFeedback={lastAction === 'mint'}
+          error={error}
+          notice={notice}
+          onConfirm={() => void submitMint()}
+          t={t}
+        />
 
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>Burn</h3>
-          <Field label="Member user ID" value={burn.targetUserId} onChange={burn.setTargetUserId} placeholder="user_…" />
-          <Field label="Amount (credits)" type="number" value={burn.amount} onChange={burn.setAmount} placeholder="0" />
-          <Field label="Governance ticket ID" value={burn.ticket} onChange={burn.setTicket} placeholder="GOV-…" />
-          <Field label="Reason" value={burn.reason} onChange={burn.setReason} placeholder="Why these credits are burned" />
-          <ConfirmAction
-            label="Burn credits"
-            tone="danger"
-            busy={busy === 'burn'}
-            disabled={!burnReady}
-            onConfirm={() => void submitBurn()}
-            summary={
-              <>
-                Burn <strong>{burnReady ? burnAmount : 0}</strong> credits from member{' '}
-                <strong>{burn.targetUserId.trim() || '—'}</strong> under ticket{' '}
-                <strong>{burn.ticket.trim() || '—'}</strong>. This reduces their balance and cannot be undone here.
-              </>
-            }
-          />
-          {lastAction === 'burn' ? <Feedback error={error} notice={notice} /> : null}
-        </div>
+        <GovernanceSubForm
+          title="Burn"
+          form={burn}
+          amount={burnAmount}
+          ready={burnReady}
+          busy={busy === 'burn'}
+          tone="danger"
+          confirmLabel="Burn credits"
+          reasonPlaceholder="Why these credits are burned"
+          verb="Burn"
+          preposition="from"
+          balanceEffect="reduces"
+          showFeedback={lastAction === 'burn'}
+          error={error}
+          notice={notice}
+          onConfirm={() => void submitBurn()}
+          t={t}
+        />
       </div>
     </section>
   );

--- a/ctf/packages/web/components/service-credits/sca-shared.ts
+++ b/ctf/packages/web/components/service-credits/sca-shared.ts
@@ -7,6 +7,14 @@
 
 export type AdminMutationResult<T = unknown> = { ok: boolean; message?: string; data?: T };
 
+// The shape of a failed admin-mutation response body: a message/reason/code plus any extra fields.
+type ScErrorBody = { ok?: boolean; message?: string; reason?: string; code?: string } & Record<string, unknown>;
+
+// Pick the most specific human-readable message from a failed response, falling back to the status.
+function scErrorMessage(data: ScErrorBody | null, status: number): string {
+  return data?.message ?? data?.reason ?? data?.code ?? `Request failed (${status}).`;
+}
+
 // All admin mutations carry the CSRF confirmation header the API requires (x-ctf-csrf: '1').
 export async function scAdminMutate<T = unknown>(
   url: string,
@@ -19,16 +27,11 @@ export async function scAdminMutate<T = unknown>(
       headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
       body: body === undefined ? undefined : JSON.stringify(body),
     });
-    const data = (await res.json().catch(() => null)) as
-      | ({ ok?: boolean; message?: string; reason?: string; code?: string } & Record<string, unknown>)
-      | null;
+    const data = (await res.json().catch(() => null)) as ScErrorBody | null;
     if (res.ok) {
       return { ok: true, data: (data as T) ?? undefined };
     }
-    return {
-      ok: false,
-      message: data?.message ?? data?.reason ?? data?.code ?? `Request failed (${res.status}).`,
-    };
+    return { ok: false, message: scErrorMessage(data, res.status) };
   } catch {
     return { ok: false, message: 'Network error. Try again.' };
   }

--- a/ctf/packages/web/components/service-credits/sca-treasury-panel.tsx
+++ b/ctf/packages/web/components/service-credits/sca-treasury-panel.tsx
@@ -16,7 +16,83 @@ import {
   type TreasuryFeeResponse,
 } from './sca-shared';
 import { useTheme } from '@/hooks/useTheme';
-import { getServiceCreditsTokens } from './sc-shared';
+import { getServiceCreditsTokens, type ServiceCreditsTokens } from './sc-shared';
+
+// Fee collection is ready once both members, a finite positive amount, a reason code, and an
+// origin plugin are supplied.
+function isFeeReady(
+  sourceUserId: string,
+  treasuryUserId: string,
+  fee: number,
+  feeReasonCode: string,
+  originPlugin: string,
+): boolean {
+  return (
+    Boolean(sourceUserId.trim()) &&
+    Boolean(treasuryUserId.trim()) &&
+    Number.isFinite(fee) &&
+    fee > 0 &&
+    Boolean(feeReasonCode.trim()) &&
+    Boolean(originPlugin.trim())
+  );
+}
+
+// The treasury-policy editor: a loading note, else the JSON textarea plus its parse error and save.
+function TreasuryPolicyEditor({
+  loading,
+  policyText,
+  policyError,
+  busy,
+  onPolicyTextChange,
+  onSave,
+  t,
+}: {
+  loading: boolean;
+  policyText: string;
+  policyError: string | null;
+  busy: boolean;
+  onPolicyTextChange: (value: string) => void;
+  onSave: () => void;
+  t: ServiceCreditsTokens;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>Treasury policy</h3>
+      {loading ? (
+        <p style={{ fontSize: 13, color: t.MUTED, margin: 0 }}>Loading…</p>
+      ) : (
+        <>
+          <textarea
+            style={{
+              height: 192,
+              width: '100%',
+              boxSizing: 'border-box',
+              borderRadius: 8,
+              border: `1px solid ${t.BORDER_SOLID}`,
+              background: t.BG,
+              color: t.TITLE,
+              padding: '9px 12px',
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+              fontSize: 12,
+              outline: 'none',
+              resize: 'vertical',
+            }}
+            value={policyText}
+            spellCheck={false}
+            onChange={(event) => onPolicyTextChange(event.target.value)}
+          />
+          {policyError ? <p style={{ fontSize: 11, color: '#FCA5A5', margin: 0 }}>{policyError}</p> : null}
+          <ConfirmAction
+            label="Save policy"
+            busy={busy}
+            onConfirm={onSave}
+            summary="Replace the stored treasury policy with the JSON above. This overwrites the whole policy object."
+          />
+        </>
+      )}
+    </div>
+  );
+}
 
 export function ServiceCreditsTreasuryPanel() {
   const { theme } = useTheme();
@@ -88,8 +164,7 @@ export function ServiceCreditsTreasuryPanel() {
   }
 
   const fee = Number(feeAmount);
-  const feeReady =
-    sourceUserId.trim() && treasuryUserId.trim() && Number.isFinite(fee) && fee > 0 && feeReasonCode.trim() && originPlugin.trim();
+  const feeReady = isFeeReady(sourceUserId, treasuryUserId, fee, feeReasonCode, originPlugin);
 
   async function collectFee() {
     setBusy('fee');
@@ -138,44 +213,18 @@ export function ServiceCreditsTreasuryPanel() {
 
       <Feedback error={error} notice={notice} />
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>Treasury policy</h3>
-        {loading ? (
-          <p style={{ fontSize: 13, color: t.MUTED, margin: 0 }}>Loading…</p>
-        ) : (
-          <>
-            <textarea
-              style={{
-                height: 192,
-                width: '100%',
-                boxSizing: 'border-box',
-                borderRadius: 8,
-                border: `1px solid ${t.BORDER_SOLID}`,
-                background: t.BG,
-                color: t.TITLE,
-                padding: '9px 12px',
-                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-                fontSize: 12,
-                outline: 'none',
-                resize: 'vertical',
-              }}
-              value={policyText}
-              spellCheck={false}
-              onChange={(event) => {
-                setPolicyText(event.target.value);
-                setPolicyError(null);
-              }}
-            />
-            {policyError ? <p style={{ fontSize: 11, color: '#FCA5A5', margin: 0 }}>{policyError}</p> : null}
-            <ConfirmAction
-              label="Save policy"
-              busy={busy === 'policy'}
-              onConfirm={() => void savePolicy()}
-              summary="Replace the stored treasury policy with the JSON above. This overwrites the whole policy object."
-            />
-          </>
-        )}
-      </div>
+      <TreasuryPolicyEditor
+        loading={loading}
+        policyText={policyText}
+        policyError={policyError}
+        busy={busy === 'policy'}
+        onPolicyTextChange={(value) => {
+          setPolicyText(value);
+          setPolicyError(null);
+        }}
+        onSave={() => void savePolicy()}
+        t={t}
+      />
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12, borderTop: `1px solid ${t.BORDER_SOLID}`, paddingTop: 16 }}>
         <h3 style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: 0 }}>Collect fee</h3>

--- a/ctf/packages/web/components/service-credits/service-credits-shell.tsx
+++ b/ctf/packages/web/components/service-credits/service-credits-shell.tsx
@@ -6,7 +6,7 @@ import { BackChevronButton } from "@/lib/nav/back-history";
 import { Badge } from "@/components/ui/badge";
 import { useTheme } from "@/hooks/useTheme";
 import { AppLoading } from "@/components/shared/app-loading";
-import { BG, fmtCredits, getServiceCreditsTokens, type Tab, type WalletData } from "./sc-shared";
+import { BG, fmtCredits, getServiceCreditsTokens, type ServiceCreditsTokens, type Tab, type WalletData } from "./sc-shared";
 import { ServiceCreditsWalletTab } from "./sc-wallet-tab";
 import { ServiceCreditsEarnTab } from "./sc-earn-tab";
 import { ServiceCreditsCirculationTab } from "./sc-circulation-tab";
@@ -20,6 +20,24 @@ function CenteredNote({ color, children }: { color: string; children: React.Reac
     <div style={{ width: "100%", minHeight: "100vh", background: BG, display: "flex", alignItems: "center", justifyContent: "center", color, fontFamily: "'Inter', system-ui, sans-serif" }}>
       {children}
     </div>
+  );
+}
+
+// One top-of-shell tab. The active tab uses the ServiceCredits accent; others stay muted.
+function TabButton({ label, active, onSelect, t }: { label: string; active: boolean; onSelect: () => void; t: ServiceCreditsTokens }) {
+  return (
+    <button onClick={onSelect} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: active ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${active ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: active ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+  );
+}
+
+// The active tab's body: wallet, earn, or economy.
+function ShellTabContent({ tab, balance, escrow }: { tab: Tab; balance: number; escrow: number }) {
+  return (
+    <>
+      {tab === "wallet" && <ServiceCreditsWalletTab balance={balance} escrow={escrow} />}
+      {tab === "earn" && <ServiceCreditsEarnTab />}
+      {tab === "economy" && <ServiceCreditsCirculationTab />}
+    </>
   );
 }
 
@@ -62,13 +80,7 @@ export function ServiceCreditsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
   const balance = wallet?.availableBalance ?? 0;
   const escrow = wallet?.escrowBalance ?? 0;
 
-  const content = (
-    <>
-      {tab === "wallet" && <ServiceCreditsWalletTab balance={balance} escrow={escrow} />}
-      {tab === "earn" && <ServiceCreditsEarnTab />}
-      {tab === "economy" && <ServiceCreditsCirculationTab />}
-    </>
-  );
+  const content = <ShellTabContent tab={tab} balance={balance} escrow={escrow} />;
 
     const tabs: { key: Tab; label: string }[] = [
       { key: "wallet", label: "Wallet" },
@@ -90,7 +102,7 @@ export function ServiceCreditsShell({ isAdmin }: { isAdmin?: boolean } = {}) {
           </div>
           <div style={{ display: "flex", gap: 6, padding: "0 12px 8px" }}>
             {tabs.map(({ key, label }) => (
-              <button key={key} onClick={() => setTab(key)} style={{ flex: 1, padding: "8px 0", borderRadius: 8, background: tab === key ? `${t.ACCENT}1A` : "transparent", border: `1px solid ${tab === key ? t.ACCENT + "40" : t.BORDER_STRONG}`, color: tab === key ? t.ACCENT : t.SUBTLE, fontSize: 13, fontWeight: 600, cursor: "pointer" }}>{label}</button>
+              <TabButton key={key} label={label} active={tab === key} onSelect={() => setTab(key)} t={t} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — server-only API routes and web admin components; no React Native surface.

## What

Rule-116 complexity cleanup for the last 19 files over the limit — the sensitive bundle held back from the earlier refactor PRs because it touches value movement, data deletion, and auth. **Strictly behavior-preserving.** Complexity was reduced only by extracting module-scope helpers (validation returning discriminated `{ error } | { data }`, error-code→response lookup tables, per-step / per-event sub-handlers) and, in the components, presentational sub-components plus grouped style/hook helpers.

**API routes (11):**
- `service-credits/transfers`, `service-credits/escrows`, `service-credits/_lib`
- `service-credits/admin/disputes/adjustments`, `admin/governance/burns`, `admin/governance/mint-grants`, `admin/treasury/fees/collect`
- `internal/account/delete`, `internal/service-credits/.../deletion-reclaims/.../execute`
- `chyme/service-credits`
- `webhooks/clerk`

**Components (8):** `sc-shared`, `sca-shared`, `sca-fields`, `sca-credit-limits-panel`, `sca-disputes-panel`, `sca-governance-panel`, `sca-treasury-panel`, `service-credits-shell`

## What did NOT change (verified per file by each author)
- No arithmetic, amounts, credit-floor, or rounding
- Idempotency keys derived/passed identically
- No SQL/DB query changes and no reordering of side effects (local writes before external ledger posts stay in order)
- Deletion scope/table set/order unchanged; escrow/eligibility guards unchanged
- Clerk webhook signature verification (`verifySvixSignature`) byte-for-byte unchanged; same event handling
- CSRF/auth/role gates, audit events and payloads, HTTP status codes, response bodies, and error-code→response mappings unchanged
- Components: no change to rendered output, props/exports, state, effects, handlers, API calls, payloads, displayed amounts/formatting, or credit copy (credits remain non-money framing)

## Verification
- complexity gate (`complexity: 10`, `max-lines-per-function: 200`) on all 19 files — passes
- `pnpm --filter @ctf/web run typecheck` — passes
- eslint on all changed files — passes
- repo-wide typecheck (pre-commit/pre-push) — passes
- `check-eof-format` — passes

No schema, route, or contract changes, so no inventory section changes are triggered (pure handler/component-internal refactor).

## Review lane
Touches the ServiceCredits ledger, data deletion, and the Clerk auth webhook → **owner-review**. Opened ready for review, **auto-merge not enabled** — the ledger, deletion, and auth paths deserve human eyes even though the change is a pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzFjp5mF5wt2tuqNi9SwyT)_