### PR TITLE
fix: seven code-review findings in the concierge, the Commons shell, and Contributions

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -296,6 +296,19 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-08-09: The star count on the cycle progress bar now counts members, not rows (#2143), and
+  dismissing the banner no longer hands back the snooze date (#2144). A GitHub star earns credits at
+  most once per member ever, and the block that enforces it at submission time only looks at stars
+  that have already been confirmed — so a member who sends two before either is reviewed ends up with
+  two confirmed star rows, the second granting 0 credits. `fetchCycleProgress`
+  (`lib/contributions/repository.ts`) counted rows, so that member showed up twice and the community
+  star total read higher than the number of people who actually starred. It now counts distinct
+  members for stars (`COUNT(DISTINCT user_id) FILTER (WHERE kind = 'github_star')`). Quora comments
+  stay a row count on purpose: they are repeatable, and each confirmed comment is a separate real
+  contribution. Separately, `dismissBanner` returned `{ snoozedUntil }` from a `RETURNING` clause even
+  though the route threw it away — the command contract says the snooze length is internal and is not
+  returned to the member, so the function now returns nothing and the `RETURNING` clause is gone. No
+  member-visible change from the dismiss edit; no schema, route, or contract change from either.
 - 2026-08-06: Submission review audit rows now record the reviewed member. The confirm/reject audit
   write in `app/api/contributions/admin/submissions/[submissionId]/review/route.ts` passed only the
   admin (`actorUserId`), so the `targetUserId` the audit contract declares for

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -210,6 +210,32 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
 
 ## Change Log
 
+- 2026-08-09: **Return on "Not now" no longer turns the AI Assistant on (#2158), plus two smaller
+  Commons fixes (#2156, #2160).** The first-use consent dialog for the AI Assistant treated Return as
+  "turn it on" no matter what had focus. That rule exists for a real reason — on a phone the soft
+  keyboard keeps focus in the chat composer, and without it a press of Return fell through to the
+  composer and re-opened the same dialog instead of answering it. But it also meant a member using a
+  keyboard could tab to "Not now", press Return, and grant consent to AI processing instead of
+  declining it. Return now leaves the press alone whenever a button inside the dialog already has
+  focus, so the browser fires that button's own click — "Not now" and the close button dismiss, the
+  confirm button confirms — and keeps the old behavior only when focus is outside the dialog, which is
+  the mobile case it was written for. Also: the "Got it" dismiss on the first-visit Commons notice now
+  sends the `x-ctf-csrf: 1` header like every other state-changing POST in the shell (the route checks
+  the Origin header rather than that one, so nothing was failing — this is consistency, so a later
+  switch to the header check cannot turn it into a dismiss that never sticks); and the notifications
+  panel now drops the result of a poll that lands after the member closes the panel, matching the
+  canceled-flag pattern used elsewhere in the shell. Web-only; no schema, route, or contract change.
+- 2026-08-09: **Removed the concierge slug-remapping layer that never ran (#2152, #2153).**
+  `lib/concierge/intents.ts` carried a `SLUG_OVERRIDES` map and a `conciergeRouteSlug()` helper meant
+  to translate a display slug into the registry slug that owns the route. Two things were wrong with
+  it. The map's only key was `lighthouse-safety`, which is not the slug of any intent in
+  `CONCIERGE_INTENTS`, so the lookup could never hit. And `lib/concierge/resolver.ts` built each
+  `ConciergeMatch` from `intent.slug` directly and never called the helper, so even a valid key would
+  have been ignored. Every one of the 16 intent slugs is already a real slug in the plugin registry
+  (`lib/plugins/repository.ts`), so nothing needs remapping: the map and the helper are deleted rather
+  than wired up, and the file header now says plainly that an intent's `slug` **is** the registry slug,
+  with no translation step to catch a typo. No member-visible change — routing behaves exactly as it
+  did, because the removed code never affected it. Web-only; no schema, route, or contract change.
 - 2026-08-03: **Removed the `GET /api/hub/bots` stub and corrected the channel/DM descriptions.** The
   route answered every caller with a hardcoded empty list behind a `TODO`, and no caller existed — a
   documented capability the product did not have. Deleted the route and its `HubBotInfo` /

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -479,14 +479,19 @@ The server returns an error (400 or 409 — the claim is not pending). The exist
 **Precondition:** A member already has one confirmed GitHub star with `credits_granted > 0`. A second GitHub star submission from the same member exists in the queue (submitted while the first was still pending, or forced into the DB for testing).
 
 **Steps:**
-1. Find the second GitHub star claim for that member in the admin queue.
-2. Confirm it.
+1. Open `/apps/contributions` as any member and write down the "Stars" number on the drive progress bar.
+2. Find the second GitHub star claim for that member in the admin queue.
+3. Confirm it.
+4. Reload `/apps/contributions` and read the "Stars" number again.
 
 **Expected:**
 - The claim status becomes "confirmed".
 - `creditsGranted` is 0.
 - The mint path is not called (no new `creditGovernanceEventId` from this claim).
 - A review note or similar record explains the duplicate star rule.
+- The "Stars" number on the progress bar is **unchanged** from step 1. The bar counts how many
+  members starred, not how many star rows exist, so a member's second confirmed star must not move
+  it. (A rise of 1 here is the bug fixed in #2143 coming back.)
 
 **Result:** web ☐
 

--- a/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
+++ b/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
@@ -66,8 +66,19 @@ export function ComicConsentModal({ open, onConfirm, onDismiss }: ComicConsentMo
 
       // Enter confirms the dialog. On mobile the soft keyboard keeps focus in the chat input, so a
       // press of Return would otherwise fall through to the composer and silently re-open this same
-      // modal instead of turning the assistant on. Treat Enter as "turn it on" regardless of focus.
+      // modal instead of turning the assistant on. Treat Enter as "turn it on" — EXCEPT when a button
+      // inside the dialog already has focus. A keyboard member who tabs to "Not now" and presses
+      // Return means "not now"; granting consent there is the opposite of what they asked for. Leave
+      // those presses alone and the browser fires the focused button's own click, so "Not now" and
+      // the close button dismiss, and the confirm button confirms.
       if (event.key === 'Enter') {
+        const root = modalRef.current;
+        const active = document.activeElement;
+        const onDialogButton =
+          root !== null && active instanceof HTMLElement && root.contains(active) && active.tagName === 'BUTTON';
+        if (onDialogButton) {
+          return;
+        }
         event.preventDefault();
         onConfirm();
         return;

--- a/ctf/packages/web/components/community-shell/commons-first-visit-notice.tsx
+++ b/ctf/packages/web/components/community-shell/commons-first-visit-notice.tsx
@@ -55,7 +55,11 @@ export function CommonsFirstVisitNotice() {
     try {
       await fetch('/api/hub/first-visit-notice', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        // The route checks the Origin header, not this one, so the dismiss records either way today.
+        // Sent anyway because every other state-changing POST in the Commons sends it, and the
+        // header-based check is what most other routes use — a later switch to it would otherwise
+        // turn this into a dismiss that silently never sticks.
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
         body: '{}',
       });
     } catch {

--- a/ctf/packages/web/components/community-shell/notifications-panel.tsx
+++ b/ctf/packages/web/components/community-shell/notifications-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { ArrowUpRight, Check } from 'lucide-react';
 import type {
   Notification,
@@ -267,23 +267,34 @@ export function NotificationsPanel({ onOpenDeepLink }: { onOpenDeepLink?: (linkP
   // browser, blocked permission, or push not configured). The opt-in is still saved either way.
   const [pushNote, setPushNote] = useState<string | null>(null);
 
+  // True only while this panel is on screen. Clearing the interval stops new polls, but a poll already
+  // in flight when the member closes the panel still resolves afterwards, and its result belongs to a
+  // panel that no longer exists. Same canceled-flag pattern the rest of the Commons shell uses.
+  const mountedRef = useRef(true);
+
   const load = useCallback(async () => {
     try {
       const payload = await requestJson<NotificationsResponse>('/api/notifications?limit=50');
+      if (!mountedRef.current) return;
       setItems(payload.notifications);
       setError(null);
     } catch (loadError) {
+      if (!mountedRef.current) return;
       setError(loadError instanceof Error ? loadError.message : 'Unable to load notifications.');
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     void load();
     // Poll while the panel is open so a device ping that lands here shows without a manual refresh.
     const timer = setInterval(() => void load(), 20_000);
-    return () => clearInterval(timer);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(timer);
+    };
   }, [load]);
 
   useEffect(() => {

--- a/ctf/packages/web/lib/concierge/intents.ts
+++ b/ctf/packages/web/lib/concierge/intents.ts
@@ -11,7 +11,9 @@
 // to every problem so none rendered blank; that real problem→best-app mapping is still to be done).
 // Routing "every app solves it" is wrong and overwhelming, so this table stays narrow and the resolver
 // surfaces only the best match(es). Keep slugs in sync with the plugin registry
-// (`lib/plugins/repository.ts`); each `slug` resolves to a route via `getPluginRoute(slug)`.
+// (`lib/plugins/repository.ts`); each `slug` resolves to a route via `getPluginRoute(slug)`. There is
+// no remapping step between the two — a `slug` here IS the registry slug, so a typo routes a member to
+// a page that does not exist. Check the registry before adding or renaming an intent.
 //
 // This is deliberately a deterministic keyword map, not an LLM: it is instant, runs server-side with
 // no model dependency, and never sends a member's words to a third party (a hard privacy rule for
@@ -203,13 +205,3 @@ export const CONCIERGE_INTENTS: ConciergeIntent[] = [
     starter: 'Does any of the work we all do here actually add up to anything?',
   },
 ];
-
-// A few intents share a problem space with a different canonical slug than their display name (kept
-// readable above). Resolve display→registry slug here so routes are always valid.
-const SLUG_OVERRIDES: Record<string, string> = {
-  'lighthouse-safety': 'click-log',
-};
-
-export function conciergeRouteSlug(intent: ConciergeIntent): string {
-  return SLUG_OVERRIDES[intent.slug] ?? intent.slug;
-}

--- a/ctf/packages/web/lib/contributions/repository.ts
+++ b/ctf/packages/web/lib/contributions/repository.ts
@@ -528,11 +528,18 @@ async function fetchCycleProgress(cycleId: string | null): Promise<ProgressRow> 
     return EMPTY_PROGRESS;
   }
 
+  // Stars count members, not rows. A star is creditable once per member ever, and the goal on the
+  // progress bar is "how many people starred" — but a member can still end up with two confirmed
+  // star rows, because the block at submission time only looks at stars that are already confirmed.
+  // Send two before either is reviewed and both get confirmed, the second with 0 credits. Counting
+  // rows would show that member twice and overstate the community total, so count distinct members.
+  // Quora comments are the opposite on purpose: they are repeatable, and every confirmed comment is
+  // a real contribution, so those stay a row count.
   const result = await queryDb<ProgressRow>(
     `SELECT
        COALESCE(SUM(confirmed_amount_usd) FILTER (WHERE kind = 'gift_card'), 0)::text AS fiat_confirmed_usd,
        COUNT(*) FILTER (WHERE kind = 'quora_comment')::text AS quora_comments_confirmed,
-       COUNT(*) FILTER (WHERE kind = 'github_star')::text AS github_stars_confirmed,
+       COUNT(DISTINCT user_id) FILTER (WHERE kind = 'github_star')::text AS github_stars_confirmed,
        COUNT(DISTINCT user_id)::text AS contributor_count
      FROM contributions_submissions
      WHERE status = 'confirmed' AND cycle_id = $1`,
@@ -568,19 +575,19 @@ export async function getFundraiserSnapshot(userId: string): Promise<FundraiserS
   };
 }
 
-export async function dismissBanner(userId: string): Promise<{ snoozedUntil: string }> {
+// Returns nothing on purpose. The snooze length is an internal config knob and the command contract
+// says the member is never told how long they have been snoozed for, so there is no snooze horizon
+// here for a future caller to pass along by accident.
+export async function dismissBanner(userId: string): Promise<void> {
   const config = await getContributionsConfig();
-  const result = await queryDb<{ snoozed_until: Date }>(
+  await queryDb(
     `INSERT INTO contributions_banner_state (user_id, snoozed_until, updated_at)
      VALUES ($1, NOW() + ($2::text || ' months')::interval, NOW())
      ON CONFLICT (user_id) DO UPDATE SET
        snoozed_until = NOW() + ($2::text || ' months')::interval,
-       updated_at = NOW()
-     RETURNING snoozed_until`,
+       updated_at = NOW()`,
     [userId, String(config.bannerSnoozeMonths)],
   );
-
-  return { snoozedUntil: result.rows[0].snoozed_until.toISOString() };
 }
 
 // --- admin review ---------------------------------------------------------------------------------


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Closes #2158
Closes #2152
Closes #2153
Closes #2143
Closes #2144
Closes #2156
Closes #2160

Each finding below was checked against the current code before anything was changed. Two of them
were right about the code but wrong about why it matters — those are called out so the next reader
does not undo the fix.

## The one that actually hurt a member: Return on "Not now" granted AI consent (#2158)

`comic-consent-modal.tsx` intercepted Return anywhere on the page and always called `onConfirm()`.
So a member using a keyboard could tab to **"Not now"**, press Return, and turn the AI Assistant on
— the opposite of what they asked for. On a consent dialog that is the worst possible direction to
get wrong.

The blanket rule was not careless. Its comment explains it: on a phone the soft keyboard keeps focus
in the chat composer, so without it a press of Return fell through to the composer and re-opened the
same dialog instead of answering it. Both cases now work: if a button **inside the dialog** already
has focus, the press is left alone and the browser fires that button's own click ("Not now" and the
close button dismiss, the confirm button confirms). If focus is outside the dialog — the mobile case
— the old behavior is unchanged. The confirm button is still auto-focused on open, so pressing
Return immediately still turns it on.

## Concierge: a remapping layer that could never run (#2152, #2153)

These two are the same defect seen from both ends. `intents.ts` had a `SLUG_OVERRIDES` map whose only
key was `lighthouse-safety` — not the slug of any intent in `CONCIERGE_INTENTS`, so the lookup could
never hit. And `resolver.ts` built each match from `intent.slug` and never called
`conciergeRouteSlug()`, so even a valid key would have been ignored.

Rather than wire the helper in, both are deleted. All 16 intent slugs (`lighthouse`, `workforce`,
`trust-transport`, `click-log`, `mood`, `chyme`, `directory`, `foundation`, `service-credits`,
`socket-relay`, `what-works`, `skills-hunt`, `level-up`, `trust`, `peer-programming`, `gdp`) are
already real slugs in `lib/plugins/repository.ts`, so there is nothing left to translate and keeping
an empty indirection would just be dead code with a comment that is no longer true. Routing behavior
is byte-for-byte the same, because the removed code never affected it. The file header now states
plainly that an intent's `slug` **is** the registry slug, so a typo routes to a page that does not
exist — check the registry before adding one.

## Contributions: the star count counted rows, not people (#2143)

A GitHub star earns credits at most once per member ever. The block that enforces it at submission
time only looks at stars that are *already confirmed*, so a member who sends two before either is
reviewed ends up with two confirmed rows — the second granting 0 credits, by design as defense in
depth. `fetchCycleProgress` counted rows, so that member showed up twice and the community star
total on the progress bar read higher than the number of people who actually starred. It now counts
distinct members for stars.

Quora comments deliberately stay a row count: they are repeatable, and each confirmed comment is a
separate real contribution. That is now written down next to the query rather than left to be
rediscovered.

## Contributions: banner dismiss returned the snooze date (#2144)

`dismissBanner()` returned `{ snoozedUntil }` from a `RETURNING` clause. The command contract says
the snooze length is internal and is not returned to the member, and the route already threw the
value away — so nothing leaked. The signature simply invited a future caller to pass it along. It
now returns nothing and the `RETURNING` clause is gone. No member-visible change.

## Finding was right about the code, wrong about the consequence (#2156)

The finding said the missing `x-ctf-csrf: 1` header on the first-visit notice dismiss means "the
dismiss will silently fail and the member will see the notice again on every visit". That is not
what happens. `app/api/hub/first-visit-notice/route.ts` validates with `checkMutationOrigin()`,
which compares the **Origin** header against the delivered host — it does not read `x-ctf-csrf` at
all. The dismiss records correctly today.

The header is added anyway, because every other state-changing POST in this module sends it and most
routes elsewhere in the app *do* check it. What is load-bearing here is consistency: if this route
is ever moved onto the header-based helper, the missing header would turn it into a dismiss that
silently never sticks. Please do not "simplify" it back out.

## Finding overstated the problem (#2160)

The finding's headline — "polling continues after component unmounts" — is not true. The cleanup
calls `clearInterval`, so polling does stop. What remains is narrower: a fetch already in flight when
the member closes the panel still resolves afterwards and calls `setItems`/`setError`/`setLoading`
on a component that is gone. Under React 19 that is a no-op rather than a leak or a warning, so this
is a consistency fix, not a repair. A `mountedRef` guard now drops that late result, matching the
canceled-flag pattern already used in `community-shell.tsx`, `announcement-card.tsx`, and
`commons-first-visit-notice.tsx`.

## Left alone

**#2154** (`isCloseRunnerUp` allows a second match when `topScore` is 0) is being closed as not a
real defect, separately from this PR. `topScore` is `scored[0].score`, and every entry in `scored`
cleared `score >= MIN_SCORE` with `MIN_SCORE = 1`, so `topScore` is never 0 when the function is
reachable. The issue text concedes this itself. The suggested guard would be unreachable code.

## Checks run locally

`@ctf/web` typecheck, lint (`--max-warnings=0`), and `build:ci`; repo-wide typecheck via the commit
hook; `check-eof-format.sh`; `check-inventory-drift.mjs`; `check-test-script-drift.mjs`. No schema,
route, or contract change, so the schema-drift gate has nothing to look at.

Feature inventories updated in the same commit: the Commons and concierge entries in
`ctf-survivor-hub-chat-feature-inventory.md`, and the star-count and dismiss entries in
`ctf-contributions-feature-inventory.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013nkowRPvg3t5VA52qsWR2L)_