### PR TITLE
fix: drop "coarse" from ClickLog sharing copy

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -37,8 +37,9 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 - Choose whether an incident is shared with the owner for trend tracking: a global "share new
   incidents by default" setting plus a per-incident override (in the log form and on each history
   row). Sharing is opt-in and off until the member turns it on, and can be turned off again per
-  incident at any time. Shared incidents contribute only coarse trend data (day, approximate area,
-  count) — never the note or exact location.
+  incident at any time. Shared incidents contribute only grouped trend data (day, approximate area,
+  count) — never the note or exact location. The member-facing copy says exactly that in plain
+  words ("only the date, rough area, and tags"), with no "coarse" wording.
 
 ## 4. Admin Features
 
@@ -166,6 +167,14 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-08-03: **Dropped the word "coarse" from the sharing copy.** "Coarse" is a technical term for
+  data that has been rounded off and grouped; a member reading the sharing checkbox has no way to
+  know that, and the word can be read as "rude". The two member-facing sharing controls now name
+  what is actually sent: the per-incident checkbox reads "Share this incident with the owner (only
+  the date, rough area, and tags)" and the global default reads "Share new incidents with the owner
+  by default (only the date, rough area, and tags — never your notes or exact location)". The owner
+  trends dashboard blurb says "Grouped data only" instead of "Coarse data only". Copy only — no
+  change to what is shared, to any route, schema, or contract.
 - 2026-08-03: **"Not listed" scheme-suggestion intake + naming pipeline (owner request).** The
   catch-all scheme tag's label changed "Other / not named yet" → "Not listed" (slug `other-scheme`
   frozen; the landing `/schemes` mirror is renamed in a companion landing-page PR). Picking it now

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -38,8 +38,9 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   incidents by default" setting plus a per-incident override (in the log form and on each history
   row). Sharing is opt-in and off until the member turns it on, and can be turned off again per
   incident at any time. Shared incidents contribute only grouped trend data (day, approximate area,
-  count) — never the note or exact location. The member-facing copy says exactly that in plain
-  words ("only the date, rough area, and tags"), with no "coarse" wording.
+  count) — never the note or exact location. The member-facing copy says so in plain words: the
+  global default reads "only trend data — never your notes" and the per-incident checkbox reads
+  "only the date, rough area, and tags". Neither uses the word "coarse".
 
 ## 4. Admin Features
 
@@ -172,7 +173,7 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
   know that, and the word can be read as "rude". The two member-facing sharing controls now name
   what is actually sent: the per-incident checkbox reads "Share this incident with the owner (only
   the date, rough area, and tags)" and the global default reads "Share new incidents with the owner
-  by default (only the date, rough area, and tags — never your notes or exact location)". The owner
+  by default (only trend data — never your notes)" (owner-set wording). The owner
   trends dashboard blurb says "Grouped data only" instead of "Coarse data only". Copy only — no
   change to what is shared, to any route, schema, or contract.
 - 2026-08-03: **"Not listed" scheme-suggestion intake + naming pipeline (owner request).** The

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -97,8 +97,9 @@ string. Trailing whitespace on a note is trimmed before the length check.
 **Expected:** Both the global setting and the form checkbox start **off**; an untouched log
 produces a **Private** row. With the default on, a new incident logs as **Shared with owner**;
 the form checkbox is seeded from the default and can be overridden per incident. The per-row
-pill flips a single incident either way at any time, and each change is logged. The copy states
-that only coarse trend data is shared — never the note or exact location.
+pill flips a single incident either way at any time, and each change is logged. The copy names
+what is shared in plain words — only the date, rough area, and tags — never the note or exact
+location; the word "coarse" appears nowhere on screen.
 **Result:** web ☐ mobile ☐ — notes:
 
 ### CL-7 · Tag an incident with a problem and a scheme (location required)

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -98,8 +98,9 @@ string. Trailing whitespace on a note is trimmed before the length check.
 produces a **Private** row. With the default on, a new incident logs as **Shared with owner**;
 the form checkbox is seeded from the default and can be overridden per incident. The per-row
 pill flips a single incident either way at any time, and each change is logged. The copy names
