### PR TITLE
fix: require the CSRF header on gated channel join; contract lists channelMemberCount

### DIFF
--- a/ctf/docs/contracts/CONTRIBUTOR_ACCESS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CONTRIBUTOR_ACCESS_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -286,12 +286,13 @@ policies:
 
   - pluginId: contributor-access
     command: contributor-access.channel.join
-    version: 1.0.0
+    version: 1.1.0
     requiredRoles:
       - member
       - admin
     attributePolicies:
       tenancy: same_workspace
+      csrfHeader: required
       channelGate: channel_open_and_eligibility_flag_or_admin
       denyShape: bare_404_no_channel_trace
       credentialScope: stream_live_layer_only_shared_resolver
@@ -309,6 +310,7 @@ policies:
       - unauthenticated
       - channel_closed
       - not_eligible
+      - csrf_denied
 
 changelog:
   - date: 2026-07-18
@@ -332,3 +334,9 @@ changelog:
       only, or admin as the disclosed moderator power; soft delete (hidden, not erased); both
       allowed paths audited under distinct commands and a non-owner attempt denied with
       not_post_owner (audited).
+  - date: 2026-08-06
+    change: >-
+      channel.join 1.1.0 - the policy now records csrfHeader required and the csrf_denied deny
+      condition, matching the route: joining is a mutation (the member is reconciled into the
+      Stream channel), so it carries the same CSRF posture as every other mutation in this
+      plugin. Code-review issue #2122.

--- a/ctf/docs/contracts/CONTRIBUTOR_ACCESS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CONTRIBUTOR_ACCESS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -1,14 +1,21 @@
 contracts:
   - pluginId: contributor-access
     command: contributor-access.config.get
-    version: 1.0.0
-    description: Read the single owner-tunable eligibility config row (weights, threshold, gate minimums, channel_open); defaults when the row has never been written.
+    version: 1.1.0
+    description: >-
+      Read the single owner-tunable eligibility config row (weights, threshold, gate minimums,
+      channel_open); defaults when the row has never been written. Also returns the best-effort
+      synced Stream member count for the admin status card (null when Stream is unconfigured or
+      the channel is not open).
     inputSchema: {}
     outputSchema:
       ok:
         type: boolean
       config:
         type: object
+      channelMemberCount:
+        type: number
+        required: false
     dataAccess:
       - contributor_access_config
       - contributor_access_audit_trail
@@ -339,7 +346,7 @@ contracts:
 
   - pluginId: contributor-access
     command: contributor-access.channel.join
-    version: 1.0.0
+    version: 1.1.0
     description: >-
       Mint Stream live-layer credentials for the gated channel (same posture as the Commons'
       /api/hub/join): the client opens a live connection beneath the custom UI for instant refresh
@@ -347,7 +354,7 @@ contracts:
       the client stays on polling. Same three-way gate as the list command - the add to the Stream
       channel only reconciles a flag-verified member into the synced membership, never grants
       access. Reuses the existing Stream credential helpers unchanged (demo mode selects the
-      *_STAGING app).
+      *_STAGING app). CSRF-confirmed mutation.
     inputSchema: {}
     outputSchema:
       ok:
@@ -403,3 +410,12 @@ changelog:
       author and admin paths are audited under distinct commands
       (contributor-access.channel.post.delete / contributor-access.channel.post.moderator-delete)
       and a non-owner attempt is a 403 with an audited deny.
+  - date: 2026-08-06
+    change: >-
+      channel.join 1.1.0 - now a CSRF-confirmed mutation like every other mutation in this
+      plugin: the route requires the x-ctf-csrf header before minting credentials, because the
+      join has a Stream-side effect (the member is reconciled into the channel) that a
+      cross-origin POST must not be able to trigger. config.get 1.1.0 - the output schema now
+      records the channelMemberCount field the route has always returned for the admin status
+      card (best-effort synced Stream member count; null when Stream is unconfigured or the
+      channel is not open). Code-review issues #2122 and #2128.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
@@ -150,7 +150,9 @@ audit-trailed, same posture as the Commons hub routes — post deletions ARE aud
   error. Contract: `contributor-access.channel.reaction.toggle`.
 - `POST /api/contributor-access/channel/join` — mints Stream live-layer credentials (channel type
   `ctf-gated`, channel `ctf-contributors`) via the shared resolver; `configured: false` when
-  Stream is absent and the client stays on polling. Contract: `contributor-access.channel.join`.
+  Stream is absent and the client stays on polling. A CSRF-confirmed mutation like the others —
+  joining reconciles the member into the Stream channel, so the route requires the `x-ctf-csrf`
+  header. Contract: `contributor-access.channel.join`.
 
 Cross-plugin read: `GET /api/hub/channels` (the Hub) reads `contributor_access_config` +
 `contributor_access_eligibility` to append the `#contributors` entry server-side for eligible
@@ -351,6 +353,14 @@ fill on the first recompute / config save / member post.
 
 ## Change Log
 
