### PR TITLE
feat: label the Community Value Index as cumulative since the June 12, 2026 launch

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -31,7 +31,13 @@ The plugin ships on web (desktop + mobile-responsive). The former native Android
 ### 1.1 GDP Transparency Overview
 
 1. Authenticated survivor-facing GDP summary dashboard.
-2. Current annual `Total GDP`, `Service GDP`, `Goods/Local GDP` with plain-language explanations.
+2. An as-of anchor under the headline Community Value Index: "Cumulative since May 25, 2026" — the
+   day the app first went live in production (Render migration completed, PRs #98–#117). The index
+   sums all recognized exchanges from launch onward and never resets to a calendar year. The date is
+   one constant (`COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` in
+   `ctf/packages/web/components/gdp/gdp-shared.ts`) so a corrected public launch date changes in one
+   place.
+3. Current annual `Total GDP`, `Service GDP`, `Goods/Local GDP` with plain-language explanations.
 3. Per-capita indicators based on population baseline and selected period.
 4. Progress-to-target indicators for $300B total and $210B services goals.
 
@@ -348,6 +354,15 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 
 ## 10) Change Log
 
+- 2026-08-05: **Dashboard hero now says what period the Community Value Index covers: "Cumulative
+  since May 25, 2026".** The index is all-time — every recognition source sums its full table history
+  with no date filter — but the surface never said so, leaving a reader to guess whether the figure
+  was yearly. Added `COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` / `COMMUNITY_VALUE_INDEX_SINCE_LABEL` to
+  `gdp-shared.ts` (single source of truth) and rendered the label under the headline figure in
+  `gdp-dashboard.tsx`. The anchor date is the production go-live on Render: the migration PRs
+  (#98–#117) all merged 2026-05-25, with PR #117's health-check fix bringing `ctf-web` to "Live".
+  If the owner fixes a different public launch date (e.g. from the announcement post), only the
+  constant changes. UI copy only — no schema, route, or contract change.
 - 2026-08-04: **Both Community Value Index figures now appear in the weekly community-stats draft, via a
   shared script module.** The weekly community-stats draft generator
   (`ctf/scripts/generate-community-stats.mjs`, run by `.github/workflows/generate-community-stats.yml`)

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -31,12 +31,11 @@ The plugin ships on web (desktop + mobile-responsive). The former native Android
 ### 1.1 GDP Transparency Overview
 
 1. Authenticated survivor-facing GDP summary dashboard.
-2. An as-of anchor under the headline Community Value Index: "Cumulative since May 25, 2026" — the
-   day the app first went live in production (Render migration completed, PRs #98–#117). The index
-   sums all recognized exchanges from launch onward and never resets to a calendar year. The date is
-   one constant (`COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` in
-   `ctf/packages/web/components/gdp/gdp-shared.ts`) so a corrected public launch date changes in one
-   place.
+2. An as-of anchor under the headline Community Value Index: "Cumulative since June 12, 2026" — the
+   soft launch date (owner decision, 2026-08-06; the Render production deploy came slightly earlier,
+   2026-05-25). The index sums all recognized exchanges from launch onward and never resets to a
+   calendar year. The date is one constant (`COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` in
+   `ctf/packages/web/components/gdp/gdp-shared.ts`) so a corrected launch date changes in one place.
 3. Current annual `Total GDP`, `Service GDP`, `Goods/Local GDP` with plain-language explanations.
 3. Per-capita indicators based on population baseline and selected period.
 4. Progress-to-target indicators for $300B total and $210B services goals.
@@ -354,6 +353,10 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 
 ## 10) Change Log
 
+- 2026-08-06: **As-of anchor corrected to the soft launch date: "Cumulative since June 12, 2026"
+  (owner decision).** The first pass anchored to the Render production deploy (2026-05-25); the
+  owner identified 2026-06-12 as the actual soft launch, so the constant in `gdp-shared.ts` now
+  carries that date. One-constant change plus this inventory; no schema, route, or contract change.
 - 2026-08-05: **Dashboard hero now says what period the Community Value Index covers: "Cumulative
   since May 25, 2026".** The index is all-time — every recognition source sums its full table history
   with no date filter — but the surface never said so, leaving a reader to guess whether the figure

--- a/ctf/docs/developer/test-scripts/gdp-test-script.md
+++ b/ctf/docs/developer/test-scripts/gdp-test-script.md
@@ -52,11 +52,13 @@
 1. Look at the hero section of the dashboard.
 2. Confirm a "Members" count tile is shown.
 3. Confirm no "Active · 7d" tile appears anywhere on the page (it was removed 2026-07-11).
+4. Read the small line directly under the big headline figure.
 
 **Expected:**
 - One hero tile labeled "Members" shows a whole number greater than zero.
 - The weekly-active-members tile is absent.
 - No mock or placeholder numbers (e.g. "1,234,567") appear — the count matches what the Directory shows for total active members.
+- The line "Cumulative since June 12, 2026" appears directly under the headline Community Value Index figure (added 2026-08-06: the index is all-time from the soft launch date, never a yearly figure).
 
 Result: web ☐
 

--- a/ctf/packages/web/components/gdp/gdp-dashboard.tsx
+++ b/ctf/packages/web/components/gdp/gdp-dashboard.tsx
@@ -4,6 +4,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   
   COMMUNITY_VALUE_INDEX_DISCLAIMER,
+  COMMUNITY_VALUE_INDEX_SINCE_LABEL,
   GDP_ESTIMATE_CHIP_LABEL,
   type GdpCountry,
   type GdpMetrics,
@@ -54,6 +55,9 @@ function GdpHero({ metrics }: { metrics: GdpMetrics }) {
             <div style={{ fontSize: 48, fontWeight: 900, color: t.TITLE, lineHeight: 1 }}>{metrics.currentValue || "—"}</div>
             {isEstimate ? <EstimateChip /> : null}
           </div>
+          {/* The index sums all recognized exchanges since production launch — it never resets, so the
+              as-of anchor is the launch date (one constant in gdp-shared.ts). */}
+          <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 6 }}>{COMMUNITY_VALUE_INDEX_SINCE_LABEL}</div>
           <div style={{ fontSize: 16, color: t.SUBTLE }}>
             {metrics.target ? `of ${metrics.target} opportunity` : ""}
             {metrics.progress ? ` · ${metrics.progress} reached` : ""}

--- a/ctf/packages/web/components/gdp/gdp-shared.ts
+++ b/ctf/packages/web/components/gdp/gdp-shared.ts
@@ -102,13 +102,13 @@ export const COMMUNITY_VALUE_INDEX_DISCLAIMER =
   "Community Value is one measure of all the value exchanged in this community — money, crypto, ServiceCredits, and barter — combined through a fixed set of weights. It's a relative index for transparency, in the spirit of GDP. It isn't money, a price, or an exchange or redemption value for any currency or token.";
 
 // The date the index counts from. The index is cumulative — every recognition source sums its full
-// table history with no time window (lib/gdp/recognition.ts), so the honest anchor is the day the
-// app first went live in production: 2026-05-25, when the Render migration (PRs #98–#117) finished
-// and PR #117's health-check fix let ctf-web reach "Live" on Render. If the owner fixes a different
-// public launch date (e.g. from the announcement post), change it here only — every surface reads
-// this one constant.
-export const COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO = "2026-05-25";
-export const COMMUNITY_VALUE_INDEX_SINCE_LABEL = "Cumulative since May 25, 2026";
+// table history with no time window (lib/gdp/recognition.ts), so the honest anchor is the launch
+// date: 2026-06-12, the soft launch (owner decision, 2026-08-06). The Render production deploy came
+// slightly earlier (2026-05-25, PRs #98–#117), but the announced launch is the date members count
+// from. If the owner fixes a different date later, change it here only — every surface reads this
+// one constant.
+export const COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO = "2026-06-12";
+export const COMMUNITY_VALUE_INDEX_SINCE_LABEL = "Cumulative since June 12, 2026";
 
 // The projected figure: what the posts already on the board would add IF every one of them closed
 // successfully. It is a separate number from the Community Value Index and is never added to it — the

--- a/ctf/packages/web/components/gdp/gdp-shared.ts
+++ b/ctf/packages/web/components/gdp/gdp-shared.ts
@@ -101,6 +101,15 @@ export const COMMUNITY_VALUE_INDEX_LABEL = "Community Value Index";
 export const COMMUNITY_VALUE_INDEX_DISCLAIMER =
   "Community Value is one measure of all the value exchanged in this community — money, crypto, ServiceCredits, and barter — combined through a fixed set of weights. It's a relative index for transparency, in the spirit of GDP. It isn't money, a price, or an exchange or redemption value for any currency or token.";
 
+// The date the index counts from. The index is cumulative — every recognition source sums its full
+// table history with no time window (lib/gdp/recognition.ts), so the honest anchor is the day the
+// app first went live in production: 2026-05-25, when the Render migration (PRs #98–#117) finished
+// and PR #117's health-check fix let ctf-web reach "Live" on Render. If the owner fixes a different
+// public launch date (e.g. from the announcement post), change it here only — every surface reads
+// this one constant.
+export const COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO = "2026-05-25";
+export const COMMUNITY_VALUE_INDEX_SINCE_LABEL = "Cumulative since May 25, 2026";
+
 // The projected figure: what the posts already on the board would add IF every one of them closed
 // successfully. It is a separate number from the Community Value Index and is never added to it — the
 // index counts only exchanges that actually completed. Kept here as its own metric key/label/disclaimer


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

## What changed

The Community Value Index is cumulative — every recognition source sums its full table history with no time window — but the GDP dashboard never said what period the figure covers, leaving a reader to guess whether it was a yearly number.

- The dashboard hero now shows **"Cumulative since June 12, 2026"** directly under the headline figure. June 12, 2026 is the soft launch date (owner decision, 2026-08-06); the Render production deploy came slightly earlier (2026-05-25, PRs #98–#117).
- The date lives in one constant (`COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` in `ctf/packages/web/components/gdp/gdp-shared.ts`), so a corrected launch date is a one-line change.
- The GDP feature inventory has the matching User Features line and change-log entries.

## Files

- `ctf/packages/web/components/gdp/gdp-shared.ts` — new constants with provenance comment
- `ctf/packages/web/components/gdp/gdp-dashboard.tsx` — renders the anchor line in the hero
- `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md` — inventory sync

## Verification

- Typecheck (all packages), web production build, end-of-file format check, and inventory drift check all pass locally on top of the latest `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZnuMiKAqC4ZzwuAkDT5df)_