### PR TITLE
fix: stop the admin drive form wiping cycle goals, and trap focus in the Weavers explainer

### DIFF
--- a/ctf/docs/contracts/CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -34,11 +34,17 @@ contracts:
       quoraPostUrl:
         type: string
         required: false
-        note: Optional for kind quora_comment (the owner can paste it in during review).
+        note: >-
+          Optional for kind quora_comment (the owner can paste it in during review). The web form
+          asks for it and will not submit without it, on purpose — an untrackable claim cannot be
+          confirmed, so the form points the member to the Commons for help finding the link instead.
+          The command stays optional so a claim recorded by the owner during review is still valid.
       githubProfileUrl:
         type: string
         required: false
-        note: Optional for kind github_star (the owner can paste it in during review).
+        note: >-
+          Optional for kind github_star (the owner can paste it in during review). Same as
+          quoraPostUrl: the web form requires it by design, the command does not.
     outputSchema:
       ok:
         type: boolean

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -296,6 +296,20 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-08-09: Opening the admin Drive tab before the cycle finished loading could wipe all three
+  goals (#2137), and the contract now says plainly that the web form requires a contribution link
+  even though the command does not (#2140). The drive form seeds its three goal inputs with
+  `useState`, which reads the cycle only on the component's first render. The admin dashboard fetches
+  the cycle after mount and opens on the review queue, so an admin who reached the Drive tab before
+  that fetch landed saw three empty boxes — and saving an empty box sends `0`, which the update's
+  `COALESCE` treats as a real value and writes over the stored goal. `ContributionsAdminDrive` is now
+  keyed on the cycle id in `contributions-admin-shell.tsx`, so it remounts with the loaded values the
+  moment the cycle arrives. Nothing about `0` itself changed: an admin who deliberately types 0 still
+  gets a goal of 0, which is a legitimate setting. Separately,
+  `CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml` now records why `quoraPostUrl` / `githubProfileUrl`
+  are optional on `contributions.submission.create` while the web form still insists on them — the
+  owner can record a link during review, but a member-submitted claim with no link cannot be found
+  and confirmed. Contract text only; no behavior, schema, or route change from either.
 - 2026-08-09: The star count on the cycle progress bar now counts members, not rows (#2143), and
   dismissing the banner no longer hands back the snooze date (#2144). A GitHub star earns credits at
   most once per member ever, and the block that enforces it at submission time only looks at stars

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -210,6 +210,15 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
 
 ## Change Log
 
+- 2026-08-09: **The Weavers of the Commons explainer is usable from the keyboard now (#2159).** That
+  dialog — shown when a member taps the locked contributor chip — declared `role="dialog"` and
+  `aria-modal="true"` but did none of what those promise. Focus stayed on the page behind it, Tab
+  walked straight out into content the member could no longer see, Escape did nothing, and closing
+  the dialog dropped focus at the top of the document instead of returning it to the chip. It now
+  moves focus into the card on open, cycles Tab and Shift+Tab within it, closes on Escape, and
+  restores focus to whatever opened it. The trap itself moved out of `comic-consent-modal.tsx` into a
+  new `dialog-focus.ts` so both dialogs share one copy rather than each carrying its own; the consent
+  dialog's behavior is unchanged. Web-only; no schema, route, or contract change.
 - 2026-08-09: **Return on "Not now" no longer turns the AI Assistant on (#2158), plus two smaller
   Commons fixes (#2156, #2160).** The first-use consent dialog for the AI Assistant treated Return as
   "turn it on" no matter what had focus. That rule exists for a real reason — on a phone the soft

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -516,6 +516,29 @@ The new cycle is saved and displayed with correct start/end dates and all three 
 
 ---
 
+### CONT-A10b — Opening the Drive tab early does not wipe the cycle goals
+
+**Role:** Admin
+**Surfaces:** Web (`/admin/contributions`)
+**Precondition:** Signed in as admin, with an existing cycle whose three goals are all non-zero (CONT-A10 leaves one). Note the three goal values before you start.
+
+**Steps:**
+1. Throttle the connection in browser dev tools (Network → Slow 3G) so the dashboard's data takes a few seconds to arrive. This is the whole point of the case — the bug only appears while the cycle is still loading.
+2. Load `/admin/contributions` and tap the **Drive** tab immediately, before the page finishes loading.
+3. Wait for loading to finish and look at the three goal boxes.
+4. Without editing anything, save.
+5. Reload `/apps/contributions` as a member and read the drive progress targets.
+
+**Expected:**
+- After loading finishes, the three goal boxes show the cycle's real values — not empty boxes.
+- The save leaves all three goals unchanged, matching what you noted in the precondition.
+- Empty boxes at step 3, or goals that read 0 at step 5, is the bug from #2137: the form kept its first-render empty values and the save wrote 0 over each real goal.
+- Typing 0 into a goal box on purpose and saving still stores 0. That is a valid goal, not the bug.
+
+**Result:** web ☐
+
+---
+
 ### CONT-A11 — Cycle with end before start is rejected
 
 **Role:** Admin

--- a/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
+++ b/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { Check, EyeOff, Lock, Server, ShieldCheck, Sparkles, X } from 'lucide-react';
 import styles from './community-shell.module.css';
+import { cycleFocusTrap } from './dialog-focus';
 
 type ComicConsentModalProps = {
   open: boolean;
@@ -18,34 +19,6 @@ const POINTS = [
   { icon: ShieldCheck, title: 'A teammate reviews answers', desc: 'Sensitive answers are checked by a trained human before they reach you.' },
   { icon: Lock, title: 'Your safety comes first', desc: 'The assistant will never reveal your location or identity, or ask you to.' },
 ];
-
-// Tab-focusable elements inside the dialog, used to cycle focus (focus trap).
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
-
-// Focus trap for a single Tab / Shift+Tab press: keep focus cycling within the dialog root.
-function cycleFocusTrap(root: HTMLElement, event: KeyboardEvent) {
-  const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
-    (element) => element.offsetParent !== null || element === document.activeElement,
-  );
-  if (focusable.length === 0) return;
-
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  const active = document.activeElement;
-
-  if (event.shiftKey) {
-    if (active === first || !root.contains(active)) {
-      event.preventDefault();
-      last.focus();
-    }
-    return;
-  }
-  if (active === last || !root.contains(active)) {
-    event.preventDefault();
-    first.focus();
-  }
-}
 
 export function ComicConsentModal({ open, onConfirm, onDismiss }: ComicConsentModalProps) {
   const confirmRef = useRef<HTMLButtonElement | null>(null);

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -24,6 +24,7 @@ import { HelpControl } from '../bug-reports/help-control';
 import { SeMark } from '../shared/se-mark';
 import type { UnlockReviewStatus } from '../../lib/unlock/types';
 import styles from './community-shell.module.css';
+import { cycleFocusTrap, focusableWithin } from './dialog-focus';
 import { failureText } from 'lib/errors/client-failure';
 
 // Verification state for a signed-in member who has not yet completed Quora verification but reaches
@@ -406,6 +407,32 @@ function ShellMainContent({
 // contributor chip. Same honest copy the Directory braided badge shows (proposal
 // section 3: no "verified", no "vetted"). "Anyone can earn this."
 function ContributorExplainerModal({ onClose }: { onClose: () => void }) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  // This dialog says aria-modal, so it has to behave like one for a keyboard member: focus starts
+  // inside it, Escape closes it, Tab cannot walk out into the page behind the backdrop, and focus
+  // returns to whatever opened it. Same handling the AI-consent dialog uses.
+  useEffect(() => {
+    const opener = document.activeElement as HTMLElement | null;
+    focusableWithin(cardRef.current ?? document.body)[0]?.focus();
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const root = cardRef.current;
+      if (root) cycleFocusTrap(root, event);
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      opener?.focus?.();
+    };
+  }, [onClose]);
+
   return (
     <div
       className={styles.explainerOverlay}
@@ -419,7 +446,7 @@ function ContributorExplainerModal({ onClose }: { onClose: () => void }) {
         className={styles.explainerBackdrop}
         onClick={onClose}
       />
-      <div className={styles.explainerCard}>
+      <div className={styles.explainerCard} ref={cardRef}>
         <div className={styles.explainerHead}>
           <WeaversBadge size={30} />
           <div className={styles.explainerTitle}>Weavers of the Commons</div>

--- a/ctf/packages/web/components/community-shell/dialog-focus.ts
+++ b/ctf/packages/web/components/community-shell/dialog-focus.ts
@@ -1,0 +1,42 @@
+// Keyboard handling shared by the Commons shell's modal dialogs.
+//
+// A dialog that says `role="dialog" aria-modal="true"` is promising a keyboard member three things:
+// focus starts inside it, Tab cannot wander out to the page behind the backdrop, and focus returns to
+// whatever opened it when it closes. A mouse user never notices when those are missing; someone
+// navigating by keyboard or screen reader loses their place entirely and can end up typing into a
+// page they cannot see. This module holds that behavior once so each dialog does not re-derive it.
+
+// Tab-focusable elements inside a dialog, used to cycle focus.
+export const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+// Every focusable element currently inside `root`, in tab order. Hidden elements are dropped —
+// `offsetParent` is null for anything `display: none` — but the currently focused element is kept
+// even if it reports hidden, so focus is never lost mid-cycle.
+export function focusableWithin(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => element.offsetParent !== null || element === document.activeElement,
+  );
+}
+
+// Focus trap for a single Tab / Shift+Tab press: keep focus cycling within the dialog root.
+export function cycleFocusTrap(root: HTMLElement, event: KeyboardEvent) {
+  const focusable = focusableWithin(root);
+  if (focusable.length === 0) return;
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+
+  if (event.shiftKey) {
+    if (active === first || !root.contains(active)) {
+      event.preventDefault();
+      last.focus();
+    }
+    return;
+  }
+  if (active === last || !root.contains(active)) {
+    event.preventDefault();
+    first.focus();
+  }
+}

--- a/ctf/packages/web/components/contributions/admin/contributions-admin-shell.tsx
+++ b/ctf/packages/web/components/contributions/admin/contributions-admin-shell.tsx
@@ -183,7 +183,11 @@ export function ContributionsAdminShell() {
         />
       )}
       {tab === 'drive' && (
-        <ContributionsAdminDrive t={t} cycle={currentCycle} saving={savingDrive} error={driveError} onSave={onSaveDrive} isMobile={true} />
+        // Keyed on the cycle so the form re-reads its fields when the cycle finishes loading. The
+        // form seeds its inputs with useState, which only reads the cycle on the first render — open
+        // this tab before the fetch lands and the boxes stay empty, and saving an empty box writes a
+        // goal of 0 over the real one. Changing the key remounts the form with the loaded values.
+        <ContributionsAdminDrive key={currentCycle?.id ?? 'new-cycle'} t={t} cycle={currentCycle} saving={savingDrive} error={driveError} onSave={onSaveDrive} isMobile={true} />
       )}
       {tab === 'settings' &&
         (config ? (


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Closes #2137
Closes #2159
Closes #2140

This is the remaining `code-review` backlog — the eight issues that were never labeled
`code-review:actionable`. Three of them describe something real and are fixed here. Five do not
survive a read of the code and are being closed separately with an explanation on each; they are
listed at the bottom so the decisions are in one place.

## Admin drive form could wipe all three cycle goals (#2137)

The highest-severity one, and real — though not by the route the finding describes.

`ContributionsAdminDrive` seeds its three goal inputs with `useState(initial.fiatGoal)` and friends.
`initialDriveForm(cycle)` is recomputed every render, but `useState` only reads its argument on the
**first** render, so once the component has mounted the boxes never pick up a cycle that arrives
later. The admin dashboard fetches the cycle in a mount effect and opens on the review queue tab, so
an admin who taps **Drive** before that fetch lands gets three empty boxes. `Number('') || 0` turns
each one into `0`, and `updateCycle`'s `COALESCE($4, fiat_goal_usd)` treats `0` as a real value — so
a save the admin thinks is a no-op silently replaces every goal with zero.

Fixed by keying the form on the cycle id at its one call site, so it remounts with the loaded values
the moment the cycle arrives. Nothing about `0` itself changed: an admin who deliberately types 0
still gets a goal of 0, which is a legitimate setting, and the server still distinguishes "field
omitted" (`undefined` → `null` → `COALESCE` keeps the stored value) from "field set to 0".

**Where the finding's reasoning was wrong**, so nobody re-derives it: it blamed `COALESCE` accepting
`0`, and proposed passing `undefined` for goals "that were not changed". That would be the wrong
fix — `COALESCE` handling `0` as a value is correct, and tracking which fields an admin touched adds
state for a problem that is really just a form that never re-read its props. It also said the route
layer uses `body.fiatGoalUsd ?? null`; the route passes the value straight through, and the `?? null`
is in `updateCycle`.

New test case **CONT-A10b** covers it, including the throttled-connection setup needed to see it at
all, and states plainly that a deliberate 0 is not the bug.

## Weavers of the Commons explainer had no keyboard handling (#2159)

`ContributorExplainerModal` declares `role="dialog"` and `aria-modal="true"` and then does none of
what those promise: focus stays on the page behind the backdrop, Tab walks straight out into content
the member can no longer see, Escape does nothing, and closing drops focus at the top of the
document instead of returning it to the chip that opened the dialog. A mouse user never notices; a
keyboard or screen-reader member loses their place entirely.

It now moves focus into the card on open, cycles Tab and Shift+Tab within it, closes on Escape, and
restores focus to the opener. Rather than copy the trap that already existed inside
`comic-consent-modal.tsx`, that helper moved to a new `dialog-focus.ts` and both dialogs import it.
The consent dialog's behavior is unchanged — same function, same call site, only its home moved.

The backdrop's own close button sits outside the card and is deliberately left out of the tab cycle:
it is a mouse affordance, the card carries a visible **Close** button, and Escape works.

## Submission URL: contract and form disagreed on paper only (#2140)

The contract marks `quoraPostUrl` / `githubProfileUrl` optional; the web form refuses to submit
without one. Both are correct, and neither is changed here. The command really does accept a
submission with no link — that is how the owner records a contribution during review — while the
form requires one because a member-submitted claim with no link cannot be found and confirmed, which
is why its help text points to the Commons instead. The code says so in a comment; the contract did
not, which is what made this look like a conflict.

Only the contract's `note` text changed to record the split. `required: false` is untouched, so
there is no behavior or validation change. I did not touch the shipped form — making the field
optional would rewrite shipped copy and UI to satisfy a review finding.

## Closed as not real (no code changed for these)

- **#2162** — "Shell re-fetches `/api/plugins` on every render cycle". It does not; the effect has an
  empty dependency array and a canceled flag, which the finding's own body concedes. It also claims
  the failure is "silently swallowed" — `loadError` is rendered in a `role="alert"` section.
- **#2161** — index keys in `NoticeParagraphs`. The component derives paragraphs from a string on
  every render and emits only text and `<br>`; there is no per-item state, ref, or input for React to
  misplace, so position *is* the identity. The suggested content-based key would be worse: duplicate
  lines in a notice would produce duplicate keys.
- **#2157** — `loadReplies` "ignoring server-side total". `listAnnouncementReplies` has no `LIMIT` and
  filters on `moderation_status = 'accepted'`, the identical filter used to compute the `replyCount`
  prop, so `payload.replies.length` **is** the true total. The line reconciles a prop that went out
  of date while the page was open. The suggested fix — never set the count from the payload — would
  reintroduce exactly that staleness. If a `LIMIT` is ever added to that query, this line has to
  change with it.
- **#2141** — fractional gift-card amounts. `GIFT_CARD_MIN_USD` is 0 and the confirm path requires
  `amount > 0`, which is what the contract says ("greater than 0"). Code and contract agree, so there
  is no defect to fix; introducing a floor is a product decision for the owner, not a review fix.
  Flagged in my summary rather than decided here.
- **#2138** — `signalContact` on non-gift-card submissions. The load-bearing claim is that
  `signalContact: ''` "passes the `!== undefined` check". It does not — `'' !== undefined` is true, so
  the guard throws and an empty string is rejected like any other value. What is left is a request
  for a more specific error code than `invalid_payload`, which is cosmetic and would mean touching
  the contract's `denyConditions`.

## Checks run locally

`@ctf/web` typecheck, lint (`--max-warnings=0`), and `build:ci`; repo-wide typecheck via the commit
hook; `check-eof-format.sh`; `check-inventory-drift.mjs`; `check-test-script-drift.mjs` (verified
after committing, so it compares the real branch diff). The edited contract YAML was parsed to
confirm the folded note is still valid YAML. No schema or route change, so the schema-drift gate has
nothing to look at.

Inventories updated in the same commit: the drive-goal and contract entries in
`ctf-contributions-feature-inventory.md`, and the explainer entry in
`ctf-survivor-hub-chat-feature-inventory.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013nkowRPvg3t5VA52qsWR2L)_