### PR TITLE
fix: give Beacon's recording a picture size so Go live works

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -246,6 +246,21 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 
 ## Change Log
 
+- 2026-08-08: **"Go live" failed every time because the recording settings were incomplete (owner
+  report).** Opening the broadcast call was rejected by Stream with a 400 and the message
+  `GetOrCreateCall failed with error: "recording quality is required when audio_only is false and
+  recording is enabled"`, so the admin screen showed "Broadcast input unavailable" and no broadcast
+  could start at all. Beacon asked Stream to create the call with `recording: { mode: 'available' }`
+  and nothing else; Stream treats a video recording with no stated picture size as invalid and
+  refuses the whole request, which meant the call was never created and neither the phone (RTMP) nor
+  the in-browser screen-share input path had anything to publish into. The create request in
+  `lib/beacon/stream.ts` now states both values Stream validates together: `audio_only: false` and
+  `quality: '720p'`. 720p landscape matches what Beacon actually broadcasts — a shared screen or
+  window from the browser, or a phone pushing RTMP — so the saved replay records the broadcast
+  without being stretched. Recording behaviour is otherwise unchanged: recording is still
+  `available` (started later by `start-broadcast` once someone is publishing), the recording-ready
+  webhook and the Commons replay post are untouched. No schema, route, or contract change.
+  Quota-impact note: `ctf/docs/quota-impact/2026-08-08-beacon-recording-quality.md`.
 - 2026-07-27: **Admins can delete a draft event (owner report).** A mistyped or abandoned draft was
   permanent from the app's side — there was no delete control, no `DELETE` route, and no repository
   function — so the only way to remove one was a hand-written `DELETE` straight against the

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -257,7 +257,7 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
   `lib/beacon/stream.ts` now states both values Stream validates together: `audio_only: false` and
   `quality: '720p'`. 720p landscape matches what Beacon actually broadcasts — a shared screen or
   window from the browser, or a phone pushing RTMP — so the saved replay records the broadcast
-  without being stretched. Recording behaviour is otherwise unchanged: recording is still
+  without being stretched. Recording behavior is otherwise unchanged: recording is still
   `available` (started later by `start-broadcast` once someone is publishing), the recording-ready
   webhook and the Commons replay post are untouched. No schema, route, or contract change.
   Quota-impact note: `ctf/docs/quota-impact/2026-08-08-beacon-recording-quality.md`.

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -157,6 +157,10 @@ there too, with `policy_status = 'allow'`.
 to the Commons. The host stage mounts after go-live; HLS + recording start once a host is actually
 publishing (the in-browser screen-share triggers `start-broadcast`). Only the host can publish —
 viewers never can. On error, the underlying Stream message is surfaced, not a generic text.
+Opening the call must succeed on the first press: Beacon asks Stream to record at 720p, and a
+missing recording size is what previously made every Go Live come back with `(400)` and
+`recording quality is required when audio_only is false and recording is enabled`. Seeing that
+message again means the recording settings sent on call creation regressed.
 **Result:** web ☐ mobile ☐ — notes:
 
 ### BCN-A2b · A failed Go Live says which step failed

--- a/ctf/docs/quota-impact/2026-08-08-beacon-recording-quality.md
+++ b/ctf/docs/quota-impact/2026-08-08-beacon-recording-quality.md
@@ -30,7 +30,7 @@
   Beacon broadcast could start, so the feature consumed **zero** video minutes and produced zero
   recordings. With it working, Beacon consumes what it was always designed to consume: one live
   event at a time, HLS distribution to viewers, and one recording per event. That is the budgeted
-  behaviour from the original Beacon note (`2026-06-21-beacon-livestream-video.md`), not new
+  behavior from the original Beacon note (`2026-06-21-beacon-livestream-video.md`), not new
   spending on top of it. The recording is written at 720p; a 1080p recording would have been roughly
   double the stored bytes per minute, so this choice is the cheaper of the two sensible ones and is
   bounded by how often the owner broadcasts and for how long.

