### PR TITLE
fix: announcement dismiss returns the timestamp the database stored

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -367,6 +367,16 @@ All three feed channels (announcements, questions, community) are shipped on web
   no registry entry existed, so the engine never executed the promise), `announcement_reactions`, and
   `feed_hub_last_seen` (unread-badge state) are now deleted with the account. Caught by the
   deletion-coverage gate added in #2056. Contract updated to match.
+- 2026-08-01: **Dismissing an announcement now reports the time the database actually recorded
+  (code-review issue #2016).** `dismissAnnouncement` returned the literal string `'ok'` and its
+  insert did not read `dismissed_at` back, so `POST /api/announcements/{announcementId}/dismiss`
+  filled the contract's `dismissedAt` field with a timestamp the route computed itself just before
+  the write. That value could disagree with the stored one whenever the app server and the database
+  clocks differ. The insert now ends with `RETURNING dismissed_at`, the function returns
+  `{ dismissedAtIso }`, and the route sends that value — the same shape `dismissFeedItem` and the
+  feed-item dismiss route already use. Response fields are unchanged; only the source of the
+  timestamp is.
+
 - 2026-08-01: **Two code-review corrections (issues #2021, #2019).** (1) `GET /api/feed/items` now
   honors the `mentions=me` input its contract (feed.timeline.fetch) has always documented: handle
   tokens are derived server-side from the authenticated caller (never client-supplied) and passed to

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -119,6 +119,8 @@
 - The announcement is removed from the timeline immediately.
 - After reload it remains hidden (dismissal is persisted per user).
 - Every announcement has a dismiss control — there is no mandatory/non-dismissable announcement.
+- (API-level, if inspecting the response) the `dismissedAt` value in the dismiss response is the
+  timestamp the database stored, not one the route computed — it matches the persisted row.
 
 **Result:** web ☐
 

--- a/ctf/packages/web/app/api/announcements/[announcementId]/dismiss/route.ts
+++ b/ctf/packages/web/app/api/announcements/[announcementId]/dismiss/route.ts
@@ -25,8 +25,7 @@ export async function POST(request: Request, { params }: RouteParams) {
   const { announcementId } = await params;
 
   try {
-    const dismissedAt = new Date().toISOString();
-    await dismissAnnouncement(gate.auth.userId, announcementId);
+    const { dismissedAtIso } = await dismissAnnouncement(gate.auth.userId, announcementId);
 
     logFeedAudit({
       actorId: gate.auth.userId,
@@ -41,7 +40,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     });
 
     // The command contract (announcements.dismiss) declares { announcementId, dismissedAt } as output.
-    return NextResponse.json({ ok: true, announcementId, dismissedAt }, { status: 200 });
+    return NextResponse.json({ ok: true, announcementId, dismissedAt: dismissedAtIso }, { status: 200 });
   } catch (error) {
     reportError(error, { area: 'announcements', op: 'announcementid_dismiss' });
     return NextResponse.json(

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -1951,7 +1951,10 @@ export async function markAnnouncementRead(
   return { readAtIso: new Date(result.rows[0].read_at).toISOString() };
 }
 
-export async function dismissAnnouncement(userId: string, announcementId: string): Promise<'ok'> {
+export async function dismissAnnouncement(
+  userId: string,
+  announcementId: string,
+): Promise<{ dismissedAtIso: string }> {
   const result = await queryDb<{ id: string }>(
     'SELECT id FROM announcements WHERE id = $1::uuid LIMIT 1',
     [announcementId],
@@ -1961,17 +1964,18 @@ export async function dismissAnnouncement(userId: string, announcementId: string
     throw new Error('announcement_not_found');
   }
 
-  await queryDb(
+  const dismissed = await queryDb<{ dismissed_at: string }>(
     `
       INSERT INTO announcement_user_state (user_id, announcement_id, dismissed_at, updated_at)
       VALUES ($1, $2::uuid, NOW(), NOW())
       ON CONFLICT (user_id, announcement_id)
       DO UPDATE SET dismissed_at = NOW(), updated_at = NOW()
+      RETURNING dismissed_at
     `,
     [userId, announcementId],
   );
 
-  return 'ok';
+  return { dismissedAtIso: new Date(dismissed.rows[0].dismissed_at).toISOString() };
 }
 
 export function validateAnnouncementTargeting(targeting: unknown): { ok: boolean; normalized: AnnouncementTargeting } {


### PR DESCRIPTION
Closes #2016

## What was wrong

The issue was filed against `feed.item.dismiss`, which has since been fixed — that route already returns `dismissedAt` from the stored value. The regression comment on the issue points at the sibling command, and that one is still wrong:

`dismissAnnouncement` in `ctf/packages/web/lib/feed/repository.ts` returned the literal string `'ok'`, and its insert into `announcement_user_state` never read `dismissed_at` back. So `POST /api/announcements/{announcementId}/dismiss` filled the `dismissedAt` field its command contract declares with a timestamp the route computed itself, just before the write. Whenever the app server clock and the database clock differ, a caller gets back a time that is not the time the row records.

## The change

- The insert now ends with `RETURNING dismissed_at`, and `dismissAnnouncement` returns `{ dismissedAtIso }`.
- The route sends that value instead of its own `new Date().toISOString()`.

This is the same shape `dismissFeedItem` and the feed-item dismiss route already use. The response fields are unchanged — `{ ok, announcementId, dismissedAt }` — so no contract, schema, or route change; only the source of the timestamp. The two functions are the only callers.

Feed inventory change log updated.

## Checks

- `pnpm --filter @ctf/web typecheck` passes; the pre-commit gate ran typecheck across web, mobile, and shared.
- `ctf/scripts/check-eof-format.sh` passes.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105).