### PR TITLE
fix: say which step blocked a Beacon go-live, and stop non-video steps blocking it

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -364,3 +364,28 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
   `event.start-broadcast` command, access-policy, and audit contract entries. Note: HLS/recording are
   started once when a publisher is present (replacing the call that always failed), so net Stream usage
   is unchanged-to-positive with no new recurring calls.
+- 2026-08-03: Made a failed "Go live" say why, and stopped two non-video steps from blocking a broadcast
+  (branch `fix/beacon-go-live-failure-detail`; owner report from a phone: the banner read only
+  "Broadcast input unavailable." with no way to tell what was wrong). Three changes, no route, schema,
+  or contract change:
+  1. `GET /api/beacon/[id]/ingest` no longer wraps every step in one catch that returns a single fixed
+     sentence. Each step is attempted separately and names itself in the message the admin sees:
+     loading the event ("Could not load the event: …", `beacon_persistence_unavailable`), preparing the
+     host ("Broadcast input unavailable — preparing the host failed: …"), and opening the broadcast call
+     ("Broadcast input unavailable — opening the broadcast call failed: …"). Stream-not-configured still
+     answers "Live video is not configured." The echoed reason is capped at 300 characters. Each step
+     also reports separately (`ingest_load_event`, `ingest_host_credentials`, `ingest_open_call`,
+     `ingest_audit`), so error reporting shows which one failed.
+  2. The ingest audit row is now written best-effort. It is bookkeeping; a failed audit write used to
+     surface as a broadcast failure even though the RTMP details and host token were ready.
+  3. Registering the host on Stream Chat (`upsertUser`) inside `createBeaconHostCredentials` is now
+     best-effort, and releasing the Stream client is guarded. The host token is signed locally from the
+     app secret and publishing video does not need the chat user to exist, so a Chat-side failure (quota,
+     a chat-disabled app, a transient error) no longer stops a broadcast — it is reported
+     (`host_chat_upsert`) and only the host's chat display name and moderator role are missed.
+  Also, a failed Stream Video REST call now carries its HTTP status and endpoint alongside Stream's own
+  message (`Stream Video POST /api/v2/video/call/… failed (403): …`) — the status is what distinguishes
+  a misconfigured app from an unauthorized one from an over-quota one — and a non-JSON error body no
+  longer replaces the status with a JSON parse error. The API key is never included (the path is logged
+  without its query string). Quota-impact note:
+  `ctf/docs/quota-impact/2026-08-03-beacon-go-live-failure-detail.md`.

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -159,6 +159,24 @@ publishing (the in-browser screen-share triggers `start-broadcast`). Only the ho
 viewers never can. On error, the underlying Stream message is surfaced, not a generic text.
 **Result:** web ☐ mobile ☐ — notes:
 
