### PR TITLE
docs: refresh contributor-access manual test script

### DIFF
--- a/ctf/config/code-review-ledger.json
+++ b/ctf/config/code-review-ledger.json
@@ -142,34 +142,48 @@
     {
       "name": "contributor-access",
       "type": "plugin",
-      "lastReviewedAt": null,
-      "lastRunIssues": 0,
+      "lastReviewedAt": "2026-08-05T14:30:46.085Z",
+      "lastRunIssues": 8,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/app/api/contributor-access",
+        "ctf/packages/web/components/contributor-access",
+        "ctf/packages/web/lib/contributor-access"
+      ]
     },
     {
       "name": "currencies",
       "type": "module",
-      "lastReviewedAt": null,
+      "lastReviewedAt": "2026-08-05T09:14:09.920Z",
       "lastRunIssues": 0,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/app/api/currencies"
+      ]
     },
     {
       "name": "currency",
       "type": "module",
-      "lastReviewedAt": null,
+      "lastReviewedAt": "2026-08-04T23:38:50.123Z",
       "lastRunIssues": 0,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/lib/currency"
+      ]
     },
     {
       "name": "db",
       "type": "module",
-      "lastReviewedAt": null,
+      "lastReviewedAt": "2026-08-04T23:12:28.808Z",
       "lastRunIssues": 0,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/lib/db"
+      ]
     },
     {
       "name": "directory",
@@ -188,34 +202,58 @@
     {
       "name": "engagement",
       "type": "module",
-      "lastReviewedAt": null,
+      "lastReviewedAt": "2026-08-03T10:10:15.973Z",
+      "lastRunIssues": 3,
+      "cursor": 0,
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/lib/engagement"
+      ]
+    },
+    {
+      "name": "errors",
+      "type": "module",
+      "lastReviewedAt": "2026-08-04T09:16:34.636Z",
       "lastRunIssues": 0,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/lib/errors"
+      ]
     },
     {
       "name": "feature-flags",
       "type": "module",
-      "lastReviewedAt": null,
-      "lastRunIssues": 0,
+      "lastReviewedAt": "2026-08-02T08:41:34.630Z",
+      "lastRunIssues": 5,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/lib/feature-flags"
+      ]
     },
     {
       "name": "feed",
       "type": "plugin",
-      "lastReviewedAt": null,
-      "lastRunIssues": 0,
+      "lastReviewedAt": "2026-08-01T08:38:06.926Z",
+      "lastRunIssues": 8,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/app/api/feed",
+        "ctf/packages/web/lib/feed"
+      ]
     },
     {
       "name": "feed-announcements",
       "type": "module",
-      "lastReviewedAt": null,
+      "lastReviewedAt": "2026-07-30T09:08:07.260Z",
       "lastRunIssues": 0,
       "cursor": 0,
-      "partial": false
+      "partial": false,
+      "paths": [
+        "ctf/packages/web/components/feed-announcements"
+      ]
     },
     {
       "name": "foundation",

--- a/ctf/docs/developer/test-scripts/contributor-access-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributor-access-test-script.md
@@ -1,345 +1,631 @@
 # Contributor Access — Manual Test Script
 
-> **Android: not applicable.** This feature is web-only (rule 105 / PR #1742, 2026-07-20). Test on web only: desktop and the mobile-responsive (~390px) layout. Any `android` surface tags below are retained as history but no longer apply.
+> Generated from the feature inventory and plugin contracts; this is the runnable checklist for the Contributor Access plugin. To regenerate: `pnpm --dir ctf test-script:generate -- contributor-access`
 
-> Walk these steps on a real device to confirm the module works end to end. This script is
-> generated from the module's feature inventory and contracts — those files are the source of
-> truth, this is the runnable checklist derived from them. Do not edit a step here to match a
-> bug; fix the code (or the inventory) and regenerate.
-
-| | |
+| Field | Value |
 |---|---|
-| **Module** | Contributor Access (`contributor-access`) |
-| **Visibility** | Admin dashboard + two member surfaces: the gated `#contributors` channel inside the Commons (eligible members and admins only — invisible to everyone else) and the "Weavers of the Commons" badge on Directory profiles (no launcher tile) |
-| **Roles to test** | admin · an eligible member · a non-eligible member |
-| **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) · android (React Native — member badge + gated channel surfaces) |
-| **Seed first** | `pnpm --dir ctf seed:demo` (the engine reads upstream seeded tables) |
+| **Plugin** | Contributor Access (`contributor-access`) |
+| **Visibility** | Member |
+| **Roles to test** | admin, member |
+| **Surfaces** | Web (desktop), Web (mobile-responsive) |
+| **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md` |
-| **Generated** | 2026-07-18 (initial authoring) · updated 2026-07-18 (badge + gated channel slices; channel moderation, rate limit, delete) · updated 2026-07-19 (android parity ships: badge #1680 + gated channel #1681 — member cases gain an android column) |
+| **Generated** | 2026-08-05 (commit efb8d7710) |
+
+> **Android note:** The Android (React Native) surface was removed 2026-07-20 (rule 105, PR #1742). This plugin is web-only. No android checkboxes appear in this script.
+
+---
 
 ## How to run this
 
-- Each case is **precondition → steps → expected**. Do it on each surface listed for the case.
-- Mark each surface box: ✅ pass · ❌ fail · ⛔ blocked/can't reach.
-- A ❌ becomes a row in the **Bug Reporting** plugin. Put the bug link in the notes line so the
-  next run knows it's already filed.
-- Run the **Core smoke** block every session. Run the full walkthrough when you changed this
-  module or on a pre-release sweep.
-- The member surfaces are the gated channel and the Directory badge (CA-M1/CA-M2). The single
-  most important property to confirm is the negative one: a non-eligible member finds **no
-  trace** of the channel anywhere and no badge-absence state on any profile. Also confirm a
-  non-admin cannot reach any of the admin surface.
+- Mark each check **✅ pass**, **❌ fail**, or **⛔ blocked** as you go.
+- A **❌** becomes a row in the Bug Reporting plugin — note the case ID, what you expected, and what actually happened.
+- Run **Core smoke** at the start of every test session before anything else.
+- "Web" means desktop browser unless the step says "narrow the browser to phone width" — do that for mobile-responsive checks.
 
 ---
 
 ## Core smoke (every session)
 
-1. **Non-admin cannot reach it.** As a plain member, `/admin/contributor-access` redirects to
-   `/apps`; there is no Contributor Access tile in the app launcher; the admin routes
-   (`/api/contributor-access/admin/...`) deny with a stable reason and the deny is written to
-   `contributor_access_audit_trail`. → web ☐ mobile ☐
-2. **Config edits persist.** As an admin, change the score threshold and one per-event weight,
-   save, reload the page: the saved values come back (they live in `contributor_access_config`,
-   not browser state). → web ☐ mobile ☐
-3. **Revoke requires a reason.** On an eligible member, the revoke action asks for a reason and a
-   confirmation; an empty reason is refused with a visible message and no change lands. → web ☐ mobile ☐
-4. **No score anywhere.** Nothing on the page, in any API response, or in any error shows a
-   numeric score, points, rank, or per-event counts for a member — the standing is only
-   eligible / revoked. This includes the eligible list payload
-   (`GET /api/contributor-access/admin/eligible`: id, username, date, flags only) and the
-   Directory badge read (`hasWeaversBadge` boolean only). → web ☐ mobile ☐
-5. **Badge is positive-only.** On the Directory, a member without the badge shows nothing
-   badge-related — no empty slot, no lock, no "not yet earned" state — and a community-generated
-   (unclaimed) profile never carries the field. Same on the Android profile detail. → web ☐ mobile ☐
-6. **Non-eligible member sees no gated channel.** As a signed-in member without the eligibility
-   flag: the Commons channel list shows only `#general` (desktop rail; at phone widths no channel
-   switch row appears at all), `GET /api/hub/channels` contains no `contributors` entry, and every
-   `/api/contributor-access/channel/...` call answers a bare 404 — no locked teaser, no absence
-   state, no different copy. On Android, the Commons shows no channel pill row at all — the screen
-   is exactly the shipped single-channel Commons. → web ☐ mobile ☐
+1. Sign in as an **admin**. Go to `/admin/contributor-access`. The page loads — no redirect, no blank screen, no unhandled error. web ☐
+2. Go to `/apps/directory`. Open any **claimed** Directory profile that the seed data marks as a badge holder. The "Weavers of the Commons" braid badge renders next to the member's name. web ☐
+3. Go to `/apps/directory/weavers-of-the-commons` while signed in as a **member**. The explainer page loads — no redirect, no error. web ☐
+4. Sign out, then navigate directly to `/apps/directory/weavers-of-the-commons`. You are redirected to `/apps/directory` — the page does not render. web ☐
+5. Sign in as an **eligible member** (one whose eligibility flag is set in the seed data or set manually via the admin panel). Open the Commons. The `#contributors` channel appears in the channel list alongside `#general`. web ☐
 
 ---
 
