### PR TITLE
feat: even spacing in the phone top bar and the product name for signed-in members

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -72,7 +72,8 @@ The Survivor Hub is the primary entry point of CTF for both unauthenticated visi
 5. Right rail no longer shows a "Ready/Active Apps" list (removed 2026-06-18) — apps are reached via the Apps section; the "· N ready apps" line was also dropped from the signed-in profile card.
 6. Sign-in and Create-Account CTAs visible in icon rail and right rail for unsigned visitors.
 7. Hero banner ("Free to join · End-to-end encrypted") visible to unsigned visitors.
-8. The phone-width top bar switches sections with two icon buttons — a speech-bubbles icon for the Commons and a grid icon for Apps — the same 38px square as the admin, help and settings buttons beside them, so the whole bar is one row of equal boxes. Each button names itself for screen readers and on hover ("Commons", "Apps"). Once a member is there, the page says which one it is: the Apps page heads "All Apps", and the Commons channel row starts with the word "Commons" ahead of the `#general` chip.
+8. Signed-in members see the product name "Skills Economy" beside the brand mark in the phone top bar, set on two short lines so it fits the narrowest phone. Signed-out visitors keep the single-line "SE / SKILLS ECONOMY" lockup.
+9. The phone-width top bar switches sections with two icon buttons — a speech-bubbles icon for the Commons and a grid icon for Apps — the same 38px square as the admin, help and settings buttons beside them, so the whole bar is one row of equal boxes. Each button names itself for screen readers and on hover ("Commons", "Apps"). Once a member is there, the page says which one it is: the Apps page heads "All Apps", and the Commons channel row starts with the word "Commons" ahead of the `#general` chip.
 
 ### Hub Chat (the blended `community` channel)
 
@@ -211,6 +212,24 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
 
 ## Change Log
 
+- 2026-08-09: **Even spacing across the phone top bar, and the product name is back on it for
+  signed-in members (owner report, follow-up to the icon tabs below).** Three different gaps ran
+  across one row of identical squares: `.mobileBar` used 5px, `.mobileBarSections` used 4px between
+  the two section tabs, and `.mobileBarAuth` had no gap at all, so help, settings and the avatar sat
+  flush against each other. All three are 5px now. The avatar was also sitting 4px low: the shared
+  `.clerkAvatarSlot` carries `margin-top: 4px` for the vertical desktop icon rail, where it separates
+  the avatar from the button above it; that margin is reset to 0 inside `.mobileBarAuth`, where the
+  controls sit side by side. Second, turning the section tabs into icons freed room beside the brand
+  mark, so the signed-in bar shows the product name again instead of the mark alone. It is not the
+  signed-out lockup: measured in Chromium at the app's own Inter, that lockup is 85px wide and an
+  admin on a 375px phone has only 65px to spare. Setting the two words on their own lines
+  (`.mobileBarWordmarkStacked`, 8px uppercase) is 50px and fits with room left at every phone width —
+  verified at 360, 375, 393, 430 and 560px, with and without the admin button, the wordmark never
+  shrinking below its full width and nothing reaching the right edge. The single-line "SE / SKILLS
+  ECONOMY" lockup is untouched for signed-out visitors, whose bar carries no admin, help, settings or
+  avatar and has the width for it. Web-only (the Commons is web-only per rule 105); UI only — no
+  backend, schema, route, or contract change. Verified: `@ctf/web` typecheck, lint, and a production
+  build.
 - 2026-08-09: **One row of equal boxes in the phone top bar, and the Commons page says its own name
   (owner report).** The "Commons" and "Apps" section tabs were word buttons sized by their text
   (`padding: 6px 9px`), so they stood noticeably shorter than the 38px square admin, help and

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -1903,6 +1903,33 @@
   white-space: nowrap;
 }
 
+/* Compact wordmark for the signed-in bar. Turning the section tabs into icons freed room beside the
+   mark, but not enough for the signed-out lockup: measured in Chromium at the app's own Inter, that
+   lockup is 85px wide and an admin on a 375px phone has 65px to spare. Setting the two words on their
+   own lines instead of one is 50px, which fits every phone width with room left over — so the product
+   name reads on the bar for signed-in members too, without risking the avatar being clipped off the
+   right edge again (the 2026-07-19 report). The single-line lockup is unchanged for signed-out
+   visitors, whose bar carries no admin, help, settings or avatar and has the width for it. */
+.mobileBarWordmarkStacked {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1px;
+  line-height: 1;
+  min-width: 0;
+  overflow: hidden;
+  user-select: none;
+}
+
+.mobileBarWordmarkStackedLine {
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--ctf-text-subtle);
+  white-space: nowrap;
+}
+
 .mobileBarTitle {
   font-size: 14px;
   font-weight: 700;
@@ -1912,9 +1939,12 @@
   text-overflow: ellipsis;
 }
 