+### BCN-A2b · A failed Go Live says which step failed
+**Role:** admin · **Surfaces:** web (admin surface)
+**Precondition:** a draft event. To force a failure, point the app at a Stream app whose Video product
+is unavailable (or temporarily set a wrong `STREAM_API_SECRET`); with Stream fully unset you get the
+not-configured case in the expectation below instead.
+**Steps:**
+1. Open the draft and press Go Live.
+2. Read the red banner at the top of the admin screen.
+**Expected:** The banner names the step that failed and carries the reason behind it — "Could not load
+the event: …", "Broadcast input unavailable — preparing the host failed: …", or "Broadcast input
+unavailable — opening the broadcast call failed: …" with Stream's own text plus the HTTP status and
+endpoint (for example `failed (403)`). With Stream not configured at all the banner reads "Live video
+is not configured." No banner ever shows a bare "Broadcast input unavailable." with no reason, and no
+API key or stream key appears in it. A Stream Chat problem alone (the host's chat registration) must
+not stop the broadcast: the event still goes live and only the host's chat name/moderator role is
+missing.
+**Result:** web ☐ mobile ☐ — notes:
+
 ### BCN-A3 · Moderate the chat
 **Role:** admin · **Surfaces:** web (admin surface)
 **Precondition:** a live event with member chat.

--- a/ctf/docs/quota-impact/2026-08-03-beacon-go-live-failure-detail.md
+++ b/ctf/docs/quota-impact/2026-08-03-beacon-go-live-failure-detail.md
@@ -1,0 +1,74 @@
+# Stream Quota Impact Note — Beacon go-live failure detail
+
+## Summary
+
+- Feature/Change: Make a failed Beacon "Go live" explain itself, and stop two non-video steps from
+  blocking a broadcast. The admin ingest route used to wrap every setup step in one catch that returned
+  the fixed sentence "Broadcast input unavailable.", so an owner holding a phone could not tell whether
+  the database read, the Stream Chat host registration, or the Stream Video call was at fault. Each step
+  is now attempted separately and names itself in the message; the Stream Chat host registration and the
+  audit row are best-effort (reported, not fatal), because neither is needed to publish video; and a
+  failed Stream Video REST call now carries its HTTP status and endpoint alongside Stream's own message.
+- PR: opened from branch `fix/beacon-go-live-failure-detail`.
+- Owner: chargingthefuture
+- Date: 2026-08-03
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: **Chat and Video**, error handling only. No Stream call
+  is added, removed, retried, or moved. The Chat `upsertUser` for the host and the Video get-or-create
+  call still run exactly once per "Go live" click, as before; only what happens when one of them fails
+  changes. No change to Activity Feeds or AI Moderation.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: no change. The same one host user is registered per go-live; when that
+  registration fails it is no longer retried by the admin re-clicking through a dead end, so if anything
+  the call count goes down slightly.
+- Activity Feed API calls estimate: no change.
+- Video participant-minutes / HLS / recording estimate: no change in the success path. In the failure
+  path, a broadcast that previously could not start (because a Chat-side or audit-side failure aborted
+  it) can now start, so video minutes are consumed as the feature intends rather than not at all. This
+  is bounded by Beacon allowing one live event at a time.
+- AI Moderation credits estimate: no change.
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): **Green.** No new recurring call, no
+  polling, no fan-out. Usage stays driven by how often the owner broadcasts and for how long.
+- Peak scenario estimate: unchanged — one long, well-attended broadcast (HLS distribution plus one
+  recording). This change does not raise the ceiling.
+
+## Fallback and Degradation Plan
+
+- What degrades first: Stream not configured still returns 503 "Live video is not configured." and every
+  Beacon surface stays in its calm idle state. A Stream Chat failure now degrades the host's chat
+  identity (display name, moderator role) instead of the broadcast itself. A failed audit write degrades
+  the audit trail for that read, and is reported.
+- User-visible messaging behavior: the admin banner now names the failing step and includes the
+  underlying reason, capped at 300 characters. This surface is admin-gated. The API key is never
+  included in the message — the endpoint path is recorded without its query string, which is where the
+  key travels.
+- Kill switch / feature flag: unchanged. Demo-mode sessions still route to the dedicated **staging**
+  Stream app via `resolveStreamCredentials`, so recording sessions never draw on the production
+  Maker-tier quota. Ending the event (`POST /api/beacon/[id]/end`) still stops the call, HLS
+  distribution, and recording.
+
+## Observability
+
+- Metrics and alerts added/updated: no new metrics. Four separate `reportError` operations replace one
+  generic report on the ingest path (`ingest_load_event`, `ingest_host_credentials`, `ingest_open_call`,
+  `ingest_audit`), plus `host_chat_upsert` for the best-effort host registration. Error reporting now
+  shows which step failed instead of one bucket. Stream's dashboard remains the source of truth for
+  usage.
+
+## Validation
+
+- Tests added for degraded mode: none automated (Rule 118 defers automated tests during MVP). The
+  degraded paths are: Stream unconfigured → 503 with the not-configured message; a throwing
+  `upsertUser` → reported and the broadcast continues; a throwing audit insert → reported and the ingest
+  response still returns. Lint, typecheck, the end-of-file format check, and the inventory drift gate
+  pass for the changed files.
+- Rollback strategy: revert the branch. Beacon returns to the single generic "Broadcast input
+  unavailable." message and to treating a Chat or audit failure as a broadcast failure. No schema,
+  contract, or route change is involved, so there is nothing to migrate.