-## Member walkthrough — the "Weavers of the Commons" badge
+## Member walkthrough
 
-### CA-M1 · Badge appears only on claimed profiles of badge holders
-**Role:** member · **Surfaces:** web (desktop), web (mobile-responsive)
-**Precondition:** a claimed Directory profile whose member holds the badge
-(`contributor_access_eligibility`: `eligible = TRUE`, `revoked_for_cause = FALSE`), a claimed
-profile without it, an unclaimed (community-generated) profile, and — if available — a member who
-was revoked for cause.
+### CA-1 — Badge renders on a claimed, eligible profile
+**Role:** member (signed in) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** At least one member in the seed data has `eligible = TRUE` and `revoked_for_cause = FALSE` and has a **claimed** Directory profile. Sign in as any member.
+
 **Steps:**
-1. Open the badge-holder's Directory profile.
-2. Open the claimed profile without the badge, then the unclaimed profile.
-3. If a revoked member exists, open their claimed profile.
-**Expected:** The braid badge (rust circle, cream/gold three-strand braid ring) renders next to
-the holder's name only. On everyone else — non-holder, unclaimed, revoked-for-cause — NOTHING
-badge-related renders: no empty slot, no lock, no "not yet earned" state. The unclaimed profile's
-API payload (`GET /api/directory/profiles/:id`) has no `hasWeaversBadge` field at all; a claimed
-non-holder carries `hasWeaversBadge: false` in the payload but shows nothing in the UI. On
-Android, the same rules hold on the Directory profile detail (the RN client reads the same list
-payload).
-**Result:** web ☐ mobile ☐ — notes:
+1. Go to `/apps/directory`.
+2. Open the claimed profile of the eligible badge holder.
+3. Look at the area next to the member's name.
 
-### CA-M2 · Click-through dialog + "how it's earned" page
-**Role:** member · **Surfaces:** web (desktop), web (mobile-responsive)
+**Expected:** The "Weavers of the Commons" braid emblem (rust circle, cream/gold three-strand braid) is visible next to the name. No score, no date, no points label appears anywhere on the profile.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-2 — Badge does not render on a non-eligible profile
+**Role:** member (signed in) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** At least one member in the seed data is either not eligible or has `revoked_for_cause = TRUE`, and has a claimed profile.
+
 **Steps:**
-1. Click/tap the badge on a holder's profile.
-2. Read every word of the dialog.
-3. Follow the "How it's earned" link.
-4. Sign out and open `/apps/directory/weavers-of-the-commons` directly.
-**Expected:** The dialog is titled **"Weavers of the Commons"** with the body "This member is a
-consistent, broad contributor to the community — real help, delivered over time. Anyone can earn
-this." and a "How it's earned" link. Neither the dialog nor the page contains the words
-"verified", "vetted", or "trusted". The page explains in plain language: earned by steadily
-delivering real help to other members; permanent once earned; no application and no way to buy
-it; no score shown anywhere; the same standing opens the members-only channel in the Commons when
-it launches. It renders in the Directory shell style and works at phone width. Signed out, the
-page redirects to `/apps/directory`.
-**Android:** tapping the badge opens the same-titled dialog with the same body copy; instead of a
-link, a condensed "How it's earned" paragraph renders inline in the dialog (earned by steadily
-delivering real help; automatic; permanent; no application, no way to buy it, no score anywhere) —
-steps 3–4 are web-only. The android copy must also never contain "verified", "vetted", or
-"trusted".
-**Result:** web ☐ mobile ☐ — notes:
+1. Go to `/apps/directory`.
+2. Open the claimed profile of a non-eligible or revoked member.
+3. Look next to the member's name.
 
