### PR TITLE
feat: pseudonymize a departing member on rows the other party owns

### DIFF
--- a/ctf/docs/contracts/SOCKET_RELAY_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/SOCKET_RELAY_PROFILE_AND_DELETION_CONTRACT.md
@@ -102,6 +102,26 @@ the dependent rows itself instead of leaving orphans:
   gone they are unreachable through the participant-gated read path.
 - Audited: the removal writes a `socket-relay.admin.request.delete` row to `socket_relay_admin_audit_trail`.
 
+### Rows you appear on but do not own (pseudonymized, not deleted)
+
+A fulfillment where you were the **helper** belongs to the member who posted the request: deleting it
+would destroy their record of what happened on their own request. So the row stays and your identity
+is overwritten instead — `socket_relay_fulfillments.fulfiller_user_id` is set to `deleted_member` and
+the handle captured at claim time (`fulfiller_username`) is set to `NULL`.
+
+Why a single shared constant and not a per-user token: a token would still link that person's rows to
+one another, which is the thing deletion is meant to end. Two departed helpers on one request both
+read as "Deleted member", and that is correct — the surviving party has no need to tell them apart.
+
+Rows where you were the **requester** are deleted outright, as before; you own those.
+
+Deliberately NOT pseudonymized, for reasons that outrank tidiness:
+- a safety report's subject (`member_safety_reports.reported_user_id`) — abuse evidence, retained;
+- reviewer/admin columns (`reviewed_by_user_id`, `updated_by_user_id`) — an audit trail of who
+  decided what, retained for compliance;
+- `member_blocks.blocked_user_id` — the column a block is enforced by; overwriting it could unblock
+  someone.
+
 ## 6) Full-Account Deletion Contract
 
 When user requests full account deletion:

--- a/ctf/docs/contracts/TRUST_TRANSPORT_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/TRUST_TRANSPORT_PROFILE_AND_DELETION_CONTRACT.md
@@ -116,6 +116,13 @@ Implemented via the generic per-plugin deletion route (Section 9) driven by the
   (see `GET /api/account/services`, which lists TrustTransport under "deletable" with the
   `dataSummary` above).
 
+### Rows you appear on but do not own (pseudonymized, not deleted)
+
+A trip you **drove or delivered** belongs to the rider who requested it, so the row stays and your
+identity is overwritten instead: `trust_transport_trips.provider_user_id` is set to `deleted_member`.
+Trips you requested are deleted outright, as before. Same rule and same reasoning as SocketRelay —
+see that plugin's contract for why a shared constant is used rather than a per-user token.
+
 ## 6) Full-Account Deletion Contract
 
 Full-account deletion runs the same table operations as Section 5 for every service in the deletion

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
@@ -175,6 +175,16 @@ alongside the legacy `category`) and fulfillment outcomes for dev validation.
 
 ## 9) Change Log
 
