### PR TITLE
ci: check that every table holding a member's id is covered by account deletion

### DIFF
--- a/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
+++ b/ctf/docs/developer/PRODUCTION_READINESS_PLAN.md
@@ -244,6 +244,17 @@ known-open item — sign-in via Clerk (auth) — is owned by the owner's separat
 
 ## Change log
 
+- 2026-08-02: **Account deletion has never been checked for coverage; 68 tables holding a member's
+  id are unclassified.** `check-deletion-registry.mjs` only ever asked "does every table the registry
+  names exist in schema.sql?" — never the question that matters to a member: "is every table holding
+  my id accounted for when I delete my account?" Adding that second direction found 68 tables in no
+  registry entry at all, among them `lighthouse_matches`, `lighthouse_blocks`, `mood_submissions`, `service_credits_escrow_holds`. They are recorded
+  in `ctf/scripts/deletion-coverage-allowlist.json` as a burn-down list (it may only shrink; the gate
+  fails both on a new unclassified table and on a classified table left in the list — both verified).
+  Nothing is deleted differently yet: each table needs an owner decision, and they are not the same
+  kind of thing — ledger and audit rows must be retained, abuse evidence must be retained, while
+  wellbeing and match data plainly should go. This entry is the record that the gap is known and
+  measured rather than discovered later.
 - 2026-05-20: Plan created; strategic decisions locked; design submodule confirmed populated
   (17 user-facing plugins have pixel-perfect desktop + mobile + 4-state mockups).
 - 2026-05-20: Rule 127 updated — nothing is design-skippable; no admin/internal UI exemption.

--- a/ctf/scripts/check-deletion-registry.mjs
+++ b/ctf/scripts/check-deletion-registry.mjs
@@ -106,6 +106,13 @@ function parseRegistry(src) {
   return refs;
 }
 
