### PR TITLE
fix: a failed currency catalog is now retryable, honest, and reported

### DIFF
--- a/ctf/packages/web/app/api/currencies/route.ts
+++ b/ctf/packages/web/app/api/currencies/route.ts
@@ -8,12 +8,24 @@ import { reportError } from 'lib/observability/report';
 // form. `any_authenticated` so a still-gated user can also see the options. ServiceCredits sorts first;
 // barter is included when present in the catalog (kind=barter, requiresAmount=false).
 export async function GET() {
-  const decision = await evaluatePluginAccess({ minUnlockTier: 'any_authenticated' });
-  if (!decision.allowed) {
-    return NextResponse.json(decision, { status: decision.status });
-  }
-
+  // The access check is inside the try on purpose. It reads the session and the account-restriction
+  // table, so it can throw — and when it did, the throw escaped this handler as an unlogged 500. The
+  // client only saw "not ok" and disabled the settlement control across every value-bearing plugin,
+  // with nothing recorded to say why (owner report: the SocketRelay settlement field was stuck and
+  // undiagnosable). Every failure path now reports before it answers.
   try {
+    const decision = await evaluatePluginAccess({ minUnlockTier: 'any_authenticated' });
+    if (!decision.allowed) {
+      // Logged as well as returned: a member being denied reference data they are supposed to be able
+      // to read is a misconfiguration, not a normal outcome, and it looks identical to an outage from
+      // the client's side.
+      reportError(new Error(`Currency catalog denied: ${decision.code}/${decision.reason}`), {
+        area: 'currency',
+        op: 'list_denied',
+      });
+      return NextResponse.json(decision, { status: decision.status });
+    }
+
     const currencies = await listActiveCurrencies();
     return NextResponse.json({ ok: true, currencies }, { status: 200 });
   } catch (error) {

--- a/ctf/packages/web/components/shared/currency-select.tsx
+++ b/ctf/packages/web/components/shared/currency-select.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Currency } from "lib/currency/types";
 import { SERVICE_CREDITS_LABEL } from "lib/currency/types";
 import { sortPreferred } from "lib/currency/format";
+import { reportError } from "lib/observability/report";
 
 // Shared payment-currency selector (issue #420). One control reused by every value-bearing plugin so
 // the options and ordering stay identical: ServiceCredits first, then fiat, crypto, and barter — read
@@ -42,6 +43,12 @@ export function CurrencySelect({
 }: CurrencySelectProps) {
   const [currencies, setCurrencies] = useState<Currency[]>(provided ?? []);
   const [error, setError] = useState<string | null>(null);
+  // Bumped by Retry to re-run the load. Without it a member whose catalog request failed once was
+  // stuck with a disabled control for the life of the page — the failure was terminal with no way
+  // back, which is how a paid post got published carrying the default settlement instead of the one
+  // its author meant to choose (owner report).
+  const [reloadKey, setReloadKey] = useState(0);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (provided) {
@@ -49,24 +56,36 @@ export function CurrencySelect({
       return;
     }
     let active = true;
+    setLoading(true);
+    setError(null);
     void (async () => {
       try {
         const res = await fetch("/api/currencies", { cache: "no-store" });
-        if (!res.ok) throw new Error("Failed to load currencies");
+        // Carry the status into the message and the report. "Failed to load currencies" alone cannot
+        // be told apart from a 403, a 500, or an offline phone, which left this undiagnosable in
+        // production.
+        if (!res.ok) throw new Error(`Currency catalog request failed (HTTP ${res.status})`);
         const data = (await res.json()) as { currencies?: Currency[] };
         if (active) setCurrencies(Array.isArray(data.currencies) ? data.currencies : []);
       } catch (e: unknown) {
+        // Reported, not just shown: a silent client-side failure here disables the settlement control
+        // in every value-bearing plugin at once, and nothing surfaced it.
+        reportError(e, { area: "currency", op: "select_catalog_load" });
         if (active) setError(e instanceof Error ? e.message : "Failed to load currencies");
+      } finally {
+        if (active) setLoading(false);
       }
     })();
     return () => {
       active = false;
     };
-  }, [provided]);
+  }, [provided, reloadKey]);
 