-what is shared in plain words — only the date, rough area, and tags — never the note or exact
-location; the word "coarse" appears nowhere on screen.
+what is shared in plain words — the global default says "only trend data — never your notes" and
+the per-incident checkbox says "only the date, rough area, and tags"; the word "coarse" appears
+nowhere on screen.
 **Result:** web ☐ mobile ☐ — notes:
 
 ### CL-7 · Tag an incident with a problem and a scheme (location required)

--- a/ctf/packages/web/components/click-log/click-log-admin-trends.tsx
+++ b/ctf/packages/web/components/click-log/click-log-admin-trends.tsx
@@ -103,7 +103,7 @@ export function ClickLogAdminTrends() {
         {!loading && !error && (
           <>
             <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5, marginBottom: 16 }}>
-              Aggregate of incidents members chose to share, last 90 days. Coarse data only: day, an
+              Aggregate of incidents members chose to share, last 90 days. Grouped data only: day, an
               approximate area (about 11 km), counts, and which problem/scheme tags members picked —
               no notes, exact locations, or member identity.
             </div>

--- a/ctf/packages/web/components/click-log/click-log-log-panel.tsx
+++ b/ctf/packages/web/components/click-log/click-log-log-panel.tsx
@@ -209,7 +209,7 @@ function ClickLogNoteForm({
           onChange={(e) => onShareChange(e.target.checked)}
           style={{ accentColor: t.ACCENT }}
         />
-        Share this incident with the owner (coarse trend data only)
+        Share this incident with the owner (only the date, rough area, and tags)
       </label>
       <div style={{ display: "flex", gap: 8, marginTop: 10, alignItems: "center" }}>
         <ClickLogLocationButton

--- a/ctf/packages/web/components/click-log/click-log-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-shell.tsx
@@ -252,7 +252,7 @@ export function ClickLogShell() {
           onChange={(e) => void share.setDefault(e.target.checked)}
           style={{ accentColor: t.ACCENT }}
         />
-        Share new incidents with the owner by default (only coarse trend data — never your notes or exact location)
+        Share new incidents with the owner by default (only the date, rough area, and tags — never your notes or exact location)
       </label>
 
       {incidents.length > 0 && (

--- a/ctf/packages/web/components/click-log/click-log-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-shell.tsx
@@ -252,7 +252,7 @@ export function ClickLogShell() {
           onChange={(e) => void share.setDefault(e.target.checked)}
           style={{ accentColor: t.ACCENT }}
         />
-        Share new incidents with the owner by default (only the date, rough area, and tags — never your notes or exact location)
+        Share new incidents with the owner by default (only trend data — never your notes)
       </label>
 
       {incidents.length > 0 && (


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What "coarse" meant, and why it is going

In the ClickLog sharing controls the word meant "rounded off and grouped" — the owner sees the date, an approximate area (about 11 km), a count, and the problem/scheme tags, and never the note or the exact location. That is a data-processing term. A member reading a checkbox before deciding whether to share an incident has no way to know that, and the everyday sense of "coarse" is "rude" or "rough", which is the wrong signal on a privacy control. The copy now names what is actually sent.

## Changes (copy only)

| Where | Before | After |
|---|---|---|
| `click-log-log-panel.tsx` — per-incident checkbox | Share this incident with the owner (coarse trend data only) | Share this incident with the owner (only the date, rough area, and tags) |
| `click-log-shell.tsx` — global default | Share new incidents with the owner by default (only coarse trend data — never your notes or exact location) | Share new incidents with the owner by default (only trend data — never your notes) |
| `click-log-admin-trends.tsx` — owner dashboard blurb | Coarse data only: day, an approximate area … | Grouped data only: day, an approximate area … |

The global-default line is the owner's own wording, set on this branch.

Nothing about what is shared changed — no route, schema, contract, or query change. The owner trends aggregate still returns the same rounded day/area/count/tag buckets.

Docs updated alongside: the ClickLog feature inventory (User Features line plus a change-log entry) and test CL-6 in the ClickLog test script, which previously told the tester to look for the "coarse" wording.

## Checks run locally

`typecheck` (shared, web, mobile), web `lint`, web `build`, `check-eof-format.sh`, `check:inventory-drift`, `check:test-script-drift`, `check:us-spelling` — all pass.
