### PR TITLE
fix: move the contribute gift into the Commons chip row and drop a repeated line

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -57,12 +57,11 @@ flow is one-way, like gas-station reward points.
 - See their own claim history and statuses (pending / confirmed / rejected).
 - See the current fundraiser cycle and collective progress (USD raised, comments, stars,
   contributor count) toward the owner-set goals.
-- Dismiss the fundraiser banner — a silent two-month snooze. On phone width, dismissing does not
-  remove the reminder entirely: the full banner collapses to a small gift emoji (🎁) in its place that
-  still opens the plugin, so it stays a subtle nudge without taking up space; the full banner returns
-  on its own when the snooze lapses. On desktop, dismissing hides it until the snooze lapses (no
-  emoji — the slim desktop bar is already unobtrusive). If the admin turns the banner feature off,
-  neither the banner nor the emoji shows.
+- Dismiss the fundraiser banner — a silent two-month snooze. Dismissing does not remove the reminder
+  entirely: the full banner collapses to a small gift emoji (🎁) that appears in the Commons chip row
+  just after the 🔔 notifications chip and still opens the plugin, so it stays a subtle nudge without
+  taking up space; the full banner returns on its own when the snooze lapses. If the admin turns the
+  banner feature off, neither the banner nor the emoji shows.
 - Open to any signed-in member: contributing requires no Unlock verification and never changes
   Unlock state.
 
@@ -315,6 +314,14 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
   computes `changedKnobs` from the fields present in the request body (the list the audit contract
   already declares) and keeps the resulting values under `resultingConfig`. No schema, route, or
   contract change.
+- 2026-08-07: **Gift reminder moved out of the top bar and into the Commons chip row (owner report:
+  the top bar was crowded on an iPhone SE).** `ContributionsGiftTrigger` is no longer mounted by
+  `community-shell.tsx`; it now renders in `ConciergeChipRail` (`shell-chat-panel.tsx`) immediately
+  after the 🔔 notifications chip, styled by a new `.contributeGiftBtn` chip class (rose accent, same
+  size as the @ / 📣 / 🔔 pills, with a comic-theme variant). The component takes a `className` prop
+  instead of carrying its old inline top-bar box style. When it shows and where it goes on tap are
+  unchanged: only while a drive is running and the full banner is dismissed or snoozed, and it opens
+  `/apps/contributions`. UI-only — no route, schema, or contract change.
 - 2026-08-06: Submission review audit rows now record the reviewed member. The confirm/reject audit
   write in `app/api/contributions/admin/submissions/[submissionId]/review/route.ts` passed only the
   admin (`actorUserId`), so the `targetUserId` the audit contract declares for

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -308,20 +308,20 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
   though the route threw it away — the command contract says the snooze length is internal and is not
   returned to the member, so the function now returns nothing and the `RETURNING` clause is gone. No
   member-visible change from the dismiss edit; no schema, route, or contract change from either.
+- 2026-08-09: **Gift reminder moved out of the top bar and into the Commons chip row (owner report:
+  the top bar was crowded on an iPhone SE).** `ContributionsGiftTrigger` is no longer mounted by
+  `community-shell.tsx`; it now renders in `ConciergeChipRail` (`shell-chat-panel.tsx`) immediately
+  after the 🔔 notifications chip, styled by a new `.contributeGiftBtn` chip class (violet accent,
+  same size as the @ / 📣 / 🔔 pills, with a comic-theme variant). The component takes a `className` prop
+  instead of carrying its old inline top-bar box style. When it shows and where it goes on tap are
+  unchanged: only while a drive is running and the full banner is dismissed or snoozed, and it opens
+  `/apps/contributions`. UI-only — no route, schema, or contract change.
 - 2026-08-07: Admin settings audit rows now record which settings the admin actually sent. The
   audit write in `app/api/contributions/admin/config/route.ts` logged every setting's resulting
   value, so a record could not show whether a knob was edited or merely carried over. The route now
   computes `changedKnobs` from the fields present in the request body (the list the audit contract
   already declares) and keeps the resulting values under `resultingConfig`. No schema, route, or
   contract change.
