### PR TITLE
fix: feed routes return contract-promised timestamps; guard flagged-answers limit

### DIFF
--- a/ctf/packages/web/app/api/feed/admin/moderation/flagged-answers/route.ts
+++ b/ctf/packages/web/app/api/feed/admin/moderation/flagged-answers/route.ts
@@ -21,8 +21,11 @@ export async function GET(request: Request) {
     return gate.response;
   }
 
+  // `Number('')` is 0 and negative numbers are finite, so a bare or negative `limit` param must
+  // fall back to the intended default of 50 rather than slipping through (issue #2018). Matches
+  // the moderation-queue route's pattern; listFlaggedAnswers still clamps the upper bound.
   const limitParam = Number(new URL(request.url).searchParams.get('limit') ?? '50');
-  const limit = Number.isFinite(limitParam) ? limitParam : 50;
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 50;
 
   try {
     const [answers, pending] = await Promise.all([

--- a/ctf/packages/web/app/api/feed/items/[itemId]/dismiss/route.ts
+++ b/ctf/packages/web/app/api/feed/items/[itemId]/dismiss/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request, { params }: RouteParams) {
   const { itemId } = await params;
 
   try {
-    await dismissFeedItem(gate.auth.userId, itemId);
+    const { dismissedAtIso } = await dismissFeedItem(gate.auth.userId, itemId);
 
     logFeedAudit({
       actorId: gate.auth.userId,
@@ -39,7 +39,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       errorCategory: null,
     });
 
-    return NextResponse.json({ ok: true, itemId }, { status: 200 });
+    return NextResponse.json({ ok: true, itemId, dismissedAt: dismissedAtIso }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'feed', op: 'items_itemid_dismiss' });
     return NextResponse.json(

--- a/ctf/packages/web/app/api/feed/items/[itemId]/read/route.ts
+++ b/ctf/packages/web/app/api/feed/items/[itemId]/read/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request, { params }: RouteParams) {
   const { itemId } = await params;
 
   try {
-    await markFeedItemRead(gate.auth.userId, itemId);
+    const { readAtIso } = await markFeedItemRead(gate.auth.userId, itemId);
     logFeedAudit({
       actorId: gate.auth.userId,
       pluginId: 'feed',
@@ -38,7 +38,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       errorCategory: null,
     });
 
-    return NextResponse.json({ ok: true, itemId }, { status: 200 });
+    return NextResponse.json({ ok: true, itemId, readAt: readAtIso }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'feed', op: 'items_itemid_read' });
     logFeedAudit({

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -1511,19 +1511,31 @@ export async function listFeedTimeline(
   });
 }
 
-export async function markFeedItemRead(userId: string, itemId: string): Promise<void> {
-  await queryDb(
+// Returns the stored read_at so the route can satisfy the feed.item.read.mark contract, whose
+// output schema includes readAt (issue #2017 — the route previously returned only ok/itemId).
+export async function markFeedItemRead(
+  userId: string,
+  itemId: string,
+): Promise<{ readAtIso: string }> {
+  const result = await queryDb<{ read_at: string }>(
     `
       INSERT INTO feed_user_read_state (user_id, item_id, read_at)
       VALUES ($1, $2::uuid, NOW())
       ON CONFLICT (user_id, item_id)
       DO UPDATE SET read_at = EXCLUDED.read_at
+      RETURNING read_at
     `,
     [userId, itemId],
   );
+  return { readAtIso: new Date(result.rows[0].read_at).toISOString() };
 }
 
-export async function dismissFeedItem(userId: string, itemId: string): Promise<'ok'> {
+// Returns the stored dismissed_at so the route can satisfy the feed.item.dismiss contract, whose
+// output schema includes dismissedAt (issue #2016 — the route previously returned only ok/itemId).
+export async function dismissFeedItem(
+  userId: string,
+  itemId: string,
+): Promise<{ dismissedAtIso: string }> {
   const result = await queryDb<{ id: string }>(
     'SELECT id FROM feed_items WHERE id = $1::uuid LIMIT 1',
     [itemId],
@@ -1533,17 +1545,18 @@ export async function dismissFeedItem(userId: string, itemId: string): Promise<'
     throw new Error('feed_item_not_found');
   }
 
-  await queryDb(
+  const dismissed = await queryDb<{ dismissed_at: string }>(
     `
       INSERT INTO feed_user_dismissals (user_id, item_id, dismissed_at)
       VALUES ($1, $2::uuid, NOW())
       ON CONFLICT (user_id, item_id)
       DO UPDATE SET dismissed_at = EXCLUDED.dismissed_at
+      RETURNING dismissed_at
     `,
     [userId, itemId],
   );
 
-  return 'ok';
+  return { dismissedAtIso: new Date(dismissed.rows[0].dismissed_at).toISOString() };
 }
 
 export async function listAnnouncements(includeArchived: boolean): Promise<Announcement[]> {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Closes #2016
Closes #2017
Closes #2018

## What changed

Three of the five open feed code-review findings were real; this fixes them. Every finding was verified against the current code before acting.

1. **#2016 / #2017 — contract outputs.** `feed.item.dismiss` and `feed.item.read.mark` promise `dismissedAt` / `readAt` in their command-contract output schemas, but the routes returned only `{ ok, itemId }`. `dismissFeedItem` and `markFeedItemRead` now `RETURNING` the stored timestamp, and the routes include it as an ISO string. Additive response change — no caller breaks, and the contract YAML is untouched (the code moved to the contract, not the other way).
2. **#2018 — limit guard.** The flagged-answers admin route accepted `limit=` (empty → `Number('') === 0`) and negative values because `Number.isFinite` alone passed them. The guard now requires `limitParam > 0`, falling back to the intended 50, matching the moderation-queue route. The repository function still clamps the upper bound at 200.

## Findings closed as not real (no code change)

- **#2015** claimed `claimGuidanceMilestone` swaps its INSERT parameters. It does not: `VALUES ($2, $1)` with params `[milestoneCount, noticeKey]` maps `$2` (the key) into `notice_key` and `$1` (the count) into `milestone_count` — correct, just transposed in a way that invites misreading.
- **#2020** claimed the pseudonym mention token is stored without the `@` prefix. The current code pushes `` `@${pseudonym}` `` — the prefix is there.

## Checks

Typecheck (web/shared/mobile), US spelling gate, test-script drift, modularity governance — all pass locally. No inventory change needed: the inventory lists these routes without enumerating response fields, so nothing drifted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_