### PR TITLE
fix: Direct Line dark theme and a plain closed-conversation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ bash scripts/check-eof-format.sh  # EOF validation
 
 ---
 
-**Last updated:** May 2026 | v3 rewrite (Render migration)
+**Last updated:** August 2026 | v3

--- a/ctf/docs/quota-impact/2026-08-02-stream-chat-dark-theme-and-readonly-composer.md
+++ b/ctf/docs/quota-impact/2026-08-02-stream-chat-dark-theme-and-readonly-composer.md
@@ -1,0 +1,40 @@
+# Stream Quota Impact Note — Chat Dark Theme Fix and Read-Only Composer
+
+## Summary
+
+- Feature/Change: Fix the shared chat panel so Stream's dark theme actually applies (theme class moved onto the `<Chat theme>` prop; plugin accent re-declared on the `.str-chat` element), and add a `readOnlyNotice` prop that replaces the message composer with a plain notice on ended Direct Lines.
+- PR: #2060
+- Owner: farahbrunache
+- Date: 2026-08-02
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: Chat rendering only. No new channels, watches, queries, or messages. The read-only state removes the composer, so a panel in that state can no longer attempt sends at all.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: 0 — same members, same channels, same connection lifecycle.
+- Activity Feed API calls estimate: 0.
+- Video participant-minutes estimate: 0.
+- AI Moderation credits estimate: 0.
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): unchanged (Green).
+- Peak scenario estimate: unchanged. If anything, marginally fewer API calls: the doomed sends that previously failed "Unauthorized" on ended conversations are no longer attempted.
+
+## Fallback and Degradation Plan
+
+- What degrades first: nothing new — theming is CSS-only; the read-only notice is a static element.
+- User-visible messaging behavior: on an ended Direct Line the transcript stays readable and the notice explains why sending is off; live conversations are unchanged.
+- Kill switch / feature flag: none needed; reverting the PR restores the prior rendering.
+
+## Observability
+
+- Metrics and alerts added/updated: none — no quota-bearing behavior changed.
+- Dashboard link (if available): n/a.
+
+## Validation
+
+- Tests added for degraded mode: n/a (no degraded mode introduced); typecheck, lint, and full web build pass.
+- Rollback strategy: revert the PR; the change is presentation-only.

--- a/ctf/packages/web/components/shared/stream-chat-panel.css
+++ b/ctf/packages/web/components/shared/stream-chat-panel.css
@@ -8,6 +8,18 @@
  * This file is imported after Stream's stylesheet so these rules win; it targets Stream's stable
  * v12 message classes. */
 
+/* Plugin accent → Stream accent variables. Stream's stylesheet defines --str-chat__primary-color and
+ * --str-chat__active-primary-color as element-own custom properties on the `.str-chat` element, and
+ * element-own values beat anything inherited — so setting these variables on the wrapper div (the old
+ * approach) never changed them. This rule re-declares them on the `.str-chat` element itself; the
+ * `.ctf-chat-accented` scope is only present when the panel was given a plugin accent, so a panel
+ * without one keeps Stream's defaults untouched. --ctf-chat-accent inherits from the wrapper. */
+.ctf-chat-accented .str-chat {
+  --str-chat__primary-color: var(--ctf-chat-accent);
+  --str-chat__active-primary-color: var(--ctf-chat-accent);
+  --str-chat__message-send-color: var(--ctf-chat-accent);
+}
+
 .str-chat__theme-dark .str-chat__message-bubble {
   background-color: var(--ctf-chat-other-bg, var(--str-chat__message-bubble-background-color));
 }
@@ -236,6 +248,19 @@
   line-height: 1.5;
   color: #9CA3AF;
   max-width: 320px;