-- 2026-08-07: **Gift reminder moved out of the top bar and into the Commons chip row (owner report:
-  the top bar was crowded on an iPhone SE).** `ContributionsGiftTrigger` is no longer mounted by
-  `community-shell.tsx`; it now renders in `ConciergeChipRail` (`shell-chat-panel.tsx`) immediately
-  after the 🔔 notifications chip, styled by a new `.contributeGiftBtn` chip class (rose accent, same
-  size as the @ / 📣 / 🔔 pills, with a comic-theme variant). The component takes a `className` prop
-  instead of carrying its old inline top-bar box style. When it shows and where it goes on tap are
-  unchanged: only while a drive is running and the full banner is dismissed or snoozed, and it opens
-  `/apps/contributions`. UI-only — no route, schema, or contract change.
 - 2026-08-06: Submission review audit rows now record the reviewed member. The confirm/reject audit
   write in `app/api/contributions/admin/submissions/[submissionId]/review/route.ts` passed only the
   admin (`actorUserId`), so the `targetUserId` the audit contract declares for

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -236,6 +236,21 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
   than wired up, and the file header now says plainly that an intent's `slug` **is** the registry slug,
   with no translation step to catch a typo. No member-visible change — routing behaves exactly as it
   did, because the removed code never affected it. Web-only; no schema, route, or contract change.
