### PR TITLE
fix: block a canceled helper from re-claiming the same SocketRelay request

### DIFF
--- a/ctf/docs/contracts/SOCKET_RELAY_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/SOCKET_RELAY_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -57,8 +57,11 @@ contracts:
 
   - pluginId: socket-relay
     command: socket-relay.fulfillment.claim
-    version: 1.0.0
-    description: Claim an eligible request for fulfillment.
+    version: 1.1.0
+    description: >-
+      Claim an eligible request for fulfillment. A helper whose earlier claim on the same request
+      was canceled by the requester (resolve outcome unsuccessful_reopen) is not eligible to claim
+      it again — the reopen is for other helpers (helper_previously_canceled, 409).
     inputSchema:
       requestId:
         type: string

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
@@ -46,7 +46,11 @@ building a UI for it, unless the owner asks for a plugin-specific profile.
 
 ### 1.3 Fulfillment Lifecycle
 
-1. Fulfillment claim flow for eligible requests.
+1. Fulfillment claim flow for eligible requests. A helper whose earlier claim on the same request
+   was canceled by the requester ("didn't work — reopen for others", outcome `unsuccessful_reopen`)
+   cannot claim that request again: the reopen is for **other** helpers. The server rejects the
+   re-claim (409, `SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`) and the web feed shows an
+   "Open to other helpers" note in place of the "I can help" button on those posts.
 2. Fulfillment detail and “my fulfillments” views.
 3. Closure outcomes with canonical status taxonomy.
 4. **Record a favor as a regular one, without leaving SocketRelay (2026-08-03).** The Direct Line carries
@@ -99,7 +103,9 @@ User/authenticated routes:
 - `POST /api/socket-relay/requests`
 - `PUT /api/socket-relay/requests/:id`
 - `POST /api/socket-relay/requests/:id/repost`
-- `POST /api/socket-relay/requests/:id/fulfill`
+- `POST /api/socket-relay/requests/:id/fulfill` — claim a request. Rejected with 409
+  (`SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`) when the caller's earlier claim on this request was
+  canceled by the requester via `unsuccessful_reopen` — the reopen is for other helpers.
 - `GET /api/socket-relay/fulfillments/:id`
 - `GET /api/socket-relay/my-fulfillments`
 - `POST /api/socket-relay/fulfillments/:id/close` — requester-only resolve; body `{ outcome: 'successful' | 'no_longer_needed' | 'unsuccessful_reopen' | 'unsuccessful_close' }`. `unsuccessful_reopen` returns the request to `open`; the others close it. Helpers cannot resolve.
@@ -185,6 +191,18 @@ alongside the legacy `category`) and fulfillment outcomes for dev validation.
 
 ## 9) Change Log
 
