### PR TITLE
fix: check gated channel posting rate limit before reply lookup

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
@@ -133,7 +133,9 @@ audit-trailed, same posture as the Commons hub routes — post deletions ARE aud
   at most three links — a failing post is refused with 422 `content_policy_violation`, never
   stored, never visible to anyone) and the per-member posting rate limit (8 posts per 30 minutes,
   counted in the database like the Commons' `evaluateFeedRateLimit` — over the window is 429
-  `rate_limit_exceeded`, shown to the member as the same error banner the Commons shows).
+  `rate_limit_exceeded`, shown to the member as the same error banner the Commons shows). The rate
+  limit is checked before the reply-target lookup, so a member over the window always gets
+  `rate_limit_exceeded` whatever `replyToPostId` they send.
   Contract: `contributor-access.channel.message.create`.
 - `DELETE /api/contributor-access/channel/messages/[postId]` — soft-delete a post (same route
   shape as the Commons' `DELETE /api/hub/messages/[postId]`): the author may delete their own
@@ -350,6 +352,13 @@ fill on the first recompute / config save / member post.
 
 ## Change Log
 
+- 2026-08-05 — Gated channel post creation: the per-member posting rate limit now runs as the first
+  database check, before the reply-target lookup (`createGatedChannelPost` in
+  `lib/contributor-access/channel-repository.ts`). A member over the 8-per-30-minutes window used to
+  get `reply_target_not_found` instead of `rate_limit_exceeded` when they also sent an unknown
+  `replyToPostId`; the error a caller sees no longer depends on the reply id, and no reply lookup
+  runs for someone who cannot post anyway. Both cases were already refused, so nothing that was
+  blocked before is allowed now. No schema, route, or contract change. Code review issue #2121.
 - 2026-07-23 — Contributor eligibility now grants a **second private surface**: a private "Weavers of the Commons" **Chyme audio room** (`chyme-contributors-room`), alongside the existing gated Commons chat channel. Same gate as the channel — the channel-open switch plus the eligibility flag (or admin) — enforced by a new `requireChymeContributorAccess` in the Chyme plugin, with the same bare-404 no-shaming behavior. Built entirely in the Chyme plugin (room switcher + room-scoped routes/repository); this module's eligibility engine and `isMemberEligible`/`getContributorAccessConfig` are reused unchanged — no change to contributor-access schema, routes, or contracts. See the Chyme inventory for the implementation. Audio + room-chat MVP (tips/Back Channel deferred). Web-only (rule 105).
 - 2026-07-22 — Gated #contributors channel: added an **Edit** action on a member's own message (edit = delete + repost, matching the Commons home channel). It loads the message text into the composer and deletes the original (existing author-only delete), so the member fixes it and sends a fresh message — no in-place edit, a new row with a new timestamp. Edit shows on your own messages only (admins keep delete-any as moderation, but cannot "edit" someone else's). `gated-chat-panel.tsx` + `use-gated-chat.ts`; reuses the existing delete + send, no schema/route/contract change. Verified: `@ctf/web` typecheck + eslint clean.
 - 2026-07-19 — Gated channel: tapping a quoted reply now jumps to the original message on web (same

--- a/ctf/docs/developer/test-scripts/contributor-access-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributor-access-test-script.md
@@ -297,6 +297,8 @@ Result: web ☐
 
 **Expected:** Messages 1–8 appear in the channel. The 9th attempt is rejected with a 429 error. The UI shows the same rate-limit error banner the Commons shows (`rate_limit_exceeded`). The 9th message does not appear in the channel.
 
+**API edge (optional, developer tools):** while over the window, a POST to `/api/contributor-access/channel/messages` with an unknown `replyToPostId` still returns the 429 `rate_limit_exceeded` — the rate limit is checked before the reply-target lookup, so the reply id cannot change which error comes back (2026-08-05 fix, issue #2121).
+
 Result: web ☐
 
 ---

--- a/ctf/packages/web/lib/contributor-access/channel-repository.ts
+++ b/ctf/packages/web/lib/contributor-access/channel-repository.ts
@@ -162,6 +162,13 @@ export async function createGatedChannelPost(input: {
   if (!passesGatedChannelModeration(body)) {
     throw new Error('content_policy_violation');
   }
+  // The rate limit is the first database check, before the reply-target lookup, so a member who
+  // is over the posting window always gets 'rate_limit_exceeded' — the reply id they send cannot
+  // change which error comes back, and no extra query runs for a caller who cannot post anyway.
+  const allowed = await evaluateGatedChannelPostRateLimit(input.authorUserId);
+  if (!allowed) {
+    throw new Error('rate_limit_exceeded');
+  }
   if (input.replyToPostId) {
     const target = await queryDb<{ id: string }>(
       `SELECT id FROM contributor_access_channel_posts
@@ -171,10 +178,6 @@ export async function createGatedChannelPost(input: {
     if (target.rows.length === 0) {
       throw new Error('reply_target_not_found');
     }
-  }
-  const allowed = await evaluateGatedChannelPostRateLimit(input.authorUserId);
-  if (!allowed) {
-    throw new Error('rate_limit_exceeded');
   }
   const result = await queryDb<{ id: string; created_at: string }>(
     `INSERT INTO contributor_access_channel_posts (id, author_user_id, author_username, body, reply_to_post_id, moderation_status)


### PR DESCRIPTION
Closes #2121

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — this is a server-side ordering change inside the shared `POST /api/contributor-access/channel/messages` handler, so the Android channel screen gets it with no client change.

## What changed

In `createGatedChannelPost` (`ctf/packages/web/lib/contributor-access/channel-repository.ts`) the per-member posting rate limit now runs as the first database check, before the reply-target lookup.

Before, a member over the 8-posts-per-30-minutes window who also sent an unknown `replyToPostId` got `reply_target_not_found` instead of `rate_limit_exceeded`. Both cases were refused either way, so nothing that was blocked before can be stored now — what changes is which error the caller sees, and that a member who cannot post no longer triggers a reply lookup.

## On the second half of the finding

The issue also states the rate-limit count wrongly includes soft-deleted rows. That does not hold: counting soft-deleted rows is deliberate, so delete-and-repost cannot reset the window, and the comment above the query already says exactly that. Left as is.

## Inventory

`ctf-contributor-access-feature-inventory.md`: the `POST .../channel/messages` route description now states the check order, and a change log entry records the fix. No schema, route, or contract change.

## Checks

`pnpm --filter @ctf/web typecheck` clean; the pre-commit gate ran typecheck across web, mobile, and shared — all pass.