### PR TITLE
fix: use the Sentry keys that already exist instead of duplicates

### DIFF
--- a/.claude/rules/108-observability-provider-abstraction-rules.mdc
+++ b/.claude/rules/108-observability-provider-abstraction-rules.mdc
@@ -24,13 +24,16 @@ Enable provider-neutral error monitoring so Sentry can be used now and Signoz ca
 - Track provider health and dropped-event metrics.
 - Use v3-specific DSNs/config and keep them isolated from legacy project telemetry.
 - Configure by the environment variables the code actually reads:
-	- Web: `OBSERVABILITY_PROVIDER` (`lib/observability/provider.ts`), `SENTRY_DSN` (server/edge),
-	  `NEXT_PUBLIC_SENTRY_DSN` (browser bundle — introduced in PR #2074 because Next.js only inlines
-	  `NEXT_PUBLIC_*` variables into the client), and `CTF_SKIP_SENTRY_NEXTJS` (set to `1` to skip
-	  Sentry entirely, e.g. in CI builds).
-	- Mobile: `MOBILE_OBSERVABILITY_PROVIDER` and `EXPO_SENTRY_DSN` are passed through by
-	  `app.config.ts` but nothing consumes them yet — the mobile app has no observability
-	  integration today.
+	- Web: `OBSERVABILITY_PROVIDER` (`lib/observability/provider.ts`), `SENTRY_DSN` (server, edge,
+	  and browser), and `CTF_SKIP_SENTRY_NEXTJS` (set to `1` to skip Sentry entirely, e.g. in CI
+	  builds). The browser gets the value of `SENTRY_DSN` from the root layout, which renders it into
+	  the page as a global (`SENTRY_DSN_GLOBAL` in `lib/observability/sentry-config.ts`) — Next.js
+	  inlines only `NEXT_PUBLIC_*` names into client bundles, and a `NEXT_PUBLIC_` copy of a key that
+	  already exists would be a duplicate that can drift. Never add one.
+	- Mobile: `EXPO_SENTRY_DSN` (the mobile DSN) and the same shared `OBSERVABILITY_PROVIDER` switch,
+	  both passed through by `app.config.ts` and consumed by `src/observability/sentry.ts`. Crash
+	  reporting starts whenever a DSN is present; a provider value other than `sentry` turns it off.
+	  There is no mobile-specific provider key — do not add one.
 
 ## Prohibited
 - Embedding provider-specific APIs into domain/business logic.

--- a/ctf/README.md
+++ b/ctf/README.md
@@ -28,9 +28,12 @@ This folder contains the rewrite monorepo scaffold for:
 
 ## Observability Provider Selection
 
-- Web: set `NEXT_PUBLIC_OBSERVABILITY_PROVIDER` to `sentry`, `signoz`, or `noop`.
-- Mobile: set `MOBILE_OBSERVABILITY_PROVIDER` to `sentry`, `signoz`, or `noop`.
-- Unknown or missing values default to `noop`.
+- One shared key selects the provider for both surfaces: set `OBSERVABILITY_PROVIDER` to `sentry`,
+  `signoz`, or `noop`.
+- The DSNs are `SENTRY_DSN` (web — server, edge, and browser) and `EXPO_SENTRY_DSN` (mobile). Both
+  already exist in Infisical; do not add `NEXT_PUBLIC_` or mobile-specific copies of them.
+- Reporting starts when a DSN is present. Unknown or missing provider values fall back to the
+  documented default for that surface.
 
 ## Structure
 

