### PR TITLE
fix: Direct Line names the other person instead of "the helper"

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
@@ -175,6 +175,17 @@ alongside the legacy `category`) and fulfillment outcomes for dev validation.
 
 ## 9) Change Log
 
+- 2026-08-01: **Direct Line now names the other person (owner report).** Past conversations became
+  visible earlier the same day, but opening one still did not say who had offered to help: the header
+  read "Your request — you're talking with the helper" with no name, and kept saying "talking with"
+  on a canceled line where nobody is talking. `listMyFulfillments` now joins both participants' first
+  + last name from `directory_profiles` alongside the usernames already captured at claim time
+  (`SrFulfillment.requesterName` / `.fulfillerName`). New shared `srCounterpartLabel()` renders
+  `Name (@handle)`, falling back to the handle alone, and to nothing when the member has neither —
+  deliberately never to the Clerk id, which is not an identity to a member. The chat header now reads
+  e.g. `Your request · Helper: Jane Doe (@jane) · Canceled`, and each row in the conversation list
+  carries the same label so an owner can see who offered without opening them one at a time.
+  Read-only display change; no route, schema, or contract change.
 - 2026-08-01: **In-app "for Targeted Individuals" notice added, then removed the same day (owner
   directive).** A notice was briefly rendered above the feed, on the post form, and on the signed-out
   public shell. The owner removed it: the board sits behind Unlock verification, so everyone reading

--- a/ctf/docs/developer/test-scripts/socket-relay-test-script.md
+++ b/ctf/docs/developer/test-scripts/socket-relay-test-script.md
@@ -247,6 +247,10 @@ web ☐
 - Live conversations appear first, then your open requests waiting for a helper, then past
   (closed or canceled) conversations. A canceled claim must still be openable from the Past
   group — that is how you find out who offered to help before the claim was canceled.
+- Each conversation row names the other person (`Name (@handle)`, or just the handle when there is
+  no name on file). Open one: the header says your role, who the other person is, and — on a
+  past line — that it was canceled or closed. A canceled line must never read "you're talking
+  with the helper".
 - Claimed requests are represented by their active fulfillment row, not an extra pending row.
 - On Android, each pending-request card shows a "No helper yet" note (not a chat), explaining the request is still open on the feed.
 - Tapping an active-fulfillment row opens the chat thread (web); on Android, each active-fulfillment card shows an "Open chat" button that opens the chat (see SR-10a).

--- a/ctf/packages/web/components/socket-relay/sr-chat.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-chat.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronLeft, Clock, MessageCircle } from "lucide-react";
 import { StreamChatPanel } from "../shared/stream-chat-panel";
-import { FAINT, SUBTLE, type SrChatCredentials, type SrDirectLine, type SrFulfillment, type SrResolveOutcome } from "./sr-shared";
+import { FAINT, SUBTLE, srCounterpartLabel, type SrChatCredentials, type SrDirectLine, type SrFulfillment, type SrResolveOutcome } from "./sr-shared";
 import { useTheme } from '@/hooks/useTheme';
 import { getSocketRelayTokens } from './sr-shared';
 
