### PR TITLE
feat: make Restricted trust visibility serve a summary instead of a refusal

### DIFF
--- a/ctf/docs/contracts/TRUST_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -24,10 +24,17 @@ policies:
     highRiskFlags:
       containsPHI: false
       requiresAdditionalAudit: true
+    disclosureLevels:
+      # `restricted` is served, not refused: a non-owner non-admin viewer receives the summary
+      # projection (headline counts, no timestamps, per-plugin items collapsed to one breadth
+      # line). Only `private` refuses. The owner and admins always read `full`.
+      public: full
+      restricted: summary
+      private: denied_for_non_owner_non_admin
     denyConditions:
       - unauthenticated_session
       - unauthorized_scope
-      - trust_visibility_restricted
+      - trust_visibility_private
       - raw_signal_request_detected
 
   - pluginId: trust

--- a/ctf/docs/contracts/TRUST_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/TRUST_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -2,7 +2,7 @@ contracts:
   - pluginId: trust
     command: trust.summary.read
     version: 1.0.0
-    description: Read a member's trust panel (status, derived evidence, visibility). Implemented by GET /api/trust/user/self and GET /api/trust/user/[userId]; cross-user reads enforce the subject's trustVisibility.
+    description: Read a member's trust panel (status, derived evidence, visibility). Implemented by GET /api/trust/user/self and GET /api/trust/user/[userId]; cross-user reads enforce the subject's trustVisibility at one of two disclosure levels — full for public (and always for the owner or an admin), summary for restricted. Private refuses a non-owner non-admin read.
     inputSchema:
       subjectUserId:
         type: string
@@ -24,6 +24,12 @@ contracts:
         type: string
       updatedAt:
         type: string
+      trustDisclosure:
+        type: string
+        enum:
+          - full
+          - summary
+        description: Which projection the viewer received. summary carries headline counts only — no timestamps, no supporting detail, per-plugin items collapsed to a single breadth line.
     dataAccess:
       - trust_user_extension
       - trust_signal_snapshot

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -18,13 +18,15 @@ Trust gives the community a privacy-respecting, **non-numeric** way to gauge how
 1. View their trust badge (qualitative standing, not a number), evidence panel, and verification status on profile/directory surfaces.
 2. Choose who can see their own trust signals, from a labeled "Who can see your trust signals"
    dropdown on their own Trust card (account hub, community right rail, own Directory profile).
-   The choices name their audience: **Public** — any signed-in member who opens your profile sees
-   every signal; **Restricted** — other members see a summary of how active you are (sign-in days,
-   how many plugins you take part in, and any ServiceCredits counts) without the detail or the
-   dates; **Private** — other members cannot open your panel at all. The member's own card always
-   lists every signal whichever choice is active, and a "What other members see" preview under the
-   dropdown shows exactly what a peer would receive at the current choice. A "Saved" confirmation
-   appears when the choice is stored.
+   Each choice states the outcome in plain words rather than naming a category: **"Members see
+   everything"** — any signed-in member who opens your profile sees every signal; **"Members see a
+   summary"** — members see how active you are (sign-in days, how many plugins you take part in, and
+   any ServiceCredits counts) without the detail or the dates; **"Only you see this"** — no other
+   member can open the panel, though admins can, as they can for every member. The member always
+   sees every signal on their own card whichever choice is active, and a "What members see" preview
+   under the dropdown shows exactly what a member would receive at the current choice. A "Saved"
+   confirmation appears when the choice is stored. The setting governs the trust panel only; it is
+   not a platform-wide visibility switch.
 3. Inspect their own trust signal snapshot via `GET /api/trust/user/self`.
 
 ## Admin Features
@@ -163,6 +165,21 @@ Trust has no dedicated seed script, and none is required. Trust is a derived plu
    closing if the status is ever meant to stay admin-side.
 
 ## Change Log
+
+- 2026-08-08: **Plain-language names for the three choices.** Owner direction: the labels named a
+  category and left the member to work out the category's rules, which is how the three were read as
+  kinds of transaction in the first place. "Public" / "Restricted" / "Private" are now
+  **"Members see everything"** / **"Members see a summary"** / **"Only you see this"** — each states
+  who sees what, so the three read as one scale and nothing has to be inferred. Admins stay named in
+  the effect line under the dropdown rather than in the label, so "Only you see this" is not a claim
+  the app fails to keep. The read-only row on another member's card is relabeled from
+  "Visible to: Public" to the same outcome stated from the viewer's side ("This member shares
+  everything" / "This member shares a summary"), and is dropped from a peer's summary card where the
+  note above the list already says it. The stored enum values are unchanged
+  (`public` / `restricted` / `private`) — this is presentation only, no route, contract, or schema
+  change. Also corrected an error in the previous entry's framing: this setting governs the trust
+  panel and nothing else, so `private` was never a claim of platform-wide invisibility and the
+  ungated presence list is not in tension with it.
 
 - 2026-08-07: **`Restricted` became a real middle tier.** Owner direction: a member checking whether
   someone is an engaged participant should be able to see *something*, otherwise only admins can.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -18,11 +18,13 @@ Trust gives the community a privacy-respecting, **non-numeric** way to gauge how
 1. View their trust badge (qualitative standing, not a number), evidence panel, and verification status on profile/directory surfaces.
 2. Choose who can see their own trust signals, from a labeled "Who can see your trust signals"
    dropdown on their own Trust card (account hub, community right rail, own Directory profile).
-   The choices name their audience: **Public** — any signed-in member who opens your profile;
-   **Private** — only you and admins; **Restricted** — only you and admins, the same as Private
-   today. The member's own card always lists every signal whichever choice is active, so the
-   setting changes only what other members see; a "Saved" confirmation appears when the choice is
-   stored.
+   The choices name their audience: **Public** — any signed-in member who opens your profile sees
+   every signal; **Restricted** — other members see a summary of how active you are (sign-in days,
+   how many plugins you take part in, and any ServiceCredits counts) without the detail or the
+   dates; **Private** — other members cannot open your panel at all. The member's own card always
+   lists every signal whichever choice is active, and a "What other members see" preview under the
+   dropdown shows exactly what a peer would receive at the current choice. A "Saved" confirmation
+   appears when the choice is stored.
 3. Inspect their own trust signal snapshot via `GET /api/trust/user/self`.
 
 ## Admin Features
@@ -34,7 +36,7 @@ Trust gives the community a privacy-respecting, **non-numeric** way to gauge how
 ## API Surface and Route Map
 
 - `GET /api/trust/user/self` — Implemented. Recomputes the caller's trust signals before returning, so the panel reflects their current participation instead of a frozen snapshot that nothing refreshed. Calls `refreshTrustSignalSnapshot(userId)` (the same logic as `POST /api/trust/signal/snapshot`), persists a snapshot row, refreshes derived evidence, and returns the fresh `trust_user_extension`. Resilient: if the recompute throws, it falls back to the last stored extension so the member's own read never errors. Gated by server-side plugin authz (`evaluatePluginAccess`). The cross-user route stays a plain read (no recompute).
-- `GET /api/trust/user/[userId]` — Implemented. Returns another member's trust panel, gated by authentication AND the target's `trust_visibility`: `public` is readable by any authenticated, unlocked member; `private` and `restricted` are readable only by the owner (self) or an admin. A blocked viewer receives `403`. A target with no extension row defaults to `public`.
+- `GET /api/trust/user/[userId]` — Implemented. Returns another member's trust panel, gated by authentication AND the target's `trust_visibility`, at one of two disclosure levels reported on the response as `trustDisclosure`. `public` → `full` for any authenticated, unlocked member. `restricted` → `summary` for any other member: headline counts only, with every timestamp and supporting detail dropped and the per-plugin participation items collapsed to a single "Took part in N plugins" breadth line (`lib/trust/peer-summary.ts`). `private` → `403` for anyone but the owner or an admin. The owner (self) and admins always receive `full`, whatever the setting. A target with no extension row defaults to `public`.
 - `POST /api/trust/visibility` — Implemented. Updates the caller's own visibility (`public` | `private` | `restricted`); rejects any other value with `400`; CSRF-guarded; writes a `trust_admin_audit_trail` row. Self-scope only.
 - `POST /api/trust/signal/snapshot` — Implemented. Recomputes the caller's trust signal (model `cross_plugin_engagement_v4`) from real cross-plugin engagement — login frequency from `login_events`; SocketRelay trades/requests; ServiceCredits received (distinct payers + undisputed completed transfers); per-plugin participation COUNTs across LightHouse, TrustTransport, SkillsHunt, LevelUp, Chyme, Directory, WhatWorks, PeerProgramming, Contributions, and Foundation (provider side); and the count of DISTINCT members with a confirmed recurring activity (`recurring_activities`, either side). Coarse COUNTs only; privacy-sensitive plugins (ClickLog, Mood, GentlePulse, Unlock, and the Foundation seeker side) are excluded — see the Trust Signal Model section. Persists a `trust_signal_snapshot` row and refreshes the caller's derived evidence. Never changes `trust_status`. CSRF-guarded; writes an audit row.
 - `POST /api/trust/admin/verification` — Implemented. Admin-only (`evaluatePluginAccess({ requiredRoles: ['admin'] })`). Sets a target user's `trust_status` to `verified` or `flagged`, appends an admin evidence item, and writes an audit row. Validates `targetUserId` and `trustStatus` (`400` on bad input). CSRF-guarded.