+**Expected:** No badge, no empty badge slot, no lock icon, no "not yet earned" text. The name area looks identical to what it would look like if the badge feature did not exist.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-3 — Badge does not render on an unclaimed (community-generated) profile
+**Role:** member (signed in) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** At least one unclaimed (community-generated) Directory profile exists in the seed data.
+
+**Steps:**
+1. Go to `/apps/directory`.
+2. Open an unclaimed profile.
+3. Look next to the name.
+
+**Expected:** No badge field of any kind. The profile layout is unchanged.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-4 — Badge click-through dialog content
+**Role:** member (signed in) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** A claimed, eligible profile is visible (same as CA-1).
+
+**Steps:**
+1. Open the eligible member's Directory profile.
+2. Click the "Weavers of the Commons" badge.
+3. Read the dialog that opens.
+
+**Expected:**
+- Title is exactly "Weavers of the Commons".
+- Body copy says this member is a consistent, broad contributor — real help delivered over time — and that anyone can earn it.
+- A "How it's earned" link is present.
+- The copy does not use the words "verified", "vetted", or "trusted by the platform".
+- No score or numeric value appears anywhere in the dialog.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-5 — "How it's earned" link navigates to the explainer page
+**Role:** member (signed in) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** The badge dialog from CA-4 is open.
+
+**Steps:**
+1. Click the "How it's earned" link inside the dialog.
+2. Observe where you land.
+
+**Expected:** You arrive at `/apps/directory/weavers-of-the-commons`. The page loads in the Directory shell. No redirect occurs.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-6 — Explainer page content
+**Role:** member (signed in) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Signed in as any member. Navigate to `/apps/directory/weavers-of-the-commons`.
+
+**Steps:**
+1. Read the full page.
+
+**Expected:**
+- The page explains that the badge is earned by steadily delivering real help to other members across the platform.
+- It states the badge is permanent once earned.
+- It states there is no application and no way to buy it.
+- It states no score is shown anywhere.
+- It mentions the same standing opens the members-only channel in the Commons.
+- No numeric score, tier, leaderboard, or ranking appears anywhere on the page.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-7 — Explainer page requires sign-in
+**Role:** signed-out visitor | **Surfaces:** web (desktop)
+
+**Precondition:** Sign out completely.
+
+**Steps:**
+1. Navigate directly to `/apps/directory/weavers-of-the-commons`.
+
+**Expected:** You are redirected to `/apps/directory`. The explainer page does not render for unauthenticated visitors.
+
+Result: web ☐
+
+---
+
+### CA-8 — Non-eligible member does not see the #contributors channel
+**Role:** member (signed in, not eligible) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Sign in as a member who is **not** eligible (no row in `contributor_access_eligibility` with `eligible = TRUE` and `revoked_for_cause = FALSE`).
+
+**Steps:**
+1. Open the Commons (`/apps/commons` or however the app routes to it).
+2. Look at the full channel list / channel rail.
+
+**Expected:**
+- `#contributors` does not appear anywhere in the channel list.
+- There is no locked entry, no greyed-out entry, no "members only" teaser, no gap in the list — the layout is identical to that of a Commons with only `#general`.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-9 — Non-eligible member gets a bare 404 from the channel API
+**Role:** member (signed in, not eligible) | **Surfaces:** web (desktop)
+
+**Precondition:** Same sign-in as CA-8.
+
+**Steps:**
+1. Open browser developer tools (Network tab).
+2. Make a GET request to `/api/contributor-access/channel/messages` (you can do this by pasting the URL in the address bar while developer tools are open, or by using fetch in the console).
+
+**Expected:** The server returns **404**. The response body contains no text, name, or identifier that reveals the channel exists. No 401, no 403, no channel name in an error message.
+
+Result: web ☐
+
+---
+
+### CA-10 — Eligible member sees the #contributors channel
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Sign in as a member with `eligible = TRUE` and `revoked_for_cause = FALSE`. The channel must be open (`channel_open = TRUE`) — confirm in the admin panel first (CA-A4). If `channel_open` is FALSE, set it to TRUE via CA-A5 first (requires enough eligible members).
+
+**Steps:**
+1. Open the Commons.
+2. Look at the channel list.
+
+**Desktop expected:** `#contributors` appears in the channel rail alongside `#general`.
+
+**Mobile-responsive expected:** A channel-pill switch row appears in the chat section showing both `#general` and `#contributors`. (This row only appears when the member has more than one channel.)
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-11 — Channel moderator disclosure is always visible
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Same as CA-10; `#contributors` channel is accessible.
+
+**Steps:**
+1. Open the `#contributors` channel.
+2. Look at the channel header.
+3. Look below the message composer.
+
+**Expected:** The text "Moderators can read this channel." is visible in the channel header. The same (or equivalent) disclosure also appears in the composer footnote area. This text is always present — it does not disappear after you read it.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-12 — Post a message in the gated channel
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Same as CA-10.
+
+**Steps:**
+1. Open the `#contributors` channel.
+2. Type a short plain-text message (e.g. "Hello from the test run") and send it.
+3. Observe the message list.
+
+**Expected:** The message appears in the channel immediately. No image upload button or file attachment control is present anywhere in the composer.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-13 — Message character limit is 4000, not 1200
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop)
+
+**Precondition:** Same as CA-10.
+
+**Steps:**
+1. Open the `#contributors` channel composer.
+2. Paste or type exactly 4000 characters of plain text.
+3. Send the message.
+4. Observe the result.
+5. Now try to send a message that is 4001 characters.
+
+**Expected:** The 4000-character message sends successfully and appears in the channel. The 4001-character message is rejected (either the composer prevents it or the server returns an error) — it does not appear in the channel.
+
+Result: web ☐
+
+---
+
+### CA-14 — Content gate blocks raw angle-bracket markup
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop)
+
+**Precondition:** Same as CA-10.
+
+**Steps:**
+1. Open the `#contributors` channel composer.
+2. Type a message containing a raw HTML tag, e.g. `Hello <script>alert(1)</script>`.
+3. Attempt to send.
+
+**Expected:** The server returns a 422 error. The message is not stored and does not appear in the channel. The UI shows the same error banner the Commons shows for a content policy violation. No partial or mangled version of the message appears.
+
+Result: web ☐
+
+---
+
+### CA-15 — Content gate blocks more than three links
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop)
+
+**Precondition:** Same as CA-10.
+
+**Steps:**
+1. Open the `#contributors` channel composer.
+2. Type a message containing four URLs (e.g. `https://a.com https://b.com https://c.com https://d.com`).
+3. Attempt to send.
+
+**Expected:** The server returns 422. The message is not stored, does not appear in the channel, and the UI shows the content policy error banner.
+
+Result: web ☐
+
+---
+
+### CA-16 — Rate limit at 8 posts per 30 minutes
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop)
+
+**Precondition:** Same as CA-10. The test member has not posted in the last 30 minutes (or use a fresh seed / a fresh test account).
+
+**Steps:**
+1. Send 8 plain-text messages in rapid succession (each must pass the content gate — no markup).
+2. Attempt to send a 9th message within the same 30-minute window.
+
+**Expected:** Messages 1–8 appear in the channel. The 9th attempt is rejected with a 429 error. The UI shows the same rate-limit error banner the Commons shows (`rate_limit_exceeded`). The 9th message does not appear in the channel.
+
+Result: web ☐
+
+---
+
+### CA-17 — Quoted (threaded) reply
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Same as CA-10. At least one message exists in the channel.
+
+**Steps:**
+1. Hover over (or long-press on mobile) an existing message and choose the reply / quote action.
+2. Type a reply and send it.
+3. Observe the new message in the channel.
+
+**Expected:** The new message shows a quoted block referencing the original message. The quoted block is presented as a button that, when clicked, scrolls to and highlights the original message (web). The reply is stored and visible to other eligible members when they load the channel.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-18 — Reaction toggle — gated emoji set
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Same as CA-10. At least one message exists in the channel.
+
+**Steps:**
+1. Open the reaction picker on a message.
+2. Count the available emojis.
+3. Add one reaction.
+4. Click the same emoji again (toggle off).
+
+**Expected:** Exactly 12 emojis are available (more than the Commons' 6). Adding the reaction shows it on the message with a count. Clicking it again removes your reaction (count decreases or disappears). No emoji outside the fixed gated set can be submitted.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-19 — Author can delete their own message
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Same as CA-10. Post a new message as the test member.
+
+**Steps:**
+1. Hover over (or long-press on mobile) the message you just posted.
+2. Choose the Delete action.
+3. Confirm the deletion in the confirmation dialog.
+4. Observe the message list.
+
+**Expected:** The message disappears from the channel. It is no longer visible to the author or any other member loading the channel. (Internally it is soft-deleted — the row still exists — but no user-facing surface shows it.)
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-20 — Author cannot delete another member's message
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop)
+
+**Precondition:** Same as CA-10. At least one message in the channel was posted by a **different** eligible member (post one yourself as member A, then sign in as member B).
+
+**Steps:**
+1. Sign in as member B (eligible, not the author of member A's message).
+2. Open the `#contributors` channel.
+3. Hover over member A's message.
+
+**Expected:** No Delete action is available for member B on member A's message. If the action is somehow invoked (e.g. via a direct API call), the server returns 403 and the message remains visible.
+
+Result: web ☐
+
+---
+
+### CA-21 — Edit action on own message (delete + repost flow)
+**Role:** member (signed in, eligible) | **Surfaces:** web (desktop)
+
+**Precondition:** Same as CA-10. Post a message as the test member.
+
+**Steps:**
+1. Hover over your own message and choose the Edit action.
+2. The composer loads with the original text.
+3. Change the text and send.
+4. Observe the channel.
+
+**Expected:** The original message is removed from the channel. A new message with the updated text appears. The new message has a new timestamp. No in-place edit occurred — it is a fresh post. No edit action appears on another member's message.
+
+Result: web ☐
 
 ---
 
 ## Admin walkthrough
 
-### CA-A1 · Access gate — admin only
-**Role:** admin (and a plain member to confirm denial) · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. As a plain member, open `/admin/contributor-access` and call `GET /api/contributor-access/admin/config`.
-2. As an admin, open the same page.
-**Expected:** The member is redirected to `/apps` and the route denies `missing_required_role`
-(the `operations` role is NOT admitted — this module is admin-only). The admin sees the shell with
-its three sections. Allow and deny both write `contributor_access_audit_trail` rows.
-**Result:** web ☐ mobile ☐ — notes:
+### CA-A1 — Admin page access gate
+**Role:** admin, then member | **Surfaces:** web (desktop)
 
-### CA-A2 · Eligible members list, revoke, reinstate
-**Role:** admin · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. Read the eligible list (empty state first if nobody qualifies yet — it explains the weekly
-   recompute admits members as they qualify).
-2. After a recompute has admitted someone, revoke them: supply a reason, confirm.
-3. Reinstate the same member.
-**Expected:** Revoke flips the row to "Revoked for cause" with the reason shown; the member's
-`eligible` flag turns off but `first_earned_at` is untouched. Reinstate restores `eligible` and
-clears the revocation fields. Both actions require the CSRF header (the shell sends it), write
-audit rows, and 404 cleanly when the member has no earned row. Loading, empty, error, and
-populated states all render.
-**Result:** web ☐ mobile ☐ — notes:
+**Precondition:** Have both an admin account and a plain member account available.
 
-### CA-A3 · Config editor
-**Role:** admin · **Surfaces:** web (desktop), web (mobile-responsive)
 **Steps:**
-1. Edit threshold, the four minimums, and several per-event weights (the fixed fifteen-key list —
-   one labeled numeric input each); save.
-2. Try a negative number and a non-number.
-3. Look at the channel-open toggle.
-**Expected:** Valid saves persist and reload; invalid values are refused with a plain message
-(client-side and again server-side — the route rejects unknown weight keys and negative numbers).
-**Result:** web ☐ mobile ☐ — notes:
+1. Sign in as **admin**. Navigate to `/admin/contributor-access`.
+2. Confirm the page loads.
+3. Sign out. Sign in as a plain **member**. Navigate to `/admin/contributor-access`.
 
-### CA-A4 · Channel launch gate and status card
-**Role:** admin · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. With the eligible count BELOW `min_eligible_to_open_channel`: look at the channel-open toggle,
-   then try to force it anyway with a direct
-   `PUT /api/contributor-access/admin/config` carrying `{"channelOpen": true}`.
-2. Lower `min_eligible_to_open_channel` to at or below the current eligible count, save, and flip
-   the toggle on.
-3. Read the status card in both states.
-**Expected:** Below the minimum the toggle is disabled with the explanatory note (locked until N
-members are eligible), and the direct API call is refused with 409 and the stable code
-`contributor_access_channel_below_minimum` (the deny lands in the audit trail) — the client is
-never trusted. At or above the minimum the toggle works; saving open creates the Stream channel
-and runs the first membership sync. The status card shows `eligible / needed`, the OPEN/CLOSED
-badge, and (when open and Stream is configured) the synced member count; closing an open channel
-is always allowed.
-**Result:** web ☐ mobile ☐ — notes:
+**Expected:** Admin sees the full Contributor Access admin shell — eligible members section, config editor, and channel status card. The member is redirected to `/apps` and never sees admin content.
 
-### CA-A5 · Internal recompute route
-**Role:** operator with `INTERNAL_SERVICE_SECRET` · **Surfaces:** API only
-**Steps:**
-1. `POST /api/internal/contributor-access/recompute` with no auth header, a wrong bearer, and the
-   real bearer.
-2. Run it twice in a row.
-**Expected:** 501 when the secret is unconfigured; 401 on a missing/wrong bearer; 200 with
-`{ ok, evaluated, eligible }` counts only (no per-member data) on the real bearer. A second run is
-safe (idempotent upserts). A member who was eligible before the run is still eligible after —
-recompute never revokes. The weekly workflow (`contributor-access-recompute.yml`, Mondays
-06:30 UTC + manual dispatch) calls this same route.
-**Result:** api ☐ — notes:
+Result: web ☐
 
 ---
 
-## Gated channel walkthrough (member surface)
+### CA-A2 — Eligible members list shows categorical data only
+**Role:** admin | **Surfaces:** web (desktop)
 
-> Precondition for all cases: the channel is open (`channel_open` TRUE — see CA-A4) and the
-> one-time Stream channel-type script has run for this environment (only needed for the live
-> layer; polling works without it).
+**Precondition:** At least one member is eligible (seed data or manually triggered). Sign in as admin. Go to `/admin/contributor-access`.
 
-### CA-C1 · Non-eligible member sees nothing, anywhere
-**Role:** signed-in member WITHOUT the eligibility flag · **Surfaces:** web (desktop), web (mobile-responsive)
 **Steps:**
-1. Open the Commons. Inspect the desktop channel rail and the phone-width chat section.
-2. Call `GET /api/hub/channels` and each `/api/contributor-access/channel/...` route directly.
-**Expected:** Only `#general` in the rail; at phone widths NO channel switch row renders (it only
-exists with more than one channel). The channels payload has no `contributors` entry. Every
-channel route answers a bare 404 with no channel name, no "locked", no "you need X" — nothing
-that reveals the channel exists. There is no teaser on any surface. On Android, the Commons
-renders exactly as it ships today — no channel pill row exists at all (it only renders when the
-server-filtered channel list carries the contributors entry).
-**Result:** web ☐ mobile ☐ — notes:
+1. Look at the eligible members section.
+2. Check every column and data point displayed per member.
 
-### CA-C2 · Eligible member: sees, posts, threads, reacts — no image upload
-**Role:** eligible member · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. Open the Commons: pick `#contributors` (desktop rail; phone-width pill row).
-2. Post a message; reply to an existing message (Reply → send); toggle reactions, opening the
-   picker to view the full set.
-3. Try to attach an image by any means (look for any attach/upload affordance; paste an image
-   into the composer).
-4. Write a long message (over 1200 characters, under 4000) and send it.
-**Expected:** The channel renders with the Commons look. Posting works; the reply renders with the
-quoted block (thread), and **tapping that quoted block on web scrolls to the original message and
-briefly highlights it** (the same jump the Commons has; on Android the quoted block is not yet
-tappable — tracked parity gap). The reaction picker offers the twelve-emoji gated set (richer than the
-Commons' six) and toggling works. There is NO image/file affordance anywhere and pasting an image
-does nothing — text only. The long message sends (the gated cap is 4000, higher than the Commons'
-1200). With a second eligible account: a new post appears on the other screen within the poll
-interval (or instantly when the live layer is connected, with typing indicators). On Android, the
-Commons header gains a `#general` / `#contributors` pill row; picking `#contributors` opens the
-channel with the same behavior (post, quoted reply, twelve-emoji reaction picker, no upload
-affordance, 4000-character composer limit; polling only — no typing indicators on Android).
-**Result:** web ☐ mobile ☐ — notes:
+**Expected:** Each row shows user ID (or username), first-earned date, and revoke flag/reason. **No score, no numeric point total, no per-event counts, no reason_snapshot data appears anywhere** — not in a tooltip, not in a collapsed section. The list is categorical only.
 
-### CA-C3 · Moderator disclosure is plainly visible
-**Role:** eligible member (and an admin) · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. Open `#contributors` and read the header area and the composer footnote.
-2. As an admin (without the eligibility flag): confirm the channel is listed and readable.
-**Expected:** The header carries "Moderators can read this channel." at all widths, always — not
-in a tooltip, not behind a tap; the composer footnote repeats it. The admin can open and read the
-channel (that read access is exactly what the disclosure line discloses). Android shows the same
-line in the channel header and repeats it under the composer.
-**Result:** web ☐ mobile ☐ — notes:
-
-### CA-C4 · Revoke removes the member from the channel
-**Role:** admin + the revoked member · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. With the channel open, revoke an eligible member for cause (CA-A2 flow).
-2. As that member: reload the Commons; call the channel routes directly.
-3. Reinstate the member and re-check.
-**Expected:** After the revoke, the member's channel entry is gone from `/api/hub/channels`, the
-channel routes answer a bare 404, and the Stream membership sync has removed them from
-`ctf-contributors` (the admin status card's member count drops). No teaser remains — their Commons
-looks exactly like a never-eligible member's. Reinstating restores the entry and access. A Stream
-outage during revoke/reinstate never blocks the action itself (the response carries a
-`channelSyncWarning` and membership reconciles on the next sync). On Android, a 404 mid-session
-silently drops the pill row and lands the member back on the Commons — no error banner, no retry
-loop.
-**Result:** web ☐ mobile ☐ — notes:
-
-### CA-C5 · Posting rate limit (same threshold as the Commons)
-**Role:** eligible member · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. In `#contributors`, post 8 short messages inside a few minutes.
-2. Post a 9th.
-3. Wait past the window (or use a second account) and post again.
-**Expected:** The first 8 send. The 9th is refused with the same error-banner state the Commons
-shows when its posting limit trips (the route answers 429 with the stable code
-`rate_limit_exceeded`); nothing is stored for it. Deleting one of your posts does NOT free a slot
-(deleted rows still count toward the window). After the 30-minute window passes, posting works
-again. Android shows the refusal as the same send-error line the Commons uses ("You are posting
-too quickly…").
-**Result:** web ☐ mobile ☐ — notes:
-
-### CA-C6 · Content gate — a blocked post is never shown to anyone
-**Role:** eligible member + a second eligible account · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. Try to post a message containing raw angle-bracket markup (e.g. `<script>hello</script>`).
-2. Try to post a message containing four or more `https://` links.
-3. On the second account, watch the channel during and after both attempts.
-**Expected:** Both posts are refused with a visible moderation message (the route answers 422
-with the stable code `content_policy_violation`) — the same content gate the Commons runs on
-community posts. Neither post is ever stored, so the second account never sees them, not even
-briefly; the composer keeps the text so the member can fix and resend. Android surfaces the same
-moderation message on refusal.
-**Result:** web ☐ mobile ☐ — notes:
-
-### CA-C7 · Delete — author-only, admin-any, gone for good
-**Role:** two eligible members + an admin · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. As member A: post a message; confirm a Delete action shows on your own message but NOT on
-   member B's messages; delete your message (a confirm step must appear).
-2. As member A: call `DELETE /api/contributor-access/channel/messages/[postId]` directly on one
-   of member B's posts.
-3. As the admin: confirm the Delete action shows on every message; delete one of member B's
-   posts (confirm step again).
-4. On every account: hard-refresh the channel and re-read
-   `GET /api/contributor-access/channel/messages`.
-**Expected:** The member's own delete works after the confirm and the message disappears
-everywhere (both accounts, within the poll interval). The direct API attempt on someone else's
-post is refused with 403 and changes nothing (the denied attempt lands in
-`contributor_access_audit_trail`). The admin can delete any message — that is the disclosed
-moderator power — and the removal is audited under the distinct moderator command. Deleted
-messages stay gone after refresh and re-login (soft delete: `deleted_at`/`deleted_by` set,
-content excluded from every read, and a reply that quoted a deleted message shows no quoted
-block). Reacting to or replying to a deleted message answers 404/400. On Android, the Delete
-action shows only on the member's own messages and is confirm-gated (system dialog); the admin
-delete-any affordance is web-only for now (the server still enforces admin delete on the API).
-**Result:** web ☐ mobile ☐ — notes:
-
-### CA-C8 · Edit — delete + repost, no history rewrite
-**Role:** eligible member + a second eligible account · **Surfaces:** web (desktop), web (mobile-responsive)
-**Steps:**
-1. As member A: post a message; confirm an Edit action shows on your own message but NOT on
-   member B's messages.
-2. Tap Edit: confirm the original message is deleted and its text is loaded into the composer.
-3. Change the text and send the fresh message.
-4. On the second account: read the channel and re-read `GET /api/contributor-access/channel/messages`.
-**Expected:** There is no in-place edit — tapping Edit deletes the original (it disappears
-everywhere within the poll interval) and drops its text into the composer. The reposted message
-is a brand-new message with a new id and a new timestamp; the original's timestamp is not
-carried over and its history is not rewritten. The second account sees the original vanish and the
-new message appear. Edit shows only on the member's own messages.
-**Result:** web ☐ mobile ☐ — notes:
+Result: web ☐
 
 ---
 
-### CA-C9 · Contributor eligibility also grants the private Chyme audio room
-**Role:** eligible member, non-eligible member, admin · **Surfaces:** web (mobile-responsive)
-**Note:** the room itself lives in the Chyme plugin; this check confirms the SAME eligibility gate
-carries over. The full room walkthrough is the Chyme test script's **CH-17** — run that for the audio
-and chat behavior; here just confirm the gate matches this module's channel gate.
+### CA-A3 — For-cause revoke requires a non-empty reason
+**Role:** admin | **Surfaces:** web (desktop)
+
+**Precondition:** At least one eligible member is listed. Sign in as admin.
+
 **Steps:**
-1. Confirm the contributor channel is open (`contributor_access_config.channel_open = true`).
-2. In Chyme, open the **Weavers of the Commons** room tab as each role.
-**Expected:** The private Chyme room opens for exactly the same members as the gated Commons chat
-channel — eligible members and admins get in; a non-eligible member sees the "how it's earned"
-explainer (no locked/absence state). With the channel closed, only an admin enters. The gate is the
-shared eligibility flag + channel-open switch (no separate Chyme allowlist).
-**Result:** web ☐ mobile ☐ — notes:
+1. Go to `/admin/contributor-access`, eligible members section.
+2. Click Revoke on an eligible member.
+3. Leave the reason field empty and attempt to confirm.
+4. Then enter a reason (e.g. "Test revocation — this is a manual test run") and confirm.
+
+**Expected:** With an empty reason, the revoke does not proceed — the UI shows a validation error or the confirm button is disabled. With a non-empty reason and confirmation, the revoke succeeds, the member is marked revoked, and their revoked status is visible in the list.
+
+Result: web ☐
+
+---
+
+### CA-A4 — Revoked member loses channel access and badge
+**Role:** admin (to revoke), then member (to verify) | **Surfaces:** web (desktop)
+
+**Precondition:** An eligible member with a claimed Directory profile has been revoked per CA-A3. The channel is open.
+
+**Steps:**
+1. Sign in as the revoked member.
+2. Open the Commons and look at the channel list.
+3. Navigate to `/api/contributor-access/channel/messages` (or attempt to use the channel UI).
+4. Open the revoked member's Directory profile.
+
+**Expected:**
+- `#contributors` does not appear in the channel list. No locked teaser is shown.
+- The channel API returns a bare 404 with no channel trace.
+- The "Weavers of the Commons" badge does not appear on the Directory profile. No empty badge slot renders.
+
+Result: web ☐
+
+---
+
+### CA-A5 — Reinstate restores channel access and badge
+**Role:** admin (to reinstate), then member (to verify) | **Surfaces:** web (desktop)
+
+**Precondition:** The member revoked in CA-A3/CA-A4 is still revoked. The channel is open.
+
+**Steps:**
+1. Sign in as admin. Go to `/admin/contributor-access`.
+2. Click Reinstate on the revoked member. Confirm.
+3. Sign in as the reinstated member.
+4. Open the Commons.
+5. Open the reinstated member's Directory profile.
+
+**Expected:** The reinstate succeeds. The member can now see `#contributors` in the channel list. The "Weavers of the Commons" badge reappears on their Directory profile. The `first_earned_at` date in the admin list is unchanged (it was not reset by the revoke/reinstate cycle).
+
+Result: web ☐
+
+---
+
+### CA-A6 — Admin can read the gated channel (moderator read access)
+**Role:** admin | **Surfaces:** web (desktop)
+
+**Precondition:** The channel is open and contains at least one message.
+
+**Steps:**
+1. Sign in as admin (the admin does not need the eligibility flag).
+2. Open the Commons. Look for `#contributors` in the channel list.
+3. Open the channel and read the messages.
+
+**Expected:** `#contributors` is visible to the admin in the channel list. The admin can read all messages. The moderator disclosure ("Moderators can read this channel.") is present in the channel header, consistent with what eligible members see (CA-11).
+
+Result: web ☐
+
+---
+
+### CA-A7 — Admin can delete any member's message (moderator delete)
+**Role:** admin | **Surfaces:** web (desktop)
+
+**Precondition:** The channel is open and contains a message posted by a member (not the admin).
+
+**Steps:**
+1. Sign in as admin. Open the `#contributors` channel.
+2. Hover over a message posted by a member and choose the Delete action.
+3. Confirm the deletion.
+4. Observe the channel.
+
+**Expected:** The message disappears from the channel. It is no longer visible to any user loading the channel. The admin's delete is a soft delete (the row is retained internally with `deleted_by` set). This is a distinct audit path from an author self-delete (tracked internally as `contributor-access.channel.post.moderator-delete`).
+
+Result: web ☐
+
+---
+
+### CA-A8 — Config editor loads with current values
+**Role:** admin | **Surfaces:** web (desktop), web (mobile-responsive)
+
+**Precondition:** Sign in as admin. Go to `/admin/contributor-access`.
+
+**Steps:**
+1. Open the config editor section.
+2. Note the visible fields.
+
+**Expected:** The editor shows: score threshold, minimum account age (days), minimum distinct plugins, minimum distinct counterparties, minimum eligible members to open channel, and per-event weight overrides. It also shows the channel open/closed toggle and the channel status card (eligible count vs minimum, OPEN/CLOSED badge, synced Stream member count or "unavailable"). All values match the system defaults (threshold 100, age 90 days, 3 plugins, 5 counterparties, 10 min eligible) if the config has never been written.
+
+Result: web ☐ mobile-responsive ☐
+
+---
+
+### CA-A9 — Config update saves successfully
+**Role:** admin | **Surfaces:** web (desktop)
+
+**Precondition:** Sign in as admin. Go to `/admin/contributor-access`, config editor.
+
+**Steps:**
+1. Change the score threshold to a new value (e.g. 95).
+2. Save.
+3. Reload the page and reopen the config editor.
+
+**Expected:** The saved threshold value (95) is shown on reload. The update did not error. The channel open state is unchanged.
+
+Result: web ☐
+
+---
+
+### CA-A10 — Channel open toggle is launch-gated below the minimum
+**Role:** admin | **Surfaces:** web (desktop)
+
+**Precondition:** Sign in as admin. The eligible count is below `min_eligible_to_open_channel` (default 10). If the seed data produces fewer than 10 eligible members, this condition should hold naturally.
+
+**Steps:**
+1. Go to `/admin/contributor-access`, config editor.
+2. Observe the channel toggle.
+3. Attempt to turn the channel open toggle ON and save.
+
+**Expected:** The toggle is locked or carries an explanatory note indicating the channel cannot open until the eligible count reaches the minimum. If the toggle is somehow enabled and the save is sent, the server returns **409** with the stable code `contributor_access_channel_below_minimum`. The channel state remains closed. The channel status card shows the current eligible count vs the required minimum.
+
+Result: web ☐
+
+---
+
+### CA-A11 — Channel open toggle works once the minimum is met
+**Role:** admin | **Surfaces:** web (desktop)
+
+**Precondition:** The eligible count meets or exceeds `min_eligible_to_open_channel`. (Lower the minimum via the config editor if needed — set it to 1, save, then try the open toggle. Remember to restore it after the test.) The channel is currently closed.
+
+**Steps:**
+1. Go to `/admin/contributor-access`, config editor.
+2. Set `minEligibleToOpenChannel` to 1 (if eligible count is low) and save.
+3. Turn the channel open toggle ON and save.
+
+**Expected:** The save succeeds. The channel status card shows **OPEN**. Eligible members can now see `#contributors` in the Commons (verify with CA-10 using an eligible member account). A `channelSyncWarning` may appear if Stream is not configured in the demo environment — that is expected and is not a failure of the config save itself.
+
+Result: web ☐
+
+---
+
+### CA-A12 — Closing an open channel is always allowed
+**Role:** admin | **Surfaces:** web (desktop)
+
+**Precondition:** The channel is currently open (CA-A11 completed). Sign in as admin.
+
+**Steps:**
+1. Go to `/admin/contributor-access`, config editor.
+2. Turn the channel open toggle OFF and save.
+3. Sign in as an eligible member and open the Commons.
+
+**Expected:** The save succeeds immediately with no minimum-check error — closing is unconditional. The eligible member no longer sees `#contributors` in the channel list. The channel API returns a bare 404. The channel status card shows **CLOSED**.
+
+Result: web ☐
+
+---
+
+### CA-A13 — Operations role cannot access the admin page
+**Role:** user with `operations` role only | **Surfaces:** web (desktop)
+
+**Precondition:** A user account exists with the `operations` role but not `admin`. If the seed data does not provide one, skip this case and note it as blocked.
+
+**Steps:**
+1. Sign in as the operations-role user.
+2. Navigate to `/admin/contributor-access`.
+
+**Expected:** The user is redirected to `/apps`. No admin content renders.
+
+Result: web ☐
+
+---
+
+## Parity check (web ↔ android)
+
+Android was removed on 2026-07-20 (rule 105, PR #1742). There is no Android surface to compare. All parity checks in this script are web desktop ↔ web mobile-responsive only.
+
+| Case | What must match across desktop and mobile-responsive |
+|---|---|
+| CA-1 | Badge renders on eligible claimed profile |
+| CA-2 | Badge absent on non-eligible profile (no empty slot) |
+| CA-3 | Badge absent on unclaimed profile |
+| CA-4 | Dialog title, body copy, link — identical content |
+| CA-8 | Non-eligible member sees no channel entry, no teaser |
+| CA-10 | Eligible member sees `#contributors` (pill row on mobile, rail on desktop) |
+| CA-11 | Moderator disclosure text present in header and composer footnote |
+| CA-12 | Post sends; no upload affordance in composer |
+| CA-17 | Quoted reply renders with quote block |
+| CA-18 | Reaction picker shows 12 emojis; toggle works |
+| CA-19 | Author can delete own message with confirmation |
+| CA-A8 | Config editor fields and channel status card visible |
 
 ---
 
 ## Known gaps — do not file these as bugs
 
-Carried from the inventory's "Gaps & Known Technical Debt" section:
-
-- One-time owner step per Stream app: run `ctf/scripts/setupGatedChannelType.mjs` (production and
-  staging) before the live layer/channel config exists in Stream; until then opening the channel
-  returns a `channelSyncWarning`.
-- Android parity shipped 2026-07-19 (#1680 badge, #1681 channel). Remaining android deltas
-  (deliberate): no live typing indicators (polling only), no admin delete-any affordance in the
-  RN channel UI (server-enforced on the API), and the "how it's earned" explainer is condensed
-  into the badge dialog instead of a separate page.
-- No in-place message edit in the gated channel (deliberate). Edit is delete + repost: the Edit
-  action pulls the text into the composer, deletes the original, and the member sends a fresh
-  message with a new timestamp — history is never rewritten. Same behavior as the Commons.
-- Default weights/threshold are a starting point pending owner tuning.
-- Active blocks/safety reports are not yet an admission gate (owner decision pending).
+- **One-time Stream setup not done:** The `ctf-gated` channel type must be created manually by running `ctf/scripts/setupGatedChannelType.mjs` against the staging credentials before the channel can be created on Stream. If the channel open toggle succeeds but returns a `channelSyncWarning`, and Stream membership is not visible, this is the likely cause — not a code bug.
+- **Default weights not owner-tuned:** The shipped `DEFAULT_WEIGHTS` are a starting point. Members may or may not reach eligibility in the seed data depending on the demo data volume. Adjust `minEligibleToOpenChannel` downward in the config editor for local testing if needed.
+- **Clean-standing gate is partial:** Active blocks and safety reports are not yet read as an admission gate. A member with an active block could be eligible. This is a tracked gap pending an owner decision, not a bug.
+- **No per-member admin drill-down:** The admin eligible list shows no breakdown of how a member earned eligibility (no score, no per-event view). This is intentional.
+- **Quoted-reply jump not available on mobile-responsive:** Clicking the quoted block to scroll to the original message is web (desktop) only. The mobile-responsive quoted block displays the reference but is not yet a tappable scroll target.
+- **No message edit on mobile-responsive:** The Edit (delete + repost) action is confirmed on web desktop. Mobile-responsive parity for the edit action is not tracked as a separate gap in the inventory — verify whether it surfaces in the mobile layout during CA-21, but do not file if absent (it is not listed as a completed mobile feature).
+- **`CONTRIBUTOR_ACCESS_PROFILE_AND_DELETION_CONTRACT.md` not yet authored:** The deletion behavior is wired, but the standalone contract document is still outstanding. Do not file this as a bug.

--- a/ctf/docs/developer/test-scripts/contributor-access-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributor-access-test-script.md
@@ -166,7 +166,7 @@ Result: web ☐
 
 **Expected:**
 - `#contributors` does not appear anywhere in the channel list.
-- There is no locked entry, no greyed-out entry, no "members only" teaser, no gap in the list — the layout is identical to that of a Commons with only `#general`.
+- There is no locked entry, no grayed-out entry, no "members only" teaser, no gap in the list — the layout is identical to that of a Commons with only `#general`.
 
 Result: web ☐ mobile-responsive ☐
 


### PR DESCRIPTION
Auto-refresh of the manual test script for the plugin the code-review sweep just covered.

Parity Status: web + mobile-responsive + android complete