### PR TITLE
fix: make the phone top bar one row of equal boxes and name the Commons page

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -72,6 +72,7 @@ The Survivor Hub is the primary entry point of CTF for both unauthenticated visi
 5. Right rail no longer shows a "Ready/Active Apps" list (removed 2026-06-18) — apps are reached via the Apps section; the "· N ready apps" line was also dropped from the signed-in profile card.
 6. Sign-in and Create-Account CTAs visible in icon rail and right rail for unsigned visitors.
 7. Hero banner ("Free to join · End-to-end encrypted") visible to unsigned visitors.
+8. The phone-width top bar switches sections with two icon buttons — a speech-bubbles icon for the Commons and a grid icon for Apps — the same 38px square as the admin, help and settings buttons beside them, so the whole bar is one row of equal boxes. Each button names itself for screen readers and on hover ("Commons", "Apps"). Once a member is there, the page says which one it is: the Apps page heads "All Apps", and the Commons channel row starts with the word "Commons" ahead of the `#general` chip.
 
 ### Hub Chat (the blended `community` channel)
 
@@ -210,6 +211,22 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
 
 ## Change Log
 
+- 2026-08-09: **One row of equal boxes in the phone top bar, and the Commons page says its own name
+  (owner report).** The "Commons" and "Apps" section tabs were word buttons sized by their text
+  (`padding: 6px 9px`), so they stood noticeably shorter than the 38px square admin, help and
+  settings buttons next to them and the bar read as two mismatched rows. Both tabs are icons now
+  (`MessagesSquare` for the Commons, `LayoutGrid` for Apps, from `lucide-react`) in the same 38px
+  square with the same surface, border and radius, so every control in the bar matches. Nothing is
+  lost by dropping the words: each button keeps an `aria-label` and a hover title, `role="tab"` and
+  `aria-selected` are unchanged, and each destination announces itself on arrival — the Apps page
+  already heads "All Apps", and `ChannelSwitchRow` now leads with a plain "Commons" label before the
+  `#general` chip (new `.channelSwitchBar` wrapper carrying the row's padding, plus
+  `.channelSwitchPageLabel`, deliberately without pill chrome so it does not read as a tappable
+  channel). The label sits outside the `role="tablist"` element, so screen readers still count only
+  the real channel tabs. Also hyphenated the composer helper line to "AI Assistant
+  (human-in-the-loop)", matching the spelling every doc and contract already uses. Web-only (the
+  Commons is web-only per rule 105); UI and copy only — no backend, schema, route, or contract
+  change. Verified: `@ctf/web` typecheck, lint, and a production build.
 - 2026-08-09: **The Weavers of the Commons explainer is usable from the keyboard now (#2159).** That
   dialog — shown when a member taps the locked contributor chip — declared `role="dialog"` and
   `aria-modal="true"` but did none of what those promise. Focus stayed on the page behind it, Tab

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1920,17 +1920,23 @@
 }
 
 .mobileBarSectionBtn {
-  padding: 6px 9px;
   /* Both section tabs carry the same boxed chrome as the other top-bar controls so
      the pair reads as one segmented control; the active state (below) only changes
-     the tint, not the presence of the box. */
+     the tint, not the presence of the box. They are icon-only now and share the exact
+     38px square of the admin, help and settings buttons, so every box in the bar is
+     one height — text padding used to leave these two visibly shorter than the rest. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  padding: 0;
   border-radius: 10px;
   background: var(--ctf-surface);
   border: 1px solid var(--ctf-border);
-  color: var(--ctf-text-subtle);
-  font-size: 13px;
-  font-weight: 600;
+  color: var(--ctf-text-secondary);
   cursor: pointer;
+  flex-shrink: 0;
 }
 
 .mobileBarSectionBtnActive {
@@ -3247,7 +3253,26 @@
   gap: 8px;
   flex-wrap: wrap;
   flex-shrink: 0;
+}
+
+/* Wrapper holding the page name plus the channel pills on one line. The padding that used to sit
+   on .channelSwitchRow lives here now so the label shares the row's inset. */
+.channelSwitchBar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
   padding: 10px 16px 0;
