### PR TITLE
fix: skip the Sentry source-map upload in the Android build

### DIFF
--- a/ctf/packages/mobile/app.config.ts
+++ b/ctf/packages/mobile/app.config.ts
@@ -107,7 +107,16 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       'expo-notifications',
       // Wires the Sentry native SDK into the EAS Android build so crashes in the keep-list app are
       // reported again (the JS init lives in src/observability/sentry.ts and no-ops without a DSN).
-      '@sentry/react-native/expo',
+      //
+      // `disableAutoUpload: true` turns off the Gradle step that uploads JavaScript source maps to
+      // Sentry at the end of the release bundle. That step shells out to sentry-cli, which needs a
+      // Sentry organization, project, and auth token. Only the DSN is configured (EXPO_SENTRY_DSN),
+      // so the upload had nothing to authenticate with and failed the whole Android build:
+      // "error: An organization ID or slug is required". Crash reporting itself does not depend on
+      // the upload — it only makes stack traces in Sentry point at original source lines instead of
+      // the bundled output. To turn the upload back on later, add SENTRY_ORG, SENTRY_PROJECT, and
+      // SENTRY_AUTH_TOKEN to the build environment first, then drop this option.
+      ['@sentry/react-native/expo', { disableAutoUpload: true }],
     ],
     updates: {
       ...(updatesUrl ? { url: updatesUrl } : {}),


### PR DESCRIPTION
Opened automatically for the failed scheduled Android test build: https://github.com/chargingthefuture/chargingthefuture/actions/runs/30811721236

Parity Status: web + mobile-responsive + android complete

Android: build-config only — no app surface changes.

## What failed

The EAS build ([`17a7bba7`](https://expo.dev/accounts/charging-the-future/projects/charging-the-future/builds/17a7bba7-776c-4a88-99a7-c0f6ce7ca504)) got through compilation and died in the Gradle release bundle:

```
> Task :app:createBundleReleaseJsAndAssets_SentryUpload_com.chargingthefuture.app@0.1.1+1_1
error: An organization ID or slug is required (provide with --org, set SENTRY_ORG, or use an org-scoped auth token)
FAILURE: Build failed with an exception.
```

That task shells out to sentry-cli to upload JavaScript source maps to Sentry. Uploading needs a Sentry organization, project, and auth token. The build environment has only the DSN (`EXPO_SENTRY_DSN`), and EAS reported `No environment variables with visibility "Plain text" and "Sensitive" found for the "preview" environment`. So the upload had nothing to authenticate with, could never succeed, and failed the whole APK build.

The upload task came in with #2083, which registered the `@sentry/react-native/expo` config plugin to restore native crash reporting. The crash reporting part works; the source-map upload that the plugin also turns on does not, because its credentials were never added.

## The change

One line in `ctf/packages/mobile/app.config.ts`: register the plugin with `disableAutoUpload: true`.

That makes the plugin write `project.ext.shouldSentryAutoUploadGeneral = { -> return false }` into `android/app/build.gradle`. The upload task is registered with `onlyIf { sentryAutoUploadGeneralEnabled }`, so it is skipped rather than run, and the bundle finishes.

Crash reporting is not affected: the native Sentry SDK is still wired into the build, and the JS init in `src/observability/sentry.ts` still reports crashes. The upload only changes how stack traces read inside Sentry — without it they point at the bundled output instead of original source lines. To turn the upload back on, `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN` have to be added to the build environment first (a secrets change, which needs owner approval). The code comment records that.

## Checks run

- `expo prebuild --platform android` locally: the override is written at `android/app/build.gradle:85`, right after the `apply from: ... sentry.gradle.kts` line, which is where the Gradle script reads it.
- `pnpm --dir ctf --filter @ctf/mobile run typecheck` — passed.
- `pnpm --dir ctf --filter @ctf/mobile run lint` — passed.
- `ctf/scripts/check-eof-format.sh` — passed.

No route, data model, contract, or delivery-status change, so no feature inventory update applies.
