### PR TITLE
ci: treat an Expo plan-quota rejection as a clean skip, not a red run

### DIFF
--- a/.github/workflows/expo-android-scheduled-build.yml
+++ b/.github/workflows/expo-android-scheduled-build.yml
@@ -127,7 +127,26 @@ jobs:
         working-directory: ctf/packages/mobile
         run: |
           set -euo pipefail
-          eas build --platform android --profile preview --non-interactive --wait --json > build.json
+          # The quota guard above counts this project's builds via `eas build:list`, but Expo
+          # enforces the free-plan cap per ACCOUNT and by its own attempt accounting, so the guard
+          # can undercount and let a build through that Expo then rejects (issue #2030: main went
+          # red on "This account has used its Android builds from the Free plan this month").
+          # A plan-quota rejection is an expected monthly condition, not a defect on main — catch
+          # it and skip cleanly, exactly like a guard-detected skip. Everything else still fails
+          # the job (and the autofix agent still fires for real build failures).
+          if ! eas build --platform android --profile preview --non-interactive --wait --json > build.json 2> eas-stderr.txt; then
+            cat eas-stderr.txt >&2 || true
+            if grep -qi "used its Android builds" eas-stderr.txt build.json 2>/dev/null; then
+              {
+                echo "### Android test build skipped"
+                echo ""
+                echo "Expo rejected the build: the account's free-plan Android builds for this month are used up (the pre-check undercounted — Expo's cap is account-wide). The build runs again after the monthly reset."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "quota_exhausted=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
           # Two links from the finished build: the Expo "internal distribution"
           # install page (the easy phone path — open it on Android and tap
           # Install) and the direct .apk download URL. Build-page key names vary
@@ -146,7 +165,7 @@ jobs:
           echo "apk_url=${APK_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Record build in summary
-        if: ${{ steps.quota.outputs.build_allowed == 'true' && success() }}
+        if: ${{ steps.quota.outputs.build_allowed == 'true' && steps.build.outputs.quota_exhausted != 'true' && success() }}
         run: |
           {
             echo "### Android test build finished"

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -146,7 +146,17 @@ jobs:
         run: |
           set -euo pipefail
           # --no-wait returns immediately with the build record (id + expo.dev page).
-          eas build --platform android --profile preview --non-interactive --no-wait --json > build.json
+          # Expo enforces the free-plan cap per ACCOUNT, so the guard above can undercount and let
+          # a build through that Expo then rejects (see issue #2030). That rejection is an expected
+          # monthly condition — surface it as a skip, not a red check on the PR.
+          if ! eas build --platform android --profile preview --non-interactive --no-wait --json > build.json 2> eas-stderr.txt; then
+            cat eas-stderr.txt >&2 || true
+            if grep -qi "used its Android builds" eas-stderr.txt build.json 2>/dev/null; then
+              echo "quota_exhausted=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
           # Read the build page URL straight from the EAS response so we do not
           # need an EXPO_OWNER secret. Different EAS versions expose it under
           # slightly different keys, so check the known ones in order.
@@ -158,8 +168,26 @@ jobs:
           ")
           echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
 
+      - name: Quota rejected at build time — tell the pull request
+        if: ${{ steps.quota.outputs.build_allowed == 'true' && steps.build.outputs.quota_exhausted == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- expo-preview-build -->';
+            const body = `${marker}\n**Android preview build skipped — free-tier quota reached.**\n\nExpo rejected the build: the account's free-plan Android builds for this month are used up (the pre-check undercounted — Expo's cap is account-wide). Builds resume after the monthly reset.`;
+            if (!context.issue.number) { core.info(body); return; }
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
       - name: Comment install link on the pull request
-        if: ${{ steps.quota.outputs.build_allowed == 'true' }}
+        if: ${{ steps.quota.outputs.build_allowed == 'true' && steps.build.outputs.quota_exhausted != 'true' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Fixes the workflow-health failure behind #2030 (the issue itself auto-closes once the next scheduled run on main passes).

## What happened

The scheduled Android build went red on main with "This account has used its Android builds from the Free plan this month" — after the quota guard ran and said the build was allowed. The guard counts this project's builds via `eas build:list`, but Expo enforces the free-plan cap **per account** and by its own attempt accounting, so the guard can undercount and let a build through that Expo then rejects at submission.

## The fix

A plan-quota rejection is an expected monthly condition, not a defect on main, so the build steps now catch it:

- **Scheduled build** (`expo-android-scheduled-build.yml`): a failed `eas build` whose output carries the quota message exits 0 with a skip summary; the success-summary step is gated off for that path. Any other failure still fails the job, so the autofix agent still fires for real defects.
- **On-demand preview** (`expo-preview.yml`): same catch; the PR gets a "build skipped — quota reached" comment instead of an install link, and the check stays green.
- **Manual release** (`expo-android-release.yml`): left alone on purpose — a release build hitting the cap should fail loudly so the owner sees it.

## Why not fix the counter instead

The undercount cannot be closed from this side: the EAS CLI lists builds per project, and the plan meter is account-wide and includes attempt states the CLI reporting does not expose consistently. The pre-check still prevents most overruns cheaply; the build-time catch makes the residual case terminal instead of red.

## Notes

- Quota resets August 1, so the next cron run goes green either way — guard skip before the reset, real build after. #2030 then closes itself.
- Both workflow files validate as YAML; EOF and spelling gates pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_