+/* One gap value governs the whole bar (owner report, 2026-08-09): this row's own 4px, the auth
+   cluster's missing gap, and .mobileBar's 5px used to give three different spacings across one row
+   of identical squares. All three are 5px now, so the boxes are evenly spaced end to end. */
 .mobileBarSections {
   display: flex;
-  gap: 4px;
+  gap: 5px;
   margin-left: auto;
   flex-shrink: 0;
 }
@@ -1948,7 +1978,17 @@
 .mobileBarAuth {
   display: flex;
   align-items: center;
+  /* Help, settings and the avatar sat flush against each other with no gap at all, while every other
+     pair in the bar had one — the same 5px used everywhere else separates them now. */
+  gap: 5px;
   flex-shrink: 0;
+}
+
+/* The shared avatar slot carries margin-top: 4px for the vertical desktop icon rail, where it
+   separates the avatar from the button above it. In this horizontal row that margin only pushed the
+   avatar 4px below the line of squares beside it, so it is dropped here. */
+.mobileBarAuth .clerkAvatarSlot {
+  margin-top: 0;
 }
 
 /* The phone top bar carries tabs + (admin) + help + settings + avatar in one non-wrapping row.

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -182,14 +182,21 @@ function MobileTopBar({ section, onSectionChange, isAuthenticated, isAdmin, sign
       </div>
       {/* Signed out, the bar carries far fewer controls (no help, settings or avatar), so the full
           "SE / SKILLS ECONOMY" lockup fits beside the mark and a first-time visitor sees the
-          product name, not just a symbol. Signed in, the name is dropped again so the mark, tabs
-          and account controls all fit a 375px phone (iPhone SE). */}
-      {!isAuthenticated ? (
+          product name, not just a symbol. Signed in, the bar used to show the mark alone so
+          everything fit a 375px phone (iPhone SE); icon section tabs freed enough room to bring the
+          name back, set on two lines so it fits even the narrowest phone with an admin button
+          present (see .mobileBarWordmarkStacked for the measurements). */}
+      {isAuthenticated ? (
+        <span className={styles.mobileBarWordmarkStacked} aria-hidden="true">
+          <span className={styles.mobileBarWordmarkStackedLine}>Skills</span>
+          <span className={styles.mobileBarWordmarkStackedLine}>Economy</span>
+        </span>
+      ) : (
         <span className={styles.mobileBarWordmark} aria-hidden="true">
           <span className={styles.mobileBarWordmarkInitials}>SE</span>
           <span className={styles.mobileBarWordmarkName}>Skills Economy</span>
         </span>
-      ) : null}
+      )}
       {/* The fundraiser gift reminder used to sit here, between the mark and the tabs. On a 375px
           phone that made the bar too crowded, so it moved down into the Commons chip row after the
           🔔 chip (owner directive, 2026-08-09) — see ConciergeChipRail in shell-chat-panel.tsx. */}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Follow-up to #2175, from the owner's second screenshot: the spacing between the bug, settings and avatar is wrong, and there is now room for the full logo with "Skills Economy".

## What changed

**1. Even spacing across the bar.** Three different gaps ran across one row of identical squares:

| Where | Was | Now |
|---|---|---|
| `.mobileBar` (between groups) | 5px | 5px |
| `.mobileBarSections` (between the two section tabs) | 4px | 5px |
| `.mobileBarAuth` (help / settings / avatar) | none — flush | 5px |

The avatar was also sitting 4px low. The shared `.clerkAvatarSlot` carries `margin-top: 4px` for the vertical desktop icon rail, where it separates the avatar from the button above it; in this horizontal row it only pushed the avatar below the line of squares, so it is reset to 0 inside `.mobileBarAuth`.

**2. The product name is back on the signed-in bar.** It used to show the mark alone, because the word tabs left no room. It is not the signed-out lockup — that one does not fit. Measured in Chromium at the app's own Inter:

| | Width |
|---|---|
| Signed-out lockup ("SE" over "SKILLS ECONOMY") | 85px |
| Space free for an admin on a 375px phone | 65px |
| Two words on their own lines (what shipped here) | 50px |

Verified at 360, 375, 393, 430 and 560px, with and without the admin button: the wordmark holds its full 50px (never shrinks into a clipped state) and nothing reaches the right edge — even at 360px, narrower than any current iPhone, 12px is left over. This matters because the bar has been overflowed before and clipped the avatar off the right edge (the 2026-07-19 report).

The signed-out lockup is untouched: that bar carries no admin, help, settings or avatar, so it has the width for the single-line version.

## Files

- `components/community-shell/community-shell.tsx` — signed-in branch renders the stacked wordmark.
- `components/community-shell/community-shell.module.css` — the three gaps unified; avatar margin reset; new `.mobileBarWordmarkStacked` / `.mobileBarWordmarkStackedLine`.
- `ctf-survivor-hub-chat-feature-inventory.md` — user-feature line and change-log entry.

No backend, schema, route, or contract change.

## Verified locally

`@ctf/web` typecheck, lint, and a production build (`build:ci`); `check-eof-format.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs` all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XWGEkqGfrVNy3zpjpryeQe)_