### PR TITLE
feat: optional tester admin and member accounts in the demo seed workflow

### DIFF
--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      demo_tester_admin_id:
+        description: "Optional: the hired tester's ADMIN Clerk user ID (issue #2037). The seed grants entry + wallet + profile; you must also set role=admin on it in Clerk and target the demo-mode Unleash flag at it."
+        required: false
+        type: string
+        default: ""
+      demo_tester_member_id:
+        description: "Optional: the hired tester's MEMBER Clerk user ID (issue #2037). The seed grants entry + wallet + profile; also target the demo-mode Unleash flag at it."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   seed:
@@ -62,6 +72,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DEMO_OWNER_ID: ${{ inputs.demo_owner_id }}
           DEMO_SECOND_OWNER_ID: ${{ inputs.demo_second_owner_id }}
+          DEMO_TESTER_ADMIN_ID: ${{ inputs.demo_tester_admin_id }}
+          DEMO_TESTER_MEMBER_ID: ${{ inputs.demo_tester_member_id }}
         run: |
           if [ -z "$DATABASE_URL_DIRECT" ] && [ -z "$DATABASE_URL" ]; then
             echo "DATABASE_URL_DIRECT or DATABASE_URL secret is not set."
@@ -72,4 +84,10 @@ jobs:
           echo "Demo schema seeded for $DEMO_OWNER_ID."
           if [ -n "$DEMO_SECOND_OWNER_ID" ]; then
             echo "Two-sided counterparty seeded: $DEMO_SECOND_OWNER_ID (also target the demo-mode Unleash flag at this ID)."
+          fi
+          if [ -n "$DEMO_TESTER_ADMIN_ID" ]; then
+            echo "Tester admin seeded: $DEMO_TESTER_ADMIN_ID (set role=admin on it in Clerk, and target the demo-mode Unleash flag at it)."
+          fi
+          if [ -n "$DEMO_TESTER_MEMBER_ID" ]; then
+            echo "Tester member seeded: $DEMO_TESTER_MEMBER_ID (target the demo-mode Unleash flag at it)."
           fi

--- a/ctf/docs/developer/demo-seed-notes.md
+++ b/ctf/docs/developer/demo-seed-notes.md
@@ -166,3 +166,20 @@ The seed changes only insert into tables and columns that already exist in
 `recurring_activities`). No table, column, constraint, index, or contract is added or
 changed, so no `schema.sql` migration is required (recorded here per
 `.claude/rules/122-schema-drift-predeployment-rules.mdc`).
+
+## Tester accounts (issue #2037) — 2026-08-02
+
+The seed workflow gained two optional inputs, `demo_tester_admin_id` and
+`demo_tester_member_id`, for the hired tester's two demo accounts (one used as an
+admin, one as a plain member). For each id given, `seedDemo.mjs` inserts the same
+baseline the second owner gets: an `unlock_verification_submissions` tier row, a
+`service_credits_wallets` row, and a `directory_profiles` /
+`directory_user_extension` pair. Two things stay outside the seed because only
+Clerk and Unleash hold them: the admin role (set role=admin on the tester-admin
+account in the Clerk dashboard) and demo routing (target the `demo-mode` Unleash
+flag at both ids).
+
+All inserts target tables and columns that already exist in `ctf/schema.sql`; no
+table, column, constraint, index, or contract is added or changed, so no
+`schema.sql` migration is required (recorded here per
+`.claude/rules/122-schema-drift-predeployment-rules.mdc`).

--- a/ctf/scripts/seedDemo.mjs
+++ b/ctf/scripts/seedDemo.mjs
@@ -52,6 +52,30 @@ if (OWNER2 && OWNER2 === OWNER) {
   throw new Error('DEMO_SECOND_OWNER_ID must be a different Clerk id than DEMO_OWNER_ID');
 }
 