@@ -106,8 +108,13 @@ numeric score is ever computed or stored. The snapshot route never changes `trus
 ## Security, Privacy, and Compliance Controls
 
 - Authentication on every route via `evaluatePluginAccess` (web Clerk headers or verified bearer token).
-- Cross-user read (`GET /api/trust/user/[userId]`) enforces the target's `trust_visibility`: `public`
-  = any authenticated member; `private`/`restricted` = owner or admin only. Blocked viewers get `403`.
+- Cross-user read (`GET /api/trust/user/[userId]`) enforces the target's `trust_visibility` as a
+  disclosure level, not a single allow/deny: `public` = the full panel to any authenticated member;
+  `restricted` = the summary projection to any other member (headline counts, no timestamps, no
+  supporting detail, per-plugin items collapsed to one breadth line); `private` = owner or admin only,
+  everyone else gets `403`. The owner and admins always read the full panel. The projection lives in
+  `lib/trust/peer-summary.ts`, is covered by `lib/trust/peer-summary.test.ts`, and fails closed — an
+  evidence type it does not recognize is dropped rather than passed through.
 - Admin-only gate on `POST /api/trust/admin/verification` via `evaluatePluginAccess({ requiredRoles: ['admin'] })`.
 - All three mutation routes require the same-origin CSRF confirmation header and reject cross-origin
   mutations.
@@ -142,17 +149,45 @@ Trust has no dedicated seed script, and none is required. Trust is a derived plu
 5. Trust evidence content is rendered from a structured JSONB field on `trust_user_extension`; no rich-text schema or attachment storage contract has been published.
 6. No automated/scheduled refresh job exists for recomputing the derived signal — refresh is on-demand via the snapshot route (a future scheduled job could call the same logic).
 7. The model counts engagement but does not yet expose a `member_since` or active-plugin-count signal; those design fields remain omitted per real-data-only until a backing source is wired.
-8. `restricted` and `private` are two names for one behavior. `GET /api/trust/user/[userId]` is the
-   only place trust visibility is enforced, and it treats both as owner-or-admin, so the picker
-   offers three choices that produce two outcomes. The route comment records the intent — `restricted`
-   was meant to mean "members see a coarse summary, not the full evidence list" — but no
-   profile-embedded summary surface was ever built to differentiate it. Two ways out, both needing an
-   owner decision because each changes a shipped member-facing choice: build the coarse summary view
-   so `restricted` earns its name, or drop it from the picker (keeping the enum value accepted
-   server-side so existing rows stay valid). Until then the UI states the duplication rather than
-   implying an audience that does not exist.
+8. ~~`restricted` and `private` are two names for one behavior.~~ Resolved (2026-08-07) — `restricted`
+   now serves the summary projection to other members instead of refusing them, so the three choices
+   produce three outcomes. See the change log entry for the disclosure rules.
+9. The summary projection classifies evidence by `type` and fails closed, so a NEW signal added to
+   `buildTrustEvidence` is dropped from the `restricted` view until it is deliberately listed in
+   `PLUGIN_BY_EVIDENCE_TYPE` or `PASSTHROUGH_EVIDENCE_TYPES` in `lib/trust/peer-summary.ts`. That is
+   the safe default for a disclosure boundary, but it does mean a new signal silently under-reports
+   there — adding a signal means classifying it in the same change.
+10. `trustStatus` is returned to peers at both disclosure levels, so a `flagged` status is in the
+   payload of a public or restricted read even though no surface renders it (the widget has no status
+   chip by design). Pre-existing on `public`; the summary projection did not widen it, but it is worth
+   closing if the status is ever meant to stay admin-side.
 
 ## Change Log
+
+- 2026-08-07: **`Restricted` became a real middle tier.** Owner direction: a member checking whether
+  someone is an engaged participant should be able to see *something*, otherwise only admins can.
+  Until now `restricted` was enforced identically to `private` — both `403` — so picking it hid
+  everything from peers, the opposite of its purpose. `GET /api/trust/user/[userId]` now resolves
+  visibility to a disclosure level instead of a single allow/deny: `public` serves the full panel,
+  `restricted` serves a summary projection, `private` still refuses. The owner and admins always
+  receive the full panel. The response carries `trustDisclosure` (`full` | `summary`) so the widget
+  can label a summary as one rather than passing it off as the member's whole record.
+  The projection (`lib/trust/peer-summary.ts`) follows two rules: no timestamps and no supporting
+  detail survive (the login item's `details` carries the exact last sign-in, which is a record), and
+  per-plugin participation collapses into a single "Took part in N plugins" line counting DISTINCT
+  plugins — so a peer learns the member is active without learning what they did or where.
+  Aggregate counts that are already coarse (sign-in days, the two ServiceCredits lines) pass through
+  with their shipped wording unchanged; the projection never rewrites a summary string, so approved
+  copy cannot drift there. It fails closed: an unrecognized evidence type is dropped.
+  On the member's own card the visibility control now renders a "What other members see" preview
+  built by calling the same projection function, so the preview cannot disagree with what peers
+  actually receive — and changing the setting finally changes something on the owner's own screen,
+  which was the root of the original "appears to change nothing" report. Option order runs
+  Public → Restricted → Private so the dropdown reads as a scale. New tests:
+  `lib/trust/peer-summary.test.ts` (8 cases) lock the disclosure boundary. Contracts updated:
+  `trust.summary.read` gains the `trustDisclosure` output field and the access policy records
+  `disclosureLevels`, replacing the `trust_visibility_restricted` deny condition with
+  `trust_visibility_private`. No schema change — the stored enum is unchanged.
 
 - 2026-08-07: **Visibility control says what it does.** Member report: the control was not noticed at
   all, and changing it appeared to do nothing — the member guessed their account simply had no

--- a/ctf/docs/developer/test-scripts/trust-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-test-script.md
@@ -12,7 +12,7 @@
 | **Surfaces** | Web: `TrustWidgetCard.tsx`, `trust-visibility-control.tsx`, `lib/trust/peer-summary.ts`, `trust-public-shell.tsx`, `/api/trust/*` routes · Android: `Trust.tsx`, `api.ts` |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md` |
-| **Generated** | 2026-08-07 (hand-updated: restricted serves the summary projection — TR-A4b; visibility control preview and save confirmation — TR-A5b; admin verification page `/admin/trust` — TR-A9b) |
+| **Generated** | 2026-08-08 (hand-updated: plain-language choice labels — TR-A5b; restricted serves the summary projection — TR-A4b; admin verification page `/admin/trust` — TR-A9b) |
 
 ---
 
@@ -149,6 +149,7 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 - No per-plugin item survives — the response must not name SkillsHunt, Chyme, LightHouse, Foundation, or any other plugin, and must not carry a per-plugin count.
 - The breadth line counts DISTINCT plugins: a member with both a SocketRelay trades item and a SocketRelay requests item counts SocketRelay once.
 - On the Directory profile the Trust card renders normally with the shorter list, above it the note "This member shares a summary of their participation, not the detail." The "This member limits who can view their trust" refusal note must **not** appear (that is now the `private` state only).
+- The read-only visibility row at the bottom of that card is **not** rendered on a summary card — the note above the list already says the member shares a summary, so repeating it below would be noise. It is still rendered on a full peer card, reading "This member shares everything".
 - The read writes a `trust.summary.read` row with `policy_status = allow` and reason `restricted_summary_read`.
 
 **Result:** web ☐
@@ -184,20 +185,21 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 **Precondition:** Admin signed in.
 
 **Steps:**
-1. Open the account hub (or the community shell right rail) and find the Trust widget's "Who can see your trust signals" control.
-2. Change the dropdown to `Private — only you and admins`, then reload the page.
+1. Open the account hub (or the community shell right rail) and find the Trust widget's "Who sees your trust signals" control.
+2. Change the dropdown to "Only you see this", then reload the page.
 3. Open another member's Directory profile and find their Trust widget (member with `public` visibility).
-4. Reset your own visibility to `Public — any signed-in member`.
+4. Reset your own choice to "Members see everything".
 
 **Expected:**
-- On your own widget the control has a heading ("Who can see your trust signals") above a full-width dropdown, so it reads as something you can change rather than a status line.
-- The choices are ordered most open to most private and each names its audience: "Public — any signed-in member", "Restricted — a summary, no detail", "Private — only you and admins". Below the dropdown, a sentence states what the current choice does and that your own card always shows everything whichever one you pick.
-- Under that, a **"What other members see"** preview shows the result of the current choice: on `Public`, "Everything listed above, exactly as you see it."; on `Private`, "Nothing. Your panel is hidden from other members."; on `Restricted`, the actual summary lines a peer would receive.
-- The `Restricted` preview must match what the API returns for a peer (cross-check against TR-A4b) — both come from the same projection function, so any disagreement is a bug.
+- On your own widget the control has a heading ("Who sees your trust signals") above a full-width dropdown, so it reads as something you can change rather than a status line.
+- The choices are ordered most open to most private and each states the outcome in plain words — **"Members see everything"**, **"Members see a summary"**, **"Only you see this"**. No choice is named after a category ("Public"/"Restricted"/"Private" must not appear as option text).
+- Below the dropdown, a sentence states what the current choice does and that you always see everything on your own card whichever one you pick. On "Only you see this" that sentence must also say admins can read the panel — the label alone would otherwise overpromise.
+- Under that, a **"What members see"** preview shows the result of the current choice: on "Members see everything", "Everything listed above, exactly as you see it."; on "Only you see this", "Nothing — this panel does not appear on your profile for them."; on "Members see a summary", the actual summary lines a member would receive.
+- The summary preview must match what the API returns for a peer (cross-check against TR-A4b) — both come from the same projection function, so any disagreement is a bug.
 - Changing it POSTs `/api/trust/visibility`, shows "Saving…" while in flight, then a "Saved" confirmation that clears itself after a few seconds. After reload the chosen value is still selected.
 - Your own evidence list above the control does **not** change when the setting changes — that is correct; the preview is where the effect shows. Do not file the unchanged list as a bug.
 - On failure (e.g. network cut), the dropdown reverts to the previous value and a short plain-language error appears under it, replacing the confirmation.
-- On **another member's** widget the row is plain text ("Visible to: …"), never a dropdown, and no preview is shown — the route is self-scope only.
+- On **another member's** widget the row is plain text stating what they share ("This member shares everything"), never a dropdown, and no preview is shown — the route is self-scope only.
 
 **Result:** web ☐
 

--- a/ctf/docs/developer/test-scripts/trust-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-test-script.md
@@ -9,10 +9,10 @@
 | **Plugin** | Trust (`trust`) |
 | **Visibility** | Internal |
 | **Roles to test** | Admin only |
-| **Surfaces** | Web: `TrustWidgetCard.tsx`, `trust-visibility-control.tsx`, `trust-public-shell.tsx`, `/api/trust/*` routes · Android: `Trust.tsx`, `api.ts` |
+| **Surfaces** | Web: `TrustWidgetCard.tsx`, `trust-visibility-control.tsx`, `lib/trust/peer-summary.ts`, `trust-public-shell.tsx`, `/api/trust/*` routes · Android: `Trust.tsx`, `api.ts` |
 | **Seed first** | `pnpm --dir ctf seed:demo` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md` |
-| **Generated** | 2026-08-07 (hand-updated: visibility control labeled and confirmed on save — TR-A5b; admin verification page `/admin/trust` — TR-A9b) |
+| **Generated** | 2026-08-07 (hand-updated: restricted serves the summary projection — TR-A4b; visibility control preview and save confirmation — TR-A5b; admin verification page `/admin/trust` — TR-A9b) |
 
 ---
 
@@ -112,7 +112,7 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 
 ---
 
-### TR-A4 — Cross-user read: private/restricted visibility blocks non-owner non-admin
+### TR-A4 — Cross-user read: private visibility refuses a non-owner non-admin
 
 **Role:** Admin (to set up); tested from a non-owner non-admin caller  
 **Surfaces:** Web API  
@@ -124,8 +124,32 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 
 **Expected:**
 - Non-owner, non-admin caller: HTTP 403.
-- Admin caller: HTTP 200 with full panel.
-- Each read writes a `trust.summary.read` row to `trust_admin_audit_trail`: the blocked non-owner read as `policy_status = deny` (reason `forbidden_visibility`), the admin read as `policy_status = allow` (reason `admin_summary_read`).
+- Admin caller: HTTP 200 with the full panel and `trustDisclosure: "full"`.
+- Each read writes a `trust.summary.read` row to `trust_admin_audit_trail`: the refused non-owner read as `policy_status = deny` (reason `forbidden_visibility`), the admin read as `policy_status = allow` (reason `admin_summary_read`).
+
+**Result:** web ☐
+
+---
+
+### TR-A4b — Cross-user read: restricted visibility serves the summary, not a refusal
+
+**Role:** Admin (to set up); tested from a non-owner non-admin caller  
+**Surfaces:** Web API + Web UI  
+**Precondition:** Member B's `trust_visibility` is set to `restricted`, and Member B has real upstream activity (sign-ins plus participation in at least two plugins) so the summary has something to report.
+
+**Steps:**
+1. Authenticate as a **different** member (not Member B, not admin) and call `GET /api/trust/user/[memberB_userId]`.
+2. Compare the response against Member B's own full panel (read it as admin).
+3. Open Member B's Directory profile as that same non-admin member.
+
+**Expected:**
+- HTTP 200, **not** 403 — this is the point of the setting. `trustDisclosure` is `"summary"`.
+- `trustEvidence` contains headline counts only. Specifically: a sign-in line ("Active on N days") if they have one, a single breadth line reading "Took part in N plugins", and any ServiceCredits count lines.
+- **No item carries a `createdAt` or a `details` field.** The full panel's last-sign-in detail must not appear anywhere in the response.
+- No per-plugin item survives — the response must not name SkillsHunt, Chyme, LightHouse, Foundation, or any other plugin, and must not carry a per-plugin count.
+- The breadth line counts DISTINCT plugins: a member with both a SocketRelay trades item and a SocketRelay requests item counts SocketRelay once.
+- On the Directory profile the Trust card renders normally with the shorter list, above it the note "This member shares a summary of their participation, not the detail." The "This member limits who can view their trust" refusal note must **not** appear (that is now the `private` state only).
+- The read writes a `trust.summary.read` row with `policy_status = allow` and reason `restricted_summary_read`.
 
 **Result:** web ☐
 
@@ -167,12 +191,13 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 
 **Expected:**
 - On your own widget the control has a heading ("Who can see your trust signals") above a full-width dropdown, so it reads as something you can change rather than a status line.
-- Each choice names its audience: "Public — any signed-in member", "Private — only you and admins", "Restricted — only you and admins". Below the dropdown, a sentence states what the current choice does and that your own card always shows everything whichever one you pick.
-- `Restricted` says plainly that it behaves the same as `Private` today — the two enforce identically at `GET /api/trust/user/[userId]`, so neither claims a members-only audience.
+- The choices are ordered most open to most private and each names its audience: "Public — any signed-in member", "Restricted — a summary, no detail", "Private — only you and admins". Below the dropdown, a sentence states what the current choice does and that your own card always shows everything whichever one you pick.
+- Under that, a **"What other members see"** preview shows the result of the current choice: on `Public`, "Everything listed above, exactly as you see it."; on `Private`, "Nothing. Your panel is hidden from other members."; on `Restricted`, the actual summary lines a peer would receive.
+- The `Restricted` preview must match what the API returns for a peer (cross-check against TR-A4b) — both come from the same projection function, so any disagreement is a bug.
 - Changing it POSTs `/api/trust/visibility`, shows "Saving…" while in flight, then a "Saved" confirmation that clears itself after a few seconds. After reload the chosen value is still selected.
-- Your own evidence list does **not** change when the setting changes — that is correct, and the sentence under the dropdown says so. Do not file it as a bug.
+- Your own evidence list above the control does **not** change when the setting changes — that is correct; the preview is where the effect shows. Do not file the unchanged list as a bug.
 - On failure (e.g. network cut), the dropdown reverts to the previous value and a short plain-language error appears under it, replacing the confirmation.
-- On **another member's** widget the row is plain text ("Visible to: …"), never a dropdown — the route is self-scope only.
+- On **another member's** widget the row is plain text ("Visible to: …"), never a dropdown, and no preview is shown — the route is self-scope only.
 
 **Result:** web ☐
 

--- a/ctf/packages/web/app/api/trust/user/[userId]/route.ts
+++ b/ctf/packages/web/app/api/trust/user/[userId]/route.ts
@@ -2,17 +2,39 @@ import { NextResponse } from 'next/server';
 import { requireTrustMemberAccess, resolveRequestId } from 'lib/trust/_lib';
 import { TRUST_ERROR_CODE } from 'lib/trust/constants';
 import { getTrustUserExtension } from 'lib/trust/repository';
+import { summarizeTrustEvidenceForPeer } from 'lib/trust/peer-summary';
 import { logTrustAuditEvent } from 'lib/trust/audit';
 import { reportError } from 'lib/observability/report';
+import type { TrustPeerView, TrustUserExtension } from 'lib/trust/types';
 
 // GET /api/trust/user/[userId]
 // Returns another member's trust panel, gated by authentication AND the target's visibility setting:
-//   - public     → any authenticated, unlocked member may read.
-//   - private    → only the owner (self) or an admin.
-//   - restricted → only the owner (self) or an admin (this full-evidence endpoint is owner/admin
-//                  only; coarser, profile-embedded surfaces decide their own restricted display).
-// A blocked viewer gets 403 (the row exists but is not visible to them). A non-existent target
-// with no extension row defaults to `public` (the default state), so it reads like any new member.
+//   - public     → any authenticated, unlocked member reads the full panel.
+//   - restricted → the owner and admins read the full panel; any other member reads the SUMMARY
+//                  projection (headline counts, no timestamps, per-plugin items collapsed to one
+//                  breadth line). This is the middle tier the setting is named for: a member
+//                  checking whether someone is an engaged participant gets that answer without
+//                  seeing the record behind it.
+//   - private    → only the owner (self) or an admin; everyone else is refused.
+// A refused viewer gets 403 (the row exists but is not visible to them). A non-existent target with
+// no extension row defaults to `public` (the default state), so it reads like any new member.
+//
+// `trustDisclosure` on the response tells the client which of the two it received, so the widget can
+// label a summary as a summary instead of presenting it as the member's whole record.
+function fullView(trust: TrustUserExtension): TrustPeerView {
+  return { ...trust, trustDisclosure: 'full' };
+}
+
+// Build the reduced projection from the stored evidence. Nothing else on the extension is widened:
+// the same fields a `public` profile already exposes are returned, with only the evidence narrowed.
+function summaryView(trust: TrustUserExtension): TrustPeerView {
+  return {
+    ...trust,
+    trustEvidence: summarizeTrustEvidenceForPeer(trust.trustEvidence),
+    trustDisclosure: 'summary',
+  };
+}
+
 export async function GET(request: Request, context: unknown) {
   const { userId: targetUserId } = (context as { params: { userId: string } }).params;
 
@@ -48,22 +70,33 @@ export async function GET(request: Request, context: unknown) {
     const trust = await getTrustUserExtension(targetUserId);
 
     const isOwner = viewerUserId === targetUserId;
-    const isPublic = trust.trustVisibility === 'public';
+    const isPrivileged = isOwner || viewerIsAdmin;
 
-    if (!isPublic && !isOwner && !viewerIsAdmin) {
-      await audit('deny', 'forbidden_visibility');
-      return NextResponse.json(
-        {
-          ok: false,
-          code: TRUST_ERROR_CODE.forbiddenVisibility,
-          message: 'This member limits who can view their trust details.',
-        },
-        { status: 403 },
-      );
+    // The owner and admins always read the full panel, whatever the setting says.
+    if (isPrivileged) {
+      await audit('allow', isOwner ? 'self_summary_read' : 'admin_summary_read');
+      return NextResponse.json(fullView(trust), { status: 200 });
     }
 
-    await audit('allow', isOwner ? 'self_summary_read' : viewerIsAdmin ? 'admin_summary_read' : 'public_summary_read');
-    return NextResponse.json(trust, { status: 200 });
+    if (trust.trustVisibility === 'public') {
+      await audit('allow', 'public_summary_read');
+      return NextResponse.json(fullView(trust), { status: 200 });
+    }
+
+    if (trust.trustVisibility === 'restricted') {
+      await audit('allow', 'restricted_summary_read');
+      return NextResponse.json(summaryView(trust), { status: 200 });
+    }
+
+    await audit('deny', 'forbidden_visibility');
+    return NextResponse.json(
+      {
+        ok: false,
+        code: TRUST_ERROR_CODE.forbiddenVisibility,
+        message: 'This member limits who can view their trust details.',
+      },
+      { status: 403 },
+    );
   } catch (error) {
     reportError(error, { area: 'trust', op: 'user_read' });
     return NextResponse.json(

--- a/ctf/packages/web/components/directory/directory-profile-detail.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-detail.tsx
@@ -12,7 +12,7 @@ import { TrustWidgetCard } from "@/components/trust/TrustWidgetCard";
 import { BlockMemberButton } from "@/components/blocks/block-member-button";
 import { WeaversBadgeControl } from "@/components/contributor-access/weavers-badge-control";
 import { ShareLink } from "@/components/shared/share-link";
-import type { TrustUserExtension } from "@/lib/trust/types";
+import type { TrustPeerView, TrustUserExtension } from "@/lib/trust/types";
 
 // One cross-plugin presence entry returned by GET /api/presence/user/[userId].
 interface PresenceEntry {
@@ -28,8 +28,8 @@ interface PresenceEntry {
 // trust response renders a calm note rather than an error.
 type TrustState =
   | { kind: "loading" }
-  | { kind: "ready"; trust: TrustUserExtension }
-  | { kind: "restricted" }
+  | { kind: "ready"; trust: TrustUserExtension | TrustPeerView }
+  | { kind: "withheld" }
   | { kind: "hidden" };
 
 // Shared uppercase section-label style, so every section reads identically.
@@ -93,15 +93,16 @@ function usePresenceAndTrust(claimedUserId: string | null, isOwnProfile: boolean
         const res = await fetch(url, { signal: controller.signal });
         if (controller.signal.aborted) return;
         if (res.status === 403) {
-          // The member limits who can view their trust details — a calm state, not an error.
-          setTrustState({ kind: "restricted" });
+          // Only a `private` profile refuses now: `restricted` returns 200 with the summary
+          // projection, which renders as an ordinary (shorter) card. A calm state, not an error.
+          setTrustState({ kind: "withheld" });
           return;
         }
         if (!res.ok) {
           setTrustState({ kind: "hidden" });
           return;
         }
-        const trust = (await res.json()) as TrustUserExtension;
+        const trust = (await res.json()) as TrustUserExtension | TrustPeerView;
         setTrustState({ kind: "ready", trust });
       } catch {
         if (!controller.signal.aborted) setTrustState({ kind: "hidden" });
@@ -407,7 +408,7 @@ function PresenceRow({ tokens: t, entry }: { tokens: DirectoryTokens; entry: Pre
 // The trust card (or a calm restricted note) that sits beneath the presence list.
 function TrustPanel({ tokens: t, trustState, isOwnProfile }: { tokens: DirectoryTokens; trustState: TrustState; isOwnProfile: boolean }) {
   if (trustState.kind === "ready") return <TrustWidgetCard trust={trustState.trust} editable={isOwnProfile} />;
-  if (trustState.kind === "restricted") {
+  if (trustState.kind === "withheld") {
     return (
       <div style={{ padding: "14px 16px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: `1px solid ${t.BORDER}` }}>
         <div style={{ fontSize: 13, color: t.MUTED, lineHeight: 1.5 }}>

--- a/ctf/packages/web/components/trust/TrustWidgetCard.tsx
+++ b/ctf/packages/web/components/trust/TrustWidgetCard.tsx
@@ -128,9 +128,13 @@ function EvidenceBody({ evidence, visibility, editable, disclosure }: { evidence
           <EvidenceItem key={idx} item={item} />
         ))}
       </div>
-      <div style={{ paddingTop: 7, borderTop: `1px solid ${HAIRLINE}` }}>
-        <TrustVisibilityControl visibility={visibility} bordered={false} editable={editable} evidence={evidence} />
-      </div>
+      {/* On a peer's summary card the note above already says the member shares a summary, so the
+          read-only row would repeat it. Keep the row for a full peer card and for the owner. */}
+      {(editable || disclosure === "full") && (
+        <div style={{ paddingTop: 7, borderTop: `1px solid ${HAIRLINE}` }}>
+          <TrustVisibilityControl visibility={visibility} bordered={false} editable={editable} evidence={evidence} />
+        </div>
+      )}
     </div>
   );
 }