+}
+
+/* "Commons" page name. Deliberately unlike a pill — no border, no fill — so it reads as the name of
+   the page rather than another channel a member could tap. */
+.channelSwitchPageLabel {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--ctf-text-shell, #E2E8F0);
 }
 
 .channelSwitchBtn {

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { UserButton } from '@clerk/nextjs';
-import { SlidersHorizontal, Settings } from 'lucide-react';
+import { SlidersHorizontal, Settings, MessagesSquare, LayoutGrid } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import type { TrustUserExtension } from '../../lib/trust/types';
 import type { PluginRegistryItem } from '../../lib/plugins/repository';
@@ -193,24 +193,34 @@ function MobileTopBar({ section, onSectionChange, isAuthenticated, isAdmin, sign
       {/* The fundraiser gift reminder used to sit here, between the mark and the tabs. On a 375px
           phone that made the bar too crowded, so it moved down into the Commons chip row after the
           🔔 chip (owner directive, 2026-08-09) — see ConciergeChipRail in shell-chat-panel.tsx. */}
+      {/* Section switch. These were word buttons ("Commons" / "Apps") sized by their text, so they
+          stood shorter than the 38px square icon controls beside them and the bar read as two
+          different rows of boxes. They are icons now (owner directive, 2026-08-09) so every control
+          in the bar is the same square. The words are not lost: the icon carries an aria-label and
+          a tooltip, and each destination names itself on arrival — the Apps page heads "All Apps",
+          and the Commons page now leads its channel row with a "Commons" label. */}
       <div className={styles.mobileBarSections} role="tablist" aria-label="Sections">
         <button
           type="button"
           role="tab"
           aria-selected={section === 'chat'}
+          aria-label="Commons"
+          title="Commons — the community channels"
           className={sectionTabClass(section === 'chat')}
           onClick={() => onSectionChange('chat')}
         >
-          Commons
+          <MessagesSquare size={18} aria-hidden="true" />
         </button>
         <button
           type="button"
           role="tab"
           aria-selected={section === 'apps'}
+          aria-label="Apps"
+          title="Apps — every app on the platform"
           className={sectionTabClass(section === 'apps')}
           onClick={() => onSectionChange('apps')}
         >
-          Apps
+          <LayoutGrid size={18} aria-hidden="true" />
         </button>
       </div>
       {/* Admins reach /admin straight from the top bar on phones — the left rail
@@ -271,31 +281,38 @@ function ChannelSwitchRow({ channels, activeChannel, onChannelSelect, onLockedCh
   const hasGatedChannel = channels.some((ch) => ch.slug === GATED_CHANNEL_SLUG);
 
   return (
-    <div className={styles.channelSwitchRow} role="tablist" aria-label="Channels">
-      {channels.map((ch) => (
-        <button
-          key={ch.slug}
-          type="button"
-          role="tab"
-          aria-selected={fallbackSlug === ch.slug}
-          className={channelSwitchClass(fallbackSlug === ch.slug)}
-          onClick={() => onChannelSelect(ch.slug)}
-        >
-          #{ch.slug}
-        </button>
-      ))}
-      {!hasGatedChannel ? (
-        <button
-          type="button"
-          className={`${styles.channelSwitchBtn} ${styles.channelSwitchBtnLocked}`}
-          onClick={onLockedChannelClick}
-          aria-haspopup="dialog"
-          title="Weavers of the Commons"
-        >
-          <WeaversBadge size={13} />
-          <span>#{GATED_CHANNEL_SLUG}</span>
-        </button>
-      ) : null}
+    <div className={styles.channelSwitchBar}>
+      {/* Page name, sitting left of the channel chips. With the top-bar section switch now icon-only,
+          this is what tells a member which page they landed on — the Commons — the same way the Apps
+          page announces itself with its "All Apps" heading. It is a label, not a control: no chip
+          chrome, and it stays outside the tablist so screen readers still read exactly two tabs. */}
+      <span className={styles.channelSwitchPageLabel}>Commons</span>
+      <div className={styles.channelSwitchRow} role="tablist" aria-label="Channels">
+        {channels.map((ch) => (
+          <button
+            key={ch.slug}
+            type="button"
+            role="tab"
+            aria-selected={fallbackSlug === ch.slug}
+            className={channelSwitchClass(fallbackSlug === ch.slug)}
+            onClick={() => onChannelSelect(ch.slug)}
+          >
+            #{ch.slug}
+          </button>
+        ))}
+        {!hasGatedChannel ? (
+          <button
+            type="button"
+            className={`${styles.channelSwitchBtn} ${styles.channelSwitchBtnLocked}`}
+            onClick={onLockedChannelClick}
+            aria-haspopup="dialog"
+            title="Weavers of the Commons"
+          >
+            <WeaversBadge size={13} />
+            <span>#{GATED_CHANNEL_SLUG}</span>
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -1071,7 +1071,7 @@ function ChatComposer({
           dropped and the line is relabeled to name the assistant and its human-in-the-loop review. */}
       <div className={styles.comicComposerHelper}>
         <span className={styles.comicComposerHelperText}>
-          AI Assistant (human in the loop) — type <span className={styles.comicComposerHelperToken}>@comic</span> to ask
+          AI Assistant (human-in-the-loop) — type <span className={styles.comicComposerHelperToken}>@comic</span> to ask
         </span>
       </div>
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

Owner report: the boxes in the top bar are different heights — the word buttons next to the icon buttons.

1. **The section switch is icons now.** "Commons" and "Apps" were word buttons sized by their text (`padding: 6px 9px`), so they stood visibly shorter than the 38px square admin, help and settings buttons beside them, and the bar read as two mismatched rows. Both are now icons — a speech-bubbles icon for the Commons, a grid icon for Apps — in the same 38px square with the same surface, border and radius. Every control in the bar is one height.

2. **Nothing is lost by dropping the words.** Each button keeps a screen-reader label and a hover title ("Commons", "Apps"); `role="tab"` and `aria-selected` are unchanged, so the active tint still shows which section you are in.

3. **Each page names itself on arrival.** The Apps page already heads "All Apps". The Commons channel row now leads with a plain "Commons" label before the `#general` chip, exactly as the owner suggested. It is a label, not a chip — no border, no fill — so it does not read as a tappable channel, and it sits outside the `role="tablist"` element so screen readers still count only the real channel tabs.

4. **Composer copy.** "AI Assistant (human in the loop)" → "AI Assistant (human-in-the-loop)", matching the spelling every doc and contract in the repo already uses.

## Files

- `components/community-shell/community-shell.tsx` — icon tabs in `MobileTopBar`; `ChannelSwitchRow` wrapped in a new bar with the page label.
- `components/community-shell/community-shell.module.css` — `.mobileBarSectionBtn` becomes a 38px square; new `.channelSwitchBar` (carries the padding the row used to hold) and `.channelSwitchPageLabel`.
- `components/community-shell/shell-chat-panel.tsx` — the hyphenated helper line.
- `ctf-survivor-hub-chat-feature-inventory.md` — user-feature line and change-log entry.

No backend, schema, route, or contract change.

## Verified locally

`@ctf/web` typecheck, lint, and a production build (`build:ci`); `check-eof-format.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs` all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XWGEkqGfrVNy3zpjpryeQe)_