### PR TITLE
docs: state that outside code contributions are not accepted, and why

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,30 @@ See `render.yaml` for service definitions and `ctf/docs/developer/` for runbooks
 
 ## Contributing
 
-Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) (if present) or open an issue to discuss changes.
+**This project does not accept outside code contributions.** Pull requests from outside the core
+team are closed unread. That is not about the quality of the offer — it is about who uses this app.
+
+The people here are survivors of organized stalking and trafficking. For them, a defect in this
+codebase is not an inconvenience: a leaked location, an exposed identity, a message reaching the
+wrong person, or an account someone else can reach is a physical-safety event. Every line that ships
+is written and reviewed by people who understand that threat model and who are accountable for it.
+Accepting code from someone outside that circle — however well-intentioned — introduces a path we
+cannot vouch for, and it is the members who would carry the consequence, not us.
+
+There is a second reason, and it is the more serious one. Targeting operations actively try to place
+people inside the communities they target. An open contribution path is a standing invitation to do
+exactly that. Refusing outside code removes that route entirely rather than relying on catching it.
+
+**Please also read this if you are thinking of helping in any other capacity.** If you are not
+targeted yourself, taking part in this project can put you in real danger: people who step in from
+the outside get noticed, are approached and asked to take part in trafficking, and those who refuse
+have been killed or have become targets themselves. Nobody here is asking you to carry that risk on
+our behalf.
+
+**The repository is public to be read, audited, and verified, not to be built on.** Reading the code,
+checking the claims made in the docs, and reporting a security problem you find are all welcome —
+see [Support](#support) for where to send a report. Members of the app report bugs in-app, which
+routes to a private triage repository.
 
 ### Code Quality
 
@@ -124,7 +147,7 @@ All commits run through:
 - **TypeScript** type checking (tsc)
 - **EOF format validation** (all files end with exactly one newline)
 - **Pre-commit hooks** (Husky) — runs tsc + linting
-- **CI workflow** (`rewrite-ci.yml`) — full test suite, schema drift checks, dependency audit
+- **CI workflow** (`.github/workflows/ci.yml`) — full test suite, schema drift checks, dependency audit
 
 To prepare a PR:
 
@@ -141,9 +164,12 @@ bash scripts/check-eof-format.sh  # EOF validation
 
 ## Support
 
-- **Issues & bugs:** GitHub Issues
-- **Discussions:** GitHub Discussions
-- **Documentation:** See `ctf/docs/developer/` and inline code comments
+- **Members:** report bugs from inside the app — reports route to a private triage repository so no
+  member's words end up on a public issue.
+- **Security problems found by reading the code:** open a GitHub issue describing the problem. Do not
+  include any member's data, and do not open a pull request with a fix — see
+  [Contributing](#contributing).
+- **Documentation:** See `ctf/docs/developer/` and inline code comments.
 
 ---
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (docs only)

## Why

The README said **"Contributions welcome"** and linked a `CONTRIBUTING.md` that does not exist. Both were wrong, and the first one is wrong in a way that matters: this app is used by survivors of organized stalking and trafficking, where a defect is not an inconvenience but a physical-safety event — a leaked location, an exposed identity, a message reaching the wrong person, an account someone else can reach.

## What the section now says

Two reasons, stated plainly rather than left implied:

1. **Accountability.** Code that ships has to come from people who understand this threat model and are accountable for it. Accepting code from outside that circle adds a path nobody can vouch for, and it is members who carry the consequence.
2. **The more serious one.** Targeting operations actively try to place people inside the communities they target. An open contribution path is a standing invitation to do exactly that. Refusing outside code closes the route rather than relying on catching it.

It also carries the warning already live on the public job posting — that someone who is **not** targeted can be put in real danger by taking part at all, in any capacity. The README is the other public door into this project, so it belongs here too.

## What is still welcome

The refusal is written so it does not read as hostility to scrutiny — the repository is public *to be read, audited, and verified, not to be built on*. Reading the code and reporting a security problem you find are invited; a pull request fixing it is not.

The Support section now routes:

- **members** → the in-app bug report, which goes to the private triage repo, keeping their words off a public issue;
- **outside readers** → a GitHub issue, with an explicit "no member data, and no PR with a fix".

## Also fixed

The Code Quality list still named `rewrite-ci.yml`; that workflow was renamed to `.github/workflows/ci.yml` during the Render migration.

## Checks

US spelling gate and EOF formatting pass. Documentation only — no code, route, schema, or contract change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_