### PR TITLE
feat: add The Fabricated Flaw to the ClickLog scheme tags

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -168,6 +168,14 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-08-03: **New scheme tag: The Fabricated Flaw (owner-named).** Added slug `fabricated-flaw`
+  to `CLICK_LOG_SCHEME_TAGS` — staged criticism of an invented flaw, timed to be absurd, meant to
+  sensitize the member into self-criticism and to capture audio of the remark so uninvolved
+  operatives believe the "problem" is real and recurring. First scheme named through the
+  ClickLog-era flow (Discourse stays deprecated). List-data only: no schema, route, contract, or
+  UI change — the pickers, validation, and trends pick the new slug up from the canonical list.
+  The landing `/schemes` page gains the matching entry in a companion landing-page PR.
+
 - 2026-08-03: **Dropped the word "coarse" from the sharing copy.** "Coarse" is a technical term for
   data that has been rounded off and grouped; a member reading the sharing checkbox has no way to
   know that, and the word can be read as "rude". The two member-facing sharing controls now name

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -208,3 +208,5 @@ of these, it is already tracked, not a new bug:
 - There is no advanced search or filtering on incident history.
 
 > _Terminology (2026-07-20): the source inventory's user-facing section is now titled **User Features** (was "Target User Features"), and its admin section **Admin Features**. Heading rename only — no test steps changed._
+
+> _Scheme list update (2026-08-03): added "The Fabricated Flaw" to the canonical scheme tags. List-data only — no test steps changed; CL-7/CL-8 cover tagging and suggestions generically._

--- a/ctf/packages/web/lib/click-log/tags.ts
+++ b/ctf/packages/web/lib/click-log/tags.ts
@@ -88,6 +88,12 @@ export const CLICK_LOG_SCHEME_TAGS: readonly ClickLogTag[] = [
   { slug: 'fake-counselor', label: 'Fake Counselor / Fake Help' },
   { slug: 'lure-to-location', label: 'Lure to a Location' },
   { slug: 'staged-narratives', label: 'Staged Narratives / Loud "Podcasts"' },
+  // Named by the owner (2026-08-03), the first scheme added through the ClickLog-era flow:
+  // staged criticism of an invented flaw, timed to be absurd (e.g. "you stink" after hours in
+  // 100-degree heat on the way to a shower). Dual purpose: sensitize the member into being
+  // overly self-critical, and capture audio of the remark so operatives who know nothing
+  // believe the "problem" is real and recurring.
+  { slug: 'fabricated-flaw', label: 'The Fabricated Flaw' },
   // Catch-all while new schemes get named. Label renamed 2026-08-02 ("Other / not named yet" →
   // "Not listed"); the slug is frozen like every other slug. Picking it requires a written
   // description of the scheme (see click-log.incident.create) — that is the intake that names


### PR DESCRIPTION
New owner-named scheme tag, slug `fabricated-flaw`, label "The Fabricated Flaw": staged criticism of an invented flaw, timed to be absurd (e.g. "you stink" after hours in 100-degree heat on the way to a shower). Dual purpose: sensitize the member into being overly self-critical, and capture audio of the remark so operatives who know nothing believe the "problem" is real and recurring.

List-data only — the pickers, create-route validation, and trend aggregates all read the canonical list, so no schema, route, contract, or UI change. Inventory change log and a test-script note included (no test steps change; CL-7/CL-8 cover tagging generically). First scheme named through the ClickLog-era flow rather than the deprecated Discourse thread.

Companion landing-page PR adds the matching `/schemes` entry; merge that one after this.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_