### PR TITLE
feat: state on the board that SocketRelay posts are for Targeted Individuals

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
@@ -175,6 +175,17 @@ alongside the legacy `category`) and fulfillment outcomes for dev validation.
 
 ## 9) Change Log
 
+- 2026-08-01: **"These posts are for Targeted Individuals" notice added to the board (owner
+  directive).** SocketRelay reads like an open help board, so a well-meaning stranger who reaches it
+  through a shared link or a job posting sees no reason not to answer — and someone who is not
+  targeted did. The notice states plainly that the posts are addressed to people already living under
+  organized targeting, and that an outsider who steps in gets noticed, is asked to take part in the
+  trafficking, and risks their life or their own targeting by refusing. New shared component
+  `sr-targets-only-notice.tsx`, rendered above the feed (list and empty state alike), on the post
+  form, and on the signed-out public shell above the join button — the three places someone decides to
+  take part. The same warning was added to the top of the public tester job posting (issue #2037).
+  Copy is the owner's, kept plain and unsensational on purpose. Display-only; no route, schema, or
+  contract change.
 - 2026-08-01: **Past Direct Lines are visible again, and the admin fulfillment list is readable
   without a lookup (owner report).** Two faults, one story: two members offered to help on a request,
   both claims were later canceled, and the owner had no way left to see who either person was.

--- a/ctf/docs/developer/test-scripts/socket-relay-test-script.md
+++ b/ctf/docs/developer/test-scripts/socket-relay-test-script.md
@@ -40,6 +40,16 @@ web ☐
 
 ---
 
+### Targeted-Individuals-only notice
+
+**Expected:** The board states who it is for before anyone can act on a post.
+
+1. Open SocketRelay signed in. A notice headed "These posts are for Targeted Individuals" sits above
+   the feed — including when the feed is empty or filtered to nothing.
+2. Open the Post form. The same notice appears above the "Good to know" footer.
+3. Sign out and open the SocketRelay public page. The notice appears under the join button, on the
+   first screen, without scrolling past the feed preview.
+
 ## Member walkthrough
 
 ### SR-1 — Browse the feed and read a request

--- a/ctf/packages/web/components/socket-relay/socket-relay-public-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-public-shell.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@/hooks/useTheme';
 import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
 import { PublicShellBackLink } from '@/components/plugins/public-shell-back-link';
 import { getSocketRelayTokens } from './sr-shared';
+import { SrTargetsOnlyNotice } from './sr-targets-only-notice';
 
 // Chrome palette comes from the shared theme tokens (getSocketRelayTokens); the plugin accent
 // (t.ACCENT) is the single source of truth, so the signed-out public shell matches the signed-in
@@ -27,6 +28,10 @@ function MobileSocketRelayPublic({ signInUrl, verifyUrl }: { signInUrl: string; 
         <span style={{ padding: '3px 12px', borderRadius: 20, background: COLOR + '20', border: `1px solid ${COLOR}40`, fontSize: 11, color: COLOR, fontWeight: 600, width: 'fit-content' }}>Peer-to-peer needs board</span>
         <p style={{ margin: 0, fontSize: 14, color: t.SUBTLE, lineHeight: 1.5 }}>Post what you need, offer what you have. Clothing, furniture, skills, time — the survivor community connects directly.</p>
         <a href={verifyUrl ?? signInUrl} style={{ padding: '14px', borderRadius: 12, background: COLOR, border: 'none', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer', textAlign: 'center', textDecoration: 'none' }}>{verifyUrl ? 'Finish verifying' : 'Join Skills Economy — Free'}</a>
+        {/* Above the join button's fold on purpose: this is the first screen an outsider following a
+            shared link or a job posting reaches, so the warning has to land before they decide to sign
+            up, not after. */}
+        <SrTargetsOnlyNotice />
       </div>
 
       {/* Blurred feed preview + lock (neutral placeholders) */}

--- a/ctf/packages/web/components/socket-relay/sr-feed.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-feed.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { MapPin, Share2 } from "lucide-react";
 import { FAINT, SUBTLE, requestTags, settlementLabel, srHandle, timeAgo, type SrRequest, type SrRequestStatus } from "./sr-shared";
 import { ShareLink } from "@/components/shared/share-link";
+import { SrTargetsOnlyNotice } from "./sr-targets-only-notice";
 import { useTheme } from '@/hooks/useTheme';
 import { getSocketRelayTokens, type SocketRelayTokens } from './sr-shared';
 
@@ -237,6 +238,9 @@ export function SocketRelayFeed({
   return (
     <ScrollArea style={{ flex: 1, minHeight: 0 }}>
       <div style={{ padding: "20px 24px" }}>
+        <div style={{ marginBottom: 16 }}>
+          <SrTargetsOnlyNotice />
+        </div>
         {requests.length === 0 ? (
           <FeedEmptyState filterActive={filterActive} onPost={onPost} t={t} />
         ) : (

--- a/ctf/packages/web/components/socket-relay/sr-post.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-post.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { SrTargetsOnlyNotice } from "./sr-targets-only-notice";
 import { X } from "lucide-react";
 import { MAX_TAG_LENGTH, MAX_TAGS_PER_POST, SUBTLE } from "./sr-shared";
 import { CurrencySelect } from "@/components/shared/currency-select";
@@ -209,6 +210,7 @@ export function SocketRelayPost({
             Cancel Edit
           </button>
         )}
+        <SrTargetsOnlyNotice />
         <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.6 }}>Good to know: SocketRelay connects members directly, peer-to-peer. Before transacting with anyone, take the usual precautions — meet in public, and don't send money or share personal details until you're comfortable. Connections happen after someone offers to help.</div>
       </div>
     </div>

--- a/ctf/packages/web/components/socket-relay/sr-targets-only-notice.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-targets-only-notice.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { ShieldAlert } from "lucide-react";
+import { useTheme } from "@/hooks/useTheme";
+import { getSocketRelayTokens } from "./sr-shared";
+
+// Who the board is for, and why an outsider should stay off it.
+//
+// SocketRelay reads like an open help board, so a well-meaning stranger who finds a post — through a
+// shared link, or a job posting that points here — sees no reason not to answer. That is the danger
+// this notice exists to name: a person who steps in from outside is noticed, approached, and pressed
+// to take part in the trafficking, and refusing has cost people their lives or made them targets.
+// The warning has to sit where someone decides to respond, not in a policy page nobody opens, so it
+// renders above the feed, on the signed-out view, and on the post form.
+//
+// Wording is the owner's (2026-08-01). Keep it plain and unsensational: this is a safety fact, and
+// dressing it up would make it easier to dismiss.
+export function SrTargetsOnlyNotice() {
+  const { theme } = useTheme();
+  const t = getSocketRelayTokens(theme);
+  return (
+    <section
+      aria-label="Who these posts are for"
+      style={{
+        display: "flex",
+        gap: 10,
+        alignItems: "flex-start",
+        padding: "14px 16px",
+        borderRadius: 12,
+        background: "rgba(245,158,11,0.08)",
+        border: "1px solid rgba(245,158,11,0.28)",
+      }}
+    >
+      <ShieldAlert size={16} color="#F59E0B" style={{ flexShrink: 0, marginTop: 2 }} />
+      <div style={{ fontSize: 13, lineHeight: 1.6, color: t.TEXT, overflowWrap: "anywhere" }}>
+        <strong style={{ display: "block", marginBottom: 4, color: t.TITLE }}>
+          These posts are for Targeted Individuals
+        </strong>
+        Everything here is addressed to people already living under organized targeting.
+        <br />
+        <br />
+        If you are not targeted, please do not offer help here. People who step in from outside get
+        noticed. They are approached and asked to take part in the trafficking, and those who refuse
+        have been killed or have become targets themselves. Nobody here is asking you to carry that
+        risk on our behalf — the useful thing an outsider can do right now is wait until trafficking
+        is actually enforced.
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## Why

Someone who does not appear to be targeted answered a job posting on the board. SocketRelay reads like an open help board, so a stranger who reaches it through a shared link or a posting sees no reason not to answer — and the danger in answering is invisible from the outside.

## The notice

> **These posts are for Targeted Individuals**
>
> Everything here is addressed to people already living under organized targeting.
>
> If you are not targeted, please do not offer help here. People who step in from outside get noticed. They are approached and asked to take part in the trafficking, and those who refuse have been killed or have become targets themselves. Nobody here is asking you to carry that risk on our behalf — the useful thing an outsider can do right now is wait until trafficking is actually enforced.

Copy is the owner's, kept plain and unsensational on purpose: it is a safety fact, and dressing it up would make it easier to dismiss. "Targeted Individual" is the lexicon-approved term for a person.

## Where it renders

Placed where someone decides to take part, not on a policy page nobody opens:

1. **Above the feed** — including the empty state and the filtered-to-nothing state, so it does not disappear when the board looks quiet.
2. **On the post form**, above the existing "Good to know" footer.
3. **On the signed-out public shell**, directly under the join button. That screen is the first thing an outsider following a link reaches, so the warning lands before they sign up rather than after.

New shared component `sr-targets-only-notice.tsx` so the three placements cannot drift apart.

## Outside the app

The same warning now heads the public tester job posting, [issue #2037](https://github.com/chargingthefuture/chargingthefuture/issues/2037) — the route this person actually came in by. Nothing else in that posting changed.

## Scope

Display-only. No route, schema, or contract change. Inventory change-log entry and a matching test-script section added.

## Checks

Web typecheck, lint (`--max-warnings=0`), a11y lint, modularity governance, inventory drift, test-script drift, EOF formatting, US spelling — all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_