+- 2026-08-06 — Channel join CSRF + config contract catch-up (code-review issues #2122, #2128).
+  `POST /api/contributor-access/channel/join` now runs `ensureMutationCsrf` like every other
+  mutation in this plugin — the join reconciles the member into the Stream channel, a side effect
+  a cross-origin POST must not be able to trigger; the web client's join call sends the
+  `x-ctf-csrf: '1'` header (`use-gated-chat.ts`). Contracts: `channel.join` 1.1.0 (command
+  description + access policy record the CSRF requirement and `csrf_denied` deny) and
+  `config.get` 1.1.0 (output schema now lists the `channelMemberCount` field the route has always
+  returned for the admin status card). No schema change; member-visible behavior unchanged.
 - 2026-08-06 — Gated channel hardening from the code-review sweep (issues #2124, #2125, #2126,
   #2127; `lib/contributor-access/channel-repository.ts` + `lib/contributor-access/gated-channel.ts`).
   (1) `toggleGatedChannelReaction` now runs the same UUID format guard as

--- a/ctf/docs/developer/test-scripts/contributor-access-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributor-access-test-script.md
@@ -200,6 +200,8 @@ Result: web ☐
 
 **Mobile-responsive expected:** A channel-pill switch row appears in the chat section showing both `#general` and `#contributors`. (This row only appears when the member has more than one channel.)
 
+**API edge (optional, developer tools):** opening the channel still connects the live layer normally — the client's join call sends the `x-ctf-csrf: '1'` header. A bare `fetch('/api/contributor-access/channel/join', {method: 'POST'})` from the dev-tools console **without** that header is refused (the CSRF deny), the same posture as every other mutation in this plugin (2026-08-06 fix, issue #2122).
+
 Result: web ☐ mobile-responsive ☐
 
 ---

--- a/ctf/packages/web/app/api/contributor-access/channel/join/route.ts
+++ b/ctf/packages/web/app/api/contributor-access/channel/join/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireGatedChannelAccess } from '../_lib';
+import { ensureMutationCsrf } from '../../admin/_lib';
 import { getGatedStreamCredentials } from 'lib/contributor-access/gated-channel';
 import { reportError } from 'lib/observability/report';
 
@@ -9,10 +10,18 @@ import { reportError } from 'lib/observability/report';
 // has already verified the eligibility flag (or the moderator role) — membership is only ever
 // derived from that flag.
 
-export async function POST() {
+export async function POST(request: Request) {
   const gate = await requireGatedChannelAccess();
   if (!gate.allowed) {
     return gate.response;
+  }
+
+  // Same CSRF posture as every other mutation in this plugin: joining has a Stream-side effect
+  // (the member is reconciled into the channel), so a cross-origin POST must not be able to
+  // trigger it from a logged-in member's browser.
+  const csrfDeny = ensureMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
   }
 
   try {

--- a/ctf/packages/web/components/community-shell/use-gated-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-gated-chat.ts
@@ -177,7 +177,10 @@ export function useGatedChat(currentUser: ShellCurrentUser) {
       }
 
       try {
-        const join = await requestJson<GatedJoinResponse>('/api/contributor-access/channel/join', { method: 'POST' });
+        const join = await requestJson<GatedJoinResponse>('/api/contributor-access/channel/join', {
+          method: 'POST',
+          headers: { 'x-ctf-csrf': '1' },
+        });
         if (!active) return;
 
         const live = await connectLiveIfConfigured(join, {


### PR DESCRIPTION
Closes #2122
Closes #2128

Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

## What changed

**Channel join now checks CSRF (#2122).** `POST /api/contributor-access/channel/join` was the one mutation in this plugin without `ensureMutationCsrf`. The finding holds: the join has a Stream-side effect — `getGatedStreamCredentials` reconciles the member into the channel via `channel.addMembers` — so a cross-origin POST from a logged-in eligible member's browser could trigger it. The route now runs the same check as the other channel mutations (gate first, then CSRF, 403 `contributor_access_csrf_denied` on a missing header), and the web client's join call in `use-gated-chat.ts` now sends the `x-ctf-csrf: '1'` header, which it previously did not — without that client change this fix would have broken the channel's live layer.

**Contract catch-up for the admin config read (#2128).** `contributor-access.config.get`'s output schema now lists the `channelMemberCount` field the route has always returned for the admin status card (best-effort synced Stream member count; null when Stream is unconfigured or the channel is not open). Contract-only — the route response is unchanged.

Contract versions: `channel.join` 1.0.0 → 1.1.0 (command description says "CSRF-confirmed mutation"; access policy adds `csrfHeader: required` and the `csrf_denied` deny condition) and `config.get` 1.0.0 → 1.1.0, each with a dated changelog entry. The inventory documents both, and the manual test script's channel-access case (CA-10) gains the matching API edge check.

## Lane

**Owner-review lane — auto-merge not enabled.** This touches an auth-adjacent gate (CSRF) and changes contract files, so it waits for your review.

## Checks

Typecheck (web + mobile), eslint, EOF format, US spelling, inventory drift, test-script drift, and the pre-push production build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C24huhwdadeze9XQc3BBym

---
_Generated by [Claude Code](https://claude.ai/code/session_01C24huhwdadeze9XQc3BBym)_