+}
+
+/* Read-only notice (ConversationBody in stream-chat-panel.tsx). Shown in place of the composer when
+ * the conversation has reached a terminal state (rule 100): the transcript stays readable, and the
+ * member is told plainly why they cannot send instead of watching a send fail. */
+.ctf-chat-readonly {
+  flex: 0 0 auto;
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background-color: rgba(0, 0, 0, 0.18);
+  color: #9CA3AF;
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 /* Polls (default stream-chat-react 12.16 Poll components, created from the composer's attachment menu

--- a/ctf/packages/web/components/shared/stream-chat-panel.tsx
+++ b/ctf/packages/web/components/shared/stream-chat-panel.tsx
@@ -370,7 +370,12 @@ const ConversationBody: React.FC<{
   // The Stream Channel value is loosely typed throughout this panel; passed straight to the hook.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   channel: any;
-}> = ({ channel }) => {
+  // When set, the conversation is over (rule 100: transaction-scoped chats close at a terminal
+  // state). The transcript stays readable but the composer is replaced by this notice — otherwise a
+  // member types a message and watches the send fail "Unauthorized" with no explanation (owner
+  // report on a canceled Direct Line).
+  readOnlyNotice?: string | null;
+}> = ({ channel, readOnlyNotice }) => {
   const { customMessageActions, toast } = useReminderActions(channel);
   return (
     <>
@@ -398,7 +403,11 @@ const ConversationBody: React.FC<{
               message you delete it and repost, so a correction lands as a fresh message with a new
               timestamp. Delete and every other action stay. */}
           <MessageList customMessageActions={customMessageActions} messageActions={MESSAGE_ACTIONS_NO_EDIT} />
-          <MessageInput />
+          {readOnlyNotice ? (
+            <div className="ctf-chat-readonly" role="status">{readOnlyNotice}</div>
+          ) : (
+            <MessageInput />
+          )}
         </Window>
         {toast}
       </div>
@@ -415,6 +424,9 @@ export interface StreamChatPanelProps {
   channelType?: string;
   /** Plugin brand color used to tint Stream's accent (send button, links, active states). */
   accentColor?: string;
+  /** When set, the conversation is over: the transcript stays readable, the composer is replaced by
+   * this notice, and no send can fail unexplained. */
+  readOnlyNotice?: string | null;
 }
 
 export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
@@ -424,6 +436,7 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
   streamChannelId,
   channelType = 'messaging',
   accentColor,