--- a/ctf/packages/web/app/api/beacon/[id]/ingest/route.ts
+++ b/ctf/packages/web/app/api/beacon/[id]/ingest/route.ts
@@ -10,6 +10,42 @@ export const dynamic = 'force-dynamic';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
+// How much of an upstream failure reason we pass back to the admin banner. The text comes from Stream
+// (or the database driver) and this route is admin-only, but a runaway message should not fill the
+// screen.
+const MAX_REASON_LENGTH = 300;
+
+function reasonFrom(error: unknown): string {
+  const raw = (error instanceof Error ? error.message : String(error)).trim();
+  if (raw.length === 0) {
+    return 'unknown error';
+  }
+  return raw.length > MAX_REASON_LENGTH ? `${raw.slice(0, MAX_REASON_LENGTH)}…` : raw;
+}
+
+function streamUnavailable(message: string): NextResponse {
+  return NextResponse.json(
+    { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message },
+    { status: 503 },
+  );
+}
+
+// Run one setup step and turn a throw into the reason we show the admin. Each step is reported
+// separately so the banner names which step failed instead of one generic sentence for all of them —
+// a broadcast that will not start is otherwise undiagnosable from the phone the admin is holding.
+async function step<T>(
+  op: string,
+  eventId: string,
+  run: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; reason: string }> {
+  try {
+    return { ok: true, value: await run() };
+  } catch (error) {
+    reportError(error, { area: 'beacon', op, extra: { eventId } });
+    return { ok: false, reason: reasonFrom(error) };
+  }
+}
+
 // Admin: the per-event RTMP ingest URL + stream key (for a phone broadcaster app) and a host token
 // (for desktop in-browser screen-share). Only the host token can publish.
 export async function GET(_request: Request, context: RouteContext) {
@@ -20,40 +56,59 @@ export async function GET(_request: Request, context: RouteContext) {
 
   const { id } = await context.params;
 
-  try {
-    const event = await getBeaconEvent(id);
-    if (!event) {
-      return NextResponse.json(
-        { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
-        { status: 404 },
-      );
-    }
+  const loaded = await step('ingest_load_event', id, () => getBeaconEvent(id));
+  if (!loaded.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: BEACON_ERROR_CODE.persistenceUnavailable,
+        message: `Could not load the event: ${loaded.reason}`,
+      },
+      { status: 503 },
+    );
+  }
+  const event = loaded.value;
+  if (!event) {
+    return NextResponse.json(
+      { ok: false, code: BEACON_ERROR_CODE.notFound, message: 'Event not found.' },
+      { status: 404 },
+    );
+  }
 
-    const credentials = await createBeaconHostCredentials({
+  const minted = await step('ingest_host_credentials', id, () =>
+    createBeaconHostCredentials({
       userId: gate.auth.userId,
       name: buildIdentityDisplayName(gate.auth.username, gate.auth.userId),
       eventId: event.id,
-    });
-    if (!credentials) {
-      return NextResponse.json(
-        { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Live video is not configured.' },
-        { status: 503 },
-      );
-    }
+    }),
+  );
+  if (!minted.ok) {
+    return streamUnavailable(`Broadcast input unavailable — preparing the host failed: ${minted.reason}`);
+  }
+  const credentials = minted.value;
+  if (!credentials) {
+    return streamUnavailable('Live video is not configured.');
+  }
 
-    const ingest = await ensureBeaconCallAndIngest({
+  const opened = await step('ingest_open_call', id, () =>
+    ensureBeaconCallAndIngest({
       eventId: event.id,
       hostUserId: gate.auth.userId,
       hostToken: credentials.hostToken,
-    });
-    if (!ingest) {
-      return NextResponse.json(
-        { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Live video is not configured.' },
-        { status: 503 },
-      );
-    }
+    }),
+  );
+  if (!opened.ok) {
+    return streamUnavailable(`Broadcast input unavailable — opening the broadcast call failed: ${opened.reason}`);
+  }
+  const ingest = opened.value;
+  if (!ingest) {
+    return streamUnavailable('Live video is not configured.');
+  }
 
-    await insertBeaconAudit({
+  // The audit row is bookkeeping. A failed write is reported but must not be reported to the admin as
+  // a broadcast failure — the broadcast input above is ready either way.
+  await step('ingest_audit', id, () =>
+    insertBeaconAudit({
       actorId: gate.auth.userId,
       command: 'beacon.event.ingest',
       policyStatus: 'allow',
@@ -61,26 +116,20 @@ export async function GET(_request: Request, context: RouteContext) {
       targetType: 'event',
       targetId: event.id,
       metadata: { streamCallId: credentials.streamCallId },
-    });
+    }),
+  );
 
-    return NextResponse.json(
-      {
-        ok: true,
-        rtmpIngestUrl: ingest.rtmpIngestUrl,
-        streamKey: ingest.streamKey,
-        streamApiKey: credentials.streamApiKey,
-        streamCallType: credentials.streamCallType,
-        streamCallId: credentials.streamCallId,
-        streamUserId: credentials.streamUserId,
-        hostToken: credentials.hostToken,
-      },
-      { status: 200 },
-    );
-  } catch (error) {
-    reportError(error, { area: 'beacon', op: 'ingest', extra: { eventId: id } });
-    return NextResponse.json(
-      { ok: false, code: BEACON_ERROR_CODE.streamUnavailable, message: 'Broadcast input unavailable.' },
-      { status: 503 },
-    );
-  }
+  return NextResponse.json(
+    {
+      ok: true,
+      rtmpIngestUrl: ingest.rtmpIngestUrl,
+      streamKey: ingest.streamKey,
+      streamApiKey: credentials.streamApiKey,
+      streamCallType: credentials.streamCallType,
+      streamCallId: credentials.streamCallId,
+      streamUserId: credentials.streamUserId,
+      hostToken: credentials.hostToken,
+    },
+    { status: 200 },
+  );
 }

--- a/ctf/packages/web/lib/beacon/stream.ts
+++ b/ctf/packages/web/lib/beacon/stream.ts
@@ -1,6 +1,7 @@
 import { createHmac } from 'crypto';
 import { StreamChat } from 'stream-chat';
 import { resolveStreamCredentials } from 'lib/integrations/stream-credentials';
+import { reportError } from 'lib/observability/report';
 import { BEACON_CHAT_CHANNEL_TYPE, BEACON_STREAM_CALL_TYPE } from './constants';
 
 // Beacon's Stream Video integration. Beacon is a one-way `livestream`: only the admin host
@@ -98,10 +99,24 @@ async function streamVideoFetch(
     cache: 'no-store',
   });
   const text = await response.text();
-  const parsed = text.length > 0 ? (JSON.parse(text) as Record<string, unknown>) : {};
+  // A failing request does not always answer with JSON (a proxy or gateway can return HTML), and a
+  // JSON.parse throw there would replace the real status with "Unexpected token <". Parse defensively
+  // so the status below is always the thing the caller sees.
+  let parsed: Record<string, unknown> = {};
+  if (text.length > 0) {
+    try {
+      parsed = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      parsed = {};
+    }
+  }
   if (!response.ok) {
-    const message = typeof parsed.message === 'string' ? parsed.message : `Stream Video request failed (${response.status}).`;
-    throw new Error(message);
+    // Keep the HTTP status and the endpoint alongside Stream's own message. Stream's message alone
+    // ("call type does not exist", "not allowed") does not say whether the app is misconfigured,
+    // unauthorized, or over quota; the status does, and the admin surfaces show this text. The path
+    // is included but never the query string — that carries the API key.
+    const detail = typeof parsed.message === 'string' && parsed.message.length > 0 ? `: ${parsed.message}` : '.';
+    throw new Error(`Stream Video ${init.method} ${path} failed (${response.status})${detail}`);
   }
   return parsed;
 }
@@ -129,7 +144,17 @@ export async function createBeaconHostCredentials(input: {
   const chatClient = new StreamChat(credentials.apiKey, credentials.apiSecret);
   try {
     const streamUserId = beaconStreamUserId(input.userId);
-    await chatClient.upsertUser({ id: streamUserId, name: input.name, role: 'admin' });
+    // Registering the host on Stream Chat is best-effort on purpose. The host token below is signed
+    // locally from the app secret and needs no network call, and publishing video does not depend on
+    // the chat user existing (the video client sends the user object when it connects). So a Chat-side
+    // failure — quota, a chat-disabled app, a transient error — must not be the reason a broadcast
+    // cannot start. It is reported and the broadcast proceeds; only the host's chat display name and
+    // moderator role are missed.
+    try {
+      await chatClient.upsertUser({ id: streamUserId, name: input.name, role: 'admin' });
+    } catch (error) {
+      reportError(error, { area: 'beacon', op: 'host_chat_upsert', extra: { eventId: input.eventId } });
+    }
     return {
       streamApiKey: credentials.apiKey,
       streamCallType: BEACON_STREAM_CALL_TYPE,
@@ -138,7 +163,11 @@ export async function createBeaconHostCredentials(input: {
       hostToken: chatClient.createToken(streamUserId),
     };
   } finally {
-    await chatClient.disconnectUser();
+    // A throw in a finally block replaces the value being returned, so closing the client is guarded
+    // too: releasing a server-side client must never be what stops a broadcast from starting.
+    try {
+      await chatClient.disconnectUser();
+    } catch { /* nothing to release */ }
   }
 }
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

Pressing **Go live** on the Beacon admin screen showed one red banner — `Broadcast input unavailable.` — and nothing else. That sentence is the single `catch` at the bottom of `GET /api/beacon/[id]/ingest`, which wrapped four different steps: loading the event from the database, registering the host on Stream Chat, minting the host token, opening the Stream Video call, and writing the audit row. Any one of them failing produced the same text, so from a phone there was no way to tell what to fix — and two of those steps do not affect video at all yet still killed the broadcast.

## What changed

No route, schema, or contract change. Three code changes:

1. **The ingest route names the failing step.** Each step is attempted separately and reports separately (`ingest_load_event`, `ingest_host_credentials`, `ingest_open_call`, `ingest_audit`). The admin now sees `Could not load the event: …`, `Broadcast input unavailable — preparing the host failed: …`, or `Broadcast input unavailable — opening the broadcast call failed: …` with the underlying reason, capped at 300 characters. Stream not configured still answers `Live video is not configured.`
2. **The audit row is best-effort.** It is bookkeeping; a failed write used to present as a broadcast failure even though the RTMP details and host token were ready.
3. **Registering the host on Stream Chat is best-effort, and releasing the Stream client is guarded.** The host token is signed locally from the app secret and publishing video does not need the chat user to exist, so a Chat-side failure (quota, a chat-disabled app, a transient error) no longer stops a broadcast — it is reported and only the host's chat display name and moderator role are missed. A throw inside the old `finally` could also replace the returned credentials; that is guarded now.

Also, a failed Stream Video REST call carries its HTTP status and endpoint next to Stream's own message (`Stream Video POST /api/v2/video/call/… failed (403): …`) — the status is what separates a misconfigured app from an unauthorized one from an over-quota one — and a non-JSON error body (an HTML gateway page) no longer replaces the status with a JSON parse error. The API key is never included: the path is recorded without its query string, which is where the key travels. This surface is admin-gated.

## What this does and does not fix

If the failure is in the Chat registration or the audit write, the broadcast now starts. If it is the Stream Video call itself, the broadcast still cannot start — but the banner now says so with Stream's status and message, which is the information needed to fix the Stream side. The old behavior gave neither.

## Files

- `ctf/packages/web/app/api/beacon/[id]/ingest/route.ts` — per-step attempts, per-step reports, best-effort audit
- `ctf/packages/web/lib/beacon/stream.ts` — status + endpoint in the failure message, defensive body parse, best-effort host chat registration, guarded client release
- `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md` — change log entry
- `ctf/docs/developer/test-scripts/beacon-test-script.md` — new step BCN-A2b
- `ctf/docs/quota-impact/2026-08-03-beacon-go-live-failure-detail.md` — new note (no Stream call added, removed, or retried)

## Checks run locally

`pnpm --filter @ctf/web typecheck`, `lint`, `build`, `check-eof-format.sh`, `check-modularity-governance.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-us-spelling.mjs`, `check-notice-formatting.mjs` — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHd1iPrfcpHEEJiTDpecFZ)_