### PR TITLE
fix: gated channel reaction UUID guard, SQL-ordered window, Stream client cleanup

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
@@ -145,8 +145,9 @@ audit-trailed, same posture as the Commons hub routes — post deletions ARE aud
   message content never enters Stream (the live layer carries only presence/typing). Contract:
   `contributor-access.channel.post.delete`.
 - `POST /api/contributor-access/channel/messages/[postId]/reactions` — body `{ emoji }`; toggles
-  the viewer's reaction; emoji validated against the fixed twelve-emoji gated set. Contract:
-  `contributor-access.channel.reaction.toggle`.
+  the viewer's reaction; emoji validated against the fixed twelve-emoji gated set. A malformed
+  (non-UUID) post id is a 404 `post_not_found`, same as a missing post — never a database cast
+  error. Contract: `contributor-access.channel.reaction.toggle`.
 - `POST /api/contributor-access/channel/join` — mints Stream live-layer credentials (channel type
   `ctf-gated`, channel `ctf-contributors`) via the shared resolver; `configured: false` when
   Stream is absent and the client stays on polling. Contract: `contributor-access.channel.join`.
@@ -350,6 +351,17 @@ fill on the first recompute / config save / member post.
 
 ## Change Log
 
+- 2026-08-06 — Gated channel hardening from the code-review sweep (issues #2124, #2125, #2126,
+  #2127; `lib/contributor-access/channel-repository.ts` + `lib/contributor-access/gated-channel.ts`).
+  (1) `toggleGatedChannelReaction` now runs the same UUID format guard as
+  `deleteGatedChannelPost` (shared `UUID_PATTERN`), so a malformed post id returns the mapped 404
+  `post_not_found` instead of a Postgres cast error surfacing as a 503. (2) The message-list query
+  orders its most-recent window oldest-first in SQL (inner `DESC LIMIT` window, outer `ASC`) —
+  same rows, same order as before, no in-process `.reverse()`. (3) The Stream helpers dropped the
+  `disconnectUser()` `finally` teardown: server-side clients never open a user WebSocket, so there
+  is nothing to tear down, and a throw from the `finally` could mask the real channel-operation
+  error — the Commons (`lib/feed/stream.ts`) removed it earlier for the same reason. Member-visible
+  behavior otherwise unchanged; no schema, route, or contract change.
 - 2026-07-23 — Contributor eligibility now grants a **second private surface**: a private "Weavers of the Commons" **Chyme audio room** (`chyme-contributors-room`), alongside the existing gated Commons chat channel. Same gate as the channel — the channel-open switch plus the eligibility flag (or admin) — enforced by a new `requireChymeContributorAccess` in the Chyme plugin, with the same bare-404 no-shaming behavior. Built entirely in the Chyme plugin (room switcher + room-scoped routes/repository); this module's eligibility engine and `isMemberEligible`/`getContributorAccessConfig` are reused unchanged — no change to contributor-access schema, routes, or contracts. See the Chyme inventory for the implementation. Audio + room-chat MVP (tips/Back Channel deferred). Web-only (rule 105).
 - 2026-07-22 — Gated #contributors channel: added an **Edit** action on a member's own message (edit = delete + repost, matching the Commons home channel). It loads the message text into the composer and deletes the original (existing author-only delete), so the member fixes it and sends a fresh message — no in-place edit, a new row with a new timestamp. Edit shows on your own messages only (admins keep delete-any as moderation, but cannot "edit" someone else's). `gated-chat-panel.tsx` + `use-gated-chat.ts`; reuses the existing delete + send, no schema/route/contract change. Verified: `@ctf/web` typecheck + eslint clean.
 - 2026-07-19 — Gated channel: tapping a quoted reply now jumps to the original message on web (same

--- a/ctf/docs/developer/test-scripts/contributor-access-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributor-access-test-script.md
@@ -330,6 +330,8 @@ Result: web ☐ mobile-responsive ☐
 
 **Expected:** Exactly 12 emojis are available (more than the Commons' 6). Adding the reaction shows it on the message with a count. Clicking it again removes your reaction (count decreases or disappears). No emoji outside the fixed gated set can be submitted.
 
+**API edge (optional, developer tools):** a POST to `/api/contributor-access/channel/messages/not-a-uuid/reactions` with a valid emoji returns a 404 ("That message is no longer available."), not a 503 — a malformed post id is treated as not-found (2026-08-06 hardening, issues #2125/#2127).
+
 Result: web ☐ mobile-responsive ☐
 
 ---

--- a/ctf/packages/web/lib/contributor-access/channel-repository.ts
+++ b/ctf/packages/web/lib/contributor-access/channel-repository.ts
@@ -52,6 +52,10 @@ type ReactionRow = {
   reacted_by_me: boolean;
 };
 
+// A malformed post id is treated as not-found (mirrors the Commons' normalizeUuid handling)
+// instead of surfacing a database cast error as a 503.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // Recent messages, oldest-first, with quoted-reply references and the viewer's reaction state.
 // Reads exclude soft-deleted posts and filter to moderation_status 'accepted' (mirroring the
 // Commons column); a quote whose source post was since deleted or not accepted resolves to
@@ -60,21 +64,29 @@ export async function listGatedChannelMessages(
   viewerUserId: string,
   limit = 50,
 ): Promise<GatedChannelMessage[]> {
+  // The inner query selects the most-recent window; the outer ORDER BY flips it to oldest-first
+  // so the database returns the rows in display order and no in-process reversal is needed.
   const posts = await queryDb<PostRow>(
-    `SELECT p.id, p.author_user_id, p.author_username, p.body, p.reply_to_post_id,
-            p.created_at::text,
-            q.author_user_id AS quoted_author_user_id,
-            q.author_username AS quoted_author_username,
-            q.body AS quoted_body
-     FROM contributor_access_channel_posts p
-     LEFT JOIN contributor_access_channel_posts q
-       ON q.id = p.reply_to_post_id
-      AND q.deleted_at IS NULL
-      AND q.moderation_status = 'accepted'
-     WHERE p.deleted_at IS NULL
-       AND p.moderation_status = 'accepted'
-     ORDER BY p.created_at DESC, p.id DESC
-     LIMIT $1`,
+    `SELECT recent.id, recent.author_user_id, recent.author_username, recent.body,
+            recent.reply_to_post_id, recent.created_at::text,
+            recent.quoted_author_user_id, recent.quoted_author_username, recent.quoted_body
+     FROM (
+       SELECT p.id, p.author_user_id, p.author_username, p.body, p.reply_to_post_id,
+              p.created_at,
+              q.author_user_id AS quoted_author_user_id,
+              q.author_username AS quoted_author_username,
+              q.body AS quoted_body
+       FROM contributor_access_channel_posts p
+       LEFT JOIN contributor_access_channel_posts q
+         ON q.id = p.reply_to_post_id
+        AND q.deleted_at IS NULL
+        AND q.moderation_status = 'accepted'
+       WHERE p.deleted_at IS NULL
+         AND p.moderation_status = 'accepted'
+       ORDER BY p.created_at DESC, p.id DESC
+       LIMIT $1
+     ) recent
+     ORDER BY recent.created_at ASC, recent.id ASC`,
     [Math.max(1, Math.min(limit, 100))],
   );
 
@@ -96,7 +108,7 @@ export async function listGatedChannelMessages(
     }
   }
 
-  return posts.rows.reverse().map((row) => ({
+  return posts.rows.map((row) => ({
     id: row.id,
     authorUserId: row.author_user_id,
     authorUsername: row.author_username,
@@ -195,9 +207,7 @@ export async function deleteGatedChannelPost(input: {
   actorId: string;
   isAdmin: boolean;
 }): Promise<'author' | 'admin'> {
-  // A malformed id is treated as not-found (mirrors the Commons' normalizeUuid handling) instead
-  // of surfacing a database cast error.
-  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(input.postId)) {
+  if (!UUID_PATTERN.test(input.postId)) {
     throw new Error('post_not_found');
   }
   const post = await queryDb<{ author_user_id: string }>(
@@ -230,6 +240,9 @@ export async function toggleGatedChannelReaction(input: {
 }): Promise<{ reacted: boolean }> {
   if (!isGatedReactionEmoji(input.emoji)) {
     throw new Error('invalid_emoji');
+  }
+  if (!UUID_PATTERN.test(input.postId)) {
+    throw new Error('post_not_found');
   }
   const post = await queryDb<{ id: string }>(
     `SELECT id FROM contributor_access_channel_posts

--- a/ctf/packages/web/lib/contributor-access/gated-channel.ts
+++ b/ctf/packages/web/lib/contributor-access/gated-channel.ts
@@ -9,7 +9,10 @@ import {
 
 // Server-side Stream helpers for the single gated contributor channel. Mirrors lib/feed/stream.ts
 // exactly (same credential resolver — demo mode selects the *_STAGING app — same create/watch
-// fallback, same per-call client + disconnect). The only differences are the distinct channel type
+// fallback, same per-call server client). Server-side clients (apiKey + apiSecret) issue tokens
+// and make REST calls; they never open a user WebSocket, so there is no disconnectUser() teardown
+// to run — calling it in a finally only risked masking a real error from the channel operation
+// (the Commons removed it for the same reason). The only differences are the distinct channel type
 // ('ctf-gated': threads on, richer reactions, longer messages, uploads OFF — created once by
 // ctf/scripts/setupGatedChannelType.mjs) and that membership is derived ONLY from the
 // contributor_access_eligibility flag: eligible members are added, for-cause-revoked members are
@@ -58,13 +61,9 @@ export async function ensureGatedChannel(): Promise<boolean> {
   const streamConfig = await resolveStreamCredentials();
   if (!streamConfig) return false;
   const streamClient = new StreamChat(streamConfig.apiKey, streamConfig.apiSecret);
-  try {
-    await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: 'Survivor Hub' });
-    await createOrWatchGatedChannel(streamClient);
-    return true;
-  } finally {
-    await streamClient.disconnectUser();
-  }
+  await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: 'Survivor Hub' });
+  await createOrWatchGatedChannel(streamClient);
+  return true;
 }
 
 export type GatedChannelSyncResult = {
@@ -80,26 +79,22 @@ export async function syncGatedChannelMembership(): Promise<GatedChannelSyncResu
   if (!streamConfig) return null;
   const targets = await listChannelMembershipTargets();
   const streamClient = new StreamChat(streamConfig.apiKey, streamConfig.apiSecret);
-  try {
-    await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: 'Survivor Hub' });
-    const channel = await createOrWatchGatedChannel(streamClient);
+  await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: 'Survivor Hub' });
+  const channel = await createOrWatchGatedChannel(streamClient);
 
-    const eligibleIds = targets.eligibleUserIds.map(streamMemberId);
-    const revokedIds = targets.revokedUserIds.map(streamMemberId);
+  const eligibleIds = targets.eligibleUserIds.map(streamMemberId);
+  const revokedIds = targets.revokedUserIds.map(streamMemberId);
 
-    // Stream member/user calls are capped per request, so batch in chunks of 100.
-    for (const ids of chunk(eligibleIds, 100)) {
-      await streamClient.upsertUsers(ids.map((id) => ({ id })));
-      await channel.addMembers(ids);
-    }
-    for (const ids of chunk(revokedIds, 100)) {
-      await channel.removeMembers(ids);
-    }
-
-    return { added: eligibleIds.length, removed: revokedIds.length };
-  } finally {
-    await streamClient.disconnectUser();
+  // Stream member/user calls are capped per request, so batch in chunks of 100.
+  for (const ids of chunk(eligibleIds, 100)) {
+    await streamClient.upsertUsers(ids.map((id) => ({ id })));
+    await channel.addMembers(ids);
   }
+  for (const ids of chunk(revokedIds, 100)) {
+    await channel.removeMembers(ids);
+  }
+
+  return { added: eligibleIds.length, removed: revokedIds.length };
 }
 
 // Guarded membership sync for the eligibility-changing paths (recompute, revoke, reinstate).
@@ -132,8 +127,6 @@ export async function getGatedChannelMemberCount(): Promise<number | null> {
     return typeof state.channel.member_count === 'number' ? state.channel.member_count : null;
   } catch {
     return null;
-  } finally {
-    await streamClient.disconnectUser();
   }
 }
 
@@ -156,20 +149,16 @@ export async function getGatedStreamCredentials(
   const streamConfig = await resolveStreamCredentials();
   if (!streamConfig) return null;
   const streamClient = new StreamChat(streamConfig.apiKey, streamConfig.apiSecret);
-  try {
-    const streamUserId = streamMemberId(userId);
-    await streamClient.upsertUser({ id: streamUserId, name: displayName });
-    const token = streamClient.createToken(streamUserId);
-    const channel = await createOrWatchGatedChannel(streamClient);
-    await channel.addMembers([streamUserId]);
-    return {
-      streamApiKey: streamConfig.apiKey,
-      streamToken: token,
-      streamUserId,
-      streamChannelType: GATED_STREAM_CHANNEL_TYPE,
-      streamChannelId: GATED_STREAM_CHANNEL_ID,
-    };
-  } finally {
-    await streamClient.disconnectUser();
-  }
+  const streamUserId = streamMemberId(userId);
+  await streamClient.upsertUser({ id: streamUserId, name: displayName });
+  const token = streamClient.createToken(streamUserId);
+  const channel = await createOrWatchGatedChannel(streamClient);
+  await channel.addMembers([streamUserId]);
+  return {
+    streamApiKey: streamConfig.apiKey,
+    streamToken: token,
+    streamUserId,
+    streamChannelType: GATED_STREAM_CHANNEL_TYPE,
+    streamChannelId: GATED_STREAM_CHANNEL_ID,
+  };
 }


### PR DESCRIPTION
Closes #2124
Closes #2125
Closes #2126
Closes #2127

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

## What changed

Three small hardenings in the gated contributor channel, all verified against the current code before fixing:

1. **Malformed post id on the reaction toggle is now a 404, not a 503** (#2125, #2127 — one defect filed twice). `toggleGatedChannelReaction` in `ctf/packages/web/lib/contributor-access/channel-repository.ts` now runs the same UUID format guard `deleteGatedChannelPost` already had (shared `UUID_PATTERN` constant), throwing `post_not_found` before the query. Before, a non-UUID post id hit `WHERE id = $1` on a uuid column, and the Postgres cast error surfaced through the route's generic handler as a 503. Note: #2125's title names `deleteGatedChannelPost`, but its body (and the code) show the gap was in the reaction toggle — the delete path already had the guard.

2. **The message list window is ordered by the database** (#2126). The query now selects the most-recent window in an inner `ORDER BY ... DESC LIMIT` subquery and flips it oldest-first in the outer `ORDER BY`, so the in-process `.reverse()` is gone. Same rows, same order as before. The finding's claim that the old code "fetches the wrong 50 rows if the caller ever changes limit" does not hold — it always fetched the most recent `limit` rows, which is the intent; what is load-bearing here is only that the display ordering moves into SQL instead of an array reversal.

3. **`disconnectUser()` removed from the Stream helpers' `finally` blocks** (#2124). The finding asked to verify whether the call is safe on a server-side client. The answer is already in this repo: the Commons `lib/feed/stream.ts`, which this file's header says it mirrors, removed the same calls with the explanation that a server client (apiKey + apiSecret) never opens a user WebSocket — there is nothing to tear down, and an `await` in `finally` only risked masking the real error from the channel operation. `gated-channel.ts` now matches the current Commons pattern, and its header comment says why.

## Inventory / test script

The contributor-access inventory documents the new malformed-id behavior on the reaction route and carries a change-log entry; the manual test script's reaction case (CA-18) gains the matching API edge check.

## Checks

Typecheck (web + mobile), eslint, EOF format, US spelling, inventory drift, test-script drift, and the pre-push production build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C24huhwdadeze9XQc3BBym

---
_Generated by [Claude Code](https://claude.ai/code/session_01C24huhwdadeze9XQc3BBym)_