### PR TITLE
feat: deletion burn-down batch 1 — six member-data tables classified (68 → 62)

### DIFF
--- a/ctf/docs/contracts/FEED_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/FEED_PROFILE_AND_DELETION_CONTRACT.md
@@ -72,7 +72,10 @@ When user deletes Feed usage only:
 
 - Delete immediately:
   - per-user state rows in `feed_user_read_state`, `feed_user_dismissals`, `feed_answer_ratings`,
-    `feed_community_post_reactions`, and `announcement_user_state`
+    `feed_community_post_reactions`, `announcement_user_state`, `announcement_reactions`, and
+    `feed_hub_last_seen` (2026-08-02: the last three now have registry entries — this contract
+    already promised `feed_community_post_reactions` would clear, but no registry entry existed, so
+    the deletion engine never executed that promise until the deletion-coverage gate caught it)
 - Anonymize/pseudonymize:
   - historical authored content (`feed_community_posts`, `feed_community_replies`, `feed_questions`)
     where hard delete is not policy-allowed

--- a/ctf/docs/contracts/MOOD_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/MOOD_PROFILE_AND_DELETION_CONTRACT.md
@@ -16,6 +16,12 @@
 > (`ON DELETE CASCADE`). No mood data tied to the user survives. The community
 > pulse aggregate reads only `mood_value` + `submitted_at`, so it never exposed
 > per-user data in the first place.
+>
+> Defense-in-depth (2026-08-02): the registry also deletes `mood_submissions`
+> directly by `user_id`. This matches nothing today — every v3 row stores
+> `user_id` as `''` — and exists so any row that ever carries a real id (a
+> legacy import, a write path that forgets the convention) is cleared with the
+> account rather than surviving as wellbeing data with a name on it.
 
 ## 1) Plugin Metadata
 

--- a/ctf/docs/contracts/WHAT_WORKS_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/WHAT_WORKS_PROFILE_AND_DELETION_CONTRACT.md
@@ -51,6 +51,10 @@ back to the departing survivor is removed or anonymized.
 On service-scoped or full profile deletion for `user_id = X`:
 
 - `DELETE FROM what_works_endorsements WHERE user_id = X`
+  - 2026-08-02: this line was a promise without an executor — WhatWorks had no entry in the
+    account-deletion registry at all, so the deletion engine never ran it. The registry now carries a
+    `what-works` entry (endorsements deleted; the curated problem/tool lists retained as community
+    content with their review-audit columns), caught by the deletion-coverage gate.
   — removes the survivor's "this helped me" marks; each affected tool's verified count drops by one.
 - `UPDATE what_works_products SET suggested_by = NULL WHERE suggested_by = X`
   — anonymizes authorship; the suggested tool stays on the list.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -362,6 +362,11 @@ All three feed channels (announcements, questions, community) are shipped on web
   (4) `markAnnouncementRead` now returns the stored `read_at`; `POST /api/announcements/[id]/read`
   reports that persisted timestamp instead of a route-computed one, matching `markFeedItemRead` and
   `dismissFeedItem`. The response shape (`{ ok, announcementId, readAt }`) is unchanged.
