### PR TITLE
fix: record the reviewed member in the contributions review audit row

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -296,6 +296,12 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-08-06: Submission review audit rows now record the reviewed member. The confirm/reject audit
+  write in `app/api/contributions/admin/submissions/[submissionId]/review/route.ts` passed only the
+  admin (`actorUserId`), so the `targetUserId` the audit contract declares for
+  `contributions.admin.submission.confirm` / `.reject` was never stored. The member's id is now
+  written as `targetUserId` inside the audit `metadata` object (the `contributions_audit_log` table
+  keeps its existing columns — no schema or contract change).
 - 2026-07-19: Banner dismiss snooze shortened from six months to **two** (owner request). Changed the
   `banner_snooze_months` default in `schema.sql` / `schema.demo.sql` (6 → 2), the `DEFAULT_CONFIG`
   fallback in `repository.ts`, and the demo seed, and added a one-time data migration

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -153,14 +153,18 @@ Admins see the shared Admin pill in the member shell header, and the admin scree
 over Signal). On confirm, credits = confirmed amount × `credits_per_usd`, clamped by the
 per-user-per-cycle cap; a positive grant goes through the canonical service-credits mint exactly
 once. A grant clamped to 0 still confirms with `credits_granted = 0`. A claim can be reviewed only
-once.
+once. The audit row written for the confirm records the reviewed member as `targetUserId` in its
+metadata alongside the admin who acted (check `contributions_audit_log` if you are verifying the
+audit trail).
 **Result:** web ☐ mobile ☐ — notes:
 
 ### CON-A2 · Review queue (reject)
 **Role:** admin · **Surfaces:** web (admin surface)
 **Steps:**
 1. Reject a pending claim with a review note.
-**Expected:** The claim moves to `rejected` and grants nothing. It cannot be reviewed again.
+**Expected:** The claim moves to `rejected` and grants nothing. It cannot be reviewed again. The
+audit row for the rejection records the reviewed member as `targetUserId` in its metadata, same as
+the confirm path.
 **Result:** web ☐ mobile ☐ — notes:
 
 ### CON-A3 · Duplicate star confirms with zero credits

--- a/ctf/packages/web/app/api/contributions/admin/submissions/[submissionId]/review/route.ts
+++ b/ctf/packages/web/app/api/contributions/admin/submissions/[submissionId]/review/route.ts
@@ -69,6 +69,9 @@ export async function POST(request: Request, { params }: RouteParams) {
       action: body.action === 'confirm' ? 'contributions.admin.submission.confirm' : 'contributions.admin.submission.reject',
       targetSubmissionId: submission.id,
       metadata: {
+        // The reviewed member — required by the audit contract's targetContext for
+        // contributions.admin.submission.confirm / .reject.
+        targetUserId: submission.userId,
         kind: submission.kind,
         confirmedAmountUsd: submission.confirmedAmountUsd,
         creditsGranted: submission.creditsGranted,


### PR DESCRIPTION
Closes #2139

## What was wrong

The audit contract for `contributions.admin.submission.confirm` and
`contributions.admin.submission.reject` declares `targetUserId` — the member whose claim is being
reviewed — in `targetContext`. The audit write in the admin review route passed only the admin
(`actorUserId`), the submission id, kind, confirmed amount, credits granted, governance event id,
and cycle id. The reviewed member was never stored, so an audit row could not answer "whose claim
was this".

## Change

- `ctf/packages/web/app/api/contributions/admin/submissions/[submissionId]/review/route.ts`: add
  `targetUserId: submission.userId` to the audit `metadata` object for both confirm and reject.
- Inventory change log and the CON-A1 / CON-A2 steps in the manual test script updated to match.

`contributions_audit_log` has no `target_user_id` column, so the member id goes in `metadata` —
no schema change, no migration, no contract change, no behavior change for members or admins.
The audit write stays best-effort as before.

Verified with `pnpm --filter @ctf/web typecheck`, `check-inventory-drift.mjs`,
`check-test-script-drift.mjs`, and `check-eof-format.sh` — all pass.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — this is a server-side audit write with no rendered
surface.