--- a/ctf/agents/observability-incident.agent.md
+++ b/ctf/agents/observability-incident.agent.md
@@ -23,10 +23,11 @@ Ensures Sentry and observability provider abstraction is implemented. Monitors f
 - Web entry points: `ctf/packages/web/lib/observability/report.ts` (`reportError`, the shared
   reporter), `instrumentation.ts` (server/edge init), `instrumentation-client.ts` (browser init),
   and `app/global-error.tsx` (root render-error boundary, PR #2074).
-- Env vars the code reads: `OBSERVABILITY_PROVIDER`, `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`
-  (browser, PR #2074), `CTF_SKIP_SENTRY_NEXTJS`. Everything fails open to noop with stdout
-  logging when the DSN is unset.
-- The mobile app has no Sentry integration; `app.config.ts` only passes through
-  `MOBILE_OBSERVABILITY_PROVIDER` / `EXPO_SENTRY_DSN`, which nothing consumes yet.
+- Env vars the code reads: `OBSERVABILITY_PROVIDER`, `SENTRY_DSN` (server, edge, and — via the
+  global the root layout renders — the browser), `CTF_SKIP_SENTRY_NEXTJS`. Everything fails open to
+  noop with stdout logging when the DSN is unset. There is no `NEXT_PUBLIC_` copy of the DSN and
+  none should be added: it would duplicate a key that already exists.
+- The mobile app reports crashes through `src/observability/sentry.ts`, from `EXPO_SENTRY_DSN` and
+  the shared `OBSERVABILITY_PROVIDER` switch — the same keys, no mobile-specific duplicates.
 - Runtime logs live on Render (services `ctf-web`, `ctf-route-weather`); the Render MCP server in
   `.mcp.json` and `render-debug-agent.yml` are the debugging paths.

--- a/ctf/packages/mobile/app.config.ts
+++ b/ctf/packages/mobile/app.config.ts
@@ -132,7 +132,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       signInUrl: process.env.NEXT_PUBLIC_AUTH_SIGN_IN_URL,
       oauthClientId: process.env.EXPO_PUBLIC_CLERK_OAUTH_CLIENT_ID,
       updatesUrl,
-      mobileObservabilityProvider: process.env.MOBILE_OBSERVABILITY_PROVIDER || 'noop',
+      // Both keys already exist in Infisical — EXPO_SENTRY_DSN is the mobile DSN and
+      // OBSERVABILITY_PROVIDER is the shared provider switch. Neither gets a mobile-specific
+      // duplicate: a second key holding the same value is one more thing that can drift.
+      mobileObservabilityProvider: process.env.OBSERVABILITY_PROVIDER || 'sentry',
       mobileSentryDsn: process.env.EXPO_SENTRY_DSN,
       eas: {
         ...(config.extra?.eas ?? {}),

--- a/ctf/packages/mobile/src/observability/sentry.ts
+++ b/ctf/packages/mobile/src/observability/sentry.ts
@@ -1,20 +1,24 @@
 import Constants from 'expo-constants';
 import * as Sentry from '@sentry/react-native';
 
-// Crash reporting for the native Android app (the Chyme keep-list surface, rule 105). The DSN and
-// provider flag have been passed through app config as `mobileSentryDsn` / `mobileObservabilityProvider`
-// (from EXPO_SENTRY_DSN / MOBILE_OBSERVABILITY_PROVIDER) since the config was written, but the
-// integration that consumed them was lost when the app was narrowed from the full plugin set to the
-// keep-list — so native crashes went unreported (owner report; restored 2026-08-03). Init is a no-op
-// when the DSN is absent or the provider is not 'sentry', so a local dev build without secrets runs
-// exactly as before.
+// Crash reporting for the native Android app (the Chyme keep-list surface, rule 105). The DSN has
+// been carried through app config as `mobileSentryDsn` (from EXPO_SENTRY_DSN, which already exists in
+// Infisical) all along, but the code that consumed it was lost when the app was narrowed from the
+// full plugin set to the keep-list — so the DSN sat unused and native crashes went unreported (owner
+// report; restored 2026-08-03).
+//
+// Turning it on takes no new secret: reporting starts whenever a DSN is present, and the existing
+// shared OBSERVABILITY_PROVIDER key can switch it off by naming a different provider. A build with no
+// DSN — a local dev build — runs exactly as before.
 export function initMobileSentry(): void {
   const extra = (Constants.expoConfig?.extra ?? {}) as {
     mobileSentryDsn?: string;
     mobileObservabilityProvider?: string;
   };
   const dsn = (extra.mobileSentryDsn ?? '').trim();
-  const provider = (extra.mobileObservabilityProvider ?? 'noop').trim().toLowerCase();
+  // Default to on when a DSN is configured: requiring a second opt-in switch is how this stayed
+  // silently off. Setting OBSERVABILITY_PROVIDER to anything other than 'sentry' turns it off.
+  const provider = (extra.mobileObservabilityProvider ?? 'sentry').trim().toLowerCase();
   if (!dsn || provider !== 'sentry') return;
   Sentry.init({
     dsn,

--- a/ctf/packages/web/app/layout.tsx
+++ b/ctf/packages/web/app/layout.tsx
@@ -20,6 +20,7 @@ import {
   getHostedAfterSignOutUrl,
   getAppUrl,
 } from '@/lib/auth/clerk-env';
+import { SENTRY_DSN_GLOBAL } from '@/lib/observability/sentry-config';
 import './globals.css';
 
 // The site title doubles as the link-preview descriptor other sites (e.g. Quora) show when a page
@@ -88,6 +89,19 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        {/*
+          Hands the browser the Sentry DSN the server already holds (SENTRY_DSN in Infisical). Next.js
+          inlines only NEXT_PUBLIC_* names into client bundles, so without this the browser had no DSN
+          and crash reporting never started there. Rendering it here keeps one secret key instead of a
+          NEXT_PUBLIC_ duplicate, and keeps it a runtime value — rotating the secret takes effect on
+          restart, with no image rebuild. A DSN only permits sending events to the project, so it is
+          meant to travel to the client. JSON.stringify keeps the value a string literal.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window[${JSON.stringify(SENTRY_DSN_GLOBAL)}]=${JSON.stringify(process.env.SENTRY_DSN ?? '')};`,
+          }}
+        />
         {/*
           No-flash theme script: runs before paint, reads the saved theme from
           localStorage, and sets data-theme="comic" on <html> so a returning comic-theme

--- a/ctf/packages/web/lib/observability/sentry-config.ts
+++ b/ctf/packages/web/lib/observability/sentry-config.ts
@@ -1,10 +1,26 @@
+// The one secret this reads is SENTRY_DSN — the key that already exists in Infisical. There is no
+// NEXT_PUBLIC_ copy of it and none should be added: a second key holding the same value is a
+// duplicate that can drift.
+//
+// Getting that value into the browser takes one step, because Next.js inlines only NEXT_PUBLIC_*
+// names into client bundles, so a plain process.env.SENTRY_DSN read is empty there. Instead the root
+// layout renders the value the server already holds into the page as a global (see
+// `SENTRY_DSN_GLOBAL` and its use in app/layout.tsx), and the browser reads it from there. That also
+// keeps it a runtime value: no build argument, and rotating the secret takes effect on restart
+// rather than requiring an image rebuild.
+//
+// A Sentry DSN is designed to sit in client code — it only permits sending events to the project —
+// so rendering it into the page is its intended use, not an exposure.
+
+/** Name of the window property the layout writes the DSN to. Keep in sync with app/layout.tsx. */
+export const SENTRY_DSN_GLOBAL = '__ctfSentryDsn';
+
 export function resolveWebSentryDsn(): string {
-  // NEXT_PUBLIC_SENTRY_DSN must be read here, by that literal name: Next.js inlines only
-  // NEXT_PUBLIC_* variables into browser bundles, so in the browser the plain SENTRY_DSN read is
-  // always empty. Until this chain existed the client never saw a DSN, Sentry.init never ran in the
-  // browser, and no member-side error reached Sentry (agent-team pass finding). The server keeps
-  // reading SENTRY_DSN; set NEXT_PUBLIC_SENTRY_DSN to the same value in Infisical/Render.
-  return (process.env.NEXT_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN ?? '').trim();
+  if (typeof window !== 'undefined') {
+    const fromPage = (window as unknown as Record<string, unknown>)[SENTRY_DSN_GLOBAL];
+    return typeof fromPage === 'string' ? fromPage.trim() : '';
+  }
+  return (process.env.SENTRY_DSN ?? '').trim();
 }
 
 export function shouldEnableWebSentry(): boolean {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: in scope — this is what actually switches the restored crash reporting on.

## What was wrong

Both Sentry secrets were already in Infisical: **`SENTRY_DSN`** (web), **`EXPO_SENTRY_DSN`** (mobile), with **`OBSERVABILITY_PROVIDER`** as the shared provider switch. My earlier fixes asked for two more keys holding the same values — `NEXT_PUBLIC_SENTRY_DSN` and `MOBILE_OBSERVABILITY_PROVIDER`. That is a duplicate of an existing key, which can drift out of sync, and it is exactly what the secrets rule forbids. Worse, the mobile one meant crash reporting would have stayed silently off, because the key it gated on does not exist.

Both invented keys are gone — zero references remain anywhere in the repo.

## How the browser gets the DSN now, with one key

Next.js inlines only `NEXT_PUBLIC_*` names into client bundles, so `process.env.SENTRY_DSN` is empty in the browser. Instead the root layout renders the value the server already holds into the page as a global, and the client reads it from there. Two things this buys beyond avoiding the duplicate:

- It stays a **runtime** value — rotating the secret takes effect on restart, with no image rebuild and no new Docker build argument (the web image build has no `SENTRY_DSN` today).
- A Sentry DSN only permits sending events to its own project; travelling to the client is its intended use, not an exposure.

## Mobile

`app.config.ts` reads the shared `OBSERVABILITY_PROVIDER`, and reporting starts whenever a DSN is present — requiring a second opt-in switch is precisely how this stayed off. A provider value other than `sentry` turns it off; a build with no DSN behaves exactly as before.

**Net effect: nothing to add in Infisical.** The next web build and the next Android build pick up the existing keys.

## Docs

Rule 108, the observability role file, and `ctf/README.md` now name these keys correctly and state plainly that no `NEXT_PUBLIC_` or mobile-specific copy should ever be added.

## Checks

Web and mobile typecheck, lint, US-spelling, and EOF gates pass; pre-push typecheck gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKr7ZGSkebriSZqhMT1bP8)_