+- 2026-08-02: **Deletion burn-down batch 1: three per-user tables join the deletion registry.**
+  `feed_community_post_reactions` (the deletion contract already promised this table would clear, but
+  no registry entry existed, so the engine never executed the promise), `announcement_reactions`, and
+  `feed_hub_last_seen` (unread-badge state) are now deleted with the account. Caught by the
+  deletion-coverage gate added in #2056. Contract updated to match.
 - 2026-08-01: **Two code-review corrections (issues #2021, #2019).** (1) `GET /api/feed/items` now
   honors the `mentions=me` input its contract (feed.timeline.fetch) has always documented: handle
   tokens are derived server-side from the authenticated caller (never client-supplied) and passed to

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
@@ -116,6 +116,12 @@ Seed script requirement: Provide a deterministic plugin seed script with dummy d
 
 ## 9) Change Log
 
+- 2026-08-02: **Deletion burn-down batch 1: defense-in-depth entry for `mood_submissions`.** The
+  registry deleted only `mood_client_identities` (correct — v3 rows store `user_id` as `''` and
+  cascade via the pseudonym FK). It now also deletes `mood_submissions` by `user_id` directly: a
+  no-op today, present so any row that ever carries a real id — a legacy import, a future write path
+  that forgets the convention — clears with the account instead of surviving as wellbeing data with a
+  name on it. Satisfies the deletion-coverage gate added in #2056. Contract updated.
 - 2026-07-17: **History-aware back navigation (app-wide sweep).** The member shell's hand-rolled
   back chevron was replaced by the shared `BackChevronButton` — it returns to the previous in-app
   page and falls back to All Apps when there is no in-app history. UI-only; no schema, route, or

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-what-works-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-what-works-feature-inventory.md
@@ -161,6 +161,12 @@ Derived metrics (no stored counters): a tool's verified count is `COUNT(*)` of i
 
 ## Change Log
 
+- 2026-08-02: **Deletion burn-down batch 1: WhatWorks gains its first deletion-registry entry.** The
+  plugin had none at all, while its deletion contract promised `DELETE FROM what_works_endorsements
+  WHERE user_id = X` — a promise without an executor. The registry now deletes a member's
+  endorsements with their account and retains the curated problem/tool lists as community content
+  (their `suggested_by`/`reviewed_by` columns are review audit). Caught by the deletion-coverage gate
+  added in #2056. Contract updated to record that the promise is now executed.
 - 2026-07-17: **History-aware back + admin↔member navigation (app-wide sweep).** The member
   shell's hand-rolled back chevron was replaced by the shared `BackChevronButton` — it returns to
   the previous in-app page and falls back to All Apps when there is no in-app history. The admin

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -417,6 +417,11 @@
 
 ---
 
+### Account deletion clears reactions and Hub read-state
+
+**Expected:** Deleting the account removes the member's post reactions, announcement reactions, and
+`feed_hub_last_seen` row along with the per-user state the script already covers.
+
 ## Admin walkthrough
 
 ### FD-A1 — Admin page renders with real data

--- a/ctf/docs/developer/test-scripts/mood-test-script.md
+++ b/ctf/docs/developer/test-scripts/mood-test-script.md
@@ -145,6 +145,14 @@ anonymous aggregate. Note any drift here rather than filing separate bugs.
 
 ---
 
+### Account deletion clears mood data
+
+**Expected:** No mood row tied to the member survives account deletion.
+
+1. Submit a check-in, then delete the account (Account & Data).
+2. Confirm the member's `mood_client_identities` row is gone and no `mood_submissions` row remains
+   under their pseudonym. No surviving row may carry their real user id.
+
 ## Known gaps — do not file these as bugs
 
 Carried from the inventory's "Gaps and Known Technical Debt" section at authoring time. If you hit one

--- a/ctf/docs/developer/test-scripts/what-works-test-script.md
+++ b/ctf/docs/developer/test-scripts/what-works-test-script.md
@@ -116,6 +116,11 @@ header shows a "Member view" pill opening `/apps/what-works`.
 
 ---
 
+### Account deletion clears endorsements
+
+**Expected:** Deleting the account removes the member's endorsements; tool endorsement counts drop
+accordingly. The curated problem and tool lists themselves are unchanged.
+
 ## Admin walkthrough
 
 ### WW-A1 · Review queue (approve / reject)

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -119,6 +119,17 @@ const retain = (table: string, note: string, reviewNote?: string): OwnedTable =>
 
 export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
   {
+    slug: 'app-preferences',
+    name: 'App preferences',
+    dataSummary: 'Your theme and other app-wide display preferences.',
+    // Cross-cutting like notifications: not a service a member joins or leaves, so no per-service
+    // scope — it clears with the account.
+    serviceScopeSupported: false,
+    tables: [
+      del('user_ui_preferences', 'user_id', 'Your theme and display preferences.'),
+    ],
+  },
+  {
     slug: 'notifications',
     name: 'Notifications',
     dataSummary: 'Your notifications feed and your device-push preferences.',
@@ -182,6 +193,7 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     serviceScopeSupported: true,
     tables: [
       del('feed_answer_ratings', 'user_id', 'Your ratings on answers.'),
+      del('feed_community_post_reactions', 'user_id', 'Your reactions on community posts.'),
       del('feed_answers', 'author_user_id', 'Your answers.'),
       del('feed_questions', 'asked_by_user_id', 'Your questions.'),
       del('feed_community_replies', 'author_user_id', 'Your replies.'),
@@ -191,6 +203,8 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
       del('feed_user_read_state', 'user_id', 'Your read state.'),
       del('feed_membership_events', 'user_id', 'Your feed membership events.'),
       del('announcement_user_state', 'user_id', 'Your announcement read/ack state.'),
+      del('announcement_reactions', 'user_id', 'Your reactions on announcements.'),
+      del('feed_hub_last_seen', 'user_id', 'When you last opened the Hub (unread-badge state).'),
       del('announcement_membership_events', 'user_id', 'Your announcement membership events.'),
       // feed_items / announcements / announcement_revisions / announcement_delivery_events are
       // admin-authored platform content (created_by_user_id), retained.
@@ -235,12 +249,16 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     dataSummary: 'Your mood check-in submissions.',
     serviceScopeSupported: true,
     tables: [
-      // Mood check-ins are stored pseudonymously: mood_submissions rows carry a
-      // pseudonym, not user_id, and the only user link lives in
-      // mood_client_identities. Deleting that mapping row cascades all the user's
-      // check-ins via the mood_submissions.pseudonym FK (ON DELETE CASCADE), so
-      // this single entry removes everything for the user.
-      del('mood_client_identities', 'user_id', 'Your mood check-ins (deleting your pseudonym mapping removes every check-in stored under it).'),
+      // Check-ins are pseudonymous by design: the v3 insert stores user_id as '' on every row and
+      // the account link lives only in mood_client_identities, so deleting that mapping cascades the
+      // member's check-ins via the pseudonym FK. The direct delete below is defense-in-depth, not a
+      // correction: it matches nothing today (no row carries a real id), and exists so that any row
+      // that EVER carries one — a legacy import, a future write path that forgets the convention —
+      // is cleared with the account instead of surviving as wellbeing data with a name on it. It
+      // also makes this table's coverage visible to the deletion-coverage gate, which flags any
+      // table with a user_id column that no registry entry names.
+      del('mood_submissions', 'user_id', 'Defense-in-depth: any check-in row carrying your raw id (none are written today).'),
+      del('mood_client_identities', 'user_id', 'Your pseudonym mapping — removing it cascades every check-in stored under it.'),
     ],
   },
   {
@@ -466,6 +484,20 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     dataSummary: 'Weekly performance figures are aggregate; no per-user data is stored.',
     serviceScopeSupported: false,
     tables: [],
+  },
+  {
+    slug: 'what-works',
+    name: 'WhatWorks',
+    dataSummary: 'Your endorsements of tools on the shared list.',
+    serviceScopeSupported: true,
+    tables: [
+      del('what_works_endorsements', 'user_id', 'Your endorsements.'),
+      // The list itself is community content, not personal data: problems and products are curated
+      // entries that other members rely on, and the suggested_by/reviewed_by columns on them are the
+      // admin/review audit trail — same retain reasoning as every other reviewer column.
+      retain('what_works_problems', 'Curated problem list; community content, not personal data.'),
+      retain('what_works_products', 'Curated tool list; suggested_by/reviewed_by retained as review audit.'),
+    ],
   },
   {
     slug: 'contributions',

--- a/ctf/scripts/deletion-coverage-allowlist.json
+++ b/ctf/scripts/deletion-coverage-allowlist.json
@@ -32,12 +32,6 @@
       ],
       "decision": "unreviewed"
     },
-    "announcement_reactions": {
-      "userColumns": [
-        "user_id"
-      ],
-      "decision": "unreviewed"
-    },
     "announcement_replies": {
       "userColumns": [
         "author_user_id"
@@ -108,18 +102,6 @@
       "userColumns": [
         "created_by_user_id",
         "overridden_by_user_id"
-      ],
-      "decision": "unreviewed"
-    },
-    "feed_community_post_reactions": {
-      "userColumns": [
-        "user_id"
-      ],
-      "decision": "unreviewed"
-    },
-    "feed_hub_last_seen": {
-      "userColumns": [
-        "user_id"
       ],
       "decision": "unreviewed"
     },
@@ -244,12 +226,6 @@
       "decision": "unreviewed"
     },
     "login_events": {
-      "userColumns": [
-        "user_id"
-      ],
-      "decision": "unreviewed"
-    },
-    "mood_submissions": {
       "userColumns": [
         "user_id"
       ],
@@ -392,21 +368,9 @@
       ],
       "decision": "unreviewed"
     },