--- a/ctf/packages/web/components/trust/TrustWidgetCard.tsx
+++ b/ctf/packages/web/components/trust/TrustWidgetCard.tsx
@@ -13,9 +13,9 @@
 //   surfaces (`editable`), because POST /api/trust/visibility is self-scope only;
 //   when the card shows another member's trust the row stays read-only.
 import React from "react";
-import { ShieldCheck, CheckCircle2 } from "lucide-react";
+import { ShieldCheck, CheckCircle2, Eye } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
-import type { TrustUserExtension, TrustEvidenceItem } from "../../lib/trust/types";
+import type { TrustUserExtension, TrustPeerView, TrustPeerEvidenceItem, TrustDisclosure } from "../../lib/trust/types";
 import { getTrustTokens } from "./trust-shared";
 import { TrustVisibilityControl } from "./trust-visibility-control";
 
@@ -56,7 +56,7 @@ function WidgetHeader() {
   );
 }
 
-function EmptyBody({ visibility, editable }: { visibility: string; editable?: boolean }) {
+function EmptyBody({ visibility, editable, evidence }: { visibility: string; editable?: boolean; evidence: readonly TrustPeerEvidenceItem[] }) {
   const { theme } = useTheme();
   const t = getTrustTokens(theme);
   return (
@@ -80,12 +80,12 @@ function EmptyBody({ visibility, editable }: { visibility: string; editable?: bo
         ))}
       </div>
 
-      <TrustVisibilityControl visibility={visibility} bordered editable={editable} />
+      <TrustVisibilityControl visibility={visibility} bordered editable={editable} evidence={evidence} />
     </div>
   );
 }
 