+- 2026-08-06: **"Reopen for others" now blocks the same helper from claiming the post again (owner
+  directive).** When a requester resolves a Direct Line with "didn't work — reopen for others"
+  (`unsuccessful_reopen`), the canceled helper could immediately claim the same request again,
+  re-opening the very conversation the requester had just ended. `claimRequest` now rejects a claim
+  when the caller already has a **canceled** fulfillment on that request (the only path to
+  'canceled' is `unsuccessful_reopen`), with the new `helper_previously_canceled` →
+  `SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED` mapping (409, "You already offered to help with this
+  request, and the poster reopened it for other helpers."); checked inside the claim transaction,
+  before the idempotent-retry branch, so a retry cannot resurrect the canceled claim. The web feed
+  hides the "I can help" button on those posts (derived client-side from the member's own
+  `my-fulfillments`) and shows an "Open to other helpers" note instead. Claim command contract
+  bumped to 1.1.0 (eligibility change; no dataAccess change). No schema or route change.
 - 2026-08-05: **Member blocks enforced (issue #809 task 4).** The browse feed
   (`GET /api/socket-relay/requests`) now hides posts whose owner is blocked (either direction)
   relative to the signed-in viewer — owner-scoped "Mine" lists and admin lists stay complete — and

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-socket-relay-feature-inventory.md
@@ -49,8 +49,10 @@ building a UI for it, unless the owner asks for a plugin-specific profile.
 1. Fulfillment claim flow for eligible requests. A helper whose earlier claim on the same request
    was canceled by the requester ("didn't work — reopen for others", outcome `unsuccessful_reopen`)
    cannot claim that request again: the reopen is for **other** helpers. The server rejects the
-   re-claim (409, `SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`) and the web feed shows an
-   "Open to other helpers" note in place of the "I can help" button on those posts.
+   re-claim (409, `SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`) and the web feed shows a
+   "You already offered to help" note in place of the "I can help" button on those posts. The
+   member-facing copy is deliberately soft (owner directive): it reads as "one offer per post",
+   never as being blocked, and never reveals that the poster ended the earlier Direct Line.
 2. Fulfillment detail and “my fulfillments” views.
 3. Closure outcomes with canonical status taxonomy.
 4. **Record a favor as a regular one, without leaving SocketRelay (2026-08-03).** The Direct Line carries
@@ -197,12 +199,14 @@ alongside the legacy `category`) and fulfillment outcomes for dev validation.
   re-opening the very conversation the requester had just ended. `claimRequest` now rejects a claim
   when the caller already has a **canceled** fulfillment on that request (the only path to
   'canceled' is `unsuccessful_reopen`), with the new `helper_previously_canceled` →
-  `SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED` mapping (409, "You already offered to help with this
-  request, and the poster reopened it for other helpers."); checked inside the claim transaction,
-  before the idempotent-retry branch, so a retry cannot resurrect the canceled claim. The web feed
-  hides the "I can help" button on those posts (derived client-side from the member's own
-  `my-fulfillments`) and shows an "Open to other helpers" note instead. Claim command contract
-  bumped to 1.1.0 (eligibility change; no dataAccess change). No schema or route change.
+  `SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED` mapping (409, "You’ve already offered to help with this
+  request — each member can offer once per post."); checked inside the claim transaction, before
+  the idempotent-retry branch, so a retry cannot resurrect the canceled claim. The web feed hides
+  the "I can help" button on those posts (derived client-side from the member's own
+  `my-fulfillments`) and shows a "You already offered to help" note instead. The member-facing copy
+  is deliberately soft (owner directive): it never reads as being blocked or reveals the poster's
+  choice. Claim command contract bumped to 1.1.0 (eligibility change; no dataAccess change). No
+  schema or route change.
 - 2026-08-05: **Member blocks enforced (issue #809 task 4).** The browse feed
   (`GET /api/socket-relay/requests`) now hides posts whose owner is blocked (either direction)
   relative to the signed-in viewer — owner-scoped "Mine" lists and admin lists stay complete — and

--- a/ctf/docs/developer/test-scripts/socket-relay-test-script.md
+++ b/ctf/docs/developer/test-scripts/socket-relay-test-script.md
@@ -363,10 +363,11 @@ web ☐
 - The Direct Line row for this fulfillment disappears.
 - A pending-request placeholder row appears in the Direct Line for the now-open request.
 - The **canceled helper cannot claim this request again**: signed in as that helper, the feed card
-  shows an "Open to other helpers" note instead of the "I can help" button, and a direct
+  shows a "You already offered to help" note instead of the "I can help" button, and a direct
   `POST /api/socket-relay/requests/{id}/fulfill` returns **409**
-  (`SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`) with a readable message. A different member can still
-  claim the re-opened request normally.
+  (`SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`). The copy must read as "one offer per post" — it must
+  **not** say the member was blocked or that the poster reopened the post for others. A different
+  member can still claim the re-opened request normally.
 
 web ☐
 

--- a/ctf/docs/developer/test-scripts/socket-relay-test-script.md
+++ b/ctf/docs/developer/test-scripts/socket-relay-test-script.md
@@ -362,6 +362,11 @@ web ☐
 - The 28-day expiry clock is reset, so the re-opened request is claimable again (not immediately expired), even if it had aged close to expiry before the claim.
 - The Direct Line row for this fulfillment disappears.
 - A pending-request placeholder row appears in the Direct Line for the now-open request.
+- The **canceled helper cannot claim this request again**: signed in as that helper, the feed card
+  shows an "Open to other helpers" note instead of the "I can help" button, and a direct
+  `POST /api/socket-relay/requests/{id}/fulfill` returns **409**
+  (`SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`) with a readable message. A different member can still
+  claim the re-opened request normally.
 
 web ☐
 

--- a/ctf/packages/web/app/api/socket-relay/_lib.ts
+++ b/ctf/packages/web/app/api/socket-relay/_lib.ts
@@ -94,7 +94,9 @@ const SOCKET_RELAY_ERROR_RESPONSES: Record<string, { code: string; message: stri
   actor_is_owner: { code: SOCKET_RELAY_ERROR_CODE.actorIsOwner, message: 'Request owner cannot claim fulfillment.', status: 403 },
   // Neutral copy on purpose (mirrors LightHouse): a block must not reveal itself to the blocked person.
   blocked_pair: { code: SOCKET_RELAY_ERROR_CODE.blockedPair, message: 'This request is not available to you.', status: 403 },
-  helper_previously_canceled: { code: SOCKET_RELAY_ERROR_CODE.helperPreviouslyCanceled, message: 'You already offered to help with this request, and the poster reopened it for other helpers.', status: 409 },
+  // Soft copy on purpose (owner directive): the message must not read as being turned away or reveal
+  // that the poster ended the earlier Direct Line — it simply notes that one offer per post is the rule.
+  helper_previously_canceled: { code: SOCKET_RELAY_ERROR_CODE.helperPreviouslyCanceled, message: 'You’ve already offered to help with this request — each member can offer once per post.', status: 409 },
   actor_not_participant: { code: SOCKET_RELAY_ERROR_CODE.actorNotParticipant, message: 'Not a fulfillment participant.', status: 403 },
   prohibited_content_detected: { code: SOCKET_RELAY_ERROR_CODE.prohibitedContent, message: 'Message rejected by moderation policy.', status: 400 },
   'invalid payload': { code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },

--- a/ctf/packages/web/app/api/socket-relay/_lib.ts
+++ b/ctf/packages/web/app/api/socket-relay/_lib.ts
@@ -94,6 +94,7 @@ const SOCKET_RELAY_ERROR_RESPONSES: Record<string, { code: string; message: stri
   actor_is_owner: { code: SOCKET_RELAY_ERROR_CODE.actorIsOwner, message: 'Request owner cannot claim fulfillment.', status: 403 },
   // Neutral copy on purpose (mirrors LightHouse): a block must not reveal itself to the blocked person.
   blocked_pair: { code: SOCKET_RELAY_ERROR_CODE.blockedPair, message: 'This request is not available to you.', status: 403 },
+  helper_previously_canceled: { code: SOCKET_RELAY_ERROR_CODE.helperPreviouslyCanceled, message: 'You already offered to help with this request, and the poster reopened it for other helpers.', status: 409 },
   actor_not_participant: { code: SOCKET_RELAY_ERROR_CODE.actorNotParticipant, message: 'Not a fulfillment participant.', status: 403 },
   prohibited_content_detected: { code: SOCKET_RELAY_ERROR_CODE.prohibitedContent, message: 'Message rejected by moderation policy.', status: 400 },
   'invalid payload': { code: SOCKET_RELAY_ERROR_CODE.invalidPayload, message: 'Invalid payload.', status: 400 },

--- a/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
+++ b/ctf/packages/web/components/socket-relay/socket-relay-shell.tsx
@@ -525,6 +525,8 @@ type SocketRelayTabContentProps = {
   requests: SrRequest[];
   allRequests: SrRequest[];
   userId?: string;
+  // Request ids the member cannot claim again (their earlier claim was canceled by the poster).
+  reclaimBlockedIds: Set<string>;
   submitting: boolean;
   search: string;
   category: string;
@@ -556,7 +558,7 @@ type SocketRelayTabContentProps = {
 // The body under the header: whichever tab is active. `requests` is the filtered feed list; suggestions
 // pull from `allRequests` (the full loaded set) so tag autocomplete is not limited to the visible rows.
 function SocketRelayTabContent(props: SocketRelayTabContentProps) {
-  const { tab, requests, allRequests, userId, submitting, search, category } = props;
+  const { tab, requests, allRequests, userId, reclaimBlockedIds, submitting, search, category } = props;
   const { hasMore, loadingMore, onLoadMore, onClaim, onPost, onEdit, onRepost } = props;
   const { draft, editing, onChange, postError, postSuccess, onSubmit, onCancelEdit } = props;
   const { directLines, selectedLine, resolving, onSelect, onBack, onResolve, chatLoading, chatError, chatCredentials } = props;
@@ -567,6 +569,7 @@ function SocketRelayTabContent(props: SocketRelayTabContentProps) {
         <SocketRelayFeed
           requests={requests}
           currentUserId={userId}
+          reclaimBlockedIds={reclaimBlockedIds}
           submitting={submitting}
           filterActive={filterActive}
           hasMore={hasMore}
@@ -641,6 +644,14 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
   // The Direct Line list: active conversations plus your own still-open requests as pending
   // placeholders. Canceled/closed lines drop out — one row per request you're waiting on or talking through.
   const directLines = buildDirectLines(sr.fulfillments, sr.myRequests);
+  // Requests this member was canceled off as the helper (the poster chose "didn't work — reopen for
+  // others"). The server refuses a re-claim on these, so the feed replaces the "I can help" button
+  // with a plain note instead of offering an action that would fail.
+  const reclaimBlockedIds = new Set(
+    sr.fulfillments
+      .filter((f) => f.status === "canceled" && f.fulfillerUserId === userId)
+      .map((f) => f.requestId),
+  );
 
   const tabs: { key: Tab; label: string }[] = [
     { key: "feed", label: "Feed" },
@@ -668,6 +679,7 @@ export function SocketRelayShell({ userId, isAdmin }: SocketRelayShellProps) {
         requests={visible}
         allRequests={sr.requests}
         userId={userId}
+        reclaimBlockedIds={reclaimBlockedIds}
         submitting={sr.submitting}
         search={sr.search}
         category={sr.category}

--- a/ctf/packages/web/components/socket-relay/sr-feed.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-feed.tsx
@@ -56,6 +56,26 @@ function CardAction({
   if (status === "claimed") return <div style={{ fontSize: 12, color: "#F59E0B", fontWeight: 600 }}>Being helped</div>;
   if (status === "canceled") return <div style={{ fontSize: 12, color: SUBTLE, fontWeight: 600 }}>Canceled</div>;
   if (!open) return <div style={{ fontSize: 12, color: "#22C55E", fontWeight: 600 }}>✓ closed</div>;
+  return <OpenCardAction isOwn={isOwn} reclaimBlocked={reclaimBlocked} submitting={submitting} onClaim={onClaim} onEdit={onEdit} t={t} />;
+}
+
+// The action column for an open, claimable post: the owner edits, a canceled-off helper sees a plain
+// note, anyone else gets the claim button. Split from CardAction to stay within the complexity limit.
+function OpenCardAction({
+  isOwn,
+  reclaimBlocked,
+  submitting,
+  onClaim,
+  onEdit,
+  t,
+}: {
+  isOwn: boolean;
+  reclaimBlocked: boolean;
+  submitting: boolean;
+  onClaim: () => void;
+  onEdit: () => void;
+  t: SocketRelayTokens;
+}) {
   if (isOwn) {
     return (
       <>
@@ -66,8 +86,10 @@ function CardAction({
       </>
     );
   }
+  // Soft copy on purpose (owner directive): reads as "you already offered", never as being blocked
+  // or as the poster having ended the earlier Direct Line.
   if (reclaimBlocked) {
-    return <div style={{ fontSize: 12, color: SUBTLE, fontWeight: 600, textAlign: "right" }}>Open to other helpers</div>;
+    return <div style={{ fontSize: 12, color: SUBTLE, fontWeight: 600, textAlign: "right" }}>You already offered to help</div>;
   }
   return (
     <button onClick={onClaim} disabled={submitting} style={{ padding: "8px 14px", borderRadius: 8, background: `${t.ACCENT}15`, border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 12, fontWeight: 600, cursor: submitting ? "not-allowed" : "pointer" }}>

--- a/ctf/packages/web/components/socket-relay/sr-feed.tsx
+++ b/ctf/packages/web/components/socket-relay/sr-feed.tsx
@@ -14,6 +14,7 @@ function CardAction({
   status,
   expired,
   isOwn,
+  reclaimBlocked,
   submitting,
   onClaim,
   onEdit,
@@ -22,6 +23,9 @@ function CardAction({
   status: SrRequestStatus;
   expired: boolean;
   isOwn: boolean;
+  // The poster canceled this member's earlier claim ("didn't work — reopen for others"), so the
+  // server refuses a re-claim; show a plain note instead of a button that would fail.
+  reclaimBlocked: boolean;
   submitting: boolean;
   onClaim: () => void;
   onEdit: () => void;
@@ -61,6 +65,9 @@ function CardAction({
         </button>
       </>
     );
+  }
+  if (reclaimBlocked) {
+    return <div style={{ fontSize: 12, color: SUBTLE, fontWeight: 600, textAlign: "right" }}>Open to other helpers</div>;
   }
   return (
     <button onClick={onClaim} disabled={submitting} style={{ padding: "8px 14px", borderRadius: 8, background: `${t.ACCENT}15`, border: `1px solid ${t.ACCENT}30`, color: t.ACCENT, fontSize: 12, fontWeight: 600, cursor: submitting ? "not-allowed" : "pointer" }}>
@@ -113,6 +120,7 @@ function CardMeta({ request: r, t }: { request: SrRequest; t: SocketRelayTokens 
 function RequestCard({
   request,
   isOwn,
+  reclaimBlocked,
   submitting,
   onClaim,
   onEdit,
@@ -120,6 +128,7 @@ function RequestCard({
 }: {
   request: SrRequest;
   isOwn: boolean;
+  reclaimBlocked: boolean;
   submitting: boolean;
   onClaim: (id: string) => void;
   onEdit: (request: SrRequest) => void;
@@ -148,7 +157,7 @@ function RequestCard({
           <CardMeta request={r} t={t} />
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-end", flexShrink: 0 }}>
-          <CardAction status={r.status} expired={expired} isOwn={isOwn} submitting={submitting} onClaim={() => onClaim(r.id)} onEdit={() => onEdit(r)} onRepost={() => onRepost(r.id)} />
+          <CardAction status={r.status} expired={expired} isOwn={isOwn} reclaimBlocked={reclaimBlocked} submitting={submitting} onClaim={() => onClaim(r.id)} onEdit={() => onEdit(r)} onRepost={() => onRepost(r.id)} />
         </div>
       </div>
     </div>
@@ -207,6 +216,7 @@ function LoadMoreButton({
 export function SocketRelayFeed({
   requests,
   currentUserId,
+  reclaimBlockedIds,
   submitting,
   filterActive = false,
   hasMore = false,
@@ -219,6 +229,9 @@ export function SocketRelayFeed({
 }: {
   requests: SrRequest[];
   currentUserId: string | undefined;
+  // Ids of requests this member cannot claim again (their earlier claim was canceled by the poster,
+  // who reopened the post for other helpers). The server refuses these; the card shows a note instead.
+  reclaimBlockedIds?: Set<string>;
   submitting: boolean;
   // True when a search term or a non-"All" category/"Mine" filter is active, so the empty state can say
   // "no matches" instead of falsely claiming the whole board is empty.
@@ -242,7 +255,7 @@ export function SocketRelayFeed({
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             {requests.map((r) => (
-              <RequestCard key={r.id} request={r} isOwn={r.ownerUserId === currentUserId} submitting={submitting} onClaim={onClaim} onEdit={onEdit} onRepost={onRepost} />
+              <RequestCard key={r.id} request={r} isOwn={r.ownerUserId === currentUserId} reclaimBlocked={reclaimBlockedIds?.has(r.id) ?? false} submitting={submitting} onClaim={onClaim} onEdit={onEdit} onRepost={onRepost} />
             ))}
             {hasMore && onLoadMore && (
               <LoadMoreButton loadingMore={loadingMore} onLoadMore={onLoadMore} t={t} />

--- a/ctf/packages/web/lib/socket-relay/constants.ts
+++ b/ctf/packages/web/lib/socket-relay/constants.ts
@@ -28,6 +28,7 @@ export const SOCKET_RELAY_ERROR_CODE = {
   invalidOutcome: 'SOCKET_RELAY_INVALID_OUTCOME',
   actorIsOwner: 'SOCKET_RELAY_ACTOR_IS_OWNER',
   blockedPair: 'SOCKET_RELAY_BLOCKED_PAIR',
+  helperPreviouslyCanceled: 'SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED',
   actorNotParticipant: 'SOCKET_RELAY_ACTOR_NOT_PARTICIPANT',
   prohibitedContent: 'SOCKET_RELAY_PROHIBITED_CONTENT',
 } as const;

--- a/ctf/packages/web/lib/socket-relay/repository.ts
+++ b/ctf/packages/web/lib/socket-relay/repository.ts
@@ -719,6 +719,23 @@ async function findExistingActiveClaim(
   return (existing.rowCount ?? 0) > 0 ? mapFulfillmentRow(existing.rows[0]) : null;
 }
 
+// A helper the requester already canceled off this request (resolve outcome `unsuccessful_reopen`,
+// the only path that sets a fulfillment to 'canceled') cannot claim the same post again — "reopen
+// for others" means other helpers, not the same person coming back (owner directive, 2026-08-06).
+// Runs before the idempotency branch so a retry cannot resurrect the canceled claim.
+async function ensureHelperNotPreviouslyCanceled(client: PoolClient, requestId: string, actorUserId: string): Promise<void> {
+  const canceledBefore = await client.query(
+    `SELECT 1
+     FROM socket_relay_fulfillments
+     WHERE request_id = $1::uuid AND fulfiller_user_id = $2 AND status = 'canceled'
+     LIMIT 1`,
+    [requestId, actorUserId],
+  );
+  if ((canceledBefore.rowCount ?? 0) > 0) {
+    throw new Error('helper_previously_canceled');
+  }
+}
+
 export async function claimRequest(requestId: string, actorUserId: string, actorUsername: string | null = null): Promise<{ request: SocketRelayRequest; fulfillment: SocketRelayFulfillment }> {
   const created = await withDbTransaction(async (client) => {
     const requestResult = await client.query<RequestRow>(
@@ -747,21 +764,7 @@ export async function claimRequest(requestId: string, actorUserId: string, actor
       throw new Error('blocked_pair');
     }
 
-    // A helper the requester already canceled off this request (resolve outcome
-    // `unsuccessful_reopen`, the only path that sets a fulfillment to 'canceled') cannot claim the
-    // same post again — "reopen for others" means other helpers, not the same person coming back
-    // (owner directive, 2026-08-06). Checked before the idempotency branch so a retry cannot
-    // resurrect the canceled claim.
-    const canceledBefore = await client.query(
-      `SELECT 1
-       FROM socket_relay_fulfillments
-       WHERE request_id = $1::uuid AND fulfiller_user_id = $2 AND status = 'canceled'
-       LIMIT 1`,
-      [requestId, actorUserId],
-    );
-    if ((canceledBefore.rowCount ?? 0) > 0) {
-      throw new Error('helper_previously_canceled');
-    }
+    await ensureHelperNotPreviouslyCanceled(client, requestId, actorUserId);
 
     if (requestRow.status !== 'open') {
       const existing = await findExistingActiveClaim(client, requestRow, actorUserId);

--- a/ctf/packages/web/lib/socket-relay/repository.ts
+++ b/ctf/packages/web/lib/socket-relay/repository.ts
@@ -747,6 +747,22 @@ export async function claimRequest(requestId: string, actorUserId: string, actor
       throw new Error('blocked_pair');
     }
 
+    // A helper the requester already canceled off this request (resolve outcome
+    // `unsuccessful_reopen`, the only path that sets a fulfillment to 'canceled') cannot claim the
+    // same post again — "reopen for others" means other helpers, not the same person coming back
+    // (owner directive, 2026-08-06). Checked before the idempotency branch so a retry cannot
+    // resurrect the canceled claim.
+    const canceledBefore = await client.query(
+      `SELECT 1
+       FROM socket_relay_fulfillments
+       WHERE request_id = $1::uuid AND fulfiller_user_id = $2 AND status = 'canceled'
+       LIMIT 1`,
+      [requestId, actorUserId],
+    );
+    if ((canceledBefore.rowCount ?? 0) > 0) {
+      throw new Error('helper_previously_canceled');
+    }
+
     if (requestRow.status !== 'open') {
       const existing = await findExistingActiveClaim(client, requestRow, actorUserId);
       if (existing) {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed and why

When a requester resolves a Direct Line with "didn't work — reopen for others" (`unsuccessful_reopen`), the helper's fulfillment is canceled and the request returns to `open` — but nothing stopped that same helper from claiming the request again, re-opening the very conversation the requester had just ended. Owner directive (2026-08-06, from a report against the live app): the reopen is for **other** helpers.

- **Server (authoritative):** `claimRequest` now rejects a claim when the caller already has a **canceled** fulfillment on that request (the only path to `canceled` is `unsuccessful_reopen`). New error mapping `helper_previously_canceled` → `SOCKET_RELAY_HELPER_PREVIOUSLY_CANCELED`, 409. The check runs inside the claim transaction, before the idempotent-retry branch, so a retry cannot resurrect the canceled claim.
- **Soft member-facing copy (owner directive):** nothing reads as being turned away, and nothing reveals that the poster ended the earlier conversation. The 409 message is "You've already offered to help with this request — each member can offer once per post."
- **Web feed:** posts the member was canceled off show a "You already offered to help" note in place of the "I can help" button (derived client-side from the member's own `my-fulfillments` — no new route).
- **Docs in step:** claim command contract bumped to 1.1.0 (eligibility change; no dataAccess change), feature inventory §1.3/§3 + change log updated, manual test script SR-13 gains the re-claim expectations, including that the copy must never read as a block.
- **Complexity gate:** the canceled-helper check lives in its own `ensureHelperNotPreviouslyCanceled` helper and the open-post action column in its own `OpenCardAction` component, keeping `claimRequest` and `CardAction` within the limit that failed the first CI run.

No schema or route change. A different member can still claim the re-opened request normally.

**Lane: owner review** — this changes claim eligibility (an access rule) and a command contract, so auto-merge is not enabled; waiting on your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NCZ8oiwUCV5GErY629fpM