--- a/ctf/docs/quota-impact/2026-08-08-beacon-recording-quality.md
+++ b/ctf/docs/quota-impact/2026-08-08-beacon-recording-quality.md
@@ -1,0 +1,78 @@
+# Stream Quota Impact Note — Beacon recording quality
+
+## Summary
+
+- Feature/Change: Fix a Beacon "Go live" that could never start. Beacon asked Stream to create the
+  broadcast call with `recording: { mode: 'available' }` and nothing else. Stream rejects that with a
+  400 — `GetOrCreateCall failed with error: "recording quality is required when audio_only is false
+  and recording is enabled"` — because a video recording has to say what picture size it records at.
+  The rejection killed the whole get-or-create, so the call was never created and the admin screen
+  showed "Broadcast input unavailable". The create request in
+  `ctf/packages/web/lib/beacon/stream.ts` now states the two values Stream validates as a pair:
+  `audio_only: false` and `quality: '720p'`.
+- PR: opened from branch `fix/beacon-recording-quality`.
+- Owner: chargingthefuture
+- Date: 2026-08-08
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: **Video only**, and only the settings sent when the
+  call is created. No Stream call is added, removed, retried, or moved: the same single get-or-create
+  runs once per "Go live" click, as before. Recording still runs in `available` mode and is still
+  started later by `start-broadcast` once someone is actually publishing. No change to Chat, Activity
+  Feeds, or AI Moderation.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: no change.
+- Activity Feed API calls estimate: no change.
+- Video participant-minutes / HLS / recording estimate: this is the honest part — before this fix no
+  Beacon broadcast could start, so the feature consumed **zero** video minutes and produced zero
+  recordings. With it working, Beacon consumes what it was always designed to consume: one live
+  event at a time, HLS distribution to viewers, and one recording per event. That is the budgeted
+  behaviour from the original Beacon note (`2026-06-21-beacon-livestream-video.md`), not new
+  spending on top of it. The recording is written at 720p; a 1080p recording would have been roughly
+  double the stored bytes per minute, so this choice is the cheaper of the two sensible ones and is
+  bounded by how often the owner broadcasts and for how long.
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): **Green.** No new recurring call, no
+  polling, no fan-out. One extra field on a request that already ran.
+- Peak scenario estimate: unchanged from the original Beacon estimate — one long, well-attended
+  broadcast (HLS distribution plus one 720p recording). This change does not raise the ceiling; it
+  restores the path to the ceiling that was already budgeted for.
+
+## Fallback and Degradation Plan
+
+- What degrades first: Stream not configured still returns 503 "Live video is not configured." and
+  every Beacon surface stays in its calm idle state. If Stream ever rejects the create request again
+  for a different reason, the admin banner still names the failing step and carries Stream's own
+  message plus the HTTP status (added 2026-08-03), so the next failure explains itself the same way
+  this one did.
+- User-visible messaging behavior: unchanged. On success the admin sees the RTMP address and stream
+  key and the "Share screen" control instead of the error banner.
+- Kill switch / feature flag: unchanged. Demo-mode sessions still route to the dedicated **staging**
+  Stream app via `resolveStreamCredentials`, so recording sessions never draw on the production
+  Maker-tier quota. Ending the event (`POST /api/beacon/[id]/end`) still stops the call, HLS
+  distribution, and recording — the cost-critical stop path is untouched.
+
+## Observability
+
+- Metrics and alerts added/updated: none. The existing per-step error reports on the ingest path
+  (`ingest_load_event`, `ingest_host_credentials`, `ingest_open_call`, `ingest_audit`) are unchanged,
+  and `ingest_open_call` is the one that was firing on every click before this fix. Stream's
+  dashboard remains the source of truth for usage.
+
+## Validation
+
+- Tests added for degraded mode: none automated (Rule 118 defers automated tests during MVP). The
+  accepted `quality` values were confirmed against the Stream Video client types shipped in the
+  workspace (`RecordSettingsRequestQualityEnum` in `@stream-io/video-client`), which lists `360p`,
+  `480p`, `720p`, `1080p`, `1440p` and the five portrait sizes. Degraded paths checked by reading:
+  Stream unconfigured → 503 with the not-configured message; a Stream rejection → the named step and
+  Stream's message in the admin banner. Lint, typecheck, the production build, the end-of-file format
+  check, and the inventory drift gate pass for the changed files.
+- Rollback strategy: revert the branch. Beacon returns to sending recording settings with no picture
+  size, which means "Go live" fails again — so a rollback is only sensible together with a different
+  fix. No schema, contract, or route change is involved, so there is nothing to migrate.

--- a/ctf/packages/web/lib/beacon/stream.ts
+++ b/ctf/packages/web/lib/beacon/stream.ts
@@ -239,7 +239,13 @@ export async function ensureBeaconCallAndIngest(input: {
         settings_override: {
           // Backstage on: the call is not visible to viewers until goLive() is called.
           backstage: { enabled: true },
-          recording: { mode: 'available' },
+          // `quality` is not optional in practice: Stream rejects the whole get-or-create with 400
+          // "recording quality is required when audio_only is false and recording is enabled" when a
+          // video recording is turned on without one, which failed every "Go live" click. Both inputs
+          // are landscape — the in-browser host shares a screen or window, and the phone path pushes
+          // RTMP — so 720p records what is broadcast without upscaling. `audio_only: false` is stated
+          // rather than left to default so the pairing Stream validates is visible in one place.
+          recording: { mode: 'available', audio_only: false, quality: '720p' },
         },
       },
     },


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

Every "Go live" click on the Beacon admin screen failed with:

```
Broadcast input unavailable — opening the broadcast call failed: Stream Video POST
/api/v2/video/call/livestream/beacon-<id> failed (400): GetOrCreateCall failed with error:
"recording quality is required when audio_only is false and recording is enabled"
```

Beacon asked Stream to create the broadcast call with `recording: { mode: 'available' }` and nothing
else. Stream refuses a video recording that does not say what picture size it records at, and it
refuses the **whole** get-or-create request — so the call was never created, and neither input path
had anything to publish into: no RTMP address or stream key for the phone, and nothing for the
in-browser screen-share host to join. Beacon could not broadcast at all.

## What changed

One request in `ctf/packages/web/lib/beacon/stream.ts` now states the two values Stream validates as
a pair:

```ts
recording: { mode: 'available', audio_only: false, quality: '720p' },
```

720p landscape matches what Beacon actually broadcasts — a screen or window shared from the browser,
or a phone pushing RTMP — so the saved replay records the broadcast without being stretched. The
accepted values were confirmed against the Stream Video client types already in the workspace
(`RecordSettingsRequestQualityEnum`), not guessed.

Recording behaviour is otherwise untouched: still `available` mode, still started later by
`start-broadcast` once someone is actually publishing, and the recording-ready webhook and the
Commons replay post are unchanged. The cost-critical "end the event" path is unchanged.

## Also in this PR

- `ctf/docs/quota-impact/2026-08-08-beacon-recording-quality.md` — required for any change to
  Stream-related code (rule 110). Video only, settings on an existing call; no new Stream calls, no
  polling, no fan-out. Threshold stays Green.
- A Beacon feature-inventory change-log entry describing the failure and the fix.

No schema, route, or contract change.

## Checked locally

Typecheck, lint, the production build, `check-eof-format.sh`, the inventory drift gate, and the
test-script drift gate all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ruczphp1YxcxxY5GQubh6Y)_