+// Optional tester accounts (issue #2037): a hired tester runs the manual test scripts against the
+// demo schema with two REAL Clerk accounts — one they use as an admin, one as a plain member. The
+// seed gives each the baseline to sign in and participate (approved_full unlock, a wallet, a
+// directory profile). Two things the seed CANNOT do, because only Clerk / Unleash hold them:
+//   - the admin role: set role=admin on the tester-admin account in the Clerk dashboard;
+//   - demo routing: target the `demo-mode` Unleash flag at both ids.
+const TESTER_ADMIN = (process.env.DEMO_TESTER_ADMIN_ID || '').trim() || null;
+const TESTER_MEMBER = (process.env.DEMO_TESTER_MEMBER_ID || '').trim() || null;
+{
+  const ids = [OWNER, OWNER2, TESTER_ADMIN, TESTER_MEMBER].filter(Boolean);
+  if (new Set(ids).size !== ids.length) {
+    throw new Error('DEMO_OWNER_ID, DEMO_SECOND_OWNER_ID, DEMO_TESTER_ADMIN_ID, and DEMO_TESTER_MEMBER_ID must all be different Clerk ids');
+  }
+}
+
+// Every REAL Clerk account the seed must let in: the owner(s) plus any tester accounts.
+const REAL_USERS = [OWNER, OWNER2, TESTER_ADMIN, TESTER_MEMBER].filter(Boolean);
+
+// Tester directory identities, keyed by id so seedDirectory can render a sensible profile for each.
+const TESTER_PROFILES = [
+  TESTER_ADMIN && { id: TESTER_ADMIN, firstName: 'Demo', lastName: 'TesterAdmin', headline: 'Test Script Runner (admin)', bio: 'Hired tester account used to run the admin sides of the manual test scripts.' },
+  TESTER_MEMBER && { id: TESTER_MEMBER, firstName: 'Demo', lastName: 'TesterMember', headline: 'Test Script Runner (member)', bio: 'Hired tester account used to run the member sides of the manual test scripts.' },
+].filter(Boolean);
+
 // Supporting synthetic users — social/relational data
 const PEER_1 = 'demo-peer-001';
 const PEER_2 = 'demo-peer-002';
@@ -113,7 +137,9 @@ async function seedUnlock(c) {
   // row makes the demo self-sufficient (the app's DB fallback reads this tier).
   // The second owner still needs the `demo-mode` Unleash flag to be routed to this
   // schema in the first place — only the running app can evaluate that.
-  const realOwners = OWNER2 ? [OWNER, OWNER2] : [OWNER];
+  // Tester accounts (issue #2037) are included: they are real Clerk accounts and need the same
+  // tier row to enter the demo's plugins.
+  const realOwners = REAL_USERS;
   for (const uid of realOwners) {
     await c.query(
       `INSERT INTO unlock_verification_submissions
@@ -127,7 +153,7 @@ async function seedUnlock(c) {
       [uid, `https://quora.com/profile/demo-${uid}`, `quora.com/profile/demo-${uid}`, ADMIN],
     );
   }
-  console.log(`  ✓ unlock (approved_full for ${realOwners.length} demo owner${realOwners.length > 1 ? 's' : ''})`);
+  console.log(`  ✓ unlock (approved_full for ${realOwners.length} real demo account${realOwners.length > 1 ? 's' : ''})`);
 }
 
 async function seedServiceCredits(c) {
@@ -205,6 +231,18 @@ async function seedServiceCredits(c) {
        VALUES ($1, $2, $3, 40, 'completed', $4, NOW())
        ON CONFLICT (id) DO NOTHING`,
       [xfer2, OWNER, OWNER2, `demo-transfer-${OWNER}-${OWNER2}`],
+    );
+  }
+
+  // Tester accounts (issue #2037): a wallet each, so credit-bearing script steps (send, escrow,
+  // Level-Up deposit) work for them without an admin grant first.
+  for (const tester of [TESTER_ADMIN, TESTER_MEMBER].filter(Boolean)) {
+    await c.query(
+      `INSERT INTO service_credits_wallets (user_id, available_balance, escrow_balance, updated_at)
+       VALUES ($1, 300, 0, NOW())
+       ON CONFLICT (user_id) DO UPDATE SET
+         available_balance = EXCLUDED.available_balance, updated_at = NOW()`,
+      [tester],
     );
   }
 
@@ -542,6 +580,30 @@ async function seedDirectory(c) {
        VALUES ($1, NOW())
        ON CONFLICT (user_id) DO UPDATE SET updated_at = NOW()`,
       [OWNER2],
+    );
+  }
+
+  // Tester accounts (issue #2037): a profile each, keyed per id like the second owner's, so the
+  // tester shows up with a readable name everywhere a member name is rendered.
+  for (const tester of TESTER_PROFILES) {
+    await c.query(
+      `INSERT INTO directory_profiles
+       (id, claimed_by_user_id, first_name, last_name, headline, bio, country, is_active, source)
+       VALUES ($1::uuid, $2, $3, $4, $5, $6, 'United States', true, 'self')
+       ON CONFLICT (id) DO UPDATE SET
+         claimed_by_user_id = EXCLUDED.claimed_by_user_id,
+         first_name = EXCLUDED.first_name,
+         last_name = EXCLUDED.last_name,
+         headline = EXCLUDED.headline,
+         bio = EXCLUDED.bio,
+         updated_at = NOW()`,
+      [sha256id('dir-profile', tester.id), tester.id, tester.firstName, tester.lastName, tester.headline, tester.bio],
+    );
+    await c.query(
+      `INSERT INTO directory_user_extension (user_id, updated_at)
+       VALUES ($1, NOW())
+       ON CONFLICT (user_id) DO UPDATE SET updated_at = NOW()`,
+      [tester.id],
     );
   }
 