-    "user_ui_preferences": {
-      "userColumns": [
-        "user_id"
-      ],
-      "decision": "unreviewed"
-    },
     "weekly_performance_weeks": {
       "userColumns": [
         "selected_by_user_id"
-      ],
-      "decision": "unreviewed"
-    },
-    "what_works_endorsements": {
-      "userColumns": [
-        "user_id"
       ],
       "decision": "unreviewed"
     },


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**⚠️ Owner-review lane — auto-merge NOT enabled.** Deletion-behavior change; you asked for the burn-down, the merge stays yours.

## Batch 1 of the #2056 burn-down: plain member data, no compliance angle (68 → 62)

| Table | Classification | Notable |
|---|---|---|
| `feed_community_post_reactions` | delete | **The FEED contract already promised this table clears on deletion — no registry entry existed, so the engine never executed the promise.** |
| `announcement_reactions` | delete | reactions |
| `feed_hub_last_seen` | delete | unread-badge timestamp |
| `what_works_endorsements` | delete | **WhatWorks had no registry entry at all**, while its contract promised `DELETE FROM what_works_endorsements WHERE user_id = X` — a promise without an executor. New entry also `retain`s the curated problem/tool lists (community content; `suggested_by`/`reviewed_by` are review audit). |
| `user_ui_preferences` | delete | new cross-cutting `app-preferences` entry, `serviceScopeSupported: false` like notifications |
| `mood_submissions` | delete (defense-in-depth) | see below — precision matters here |