+  const retry = useCallback(() => setReloadKey((n) => n + 1), []);
   const sorted = sortPreferred(currencies);
+  const failed = error !== null && sorted.length === 0;
 
-  return (
+  const select = (
     <select
       id={id}
       className={className}
@@ -80,7 +99,7 @@ export function CurrencySelect({
       }}
     >
       {sorted.length === 0 ? (
-        <option value="">{error ? "Currencies unavailable" : "Loading…"}</option>
+        <option value="">{failed ? "Couldn't load options" : "Loading…"}</option>
       ) : (
         sorted.map((currency) => (
           <option key={currency.code} value={currency.code}>
@@ -89,5 +108,38 @@ export function CurrencySelect({
         ))
       )}
     </select>
+  );
+
+  // On success the control renders exactly as before — a bare <select>, so no caller's layout moves.
+  if (!failed) return select;
+
+  // On failure it gains a Retry and says what will happen if the member saves anyway. Saying so
+  // matters: the form keeps its default settlement, so a member who cannot reach the catalog would
+  // otherwise publish a settlement they never chose without being told.
+  return (
+    <span style={{ display: "inline-flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
+      {select}
+      <button
+        type="button"
+        onClick={retry}
+        disabled={loading}
+        style={{
+          padding: "6px 12px",
+          borderRadius: 8,
+          background: "transparent",
+          border: "1px solid var(--ctf-border, rgba(255,255,255,0.18))",
+          color: "var(--ctf-text, #E8EAF0)",
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: loading ? "not-allowed" : "pointer",
+        }}
+      >
+        {loading ? "Retrying…" : "Retry"}
+      </button>
+      <span role="status" style={{ fontSize: 12, color: "var(--ctf-text-secondary, #9CA3AF)", flexBasis: "100%" }}>
+        The settlement options could not be loaded, so this post keeps its current setting. Retry to
+        choose a different one.
+      </span>
+    </span>
   );
 }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What the owner saw

The "How will this be settled?" field on a SocketRelay post showed **"Currencies unavailable"** and was disabled. The result: a paid job posting could not have its price set — not when created, and not by editing afterwards — so it published carrying the form's default settlement (Free) instead of the one its author meant to choose. The card then advertised "Free" on a post offering $12 per script.

## Root cause is still open — read this part

I could not determine **why** `GET /api/currencies` fails in production from the code alone, and I did not guess. What the code proves:

- The `currencies` table exists and is populated in production. `socket_relay_requests.price_currency` is a foreign key into `currencies(code)`, and the request saved successfully with a settlement code — which is impossible against an empty table.
- So the data layer is fine; the failure is in the HTTP request or the access check in front of it.

**To find it:** open `https://app.chargingthefuture.com/api/currencies` in the browser while signed in. The status and body name the cause immediately. After this PR the answer also lands in observability on its own.

## What this PR fixes regardless of cause

Three faults turned one failed request into a permanent dead end:

1. **No way back.** The catalog was fetched once per mount with no retry, so a single failure disabled the control for the life of the page. There is now a **Retry** action.
2. **Nothing said what happened.** "Failed to load currencies" was indistinguishable from a 403, a 500, or an offline phone. The message now carries the HTTP status.
3. **Nothing was recorded.** The client swallowed the error, and the route could throw *before* its try block — `evaluatePluginAccess` reads the session and the account-restriction table — so a 500 escaped unlogged. Both sides now report to observability. A **denial** is reported too: a member refused reference data they are entitled to read is a misconfiguration, and from the client it is indistinguishable from an outage.

It also stops the silent part. When the catalog is unavailable, the control now says plainly that saving keeps the current setting — because the form otherwise publishes a settlement the member never chose without telling them, which is exactly what happened here.

## Blast radius

On success the control renders exactly as before — a bare `<select>` — so no caller's layout moves. Only the failure path changes. This is the shared `CurrencySelect`, so every value-bearing plugin (SocketRelay, LightHouse, TrustTransport, LevelUp, Foundation…) gets the same recovery.

## Checks

Web lint (`--max-warnings=0`), a11y lint, typecheck, modularity governance, orphan routes, EOF formatting, US spelling — all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_