+- 2026-08-09: **Two Commons changes for a crowded phone screen (owner report, iPhone SE).** (1) The
+  Contributions fundraiser gift reminder moved out of the top bar, which had no room left at 375px,
+  and into the chip row: `ConciergeChipRail` (`shell-chat-panel.tsx`) now renders
+  `ContributionsGiftTrigger` immediately after the 🔔 chip and before the suggestion chips, styled
+  by the new `.contributeGiftBtn` class (violet accent, same pill size as the @ / 📣 / 🔔 chips,
+  comic-theme variant included). It stays visible with the notifications feed open, like the three
+  chips before it, and still shows only while a drive is running and the full banner is dismissed or
+  snoozed. The row already scrolls sideways, so the fourth glyph costs no width. (2) The footnote
+  under the composer dropped its live-state sentence ("Human-in-the-loop AI support and community
+  support channel.") — it repeated the helper line directly above the message box, and two
+  near-identical explanations cost a line of screen height on every phone. While the stream is live
+  the footnote is now the "Community guidelines" link alone; the not-live wording ("Support channel
+  keeps syncing as new messages arrive.") stays, because that one reports real connection status.
+  Web-only (the Commons is web-only per rule 105); UI and copy only — no backend, schema, route, or
+  contract change. Verified: `@ctf/web` typecheck, lint, and a production build.
 - 2026-08-03: **Removed the `GET /api/hub/bots` stub and corrected the channel/DM descriptions.** The
   route answered every caller with a hardcoded empty list behind a `TODO`, and no caller existed — a
   documented capability the product did not have. Deleted the route and its `HubBotInfo` /

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -257,7 +257,7 @@ The fundraiser banner is visible. It shows collective drive progress and a way t
 
 ---
 
-### CONT-11 — Dismissing the banner on phone width collapses it to a 🎁 emoji in the top bar
+### CONT-11 — Dismissing the banner collapses it to a 🎁 chip in the Commons chip row
 
 **Role:** Member
 **Surfaces:** Web (phone width)
@@ -266,12 +266,13 @@ The fundraiser banner is visible. It shows collective drive progress and a way t
 **Steps:**
 1. At phone width, locate the fundraiser banner in the Hub.
 2. Click "Not now".
-3. Observe the banner area and the top bar.
+3. Observe the banner area, the top bar, and the chip row above the message box.
 
 **Expected:**
 - The full banner collapses.
-- A small 🎁 (gift emoji) appears in the top bar between the SE mark and the section tabs.
-- The emoji is tappable and opens the contributions plugin.
+- A small 🎁 (gift emoji) chip appears in the Commons chip row, immediately after the 🔔 notifications chip.
+- No 🎁 appears in the top bar.
+- The chip is tappable and opens the contributions plugin.
 - The large banner strip is no longer shown.
 
 **Result:** web ☐

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1814,7 +1814,7 @@
   align-items: center;
   /* Tightened (owner report, 2026-07-19): with the brand mark, tabs, admin, help, settings, and
      avatar all present, 8px gaps + 12px padding overflowed a 390px phone and clipped the avatar off
-     the right edge. The gift reminder was later moved out of this bar entirely (2026-08-07) because
+     the right edge. The gift reminder was later moved out of this bar entirely (2026-08-09) because
      even at these gaps the bar was crowded on a 375px phone (iPhone SE). */
   gap: 5px;
   height: 52px;
@@ -2425,8 +2425,9 @@
 
 /* ─── Fundraiser gift (🎁) chip ──────────────────────────────────────────── */
 /* Fourth glyph pill, right after the 🔔 chip. It moved down here from the top bar, which had no
-   room left on a 375px phone (iPhone SE). Rose accent so it reads distinct from the sky-blue @,
-   emerald 📣 and amber 🔔. Sized like the other three so the four read as one row. */
+   room left on a 375px phone (iPhone SE). Violet accent so it reads distinct from the sky-blue @,
+   emerald 📣 and amber 🔔, and does not read as a warning the way the earlier rose did. Sized like
+   the other three so the four read as one row. */
 .contributeGiftBtn {
   flex: 0 0 auto;
   display: inline-flex;
@@ -2435,15 +2436,15 @@
   padding: 3px 9px;
   border-radius: 7px;
   background: transparent;
-  border: 1px solid rgba(244, 114, 182, 0.35);
-  color: #F472B6;
+  border: 1px solid rgba(167, 139, 250, 0.35);
+  color: #A78BFA;
   font-size: 14px;
   line-height: 1;
   cursor: pointer;
 }
 
 .contributeGiftBtn:hover {
-  background: rgba(244, 114, 182, 0.12);
+  background: rgba(167, 139, 250, 0.12);
 }
 
 /* ─── Notifications center panel ─────────────────────────────────────────── */

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1812,9 +1812,10 @@
 .mobileBar {
   display: none;
   align-items: center;
-  /* Tightened (owner report, 2026-07-19): with the brand mark, gift reminder, tabs, admin, help,
-     settings, and avatar all present, 8px gaps + 12px padding overflowed a 390px phone and clipped
-     the avatar off the right edge. */
+  /* Tightened (owner report, 2026-07-19): with the brand mark, tabs, admin, help, settings, and
+     avatar all present, 8px gaps + 12px padding overflowed a 390px phone and clipped the avatar off
+     the right edge. The gift reminder was later moved out of this bar entirely (2026-08-07) because
+     even at these gaps the bar was crowded on a 375px phone (iPhone SE). */
   gap: 5px;
   height: 52px;
   padding: 0 8px;
@@ -1833,8 +1834,8 @@
   padding: 6px 12px;
   /* One unified icon-control chrome across the whole phone top bar: the same
      surface fill + border + radius that the plugin header's MobileTopActions uses,
-     so admin, gift, help, settings, and the tabs all read as one system (both
-     default and comic themes derive from the theme tokens). */
+     so admin, help, settings, and the tabs all read as one system (both default and
+     comic themes derive from the theme tokens). */
   border-radius: 10px;
   background: var(--ctf-surface);
   border: 1px solid var(--ctf-border);
@@ -2420,6 +2421,29 @@
 .notificationsFilterBtnActive {
   background: rgba(245, 158, 11, 0.22);
   border-color: rgba(245, 158, 11, 0.6);
+}
+
+/* ─── Fundraiser gift (🎁) chip ──────────────────────────────────────────── */
+/* Fourth glyph pill, right after the 🔔 chip. It moved down here from the top bar, which had no
+   room left on a 375px phone (iPhone SE). Rose accent so it reads distinct from the sky-blue @,
+   emerald 📣 and amber 🔔. Sized like the other three so the four read as one row. */
+.contributeGiftBtn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 9px;
+  border-radius: 7px;
+  background: transparent;
+  border: 1px solid rgba(244, 114, 182, 0.35);
+  color: #F472B6;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.contributeGiftBtn:hover {
+  background: rgba(244, 114, 182, 0.12);
 }
 
 /* ─── Notifications center panel ─────────────────────────────────────────── */
@@ -3069,6 +3093,13 @@
 :global([data-theme='comic']) .announcementsFilterBtnActive {
   background: #7a6a5022;
   border-color: var(--ctf-border-dim);
+}
+
+/* Fundraiser gift chip → the same inkDim chip treatment. */
+:global([data-theme='comic']) .contributeGiftBtn {
+  background: var(--ctf-bg);
+  border: 1px solid var(--ctf-border-dim);
+  color: var(--ctf-border-dim);
 }
 
 :global([data-theme='comic']) .comicComposerHelperToken {

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -191,7 +191,7 @@ function MobileTopBar({ section, onSectionChange, isAuthenticated, isAdmin, sign
       ) : null}
       {/* The fundraiser gift reminder used to sit here, between the mark and the tabs. On a 375px
           phone that made the bar too crowded, so it moved down into the Commons chip row after the
-          🔔 chip (owner directive, 2026-08-07) — see ConciergeChipRail in shell-chat-panel.tsx. */}
+          🔔 chip (owner directive, 2026-08-09) — see ConciergeChipRail in shell-chat-panel.tsx. */}
       <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
         <button
           type="button"

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -18,7 +18,7 @@ import { ShellChatPanel } from './shell-chat-panel';
 import { GatedChatPanel } from './gated-chat-panel';
 import { ShellAppsPanel } from './shell-apps-panel';
 import { ShellRightRail } from './shell-right-rail';
-import { ContributionsBanner, ContributionsGiftTrigger } from '../contributions/contributions-banner';
+import { ContributionsBanner } from '../contributions/contributions-banner';
 import { UnlockVerifyBanner } from './unlock-verify-banner';
 import { HelpControl } from '../bug-reports/help-control';
 import { SeMark } from '../shared/se-mark';
@@ -179,20 +179,19 @@ function MobileTopBar({ section, onSectionChange, isAuthenticated, isAdmin, sign
       <div className={styles.mobileBarLogo}>
         <SeMark size={26} />
       </div>
-      {/* Signed out, the bar carries far fewer controls (no gift reminder, help, settings or
-          avatar), so the full "SE / SKILLS ECONOMY" lockup fits beside the mark and a first-time
-          visitor sees the product name, not just a symbol. Signed in, the name is dropped again
-          so the mark, gift reminder, tabs and account controls all fit a 390px phone. */}
+      {/* Signed out, the bar carries far fewer controls (no help, settings or avatar), so the full
+          "SE / SKILLS ECONOMY" lockup fits beside the mark and a first-time visitor sees the
+          product name, not just a symbol. Signed in, the name is dropped again so the mark, tabs
+          and account controls all fit a 375px phone (iPhone SE). */}
       {!isAuthenticated ? (
         <span className={styles.mobileBarWordmark} aria-hidden="true">
           <span className={styles.mobileBarWordmarkInitials}>SE</span>
           <span className={styles.mobileBarWordmarkName}>Skills Economy</span>
         </span>
       ) : null}
-      {/* Fundraiser gift reminder — sits between the brand mark and the section tabs (owner
-          placement). Renders only on phone widths while a drive is active and the full banner is
-          dismissed or snoozed; the banner itself (when open) stays in the content area below. */}
-      {isAuthenticated ? <ContributionsGiftTrigger /> : null}
+      {/* The fundraiser gift reminder used to sit here, between the mark and the tabs. On a 375px
+          phone that made the bar too crowded, so it moved down into the Commons chip row after the
+          🔔 chip (owner directive, 2026-08-07) — see ConciergeChipRail in shell-chat-panel.tsx. */}
       <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
         <button
           type="button"

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -948,7 +948,7 @@ function ConciergeChipRail({
       <AnnouncementsFilterButton active={announcementsOnly && !notificationsOpen} on={announcementsOnly} onClick={onToggleAnnouncements} />
       <NotificationsFilterButton open={notificationsOpen} onClick={onToggleNotifications} />
       {/* Fundraiser gift reminder — moved here from the top bar, which ran out of room on a 375px
-          phone (owner directive, 2026-08-07). It renders itself as null unless a drive is running
+          phone (owner directive, 2026-08-09). It renders itself as null unless a drive is running
           and the full banner is dismissed or snoozed, so most of the time this row is unchanged.
           It stays visible with the notifications feed open, like the three glyph chips before it. */}
       <ContributionsGiftTrigger className={styles.contributeGiftBtn} />
@@ -1119,8 +1119,12 @@ function ChatComposer({
       {/* Character count, shown only near and past the limit. */}
       {showComposerCount ? <ComposerCharacterCount composerOverBy={composerOverBy} charsLeft={maxLength - composerLength} /> : null}
 
+      {/* Footnote. While the stream is live it is the guidelines link alone (owner directive,
+          2026-08-09): the sentence that used to sit here repeated the helper line above the message
+          box, and two near-identical explanations cost a line of screen height on every phone. The
+          not-live wording stays — that one reports real connection status, not a description. */}
       <p className={styles.chatFootnote}>
-        {isLive ? 'Human-in-the-loop AI support and community support channel.' : 'Support channel keeps syncing as new messages arrive.'}{' '}
+        {isLive ? null : <>Support channel keeps syncing as new messages arrive.{' '}</>}
         <a href="/guidelines" style={{ color: 'inherit', textDecoration: 'underline' }}>Community guidelines</a>
       </p>
     </>

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -21,6 +21,7 @@ import { NotificationsPanel } from './notifications-panel';
 import { ChatReactionRow } from './chat-reaction-row';
 import { CommonsFirstVisitNotice } from './commons-first-visit-notice';
 import { ComicConsentModal } from './comic-consent-modal';
+import { ContributionsGiftTrigger } from '../contributions/contributions-banner';
 import type { HubTypingUser } from '../../lib/hub/live-stream';
 import type { HubSuggestionChip } from '../../lib/concierge/hub-suggestions';
 import styles from './community-shell.module.css';
@@ -946,6 +947,11 @@ function ConciergeChipRail({
       <MentionsFilterButton active={mentionsOnly && !notificationsOpen} on={mentionsOnly} onClick={onToggleMentions} />
       <AnnouncementsFilterButton active={announcementsOnly && !notificationsOpen} on={announcementsOnly} onClick={onToggleAnnouncements} />
       <NotificationsFilterButton open={notificationsOpen} onClick={onToggleNotifications} />
+      {/* Fundraiser gift reminder — moved here from the top bar, which ran out of room on a 375px
+          phone (owner directive, 2026-08-07). It renders itself as null unless a drive is running
+          and the full banner is dismissed or snoozed, so most of the time this row is unchanged.
+          It stays visible with the notifications feed open, like the three glyph chips before it. */}
+      <ContributionsGiftTrigger className={styles.contributeGiftBtn} />
       {notificationsOpen ? null : <SuggestionChips chips={chips} onAsk={onAsk} />}
     </div>
   );

--- a/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-icon-rail.tsx
@@ -47,10 +47,9 @@ export function ShellIconRail({ section, onSectionChange, initial = 'S', isAuthe
 
       <div className={styles.iconRailSpacer} aria-hidden="true" />
 
-      {/* Contribute shortcut: the phone top bar carries a gift trigger, but the desktop rail had no
-          equivalent, so on desktop there was no gift/contribute affordance at all. This restores
-          parity — a persistent entry to the Contributions plugin for signed-in members. Uses the
-          lucide Gift icon to match the rail's other icons (the phone bar keeps its 🎁 emoji). */}
+      {/* Contribute shortcut: a persistent entry to the Contributions plugin for signed-in members,
+          shown whether or not a drive is running. Uses the lucide Gift icon to match the rail's
+          other icons; the Commons chip row's fundraiser reminder keeps its 🎁 emoji. */}
       {isAuthenticated ? (
         <Link
           href="/apps/contributions"

--- a/ctf/packages/web/components/contributions/contributions-banner.tsx
+++ b/ctf/packages/web/components/contributions/contributions-banner.tsx
@@ -29,14 +29,12 @@ function bannerGoals(f: FundraiserResponse['fundraiser']): BannerGoal[] {
  * only renders while a drive is active and the banner feature is on. "Contribute" opens the plugin;
  * "Not now" calls the server-side silent snooze (the duration is never shown).
  *
- * On phone width, dismissing does not remove the reminder entirely — the reminder becomes the small
- * gift emoji in the top bar (ContributionsGiftTrigger below, mounted between the brand mark and the
- * section tabs), so no strip of vertical space is spent on it. The full banner returns on its own
- * when the snooze lapses. On desktop, dismissing hides it until the snooze lapses (no emoji — a
- * slim desktop bar is already unobtrusive).
+ * Dismissing does not remove the reminder entirely — the reminder becomes the small gift emoji in
+ * the Commons chip row, just after the 🔔 notifications chip (ContributionsGiftTrigger below), so no
+ * strip of vertical space is spent on it. The full banner returns on its own when the snooze lapses.
  */
 
-// Cross-component signal: the banner's "Not now" tells the top-bar trigger to appear without a
+// Cross-component signal: the banner's "Not now" tells the gift trigger to appear without a
 // reload (the two components fetch fundraiser state independently).
 const BANNER_DISMISSED_EVENT = 'ctf:contributions-banner-dismissed';
 export function ContributionsBanner() {
@@ -86,8 +84,8 @@ export function ContributionsBanner() {
 
   const showFullBanner = fundraiser.bannerVisible && !collapsed;
 
-  // Dismissed or snoozed → nothing here. On phone width the reminder lives on as the gift emoji
-  // in the top bar (ContributionsGiftTrigger); a dedicated strip here read as wasted space.
+  // Dismissed or snoozed → nothing here. The reminder lives on as the gift emoji in the Commons
+  // chip row (ContributionsGiftTrigger); a dedicated strip here read as wasted space.
   if (!showFullBanner) {
     return null;
   }
@@ -128,13 +126,16 @@ export function ContributionsBanner() {
 }
 
 /**
- * The phone-top-bar gift reminder: a small 🎁 between the brand mark and the section tabs (owner
- * placement decision, 2026-07-19). It appears only while a drive is active AND the full banner is
- * not showing (dismissed this session or server-snoozed), so the reminder survives without
- * spending a strip of vertical space. Opens the Contributions plugin. Phone widths only — on
- * desktop a dismissed banner shows nothing until the snooze lapses, unchanged.
+ * The gift reminder: a small 🎁 that opens the Contributions plugin. It appears only while a drive
+ * is active AND the full banner is not showing (dismissed this session or server-snoozed), so the
+ * reminder survives without spending a strip of vertical space.
+ *
+ * It used to sit in the top bar beside the brand mark, but on a narrow phone (iPhone SE) that bar
+ * ran out of room, so it now rides in the Commons chip row just after the 🔔 notifications chip
+ * (owner placement decision, 2026-08-07). The caller supplies `className` so the button matches
+ * whichever row it sits in.
  */
-export function ContributionsGiftTrigger() {
+export function ContributionsGiftTrigger({ className }: { className: string }) {
   const router = useRouter();
 
   const [fundraiser, setFundraiser] = useState<FundraiserResponse['fundraiser'] | null>(null);
@@ -177,26 +178,7 @@ export function ContributionsGiftTrigger() {
       onClick={() => router.push('/apps/contributions')}
       aria-label="Contribute to the platform"
       title="Contribute"
-      // Boxed to match the rest of the phone top bar's icon controls (help, settings,
-      // admin) — the same surface + border + radius the plugin header uses — so the gift
-      // is no longer a bare emoji floating among bordered buttons. Theme tokens carry the
-      // default and comic looks.
-      style={{
-        width: 38,
-        height: 38,
-        borderRadius: 10,
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'var(--ctf-surface, rgba(255, 255, 255, 0.06))',
-        border: '1px solid var(--ctf-border, rgba(255, 255, 255, 0.12))',
-        color: 'var(--ctf-text, #E5E7EB)',
-        cursor: 'pointer',
-        fontSize: 16,
-        lineHeight: 1,
-        padding: 0,
-        flexShrink: 0,
-      }}
+      className={className}
     >
       🎁
     </button>

--- a/ctf/packages/web/components/contributions/contributions-banner.tsx
+++ b/ctf/packages/web/components/contributions/contributions-banner.tsx
@@ -132,7 +132,7 @@ export function ContributionsBanner() {
  *
  * It used to sit in the top bar beside the brand mark, but on a narrow phone (iPhone SE) that bar
  * ran out of room, so it now rides in the Commons chip row just after the 🔔 notifications chip
- * (owner placement decision, 2026-08-07). The caller supplies `className` so the button matches
+ * (owner placement decision, 2026-08-09). The caller supplies `className` so the button matches
  * whichever row it sits in.
  */
 export function ContributionsGiftTrigger({ className }: { className: string }) {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Two changes for a crowded phone screen, reported by the owner on an iPhone SE (375px wide).

## The top bar had one control too many

The Commons top bar carried the brand mark, the 🎁 fundraiser reminder, the Commons and Apps tabs, the admin link, the bug-report button, the settings gear, and the avatar — all in one 52px row. At 375px they crowded together.

The 🎁 reminder now rides in the Commons chip row instead, immediately after the 🔔 notifications chip and before the suggestion chips. That row already scrolls sideways, so a fourth glyph costs no width.

- `community-shell.tsx` no longer mounts `ContributionsGiftTrigger`; `ConciergeChipRail` in `shell-chat-panel.tsx` does.
- `ContributionsGiftTrigger` takes a `className` instead of carrying its own inline top-bar box style, so the row it sits in decides how it looks.
- New `.contributeGiftBtn` class sizes it like the @ / 📣 / 🔔 pills, with a violet accent and a comic-theme variant. Violet rather than rose, because rose (`#F472B6`) is already the registered Mutual Time plugin accent and read close to a warning next to the amber bell.
- When it shows and where it goes on tap are unchanged: only while a drive is running and the full banner is dismissed or snoozed, and it opens `/apps/contributions`. It stays visible with the notifications feed open, like the three chips before it.

## The footnote said the same thing twice

The line under the message box read "Human-in-the-loop AI support and community support channel." directly below the helper line that already says "AI Assistant (human in the loop) — type @comic to ask". Two near-identical explanations cost a line of screen height on every phone.

While the stream is live the footnote is now the "Community guidelines" link alone. The disconnected wording ("Support channel keeps syncing as new messages arrive.") stays, because that one reports real connection status rather than describing the channel.

## Documentation

- Commons inventory (`ctf-survivor-hub-chat-feature-inventory.md`): change-log entry for both changes.
- Contributions inventory: change-log entry, and the User Features line now says the reminder appears in the chip row rather than the top bar.
- Contributions manual test script: step CONT-11 now looks for the 🎁 chip after the 🔔 chip and checks that no 🎁 appears in the top bar.

## Checks run locally

`@ctf/web` typecheck, lint, and a production build all pass, plus `check-eof-format.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs`.

Styling and copy only — no backend, schema, route, or contract change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2AD7WGEhd7XAr7u51Kz8Y)_