### PR TITLE
fix: name the Chyme private room in the Weavers explainer

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md
@@ -51,8 +51,8 @@ no DMs) — and the **"Weavers of the Commons" badge** on Directory.
    redirected to `/apps/directory`, same gate as the Directory profile deep link). Plain-language
    explainer: earned by steadily delivering real help to other members across the platform;
    permanent once earned; no application and no way to buy it; no score shown anywhere; the same
-   standing opens the members-only channel in the Commons when it launches. Mobile-responsive,
-   rendered in the Directory shell tokens.
+   standing opens the members-only channel in the Commons and the private room in Chyme when they
+   launch. Mobile-responsive, rendered in the Directory shell tokens.
 
 4. **Eligible members see the gated channel alongside the Commons.** The Hub channel list
    (`GET /api/hub/channels`) adds `#contributors` server-side only when `channel_open` is TRUE and
@@ -355,6 +355,12 @@ fill on the first recompute / config save / member post.
 
 ## Change Log
 
+- 2026-08-07 — "How it's earned" explainer copy catch-up: the "What it opens" section
+  (`weavers-earned-page.tsx`) now names both private surfaces the badge standing opens — the
+  members-only channel in the Commons **and** the private "Weavers of the Commons" room in Chyme
+  (shipped 2026-07-23) — instead of the Commons channel alone. Test script CA-6 updated to match.
+  Copy-only; no schema, route, or contract change. Web-only (rule 105 — no Android explainer
+  surface).
 - 2026-08-06 — Channel join CSRF + config contract catch-up (code-review issues #2122, #2128).
   `POST /api/contributor-access/channel/join` now runs `ensureMutationCsrf` like every other
   mutation in this plugin — the join reconciles the member into the Stream channel, a side effect

--- a/ctf/docs/developer/test-scripts/contributor-access-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributor-access-test-script.md
@@ -134,7 +134,7 @@ Result: web ☐ mobile-responsive ☐
 - It states the badge is permanent once earned.
 - It states there is no application and no way to buy it.
 - It states no score is shown anywhere.
-- It mentions the same standing opens the members-only channel in the Commons.
+- It mentions the same standing opens the members-only channel in the Commons and the private room in Chyme.
 - No numeric score, tier, leaderboard, or ranking appears anywhere on the page.
 
 Result: web ☐ mobile-responsive ☐

--- a/ctf/packages/web/components/contributor-access/weavers-earned-page.tsx
+++ b/ctf/packages/web/components/contributor-access/weavers-earned-page.tsx
@@ -76,7 +76,8 @@ export function WeaversEarnedPage() {
             <div style={sectionTitle}>What it opens</div>
             <p style={body}>
               The same standing that earns this badge will open the members-only channel in the
-              Commons when it launches — a space for the members who keep this community running.
+              Commons and the private room in Chyme when they launch — spaces for the members who
+              keep this community running.
             </p>
           </section>
         </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

The "What it opens" section of the "How it's earned" page (`/apps/directory/weavers-of-the-commons`) said the badge standing opens the members-only channel in the Commons, and nothing else. Since 2026-07-23 the same standing also opens the private "Weavers of the Commons" audio room in Chyme (`chyme-contributors-room`, gated by the same channel-open switch plus the eligibility flag). The page was out of date and undersold what the badge grants.

The section now names both surfaces:

> The same standing that earns this badge will open the members-only channel in the Commons and the private room in Chyme when they launch — spaces for the members who keep this community running.

## Why

A member reading the explainer had no way to learn about the second private surface. The two surfaces share one gate, so they belong in one sentence.

## Kept in sync

- `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributor-access-feature-inventory.md` — User Features item 3 restated, plus a change-log entry.
- `ctf/docs/developer/test-scripts/contributor-access-test-script.md` — step CA-6's expected content now checks for both surfaces.

## Scope

Copy only. No schema, route, contract, or access-gate change — the Chyme room gate itself is unchanged and already shipped. There is no Android explainer surface, so nothing to build there.

## Checks run locally

`@ctf/web` typecheck, lint, accessibility lint, and production build all pass. `check-eof-format.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_013aDQX4BPAqDDTs3z7kwqQP)_