## The mood one, stated precisely

I initially read this as a live privacy defect and I was wrong: the v3 insert stores `user_id` as `''` on every row, so the existing mapping-row delete plus the pseudonym-FK cascade already cleared everything — the contract was accurate. The direct delete added here **matches nothing today**. It exists so that any row which ever carries a real id — a legacy import, a future write path that forgets the `''` convention — clears with the account instead of surviving as wellbeing data with a name on it, and so the table's coverage is visible to the gate. The registry comment and the contract both state this exactly, so nobody later mistakes it for a fix of a leak that never happened.

## Wiring

None needed — verified rather than assumed: the deletion orchestrator, the export engine, and the Account & Data services list all iterate the registry, so the new entries flow through all three automatically.

## Checks

Deletion-registry gate passes both directions (113 refs; the five removed allowlist entries would each fail the "classified but still listed" check if left). Typecheck, lint, EOF, US spelling, schema drift, inventory drift, test-script drift — all green. Contracts, inventories, and test scripts updated for mood, feed, and what-works.

## Next batches, when you say go

2. **Two-party records** — `lighthouse_matches`, `lighthouse_blocks`, `chyme_back_channel_calls` (delete own side, pseudonymize counterparty, mirroring #2054).
3. **Ledger/disputes** — `service_credits_*`, `level_up_disbursements`, `*_disputes` (likely `retain`; compliance call).
4. **Admin/audit columns** — `retain` with the contract reasons.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_