### PR TITLE
fix: items route honors documented mentions=me; moderation.list contract drops unread Q&A tables

### DIFF
--- a/ctf/docs/contracts/FEED_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/FEED_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -607,11 +607,14 @@ contracts:
 
   - pluginId: feed
     command: feed.community.moderation.list
-    version: 1.0.0
+    version: 1.0.1
     description: >-
       List member-authored Commons posts and replies for admin review, newest first, with the count of
       rows currently hidden. Hidden rows are included by default so a moderator can see what has been
-      taken down and put it back; `hidden=1` narrows to only those. Admin only, read-only.
+      taken down and put it back; `hidden=1` narrows to only those. Admin only, read-only. Deliberately
+      Commons-only: Q&A answers are moderated through their own queue (feed.qa.moderation.flagged.list),
+      which is flag-driven rather than a full listing. v1.0.1 removes feed_questions/feed_answers from
+      dataAccess — the query never read them, and the listing was never meant to include Q&A rows.
     inputSchema:
       hidden:
         type: boolean
@@ -627,8 +630,6 @@ contracts:
     dataAccess:
       - feed_community_posts
       - feed_community_replies
-      - feed_questions
-      - feed_answers
     purpose: content_moderation
     retentionClass: transactional_long_lived
     idempotency: true

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -351,6 +351,14 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 ## 11) Change Log
 
+- 2026-08-01: **Two code-review corrections (issues #2021, #2019).** (1) `GET /api/feed/items` now
+  honors the `mentions=me` input its contract (feed.timeline.fetch) has always documented: handle
+  tokens are derived server-side from the authenticated caller (never client-supplied) and passed to
+  `listFeedTimeline`; any other `mentions` value is rejected with 400. The Hub "@ Mentions" toggle was
+  never broken — it calls `/api/hub/messages`, which already implemented the filter — this closes the
+  gap on the documented items route. (2) The `feed.community.moderation.list` contract (now v1.0.1) no
+  longer claims `feed_questions`/`feed_answers` in dataAccess: the queue is Commons-only by design and
+  its query never read those tables; Q&A moderation lives in `feed.qa.moderation.flagged.list`.
 - 2026-07-31: **Admin membership-event route now writes its audit entry (code-review finding).**
   `POST /api/feed/membership/events` called `emitMembershipEvent` and returned without ever calling
   `logFeedAudit`, so this admin-only command left no audit trail even though

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -54,6 +54,9 @@
 **Expected:**
 - Default view shows items from multiple channel types (announcement cards, question cards, community posts) in reverse-chronological order.
 - Each filter shows only items of that type; no items from other channels appear.
+- API check (optional): `GET /api/feed/items?mentions=me` returns only items that @-mention the
+  signed-in caller (same behavior as the Hub "@ Mentions" toggle); any other `mentions` value
+  returns 400.
 - Switching back to All restores the blended view.
 - No loading spinner stays permanently; empty state message shows if a channel has no items.
 

--- a/ctf/packages/web/app/api/feed/items/route.ts
+++ b/ctf/packages/web/app/api/feed/items/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireFeedReadAccess } from '../_lib';
 import { FEED_ERROR_CODE } from 'lib/feed/constants';
-import { isValidFeedChannel, listFeedTimeline, parsePaginationParams } from 'lib/feed/repository';
+import { feedMentionTokens, isValidFeedChannel, listFeedTimeline, parsePaginationParams } from 'lib/feed/repository';
 import { reportError } from 'lib/observability/report';
 
 export async function GET(request: Request) {
@@ -14,10 +14,22 @@ export async function GET(request: Request) {
   const params = new URL(request.url).searchParams;
   const pluginId = params.get('pluginId');
   const channel = params.get('channel');
+  const mentions = params.get('mentions');
 
   if (channel !== null && !isValidFeedChannel(channel)) {
     return NextResponse.json(
       { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid feed channel filter.' },
+      { status: 400 },
+    );
+  }
+
+  // `mentions=me` per the feed.timeline.fetch contract: only items whose body @-mentions the
+  // CALLER. The handle tokens are derived server-side from the authenticated user (`@<username>`
+  // and the `@user-<id token>` pseudonym) — a client-supplied handle is never accepted. `me` is
+  // the only defined value, so anything else is rejected rather than silently unfiltered.
+  if (mentions !== null && mentions !== 'me') {
+    return NextResponse.json(
+      { ok: false, code: FEED_ERROR_CODE.invalidPayload, message: 'Invalid mentions filter.' },
       { status: 400 },
     );
   }
@@ -27,7 +39,12 @@ export async function GET(request: Request) {
       gate.auth.userId,
       gate.auth.role,
       pagination,
-      { pluginId, channel: channel ?? 'all' },
+      {
+        pluginId,
+        channel: channel ?? 'all',
+        mentionHandles:
+          mentions === 'me' ? feedMentionTokens(gate.auth.username, gate.auth.userId) : null,
+      },
     );
 
     return NextResponse.json(payload, { status: 200 });


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Closes #2021
Closes #2019

## What changed

Both remaining feed code-review findings, each verified against the code before acting.

### #2021 — `mentions=me` on the items route (real, but the stated consequence was wrong)

The finding claimed the Hub Commons "@ Mentions" toggle "will have no effect." It works and always has — the toggle calls `/api/hub/messages`, which implements the filter. The real defect: the `feed.timeline.fetch` contract documents a `mentions` input on `GET /api/feed/items`, and that route ignored it.

The route now honors it, matching the hub route's behavior exactly: handle tokens (`@<username>` and the `@user-<id token>` pseudonym) are derived server-side from the authenticated caller — a client-supplied handle is never accepted — and passed to `listFeedTimeline`, which already supported the filter. Any `mentions` value other than `me` is rejected with 400 rather than silently unfiltered.

### #2019 — moderation-list contract over-claimed Q&A tables (real; the suggested fix was the wrong direction)

The finding suggested extending the moderation queue's UNION to include `feed_questions`/`feed_answers`. The queue is Commons posts/replies only **by design** — its own contract description says so — and Q&A moderation has its dedicated flag-driven queue (`feed.qa.moderation.flagged.list`) with the correct dataAccess. Extending the SQL would have built a second Q&A moderation surface nobody asked for.

The error was in the contract: `feed.community.moderation.list` claimed `feed_questions`/`feed_answers` in dataAccess while its query never read them. v1.0.1 removes the two tables and states the Commons-only scope explicitly.

## Drift gates

Feed inventory change-log entry plus a matching test-script API check (the contract change carries versioning evidence via the inventory). Typecheck, US spelling, test-script drift, inventory drift, modularity — all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_