@@ -1239,6 +1301,8 @@ async function main() {
   if (OWNER2) {
     console.log(`Two-sided counterparty (DEMO_SECOND_OWNER_ID): ${OWNER2}`);
   }
+  if (TESTER_ADMIN) console.log(`Tester admin account (DEMO_TESTER_ADMIN_ID): ${TESTER_ADMIN}`);
+  if (TESTER_MEMBER) console.log(`Tester member account (DEMO_TESTER_MEMBER_ID): ${TESTER_MEMBER}`);
 
   try {
     await client.query('BEGIN');
@@ -1274,6 +1338,13 @@ async function main() {
       console.log(
         `Second owner ${OWNER2} wired as the two-sided counterparty. ` +
         `Reminder: target the \`demo-mode\` Unleash flag at ${OWNER2} so the app routes them to the demo schema.`,
+      );
+    }
+    for (const tester of TESTER_PROFILES) {
+      console.log(
+        `Tester account ${tester.id} seeded (${tester.headline}). ` +
+        `Reminder: target the \`demo-mode\` Unleash flag at this id` +
+        (tester.id === TESTER_ADMIN ? ', and set role=admin on it in the Clerk dashboard (the seed cannot set the role).' : '.'),
       );
     }
   } catch (err) {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — this is a seed workflow change with no rendered surface)

## What this adds

The hired tester (issue #2037) needs to run the manual test scripts against the demo schema with two real accounts: one they use as an admin, one as a plain member. The "Demo — Seed Schema" workflow gains two optional inputs:

- `demo_tester_admin_id` — the tester's admin-account Clerk user ID
- `demo_tester_member_id` — the tester's member-account Clerk user ID

For each id given, the seed grants entry to every plugin (an approved tier row), a credits wallet (so credit-bearing script steps work without an admin grant first), and a directory profile (so the account shows a readable name everywhere names render). All inserts are idempotent like the rest of the seed, and both ids are validated as distinct from the owner ids.

Two things stay outside the seed, because only Clerk and Unleash hold them, and both the input descriptions and the run summary say so:

- the admin role — set role=admin on the tester-admin account in the Clerk dashboard;
- demo routing — target the `demo-mode` Unleash flag at both ids.

## Checks

Script syntax check, typecheck, US-spelling gate, and end-of-file gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_