### PR TITLE
docs: correct the chat panel comment about file uploads

### DIFF
--- a/ctf/packages/web/components/shared/stream-chat-panel.tsx
+++ b/ctf/packages/web/components/shared/stream-chat-panel.tsx
@@ -352,10 +352,15 @@ const ConversationBody: React.FC<{
           the panel), and link preview cards render in the MessageList via the default Attachment Card.
           Polls (create + vote) are entirely default in stream-chat-react 12.16: the composer's
           AttachmentSelector shows a "Create poll" entry whenever the channel config allows polls and
-          the member holds the send-poll capability (uploads are off, so it is the only entry there),
-          and MessageList renders the default Poll card with live voting for any message that carries a
-          poll. The owner enabled polls on the messaging channel type, so no extra wiring is needed; the
-          affordance is simply absent on channels that do not permit polls. The reminder action is the
+          the member holds the send-poll capability, and MessageList renders the default Poll card with
+          live voting for any message that carries a poll. The owner enabled polls on the messaging
+          channel type, so no extra wiring is needed; the affordance is simply absent on channels that
+          do not permit polls. Uploads are ON for the messaging channel type (a Stream dashboard
+          setting, not code), so the AttachmentSelector also shows a "File" entry. There is no custom
+          upload handler anywhere in the app: a picked file goes from the member's browser straight to
+          Stream's own file storage/CDN via the SDK default — our servers never receive the bytes.
+          (The gated contributor channel is different: its custom 'ctf-gated' channel type has uploads
+          OFF — see lib/contributor-access/gated-channel.ts.) The reminder action is the
           only message action passed in — it is empty (no extra action) when the channel does not permit
           reminders. */}
       <div className="ctf-chat-conversation">


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

Comment-only change in `ctf/packages/web/components/shared/stream-chat-panel.tsx`. The comment above the shared chat panel's `Window` block claimed that file uploads are off for Stream's `messaging` channel type (so "Create poll" would be the only attachment-selector entry). That does not match the live configuration: the Stream dashboard has uploads ON for the `messaging` type, the composer shows a "File" entry, and — since the app defines no custom upload handler — a picked file goes from the member's browser straight to Stream's own file storage. Our servers never receive the file bytes.

The comment now states that, and notes the contrast with the gated contributor channel's custom `ctf-gated` channel type, which has uploads OFF (`ctf/packages/web/lib/contributor-access/gated-channel.ts`).

## Why

The owner spotted a "File" entry in a SocketRelay Direct Line and asked where those files go. The out-of-date comment would have pointed the next reader to the wrong answer.

## Verification

- `pnpm run typecheck` (web package, pinned TypeScript) — passes
- `eslint components/shared/stream-chat-panel.tsx --max-warnings=0` — passes
- `ctf/scripts/check-eof-format.sh` — passes

No behavior change; no routes, schema, or contracts touched, so no inventory update is required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEqSLNDThKGqprojeicSkc)_