### PR TITLE
feat: gift-card claims are whole dollars, and credit grants are rounded

### DIFF
--- a/ctf/docs/contracts/CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CONTRIBUTIONS_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -26,7 +26,12 @@ contracts:
       claimedAmountUsd:
         type: number
         required: false
-        note: Required when kind is gift_card; greater than 0 and at most 500.
+        note: >-
+          Required when kind is gift_card; a whole number of US dollars, from 1 to 500. Fractions are
+          rejected — real gift cards are not sold in parts of a dollar (owner decision, 2026-08-09).
+          This is a claim-shape rule and is not what keeps a credit grant whole; grants are rounded
+          when they are issued, because the credits-per-dollar rate is admin-set and need not divide
+          evenly into a dollar.
       signalContact:
         type: string
         required: false
@@ -152,7 +157,7 @@ contracts:
   - pluginId: contributions
     command: contributions.admin.submission.review
     version: 1.0.0
-    description: Confirm or reject a pending claim, exactly once. On confirm, the credit grant (confirmedAmountUsd x credits_per_usd, clamped by the per-user-per-cycle cap) is delegated to the service-credits plugin's canonical governance.mint.grant command (idempotency key contribution-<submissionId>); contributions never writes service_credits tables directly.
+    description: Confirm or reject a pending claim, exactly once. On confirm, the credit grant (confirmedAmountUsd x credits_per_usd, clamped by the per-user-per-cycle cap, then rounded to a whole number of credits) is delegated to the service-credits plugin's canonical governance.mint.grant command (idempotency key contribution-<submissionId>); contributions never writes service_credits tables directly.
     inputSchema:
       submissionId:
         type: string
@@ -164,7 +169,12 @@ contracts:
       confirmedAmountUsd:
         type: number
         required: false
-        note: Required for gift_card confirmation; defaults to non_monetary_unit_value_usd for quora_comment and github_star.
+        note: >-
+          Required for gift_card confirmation, as a whole number of US dollars from 1 to 500 — the
+          same rule the member's claim had to clear, re-checked here because the admin records what
+          was actually redeemed and that can differ from what was claimed. Defaults to
+          non_monetary_unit_value_usd for quora_comment and github_star, which is not held to the
+          whole-dollar rule.
       reviewNote:
         type: string
         required: false

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-contributions-feature-inventory.md
@@ -43,8 +43,8 @@ flow is one-way, like gas-station reward points.
 ## 3. User Features
 
 - Submit a contribution claim of one of three kinds:
-  - **Gift card** (`amazon`, `apple`, or `dennys`): the member states the amount (over 0, at most
-    500 USD) and their own Signal contact (URL or phone number — reduces fraud). It can be a physical
+  - **Gift card** (`amazon`, `apple`, or `dennys`): the member states the amount — a whole number of
+    US dollars, from $1 to $500, no cents — and their own Signal contact (URL or phone number — reduces fraud). It can be a physical
     or a digital gift card. The gift-card **code is never collected or stored anywhere** — the member
     sends the code to the owner over Signal, outside the app. The member is warned, on both the form
     and the post-submit confirmation, to **never post the code in the Commons** (the single public
@@ -72,9 +72,14 @@ flow is one-way, like gas-station reward points.
 - Confirm or reject each claim, exactly once:
   - On confirm the admin supplies the confirmed USD amount (for gift cards: what was actually
     redeemed; for comments/stars it defaults to the configured USD-equivalent unit value).
-  - Credits = confirmed amount x `credits_per_usd`, clamped by the per-user-per-cycle cap; a
-    positive grant goes through the canonical service-credits mint with idempotency key
-    `contribution-<submissionId>`. A grant clamped to 0 still confirms with `credits_granted = 0`.
+  - Credits = confirmed amount x `credits_per_usd`, clamped by the per-user-per-cycle cap, then
+    rounded to a whole number; a positive grant goes through the canonical service-credits mint with
+    idempotency key `contribution-<submissionId>`. A grant clamped or rounded to 0 still confirms
+    with `credits_granted = 0`. The rounding is what keeps credits whole: `credits_per_usd` is an
+    admin-set number that need not divide evenly into a dollar, the per-cycle cap can be fractional,
+    and both `credits_granted` and the ledger balance are unconstrained `NUMERIC`, so a fraction
+    would otherwise persist exactly. The whole-dollar rule on gift-card amounts is a separate,
+    claim-shape rule and does not by itself guarantee this.
   - Rejection grants nothing.
 - Create and edit fundraiser cycles (window plus the three goals).
 - Edit runtime configuration: credit valuation knobs, per-cycle cap, banner on/off, banner snooze
@@ -131,7 +136,8 @@ additionally require the admin role (`ensureContributionsAdmin`).
   - `user_id TEXT NOT NULL`
   - `kind TEXT NOT NULL` CHECK in (`gift_card`, `quora_comment`, `github_star`)
   - `method TEXT` (null unless gift_card; `amazon` / `apple` / `dennys`)
-  - `claimed_amount_usd NUMERIC` (gift_card only; validated over 0, at most 500)
+  - `claimed_amount_usd NUMERIC` (gift_card only; validated as a whole number, 1 to 500 — the column
+    stays unconstrained `NUMERIC` so rows recorded before that rule keep their exact value)
   - `signal_contact TEXT` (gift_card only; required at submit; personal data — admin-only
     projection, never logged, deleted with the account). **There is deliberately no gift-card
     code column, and validation rejects any code-like request field.**
@@ -295,6 +301,26 @@ NOT EXISTS` per column) in `ctf/schema.sql`; the demo schema is regenerated into
 
 ## Change Log
 
+- 2026-08-09: **Gift-card claims are whole dollars, $1 to $500, and credit grants are rounded**
+  (owner decision, from the #2141 review discussion). Two independent changes, made together because
+  they were raised together:
+  - `GIFT_CARD_MIN_USD` moves from 0 to 1 and `isValidGiftCardAmount` now requires a whole number, so
+    `$0.001` and `$12.50` are both refused where before anything above zero was accepted. Real gift
+    cards are not sold in parts of a dollar, so nothing real is being turned away. The admin confirm
+    path applies the same rule, because the admin records what was actually redeemed and that can
+    differ from the claim. The member form and the admin field state the rule up front instead of
+    letting a member find it on submit, and the two error strings in `_lib.ts` were rewritten to
+    match.
+  - `computeCycleCappedGrant` rounds the grant after the cap clamp (rounded, not truncated, so the
+    member gets the nearer number; after, not before, so rounding cannot push a grant back over the
+    cap). This — not the whole-dollar rule — is what actually guarantees whole credits: the
+    credits-per-dollar rate is admin-set with no requirement to divide evenly into a dollar, the cap
+    can be fractional, and the `NUMERIC` columns involved carry any fraction through to the ledger
+    exactly. A grant that rounds to 0 confirms with `credits_granted = 0`, the same outcome the cap
+    clamp already produced.
+
+  No schema change: both columns stay `NUMERIC`, and existing rows with fractional grants are left
+  as they are. New test case CONT-3b covers the whole-dollar rule and the rounding.
 - 2026-08-09: Opening the admin Drive tab before the cycle finished loading could wipe all three
   goals (#2137), and the contract now says plainly that the web form requires a contribution link
   even though the command does not (#2140). The drive form seeds its three goal inputs with

--- a/ctf/docs/developer/test-scripts/contributions-test-script.md
+++ b/ctf/docs/developer/test-scripts/contributions-test-script.md
@@ -106,13 +106,44 @@ The member-facing copy shows the same numbers as the admin settings. If admin se
 1. Open the gift-card form.
 2. Try submitting with amount `0`.
 3. Try submitting with amount `501`.
-4. Try submitting without a Signal contact.
+4. Try submitting with amount `12.50`.
+5. Try submitting with amount `0.001`.
+6. Try submitting without a Signal contact.
 
 **Expected:**
 - Amount `0` is rejected with a validation error before submission reaches the server.
 - Amount `501` is rejected with a validation error.
+- `12.50` and `0.001` are both rejected, and the message says whole dollars with no cents — gift-card amounts are whole US dollars from 1 to 500.
 - Missing Signal contact is rejected with a validation error.
-- In all three cases the form stays open and no claim is created.
+- In every case the form stays open and no claim is created.
+- The amount field's label reads "Card value (whole US dollars, $1 to $500)", and on a phone the keypad it opens has no decimal point.
+
+**Result:** web ☐
+
+---
+
+### CONT-3b — A confirmed contribution never grants a fraction of a credit
+
+**Role:** Admin
+**Surfaces:** Web (`/admin/contributions`, API)
+**Precondition:** Signed in as an admin, with one pending gift-card claim in the queue.
+
+**Steps:**
+1. Go to `/admin/contributions` → Settings and set "Credits per USD" to `3`. Save. (A rate that does not divide evenly into a dollar is the point of this case — at the default rate of 10 the problem is invisible.)
+2. Go to the review queue and open the pending gift-card claim.
+3. Confirm it with a confirmed value of `10`.
+4. Read the credits granted on the reviewed claim, and the member's ServiceCredits balance.
+5. Try confirming another gift-card claim with a confirmed value of `12.50`.
+6. Put "Credits per USD" back to its original value when you are done.
+
+**Steps to check the stored value directly (optional):**
+7. In the database, read `credits_granted` for the claim you confirmed in step 3.
+
+**Expected:**
+- The confirm in step 3 succeeds and grants a whole number of credits — 30 at a rate of 3. No decimal appears in the granted figure, on the claim or in the member's balance.
+- `credits_granted` in step 7 is a whole number. A value like `29.999` or `30.5` is the bug this case exists for.
+- Step 5 is rejected: the confirmed value for a gift card is whole dollars, 1 to 500, the same rule the member's claim had to clear.
+- A grant that rounds down to 0 still marks the claim confirmed, with 0 credits granted — that is the same outcome as a claim capped to 0, not an error.
 
 **Result:** web ☐
 

--- a/ctf/packages/web/app/api/contributions/_lib.ts
+++ b/ctf/packages/web/app/api/contributions/_lib.ts
@@ -122,11 +122,11 @@ const BAD_REQUEST_CODES: Record<string, string> = {
   invalid_payload: 'Invalid request payload.',
   invalid_kind: 'kind must be gift_card, quora_comment, or github_star.',
   invalid_method: 'method must be amazon, apple, or dennys.',
-  invalid_amount: 'Amount must be greater than 0 and at most 500 USD.',
+  invalid_amount: 'Amount must be a whole number of US dollars, from 1 to 500 — no cents.',
   invalid_url: 'URL must be a valid http(s) link.',
   invalid_cycle_window: 'ends_at must be after starts_at.',
   signal_contact_required: 'A Signal contact is required for gift-card contributions.',
-  confirmed_amount_required: 'confirmedAmountUsd is required (greater than 0, at most 500 USD).',
+  confirmed_amount_required: 'confirmedAmountUsd is required, as a whole number of US dollars from 1 to 500.',
   gift_card_code_rejected: 'Never send a gift-card code here. Codes go to the owner over Signal only.',
 };
 

--- a/ctf/packages/web/components/contributions/admin/contributions-admin-queue.tsx
+++ b/ctf/packages/web/components/contributions/admin/contributions-admin-queue.tsx
@@ -108,17 +108,24 @@ function ConfirmedValueRow({
   setConfirmedValue,
   resultingSc,
   isPending,
+  isGiftCard,
 }: {
   t: ContributionsTokens;
   confirmedValue: string;
   setConfirmedValue: (value: string) => void;
   resultingSc: number;
   isPending: boolean;
+  isGiftCard: boolean;
 }) {
+  // Gift cards are whole dollars, 1 to 500, and the server rejects anything else — so say the rule
+  // here rather than letting the admin find it on submit. A comment or star has no such rule: the
+  // field carries the configured USD-equivalent, which is free to be fractional.
   return (
     <div style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-      <label htmlFor="contrib-q-confirmed-value" style={{ fontSize: 11, color: t.MUTED, flexShrink: 0 }}>Confirmed value (USD)</label>
-      <input id="contrib-q-confirmed-value" value={confirmedValue} onChange={(e) => setConfirmedValue(e.target.value)} inputMode="decimal" disabled={!isPending} style={inputStyle(t, 80)} />
+      <label htmlFor="contrib-q-confirmed-value" style={{ fontSize: 11, color: t.MUTED, flexShrink: 0 }}>
+        {isGiftCard ? 'Confirmed value (whole USD, 1–500)' : 'Confirmed value (USD)'}
+      </label>
+      <input id="contrib-q-confirmed-value" value={confirmedValue} onChange={(e) => setConfirmedValue(e.target.value)} inputMode={isGiftCard ? 'numeric' : 'decimal'} disabled={!isPending} style={inputStyle(t, 80)} />
       <span style={{ fontSize: 11, color: t.MUTED }}>→ {resultingSc.toLocaleString()} SC (credits granted automatically, subject to per-cycle cap)</span>
     </div>
   );
@@ -227,7 +234,7 @@ function ReviewPanel({
       {isUrlKind && (
         <ReviewUrlField t={t} row={row} urlField={urlField} setUrlField={setUrlField} isPending={isPending} />
       )}
-      <ConfirmedValueRow t={t} confirmedValue={confirmedValue} setConfirmedValue={setConfirmedValue} resultingSc={resultingSc} isPending={isPending} />
+      <ConfirmedValueRow t={t} confirmedValue={confirmedValue} setConfirmedValue={setConfirmedValue} resultingSc={resultingSc} isPending={isPending} isGiftCard={isGiftCard} />
       <ReviewNoteRow t={t} note={note} setNote={setNote} isPending={isPending} />
       <ReviewActions t={t} row={row} reviewing={reviewing} isPending={isPending} confirm={confirm} reject={reject} />
     </div>

--- a/ctf/packages/web/components/contributions/contributions-paths.tsx
+++ b/ctf/packages/web/components/contributions/contributions-paths.tsx
@@ -83,10 +83,29 @@ function GiftCardForm({ t, submitting, error, onSubmit, onCancel }: { t: Contrib
   const [method, setMethod] = useState<GiftCardMethod>('amazon');
   const [cardValue, setCardValue] = useState('');
   const [signalContact, setSignalContact] = useState('');
+  const [amountError, setAmountError] = useState<string | null>(null);
+
+  // Say what is wrong with the amount before a round trip does. The server enforces the same rule and
+  // is the authority; this exists so a member who types 12.50 is told about cents rather than being
+  // handed a rejection after submitting.
+  function amountProblem(): string | null {
+    const trimmed = cardValue.trim();
+    if (!trimmed) return 'Enter the value of the card.';
+    const amount = Number(trimmed);
+    if (!Number.isFinite(amount)) return 'Enter the card value as a number, like 25.';
+    if (!Number.isInteger(amount)) return 'Whole dollars only — no cents. Round to the nearest dollar.';
+    if (amount < 1 || amount > 500) return 'The card value must be between $1 and $500.';
+    return null;
+  }
 
   function handleSubmit() {
-    const amount = Number(cardValue);
-    onSubmit({ method, claimedAmountUsd: Number.isFinite(amount) ? amount : 0, signalContact: signalContact.trim() });
+    const problem = amountProblem();
+    if (problem) {
+      setAmountError(problem);
+      return;
+    }
+    setAmountError(null);
+    onSubmit({ method, claimedAmountUsd: Number(cardValue.trim()), signalContact: signalContact.trim() });
   }
 
   return (
@@ -116,8 +135,23 @@ function GiftCardForm({ t, submitting, error, onSubmit, onCancel }: { t: Contrib
         </div>
       </div>
       <div style={{ marginBottom: 14 }}>
-        <label htmlFor="contrib-path-card-value" style={labelStyle(t)}>Card value (USD, max $500)</label>
-        <input id="contrib-path-card-value" value={cardValue} onChange={(e) => setCardValue(e.target.value)} inputMode="decimal" placeholder="e.g. 25" style={inputStyle(t)} />
+        <label htmlFor="contrib-path-card-value" style={labelStyle(t)}>Card value (whole US dollars, $1 to $500)</label>
+        {/* Numeric, not decimal: cents are not accepted, so the phone keypad should not offer a
+            decimal point the member cannot use. */}
+        <input
+          id="contrib-path-card-value"
+          value={cardValue}
+          onChange={(e) => {
+            setCardValue(e.target.value);
+            if (amountError) {
+              setAmountError(null);
+            }
+          }}
+          inputMode="numeric"
+          placeholder="e.g. 25"
+          style={inputStyle(t)}
+        />
+        {amountError && <div style={{ fontSize: 12, color: '#EF4444', marginTop: 5 }}>{amountError}</div>}
       </div>
       <div style={{ marginBottom: 18 }}>
         <label htmlFor="contrib-path-signal" style={labelStyle(t)}>

--- a/ctf/packages/web/lib/contributions/repository.ts
+++ b/ctf/packages/web/lib/contributions/repository.ts
@@ -28,7 +28,11 @@ export const CONTRIBUTION_KINDS: readonly ContributionKind[] = ['gift_card', 'qu
 export const GIFT_CARD_METHODS: readonly GiftCardMethod[] = ['amazon', 'apple', 'dennys'];
 export const CONTRIBUTION_STATUSES: readonly ContributionStatus[] = ['pending', 'confirmed', 'rejected'];
 
-export const GIFT_CARD_MIN_USD = 0;
+// Gift-card claims are whole dollars, 1 to 500 (owner decision, 2026-08-09). Real gift cards do not
+// come in fractions of a dollar, so nothing is lost by refusing them, and it keeps a claim amount
+// something a member can say out loud. The floor is not what keeps credit grants whole — see
+// roundCredits below for that — the two rules are independent on purpose.
+export const GIFT_CARD_MIN_USD = 1;
 export const GIFT_CARD_MAX_USD = 500;
 
 const GRANT_REASON = 'contributions_confirmed';
@@ -180,10 +184,10 @@ export function assertNoGiftCardCodeFields(rawBody: Record<string, unknown>): vo
   }
 }
 
-function isValidGiftCardAmount(amount: unknown): boolean {
+function isValidGiftCardAmount(amount: unknown): amount is number {
   return typeof amount === 'number'
-    && Number.isFinite(amount)
-    && amount > GIFT_CARD_MIN_USD
+    && Number.isInteger(amount)
+    && amount >= GIFT_CARD_MIN_USD
     && amount <= GIFT_CARD_MAX_USD;
 }
 
@@ -621,8 +625,10 @@ function resolveConfirmedAmount(
   config: ContributionsRuntimeConfig,
 ): number {
   if (row.kind === 'gift_card') {
+    // Same whole-dollar rule the member's claim had to clear. The admin types what was actually
+    // redeemed, which can differ from the claim, so it is checked here too rather than trusted.
     const amount = input.confirmedAmountUsd;
-    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= GIFT_CARD_MIN_USD || amount > GIFT_CARD_MAX_USD) {
+    if (!isValidGiftCardAmount(amount)) {
       throw new Error('confirmed_amount_required');
     }
     return amount;
@@ -633,6 +639,23 @@ function resolveConfirmedAmount(
     throw new Error('invalid_amount');
   }
   return amount;
+}
+
+// Credits are a whole-number unit, so a grant is rounded before it is stored or minted.
+//
+// Nothing upstream guarantees this on its own. Credits are `confirmedAmountUsd × creditsPerUsd`, and
+// `creditsPerUsd` is an admin-editable number with no requirement to be a whole number or to divide
+// evenly into a dollar — set it to 3 and a whole-dollar claim still lands on a third of a credit. The
+// per-cycle cap can be fractional too, so the clamp below can produce a fraction from inputs that
+// were both whole. `credits_granted` and the ledger balance are unconstrained NUMERIC columns, so a
+// fraction would persist exactly rather than being cleaned up by the database. Rounding here is the
+// one place that holds regardless of what the rate is set to.
+//
+// Rounded, not truncated: at the boundary the member gets the nearer number rather than always the
+// lower one. A grant that rounds to 0 still confirms the claim with 0 credits, which is the same
+// outcome the cap clamp already produces and is documented on applyConfirmReview.
+function roundCredits(credits: number): number {
+  return Math.round(credits);
 }
 
 async function computeCycleCappedGrant(
@@ -648,7 +671,8 @@ async function computeCycleCappedGrant(
 
   const alreadyGranted = Number(result.rows[0]?.already_granted ?? 0);
   const remaining = Math.max(params.cap - alreadyGranted, 0);
-  return Math.max(Math.min(params.computedCredits, remaining), 0);
+  // Rounded after the clamp, never before: rounding first could push a grant back over the cap.
+  return roundCredits(Math.max(Math.min(params.computedCredits, remaining), 0));
 }
 
 async function applyReviewUpdate(


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Owner decision, made in the discussion that came out of #2141. That issue was closed as not-a-defect — the code matched the contract — but the underlying question was real: nothing stopped a gift-card claim from being a fraction of a dollar, and nothing stopped a grant from landing on a fraction of a credit.

**These are two independent rules.** They are shipped together because they were raised together, but only the second one actually guarantees whole credits. Worth keeping straight, because a future reader may otherwise assume the whole-dollar rule makes the rounding redundant and remove it.

## Whole dollars, $1 to $500

`GIFT_CARD_MIN_USD` moves from 0 to 1, and `isValidGiftCardAmount` now requires `Number.isInteger`. Previously any positive value passed, so `$0.001` and `$12.50` were both accepted. Real gift cards are not sold in parts of a dollar, so nothing real is being turned away.

The admin confirm path is held to the same rule. That is deliberate rather than symmetric-for-its-own-sake: the admin records what was **actually redeemed**, which can differ from what the member claimed, so it is a separate input that needs its own check. `resolveConfirmedAmount` now calls the same predicate instead of repeating a slightly different inline condition — the old one used `> MIN` where the claim path used `>` too, which is why moving the floor to 1 had to be done in both places or neither.

Surfaces that state the rule, so nobody discovers it by being rejected:
- the member form's label is now "Card value (whole US dollars, $1 to $500)", with `inputMode="numeric"` so the phone keypad stops offering a decimal point that cannot be used, plus an inline message naming cents specifically when someone types `12.50`;
- the admin field reads "Confirmed value (whole USD, 1–500)" for gift cards only — a comment or star carries the configured USD-equivalent, which is free to be fractional and is not held to this rule;
- the two error strings in `app/api/contributions/_lib.ts` said "greater than 0 and at most 500" and would otherwise have described a rule that no longer exists.

## Rounding at grant time

`computeCycleCappedGrant` now rounds. Two ordering choices, both deliberate:

- **Rounded, not truncated** — at the boundary the member gets the nearer number rather than always the lower one.
- **After the clamp, not before** — rounding first could push a grant back over the per-cycle cap.

This is the change that actually keeps credits whole, and the whole-dollar rule does not make it redundant:

- `creditsPerUsd` is admin-editable and only validated as positive. Set it to 3 and a clean $10 claim produces 30 — fine — but set it to 2.5 and a $1 claim produces 2.5.
- `perUserCycleCreditCap` is `NUMERIC` and can itself be fractional, so the clamp can produce a fraction from two whole inputs.
- `credits_granted` and the service-credits balance columns are bare `NUMERIC` with no precision, so a fraction persists exactly rather than being cleaned up by the database.

A grant that rounds to 0 still confirms the claim with `credits_granted = 0` — the same outcome the cap clamp already produced, and already documented on `applyConfirmReview`.

## Not changed

No schema change. Both columns stay unconstrained `NUMERIC` and existing rows keep whatever they hold; this is a rule for new claims and new grants, not a migration. I did not add a database `CHECK`, because the fractional values that exist are historical facts rather than data to reject.

## Checks run locally

`@ctf/web` typecheck, lint (`--max-warnings=0`), and `build:ci`; repo-wide typecheck via the commit hook; `check-eof-format.sh`; `check-inventory-drift.mjs`; `check-test-script-drift.mjs` (run after committing so it compares the real branch diff). The edited contract YAML was parsed to confirm the folded notes are valid.

Test script: CONT-3 gains the `12.50` and `0.001` cases and the keypad check; new **CONT-3b** confirms a whole grant at a deliberately awkward rate of 3 credits per dollar, since at the default rate of 10 the rounding problem is invisible. Inventory and both contract notes updated in the same commit.

Left for review rather than auto-merge: this changes credit granting.

---
_Generated by [Claude Code](https://claude.ai/code/session_013nkowRPvg3t5VA52qsWR2L)_