+function readCoverageAllowlist() {
+  const file = path.join(root, 'scripts', 'deletion-coverage-allowlist.json');
+  if (!fs.existsSync(file)) return new Set();
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return new Set(Object.keys(parsed.unclassifiedTables ?? {}));
+}
+
 function main() {
   if (!fs.existsSync(schemaPath)) {
     fail(`schema.sql not found at ${schemaPath}`);
@@ -129,6 +136,47 @@ function main() {
   if (refs.length === 0) {
     fail('no table references parsed from the registry — parser or registry is broken.');
     return;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Direction 2: schema -> registry. Everything above asks "does what the registry names exist?".
+  // Nothing asked the question that actually matters for a member: "is every table holding my id
+  // accounted for when I delete my account?" It was not — 64 tables with a user column appeared in
+  // no registry entry at all, including lighthouse_matches (who sought housing from whom) and
+  // mood_submissions. Those are recorded in deletion-coverage-allowlist.json as a burn-down list,
+  // and this check fails on anything new so the gap can only shrink.
+  const coverage = readCoverageAllowlist();
+  const referenced = new Set(refs.map((r) => r.table));
+  const uncovered = [];
+  for (const [table, cols] of schemaTables.entries()) {
+    const userColumns = [...cols].filter((c) => /user_id$/.test(c)).sort();
+    if (userColumns.length === 0 || referenced.has(table)) continue;
+    if (coverage.has(table)) continue;
+    uncovered.push({ table, userColumns });
+  }
+  for (const item of uncovered) {
+    fail(
+      `table "${item.table}" has user column(s) ${item.userColumns.join(', ')} but no account-deletion ` +
+        `registry entry — a member deleting their account would leave these rows behind. Classify it in ` +
+        `lib/account/deletion-registry.ts (del / soft / pseudonymize / retain).`,
+    );
+  }
+  // The allowlist may only shrink: an entry that no longer needs to be there is a finished burn-down
+  // step, and leaving it would quietly re-open the door for that table later.
+  const stillUnclassified = new Set(uncovered.map((u) => u.table));
+  for (const table of coverage) {
+    const cols = schemaTables.get(table);
+    if (!cols) {
+      fail(`allowlisted table "${table}" no longer exists in schema.sql — remove it from deletion-coverage-allowlist.json.`);
+      continue;
+    }
+    if (referenced.has(table)) {
+      fail(
+        `table "${table}" is now classified in the deletion registry but is still listed in ` +
+          `deletion-coverage-allowlist.json — remove it from the allowlist.`,
+      );
+    }
+    void stillUnclassified;
   }
 
   let checked = 0;

--- a/ctf/scripts/deletion-coverage-allowlist.json
+++ b/ctf/scripts/deletion-coverage-allowlist.json
@@ -1,0 +1,439 @@
+{
+  "_comment": "Tables that have a user-identifying column but appear in NO account-deletion registry entry, so a member deleting their account leaves those rows behind. BURN-DOWN list: it may only ever shrink. To remove an entry, classify the table in ctf/packages/web/lib/account/deletion-registry.ts (del / soft / pseudonymize / retain-with-reason) and delete it from here \u2014 the gate fails if a classified table is still listed. Never add a new table to silence the gate; classify it instead. Seeded 2026-08-02 when the schema->registry direction of the gate was first added. Every entry is UNREVIEWED and needs an owner decision: several are ledger, audit, or abuse-evidence tables where deleting would be the wrong answer, and several are plainly member data that should go.",
+  "unclassifiedTables": {
+    "account_deletion_events": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "account_restrictions": {
+      "userColumns": [
+        "restricted_by_user_id",
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "account_restrictions_audit": {
+      "userColumns": [
+        "target_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "admin_area_seen": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "announcement_delivery_events": {
+      "userColumns": [
+        "created_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "announcement_reactions": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "announcement_replies": {
+      "userColumns": [
+        "author_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "announcement_revisions": {
+      "userColumns": [
+        "created_by_user_id",
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "announcements": {
+      "userColumns": [
+        "created_by_user_id",
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "bug_reports": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "chyme_back_channel_calls": {
+      "userColumns": [
+        "ended_by_user_id",
+        "initiator_user_id",
+        "recipient_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "comic_review_queue": {
+      "userColumns": [
+        "reviewer_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "contributions_cycles": {
+      "userColumns": [
+        "created_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "contributions_runtime_config": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "directory_announcements": {
+      "userColumns": [
+        "created_by_user_id",
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "directory_quora_url_history": {
+      "userColumns": [
+        "changed_by_user_id",
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "directory_suppressed_quora_urls": {
+      "userColumns": [
+        "created_by_user_id",
+        "overridden_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "feed_community_post_reactions": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "feed_hub_last_seen": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "feed_items": {
+      "userColumns": [
+        "created_by_user_id",
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "feed_render_config": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "foundation_capacity_policies": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "foundation_capacity_policy_events": {
+      "userColumns": [
+        "changed_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "foundation_provider_accepted_currencies": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "gdp_publications": {
+      "userColumns": [
+        "created_by_user_id",
+        "host_user_id",
+        "published_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_auto_cohort_config": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_auto_cohort_term_overrides": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_cohort_proposals": {
+      "userColumns": [
+        "decided_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_cohorts": {
+      "userColumns": [
+        "created_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_disbursements": {
+      "userColumns": [
+        "recipient_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_dispute_comments": {
+      "userColumns": [
+        "actor_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_disputes": {
+      "userColumns": [
+        "opened_by_user_id",
+        "resolved_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_milestone_validations": {
+      "userColumns": [
+        "validated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_trainers": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "level_up_user_achievements": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "lighthouse_blocks": {
+      "userColumns": [
+        "blocked_user_id",
+        "blocker_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "lighthouse_matches": {
+      "userColumns": [
+        "host_user_id",
+        "seeker_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "llm_inference_log": {
+      "userColumns": [
+        "actor_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "login_events": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "mood_submissions": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "peer_programming_cohorts": {
+      "userColumns": [
+        "assigned_by_user_id",
+        "ended_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "peer_programming_settings": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "peer_programming_weekly_topics": {
+      "userColumns": [
+        "created_by_user_id",
+        "published_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "service_credits_credit_limits": {
+      "userColumns": [
+        "updated_by_user_id",
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "service_credits_dispute_adjustments": {
+      "userColumns": [
+        "destination_user_id",
+        "source_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "service_credits_disputes": {
+      "userColumns": [
+        "opened_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "service_credits_escrow_holds": {
+      "userColumns": [
+        "wallet_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "service_credits_governance_events": {
+      "userColumns": [
+        "target_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "service_credits_treasury_config": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "service_credits_treasury_events": {
+      "userColumns": [
+        "source_user_id",
+        "treasury_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "skills_hunt_directory_profiles": {
+      "userColumns": [
+        "created_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "skills_hunt_feature_reward_card": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "skills_hunt_missions": {
+      "userColumns": [
+        "created_by_user_id",
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "skills_hunt_rounds": {
+      "userColumns": [
+        "created_by_user_id",
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "skills_hunt_submission_reports": {
+      "userColumns": [
+        "reporter_user_id",
+        "resolved_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "socket_relay_request_events": {
+      "userColumns": [
+        "actor_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "trust_transport_disputes": {
+      "userColumns": [
+        "opened_by_user_id",
+        "resolved_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "trust_transport_market_config": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "trust_transport_proof_artifacts": {
+      "userColumns": [
+        "captured_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "trust_transport_risk_signals": {
+      "userColumns": [
+        "actor_user_id",
+        "resolved_by_user_id",
+        "target_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "trust_transport_status_events": {
+      "userColumns": [
+        "actor_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "user_ui_preferences": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "weekly_performance_weeks": {
+      "userColumns": [
+        "selected_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "what_works_endorsements": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "workforce_config": {
+      "userColumns": [
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "workforce_deletion_events": {
+      "userColumns": [
+        "user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "workforce_export_jobs": {
+      "userColumns": [
+        "created_by_user_id"
+      ],
+      "decision": "unreviewed"
+    },
+    "workforce_occupations": {
+      "userColumns": [
+        "created_by_user_id",
+        "updated_by_user_id"
+      ],
+      "decision": "unreviewed"
+    }
+  }
+}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**⚠️ Owner-review lane — auto-merge is NOT enabled.** It touches account-deletion tooling and surfaces 68 decisions that are yours.

## What you asked, and what I found instead

You asked me to extend the pseudonymization sweep across LightHouse, Foundation, TrustTransport and the rest. I audited rather than assuming, and the answer is uncomfortable: **the pseudonymization sweep was nearly finished, and a much larger gap sits underneath it.**

`check-deletion-registry.mjs` only ever asked one direction — *"does every table the registry names exist in schema.sql?"* It never asked the question that matters to a member: **"is every table holding my id accounted for when I delete my account?"**

Adding that direction found **68 tables in no registry entry at all**, including:

| Table | What it holds |
|---|---|
| `lighthouse_matches` | who sought housing from whom |
| `lighthouse_blocks` | blocker / blocked |
| `mood_submissions` | wellbeing check-ins |
| `level_up_disbursements` | `recipient_user_id` |
| `service_credits_escrow_holds` | `wallet_user_id` |
| `chyme_back_channel_calls` | initiator / recipient |
| `bug_reports`, `directory_quora_url_history` | member-submitted content and history |

LightHouse classifies four tables and has seven. Its own registry entry already carried a note admitting the problem for one of them: *"Listings may be referenced by other users (matches/blocks). Decide whether to delete, transfer, or anonymize before enabling."*

## What this PR deliberately does NOT do

It changes no deletion behavior. These 68 are **not the same kind of thing**, and a uniform sweep would be wrong in both directions:

- ledger and audit rows **must** be retained (`service_credits_*`, `login_events`, `llm_inference_log`);
- abuse evidence **must** be retained;
- wellbeing data and housing matches plainly **should** go.

Guessing wrong either way is worse than the gap. Each is your call — and the one time I nearly applied a rule uniformly (in #2054) it would have broken block enforcement, which is what convinced me not to here.

## What ships: the measurement and the ratchet

- `deletion-coverage-allowlist.json` records all 68 as **UNREVIEWED**, in the burn-down style this repo already uses for inventory drift and orphan routes. It may only ever shrink.
- The gate **fails on a newly unclassified table**, so the gap cannot grow.
- It **also fails on a table that has since been classified but is still listed**, so finishing a burn-down step isn't optional bookkeeping.

Both failure directions were exercised before committing, not assumed:

```
TEST 1 — remove lighthouse_matches from the allowlist
  → FAILS: "lighthouse_matches has user column(s) host_user_id, seeker_user_id but no registry entry"
TEST 2 — leave socket_relay_fulfillments in the allowlist after classifying it
  → FAILS: "is now classified ... but is still listed — remove it from the allowlist"
```

The allowlist is seeded from the gate's own output, so the list and the check cannot drift apart.

## Suggested order when you want to burn it down

1. **Member data with no compliance angle** — `mood_submissions`, `feed_hub_last_seen`, `user_ui_preferences`, `announcement_reactions`, `what_works_endorsements`. Straight `del`.
2. **Two-party records** — `lighthouse_matches`, `lighthouse_blocks`, `chyme_back_channel_calls`. Same shape as the SocketRelay fix: delete your side, pseudonymize the other party's.
3. **Ledger and disputes** — `service_credits_*`, `level_up_disbursements`, `*_disputes`. Almost certainly `retain`, but that is a compliance call, not a code call.
4. **Admin/audit columns** — `retain`, matching the reasons already written into the deletion contracts.

Say which grouping you want and I'll do them a batch at a time, each with the contract and inventory updates.

## Checks

Deletion registry gate (both directions), typecheck, lint, EOF formatting, US spelling, test-script drift — all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_