+- 2026-08-02: **A departing member's id no longer survives on the other party's rows (owner
+  directive).** Account deletion removed `socket_relay_fulfillments` by `requester_user_id` only, so a member who deleted their
+  account left their raw Clerk id sitting in the counterparty's view forever — the row belongs to the
+  other person, so deleting it was never the answer. New `pseudonymize` deletion action: the row
+  stays, `fulfiller_user_id` is overwritten with the shared constant `deleted_member` and the handle captured at claim time (`fulfiller_username`) is cleared. A single constant
+  rather than a per-user token, because a token would still link that person's rows to each other.
+  Deliberately not applied to abuse evidence, reviewer/admin audit columns, or
+  `member_blocks.blocked_user_id` (overwriting it could unblock someone) — each recorded in the
+  deletion contract. `check-deletion-registry.mjs` validates the new action and its cleared columns
+  against `schema.sql`; verified it fails on a bad column name. No schema change.
 - 2026-08-01: **Direct Line now names the other person (owner report).** Past conversations became
   visible earlier the same day, but opening one still did not say who had offered to help: the header
   read "Your request — you're talking with the helper" with no name, and kept saying "talking with"

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-transport-feature-inventory.md
@@ -292,6 +292,16 @@ Admin parity (2026-06-06): the Android admin screen `AdminTrustTransport.tsx` (e
 
 ## Change Log
 
+- 2026-08-02: **A departing member's id no longer survives on the other party's rows (owner
+  directive).** Account deletion removed `trust_transport_trips` by `requester_user_id` only, so a member who deleted their
+  account left their raw Clerk id sitting in the counterparty's view forever — the row belongs to the
+  other person, so deleting it was never the answer. New `pseudonymize` deletion action: the row
+  stays, `provider_user_id` is overwritten with the shared constant `deleted_member`. A single constant
+  rather than a per-user token, because a token would still link that person's rows to each other.
+  Deliberately not applied to abuse evidence, reviewer/admin audit columns, or
+  `member_blocks.blocked_user_id` (overwriting it could unblock someone) — each recorded in the
+  deletion contract. `check-deletion-registry.mjs` validates the new action and its cleared columns
+  against `schema.sql`; verified it fails on a bad column name. No schema change.
 - 2026-07-31: **Stored status values respelled to US English (owner-directed).** `trust_transport_requests.status`, `trust_transport_trips.status`, and `trust_transport_status_events` (the cancel event's `event_name`, now `order_canceled`, plus `from_status`/`to_status`) now store `canceled`; the trip cancel-reason column was renamed to `canceled_reason`. Existing rows are migrated by the idempotent US-spelling data migration block at the end of `ctf/schema.sql`, which re-runs on every deploy. Code, contracts, and docs were renamed in the same PR.
 - 2026-07-20: **Notifications producer.** Accepting an offer now emits a best-effort notification (`notifySafe`, `trust-transport.offer.accepted`, category `safety`) to the provider — deduped on the trip id, never to the accepting requester. Emitted from the accept-offer route. No schema/contract change.
 - 2026-07-20: **Account deletion now clears the member's Stream chat copy (privacy).** TrustTransport trip-thread chat is sent directly into Stream Chat under the Stream user `trust-transport-<userId>`, so Stream kept an independent copy that the Postgres-only account-deletion registry never removed (Stream retains messages with no expiry by default). Registered `deleteTrustTransportStreamData(userId)` (in `lib/trust-transport/stream.ts` — hard-deletes the Stream user with `mark_messages_deleted`; never throws) into the shared account-deletion external-cleanup hook (`lib/account/external-cleanup-registry.ts`), which the orchestrator runs after the DB transaction commits on every whole-account deletion path (full-account route, internal delete, Clerk webhook), best-effort (a Stream outage is logged, never blocks the deletion). No schema/route/contract change.

--- a/ctf/docs/developer/test-scripts/socket-relay-test-script.md
+++ b/ctf/docs/developer/test-scripts/socket-relay-test-script.md
@@ -499,6 +499,18 @@ is down at delete time, the deletion still succeeds and the failure is logged fo
 
 ---
 
+### Deleted counterparty is pseudonymized, not left as an id
+
+**Expected:** When the other party deletes their account, the record stays with its owner but stops
+naming them.
+
+1. As member A, post a request. As member B, claim it. Confirm the Direct Line names B.
+2. Delete member B's account (Account & Data → delete, or the admin path).
+3. As member A, open the same conversation. The row must still be there — it is A's record — and must
+   read **Deleted member**, never `user_…`.
+4. In the SocketRelay admin Fulfillments tab, the same row reads **Deleted member**, not the raw id
+   and not the literal text `deleted_member`.
+
 ## Admin walkthrough
 
 ### SR-A1 — Admin stat cards

--- a/ctf/docs/developer/test-scripts/trust-transport-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-transport-test-script.md
@@ -378,6 +378,16 @@ Stream is down at delete time, the deletion still succeeds and the failure is lo
 
 ---
 
+### Deleted driver is pseudonymized, not left as an id
+
+**Expected:** When the driver deletes their account, the rider keeps the trip record but the driver is
+no longer named by their id.
+
+1. Complete or cancel a trip so a `trust_transport_trips` row exists with a provider.
+2. Delete the provider's account.
+3. As the rider, open the trip. The record is still there and the provider reads as a deleted member,
+   never `user_…`.
+
 ## Admin walkthrough
 
 ### TT-A1 — Incident queue loads and an incident can be resolved

--- a/ctf/packages/web/components/socket-relay/socket-relay-admin-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-admin-shell.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import { PluginUserShellButton } from '@/components/shared/plugin-user-shell-button';
 import type { SocketRelayFulfillment, SocketRelayRequest } from 'lib/socket-relay/types';
+import { DELETED_MEMBER_PLACEHOLDER } from 'lib/account/deletion-registry';
 import { getSocketRelayTokens } from './sr-shared';
 
 // Admin chrome comes from the shared theme tokens (t.SURFACE / t.BORDER_SOLID are the shared
@@ -65,6 +66,10 @@ async function adminMutate(url: string, method: 'POST' | 'DELETE', body?: unknow
 function memberLabel(name: string | null | undefined, username: string | null, userId: string): string {
   if (name) return username ? `${name} (@${username})` : name;
   if (username) return `@${username}`;
+  // A row whose counterparty deleted their account carries the pseudonymize placeholder rather than a
+  // real id. Read it back as words — printing the raw sentinel would look like a bug, and the point
+  // of overwriting the id was that nobody has to decipher a token.
+  if (userId === DELETED_MEMBER_PLACEHOLDER) return 'Deleted member';
   return userId;
 }
 

--- a/ctf/packages/web/lib/account/deletion-engine.ts
+++ b/ctf/packages/web/lib/account/deletion-engine.ts
@@ -18,14 +18,14 @@
 // foreign keys when run in order.
 
 import type { PoolClient } from 'pg';
-import type { OwnedTable, PluginDeletionEntry } from './deletion-registry';
+import { DELETED_MEMBER_PLACEHOLDER, type OwnedTable, type PluginDeletionEntry } from './deletion-registry';
 
 /** A single database operation produced from one owned table. */
 export type DeletionStatement = {
   /** Real table this operates on. */
   readonly table: string;
   /** Which registry action produced it. */
-  readonly action: 'delete' | 'soft-delete';
+  readonly action: 'delete' | 'soft-delete' | 'pseudonymize';
   /** Parameterized SQL with `$1` bound to the user id. */
   readonly sql: string;
 };
@@ -64,6 +64,25 @@ export function planTable(owned: OwnedTable): DeletionStatement | null {
           `UPDATE ${owned.table} SET ${owned.softDeleteColumn} = NOW() ` +
           `WHERE ${owned.userColumn} = $1 AND ${owned.softDeleteColumn} IS NULL`,
       };
+    case 'pseudonymize': {
+      if (!owned.userColumn) {
+        throw new Error(`Table "${owned.table}" is action "pseudonymize" but has no userColumn.`);
+      }
+      // Overwrite the id, and NULL any denormalized copies of the member's identity alongside it —
+      // clearing the id while leaving a captured handle would defeat the whole point.
+      //
+      // The WHERE still matches the REAL id, so this is naturally idempotent: a second run finds no
+      // rows, because the first already replaced them with the placeholder.
+      const sets = [
+        `${owned.userColumn} = '${DELETED_MEMBER_PLACEHOLDER}'`,
+        ...(owned.clearColumns ?? []).map((column) => `${column} = NULL`),
+      ];
+      return {
+        table: owned.table,
+        action: 'pseudonymize',
+        sql: `UPDATE ${owned.table} SET ${sets.join(', ')} WHERE ${owned.userColumn} = $1`,
+      };
+    }
     default: {
       // Exhaustiveness guard: a new action must be handled here explicitly.
       const unreachable: never = owned.action;
@@ -90,7 +109,7 @@ export function planDeletion(entry: PluginDeletionEntry): DeletionStatement[] {
 /** Per-table outcome of running a deletion, for the audit/event record. */
 export type DeletionTableResult = {
   readonly table: string;
-  readonly action: 'delete' | 'soft-delete';
+  readonly action: 'delete' | 'soft-delete' | 'pseudonymize';
   /** Rows affected (deleted or soft-deleted). */
   readonly rowCount: number;
 };

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -27,7 +27,7 @@
 //   - Global catalog/aggregate tables (currencies, taxonomy, GDP metrics, weekly-performance
 //     aggregates) are not listed: they are not any individual user's data.
 
-export type DeletionAction = 'delete' | 'soft-delete' | 'retain';
+export type DeletionAction = 'delete' | 'soft-delete' | 'pseudonymize' | 'retain';
 
 export type OwnedTable = {
   /** Real table name as it appears in `ctf/schema.sql`. */
@@ -38,6 +38,12 @@ export type OwnedTable = {
   readonly action: DeletionAction;
   /** Required when `action` is `soft-delete`: the timestamp column to stamp. */
   readonly softDeleteColumn?: string;
+  /**
+   * Optional for `pseudonymize`: extra columns set to NULL alongside the user column — the
+   * denormalized copies of the member's identity (a handle captured at claim time, say), which would
+   * otherwise keep naming them after their id is gone.
+   */
+  readonly clearColumns?: readonly string[];
   /** Plain-language note for reviewers / audit. */
   readonly note?: string;
   /** Set when a human decision is still needed before this table's handling is final. */
@@ -67,6 +73,40 @@ const soft = (table: string, userColumn: string, softDeleteColumn: string, note?
   userColumn,
   action: 'soft-delete',
   softDeleteColumn,
+  note,
+});
+
+/**
+ * The value written over a departed member's id when a row is pseudonymized. A single constant, not a
+ * per-user token: a token would still link that person's rows to each other, which is the thing
+ * deletion is supposed to end. Two deleted helpers on one request both read as this, and that is
+ * correct — they are gone, and telling them apart is not something the surviving party needs.
+ */
+export const DELETED_MEMBER_PLACEHOLDER = 'deleted_member';
+
+/**
+ * Overwrite this member's id on a row that ANOTHER member owns.
+ *
+ * The case this exists for: a request owner keeps the record that someone offered to help — that row
+ * is theirs and deleting it would destroy their data — but the helper's raw Clerk id should not
+ * survive their account. Before this, deleting an account left that id sitting in the other party's
+ * view forever (owner report: a canceled SocketRelay claim kept naming `user_3FL6…` after the
+ * account behind it was gone).
+ *
+ * Only for genuine member-to-member counterparties. NOT for abuse evidence (a safety report's
+ * subject), and NOT for admin/reviewer columns, which are an audit trail — both are retained on
+ * purpose; see the notes at their call sites.
+ */
+const pseudo = (
+  table: string,
+  userColumn: string,
+  clearColumns: readonly string[],
+  note?: string,
+): OwnedTable => ({
+  table,
+  userColumn,
+  action: 'pseudonymize',
+  clearColumns,
   note,
 });
 
@@ -242,6 +282,15 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
       del('socket_relay_messages', 'sender_user_id', 'Messages you sent.'),
       del('socket_relay_fulfillment_participants', 'user_id', 'Your fulfillment participation.'),
       del('socket_relay_fulfillments', 'requester_user_id', 'Fulfillments you requested.'),
+      // The other side of the same table: rows where YOU were the helper belong to the requester, so
+      // they stay — but your id and captured handle are overwritten so you are not still named in
+      // their Direct Line and admin views after you leave.
+      pseudo(
+        'socket_relay_fulfillments',
+        'fulfiller_user_id',
+        ['fulfiller_username'],
+        'Requests you offered to help on — the record stays with its owner, your identity does not.',
+      ),
       del('socket_relay_requests', 'owner_user_id', 'Your relay requests.'),
       soft('socket_relay_user_extension', 'user_id', 'service_deleted_at', 'Your SocketRelay plugin extension record.'),
       retain('socket_relay_admin_audit_trail', 'Admin action audit log; retained for compliance.'),
@@ -254,6 +303,14 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     serviceScopeSupported: true,
     tables: [
       del('trust_transport_trips', 'requester_user_id', 'Trips you requested.'),
+      // Same shape as SocketRelay: a trip you drove belongs to the rider who requested it, so the
+      // row stays and your id is overwritten.
+      pseudo(
+        'trust_transport_trips',
+        'provider_user_id',
+        [],
+        'Trips you drove or delivered — the record stays with the rider, your identity does not.',
+      ),
       del('trust_transport_offers', 'provider_user_id', 'Offers you made.'),
       del('trust_transport_requests', 'requester_user_id', 'Your ride/package requests.'),
       soft('trust_transport_user_extension', 'user_id', 'service_deleted_at', 'Your TrustTransport plugin extension record.'),

--- a/ctf/scripts/check-deletion-registry.mjs
+++ b/ctf/scripts/check-deletion-registry.mjs
@@ -85,6 +85,9 @@ function parseRegistry(src) {
   const reDel = /\bdel\(\s*'([^']+)'\s*,\s*'([^']+)'/g;
   const reSoft = /\bsoft\(\s*'([^']+)'\s*,\s*'([^']+)'\s*,\s*'([^']+)'/g;
   const reRetain = /\bretain\(\s*'([^']+)'/g;
+  // pseudo('table', 'user_column', ['cleared', 'columns'], 'note') — the third argument is an array,
+  // captured whole so each column inside it can be checked against schema.sql like any other.
+  const rePseudo = /\bpseudo\(\s*'([^']+)'\s*,\s*'([^']+)'\s*,\s*\[([^\]]*)\]/g;
 
   let m;
   while ((m = reDel.exec(src)) !== null) {
@@ -95,6 +98,10 @@ function parseRegistry(src) {
   }
   while ((m = reRetain.exec(src)) !== null) {
     refs.push({ table: m[1], action: 'retain' });
+  }
+  while ((m = rePseudo.exec(src)) !== null) {
+    const clearColumns = [...m[3].matchAll(/'([^']+)'/g)].map((c) => c[1]);
+    refs.push({ table: m[1], userColumn: m[2], clearColumns, action: 'pseudonymize' });
   }
   return refs;
 }
@@ -136,6 +143,15 @@ function main() {
         fail(`table "${ref.table}" has action "${ref.action}" but no user column.`);
       } else if (!cols.has(ref.userColumn)) {
         fail(`table "${ref.table}" does not have column "${ref.userColumn}" (declared as its user column).`);
+      }
+    }
+    if (ref.action === 'pseudonymize') {
+      // Every cleared column must exist too. A typo here would silently no-op the part that removes
+      // the denormalized handle, leaving the member named after their id was overwritten.
+      for (const column of ref.clearColumns ?? []) {
+        if (!cols.has(column)) {
+          fail(`table "${ref.table}" does not have cleared column "${column}" (declared for pseudonymize).`);
+        }
       }
     }
     if (ref.action === 'soft-delete') {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**⚠️ Owner-review lane — auto-merge is deliberately NOT enabled.** This changes account-deletion behavior, which is on the risky list. Requested by the owner, but the merge is yours.

## The problem

Account deletion removed `socket_relay_fulfillments` by `requester_user_id` **only**. A member who deleted their account left their raw Clerk id sitting in the counterparty's view forever — the owner hit this on a canceled claim still naming `user_3FL6…` after the account behind it was gone.

Deleting the row was never the answer: a fulfillment where you were the **helper** belongs to the member who posted the request, and removing it would destroy *their* record of what happened on their own request.

## What I audited first

I cross-referenced every registry-handled table against its actual `*_user_id` columns. **Nine** tables have a user column deletion never touches. They are not the same kind of thing, so they do not get the same treatment:

| Table / column | Decision |
|---|---|
| `socket_relay_fulfillments.fulfiller_user_id` | **Pseudonymize** — genuine counterparty |
| `trust_transport_trips.provider_user_id` | **Pseudonymize** — same shape (the driver) |
| `member_safety_reports.reported_user_id` | Retain — abuse evidence |
| `member_safety_reports.reviewed_by_user_id`, `contributions_submissions.reviewed_by_user_id`, `skills_hunt_submissions.reviewed_by_user_id`, `unlock_verification_submissions.reviewed_by_user_id`, `workforce_profiles.updated_by_user_id` | Retain — audit trail of who decided what |
| `member_blocks.blocked_user_id` | **Retain — overwriting the column a block is enforced by could unblock someone** |
| `recurring_activities.ended_by_user_id` | Left alone; ambiguous (either party), no reported harm |

The three "leave alone" reasons are written into the deletion contract, so the next person auditing this finds the decision rather than re-deriving it.

## The change

New `pseudonymize` action. Generated SQL, verified by inspection rather than assumed:

```sql
UPDATE socket_relay_fulfillments SET fulfiller_user_id = 'deleted_member', fulfiller_username = NULL WHERE fulfiller_user_id = $1
UPDATE trust_transport_trips  SET provider_user_id  = 'deleted_member' WHERE provider_user_id = $1
```

Two design points:

- **Clearing the handle matters as much as the id.** `fulfiller_username` is a denormalized copy captured at claim time; overwriting the id and leaving the handle would defeat the whole point.
- **One shared constant, not a per-user token.** A token would still link that person's rows to each other, which is exactly what deletion is meant to end. Two departed helpers on one request both read "Deleted member" — correct, since the surviving party has no need to tell them apart.

The `WHERE` matches the real id, so the statement is idempotent by construction: a second run matches nothing.

## Guardrails

- `check-deletion-registry.mjs` learned the new action and validates its cleared columns against `schema.sql`. **I confirmed it fails on a bad column name** rather than silently skipping the clear — a typo there would have quietly left the handle in place.
- The SocketRelay admin list renders the placeholder as **"Deleted member"**, so the sentinel string never reaches a reader.
- Direct Line already degrades correctly: with no name and no handle, `srCounterpartLabel` returns null and the header falls back to "with the helper" — it never prints the placeholder.

No schema change. No FK on either column, so the constant is safe to write.

## Checks

Deletion registry (105 refs, up from 103), typecheck, lint (`--max-warnings=0`), a11y lint, modularity governance, inventory drift, test-script drift, schema drift, EOF formatting, US spelling — all pass locally. Both deletion contracts, both inventories, and both test scripts updated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_