+  readOnlyNotice,
 }) => {
   const [client, setClient] = useState<StreamChat | null>(null);
   // The Stream Channel type is generically parameterized and impractical to satisfy here; the value is
@@ -465,17 +478,22 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
   if (error) return <div style={{ padding: 16, color: '#EF4444', fontSize: 14 }}>{error}</div>;
   if (!client || !channel) return <div style={{ padding: 16, color: '#9CA3AF', fontSize: 14 }}>Chat unavailable.</div>;
 
-  // The whole app is dark, so the chat must use Stream's dark theme (it used to render the light
-  // theme, which looked like a white widget dropped into a dark plugin). The wrapper carries the
-  // theme class and, when given, tints Stream's accent CSS variables to the plugin's brand color.
+  // The whole app is dark, so the chat must use Stream's dark theme. The theme class MUST go on
+  // <Chat theme=...>: the SDK composes that prop into the class list of its own `.str-chat` root
+  // element, and Stream's stylesheet defines the light palette as element-own custom properties on
+  // `.str-chat` itself — element-own values always beat anything inherited, so a theme class (or an
+  // accent variable) placed only on this wrapper div never changes the palette. That was the bug:
+  // the wrapper carried `str-chat__theme-dark` while every panel still rendered the light theme
+  // (owner report — the Direct Line chat showed as a white widget inside the dark app). The
+  // wrapper keeps the class purely as a scope for our own rules in stream-chat-panel.css, and the
+  // `ctf-chat-accented` modifier + `--ctf-chat-accent` re-declare Stream's accent variables on the
+  // `.str-chat` element from that stylesheet (same reason: they must land element-own to win).
   const themeVars = {
     // Own messages are gray everywhere; other people's messages take the plugin accent (below).
     '--ctf-chat-own-bg': OWN_BUBBLE_BG,
     ...(accentColor
       ? {
-          '--str-chat__primary-color': accentColor,
-          '--str-chat__active-primary-color': accentColor,
-          '--str-chat__message-send-color': accentColor,
+          '--ctf-chat-accent': accentColor,
           '--ctf-chat-other-bg': accentColor,
           '--ctf-chat-other-fg': readableTextOn(accentColor),
         }
@@ -483,8 +501,11 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
   } as React.CSSProperties;
 
   return (
-    <div className="str-chat__theme-dark" style={{ height: '100%', display: 'flex', flexDirection: 'column', ...themeVars }}>
-      <Chat client={client}>
+    <div
+      className={`str-chat__theme-dark${accentColor ? ' ctf-chat-accented' : ''}`}
+      style={{ height: '100%', display: 'flex', flexDirection: 'column', ...themeVars }}
+    >
+      <Chat client={client} theme="str-chat__theme-dark">
         {/* enrichURLForPreview turns on URL enrichment in the composer: as a member types or pastes a
             link, Stream scrapes it and MessageInput shows a LinkPreviewList card before sending. The
             sent message then carries an og-scrape attachment, which the default Attachment renderer
@@ -492,7 +513,7 @@ export const StreamChatPanel: React.FC<StreamChatPanelProps> = ({
             while composing and in the conversation. The messaging channel type already permits URL
             enrichment in the dashboard, so no dashboard change is needed. */}
         <Channel channel={channel} enrichURLForPreview EmptyStateIndicator={ChatEmptyState}>
-          <ConversationBody channel={channel} />
+          <ConversationBody channel={channel} readOnlyNotice={readOnlyNotice} />
         </Channel>
       </Chat>
     </div>

--- a/ctf/packages/web/components/socket-relay/sr-chat.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-chat.tsx
@@ -17,6 +17,20 @@ function fulfillmentTitle(f: SrFulfillment): string {
   return f.requestTitle && f.requestTitle.trim().length > 0 ? f.requestTitle : `Request ${f.id.slice(0, 8)}`;
 }
 
+// Why the composer is gone on a past conversation. A Direct Line closes for good at a terminal state
+// (rule 100) — there is no reopen. Without this, a member typed into the still-visible composer and
+// the send failed "Unauthorized" with no explanation (owner report). The canceled-but-open case also
+// says what TO do: a fresh offer opens a fresh Direct Line.
+function readOnlyNotice(f: SrFulfillment): string | null {
+  if (f.status === "active") return null;
+  if (f.status === "canceled") {
+    return f.requestStatus === "open"
+      ? "This conversation ended when the offer was canceled and can't be reopened. The request is open again on the feed — a new offer starts a new Direct Line."
+      : "This conversation ended when the offer was canceled and can't be reopened.";
+  }
+  return "This conversation ended when the request closed. You can still read it, but no new messages can be sent.";
+}
+
 function ResolveBar({
   selected,
   isRequester,
@@ -28,13 +42,9 @@ function ResolveBar({
   resolving: boolean;
   onResolve: (fulfillmentId: string, outcome: SrResolveOutcome) => void;
 }) {
-  if (selected.status !== "active") {
-    return (
-      <div style={{ padding: "10px 16px", borderTop: "1px solid rgba(255,255,255,0.06)", fontSize: 12, color: SUBTLE }}>
-        This request is {selected.requestStatus === "open" ? "open again" : "closed"}.
-      </div>
-    );
-  }
+  // A past conversation gets its explanation where the composer used to be (readOnlyNotice in the
+  // chat panel), so no second footer line is needed here.
+  if (selected.status !== "active") return null;
   if (!isRequester) {
     return (
       <div style={{ padding: "10px 16px", borderTop: "1px solid rgba(255,255,255,0.06)", fontSize: 12, color: SUBTLE }}>
@@ -129,6 +139,7 @@ function ChatPane({
             streamUserId={chatCredentials.streamUserId}
             streamChannelId={chatCredentials.streamChannelId}
             accentColor={t.ACCENT}
+            readOnlyNotice={readOnlyNotice(selected)}
           />
         ) : (
           <div style={{ flex: 1 }} />


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What this fixes (owner report)

1. **The Direct Line chat rendered white inside the dark app.** The dark-theme class sat on a wrapper div, but the Stream chat library defines its light color palette directly on its own root element — and values set directly on an element always beat values inherited from a parent. So the wrapper class never took effect anywhere in the app. The theme class now goes through the chat library's own `theme` property, which places it on the right element, and the plugin accent color is re-declared on that same element from `stream-chat-panel.css` for the same reason. This fixes the white chat panel in every plugin that uses the shared chat, not just SocketRelay.

2. **Sending a message on a canceled Direct Line failed "Unauthorized" with no explanation.** A conversation ends for good when the claim is canceled or the request closes (rule 100) — there is no reopen. But the message box was still shown, so typing into it just failed. The panel now takes a `readOnlyNotice`: the transcript stays readable, the message box is replaced by a plain explanation, and the canceled-but-still-open case tells the member that a new offer starts a new Direct Line.

3. **Root README footer date** updated to August 2026 (missed in the contributing rewrite, #2057).

## Checks

Typecheck, lint, US-spelling gate, end-of-file gate, modularity gate, and the full web build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_