-function EvidenceItem({ item }: { item: TrustEvidenceItem }) {
+function EvidenceItem({ item }: { item: TrustPeerEvidenceItem }) {
   const { theme } = useTheme();
   const t = getTrustTokens(theme);
   return (
@@ -104,23 +104,41 @@ function EvidenceItem({ item }: { item: TrustEvidenceItem }) {
   );
 }
 
-function EvidenceBody({ evidence, visibility, editable }: { evidence: TrustEvidenceItem[]; visibility: string; editable?: boolean }) {
+// Shown above a summary projection so a viewer never mistakes the reduced list for the member's
+// whole record. Without it, "Took part in 6 plugins" reads as everything they have ever done.
+function SummaryNote() {
+  const { theme } = useTheme();
+  const t = getTrustTokens(theme);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 12 }}>
+      <Eye size={11} style={{ color: t.FAINT, flexShrink: 0 }} />
+      <span style={{ fontSize: 10, color: t.MUTED, lineHeight: 1.5 }}>
+        This member shares a summary of their participation, not the detail.
+      </span>
+    </div>
+  );
+}
+
+function EvidenceBody({ evidence, visibility, editable, disclosure }: { evidence: TrustPeerEvidenceItem[]; visibility: string; editable?: boolean; disclosure: TrustDisclosure }) {
   return (
     <div style={{ padding: "4px 14px 14px", borderTop: `1px solid ${HAIRLINE}` }}>
+      {disclosure === "summary" && <SummaryNote />}
       <div style={{ display: "flex", flexDirection: "column", gap: 6, margin: "12px 0 10px" }}>
         {evidence.map((item, idx) => (
           <EvidenceItem key={idx} item={item} />
         ))}
       </div>
       <div style={{ paddingTop: 7, borderTop: `1px solid ${HAIRLINE}` }}>
-        <TrustVisibilityControl visibility={visibility} bordered={false} editable={editable} />
+        <TrustVisibilityControl visibility={visibility} bordered={false} editable={editable} evidence={evidence} />
       </div>
     </div>
   );
 }
 
 export interface TrustWidgetCardProps {
-  trust: TrustUserExtension;
+  // Either the owner's own extension or the peer view the cross-user route returns. The peer view
+  // carries `trustDisclosure`; an extension does not, and is always the full record.
+  trust: TrustUserExtension | TrustPeerView;
   // True only when the card renders the signed-in member's own trust — the
   // visibility route is self-scope, so other-member cards stay read-only.
   editable?: boolean;
@@ -128,12 +146,13 @@ export interface TrustWidgetCardProps {
 
 export const TrustWidgetCard: React.FC<TrustWidgetCardProps> = ({ trust, editable }) => {
   const hasEvidence = trust.trustEvidence.length > 0;
+  const disclosure: TrustDisclosure = "trustDisclosure" in trust ? trust.trustDisclosure : "full";
   return (
     <div style={{ borderRadius: 12, background: CARD_BG, border: `1px solid ${CARD_BORDER}`, overflow: "hidden", fontFamily: "'Inter', system-ui, sans-serif" }}>
       <WidgetHeader />
       {hasEvidence
-        ? <EvidenceBody evidence={trust.trustEvidence} visibility={trust.trustVisibility} editable={editable} />
-        : <EmptyBody visibility={trust.trustVisibility} editable={editable} />}
+        ? <EvidenceBody evidence={trust.trustEvidence} visibility={trust.trustVisibility} editable={editable} disclosure={disclosure} />
+        : <EmptyBody visibility={trust.trustVisibility} editable={editable} evidence={trust.trustEvidence} />}
     </div>
   );
 };

--- a/ctf/packages/web/components/trust/trust-visibility-control.tsx
+++ b/ctf/packages/web/components/trust/trust-visibility-control.tsx
@@ -8,19 +8,25 @@
 // Why the control spells out its own effect: the setting changes only what OTHER members see. The
 // owner's card always renders the full evidence list whatever the setting says, so a member who
 // changes it and watches their own card sees nothing move and reasonably concludes it does
-// nothing. So the audience is named inside each choice, the effect is restated underneath, and a
-// short confirmation appears once the change is stored.
+// nothing. So the audience is named inside each choice, the effect is restated underneath, a live
+// preview shows what a peer would actually receive, and a short confirmation appears once the
+// change is stored.
 //
-// Honest labeling: `restricted` and `private` both resolve to owner-or-admin at the only place
-// visibility is enforced (GET /api/trust/user/[userId]), so Restricted does not claim a
-// members-only audience the app cannot currently deliver.
+// The three choices are three real outcomes at `GET /api/trust/user/[userId]`: `public` serves the
+// full panel to any signed-in member, `restricted` serves the summary projection, `private` refuses
+// with 403. The owner and admins always read the full panel.
 import React from "react";
-import { Eye, Check } from "lucide-react";
+import { Eye, Check, CheckCircle2 } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import type { TrustTokens } from "./trust-shared";
-import type { TrustVisibility } from "../../lib/trust/types";
+import type { TrustPeerEvidenceItem, TrustVisibility } from "../../lib/trust/types";
 import { TRUST_VISIBILITY_VALUES } from "../../lib/trust/types";
+import { summarizeTrustEvidenceForPeer } from "../../lib/trust/peer-summary";
 import { getTrustTokens } from "./trust-shared";
+
+// Display order runs most open to most private, so the dropdown reads as a scale. The exported enum
+// keeps its own order for validation; this is presentation only.
+const VISIBILITY_ORDER: readonly TrustVisibility[] = ["public", "restricted", "private"];
 
 // The 5% hairline has no exact shell-token equivalent, so it stays as the shipped literal.
 const HAIRLINE = "rgba(255,255,255,0.05)";
@@ -29,15 +35,15 @@ const HAIRLINE = "rgba(255,255,255,0.05)";
 // the menu. "Admins" is stated because an admin can always read a member's trust panel.
 const OPTION_LABEL: Record<TrustVisibility, string> = {
   public: "Public — any signed-in member",
+  restricted: "Restricted — a summary, no detail",
   private: "Private — only you and admins",
-  restricted: "Restricted — only you and admins",
 };
 
 const OPTION_EFFECT: Record<TrustVisibility, string> = {
   public: "Any signed-in member who opens your profile can see the signals listed above.",
-  private: "Other members cannot open your trust panel. Only you and admins can see these signals.",
   restricted:
-    "Other members cannot open your trust panel — the same as Private today. A members-only summary view has not been built yet.",
+    "Other members see how active you are, without the detail or the dates. Enough for someone to tell you take part here.",
+  private: "Other members cannot open your trust panel at all. Only you and admins can see these signals.",
 };
 
 function titleCase(value: string): string {
@@ -88,15 +94,56 @@ function SaveStatus({ saving, saved, error, t }: { saving: boolean; saved: boole
   return null;
 }
 
+// Shows the member exactly what a peer sees at the current setting. This is what makes the control
+// legible: the setting's whole effect is on other people's screens, so without a preview the member
+// changes it, watches their own unchanged card, and concludes it does nothing.
+//
+// The lines come from `summarizeTrustEvidenceForPeer` — the same function the cross-user route runs
+// — so the preview cannot promise something different from what peers actually receive.
+function PeerPreview({ current, evidence, t }: { current: TrustVisibility; evidence: readonly TrustPeerEvidenceItem[]; t: TrustTokens }) {
+  const lines = current === "restricted" ? summarizeTrustEvidenceForPeer(evidence) : [];
+
+  return (
+    <div style={{ marginTop: 8, padding: "8px 10px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: `1px solid ${HAIRLINE}` }}>
+      <div style={{ fontSize: 10, fontWeight: 600, color: t.FAINT, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 6 }}>
+        What other members see
+      </div>
+      {current === "public" && (
+        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>Everything listed above, exactly as you see it.</div>
+      )}
+      {current === "private" && (
+        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>Nothing. Your panel is hidden from other members.</div>
+      )}
+      {current === "restricted" && lines.length === 0 && (
+        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
+          Nothing yet — a summary appears here once you have taken part somewhere.
+        </div>
+      )}
+      {current === "restricted" && lines.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          {lines.map((line, idx) => (
+            <div key={idx} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <CheckCircle2 size={11} style={{ color: "#38BDF8", flexShrink: 0 }} />
+              <span style={{ fontSize: 11, color: t.TEXT }}>{line.summary}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export interface TrustVisibilityControlProps {
   visibility: string;
   // Draw the top hairline when the control follows a section that needs separating.
   bordered: boolean;
   // Live control only on the signed-in member's own card; POST /api/trust/visibility is self-scope.
   editable?: boolean;
+  // The member's own evidence, used to preview what a peer would see. Omitted on read-only cards.
+  evidence?: readonly TrustPeerEvidenceItem[];
 }
 
-export function TrustVisibilityControl({ visibility, bordered, editable }: TrustVisibilityControlProps) {
+export function TrustVisibilityControl({ visibility, bordered, editable, evidence }: TrustVisibilityControlProps) {
   const { theme } = useTheme();
   const t = getTrustTokens(theme);
   const selectId = React.useId();
@@ -170,7 +217,7 @@ export function TrustVisibilityControl({ visibility, bordered, editable }: Trust
           appearance: "auto",
         }}
       >
-        {TRUST_VISIBILITY_VALUES.map((value) => (
+        {VISIBILITY_ORDER.map((value) => (
           <option key={value} value={value} style={{ color: t.BG }}>
             {OPTION_LABEL[value]}
           </option>
@@ -179,6 +226,7 @@ export function TrustVisibilityControl({ visibility, bordered, editable }: Trust
       <p style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5, margin: "6px 0 0" }}>
         {OPTION_EFFECT[current]} Your own card always shows everything, whichever one you pick.
       </p>
+      <PeerPreview current={current} evidence={evidence ?? []} t={t} />
       <SaveStatus saving={saving} saved={saved} error={error} t={t} />
     </div>
   );

--- a/ctf/packages/web/components/trust/trust-visibility-control.tsx
+++ b/ctf/packages/web/components/trust/trust-visibility-control.tsx
@@ -8,9 +8,9 @@
 // Why the control spells out its own effect: the setting changes only what OTHER members see. The
 // owner's card always renders the full evidence list whatever the setting says, so a member who
 // changes it and watches their own card sees nothing move and reasonably concludes it does
-// nothing. So the audience is named inside each choice, the effect is restated underneath, a live
-// preview shows what a peer would actually receive, and a short confirmation appears once the
-// change is stored.
+// nothing. So each choice states the outcome in plain words, the effect is restated underneath, a
+// live preview shows what a member would actually receive, and a short confirmation appears once
+// the change is stored.
 //
 // The three choices are three real outcomes at `GET /api/trust/user/[userId]`: `public` serves the
 // full panel to any signed-in member, `restricted` serves the summary projection, `private` refuses
@@ -31,24 +31,37 @@ const VISIBILITY_ORDER: readonly TrustVisibility[] = ["public", "restricted", "p
 // The 5% hairline has no exact shell-token equivalent, so it stays as the shipped literal.
 const HAIRLINE = "rgba(255,255,255,0.05)";
 
-// Each choice names its audience in the option itself, so the effect is readable without opening
-// the menu. "Admins" is stated because an admin can always read a member's trust panel.
+// Each choice states who sees what, in plain words, as a sentence about members rather than an
+// abstract label. "Public" / "Restricted" / "Private" named a category and left the reader to guess
+// the category's rules — which is how the three got read as kinds of transaction. These say the
+// outcome instead, so no guessing is required and the three read as one scale.
+//
+// The stored values are still `public` / `restricted` / `private`; only what the member reads
+// changed. Nothing here is a promise about the rest of the app — this setting governs the trust
+// panel and nothing else.
 const OPTION_LABEL: Record<TrustVisibility, string> = {
-  public: "Public — any signed-in member",
-  restricted: "Restricted — a summary, no detail",
-  private: "Private — only you and admins",
+  public: "Members see everything",
+  restricted: "Members see a summary",
+  private: "Only you see this",
 };
 
+// Admins are named in the effect line rather than the label: they can read any member's panel, so
+// leaving it out would make "Only you see this" a claim the app does not keep.
 const OPTION_EFFECT: Record<TrustVisibility, string> = {
-  public: "Any signed-in member who opens your profile can see the signals listed above.",
+  public: "Any signed-in member who opens your profile sees the signals listed above.",
   restricted:
-    "Other members see how active you are, without the detail or the dates. Enough for someone to tell you take part here.",
-  private: "Other members cannot open your trust panel at all. Only you and admins can see these signals.",
+    "Members see how active you are, without the detail or the dates. Enough to tell that you take part here.",
+  private: "No other member can open this panel. Admins can, as they can for every member.",
 };
 
-function titleCase(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
+// The same three outcomes described from a viewer's side, for the read-only row on another member's
+// card. `private` is listed for completeness; that card is never rendered, because the route refuses
+// the read before there is anything to draw.
+const PEER_LABEL: Record<TrustVisibility, string> = {
+  public: "This member shares everything",
+  restricted: "This member shares a summary",
+  private: "This member keeps this to themselves",
+};
 
 // A member's stored value should always be one of the three, but a row written before the column
 // was constrained (or by hand) could be anything; fall back to the column default rather than
@@ -65,13 +78,13 @@ function wrapperStyle(bordered: boolean): React.CSSProperties {
   };
 }
 
-// Another member's card: their setting is shown, never edited.
-function ReadOnlyRow({ current, bordered, t }: { current: string; bordered: boolean; t: TrustTokens }) {
+// Another member's card: what they chose to share, stated from the viewer's side, never edited.
+function ReadOnlyRow({ current, bordered, t }: { current: TrustVisibility; bordered: boolean; t: TrustTokens }) {
   return (
     <div style={wrapperStyle(bordered)}>
       <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
         <Eye size={11} style={{ color: t.FAINT }} />
-        <span style={{ fontSize: 11, color: t.FAINT }}>Visible to: {titleCase(current)}</span>
+        <span style={{ fontSize: 11, color: t.FAINT }}>{PEER_LABEL[current]}</span>
       </div>
     </div>
   );
@@ -106,13 +119,13 @@ function PeerPreview({ current, evidence, t }: { current: TrustVisibility; evide
   return (
     <div style={{ marginTop: 8, padding: "8px 10px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: `1px solid ${HAIRLINE}` }}>
       <div style={{ fontSize: 10, fontWeight: 600, color: t.FAINT, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 6 }}>
-        What other members see
+        What members see
       </div>
       {current === "public" && (
         <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>Everything listed above, exactly as you see it.</div>
       )}
       {current === "private" && (
-        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>Nothing. Your panel is hidden from other members.</div>
+        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>Nothing — this panel does not appear on your profile for them.</div>
       )}
       {current === "restricted" && lines.length === 0 && (
         <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
@@ -199,7 +212,7 @@ export function TrustVisibilityControl({ visibility, bordered, editable, evidenc
     <div style={wrapperStyle(bordered)}>
       <label htmlFor={selectId} style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
         <Eye size={12} style={{ color: t.SUBTLE }} />
-        <span style={{ fontSize: 12, fontWeight: 600, color: t.SUBTLE }}>Who can see your trust signals</span>
+        <span style={{ fontSize: 12, fontWeight: 600, color: t.SUBTLE }}>Who sees your trust signals</span>
       </label>
       <select
         id={selectId}
@@ -224,7 +237,7 @@ export function TrustVisibilityControl({ visibility, bordered, editable, evidenc
         ))}
       </select>
       <p style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5, margin: "6px 0 0" }}>
-        {OPTION_EFFECT[current]} Your own card always shows everything, whichever one you pick.
+        {OPTION_EFFECT[current]} You always see everything on your own card, whichever one you pick.
       </p>
       <PeerPreview current={current} evidence={evidence ?? []} t={t} />
       <SaveStatus saving={saving} saved={saved} error={error} t={t} />

--- a/ctf/packages/web/lib/trust/peer-summary.test.ts
+++ b/ctf/packages/web/lib/trust/peer-summary.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeTrustEvidenceForPeer, TRUST_SUMMARY_BREADTH_TYPE } from './peer-summary';
+import type { TrustEvidenceItem } from './types';
+
+// summarizeTrustEvidenceForPeer is the disclosure boundary for the `restricted` setting: it decides
+// what one member learns about another. These tests lock the two rules that make it a summary
+// rather than a copy — no timestamps or supporting detail survive, and per-plugin participation
+// collapses to a breadth count — plus the fail-closed default for anything unclassified. The
+// function is pure (evidence in -> evidence out), so no DB is touched.
+
+const NOW = '2026-08-07T00:00:00.000Z';
+
+function item(type: string, summary: string, extra: Partial<TrustEvidenceItem> = {}): TrustEvidenceItem {
+  return { type, summary, createdAt: NOW, createdBy: 'trust-signal', ...extra };
+}
+
+describe('summarizeTrustEvidenceForPeer', () => {
+  it('drops every timestamp and supporting detail', () => {
+    const summary = summarizeTrustEvidenceForPeer([
+      item('engagement-login-frequency', 'Active on 162 days', {
+        details: 'Most recent sign-in 2026-08-06T01:11:57.210Z',
+      }),
+    ]);
+
+    expect(summary).toEqual([{ type: 'engagement-login-frequency', summary: 'Active on 162 days' }]);
+    expect(summary[0]).not.toHaveProperty('createdAt');
+    expect(summary[0]).not.toHaveProperty('details');
+  });
+
+  it('collapses per-plugin participation into one breadth line, counting distinct plugins', () => {
+    const summary = summarizeTrustEvidenceForPeer([
+      item('engagement-skillshunt-submissions', 'Accepted 24 SkillsHunt submissions'),
+      item('engagement-chyme-rooms', 'Joined 1 Chyme room'),
+      item('engagement-directory-profile', 'Claimed 1 Directory profile'),
+      // Both SocketRelay items name one plugin, so breadth counts them once.
+      item('engagement-socket-relay-trades', 'Completed 3 SocketRelay trades'),
+      item('engagement-socket-relay-requests', 'Opened 5 SocketRelay requests'),
+    ]);
+
+    expect(summary).toEqual([{ type: TRUST_SUMMARY_BREADTH_TYPE, summary: 'Took part in 4 plugins' }]);
+  });
+
+  it('never leaks what a member did or where they did it', () => {
+    const summary = summarizeTrustEvidenceForPeer([
+      item('engagement-skillshunt-submissions', 'Accepted 24 SkillsHunt submissions'),
+      item('engagement-foundation-provider', 'Connected with 2 members as a Foundation provider'),
+    ]);
+
+    const text = summary.map((line) => line.summary).join(' ');
+    expect(text).not.toMatch(/SkillsHunt|Foundation|24|submissions/);
+  });
+
+  it('uses the singular for a single plugin', () => {
+    const summary = summarizeTrustEvidenceForPeer([item('engagement-chyme-rooms', 'Joined 1 Chyme room')]);
+    expect(summary).toEqual([{ type: TRUST_SUMMARY_BREADTH_TYPE, summary: 'Took part in 1 plugin' }]);
+  });
+
+  it('passes aggregate ServiceCredits counts through with their shipped wording intact', () => {
+    const summary = summarizeTrustEvidenceForPeer([
+      item('engagement-service-credits-payers', 'Received ServiceCredits from 4 community members'),
+      item('engagement-service-credits-clean', '7 completed ServiceCredits transfers, none disputed'),
+    ]);
+
+    expect(summary.map((line) => line.summary)).toEqual([
+      'Received ServiceCredits from 4 community members',
+      '7 completed ServiceCredits transfers, none disputed',
+    ]);
+  });
+
+  it('fails closed: an unclassified or admin evidence type is dropped', () => {
+    const summary = summarizeTrustEvidenceForPeer([
+      item('admin-verification', 'Flagged for review by an administrator', { details: 'internal note' }),
+      item('engagement-some-future-signal', 'Did 9 new things'),
+    ]);
+
+    expect(summary).toEqual([]);
+  });
+
+  it('leads with sign-in activity, then breadth', () => {
+    const summary = summarizeTrustEvidenceForPeer([
+      item('engagement-chyme-rooms', 'Joined 1 Chyme room'),
+      item('engagement-login-frequency', 'Active on 162 days'),
+    ]);
+
+    expect(summary.map((line) => line.summary)).toEqual(['Active on 162 days', 'Took part in 1 plugin']);
+  });
+
+  it('returns nothing for a member with no evidence', () => {
+    expect(summarizeTrustEvidenceForPeer([])).toEqual([]);
+  });
+});

--- a/ctf/packages/web/lib/trust/peer-summary.ts
+++ b/ctf/packages/web/lib/trust/peer-summary.ts
@@ -1,0 +1,101 @@
+// The `restricted` disclosure: what one member is shown about another who has chosen to share a
+// summary rather than their full trust panel.
+//
+// Why this exists: `restricted` used to be enforced identically to `private` — both returned 403 —
+// so choosing it hid everything from peers, which is the opposite of what the setting is for. A
+// member checking whether someone is an engaged participant got nothing. This projection is the
+// middle tier: the coarse fact, never the record.
+//
+// Two rules define it:
+//   1. No timestamps and no supporting detail. A viewer learns "Active on 162 days", never when the
+//      member last signed in, and never a per-item date they could assemble into a timeline.
+//   2. Per-plugin participation collapses into one breadth line. "Accepted 24 SkillsHunt
+//      submissions" and "Joined 1 Chyme room" become "Took part in 6 plugins", so a peer sees that
+//      the member is active without seeing what they have been doing or where.
+//
+// Aggregate counts that are already coarse (sign-in days, the ServiceCredits breadth and
+// clean-record lines) pass through with their shipped wording intact — this file never rewrites a
+// summary string, so approved copy cannot drift here.
+//
+// This module is imported by BOTH the route that serves the projection and the visibility control
+// that previews it to the owner, so the preview cannot disagree with what peers actually receive.
+import type { TrustPeerEvidenceItem } from './types';
+
+// Evidence types that name a plugin the member took part in. Several types can map to one plugin
+// (SocketRelay emits both a trades and a requests item), so breadth counts DISTINCT plugins, not
+// evidence rows — otherwise a member active in one plugin two ways would read as two plugins.
+const PLUGIN_BY_EVIDENCE_TYPE: Record<string, string> = {
+  'engagement-socket-relay-trades': 'socket-relay',
+  'engagement-socket-relay-requests': 'socket-relay',
+  'engagement-lighthouse-matches': 'lighthouse',
+  'engagement-trust-transport-trips': 'trust-transport',
+  'engagement-skillshunt-submissions': 'skills-hunt',
+  'engagement-level-up-cohorts': 'level-up',
+  'engagement-chyme-rooms': 'chyme',
+  'engagement-directory-profile': 'directory',
+  'engagement-what-works-endorsements': 'what-works',
+  'engagement-peerprogramming-cohorts': 'peer-programming',
+  'engagement-contributions': 'contributions',
+  'engagement-foundation-provider': 'foundation',
+  'engagement-recurring-activity': 'recurring-activity',
+};
+
+// Aggregate signals that are already a coarse count rather than a record of a specific event, so
+// they survive the projection with their wording unchanged. Everything not listed here and not in
+// PLUGIN_BY_EVIDENCE_TYPE is dropped: this is a disclosure boundary, so it fails closed. A signal
+// added upstream stays out of the summary view until it is deliberately classified here.
+const PASSTHROUGH_EVIDENCE_TYPES: readonly string[] = [
+  'engagement-login-frequency',
+  'engagement-service-credits-payers',
+  'engagement-service-credits-clean',
+];
+
+// The breadth line's own type slug. Not produced by the signal builder — it exists only in this
+// projection — so it cannot collide with a stored evidence type.
+export const TRUST_SUMMARY_BREADTH_TYPE = 'summary-plugin-breadth';
+
+function countDistinctPlugins(evidence: readonly TrustPeerEvidenceItem[]): number {
+  const plugins = new Set<string>();
+  for (const item of evidence) {
+    const plugin = PLUGIN_BY_EVIDENCE_TYPE[item.type];
+    if (plugin) {
+      plugins.add(plugin);
+    }
+  }
+  return plugins.size;
+}
+
+// Keep the shipped summary string exactly as the signal builder wrote it; drop the timestamp and any
+// supporting detail (the login item's `details` carries the exact last sign-in, which is a record).
+function toSummaryLine(item: TrustPeerEvidenceItem): TrustPeerEvidenceItem {
+  return { type: item.type, summary: item.summary };
+}
+
+// Reduce a member's full evidence list to what a peer sees under `restricted`.
+export function summarizeTrustEvidenceForPeer(
+  evidence: readonly TrustPeerEvidenceItem[],
+): TrustPeerEvidenceItem[] {
+  const summary: TrustPeerEvidenceItem[] = [];
+
+  // Sign-in activity leads: it is the one signal every participating member has.
+  const login = evidence.find((item) => item.type === 'engagement-login-frequency');
+  if (login) {
+    summary.push(toSummaryLine(login));
+  }
+
+  const pluginCount = countDistinctPlugins(evidence);
+  if (pluginCount > 0) {
+    summary.push({
+      type: TRUST_SUMMARY_BREADTH_TYPE,
+      summary: `Took part in ${pluginCount} ${pluginCount === 1 ? 'plugin' : 'plugins'}`,
+    });
+  }
+
+  for (const item of evidence) {
+    if (item.type !== 'engagement-login-frequency' && PASSTHROUGH_EVIDENCE_TYPES.includes(item.type)) {
+      summary.push(toSummaryLine(item));
+    }
+  }
+
+  return summary;
+}

--- a/ctf/packages/web/lib/trust/types.ts
+++ b/ctf/packages/web/lib/trust/types.ts
@@ -71,6 +71,34 @@ export interface TrustUserExtension {
   updatedAt: string;
 }
 
+// How much of a member's trust panel the viewer is being shown.
+//   full    — every derived evidence item, with its timestamp and supporting detail. The owner, an
+//             admin, and (on a `public` profile) any signed-in member get this.
+//   summary — headline counts only: no timestamps, no supporting detail, and the per-plugin items
+//             collapsed to a single breadth line. What a `restricted` profile shows a peer.
+export type TrustDisclosure = 'full' | 'summary';
+
+// One evidence line as a viewer other than the owner sees it. `createdAt` and `details` are optional
+// here because the summary disclosure deliberately carries neither — a peer learns the coarse fact,
+// never the record of when it happened.
+export interface TrustPeerEvidenceItem {
+  type: string;
+  summary: string;
+  details?: string;
+  createdAt?: string;
+}
+
+// The payload `GET /api/trust/user/[userId]` returns. Same shape at both disclosure levels so the
+// widget renders one way; `trustDisclosure` tells the viewer which one they are looking at.
+export interface TrustPeerView {
+  userId: string;
+  trustStatus: TrustStatus;
+  trustEvidence: TrustPeerEvidenceItem[];
+  trustVisibility: TrustVisibility;
+  updatedAt: string;
+  trustDisclosure: TrustDisclosure;
+}
+
 export interface TrustSignalSnapshot {
   id: string;
   userId: string;


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105). Trust is not on the Android keep-list.

**Waiting on your review — auto-merge is deliberately off.** This changes an access gate (what one member may see about another) and a route's response contract, which is the owner-review lane.

Follows #2151, which made the control legible but left `Restricted` doing nothing distinguishable.

## The problem

`restricted` was enforced identically to `private` — both returned 403 — so a member who picked it to be *partly* visible went fully dark to their peers. Only the owner and admins could see anything. That is the opposite of what the setting is for, and it left no way for a member to check whether someone is an engaged participant.

## What changed

`GET /api/trust/user/[userId]` now resolves visibility to a **disclosure level** rather than a single allow/deny:

| Stored value | Member reads | Non-owner, non-admin viewer |
|---|---|---|
| `public` | "Members see everything" | Full panel |
| `restricted` | "Members see a summary" | **Summary projection** (new) |
| `private` | "Only you see this" | 403 |

The owner and admins always receive the full panel, whatever the setting. The response carries `trustDisclosure` (`full` \| `summary`) so the widget can label a summary as one instead of passing it off as the member's whole record.

## Plain-language names

The labels state the outcome rather than naming a category. "Public" / "Restricted" / "Private" named a bucket and left the reader to work out the bucket's rules — which is how the three came to be read as kinds of transaction. Admins are named in the effect line under the dropdown rather than in the label, so "Only you see this" is not a claim the app fails to keep. The heading is "Who sees your trust signals" and the preview is "What members see".

The read-only row on another member's card moves from "Visible to: Public" to the same outcome from the viewer's side ("This member shares everything"), and is dropped from a peer's summary card where the note above the list already says it.

Stored values are unchanged — this part is presentation only.

## What the summary discloses

Two rules, in `lib/trust/peer-summary.ts`:

1. **No timestamps, no supporting detail.** The login item's `details` carries the exact last sign-in — that is a record, not a count, so it is dropped. A viewer cannot assemble a timeline.
2. **Per-plugin participation collapses to one breadth line.** "Accepted 24 SkillsHunt submissions" and "Joined 1 Chyme room" become "Took part in 6 plugins", counting **distinct** plugins (SocketRelay emits two evidence types but is one plugin). A member learns another takes part here without learning what they did or where.

Aggregate counts that are already coarse — sign-in days and the two ServiceCredits lines — pass through with their shipped wording untouched. The projection never rewrites a summary string, so approved copy cannot drift there.

For the member in the original screenshot, a peer would see:

```
✓ Active on 162 days
✓ Took part in 6 plugins

👁 This member shares a summary of their participation, not the detail.
```

It **fails closed**: an evidence type it does not recognize is dropped rather than leaked. That is the safe default for a disclosure boundary, with one consequence worth knowing — a new signal added to `buildTrustEvidence` stays out of the summary view until it is deliberately classified. Recorded as gap 9 in the inventory.

## The own-card preview

The control renders a "What members see" block built by calling the **same projection function** the route runs, so the preview cannot promise something different from what members receive. On "Members see a summary" it lists the actual lines; on the other two it says so in a sentence.

This also closes the loop on the original report: changing the setting now visibly changes something on your own screen.

## Tests

`lib/trust/peer-summary.test.ts` — 8 cases locking the boundary, including that no plugin name or per-plugin count survives, that distinct-plugin counting is correct, and that an unclassified type is dropped.

## Contracts and docs

- `trust.summary.read` gains the `trustDisclosure` output field.
- The access policy records `disclosureLevels` and replaces the `trust_visibility_restricted` deny condition with `trust_visibility_private`.
- **No schema change** — the stored enum is unchanged, so existing rows stay valid.
- Inventory updated (route map, User Features, security controls, gaps, change log); gap 8 closed, gaps 9 and 10 opened.
- Test script: TR-A4 split so the new behavior is covered by a new **TR-A4b**; TR-A5b updated for the plain-language labels and the preview.

## One thing I noticed but did not change

**`trustStatus` reaches peers at both disclosure levels.** A `flagged` status sits in the payload of a public or summary read, though no surface renders it (the widget has no status chip by design). Pre-existing on `public`, and the projection did not widen it — but worth closing if status is meant to stay admin-side. Gap 10.

*(An earlier revision of this description also flagged the ungated presence list as being in tension with `private`. That was my error and is withdrawn: this setting governs the trust panel and nothing else, so `private` was never a claim of platform-wide invisibility. The correction is recorded in the inventory change log.)*

## Checks run locally

`typecheck`, `lint`, `vitest` (76 tests), `build:ci`, `check-eof-format.sh`, `check-us-spelling.mjs`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs` — all clean.