### PR TITLE
fix: use make_interval for the login-activity day window

### DIFF
--- a/ctf/packages/web/lib/engagement/login-activity.ts
+++ b/ctf/packages/web/lib/engagement/login-activity.ts
@@ -52,7 +52,7 @@ export async function getActiveUserIdsLastDays(days: number): Promise<string[]> 
   const result = await queryDb<{ user_id: string }>(
     `SELECT DISTINCT user_id
      FROM login_events
-     WHERE created_at >= NOW() - ($1::text || ' days')::interval
+     WHERE created_at >= NOW() - make_interval(days => $1::int)
      ORDER BY user_id ASC`,
     [safeDays],
   );
@@ -65,7 +65,7 @@ export async function countActiveUsersLastDays(days: number): Promise<number> {
   const result = await queryDb<{ total: string }>(
     `SELECT COUNT(DISTINCT user_id)::text AS total
      FROM login_events
-     WHERE created_at >= NOW() - ($1::text || ' days')::interval`,
+     WHERE created_at >= NOW() - make_interval(days => $1::int)`,
     [safeDays],
   );
 


### PR DESCRIPTION
Closes #2086

## What changed

`ctf/packages/web/lib/engagement/login-activity.ts` built its "last N days" window with `($1::text || ' days')::interval` in two queries. Both now use `NOW() - make_interval(days => $1::int)`, which binds the day count as an integer.

This is the same form already used in `ctf/packages/web/lib/click-log/repository.ts` and `ctf/packages/web/lib/service-credits/repository.ts`, so the file now matches the rest of the codebase.

## Note on the reported severity

The issue reports this as SQL injection. That part does not hold: `$1` is a bound query parameter, so the day count was never concatenated into the SQL text sent to the database — the concatenation happened inside Postgres on an already-bound value. The two callers (`app/api/internal/peer-programming/assignments/run`, `app/api/peer-programming/admin/assignments/run`, and `app/api/weekly-performance/current-week`) all pass the literal `7`.

What does hold is that the expression is fragile and non-idiomatic, which is what this change fixes. No behaviour change, no route/schema/contract change, so no feature inventory update is required.

## Checks

- `pnpm --filter @ctf/web typecheck` — clean.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — this is a server-side query expression with no rendered surface.