### PR TITLE
fix: stop framing credit movements as payments on the credits surfaces

### DIFF
--- a/ctf/packages/web/components/level-up/lu-admin-shell.tsx
+++ b/ctf/packages/web/components/level-up/lu-admin-shell.tsx
@@ -804,7 +804,7 @@ export function LevelUpAdminShell({
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 24 }}>
           <StatBlock label="Enrollments" value={String(kpis.enrollments)} />
           <StatBlock label="Completions" value={String(kpis.completions)} />
-          <StatBlock label="Avg days to first trainer payout" value={`${kpis.avgDaysToFirstTrainerPayout} days`} />
+          <StatBlock label="Avg days to first trainer credit grant" value={`${kpis.avgDaysToFirstTrainerPayout} days`} />
         </div>
 
         {/* Review queue: open disputes. Read-only list so the admin-landing dot leads somewhere that

--- a/ctf/packages/web/components/level-up/lu-sidebar.tsx
+++ b/ctf/packages/web/components/level-up/lu-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, CheckCircle, Coins, DollarSign, Target, Trophy, TrendingUp, Users } from "lucide-react";
+import { BookOpen, CheckCircle, Coins, Target, Trophy, TrendingUp, Users } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { getLevelUpTokens, type NavKey } from "./lu-shared";
 
@@ -14,7 +14,7 @@ const NAV_ITEMS: { icon: React.ElementType; label: string; key: NavKey }[] = [
 
 const TRAINER_TOOLS = [
   { icon: CheckCircle, label: "Validate Milestones" },
-  { icon: DollarSign, label: "Payout History" },
+  { icon: Coins, label: "Grant History" },
 ];
 
 export function LevelUpSidebar({

--- a/ctf/packages/web/components/level-up/lu-wallet.tsx
+++ b/ctf/packages/web/components/level-up/lu-wallet.tsx
@@ -19,7 +19,7 @@ import { getLevelUpTokens, type WalletView } from "./lu-shared";
 const KIND_LABELS: Record<string, string> = {
   milestone_release: "Milestone released",
   completion_bonus: "Completion bonus",
-  trainer_payout: "Trainer payout",
+  trainer_payout: "Trainer credit grant",
   stipend: "Stipend",
   microgrant: "Microgrant",
   achievement: "Achievement badge",

--- a/ctf/packages/web/components/service-credits/sc-send-panel.tsx
+++ b/ctf/packages/web/components/service-credits/sc-send-panel.tsx
@@ -23,12 +23,12 @@ function RailSelector({ rail, onChange }: { rail: Rail; onChange: (next: Rail) =
   ];
   return (
     <div style={{ marginBottom: 12 }}>
-      <label htmlFor="sc-rail" style={inputLabel}>Pay with</label>
+      <label htmlFor="sc-rail" style={inputLabel}>Send with</label>
       <select
         id="sc-rail"
         value={rail}
         onChange={(e) => onChange(e.target.value as Rail)}
-        aria-label="Payment method"
+        aria-label="Send method"
         style={{ ...inputField, marginBottom: 0, appearance: "auto" }}
       >
         {options.map((o) => (
@@ -37,7 +37,7 @@ function RailSelector({ rail, onChange }: { rail: Rail; onChange: (next: Rail) =
       </select>
       {rail === "mutual_credit" && (
         <div style={{ fontSize: 11, color: t.MUTED, marginTop: 6, lineHeight: 1.5 }}>
-          Pay now on community credit, repay as you earn.
+          Send now on community credit, repay as you earn.
         </div>
       )}
     </div>

--- a/ctf/packages/web/lib/service-credits/_lib.ts
+++ b/ctf/packages/web/lib/service-credits/_lib.ts
@@ -72,7 +72,7 @@ export function ensureMutationCsrf(request: Request): NextResponse | null {
 const SERVICE_CREDITS_ERROR_RESPONSES: Record<string, { code: string; message: string; status: number }> = {
   insufficient_balance: { code: 'service_credits_insufficient_balance', message: 'Insufficient balance.', status: 409 },
   invalid_payload: { code: 'service_credits_invalid_payload', message: 'Invalid request payload.', status: 400 },
-  credit_limit_exceeded: { code: 'service_credits_credit_limit_exceeded', message: 'This payment would exceed your mutual-credit limit.', status: 409 },
+  credit_limit_exceeded: { code: 'service_credits_credit_limit_exceeded', message: 'This send would exceed your mutual-credit limit.', status: 409 },
   mutual_credit_disabled: { code: 'service_credits_mutual_credit_disabled', message: 'Mutual credit is not enabled.', status: 409 },
   mint_budget_exceeded: { code: 'service_credits_mint_budget_exceeded', message: 'This mint would exceed the issuance budget for the current period.', status: 409 },
   credit_limit_above_max: { code: 'service_credits_credit_limit_above_max', message: 'That credit limit is above the maximum allowed by policy.', status: 409 },


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What this fixes (agent-team pass — blocker 4, flagged independently by the compliance and brand roles)

Credits are a non-fiat internal unit; a movement is a "send", "transfer", "exchange", or "grant" — never a "payment" or "payout" (CLAUDE.md "Credits Are Not Money", `BRAND_VOICE_LEXICON.md`, `DISCLAIMER.md`). The credits surfaces themselves violated this in shipped member-facing copy. You authorized the autonomous fix pass over these findings; the changes follow the lexicon's approved substitutions exactly, and touch nothing but the words:

| Where | Was | Now |
|---|---|---|
| ServiceCredits send panel label | "Pay with" | "Send with" |
| ServiceCredits send panel aria-label | "Payment method" | "Send method" |
| Mutual-credit helper line | "Pay now on community credit, repay as you earn." | "Send now on community credit, repay as you earn." |
| Mutual-credit limit error | "This payment would exceed your mutual-credit limit." | "This send would exceed your mutual-credit limit." |
| LevelUp wallet ledger label | "Trainer payout" | "Trainer credit grant" |
| LevelUp trainer sidebar | "Payout History" with a dollar-sign icon | "Grant History" with the Coins icon |
| LevelUp admin stat | "Avg days to first trainer payout" | "Avg days to first trainer credit grant" |

Code identifiers (`trainer_payout`, `payout_policy_json`, `calculateTrainerPayout`, …) keep their names, as the lexicon prescribes.

## Checks

Typecheck and lint pass; no route, schema, or contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_