### PR TITLE
fix: harden feed rate-limit SQL, drop server-side Stream teardown, scope notice update

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -351,6 +351,17 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 ## 11) Change Log
 
+- 2026-08-02: **Four code-review fixes (issues #2045, #2046, #2048, #2017).** (1) `evaluateFeedRateLimit`
+  no longer interpolates the table/column names it received: both are looked up from a frozen
+  allow-list map keyed by the four permitted table literals, so a widened type or a hostile cast can
+  never reach the SQL string (value literals stay parameterized). (2) The server-side Stream client in
+  `lib/feed/stream.ts` no longer calls `disconnectUser()` in a `finally` — that is the client-side
+  teardown for a connected user; a key+secret server client opens no WebSocket, and the call only risked
+  masking a real error. (3) `refreshPublishedGuidanceNotices` scopes its `feed_items` UPDATE to
+  `item_type = 'announcement'`, so a same-title, same-actor row of another type can never be overwritten.
+  (4) `markAnnouncementRead` now returns the stored `read_at`; `POST /api/announcements/[id]/read`
+  reports that persisted timestamp instead of a route-computed one, matching `markFeedItemRead` and
+  `dismissFeedItem`. The response shape (`{ ok, announcementId, readAt }`) is unchanged.
 - 2026-08-01: **Two code-review corrections (issues #2021, #2019).** (1) `GET /api/feed/items` now
   honors the `mentions=me` input its contract (feed.timeline.fetch) has always documented: handle
   tokens are derived server-side from the authenticated caller (never client-supplied) and passed to

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -96,6 +96,9 @@
 **Expected:**
 - After reload the item no longer shows as unread.
 - No error is thrown; the action is idempotent (triggering it again on the same item does not error).
+- If you inspect the network call, the read-mark response carries a `readAt` timestamp — the value the
+  database stored, not a client guess. The announcement read-mark endpoint
+  (`POST /api/announcements/:id/read`) reports its stored `readAt` the same way.
 
 **Result:** web ☐
 

--- a/ctf/docs/quota-impact/2026-08-02-feed-code-review-fixes.md
+++ b/ctf/docs/quota-impact/2026-08-02-feed-code-review-fixes.md
@@ -1,0 +1,57 @@
+# Stream Quota Impact Note — feed code-review fixes
+
+## Summary
+
+- Feature/Change: A batch of small code-review fixes for the `feed` plugin. The only Stream-adjacent
+  part is in `ctf/packages/web/lib/feed/stream.ts`: the two server-side `StreamChat` helpers
+  (`getFeedStreamCredentials`, `emitFeedMembershipEventToStream`) no longer call
+  `streamClient.disconnectUser()` in a `finally` block. That call is the client-side teardown for a
+  connected user; a server client built from an API key + secret opens no user WebSocket, so the call
+  did nothing useful and only risked masking a real error thrown in the body. The rest of the change is
+  non-Stream: a rate-limit SQL hardening, a scoped `feed_items` update, and returning the stored
+  `read_at` from `markAnnouncementRead`.
+- PR: harden feed rate-limit SQL, drop server-side Stream teardown, scope notice update (#2058)
+- Owner: farah
+- Date: 2026-08-02
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: Chat only, and consumption can only fall. The removed
+  `disconnectUser()` calls are the only change to Stream call patterns. No channel, connection, watch,
+  token, upsert, or event-send behavior changes; the same `upsertUser` / `createToken` /
+  `channel.create` / `addMembers` / `sendEvent` sequence runs as before.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: 0 (no new users, channels, or connections)
+- Activity Feed API calls estimate: 0 — if anything slightly fewer, since a per-call `disconnectUser`
+  REST round-trip is no longer attempted.
+- Video participant-minutes estimate: 0 (no video surface touched)
+- AI Moderation credits estimate: 0
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): Green — usage can only stay the same or
+  drop, never rise.
+- Peak scenario estimate: No change; the credential-mint and membership-event paths issue the same
+  Stream calls at the same frequency, minus the removed teardown call.
+
+## Fallback and Degradation Plan
+
+- What degrades first: Nothing — no live behavior changes. If Stream is unavailable, the helpers fail
+  exactly as before (`getFeedStreamCredentials` returns `null` when credentials cannot be resolved;
+  `emitFeedMembershipEventToStream` returns `false`).
+- User-visible messaging behavior: Unchanged. The feed chat channels connect as before.
+- Kill switch / feature flag: Not applicable.
+
+## Observability
+
+- Metrics and alerts added/updated: None. Existing `console.error` logging around `channel.create()` /
+  `channel.watch()` is unchanged.
+- Dashboard link (if available): N/A.
+
+## Validation
+
+- Tests added for degraded mode: None required. Web typecheck, lint, build, EOF, inventory-drift, and
+  test-script-drift all pass locally.
+- Rollback strategy: Revert the change; no runtime or quota impact either way.

--- a/ctf/packages/web/app/api/announcements/[announcementId]/read/route.ts
+++ b/ctf/packages/web/app/api/announcements/[announcementId]/read/route.ts
@@ -25,8 +25,7 @@ export async function POST(request: Request, { params }: RouteParams) {
   const { announcementId } = await params;
 
   try {
-    const readAt = new Date().toISOString();
-    await markAnnouncementRead(gate.auth.userId, announcementId);
+    const { readAtIso: readAt } = await markAnnouncementRead(gate.auth.userId, announcementId);
     logFeedAudit({
       actorId: gate.auth.userId,
       pluginId: 'feed',

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -380,16 +380,31 @@ function passesFeedModeration(text: string, urlCap: number = FEED_MAX_COMMUNITY_
   return urlCount <= urlCap;
 }
 
+// The (table, actor-column) pairs this rate-limit query is allowed to run against. Both identifiers
+// are looked up from this frozen map — never interpolated from the caller — so even if the parameter
+// type widened or a cast slipped a hostile string past the compiler, only these fixed identifiers can
+// ever reach the SQL string. Value literals stay parameterized ($1/$2); table and column names cannot
+// be parameters in SQL, so an allow-list is the safe form.
+const FEED_RATE_LIMIT_TABLES = {
+  feed_questions: 'asked_by_user_id',
+  feed_community_posts: 'author_user_id',
+  feed_community_replies: 'author_user_id',
+  announcement_replies: 'author_user_id',
+} as const;
+
 async function evaluateFeedRateLimit(
   client: PoolClient,
   input: {
     userId: string;
-    tableName: 'feed_questions' | 'feed_community_posts' | 'feed_community_replies' | 'announcement_replies';
+    tableName: keyof typeof FEED_RATE_LIMIT_TABLES;
     limit: number;
     windowMinutes: number;
   },
 ): Promise<boolean> {
-  const actorColumn = input.tableName === 'feed_questions' ? 'asked_by_user_id' : 'author_user_id';
+  const actorColumn = FEED_RATE_LIMIT_TABLES[input.tableName];
+  if (!actorColumn) {
+    throw new Error('invalid_rate_limit_table');
+  }
   const result = await client.query<CountRow>(
     `
       SELECT COUNT(*)::text AS total
@@ -554,7 +569,7 @@ async function refreshPublishedGuidanceNotices(client: PoolClient): Promise<void
       `
         UPDATE feed_items
         SET body = $2, updated_at = NOW()
-        WHERE title = $1 AND created_by_user_id = $3 AND body <> $2
+        WHERE title = $1 AND created_by_user_id = $3 AND item_type = 'announcement' AND body <> $2
       `,
       [notice.title, notice.body, FEED_SYSTEM_ACTOR_ID],
     );
@@ -1917,16 +1932,23 @@ export async function archiveAnnouncement(actorId: string, announcementId: strin
   });
 }
 
-export async function markAnnouncementRead(userId: string, announcementId: string): Promise<void> {
-  await queryDb(
+// Returns the stored read_at so the route can report the timestamp the database actually wrote,
+// matching markFeedItemRead/dismissFeedItem, rather than a route-computed approximation.
+export async function markAnnouncementRead(
+  userId: string,
+  announcementId: string,
+): Promise<{ readAtIso: string }> {
+  const result = await queryDb<{ read_at: string }>(
     `
       INSERT INTO announcement_user_state (user_id, announcement_id, read_at, acknowledged_at, updated_at)
       VALUES ($1, $2::uuid, NOW(), NOW(), NOW())
       ON CONFLICT (user_id, announcement_id)
       DO UPDATE SET read_at = NOW(), acknowledged_at = NOW(), updated_at = NOW()
+      RETURNING read_at
     `,
     [userId, announcementId],
   );
+  return { readAtIso: new Date(result.rows[0].read_at).toISOString() };
 }
 
 export async function dismissAnnouncement(userId: string, announcementId: string): Promise<'ok'> {

--- a/ctf/packages/web/lib/feed/stream.ts
+++ b/ctf/packages/web/lib/feed/stream.ts
@@ -28,40 +28,39 @@ export async function getFeedStreamCredentials(
 ): Promise<FeedStreamCredentials | null> {
   const streamConfig = await resolveStreamCredentials();
   if (!streamConfig) return null;
+  // Server-side client (apiKey + apiSecret): it issues tokens and makes REST calls, it never opens a
+  // user WebSocket, so there is nothing to tear down. disconnectUser() is the client-side teardown for
+  // a connected user and does not apply here — calling it in a finally only risked masking a real error.
   const streamClient = new StreamChat(streamConfig.apiKey, streamConfig.apiSecret);
+  const streamUserId = `feed-${userId}`;
+  await streamClient.upsertUser({ id: streamUserId, name: displayName });
+  const token = streamClient.createToken(streamUserId);
+  const channelDef = FEED_STREAM_CHANNELS[channelKey];
+  const channelId = channelDef.id;
+  const channel = streamClient.channel('messaging', channelId, {
+    created_by_id: streamUserId,
+    name: channelDef.name,
+  });
   try {
-    const streamUserId = `feed-${userId}`;
-    await streamClient.upsertUser({ id: streamUserId, name: displayName });
-    const token = streamClient.createToken(streamUserId);
-    const channelDef = FEED_STREAM_CHANNELS[channelKey];
-    const channelId = channelDef.id;
-    const channel = streamClient.channel('messaging', channelId, {
-      created_by_id: streamUserId,
-      name: channelDef.name,
-    });
+    await channel.create();
+  } catch (createErr) {
+    // Log the error from channel.create()
+    console.error('[getFeedStreamCredentials] channel.create() failed:', createErr);
     try {
-      await channel.create();
-    } catch (createErr) {
-      // Log the error from channel.create()
-      console.error('[getFeedStreamCredentials] channel.create() failed:', createErr);
-      try {
-        await channel.watch();
-      } catch (watchErr) {
-        // Log both errors for debugging
-        console.error('[getFeedStreamCredentials] channel.watch() also failed after create() error:', watchErr, 'Original create() error:', createErr);
-        throw watchErr;
-      }
+      await channel.watch();
+    } catch (watchErr) {
+      // Log both errors for debugging
+      console.error('[getFeedStreamCredentials] channel.watch() also failed after create() error:', watchErr, 'Original create() error:', createErr);
+      throw watchErr;
     }
-    await channel.addMembers([streamUserId]);
-    return {
-      streamApiKey: streamConfig.apiKey,
-      streamToken: token,
-      streamUserId,
-      streamChannelId: channelId,
-    };
-  } finally {
-    await streamClient.disconnectUser();
   }
+  await channel.addMembers([streamUserId]);
+  return {
+    streamApiKey: streamConfig.apiKey,
+    streamToken: token,
+    streamUserId,
+    streamChannelId: channelId,
+  };
 }
 
 export async function emitFeedMembershipEventToStream(input: {
@@ -77,41 +76,38 @@ export async function emitFeedMembershipEventToStream(input: {
     return false;
   }
 
+  // Server-side client: no user WebSocket is opened, so there is no disconnectUser() teardown to run.
   const streamClient = new StreamChat(streamConfig.apiKey, streamConfig.apiSecret);
+  const channel = streamClient.channel('messaging', 'ctf-feed-membership-events', {
+    created_by_id: `feed-${input.actorId}`,
+    name: 'CTF Feed Membership Events',
+  });
+
   try {
-    const channel = streamClient.channel('messaging', 'ctf-feed-membership-events', {
-      created_by_id: `feed-${input.actorId}`,
-      name: 'CTF Feed Membership Events',
-    });
-
+    await channel.create();
+  } catch (createErr) {
+    // Log the error from channel.create()
+    console.error('[emitFeedMembershipEventToStream] channel.create() failed:', createErr);
     try {
-      await channel.create();
-    } catch (createErr) {
-      // Log the error from channel.create()
-      console.error('[emitFeedMembershipEventToStream] channel.create() failed:', createErr);
-      try {
-        await channel.watch();
-      } catch (watchErr) {
-        // Log both errors for debugging
-        console.error('[emitFeedMembershipEventToStream] channel.watch() also failed after create() error:', watchErr, 'Original create() error:', createErr);
-        throw watchErr;
-      }
+      await channel.watch();
+    } catch (watchErr) {
+      // Log both errors for debugging
+      console.error('[emitFeedMembershipEventToStream] channel.watch() also failed after create() error:', watchErr, 'Original create() error:', createErr);
+      throw watchErr;
     }
-
-    await channel.sendEvent({
-      type: 'feed.membership.updated' as EventTypes,
-      eventName: 'feed.membership.updated',
-      actorId: input.actorId,
-      userId: input.userId,
-      pluginId: input.pluginId,
-      eventType: input.eventType,
-      requestId: input.requestId,
-      traceId: input.traceId,
-      emittedAt: new Date().toISOString(),
-    });
-
-    return true;
-  } finally {
-    await streamClient.disconnectUser();
   }
+
+  await channel.sendEvent({
+    type: 'feed.membership.updated' as EventTypes,
+    eventName: 'feed.membership.updated',
+    actorId: input.actorId,
+    userId: input.userId,
+    pluginId: input.pluginId,
+    eventType: input.eventType,
+    requestId: input.requestId,
+    traceId: input.traceId,
+    emittedAt: new Date().toISOString(),
+  });
+
+  return true;
 }


### PR DESCRIPTION
Resolves four verified feed code-review findings. Each was checked against the current code before changing anything.

## Changes

**#2045 — rate-limit SQL no longer interpolates a caller value (security).** `evaluateFeedRateLimit` now looks up both the table name and the actor column from a frozen allow-list map keyed by the four permitted table literals, and throws if the key is unknown. Table and column names cannot be SQL parameters, so an allow-list is the safe form; value literals stay parameterized (`$1`/`$2`). Behavior is identical for every current caller — this is a structural hardening so a future type-widening or cast cannot turn the interpolation into an injection point.

**#2046 — server-side Stream client no longer calls `disconnectUser()` (bug).** `getFeedStreamCredentials` and `emitFeedMembershipEventToStream` build a `StreamChat` client from `apiKey` + `apiSecret`. That client issues tokens and makes REST calls; it never opens a user WebSocket, so `disconnectUser()` (the client-side teardown for a connected user) does not apply. It was being called in a `finally`, where it could throw and mask a real error from the body. Both `finally` blocks are removed.

**#2048 — standing-notice refresh scopes its `feed_items` update to announcements (correctness).** `refreshPublishedGuidanceNotices` matched `feed_items` on `title` + `created_by_user_id = FEED_SYSTEM_ACTOR_ID`. Added `AND item_type = 'announcement'` so a same-title, same-actor row of another type can never be overwritten. The `announcements`-table update in the same function was already type-unambiguous and is unchanged.

**#2017 — announcement read-mark reports the persisted timestamp (correctness).** Note on the stated reasoning: the finding claimed the route "cannot satisfy the contract." That was not accurate — the route already returned a `readAt` (a route-computed `new Date()`), so the `{ announcementId, readAt }` contract was met. The load-bearing fix is consistency: `markAnnouncementRead` now returns the stored `read_at`, and the route reports that persisted value instead of a JS approximation, matching `markFeedItemRead` and `dismissFeedItem`. The response shape (`{ ok, announcementId, readAt }`) is unchanged, so there is no contract change.

## Not changed (findings verified as not real — closed separately)

- **#2043** (moderation hide/restore audit): the audit event **is** emitted — in the moderation route (`app/api/feed/admin/moderation/[target]/[id]/route.ts`), not the repository layer the finding inspected.
- **#2044** (community-post delete cascade): `feed_user_read_state`, `feed_user_dismissals`, and `feed_item_targets` all declare `REFERENCES feed_items(id) ON DELETE CASCADE` in `schema.sql`, so deleting the `feed_items` row cascades them. No orphaning.
- **#2047** (reply-list existence check): the `feed.announcement.reply.list` contract's `denyConditions` are `[actor_not_authenticated]` only — `announcement_not_found` is not required (unlike `reply.create`). An empty list for a well-formed, non-existent id is the correct read behavior.

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

Closes #2045
Closes #2046
Closes #2048
Closes #2017

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYKam3Xd996h6TwYDQqWYQ)_