### PR TITLE
fix: Unlock review queue names the member instead of printing a Clerk id

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -199,6 +199,17 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
+- 2026-08-01: **The review queue names the member instead of printing a Clerk id (owner report).**
+  Each card showed only `User: user_38IaPPUrRq0…`, so deciding whether to approve someone meant
+  copying the id out and cross-referencing it elsewhere to find out whose account it was.
+  `listUnlockSubmissions` now joins the member's first + last name from `directory_profiles` and their
+  handle from the legacy `public.users` table, exposed as `UnlockSubmission.memberName` /
+  `.memberUsername`. The card renders `Name (@handle)` and keeps the raw id beside it for support;
+  the id stands alone only for a member with neither a profile nor a handle. The `users` join is
+  probed with `to_regclass` first (the same guard `lib/bug-reports/repository.ts` uses) so a database
+  without that legacy table still works, returning a null handle. Every column in the query is now
+  table-qualified — `directory_profiles` and `users` both have an `id`, which would otherwise make the
+  select ambiguous. Read-only display change; no route, schema, or contract change.
 - 2026-07-30: **Admin denylist panel — view and remove spam Quora URLs.** Added a "Spam Quora-URL
   denylist" panel to the Unlock admin shell (`unlock-spam-denylist-panel.tsx`, in its own component to
   keep the shell under the rule-116 size/complexity limits), fed by `listSpamQuoraUrls` from the admin

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -121,6 +121,9 @@ not see this banner. On android the client Unlock gate lets a treatment member t
 3. Switch between the Pending, Support-only, and All views.
 4. On the Support-only view, compare the number of rows listed against the Support-only counter in
    the snapshot, and check that each row carries a gray "Support-only" pill.
+4. Check that every card names the member — first and last name with their handle, e.g.
+   `Jane Doe (@jane)` — not a bare `user_…` id. A member with no directory profile and no handle is
+   the only case where the raw id stands alone.
 **Expected:** The queue lists submissions; the Pending view shows only pending rows, the All view
 shows every status. Each row shows the submitter's Quora profile link and its review status. A
 non-admin cannot reach this page (`requireUnlockAdminAccess`). Step 3/4: the Support-only view shows

--- a/ctf/packages/web/components/unlock/unlock-admin-card.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-card.tsx
@@ -80,6 +80,21 @@ function pill(bg: string, color: string, border: string) {
   return { padding: '2px 8px', borderRadius: 6, fontSize: 11, fontWeight: 700, background: bg, color, border: `1px solid ${border}` } as const;
 }
 
+// Name first, then handle, with the Clerk id last. Reviewing a verification means deciding about a
+// person, and a raw id says nothing about who that is — an admin had to copy it out and cross-
+// reference elsewhere to find out whose account they were approving (owner report). The id is still
+// printed after the name for support and debugging, and stands alone only for a member who has
+// neither a directory profile nor a handle on file.
+function memberLabel(
+  name: string | null | undefined,
+  username: string | null | undefined,
+  userId: string,
+): string {
+  if (name) return username ? `${name} (@${username})` : name;
+  if (username) return `@${username}`;
+  return userId;
+}
+
 // Status / access-tier / reward / shared / changed pills for a submission.
 function CardBadges({ s }: { s: UnlockSubmission }) {
   return (
@@ -364,7 +379,10 @@ export function UnlockSubmissionCard(props: UnlockCardProps) {
           ) : null}
         </div>
       ) : null}
-      <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 4 }}>User: {s.userId}</div>
+      <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 4, overflowWrap: 'anywhere' }}>
+        Member: <strong style={{ color: t.TEXT }}>{memberLabel(s.memberName, s.memberUsername, s.userId)}</strong>
+        {s.memberName || s.memberUsername ? <span style={{ color: t.SUBTLE }}> · {s.userId}</span> : null}
+      </div>
       {history.openUser === s.userId ? <CardUrlHistory s={s} history={history} /> : null}
       <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 10 }}>
         Submitted {new Date(s.createdAt).toLocaleDateString()} · window expires {new Date(s.unlockWindowExpiresAt).toLocaleDateString()} · tier {s.accessTier}

--- a/ctf/packages/web/lib/unlock/repository.ts
+++ b/ctf/packages/web/lib/unlock/repository.ts
@@ -47,6 +47,10 @@ type UnlockSubmissionRow = {
   shared_url_account_count?: string;
   // Only present on the admin queue list: how many times this member changed their Quora URL.
   quora_url_change_count?: string;
+  // Only present on the admin queue list: who the member actually is. Null when they have no
+  // directory profile / no handle on file.
+  member_name?: string | null;
+  member_username?: string | null;
   created_at: Date;
   updated_at: Date;
 };
@@ -102,6 +106,8 @@ function mapUnlockSubmission(row: UnlockSubmissionRow): UnlockSubmission {
     ...(row.quora_url_change_count !== undefined
       ? { quoraUrlChangeCount: Number(row.quora_url_change_count) }
       : {}),
+    ...(row.member_name !== undefined ? { memberName: row.member_name } : {}),
+    ...(row.member_username !== undefined ? { memberUsername: row.member_username } : {}),
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
   };
@@ -331,44 +337,61 @@ export async function listUnlockSubmissions(filters: UnlockQueueFilters = {}): P
 
   if (filters.reviewStatus) {
     values.push(filters.reviewStatus);
-    whereParts.push(`review_status = $${values.length}`);
+    whereParts.push(`s.review_status = $${values.length}`);
   }
 
   if (filters.accessTier) {
     values.push(filters.accessTier);
-    whereParts.push(`access_tier = $${values.length}`);
+    whereParts.push(`s.access_tier = $${values.length}`);
   }
 
   values.push(Math.min(Math.max(filters.limit ?? 100, 1), 200));
 
   const whereClause = whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
