### PR TITLE
fix: verification approved card says the Commons instead of Hub

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -199,6 +199,12 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
+- 2026-08-03: **Approved card says "the Commons", not "Hub" (owner report).** The verification
+  approved card said "Welcome to the Survivor Hub!" with a "Continue to Hub" button; the lexicon's
+  name for the home surface is "the Commons". Web (`unlock-status-card.tsx`) now says "Welcome to
+  the Commons!" / "Continue to the Commons", and the button links to `/` (the Commons home) instead
+  of `/apps` so the label matches where it goes. The mobile approved card (`Unlock.tsx`) gets the
+  same "Welcome to the Commons!" title. Copy-only change; no route, schema, or contract change.
 - 2026-08-01: **The review queue names the member instead of printing a Clerk id (owner report).**
   Each card showed only `User: user_38IaPPUrRq0…`, so deciding whether to approve someone meant
   copying the id out and cross-referencing it elsewhere to find out whose account it was.

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -108,6 +108,20 @@ not see this banner. On android the client Unlock gate lets a treatment member t
 (instead of walling them) and the banner behaves the same. Inert when the flag is off everywhere.
 **Result:** web ☐ android ☐ — notes:
 
+### UNLOCK-M3 · Approved status card says "the Commons"
+**Role:** member (approved) · **Surfaces:** web + mobile-responsive (member Unlock status screen), android
+**Precondition:** a member whose submission has been approved.
+**Steps:**
+1. Open the Unlock status screen as the approved member.
+2. Confirm the approved card reads "Welcome to the Commons!" — not "Survivor Hub" or "Hub"
+   (terminology fix, 2026-08-03; the home surface's name is "the Commons" per the brand lexicon).
+3. On web, confirm the button reads "Continue to the Commons" and tapping it lands on the Commons
+   home page (`/`), not the plugin navigator (`/apps`).
+4. On android, confirm the same "Welcome to the Commons!" title (that card has no continue button).
+**Expected:** The approved card uses "the Commons" everywhere it names the home surface, and the
+web continue button goes to the Commons home so the label matches the destination.
+**Result:** web ☐ android ☐ — notes:
+
 ---
 
 ## Admin walkthrough

--- a/ctf/packages/mobile/src/features/unlock/Unlock.tsx
+++ b/ctf/packages/mobile/src/features/unlock/Unlock.tsx
@@ -276,7 +276,7 @@ function StatusView({
         {display === 'approved' && (
           <View style={s.approvedBox}>
             <Text style={{ fontSize: 26, textAlign: 'center' }}>🎉</Text>
-            <Text style={[s.approvedTitle, { color: accent }]}>Welcome to the Survivor Hub!</Text>
+            <Text style={[s.approvedTitle, { color: accent }]}>Welcome to the Commons!</Text>
             <Text style={[s.bodyText, { textAlign: 'center' }]}>All features are now unlocked.</Text>
             <Text style={[s.bodyText, { textAlign: 'center', marginTop: 8 }]}>
               {status.incentiveGrantedAt

--- a/ctf/packages/web/components/unlock/unlock-status-card.tsx
+++ b/ctf/packages/web/components/unlock/unlock-status-card.tsx
@@ -48,13 +48,13 @@ export function UnlockStatusCard({
         {status === "approved" && (
           <div style={{ padding: "14px", borderRadius: 12, background: `${t.ACCENT}08`, border: `1px solid ${t.ACCENT}20`, textAlign: "center" }}>
             <div style={{ fontSize: 28 }}>🎉</div>
-            <div style={{ fontSize: 16, fontWeight: 700, color: t.ACCENT, marginTop: 6 }}>Welcome to the Survivor Hub!</div>
+            <div style={{ fontSize: 16, fontWeight: 700, color: t.ACCENT, marginTop: 6 }}>Welcome to the Commons!</div>
             <div style={{ fontSize: 13, color: t.MUTED, marginTop: 4 }}>Your profile has been verified. All features are now unlocked.</div>
             <div style={{ fontSize: 12, color: t.MUTED, marginTop: 10, lineHeight: 1.5 }}>
               Your ServiceCredits reward is issued automatically and arrives within {UNLOCK_REWARD_SLA_HOURS} hours, if not sooner.
             </div>
-            <a href="/apps" style={{ marginTop: 12, padding: "10px 24px", borderRadius: 10, background: t.ACCENT, border: "none", color: "#fff", fontSize: 13, fontWeight: 700, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6, textDecoration: "none" }}>
-              Continue to Hub <ChevronRight size={14} />
+            <a href="/" style={{ marginTop: 12, padding: "10px 24px", borderRadius: 10, background: t.ACCENT, border: "none", color: "#fff", fontSize: 13, fontWeight: 700, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6, textDecoration: "none" }}>
+              Continue to the Commons <ChevronRight size={14} />
             </a>
           </div>
         )}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## What changed

Owner report (screenshot of the Unlock verification screen): the approved card says "hub" where the product's name for the home surface is "the Commons" (per `ctf/docs/BRAND_VOICE_LEXICON.md`, "home/community chat -> the Commons").

- Web `ctf/packages/web/components/unlock/unlock-status-card.tsx`: "Welcome to the Survivor Hub!" is now "Welcome to the Commons!", and the button "Continue to Hub" is now "Continue to the Commons". The button now links to `/` (the Commons home page) instead of `/apps`, so the label matches where it goes.
- Android `ctf/packages/mobile/src/features/unlock/Unlock.tsx`: the same approved-card title is now "Welcome to the Commons!" (that screen has no continue button).
- Unlock feature inventory: change-log entry added.

Left alone on purpose: other Unlock screens (the submission view and the help text) still say "Survivor Hub" as the community name; the owner report was about this approved card, so only its copy changed.

Copy-only change: no route handlers, schema, or contracts touched. Local typecheck, lint, web build, EOF format, inventory-drift, and test-script-drift checks all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRKsdZz7CWG3stAsFmDL6M)_