### PR TITLE
fix: long URLs in a SocketRelay request no longer run off the card

### DIFF
--- a/ctf/packages/web/components/socket-relay/sr-feed.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-feed.tsx
@@ -139,8 +139,12 @@ function RequestCard({
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <CardBadges request={r} t={t} open={open} expired={expired} />
-          <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 4, lineHeight: 1.4 }}>{r.title}</div>
-          {r.details && <div style={{ fontSize: 13, color: t.SUBTLE, marginBottom: 6, lineHeight: 1.5 }}>{r.details}</div>}
+          {/* overflowWrap 'anywhere' on both: members paste URLs into requests, and a long URL has no
+              space to break at, so the default wrapping rule lets it run past the card's right edge and
+              get clipped (owner report — a GitHub link in a request was cut mid-address). `minWidth: 0`
+              on the flex parent above lets the column shrink; this lets the text inside it break. */}
+          <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 4, lineHeight: 1.4, overflowWrap: "anywhere" }}>{r.title}</div>
+          {r.details && <div style={{ fontSize: 13, color: t.SUBTLE, marginBottom: 6, lineHeight: 1.5, overflowWrap: "anywhere" }}>{r.details}</div>}
           <CardMeta request={r} t={t} />
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-end", flexShrink: 0 }}>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What the owner saw

A SocketRelay request containing a GitHub link rendered with the URL running off the right edge of the card, clipped mid-address.

## Why

The card's text column already shrinks correctly (`minWidth: 0` on the flex child), so the container was not the problem. The title and details used the default `overflow-wrap`, which only breaks lines at spaces. A URL contains none, so the browser had nowhere to break it and let it overflow instead.

## The fix

`overflowWrap: 'anywhere'` on the request title and details, so any unbroken run of characters — a URL, a long token, a pasted path — wraps inside the card. Rendering only; no data, route, or contract change.

The badge row above was already `flexWrap: 'wrap'` and is not affected; its stacking at phone width is correct behavior, not a defect.

## Checks

Web lint (`--max-warnings=0`), typecheck, modularity governance, US spelling, inventory drift, test-script drift — all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_