### PR TITLE
fix: record which contribution settings an admin changed in the audit row

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -296,6 +296,12 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-08-07: Admin settings audit rows now record which settings the admin actually sent. The
+  audit write in `app/api/contributions/admin/config/route.ts` logged every setting's resulting
+  value, so a record could not show whether a knob was edited or merely carried over. The route now
+  computes `changedKnobs` from the fields present in the request body (the list the audit contract
+  already declares) and keeps the resulting values under `resultingConfig`. No schema, route, or
+  contract change.
 - 2026-08-06: Submission review audit rows now record the reviewed member. The confirm/reject audit
   write in `app/api/contributions/admin/submissions/[submissionId]/review/route.ts` passed only the
   admin (`actorUserId`), so the `targetUserId` the audit contract declares for

--- a/ctf/packages/web/app/api/contributions/admin/config/route.ts
+++ b/ctf/packages/web/app/api/contributions/admin/config/route.ts
@@ -20,6 +20,15 @@ type ConfigBody = {
   signalInstructions?: string;
 };
 
+const CONFIG_FIELDS = [
+  'creditsPerUsd',
+  'nonMonetaryUnitValueUsd',
+  'perUserCycleCreditCap',
+  'bannerSnoozeMonths',
+  'bannerEnabled',
+  'signalInstructions',
+] as const satisfies readonly (keyof ConfigBody)[];
+
 export async function GET() {
   const gate = await requireContributionsAdminAccess();
   if (!gate.allowed) {
@@ -50,6 +59,7 @@ export async function PUT(request: Request) {
     return parsed.response;
   }
   const body = parsed.body as ConfigBody;
+  const changedKnobs = CONFIG_FIELDS.filter((field) => body[field] !== undefined);
 
   try {
     const config = await updateContributionsConfig({
@@ -66,11 +76,16 @@ export async function PUT(request: Request) {
       actorUserId: gate.auth.userId,
       action: 'contributions.admin.config.update',
       metadata: {
-        creditsPerUsd: config.creditsPerUsd,
-        nonMonetaryUnitValueUsd: config.nonMonetaryUnitValueUsd,
-        perUserCycleCreditCap: config.perUserCycleCreditCap,
-        bannerSnoozeMonths: config.bannerSnoozeMonths,
-        bannerEnabled: config.bannerEnabled,
+        // Only the fields the caller actually sent — an omitted field keeps its current value,
+        // so listing every knob here would misattribute untouched settings as changed.
+        changedKnobs,
+        resultingConfig: {
+          creditsPerUsd: config.creditsPerUsd,
+          nonMonetaryUnitValueUsd: config.nonMonetaryUnitValueUsd,
+          perUserCycleCreditCap: config.perUserCycleCreditCap,
+          bannerSnoozeMonths: config.bannerSnoozeMonths,
+          bannerEnabled: config.bannerEnabled,
+        },
       },
     });
 


### PR DESCRIPTION
Closes #2142

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

The admin settings update route (`ctf/packages/web/app/api/contributions/admin/config/route.ts`) wrote every setting's resulting value into its audit record. Toggling only the banner still produced a row listing the credit rate, unit value, and caps, so a reader could not tell which setting the admin actually edited.

The route now computes `changedKnobs` from the fields present in the request body and keeps the resulting values under `resultingConfig`. Omitted fields keep their current value, so only sent fields count as changed. `changedKnobs: config_field_names` is already declared for `contributions.admin.config.update` in `CONTRIBUTIONS_PLUGIN_AUDIT_CONTRACTS.yaml` — the code was not writing what the contract said it would, and this brings the two into line. No schema, route, or contract change; the audit write stays best-effort.

## Unblocking pass (2026-08-09)

This PR had been sitting on two blockers, both now cleared:

- **Merge conflict with `main`.** #2165 added a 2026-08-09 entry to the same Contributions change-log section this PR appends to. Both entries are kept, newest first — nothing was dropped.
- **Test Script Drift Gate red.** The gate requires a matching test-script edit whenever a plugin inventory changes, and this PR changed the inventory without touching `contributions-test-script.md`. CONT-A13 (admin updates runtime configuration) now checks the audit row this PR is about: `changedKnobs` must name only the setting that was actually edited, with the post-save values under `resultingConfig`. A `changedKnobs` list naming every setting is exactly the bug #2142 reported.

Verified locally after the merge: `@ctf/web` typecheck, lint (`--max-warnings=0`), and `build:ci`; `check-eof-format.sh`; `check-inventory-drift.mjs`; `check-test-script-drift.mjs`.