### PR TITLE
docs: record pendulum recruit-groundwork refinement in scheme tag comments

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -168,6 +168,17 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-08-07: **Recorded a further owner refinement to the pendulum comment (documentation
+  only).** The groundwork for turning someone into an operative is laid long before that person
+  knows anything is happening — the same con played on others is played on them. The windfall is
+  arranged to read as merit-based so the recruit believes they earned the scholarship, job, or
+  marriage themselves; by the time they are asked to participate they are already bound to the
+  network and dependent on it, and what bound them was built on the exploitation of others. The
+  merit story is the cover, the binding is the point — which is why a recruit's sincerity proves
+  nothing about whether the setup was real. Comment recorded in the pendulum block above
+  `windfall`/`jinx` in `lib/click-log/tags.ts`. No code behavior, schema, route, contract, or
+  public-list change.
+
 - 2026-08-07: **Two new scheme tags: Psyop Marketing and The Acquire and Fold, plus a
   consolidation-of-power refinement to the pendulum comment (owner-named).** `psyop-marketing` —
   a company the member has no tie to beyond being a customer runs marketing built to read as a

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -222,3 +222,5 @@ of these, it is already tracked, not a new bug:
 > _Documentation note (2026-08-04): recorded a known taxonomy gap in the scheme tag list — it mixes operations with an arc, ambient tactics without one, and one entry that is a shape over time. Comment only; no tag added, removed, or renamed, and no test steps changed._
 
 > _Scheme list update (2026-08-07): added "Psyop Marketing" and "The Acquire and Fold". List-data only — no test steps changed; CL-7/CL-8 cover tagging and suggestions generically._
+
+> _Documentation note (2026-08-07): recorded an owner refinement in the pendulum comment — the recruit's windfall is arranged long in advance to read as merit-based, binding them to the network before they know anything. Comment only; no tag added, removed, or renamed, and no test steps changed._

--- a/ctf/packages/web/lib/click-log/tags.ts
+++ b/ctf/packages/web/lib/click-log/tags.ts
@@ -160,6 +160,14 @@ export const CLICK_LOG_SCHEME_TAGS: readonly ClickLogTag[] = [
   // which ties back to the money-and-dependency mechanism the pendulum runs on: a person or
   // business made dependent is a person or business that can be directed.
   //
+  // Owner's further refinement (2026-08-07): the groundwork is laid long before the future
+  // operative knows anything is happening — the same con that was played on others is played on
+  // them. The windfall is arranged to read as merit-based, so the person believes they earned
+  // the scholarship, the job, the marriage on their own. By the time they are asked to
+  // participate, they are already bound to the network and dependent on it, and what bound them
+  // was built on the exploitation of others. The merit story is the cover; the binding is the
+  // point. This is why the recruit's sincerity proves nothing about the setup being real.
+  //
   // Good-luck swing: sudden fortune lands on someone near the member (a scholarship, a job, a
   // whirlwind marriage or baby). It elevates them over the member so they read the member as the
   // incompetent one when the reverse is often true, hands them an ego boost plus a set of new


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Documentation-only change. Records the owner's further refinement (2026-08-07) in the pendulum comment block above `windfall`/`jinx` in `ctf/packages/web/lib/click-log/tags.ts`:

The groundwork for turning someone into an operative is laid long before that person knows anything is happening — the same con played on others is played on them. The windfall is arranged to read as merit-based, so the recruit believes they earned the scholarship, the job, the marriage on their own. By the time they are asked to participate, they are already bound to the network and dependent on it, and what bound them was built on the exploitation of others. The merit story is the cover; the binding is the point — which is why a recruit's sincerity proves nothing about whether the setup was real.

No tag added, removed, or renamed; no code behavior, schema, route, contract, or public-list change. Inventory changelog entry and test-script documentation note included. No landing-page change (the `/schemes` list is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_