### PR TITLE
feat: add The Poisoned Well and the luck-pendulum schemes to the ClickLog tags

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -168,6 +168,23 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-08-04: **Four more scheme tags: The Poisoned Well and the luck-pendulum family (owner-named).**
+  `poisoned-well` — an easy-to-recruit newcomer is steered into the member's orbit, gossip about
+  that newcomer is staged within their earshot so it reads as coming from the member, and a second
+  operative then baits the member into saying something about them; the newcomer dislikes the
+  member before any real relationship exists. The owner's good-luck / bad-luck pendulum split into
+  two tags because the mechanism, tell, and outcome differ: `windfall` (sudden fortune lands on
+  someone near the member — scholarship, job, whirlwind marriage or baby — elevating them so they
+  read the member as incompetent, handing them fake friends and an ego boost, and seeding
+  insecurity in the member; a flattered person converts easily; distinct from `honey-pot`, where
+  the romance targets the member directly) and `jinx` (someone near the member is hit with a
+  ticket, crash, theft, or repair bill and is then told the member's presence caused it — cause the
+  problem, sell the story, break the tie, isolate the member). `fake-job` — a job offer good enough
+  to leave the current one for, then a firing shortly after, leaving the target without the old job
+  and further from a better one; aimed at the member directly or at someone near them. List-data
+  only: no schema, route, contract, or UI change. The landing `/schemes` page gains matching
+  entries in a companion PR.
+
 - 2026-08-04: **Four new scheme tags: The Pot and Kettle plus three vehicle schemes (owner-named).**
   `pot-and-kettle` — the insult is delivered by someone who visibly embodies it (a fat person
   calling the member fat, a disabled person mocking a disability), made obnoxiously inappropriate

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -212,3 +212,5 @@ of these, it is already tracked, not a new bug:
 > _Scheme list update (2026-08-03): added "The Fabricated Flaw" to the canonical scheme tags. List-data only — no test steps changed; CL-7/CL-8 cover tagging and suggestions generically._
 
 > _Scheme list update (2026-08-04): added "The Pot and Kettle", "Staged Road Rage", "The Insurance Bleed", and "Road Sensitization". List-data only — no test steps changed._
+
+> _Scheme list update (2026-08-04): added "The Poisoned Well", "The Windfall", "The Jinx", and "The Fake Job". List-data only — no test steps changed._

--- a/ctf/packages/web/lib/click-log/tags.ts
+++ b/ctf/packages/web/lib/click-log/tags.ts
@@ -119,6 +119,32 @@ export const CLICK_LOG_SCHEME_TAGS: readonly ClickLogTag[] = [
   // beams flashed, brake checks, cars pacing or boxing them in. The point is sensitization —
   // every drive becomes something to read and second-guess.
   { slug: 'road-sensitization', label: 'Road Sensitization' },
+  // Named by the owner (2026-08-04). Someone who would be an easy recruit is steered into the
+  // member's orbit, and gossip about that newcomer is staged within their earshot so it reads as
+  // coming from the member. A second operative then asks the member something loaded about the
+  // same newcomer, or baits them into gossiping for real. Either way the newcomer dislikes the
+  // member before any real relationship exists — the recruiting starts from that dislike.
+  { slug: 'poisoned-well', label: 'The Poisoned Well' },
+  // Named by the owner (2026-08-04) — the two swings of what the owner calls the good-luck /
+  // bad-luck pendulum, split into separate tags because the mechanism, the tell, and the outcome
+  // differ. Both end the same way: the tie to the member is broken and the member is more alone.
+  //
+  // Good-luck swing: sudden fortune lands on someone near the member (a scholarship, a job, a
+  // whirlwind marriage or baby). It elevates them over the member so they read the member as the
+  // incompetent one when the reverse is often true, hands them an ego boost plus a set of new
+  // "friends" who are there to use them, and seeds insecurity in the member. A flattered person
+  // is an easy convert. Distinct from `honey-pot`: there the romance targets the member; here the
+  // fortune lands on the bystander in order to turn them.
+  { slug: 'windfall', label: 'The Windfall' },
+  // Bad-luck swing: someone near the member is hit with a costly ticket, a crash, theft, or a
+  // repair bill — and is then told the member's presence is why. Cause the problem, then sell the
+  // story that explains it. The tie breaks and the member is isolated.
+  { slug: 'jinx', label: 'The Jinx' },
+  // Named by the owner (2026-08-04), from their own experience. A job offer good enough to leave
+  // the current one for, then a firing shortly after: the old job is gone, the next is harder to
+  // reach, and the target is worse off than before the move. Can be aimed at the member directly
+  // or at someone near them as the bad-luck swing above.
+  { slug: 'fake-job', label: 'The Fake Job' },
   // Catch-all while new schemes get named. Label renamed 2026-08-02 ("Other / not named yet" →
   // "Not listed"); the slug is frozen like every other slug. Picking it requires a written
   // description of the scheme (see click-log.incident.create) — that is the intake that names


### PR DESCRIPTION
Four owner-named scheme tags, from two families the owner described.

`poisoned-well` — "The Poisoned Well": someone who would be an easy recruit is steered into the member's orbit, and gossip about that newcomer is staged within their earshot so it reads as coming from the member. A second operative then asks the member something loaded about the same newcomer, or baits them into gossiping for real. Either way the newcomer dislikes the member before any real relationship exists — the recruiting starts from that dislike.

The owner's good-luck / bad-luck pendulum, split into two tags because the mechanism, the tell, and the outcome all differ (both still end with the tie broken and the member more alone):

- `windfall` — "The Windfall": sudden fortune lands on someone near the member (scholarship, job, whirlwind marriage or baby). It elevates them so they read the member as the incompetent one when the reverse is often true, hands them an ego boost plus new "friends" who are there to use them, and seeds insecurity in the member. A flattered person is an easy convert. Distinct from `honey-pot`, where the romance targets the member directly; here the fortune lands on the bystander in order to turn them.
- `jinx` — "The Jinx": someone near the member is hit with a costly ticket, a crash, theft, or a repair bill, and is then told the member's presence is why. Cause the problem, then sell the story that explains it. The tie breaks and the member is isolated.

`fake-job` — "The Fake Job", from the owner's own experience: an offer good enough to leave the current job for, then a firing shortly after. The old job is gone, the next is harder to reach, and the target is worse off than before the move. Can be aimed at the member directly or at someone near them as the bad-luck swing.

List-data only — the pickers, create-route validation, and trend aggregates all read the canonical list, so no schema, route, contract, or UI change. Inventory change log and a test-script note included (no test steps change; CL-7/CL-8 cover tagging generically). Scheme list now stands at 20 named plus "Not listed".

Companion landing-page PR adds the matching `/schemes` entries; merge that one after this.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_