@@ -107,7 +107,12 @@ function ChatPane({
     <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
       <div style={{ padding: "12px 16px", borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
         <div style={{ fontSize: 14, fontWeight: 700, color: "#F0FDF4" }}>{fulfillmentTitle(selected)}</div>
-        <div style={{ fontSize: 12, color: SUBTLE }}>{isRequester ? "Your request — you're talking with the helper." : "You offered to help — talking with the requester."}</div>
+        {/* Names the other person. The old line said "you're talking with the helper" without ever
+            saying who the helper was, and kept saying it on a canceled conversation where nobody is
+            talking — so a request owner could open a past line and still not learn who had offered
+            (owner report). Falls back to the old wording only when the member has no name and no
+            handle on file. */}
+        <div style={{ fontSize: 12, color: SUBTLE }}>{counterpartHeadline(selected, isRequester)}</div>
       </div>
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
         {chatLoading ? (
@@ -156,7 +161,13 @@ function DirectLineRow({
       "Your request · Waiting for a helper"
     ) : (
       <>
-        {isRequester ? "Your request" : "You're helping"} · <span style={{ textTransform: "capitalize" }}>{line.fulfillment.status}</span>
+        {/* Names the other person in the list too, so a request owner can see who offered without
+            opening each conversation one at a time. */}
+        {isRequester ? "Your request" : "You're helping"}
+        {srCounterpartLabel(line.fulfillment, isRequester)
+          ? ` · ${srCounterpartLabel(line.fulfillment, isRequester)}`
+          : ""}{" "}
+        · <span style={{ textTransform: "capitalize" }}>{line.fulfillment.status}</span>
       </>
     );
   return (
@@ -170,6 +181,21 @@ function DirectLineRow({
       <div style={{ fontSize: 11, color: SUBTLE }}>{sub}</div>
     </button>
   );
+}
+
+// The header's second line: the viewer's role, who the other person is, and — when the conversation
+// is no longer live — that it ended. Kept out of the component so its branches stay off the chat's
+// complexity budget.
+function counterpartHeadline(f: SrFulfillment, isRequester: boolean): string {
+  const role = isRequester ? "Your request" : "You offered to help";
+  const who = srCounterpartLabel(f, isRequester);
+  const other = who
+    ? `${isRequester ? "Helper" : "Requester"}: ${who}`
+    : isRequester
+      ? "with the helper"
+      : "with the requester";
+  const ended = f.status === "canceled" ? " · Canceled" : f.status === "closed" ? " · Closed" : "";
+  return `${role} · ${other}${ended}`;
 }
 
 export function SocketRelayChat({

--- a/ctf/packages/web/components/socket-relay/sr-shared.ts
+++ b/ctf/packages/web/components/socket-relay/sr-shared.ts
@@ -69,6 +69,10 @@ export type SrFulfillment = {
   // Joined from the request by /api/socket-relay/my-fulfillments so the chat can show context.
   requestTitle?: string;
   requestStatus?: SrRequestStatus;
+  // Participants' real names, joined from directory_profiles by the same route. Null for a member
+  // with no profile on file; used with the usernames above to name the other person in the header.
+  requesterName?: string | null;
+  fulfillerName?: string | null;
 };
 
 export type SrListResponse = { ok: boolean; items: SrRequest[]; page: number; pageSize: number; total: number };
@@ -129,6 +133,17 @@ export const MAX_TAGS_PER_POST = 3;
 // instead of bouncing off the server as an invalid payload.
 export const MAX_TAG_LENGTH = 64;
 const MAX_FILTER_CHIPS = 10;
+
+// The other participant, as a member reads it: name first, then handle, and neither when the person
+// has no profile and no handle on file. Deliberately never falls back to the Clerk id — an id is not
+// an identity to a member, and the point of naming them is so a request owner can tell who offered.
+export function srCounterpartLabel(f: SrFulfillment, viewerIsRequester: boolean): string | null {
+  const name = viewerIsRequester ? f.fulfillerName : f.requesterName;
+  const username = viewerIsRequester ? f.fulfillerUsername : f.requesterUsername;
+  if (name) return username ? `${name} (@${username})` : name;
+  if (username) return `@${username}`;
+  return null;
+}
 
 export function requestTags(r: Pick<SrRequest, "category" | "tags">): string[] {
   if (r.tags && r.tags.length > 0) return r.tags;

--- a/ctf/packages/web/lib/socket-relay/repository.ts
+++ b/ctf/packages/web/lib/socket-relay/repository.ts
@@ -803,12 +803,21 @@ export async function getFulfillmentById(fulfillmentId: string): Promise<SocketR
 
 export async function listMyFulfillments(userId: string): Promise<SocketRelayFulfillment[]> {
   // Join the request so the chat can show what the conversation is about (title + current status)
-  // instead of a bare "Fulfillment <uuid>".
+  // instead of a bare "Fulfillment <uuid>", and both participants' real names so the header can say
+  // WHO the other person is. The usernames captured at claim time are null for anyone without a
+  // handle, which left a member with no way to tell who had offered to help — the whole point of
+  // being able to open a past conversation (owner report).
   const result = await queryDb<FulfillmentRow & { request_title: string | null; request_status: string | null }>(
     `SELECT f.id, f.request_id, f.requester_user_id, f.fulfiller_user_id, f.requester_username, f.fulfiller_username, f.status, f.close_reason, f.created_at, f.updated_at,
-            r.title AS request_title, r.status AS request_status
+            r.title AS request_title, r.status AS request_status,
+            NULLIF(TRIM(COALESCE(rp.first_name, '') || ' ' || COALESCE(rp.last_name, '')), '') AS requester_name,
+            NULLIF(TRIM(COALESCE(fp.first_name, '') || ' ' || COALESCE(fp.last_name, '')), '') AS fulfiller_name
      FROM socket_relay_fulfillments f
      LEFT JOIN socket_relay_requests r ON r.id = f.request_id
+     LEFT JOIN directory_profiles rp
+       ON rp.claimed_by_user_id = f.requester_user_id AND rp.deleted_at IS NULL
+     LEFT JOIN directory_profiles fp
+       ON fp.claimed_by_user_id = f.fulfiller_user_id AND fp.deleted_at IS NULL
      WHERE f.requester_user_id = $1 OR f.fulfiller_user_id = $1
      ORDER BY f.created_at DESC`,
     [userId],


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What the owner reported

> After your updates. The canceled relays show but again do not show who applied.

Correct, and the half I shipped was the less useful half. #2041 made past conversations **visible**, but opening one still did not answer the question that made them worth showing.

From the screenshots:

- The header reads **"Your request — you're talking with the helper."** — it never names the helper.
- It says that on a **canceled** line, where nobody is talking. The footer below it says "This request is open again," contradicting the header.
- The conversation list rows show only the request title and `Canceled`.

So the owner could reach the conversation and still not learn who had applied.

## The fix

`listMyFulfillments` now joins both participants' **first + last name** from `directory_profiles`, alongside the usernames already captured at claim time.

The usernames alone were not enough — they are null for anyone without a handle, which is exactly the case that left the owner unable to identify who applied. That is why the earlier admin-side fix worked while this one still failed.

New shared `srCounterpartLabel()` renders `Name (@handle)`, falls back to the handle alone, and to nothing when the member has neither. **Deliberately never falls back to the Clerk id** — an id is not an identity to a member, and printing it would just relocate the reverse-lookup problem.

| | Before | After |
|---|---|---|
| Chat header | `Your request — you're talking with the helper.` | `Your request · Helper: Jane Doe (@jane) · Canceled` |
| List row | `Your request · Canceled` | `Your request · Jane Doe (@jane) · Canceled` |

The header also stops claiming a conversation is live when it is not: a canceled or closed line says so instead of "talking with".

Naming the person in the **list** as well as the header matters here — the owner has two canceled claims on one request, so seeing both names at a glance beats opening each in turn.

## Scope

Read-only display change. No route, schema, or contract change. Inventory change-log entry and a matching test-script expectation added.

## Checks

Web typecheck, lint (`--max-warnings=0`), a11y lint, modularity governance, inventory drift, test-script drift, EOF formatting, US spelling — all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_