### PR TITLE
fix: approved card welcomes members to Skills Economy (SE)

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -199,12 +199,12 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
-- 2026-08-03: **Approved card says "the Commons", not "Hub" (owner report).** The verification
-  approved card said "Welcome to the Survivor Hub!" with a "Continue to Hub" button; the lexicon's
-  name for the home surface is "the Commons". Web (`unlock-status-card.tsx`) now says "Welcome to
-  the Commons!" / "Continue to the Commons", and the button links to `/` (the Commons home) instead
-  of `/apps` so the label matches where it goes. The mobile approved card (`Unlock.tsx`) gets the
-  same "Welcome to the Commons!" title. Copy-only change; no route, schema, or contract change.
+- 2026-08-03: **Approved card drops "Hub" (owner report).** The verification approved card said
+  "Welcome to the Survivor Hub!" with a "Continue to Hub" button. Per the brand lexicon, the card
+  title now reads "Welcome to Skills Economy (SE)" (the first-meeting form of the product name,
+  owner-specified) and the web button reads "Continue to the Commons", linking to `/` (the Commons
+  home) instead of `/apps` so the label matches where it goes. The mobile approved card
+  (`Unlock.tsx`) gets the same title. Copy-only change; no route, schema, or contract change.
 - 2026-08-01: **The review queue names the member instead of printing a Clerk id (owner report).**
   Each card showed only `User: user_38IaPPUrRq0…`, so deciding whether to approve someone meant
   copying the id out and cross-referencing it elsewhere to find out whose account it was.

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -108,18 +108,20 @@ not see this banner. On android the client Unlock gate lets a treatment member t
 (instead of walling them) and the banner behaves the same. Inert when the flag is off everywhere.
 **Result:** web ☐ android ☐ — notes:
 
-### UNLOCK-M3 · Approved status card says "the Commons"
+### UNLOCK-M3 · Approved status card wording (no "Hub")
 **Role:** member (approved) · **Surfaces:** web + mobile-responsive (member Unlock status screen), android
 **Precondition:** a member whose submission has been approved.
 **Steps:**
 1. Open the Unlock status screen as the approved member.
-2. Confirm the approved card reads "Welcome to the Commons!" — not "Survivor Hub" or "Hub"
-   (terminology fix, 2026-08-03; the home surface's name is "the Commons" per the brand lexicon).
+2. Confirm the approved card title reads "Welcome to Skills Economy (SE)" — not "Survivor Hub" or
+   "Hub" (terminology fix, 2026-08-03, owner-specified wording per the brand lexicon).
 3. On web, confirm the button reads "Continue to the Commons" and tapping it lands on the Commons
    home page (`/`), not the plugin navigator (`/apps`).
-4. On android, confirm the same "Welcome to the Commons!" title (that card has no continue button).
-**Expected:** The approved card uses "the Commons" everywhere it names the home surface, and the
-web continue button goes to the Commons home so the label matches the destination.
+4. On android, confirm the same "Welcome to Skills Economy (SE)" title (that card has no continue
+   button).
+**Expected:** The approved card welcomes the member to Skills Economy (SE) and the web continue
+button goes to the Commons home so the label matches the destination. No "Hub" wording anywhere on
+the card.
 **Result:** web ☐ android ☐ — notes:
 
 ---

--- a/ctf/packages/mobile/src/features/unlock/Unlock.tsx
+++ b/ctf/packages/mobile/src/features/unlock/Unlock.tsx
@@ -276,7 +276,7 @@ function StatusView({
         {display === 'approved' && (
           <View style={s.approvedBox}>
             <Text style={{ fontSize: 26, textAlign: 'center' }}>🎉</Text>
-            <Text style={[s.approvedTitle, { color: accent }]}>Welcome to the Commons!</Text>
+            <Text style={[s.approvedTitle, { color: accent }]}>Welcome to Skills Economy (SE)</Text>
             <Text style={[s.bodyText, { textAlign: 'center' }]}>All features are now unlocked.</Text>
             <Text style={[s.bodyText, { textAlign: 'center', marginTop: 8 }]}>
               {status.incentiveGrantedAt

--- a/ctf/packages/web/components/unlock/unlock-status-card.tsx
+++ b/ctf/packages/web/components/unlock/unlock-status-card.tsx
@@ -48,7 +48,7 @@ export function UnlockStatusCard({
         {status === "approved" && (
           <div style={{ padding: "14px", borderRadius: 12, background: `${t.ACCENT}08`, border: `1px solid ${t.ACCENT}20`, textAlign: "center" }}>
             <div style={{ fontSize: 28 }}>🎉</div>
-            <div style={{ fontSize: 16, fontWeight: 700, color: t.ACCENT, marginTop: 6 }}>Welcome to the Commons!</div>
+            <div style={{ fontSize: 16, fontWeight: 700, color: t.ACCENT, marginTop: 6 }}>Welcome to Skills Economy (SE)</div>
             <div style={{ fontSize: 13, color: t.MUTED, marginTop: 4 }}>Your profile has been verified. All features are now unlocked.</div>
             <div style={{ fontSize: 12, color: t.MUTED, marginTop: 10, lineHeight: 1.5 }}>
               Your ServiceCredits reward is issued automatically and arrives within {UNLOCK_REWARD_SLA_HOURS} hours, if not sooner.


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

## What changed

Follow-up to #2091, owner wording. The verification approved card title now reads "Welcome to Skills Economy (SE)" — the brand lexicon's first-meeting form of the product name — instead of "Welcome to the Commons!".

- Web `ctf/packages/web/components/unlock/unlock-status-card.tsx`: title updated; the button stays "Continue to the Commons" and still links to `/` (the Commons home).
- Android `ctf/packages/mobile/src/features/unlock/Unlock.tsx`: same title (that card has no continue button).
- Unlock feature inventory change log and test-script case UNLOCK-M3 updated to match, so the drift gates pass.

Copy-only change: no route handlers, schema, or contracts touched. Local typecheck, lint, web build, EOF format, and test-script-drift checks all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRKsdZz7CWG3stAsFmDL6M)_