+
+  // Who the member is, so the queue does not make an admin reverse-look-up a Clerk id to find out who
+  // they are approving (owner report). The name comes from directory_profiles; the handle comes from
+  // the legacy `public.users` table, which a fresh database may not have — probe first and fall back
+  // to a null handle, the same pattern lib/bug-reports/repository.ts uses for the same reason.
+  const usersTable = await queryDb<{ reg: string | null }>(
+    `SELECT to_regclass('public.users')::text AS reg`,
+  );
+  const hasUsersTable = usersTable.rows[0]?.reg != null;
+
   const result = await queryDb<UnlockSubmissionRow>(
+    // Every column is table-qualified: directory_profiles and users both have an `id`, so an
+    // unqualified list would fail with "column reference is ambiguous" once they are joined.
     `SELECT
-       id,
-       user_id,
-       quora_profile_url,
-       quora_profile_url_normalized,
-       review_status,
-       access_tier,
-       unlock_window_expires_at,
-       reminder_stage,
-       reviewed_by_user_id,
-       reviewed_at,
-       review_note,
-       incentive_granted_at,
-       reward_withheld_at,
-       reward_revoked_at,
-       created_at,
-       updated_at,
+       s.id,
+       s.user_id,
+       s.quora_profile_url,
+       s.quora_profile_url_normalized,
+       s.review_status,
+       s.access_tier,
+       s.unlock_window_expires_at,
+       s.reminder_stage,
+       s.reviewed_by_user_id,
+       s.reviewed_at,
+       s.review_note,
+       s.incentive_granted_at,
+       s.reward_withheld_at,
+       s.reward_revoked_at,
+       s.created_at,
+       s.updated_at,
        (SELECT COUNT(*)
           FROM unlock_verification_submissions dup
          WHERE dup.quora_profile_url_normalized = s.quora_profile_url_normalized) AS shared_url_account_count,
        (SELECT COUNT(*)
           FROM directory_quora_url_history h
-         WHERE h.user_id = s.user_id) AS quora_url_change_count
+         WHERE h.user_id = s.user_id) AS quora_url_change_count,
+       NULLIF(TRIM(COALESCE(dp.first_name, '') || ' ' || COALESCE(dp.last_name, '')), '') AS member_name,
+       ${hasUsersTable ? 'u.username' : 'NULL::text'} AS member_username
      FROM unlock_verification_submissions s
+     LEFT JOIN directory_profiles dp
+       ON dp.claimed_by_user_id = s.user_id AND dp.deleted_at IS NULL
+     ${hasUsersTable ? 'LEFT JOIN users u ON u.id::text = s.user_id' : ''}
      ${whereClause}
-     ORDER BY created_at DESC
+     ORDER BY s.created_at DESC
      LIMIT $${values.length}`,
     values,
   );

--- a/ctf/packages/web/lib/unlock/types.ts
+++ b/ctf/packages/web/lib/unlock/types.ts
@@ -27,6 +27,10 @@ export type UnlockSubmission = {
   // the admin queue list. 0/1 is normal; a higher count is a signal to open the history and review —
   // never an automatic flag (Quora sometimes deletes accounts, so re-profiling is legitimate).
   quoraUrlChangeCount?: number;
+  // Who the member is, so an admin reviewing the queue is not reading a Clerk id. Only populated by
+  // the admin queue list; null when the member has no directory profile / no handle on file.
+  memberName?: string | null;
+  memberUsername?: string | null;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What the owner reported

The Unlock review queue printed `User: user_38IaPPUrRq0CSJQ5r4D5fvHfcHp` and nothing else identifying. Deciding whether to approve someone meant copying the id out and cross-referencing it elsewhere to find out whose account it was — the same reverse-lookup the SocketRelay admin list forced (fixed in #2041).

## The fix

`listUnlockSubmissions` now joins:

- the member's **first + last name** from `directory_profiles`,
- their **handle** from the legacy `public.users` table,

exposed as `UnlockSubmission.memberName` / `.memberUsername`. The card renders **Name (@handle)** and keeps the raw id beside it for support and debugging. The id stands alone only for a member who has neither a directory profile nor a handle on file.

| | |
|---|---|
| Before | `User: user_38IaPPUrRq0CSJQ5r4D5fvHfcHp` |
| After | Member: **Jane Doe (@jane)** · user_38IaPPUrRq0CSJQ5r4D5fvHfcHp |

## Two details the joins forced

1. **The `users` join is probed first.** `public.users` is a v2-prod clone that a fresh database may not have, so the query checks `to_regclass('public.users')` and falls back to a null handle — the same guard `lib/bug-reports/repository.ts` uses for the same table and the same reason.
2. **Every column in the select is now table-qualified.** `directory_profiles` and `users` both have an `id` column, so the previously unqualified list (`SELECT id, user_id, …`) would have failed as `column reference "id" is ambiguous` the moment either was joined. The `WHERE` predicates are qualified for the same reason.

## Scope

Read-only display change. No route, schema, or contract change — the two new fields are optional and populated by the admin queue list only, matching how `sharedUrlAccountCount` and `quoraUrlChangeCount` already work.

## Checks

Web typecheck, lint (`--max-warnings=0`), a11y lint, modularity governance, inventory drift, test-script drift, schema drift, EOF formatting, US spelling — all pass locally. Inventory change-log entry and a matching test-script step added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_