### PR TITLE
docs: record the tactic-versus-scheme gap in the ClickLog tag list

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -168,6 +168,23 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-08-04: **Recorded a known taxonomy gap in the scheme tag list (documentation only).** The
+  owner observed that Color Sensitization is an individual tactic rather than a scheme, and the
+  observation holds list-wide: the entries are not all the same kind of thing. Some are operations
+  with an arc (setup, mechanism, intended end state — `poisoned-well`, `fake-job`, `jinx`,
+  `windfall`, `conspiracy-carousel`, `honey-pot`, `lure-to-location`, `staged-road-rage`,
+  `fabricated-flaw`, `scapegoating-by-proxy`). Some are ambient tactics with no arc, a standing
+  condition nobody is working to conclude (`color-sensitization`, `road-sensitization`,
+  `thats-a-nice`, `staged-narratives`). One is a shape over time rather than an act
+  (`performed-kindness`). This matters beyond naming because ambient tactics are near-continuous
+  and operations are episodic, so ranking tags by raw count places a daily-logged condition above a
+  quarterly operation — true and misleading at once. Deliberately not fixed: nothing consumes tag
+  type today and no logged data exists to distort, so a `kind` field now would be guessing at a
+  shape before seeing one. The trigger to add it is the first tag ranking on real data that
+  misleads; at that point add the field rather than reordering or renaming, since slugs are frozen.
+  Comment recorded above `CLICK_LOG_SCHEME_TAGS` in `lib/click-log/tags.ts`. No code behavior,
+  schema, route, contract, or public-list change.
+
 - 2026-08-04: **New scheme tag: Color Sensitization, plus a correction to The Warm Spell
   (owner-named).** `color-sensitization` — the people around a member all start wearing the same
   color, and it changes on a schedule; the cover story is a fashion trend. The owner reports this

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -218,3 +218,5 @@ of these, it is already tracked, not a new bug:
 > _Scheme list update (2026-08-04): added "The Warm Spell". List-data only — no test steps changed._
 
 > _Scheme list update (2026-08-04): added "Color Sensitization". List-data only — no test steps changed._
+
+> _Documentation note (2026-08-04): recorded a known taxonomy gap in the scheme tag list — it mixes operations with an arc, ambient tactics without one, and one entry that is a shape over time. Comment only; no tag added, removed, or renamed, and no test steps changed._

--- a/ctf/packages/web/lib/click-log/tags.ts
+++ b/ctf/packages/web/lib/click-log/tags.ts
@@ -74,6 +74,28 @@ export const CLICK_LOG_PROBLEM_TAGS: readonly ClickLogTag[] = [
   { slug: 'banking-blocked', label: 'Bank / finance accounts falsely blocked' },
 ] as const;
 
+// Known taxonomy gap, recorded 2026-08-04 (owner raised it about `color-sensitization`, and it
+// turns out to be list-wide). The entries below are not all the same kind of thing:
+//
+//   - Operations with an arc — a setup, a mechanism, an intended end state. `poisoned-well` steers
+//     someone in, stages the gossip, baits the member, and ends with that person turned.
+//     `fake-job` hires and fires. `jinx`, `windfall`, `conspiracy-carousel`, `honey-pot`,
+//     `lure-to-location`, `staged-road-rage`, `fabricated-flaw`, `scapegoating-by-proxy` are the
+//     same shape.
+//   - Ambient tactics with no arc — a standing condition the member is meant to keep noticing, with
+//     nobody working toward a conclusion: `color-sensitization`, `road-sensitization`,
+//     `thats-a-nice`, `staged-narratives`.
+//   - A shape over time rather than an act at all: `performed-kindness`.
+//
+// Why this is not just naming. Ambient tactics are near-continuous and operations are episodic, so
+// a raw count column ranks a tag logged most days far above one logged quarterly. That is
+// technically true and actively misleading, because it compares a persistent condition against
+// discrete operations.
+//
+// Deliberately NOT fixed yet: nothing consumes tag type today and no logged data exists to be
+// distorted, so adding a `kind` field now would be guessing at a shape before seeing one. The
+// trigger to add it is the first time a tag ranking on real data misleads the reader. When that
+// happens, add the field rather than reordering or renaming — the slugs are frozen.
 export const CLICK_LOG_SCHEME_TAGS: readonly ClickLogTag[] = [
   // Named in the Discourse thread (one post per scheme):
   { slug: 'scapegoating-by-proxy', label: 'The Scapegoating by Proxy' },


### PR DESCRIPTION
Documentation only. No tag added, removed, or renamed; no code behavior, schema, route, or contract change; the public `/schemes` page is unaffected.

The owner observed that Color Sensitization is an individual tactic rather than a scheme. Applied honestly, that holds across the list — the entries are not all the same kind of thing:

- Operations with an arc: a setup, a mechanism, an intended end state. `poisoned-well` steers someone in, stages the gossip, baits the member, and ends with that person turned. `fake-job` hires and fires. Same shape: `jinx`, `windfall`, `conspiracy-carousel`, `honey-pot`, `lure-to-location`, `staged-road-rage`, `fabricated-flaw`, `scapegoating-by-proxy`.
- Ambient tactics with no arc: a standing condition the member is meant to keep noticing, with nobody working toward a conclusion. `color-sensitization`, `road-sensitization`, `thats-a-nice`, `staged-narratives`.
- A shape over time rather than an act at all: `performed-kindness`.

Why this is more than naming: ambient tactics are near-continuous and operations are episodic, so a raw count column ranks a tag logged most days far above one logged quarterly. That is technically true and actively misleading, since it compares a persistent condition against discrete operations.

Deliberately not fixed in this PR. Nothing consumes tag type today and no logged data exists to be distorted, so adding a `kind` field now would be guessing at a shape before seeing one. The trigger to add it is the first tag ranking on real data that misleads a reader — and when that happens, the fix is the field, not reordering or renaming, because the slugs are frozen.

Recorded as a comment above `CLICK_LOG_SCHEME_TAGS` in `lib/click-log/tags.ts`, plus an inventory change-log entry and a test-script note.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_