### PR TITLE
feat: Mutual Time — Beacon as a meeting place, a preview of the form on the shared link, and two form fixes

### DIFF
--- a/ctf/docs/contracts/MUTUAL_TIME_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/MUTUAL_TIME_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -21,7 +21,7 @@ auditEvents:
     targetContext:
       eventId: <event id>
       slug: <event slug>
-      meetingPlugin: <chyme|peer-programming>
+      meetingPlugin: <chyme|peer-programming|beacon>
     requestId: <request id>
     traceId: <trace id>
     result: success

--- a/ctf/docs/contracts/MUTUAL_TIME_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/MUTUAL_TIME_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -20,7 +20,7 @@ contracts:
       meetingPlugin:
         type: string
         required: true
-        enum: [chyme, peer-programming]
+        enum: [chyme, peer-programming, beacon]
       opensAt:
         type: string
         required: false

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
@@ -33,7 +33,7 @@ to the meeting surface; members who did not vote can still come listen in.
    see the event and a message that they can come listen in at whatever time is chosen — the link is
    their invite. They are shown a sign-in prompt if they want a say in the time.
 4. **See the days and times before signing in.** Under that sign-in prompt, a visitor sees the real
-   voting form — the same day chips and one-hour windows a member picks from — greyed out and not
+   voting form — the same day chips and one-hour windows a member picks from — grayed out and not
    tappable, with the line "Here are the times on offer — sign in to pick yours". They can see exactly
    what they would be choosing from before they decide to sign in.
 5. **Know where the meeting is, from the moment the link opens.** Every state of the shared link —
@@ -121,7 +121,7 @@ is added to `TrustSignalMetrics`, `computeTrustSignalMetrics`, or `buildTrustEvi
 
 - **Web:** complete — admin dashboard (`/apps/mutual-time`), the public one-link surface
   (`/mutual-time/[slug]`) with vote/result/gate states, and all API routes. The day chips and slot grid
-  live in `components/mutual-time/mutual-time-slot-picker.tsx` so the voting form and the greyed-out
+  live in `components/mutual-time/mutual-time-slot-picker.tsx` so the voting form and the grayed-out
   preview on the sign-in gate are the same component, not two that can drift apart.
 - **Mobile-responsive web:** complete — the same web components render at phone width (single-column
   layout, horizontally scrollable date chips, wrapping slot grid).
@@ -206,7 +206,7 @@ idempotent. Fixed candidate window (`2026-07-21`, 7 days) keeps the seed determi
   clear picks nobody made.** All on `/mutual-time/<slug>`; no schema, contract, or API change.
   (1) A signed-out or not-yet-approved visitor used to see only a locked box. They now see the sign-in
   prompt with the real voting form below it — the same day chips and one-hour windows a member picks
-  from — greyed out, not tappable, not keyboard-focusable, and skipped by screen readers, under the line
+  from — grayed out, not tappable, not keyboard-focusable, and skipped by screen readers, under the line
   "Here are the times on offer — sign in to pick yours". The reason to sign in is visible instead of
   described. (2) "We'll meet in <plugin>" with a button to that plugin now shows on every state of the
   link, not just after the survey closes: the gate, the not-yet-open state, and the voting form. The

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
@@ -32,7 +32,15 @@ to the meeting surface; members who did not vote can still come listen in.
 3. **Listen-in for everyone.** A signed-out or not-yet-approved visitor can still open the link: they
    see the event and a message that they can come listen in at whatever time is chosen — the link is
    their invite. They are shown a sign-in prompt if they want a say in the time.
-4. **Copy the link.** Every surface has a Copy-link button (rule 130) for sharing the one event link.
+4. **See the days and times before signing in.** Under that sign-in prompt, a visitor sees the real
+   voting form — the same day chips and one-hour windows a member picks from — greyed out and not
+   tappable, with the line "Here are the times on offer — sign in to pick yours". They can see exactly
+   what they would be choosing from before they decide to sign in.
+5. **Know where the meeting is, from the moment the link opens.** Every state of the shared link —
+   before voting opens, while voting is open, for a signed-out visitor, and after the time is chosen —
+   shows "We'll meet in <plugin>" with a button straight to that plugin (for example Chyme, at
+   `/apps/chyme`). It no longer waits for the survey to close.
+6. **Copy the link.** Every surface has a Copy-link button (rule 130) for sharing the one event link.
 
 ## Admin Features
 
@@ -112,7 +120,9 @@ is added to `TrustSignalMetrics`, `computeTrustSignalMetrics`, or `buildTrustEvi
 ## Web and Android Delivery Status
 
 - **Web:** complete — admin dashboard (`/apps/mutual-time`), the public one-link surface
-  (`/mutual-time/[slug]`) with vote/result/gate states, and all API routes.
+  (`/mutual-time/[slug]`) with vote/result/gate states, and all API routes. The day chips and slot grid
+  live in `components/mutual-time/mutual-time-slot-picker.tsx` so the voting form and the greyed-out
+  preview on the sign-in gate are the same component, not two that can drift apart.
 - **Mobile-responsive web:** complete — the same web components render at phone width (single-column
   layout, horizontally scrollable date chips, wrapping slot grid).
 - **Android:** **out of scope (web-only per rule 105).** Mutual Time is not on the Chyme keep-list; there
@@ -192,6 +202,22 @@ idempotent. Fixed candidate window (`2026-07-21`, 7 days) keeps the seed determi
   column, so the column grew and took the field with it. The column is now `minmax(0, 1fr)`, each
   wrapper carries `minWidth: 0`, and the shared input style carries `maxWidth: 100%` — the fields line
   up with the title, description, and dropdown above them.
+- 2026-08-09: **The shared link now previews the form, names the meeting place, and stops offering to
+  clear picks nobody made.** All on `/mutual-time/<slug>`; no schema, contract, or API change.
+  (1) A signed-out or not-yet-approved visitor used to see only a locked box. They now see the sign-in
+  prompt with the real voting form below it — the same day chips and one-hour windows a member picks
+  from — greyed out, not tappable, not keyboard-focusable, and skipped by screen readers, under the line
+  "Here are the times on offer — sign in to pick yours". The reason to sign in is visible instead of
+  described. (2) "We'll meet in <plugin>" with a button to that plugin now shows on every state of the
+  link, not just after the survey closes: the gate, the not-yet-open state, and the voting form. The
+  candidate slots and the meeting plugin were already in the public read, so nothing new is exposed.
+  (3) The button under the grid read "Clear my picks" whenever nothing was selected — including on a
+  first visit, where there was nothing to clear. It now tracks what the server holds separately from
+  what is selected on screen: "Save my picks" when there is a selection, "Clear my picks" only when the
+  member has saved picks and has deselected them all, and switched off with the hint "Pick a time above,
+  then save." when there is neither. The day chips and slot grid moved to
+  `components/mutual-time/mutual-time-slot-picker.tsx` so the voting form and the gate preview share one
+  component.
 
 Ordered, dependency-based (no phases). Each item done in this initial build.
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
@@ -6,7 +6,7 @@ Mutual Time is a one-link meeting-time picker (spec #1780). An admin (the platfo
 event that has a single shareable link. Approved members open that link and pick up to three one-hour
 windows — snapped to the half-hour — in their own timezone. When the survey closes, the app chooses the
 window the most members can make (ties go to the earliest) and shows it, in each viewer's own timezone,
-with a link to where the meeting happens (Chyme or Peer Programming).
+with a link to where the meeting happens (Chyme, Peer Programming, or Beacon).
 
 - **In scope:** owner/admin event creation and manual close; a public shareable link with three viewer
   states (vote / result / sign-in gate); timezone-aware voting; the most-overlap algorithm; auto-close
@@ -37,7 +37,7 @@ to the meeting surface; members who did not vote can still come listen in.
 ## Admin Features
 
 1. **Create an event** at `/apps/mutual-time`: optional title, optional description, a "Where we'll
-   meet" plugin (Chyme or Peer Programming), and optional survey open/close date-times. Leaving close
+   meet" plugin (Chyme, Peer Programming, or Beacon), and optional survey open/close date-times. Leaving close
    blank means the admin closes it manually.
 2. **Manage events:** the dashboard lists the admin's events with voter counts, a status pill
    (scheduled / open / closed), Copy-link, View, "Close and choose the time", and — once closed — the
@@ -69,7 +69,7 @@ Defined in `ctf/schema.sql` (CREATE TABLE IF NOT EXISTS + ALTER TABLE IF EXISTS 
 1. `mutual_time_events`
    - One row per event, keyed by `id`, with a unique shareable `slug`. Columns: `created_by_user_id`
      (the admin creator), `title` (nullable), `description` (nullable), `meeting_plugin`
-     (`chyme|peer-programming`), `window_start_date` (UTC date the 7-day candidate window begins),
+     (`chyme|peer-programming|beacon`), `window_start_date` (UTC date the 7-day candidate window begins),
      `window_days` (default 7), `opens_at` (nullable — null opens immediately), `closes_at` (nullable —
      null closes manually), `status` (`open|closed`), `result_slot_start` (winning UTC slot, nullable),
      `result_can_make_it` (count, nullable), `created_at`, `closed_at` (nullable). Indexed by slug
@@ -116,8 +116,8 @@ is added to `TrustSignalMetrics`, `computeTrustSignalMetrics`, or `buildTrustEvi
 - **Mobile-responsive web:** complete — the same web components render at phone width (single-column
   layout, horizontally scrollable date chips, wrapping slot grid).
 - **Android:** **out of scope (web-only per rule 105).** Mutual Time is not on the Chyme keep-list; there
-  is intentionally no React Native surface. The meeting the result points to (Chyme / Peer Programming)
-  is where any native experience lives, not the scheduling.
+  is intentionally no React Native surface. The meeting the result points to (Chyme / Peer Programming /
+  Beacon) is where any native experience lives, not the scheduling.
 
 ## Seed Coverage Status
 
@@ -180,6 +180,18 @@ idempotent. Fixed candidate window (`2026-07-21`, 7 days) keeps the seed determi
   members only ever reach an event through its shared link (`/mutual-time/<slug>`), never
   `/apps/mutual-time`. The admin dashboard now renders the shared `MobileScreenHeader` top nav (accent
   back chevron + brand icon + title + the bug/settings/avatar actions), matching every other page.
+- 2026-08-09: **Beacon added to "Where we'll meet" + the date fields stopped running off the screen.**
+  (1) `beacon` is now a third choice in the meeting-plugin list, alongside Chyme and Peer Programming:
+  added to `MUTUAL_TIME_MEETING_PLUGINS`, to the display-name map (`Beacon`), to the command-contract
+  enum and the audit contract's target context, and to the `meeting_plugin` check in `schema.sql`
+  (plus a drop-and-re-add of `mutual_time_events_meeting_plugin_check` so a database created before
+  today accepts the new value too). The result link points at `/apps/beacon`, the same
+  `/apps/<slug>` shape as the other two. (2) The two "Survey opens / Survey closes" date-and-time
+  fields ran past the right edge of the card on a phone. A grid column sized `1fr` keeps a floor of the
+  item's own minimum width, and a `datetime-local` control reports a minimum wider than the phone-width
+  column, so the column grew and took the field with it. The column is now `minmax(0, 1fr)`, each
+  wrapper carries `minWidth: 0`, and the shared input style carries `maxWidth: 100%` — the fields line
+  up with the title, description, and dropdown above them.
 
 Ordered, dependency-based (no phases). Each item done in this initial build.
 

--- a/ctf/docs/developer/test-scripts/mutual-time-test-script.md
+++ b/ctf/docs/developer/test-scripts/mutual-time-test-script.md
@@ -32,7 +32,7 @@ Run the seed first: `pnpm --dir ctf seed:mutual-time`
 
 2. **Admin dashboard loads.** Sign in as an admin, navigate to `/apps/mutual-time`. The page renders without error and shows at least two events — "Weekly check-in" (open) and "Q3 onboarding" (closed). web ☐ mobile ☐
 
-3. **Public event link loads unauthenticated.** Sign out entirely. Open the shareable link for the seeded open event (copy it from the dashboard or use the known fixed slug). The page renders the event title, a set of time slots, and a sign-in prompt — no error, no blank screen. web ☐ mobile ☐
+3. **Public event link loads unauthenticated.** Sign out entirely. Open the shareable link for the seeded open event (copy it from the dashboard or use the known fixed slug). The page renders the event title, the line saying where the meeting is (for example "We'll meet in Chyme") with a button to that plugin, a sign-in prompt, and below it a greyed-out preview of the voting form showing the days and times on offer — no error, no blank screen. web ☐ mobile ☐
 
 4. **Closed event shows a result.** Open the shareable link for "Q3 onboarding" (seeded closed event) while signed out. The page shows the winning time and how many members can make it — no vote controls visible. web ☐ mobile ☐
 
@@ -53,7 +53,25 @@ Run the seed first: `pnpm --dir ctf seed:mutual-time`
 2. Navigate to `/mutual-time/<open-event-slug>`.
 3. Read the page.
 
-**Expected:** The event title and description are visible. The page says something to the effect that the visitor can come listen in at whatever time is chosen. A sign-in prompt is shown. No slot-picking controls are present.
+**Expected:** The event title and description are visible. The page says something to the effect that the visitor can come listen in at whatever time is chosen. A sign-in prompt is shown. Below that prompt, the real voting form is shown greyed out as a preview under the line "Here are the times on offer — sign in to pick yours" — no live slot-picking controls, just a look at what is on offer.
+
+Result: web ☐ mobile ☐
+
+---
+
+### MT-1b — The greyed-out preview cannot be used
+
+**Role:** None (signed out)
+**Surfaces:** Web, Mobile
+**Precondition:** Seed run. Open event slug known. Signed out.
+
+**Steps:**
+1. Navigate to `/mutual-time/<open-event-slug>`.
+2. Scroll to the greyed-out form below the sign-in prompt.
+3. Tap several of the day chips and time buttons in it.
+4. On a keyboard, press Tab repeatedly through the page.
+
+**Expected:** Nothing in the preview responds to a tap — no time highlights, no day switches, no count changes. Tab focus moves from the sign-in button straight past the preview; no control inside it can be focused. The days and times shown match what an approved member sees on the live form.
 
 Result: web ☐ mobile ☐
 
@@ -69,7 +87,7 @@ Result: web ☐ mobile ☐
 1. Sign in as a member whose Unlock tier is not yet `approved_full`.
 2. Navigate to `/mutual-time/<open-event-slug>`.
 
-**Expected:** The event is visible. The page shows a listen-in message and a prompt to complete approval, not a slot picker. The member cannot vote.
+**Expected:** The event is visible. The page shows a listen-in message and a prompt to complete approval, plus the same greyed-out preview of the form below it. The member cannot vote — nothing in the preview responds.
 
 Result: web ☐ mobile ☐
 
@@ -131,6 +149,24 @@ Result: web ☐ mobile ☐
 3. Save with zero picks.
 
 **Expected:** The save succeeds (no error). Reloading the page shows no picks selected for this member.
+
+Result: web ☐ mobile ☐
+
+---
+
+### MT-5b — The Clear button only appears when there is something saved to clear
+
+**Role:** Member (`approved_full`)
+**Surfaces:** Web, Mobile
+**Precondition:** Member has never voted on this open event.
+
+**Steps:**
+1. Navigate to `/mutual-time/<open-event-slug>` and read the button under the grid before touching anything.
+2. Select one time, then read the button again.
+3. Save.
+4. Deselect that time so nothing is selected, and read the button again.
+
+**Expected:** On first load the button reads "Save my picks", is switched off, and the hint below it reads "Pick a time above, then save." — it never reads "Clear my picks" before anything has been picked. After selecting a time it reads "Save my picks" and is active. After saving and then deselecting everything it reads "Clear my picks" and is active, and pressing it removes the saved picks.
 
 Result: web ☐ mobile ☐
 
@@ -237,6 +273,23 @@ Result: web ☐ mobile ☐
 **Expected:** Step 2 returns HTTP 400 with code `invalidSlot` (well-formed but unknown slot). Step 3 returns HTTP 400 with code `invalidPayload` (malformed list — element is not a string). No vote is stored in either case.
 
 Result: web ☐
+
+---
+
+### MT-12 — Where the meeting is, shown before the time is chosen
+
+**Role:** None (signed out), then Member (`approved_full`)
+**Surfaces:** Web, Mobile
+**Precondition:** An open event whose meeting plugin is known (for example Chyme).
+
+**Steps:**
+1. Signed out, open `/mutual-time/<open-event-slug>` and look above the sign-in prompt.
+2. Follow the button next to it.
+3. Sign in as an approved member, reopen the same link, and look above the voting form.
+
+**Expected:** Both views show "We'll meet in <plugin>" — for example "We'll meet in Chyme" — with a "Go to <plugin>" button beside it. The button opens that plugin's page in the app (for example `/apps/chyme`, which is `https://app.chargingthefuture.com/apps/chyme` in production). This shows before the survey closes, not only after.
+
+Result: web ☐ mobile ☐
 
 ---
 

--- a/ctf/docs/developer/test-scripts/mutual-time-test-script.md
+++ b/ctf/docs/developer/test-scripts/mutual-time-test-script.md
@@ -210,14 +210,14 @@ Result: web ☐ mobile ☐
 
 **Role:** Member (`approved_full`) and signed-out visitor
 **Surfaces:** Web, Mobile
-**Precondition:** "Q3 onboarding" closed event. Meeting plugin is Chyme or Peer Programming.
+**Precondition:** "Q3 onboarding" closed event. Meeting plugin is Chyme, Peer Programming, or Beacon.
 
 **Steps:**
 1. Open `/mutual-time/<closed-event-slug>`.
 2. Find the link to the meeting surface.
 3. Confirm the link target.
 
-**Expected:** A "Go to Chyme" or "Go to Peer Programming" link (matching whichever plugin was configured) is visible. The winning time and the count of members who can make it are shown alongside it.
+**Expected:** A "Go to Chyme", "Go to Peer Programming", or "Go to Beacon" link (matching whichever plugin was configured) is visible. The winning time and the count of members who can make it are shown alongside it.
 
 Result: web ☐ mobile ☐
 
@@ -257,6 +257,24 @@ Result: web ☐
 6. Submit.
 
 **Expected:** The new event appears in the dashboard list with status "open" (or "scheduled" if opens_at defaults to now). A shareable link / slug is shown. The Copy-link button is present. Voter count is 0.
+
+Result: web ☐ mobile ☐
+
+---
+
+### MT-A1b — "Where we'll meet" lists all three, and no field runs off the screen
+
+**Role:** Admin
+**Surfaces:** Web, Mobile
+**Precondition:** Signed in as admin. On `/apps/mutual-time`, on a phone-width screen.
+
+**Steps:**
+1. Open the "Where we'll meet" dropdown.
+2. Read every option in the list.
+3. Pick "Beacon" and submit the form with everything else left blank.
+4. Close the dropdown and look at the right edge of the "Survey opens" and "Survey closes" date-and-time fields.
+
+**Expected:** The dropdown lists exactly three options — Chyme, Peer Programming, Beacon — and the event saves with Beacon. The two date-and-time fields end at the same right edge as the title box, the description box, and the dropdown above them; nothing sticks out past the edge of the card and the page does not scroll sideways.
 
 Result: web ☐ mobile ☐
 

--- a/ctf/docs/developer/test-scripts/mutual-time-test-script.md
+++ b/ctf/docs/developer/test-scripts/mutual-time-test-script.md
@@ -32,7 +32,7 @@ Run the seed first: `pnpm --dir ctf seed:mutual-time`
 
 2. **Admin dashboard loads.** Sign in as an admin, navigate to `/apps/mutual-time`. The page renders without error and shows at least two events — "Weekly check-in" (open) and "Q3 onboarding" (closed). web ☐ mobile ☐
 
-3. **Public event link loads unauthenticated.** Sign out entirely. Open the shareable link for the seeded open event (copy it from the dashboard or use the known fixed slug). The page renders the event title, the line saying where the meeting is (for example "We'll meet in Chyme") with a button to that plugin, a sign-in prompt, and below it a greyed-out preview of the voting form showing the days and times on offer — no error, no blank screen. web ☐ mobile ☐
+3. **Public event link loads unauthenticated.** Sign out entirely. Open the shareable link for the seeded open event (copy it from the dashboard or use the known fixed slug). The page renders the event title, the line saying where the meeting is (for example "We'll meet in Chyme") with a button to that plugin, a sign-in prompt, and below it a grayed-out preview of the voting form showing the days and times on offer — no error, no blank screen. web ☐ mobile ☐
 
 4. **Closed event shows a result.** Open the shareable link for "Q3 onboarding" (seeded closed event) while signed out. The page shows the winning time and how many members can make it — no vote controls visible. web ☐ mobile ☐
 
@@ -53,13 +53,13 @@ Run the seed first: `pnpm --dir ctf seed:mutual-time`
 2. Navigate to `/mutual-time/<open-event-slug>`.
 3. Read the page.
 
-**Expected:** The event title and description are visible. The page says something to the effect that the visitor can come listen in at whatever time is chosen. A sign-in prompt is shown. Below that prompt, the real voting form is shown greyed out as a preview under the line "Here are the times on offer — sign in to pick yours" — no live slot-picking controls, just a look at what is on offer.
+**Expected:** The event title and description are visible. The page says something to the effect that the visitor can come listen in at whatever time is chosen. A sign-in prompt is shown. Below that prompt, the real voting form is shown grayed out as a preview under the line "Here are the times on offer — sign in to pick yours" — no live slot-picking controls, just a look at what is on offer.
 
 Result: web ☐ mobile ☐
 
 ---
 
-### MT-1b — The greyed-out preview cannot be used
+### MT-1b — The grayed-out preview cannot be used
 
 **Role:** None (signed out)
 **Surfaces:** Web, Mobile
@@ -67,7 +67,7 @@ Result: web ☐ mobile ☐
 
 **Steps:**
 1. Navigate to `/mutual-time/<open-event-slug>`.
-2. Scroll to the greyed-out form below the sign-in prompt.
+2. Scroll to the grayed-out form below the sign-in prompt.
 3. Tap several of the day chips and time buttons in it.
 4. On a keyboard, press Tab repeatedly through the page.
 
@@ -87,7 +87,7 @@ Result: web ☐ mobile ☐
 1. Sign in as a member whose Unlock tier is not yet `approved_full`.
 2. Navigate to `/mutual-time/<open-event-slug>`.
 
-**Expected:** The event is visible. The page shows a listen-in message and a prompt to complete approval, plus the same greyed-out preview of the form below it. The member cannot vote — nothing in the preview responds.
+**Expected:** The event is visible. The page shows a listen-in message and a prompt to complete approval, plus the same grayed-out preview of the form below it. The member cannot vote — nothing in the preview responds.
 
 Result: web ☐ mobile ☐
 

--- a/ctf/packages/web/components/mutual-time/mutual-time-admin.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-admin.tsx
@@ -184,7 +184,9 @@ export function MutualTimeAdmin() {
 
   const card: React.CSSProperties = { marginTop: 20, borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: 20 };
   const labelStyle: React.CSSProperties = { display: 'block', fontSize: 12, fontWeight: 600, color: t.SUBTLE, margin: '10px 0 4px' };
-  const inputStyle: React.CSSProperties = { width: '100%', boxSizing: 'border-box', background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, padding: '10px 12px', color: t.TITLE, fontSize: 14, fontFamily: 'inherit' };
+  // maxWidth + minWidth 0 keep a field inside the phone-width column even when the control has a wide
+  // intrinsic size — a `datetime-local` input reports one wider than the column on iOS Safari.
+  const inputStyle: React.CSSProperties = { width: '100%', maxWidth: '100%', minWidth: 0, boxSizing: 'border-box', background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 10, padding: '10px 12px', color: t.TITLE, fontSize: 14, fontFamily: 'inherit' };
 
   return (
     <div style={{ background: t.BG, minHeight: '100vh', color: t.TITLE }}>
@@ -221,14 +223,17 @@ export function MutualTimeAdmin() {
           <p style={{ fontSize: 12, color: t.SUBTLE, margin: '4px 0 10px' }}>After the time is chosen, voters see a link directly to this plugin.</p>
 
           {/* Stack the two datetime-local fields: side by side they overflowed the phone-width column
-              (each datetime picker has a wide intrinsic min-width). Mobile-first = one column. */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
-            <div>
+              (each datetime picker has a wide intrinsic min-width). Mobile-first = one column.
+              `minmax(0, 1fr)` + `minWidth: 0` are both needed: a grid track defaults to a floor of the
+              item's min-content width, so without them the datetime picker's wide intrinsic size grew
+              the track and pushed the field past the right edge of the card. */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 12 }}>
+            <div style={{ minWidth: 0 }}>
               <label htmlFor="mt-opens" style={labelStyle}>Survey opens (optional)</label>
               <input id="mt-opens" type="datetime-local" value={opensAt} onChange={(e) => setOpensAt(e.target.value)} style={inputStyle} />
               <p style={{ fontSize: 11, color: t.SUBTLE, margin: '4px 0 0' }}>Leave blank to open immediately.</p>
             </div>
-            <div>
+            <div style={{ minWidth: 0 }}>
               <label htmlFor="mt-closes" style={labelStyle}>Survey closes (optional)</label>
               <input id="mt-closes" type="datetime-local" value={closesAt} onChange={(e) => setClosesAt(e.target.value)} style={inputStyle} />
               <p style={{ fontSize: 11, color: t.SUBTLE, margin: '4px 0 0' }}>Leave blank to close manually below.</p>

--- a/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { CalendarClock, Copy, Check, Globe, ChevronDown, Clock, Lock } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { CalendarClock, Copy, Check, Globe, ChevronDown, Clock, Lock, ArrowUpRight } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { MUTUAL_TIME_MAX_PICKS } from 'lib/mutual-time/constants';
 import type { MutualTimePublicEvent, MutualTimeViewerState } from 'lib/mutual-time/types';
+import { SlotPicker, PicksSummary } from './mutual-time-slot-picker';
 import {
   getMutualTimeTokens,
   requestJson,
@@ -13,12 +14,8 @@ import {
   detectTimeZone,
   listTimeZones,
   timeZoneLabel,
-  formatSlotTime,
-  formatSlotRange,
   formatSlotDate,
   formatResultDateTime,
-  localDateKey,
-  localPeriod,
 } from './mutual-time-shared';
 
 type Props = {
@@ -101,7 +98,7 @@ export function MutualTimePublic({ initialEvent, initialViewer, isSignedIn, sign
             t={t}
           />
         ) : (
-          <GateView isSignedIn={isSignedIn} signInUrl={signInUrl} verifyUrl={verifyUrl} closesLabel={closesLabel} t={t} />
+          <GateView event={event} tz={tz} isSignedIn={isSignedIn} signInUrl={signInUrl} verifyUrl={verifyUrl} closesLabel={closesLabel} t={t} />
         )}
       </div>
     </div>
@@ -155,7 +152,8 @@ function ScheduledView({ event, tz, t }: { event: MutualTimePublicEvent; tz: str
   return (
     <>
       <StatusChip label="Voting hasn't opened yet" accentActive={false} t={t} />
-      <div style={{ borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: '32px 24px', marginTop: 16, textAlign: 'center' }}>
+      <MeetingPlaceRow event={event} t={t} />
+      <div style={{ borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: '32px 24px', textAlign: 'center' }}>
         <Clock size={28} style={{ color: t.SUBTLE, display: 'block', margin: '0 auto 12px' }} />
         <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE, marginBottom: 6 }}>Voting opens {opensLabel}</div>
         <div style={{ fontSize: 13, color: t.SUBTLE }}>Times shown in {timeZoneLabel(tz)}. Check back when voting opens to pick your times.</div>
@@ -164,12 +162,35 @@ function ScheduledView({ event, tz, t }: { event: MutualTimePublicEvent; tz: str
   );
 }
 
-function GateView({ isSignedIn, signInUrl, verifyUrl, closesLabel, t }: { isSignedIn: boolean; signInUrl: string; verifyUrl?: string; closesLabel: string | null; t: Tokens }) {
+// Where the meeting itself happens, shown before the time is picked as well as after. A visitor who
+// lands on the link should know what they're being invited to — and be able to go look at it — without
+// waiting for the survey to close. The href is the in-app plugin route, so it stays on this host.
+function MeetingPlaceRow({ event, t }: { event: MutualTimePublicEvent; t: Tokens }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', padding: '12px 16px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, marginBottom: 16 }}>
+      <span style={{ fontSize: 13, color: t.SUBTLE }}>
+        We&apos;ll meet in <strong style={{ color: t.ACCENT, fontWeight: 700 }}>{event.meetingPluginName}</strong>
+      </span>
+      <a href={event.meetingPluginRoute} style={{ flexShrink: 0, display: 'inline-flex', alignItems: 'center', gap: 5, padding: '6px 12px', borderRadius: 8, background: `${t.ACCENT}18`, border: `1px solid ${t.ACCENT}44`, color: t.ACCENT, fontSize: 12, fontWeight: 700, textDecoration: 'none' }}>
+        Go to {event.meetingPluginName} <ArrowUpRight size={13} />
+      </a>
+    </div>
+  );
+}
+
+// The signed-out / not-yet-approved view. It shows the real voting form underneath the sign-in prompt,
+// greyed out and inert, so a visitor sees the actual days and times on offer rather than only a locked
+// box — the reason to sign in is visible, not described.
+function GateView({ event, tz, isSignedIn, signInUrl, verifyUrl, closesLabel, t }: { event: MutualTimePublicEvent; tz: string; isSignedIn: boolean; signInUrl: string; verifyUrl?: string; closesLabel: string | null; t: Tokens }) {
   return (
     <>
       <StatusChip label={closesLabel ? `Voting open · closes ${closesLabel}` : 'Voting open'} accentActive t={t} />
-      <div style={{ borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: '36px 24px', marginTop: 16, display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 12 }}>
-        <Lock size={28} style={{ color: t.SUBTLE }} />
+      <p style={{ color: t.SUBTLE, fontSize: 14, margin: '0 0 16px' }}>When works for everyone? Pick up to {MUTUAL_TIME_MAX_PICKS} windows — we&apos;ll find the overlap.</p>
+
+      <MeetingPlaceRow event={event} t={t} />
+
+      <div style={{ borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: '24px 20px', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 12 }}>
+        <Lock size={26} style={{ color: t.SUBTLE }} />
         <div style={{ fontSize: 15, fontWeight: 600, color: t.TITLE }}>
           {isSignedIn ? 'Approved members can vote' : 'Sign in and get approved to vote'}
         </div>
@@ -181,6 +202,18 @@ function GateView({ isSignedIn, signInUrl, verifyUrl, closesLabel, t }: { isSign
         <a href={isSignedIn && verifyUrl ? verifyUrl : signInUrl} style={{ display: 'inline-block', padding: '10px 20px', borderRadius: 10, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}55`, color: t.ACCENT, fontSize: 14, fontWeight: 700, textDecoration: 'none', marginTop: 4 }}>
           {isSignedIn && verifyUrl ? 'Go to verification' : 'Sign in to vote'}
         </a>
+      </div>
+
+      <div style={{ fontSize: 12, fontWeight: 600, color: t.SUBTLE, margin: '20px 0 8px', textAlign: 'center' }}>
+        Here are the times on offer — sign in to pick yours
+      </div>
+      {/* Inert preview of the real form: no taps, no keyboard focus, skipped by screen readers (the
+          prompt above already says everything a non-voter needs). */}
+      <div aria-hidden="true" style={{ borderRadius: 14, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}`, padding: 20, opacity: 0.45, pointerEvents: 'none', userSelect: 'none' }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: t.SUBTLE, fontSize: 13, fontWeight: 500, marginBottom: 18 }}>
+          <Globe size={13} /> Times shown in {timeZoneLabel(tz)}
+        </div>
+        <SlotPicker event={event} tz={tz} picks={[]} toggle={() => {}} disabled t={t} />
       </div>
     </>
   );
@@ -207,64 +240,26 @@ function TimeZoneRow({ tz, showTz, setShowTz, setTz, t }: { tz: string; showTz: 
   );
 }
 
-type VotePeriod = { label: string; order: number; slots: string[] };
-
-function SlotGrid({ periods, picks, atMax, toggle, tz, t }: { periods: VotePeriod[]; picks: string[]; atMax: boolean; toggle: (iso: string) => void; tz: string; t: Tokens }) {
+// The button under the grid. It only offers to clear when there is something saved to clear: with no
+// picks selected and nothing saved yet it reads "Save my picks" and is switched off, so a first-time
+// voter is never shown a Clear button before they have picked anything.
+function SaveBar({ saving, picks, hasSavedPicks, save, t }: { saving: boolean; picks: string[]; hasSavedPicks: boolean; save: () => void; t: Tokens }) {
+  const isClear = picks.length === 0 && hasSavedPicks;
+  const nothingToDo = picks.length === 0 && !hasSavedPicks;
+  const inactive = saving || nothingToDo;
   return (
-    <div style={{ borderRadius: 14, border: `1px solid ${t.BORDER_SOLID}`, background: t.HEADER, marginBottom: 16, overflow: 'hidden' }}>
-      {periods.length === 0 ? (
-        <div style={{ padding: 14, color: t.SUBTLE, fontSize: 13 }}>No times on this day.</div>
-      ) : (
-        periods.map((period) => (
-          <div key={period.order} style={{ padding: '10px 14px', borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
-            <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.05em' }}>{period.label}</div>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-              {period.slots.map((iso) => {
-                const isSel = picks.includes(iso);
-                const isDis = !isSel && atMax;
-                return (
-                  <button key={iso} onClick={() => !isDis && toggle(iso)} style={{ padding: '5px 10px', borderRadius: 6, background: isSel ? `${t.ACCENT}22` : t.SURFACE, border: `1px solid ${isSel ? t.ACCENT : t.BORDER_SOLID}`, color: isSel ? t.ACCENT : isDis ? t.SUBTLE : t.TITLE, fontSize: 12, fontWeight: isSel ? 700 : 400, cursor: isDis ? 'not-allowed' : 'pointer', opacity: isDis ? 0.4 : 1, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                    {isSel && <Check size={11} />}
-                    {formatSlotTime(iso, tz)}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        ))
+    <div>
+      <button
+        onClick={save}
+        disabled={inactive}
+        style={{ padding: '10px 20px', borderRadius: 10, background: inactive ? t.SURFACE : `${t.ACCENT}22`, border: `1px solid ${inactive ? t.BORDER_SOLID : t.ACCENT}`, color: inactive ? t.SUBTLE : t.ACCENT, fontSize: 14, fontWeight: 700, cursor: inactive ? 'not-allowed' : 'pointer' }}
+      >
+        {saving ? 'Saving…' : isClear ? 'Clear my picks' : 'Save my picks'}
+      </button>
+      {nothingToDo && !saving && (
+        <div style={{ fontSize: 12, color: t.SUBTLE, marginTop: 8 }}>Pick a time above, then save.</div>
       )}
     </div>
-  );
-}
-
-function PicksSummary({ picks, tz, toggle, t }: { picks: string[]; tz: string; toggle: (iso: string) => void; t: Tokens }) {
-  if (picks.length === 0) return null;
-  return (
-    <div style={{ marginBottom: 12 }}>
-      <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Your picks</div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-        {[...picks].sort().map((iso) => (
-          <div key={iso} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 10px', borderRadius: 6, background: `${t.ACCENT}12`, border: `1px solid ${t.ACCENT}40`, fontSize: 13, color: t.TITLE }}>
-            <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <Clock size={12} style={{ color: t.ACCENT }} /> {formatSlotDate(iso, tz)} · {formatSlotRange(iso, tz)}
-            </span>
-            <button onClick={() => toggle(iso)} style={{ background: 'transparent', border: 'none', color: t.SUBTLE, cursor: 'pointer', fontSize: 11, fontWeight: 600 }}>remove</button>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function SaveBar({ saving, picks, save, t }: { saving: boolean; picks: string[]; save: () => void; t: Tokens }) {
-  return (
-    <button
-      onClick={save}
-      disabled={saving}
-      style={{ padding: '10px 20px', borderRadius: 10, background: `${t.ACCENT}22`, border: `1px solid ${t.ACCENT}`, color: t.ACCENT, fontSize: 14, fontWeight: 700, cursor: saving ? 'not-allowed' : 'pointer' }}
-    >
-      {saving ? 'Saving…' : picks.length === 0 ? 'Clear my picks' : 'Save my picks'}
-    </button>
   );
 }
 
@@ -296,39 +291,11 @@ function VoteView({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [activeDate, setActiveDate] = useState<string | null>(null);
+  // What the server currently holds for this voter, as opposed to what they have selected on screen.
+  // The two differ the moment they deselect everything, and that gap is what makes "Clear my picks"
+  // the right label — without it the button offered to clear picks nobody had made yet.
+  const [savedPicks, setSavedPicks] = useState<string[]>(picks);
   const atMax = picks.length >= MUTUAL_TIME_MAX_PICKS;
-
-  // Group candidate slots by the viewer's LOCAL date, then by local period. Recomputed when tz changes.
-  const { dateKeys, dateLabels, slotsByDate } = useMemo(() => {
-    const byDate = new Map<string, string[]>();
-    const labels = new Map<string, string>();
-    for (const iso of event.candidateSlots) {
-      const key = localDateKey(iso, tz);
-      if (!byDate.has(key)) {
-        byDate.set(key, []);
-        labels.set(key, formatSlotDate(iso, tz));
-      }
-      byDate.get(key)!.push(iso);
-    }
-    const keys = Array.from(byDate.keys()).sort();
-    return { dateKeys: keys, dateLabels: labels, slotsByDate: byDate };
-  }, [event.candidateSlots, tz]);
-
-  const currentDate = activeDate && dateKeys.includes(activeDate) ? activeDate : dateKeys[0] ?? null;
-
-  const periods = useMemo(() => {
-    if (!currentDate) return [] as { label: string; order: number; slots: string[] }[];
-    const groups = new Map<number, { label: string; order: number; slots: string[] }>();
-    for (const iso of slotsByDate.get(currentDate) ?? []) {
-      const p = localPeriod(iso, tz);
-      if (!groups.has(p.order)) {
-        groups.set(p.order, { label: p.label, order: p.order, slots: [] });
-      }
-      groups.get(p.order)!.slots.push(iso);
-    }
-    return Array.from(groups.values()).sort((a, b) => a.order - b.order);
-  }, [currentDate, slotsByDate, tz]);
 
   const toggle = (iso: string) => {
     setSaved(false);
@@ -349,6 +316,7 @@ function VoteView({
         body: JSON.stringify({ slots: picks }),
       });
       setPicks(data.picks);
+      setSavedPicks(data.picks);
       setSaved(true);
       // Refresh the voter count shown in the status area, and reconcile the viewer's own state
       // (canVote, picks) from the same fresh read so the UI never renders off a load-time snapshot —
@@ -361,6 +329,7 @@ function VoteView({
         if (refreshed.viewer) {
           setCanVote(refreshed.viewer.canVote);
           setPicks(refreshed.viewer.picks);
+          setSavedPicks(refreshed.viewer.picks);
         }
       } catch {
         /* count refresh is best-effort */
@@ -372,12 +341,12 @@ function VoteView({
     }
   }
 
-  const picksOnDate = (key: string) => picks.filter((p) => localDateKey(p, tz) === key).length;
-
   return (
     <>
       <StatusChip label={closesLabel ? `Voting open · closes ${closesLabel}` : 'Voting open'} accentActive t={t} />
       <p style={{ color: t.SUBTLE, fontSize: 14, margin: '0 0 16px' }}>When works for everyone? Pick up to {MUTUAL_TIME_MAX_PICKS} windows — we&apos;ll find the overlap.</p>
+
+      <MeetingPlaceRow event={event} t={t} />
 
       {saved && (
         <div style={{ marginBottom: 12, padding: '10px 14px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.ACCENT}55`, color: t.ACCENT, fontSize: 13, display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -389,34 +358,15 @@ function VoteView({
         {/* Timezone row */}
         <TimeZoneRow tz={tz} showTz={showTz} setShowTz={setShowTz} setTz={setTz} t={t} />
 
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-          <span style={{ fontSize: 13, fontWeight: 600, color: t.TITLE }}>Pick up to {MUTUAL_TIME_MAX_PICKS} one-hour windows you&apos;re free</span>
-          <span style={{ fontSize: 12, fontWeight: 700, color: atMax ? t.ACCENT : t.SUBTLE }}>{picks.length} of {MUTUAL_TIME_MAX_PICKS} selected</span>
-        </div>
-
-        {/* Date chips */}
-        <div style={{ display: 'flex', gap: 6, overflowX: 'auto', paddingBottom: 6, marginBottom: 14 }}>
-          {dateKeys.map((key) => {
-            const isActive = key === currentDate;
-            const count = picksOnDate(key);
-            return (
-              <button key={key} onClick={() => setActiveDate(key)} style={{ position: 'relative', flexShrink: 0, padding: '7px 12px', borderRadius: 6, background: isActive ? `${t.ACCENT}22` : t.SURFACE, border: `1px solid ${isActive ? t.ACCENT : t.BORDER_SOLID}`, color: isActive ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: isActive ? 700 : 400, cursor: 'pointer' }}>
-                {dateLabels.get(key)}
-                {count > 0 && <span style={{ position: 'absolute', top: -5, right: -5, width: 14, height: 14, borderRadius: '50%', background: t.ACCENT, color: '#fff', fontSize: 9, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{count}</span>}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Slot grid */}
-        <SlotGrid periods={periods} picks={picks} atMax={atMax} toggle={toggle} tz={tz} t={t} />
+        {/* Count row, day chips, and the grid of one-hour windows */}
+        <SlotPicker event={event} tz={tz} picks={picks} toggle={toggle} t={t} />
 
         {/* Picks summary */}
         <PicksSummary picks={picks} tz={tz} toggle={toggle} t={t} />
 
         {error && <div style={{ marginBottom: 10, fontSize: 13, color: '#F87171' }}>{error}</div>}
 
-        <SaveBar saving={saving} picks={picks} save={save} t={t} />
+        <SaveBar saving={saving} picks={picks} hasSavedPicks={savedPicks.length > 0} save={save} t={t} />
       </div>
     </>
   );

--- a/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
@@ -179,7 +179,7 @@ function MeetingPlaceRow({ event, t }: { event: MutualTimePublicEvent; t: Tokens
 }
 
 // The signed-out / not-yet-approved view. It shows the real voting form underneath the sign-in prompt,
-// greyed out and inert, so a visitor sees the actual days and times on offer rather than only a locked
+// grayed out and inert, so a visitor sees the actual days and times on offer rather than only a locked
 // box — the reason to sign in is visible, not described.
 function GateView({ event, tz, isSignedIn, signInUrl, verifyUrl, closesLabel, t }: { event: MutualTimePublicEvent; tz: string; isSignedIn: boolean; signInUrl: string; verifyUrl?: string; closesLabel: string | null; t: Tokens }) {
   return (
@@ -244,21 +244,21 @@ function TimeZoneRow({ tz, showTz, setShowTz, setTz, t }: { tz: string; showTz: 
 // picks selected and nothing saved yet it reads "Save my picks" and is switched off, so a first-time
 // voter is never shown a Clear button before they have picked anything.
 function SaveBar({ saving, picks, hasSavedPicks, save, t }: { saving: boolean; picks: string[]; hasSavedPicks: boolean; save: () => void; t: Tokens }) {
-  const isClear = picks.length === 0 && hasSavedPicks;
-  const nothingToDo = picks.length === 0 && !hasSavedPicks;
+  const hasSelection = picks.length > 0;
+  const isClear = !hasSelection && hasSavedPicks;
+  const nothingToDo = !hasSelection && !hasSavedPicks;
   const inactive = saving || nothingToDo;
+  const tone: React.CSSProperties = inactive
+    ? { background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.SUBTLE, cursor: 'not-allowed' }
+    : { background: `${t.ACCENT}22`, border: `1px solid ${t.ACCENT}`, color: t.ACCENT, cursor: 'pointer' };
+  const label = saving ? 'Saving…' : isClear ? 'Clear my picks' : 'Save my picks';
+  const showHint = nothingToDo && !saving;
   return (
     <div>
-      <button
-        onClick={save}
-        disabled={inactive}
-        style={{ padding: '10px 20px', borderRadius: 10, background: inactive ? t.SURFACE : `${t.ACCENT}22`, border: `1px solid ${inactive ? t.BORDER_SOLID : t.ACCENT}`, color: inactive ? t.SUBTLE : t.ACCENT, fontSize: 14, fontWeight: 700, cursor: inactive ? 'not-allowed' : 'pointer' }}
-      >
-        {saving ? 'Saving…' : isClear ? 'Clear my picks' : 'Save my picks'}
+      <button onClick={save} disabled={inactive} style={{ ...tone, padding: '10px 20px', borderRadius: 10, fontSize: 14, fontWeight: 700 }}>
+        {label}
       </button>
-      {nothingToDo && !saving && (
-        <div style={{ fontSize: 12, color: t.SUBTLE, marginTop: 8 }}>Pick a time above, then save.</div>
-      )}
+      {showHint && <div style={{ fontSize: 12, color: t.SUBTLE, marginTop: 8 }}>Pick a time above, then save.</div>}
     </div>
   );
 }

--- a/ctf/packages/web/components/mutual-time/mutual-time-slot-picker.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-slot-picker.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Check, Clock } from 'lucide-react';
+import { MUTUAL_TIME_MAX_PICKS } from 'lib/mutual-time/constants';
+import type { MutualTimePublicEvent } from 'lib/mutual-time/types';
+import {
+  getMutualTimeTokens,
+  formatSlotTime,
+  formatSlotDate,
+  formatSlotRange,
+  localDateKey,
+  localPeriod,
+} from './mutual-time-shared';
+
+type Tokens = ReturnType<typeof getMutualTimeTokens>;
+type VotePeriod = { label: string; order: number; slots: string[] };
+
+// The candidate-slot picker: the count row, the day chips, and the grid of one-hour windows for the
+// chosen day. Lives in its own file because two surfaces render it — an approved member votes with it,
+// and a signed-out visitor sees the same thing greyed out behind the sign-in prompt, so the link shows
+// what they'd be picking from instead of only a locked box.
+//
+// `disabled` makes the whole picker inert: nothing responds to a tap, nothing takes keyboard focus, and
+// screen readers skip it (the surface around it carries the real message). Everything is still laid out
+// exactly as a voter sees it.
+
+function SlotGrid({ periods, picks, atMax, toggle, tz, disabled, t }: { periods: VotePeriod[]; picks: string[]; atMax: boolean; toggle: (iso: string) => void; tz: string; disabled: boolean; t: Tokens }) {
+  return (
+    <div style={{ borderRadius: 14, border: `1px solid ${t.BORDER_SOLID}`, background: t.HEADER, marginBottom: 16, overflow: 'hidden' }}>
+      {periods.length === 0 ? (
+        <div style={{ padding: 14, color: t.SUBTLE, fontSize: 13 }}>No times on this day.</div>
+      ) : (
+        periods.map((period) => (
+          <div key={period.order} style={{ padding: '10px 14px', borderBottom: `1px solid ${t.BORDER_SOLID}` }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.05em' }}>{period.label}</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              {period.slots.map((iso) => {
+                const isSel = picks.includes(iso);
+                const isDis = disabled || (!isSel && atMax);
+                return (
+                  <button
+                    key={iso}
+                    onClick={() => !isDis && toggle(iso)}
+                    disabled={disabled}
+                    tabIndex={disabled ? -1 : undefined}
+                    style={{ padding: '5px 10px', borderRadius: 6, background: isSel ? `${t.ACCENT}22` : t.SURFACE, border: `1px solid ${isSel ? t.ACCENT : t.BORDER_SOLID}`, color: isSel ? t.ACCENT : isDis ? t.SUBTLE : t.TITLE, fontSize: 12, fontWeight: isSel ? 700 : 400, cursor: isDis ? 'not-allowed' : 'pointer', opacity: !disabled && isDis ? 0.4 : 1, display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                  >
+                    {isSel && <Check size={11} />}
+                    {formatSlotTime(iso, tz)}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+export function PicksSummary({ picks, tz, toggle, t }: { picks: string[]; tz: string; toggle: (iso: string) => void; t: Tokens }) {
+  if (picks.length === 0) return null;
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, color: t.SUBTLE, marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Your picks</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {[...picks].sort().map((iso) => (
+          <div key={iso} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 10px', borderRadius: 6, background: `${t.ACCENT}12`, border: `1px solid ${t.ACCENT}40`, fontSize: 13, color: t.TITLE }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <Clock size={12} style={{ color: t.ACCENT }} /> {formatSlotDate(iso, tz)} · {formatSlotRange(iso, tz)}
+            </span>
+            <button onClick={() => toggle(iso)} style={{ background: 'transparent', border: 'none', color: t.SUBTLE, cursor: 'pointer', fontSize: 11, fontWeight: 600 }}>remove</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SlotPicker({ event, tz, picks, toggle, disabled = false, t }: { event: MutualTimePublicEvent; tz: string; picks: string[]; toggle: (iso: string) => void; disabled?: boolean; t: Tokens }) {
+  const [activeDate, setActiveDate] = useState<string | null>(null);
+  const atMax = picks.length >= MUTUAL_TIME_MAX_PICKS;
+
+  // Group candidate slots by the viewer's LOCAL date, then by local period. Recomputed when tz changes.
+  const { dateKeys, dateLabels, slotsByDate } = useMemo(() => {
+    const byDate = new Map<string, string[]>();
+    const labels = new Map<string, string>();
+    for (const iso of event.candidateSlots) {
+      const key = localDateKey(iso, tz);
+      if (!byDate.has(key)) {
+        byDate.set(key, []);
+        labels.set(key, formatSlotDate(iso, tz));
+      }
+      byDate.get(key)!.push(iso);
+    }
+    const keys = Array.from(byDate.keys()).sort();
+    return { dateKeys: keys, dateLabels: labels, slotsByDate: byDate };
+  }, [event.candidateSlots, tz]);
+
+  const currentDate = activeDate && dateKeys.includes(activeDate) ? activeDate : dateKeys[0] ?? null;
+
+  const periods = useMemo(() => {
+    if (!currentDate) return [] as VotePeriod[];
+    const groups = new Map<number, VotePeriod>();
+    for (const iso of slotsByDate.get(currentDate) ?? []) {
+      const p = localPeriod(iso, tz);
+      if (!groups.has(p.order)) {
+        groups.set(p.order, { label: p.label, order: p.order, slots: [] });
+      }
+      groups.get(p.order)!.slots.push(iso);
+    }
+    return Array.from(groups.values()).sort((a, b) => a.order - b.order);
+  }, [currentDate, slotsByDate, tz]);
+
+  const picksOnDate = (key: string) => picks.filter((p) => localDateKey(p, tz) === key).length;
+
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, marginBottom: 10 }}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: t.TITLE }}>Pick up to {MUTUAL_TIME_MAX_PICKS} one-hour windows you&apos;re free</span>
+        {!disabled && <span style={{ flexShrink: 0, fontSize: 12, fontWeight: 700, color: atMax ? t.ACCENT : t.SUBTLE }}>{picks.length} of {MUTUAL_TIME_MAX_PICKS} selected</span>}
+      </div>
+
+      <div style={{ display: 'flex', gap: 6, overflowX: 'auto', paddingBottom: 6, marginBottom: 14 }}>
+        {dateKeys.map((key) => {
+          const isActive = key === currentDate;
+          const count = picksOnDate(key);
+          return (
+            <button
+              key={key}
+              onClick={() => !disabled && setActiveDate(key)}
+              disabled={disabled}
+              tabIndex={disabled ? -1 : undefined}
+              style={{ position: 'relative', flexShrink: 0, padding: '7px 12px', borderRadius: 6, background: isActive ? `${t.ACCENT}22` : t.SURFACE, border: `1px solid ${isActive ? t.ACCENT : t.BORDER_SOLID}`, color: isActive ? t.ACCENT : t.SUBTLE, fontSize: 12, fontWeight: isActive ? 700 : 400, cursor: disabled ? 'default' : 'pointer' }}
+            >
+              {dateLabels.get(key)}
+              {count > 0 && <span style={{ position: 'absolute', top: -5, right: -5, width: 14, height: 14, borderRadius: '50%', background: t.ACCENT, color: '#fff', fontSize: 9, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{count}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <SlotGrid periods={periods} picks={picks} atMax={atMax} toggle={toggle} tz={tz} disabled={disabled} t={t} />
+    </>
+  );
+}

--- a/ctf/packages/web/components/mutual-time/mutual-time-slot-picker.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-slot-picker.tsx
@@ -18,12 +18,36 @@ type VotePeriod = { label: string; order: number; slots: string[] };
 
 // The candidate-slot picker: the count row, the day chips, and the grid of one-hour windows for the
 // chosen day. Lives in its own file because two surfaces render it — an approved member votes with it,
-// and a signed-out visitor sees the same thing greyed out behind the sign-in prompt, so the link shows
+// and a signed-out visitor sees the same thing grayed out behind the sign-in prompt, so the link shows
 // what they'd be picking from instead of only a locked box.
 //
 // `disabled` makes the whole picker inert: nothing responds to a tap, nothing takes keyboard focus, and
 // screen readers skip it (the surface around it carries the real message). Everything is still laid out
 // exactly as a voter sees it.
+
+// Colors for one time button: picked, unavailable (already at the pick limit), or plain.
+function slotColors(isSel: boolean, isDis: boolean, t: Tokens): React.CSSProperties {
+  return {
+    background: isSel ? `${t.ACCENT}22` : t.SURFACE,
+    border: `1px solid ${isSel ? t.ACCENT : t.BORDER_SOLID}`,
+    color: isSel ? t.ACCENT : isDis ? t.SUBTLE : t.TITLE,
+    fontWeight: isSel ? 700 : 400,
+  };
+}
+
+function SlotButton({ iso, isSel, isDis, dimmed, disabled, toggle, tz, t }: { iso: string; isSel: boolean; isDis: boolean; dimmed: boolean; disabled: boolean; toggle: (iso: string) => void; tz: string; t: Tokens }) {
+  return (
+    <button
+      onClick={() => !isDis && toggle(iso)}
+      disabled={disabled}
+      tabIndex={disabled ? -1 : undefined}
+      style={{ ...slotColors(isSel, isDis, t), padding: '5px 10px', borderRadius: 6, fontSize: 12, cursor: isDis ? 'not-allowed' : 'pointer', opacity: dimmed ? 0.4 : 1, display: 'inline-flex', alignItems: 'center', gap: 4 }}
+    >
+      {isSel && <Check size={11} />}
+      {formatSlotTime(iso, tz)}
+    </button>
+  );
+}
 
 function SlotGrid({ periods, picks, atMax, toggle, tz, disabled, t }: { periods: VotePeriod[]; picks: string[]; atMax: boolean; toggle: (iso: string) => void; tz: string; disabled: boolean; t: Tokens }) {
   return (
@@ -38,18 +62,9 @@ function SlotGrid({ periods, picks, atMax, toggle, tz, disabled, t }: { periods:
               {period.slots.map((iso) => {
                 const isSel = picks.includes(iso);
                 const isDis = disabled || (!isSel && atMax);
-                return (
-                  <button
-                    key={iso}
-                    onClick={() => !isDis && toggle(iso)}
-                    disabled={disabled}
-                    tabIndex={disabled ? -1 : undefined}
-                    style={{ padding: '5px 10px', borderRadius: 6, background: isSel ? `${t.ACCENT}22` : t.SURFACE, border: `1px solid ${isSel ? t.ACCENT : t.BORDER_SOLID}`, color: isSel ? t.ACCENT : isDis ? t.SUBTLE : t.TITLE, fontSize: 12, fontWeight: isSel ? 700 : 400, cursor: isDis ? 'not-allowed' : 'pointer', opacity: !disabled && isDis ? 0.4 : 1, display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                  >
-                    {isSel && <Check size={11} />}
-                    {formatSlotTime(iso, tz)}
-                  </button>
-                );
+                // The preview is already faded as a whole, so only fade a button here when it is a live
+                // form and the member has used up their picks.
+                return <SlotButton key={iso} iso={iso} isSel={isSel} isDis={isDis} dimmed={!disabled && isDis} disabled={disabled} toggle={toggle} tz={tz} t={t} />;
               })}
             </div>
           </div>

--- a/ctf/packages/web/lib/mutual-time/constants.ts
+++ b/ctf/packages/web/lib/mutual-time/constants.ts
@@ -1,8 +1,9 @@
 export const MUTUAL_TIME_PLUGIN_ID = 'mutual-time';
 
 // The plugins a chosen meeting can point to ("Where we'll meet"). Chyme (live audio) is the default;
-// PeerProgramming is the weekly mastermind call. Both are live-meeting surfaces the result links to.
-export const MUTUAL_TIME_MEETING_PLUGINS = ['chyme', 'peer-programming'] as const;
+// PeerProgramming is the weekly mastermind call; Beacon is the live one-way broadcast. All three are
+// live-meeting surfaces the result links to.
+export const MUTUAL_TIME_MEETING_PLUGINS = ['chyme', 'peer-programming', 'beacon'] as const;
 export type MutualTimeMeetingPlugin = (typeof MUTUAL_TIME_MEETING_PLUGINS)[number];
 
 // Candidate-slot grid. Votes are one-hour windows whose start is snapped to the half-hour, so votes

--- a/ctf/packages/web/lib/mutual-time/meeting-plugin.ts
+++ b/ctf/packages/web/lib/mutual-time/meeting-plugin.ts
@@ -6,6 +6,7 @@ import type { MutualTimeMeetingPlugin } from './constants';
 const MEETING_PLUGIN_NAMES: Record<MutualTimeMeetingPlugin, string> = {
   chyme: 'Chyme',
   'peer-programming': 'Peer Programming',
+  beacon: 'Beacon',
 };
 
 export function meetingPluginName(plugin: MutualTimeMeetingPlugin): string {

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -6192,7 +6192,7 @@ CREATE TABLE IF NOT EXISTS mutual_time_events (
   created_by_user_id TEXT NOT NULL,
   title TEXT NULL,
   description TEXT NULL,
-  meeting_plugin TEXT NOT NULL CHECK (meeting_plugin IN ('chyme', 'peer-programming')),
+  meeting_plugin TEXT NOT NULL CHECK (meeting_plugin IN ('chyme', 'peer-programming', 'beacon')),
   window_start_date DATE NOT NULL,
   window_days INTEGER NOT NULL DEFAULT 7 CHECK (window_days BETWEEN 1 AND 14),
   opens_at TIMESTAMPTZ NULL,
@@ -6215,6 +6215,12 @@ ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS status TEXT NO
 ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS result_slot_start TIMESTAMPTZ;
 ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS result_can_make_it INTEGER;
 ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;
+-- "Where we'll meet" vocabulary. Beacon was added after the table shipped, so an existing database
+-- still carries the two-value check from the original CREATE TABLE. Drop + re-add keeps it idempotent
+-- and brings a legacy database up to date (same idiom as currencies_kind_check). NOT VALID so the ADD
+-- can never fail on an existing row and stop the rest of the file from being applied.
+ALTER TABLE IF EXISTS mutual_time_events DROP CONSTRAINT IF EXISTS mutual_time_events_meeting_plugin_check;
+ALTER TABLE IF EXISTS mutual_time_events ADD CONSTRAINT mutual_time_events_meeting_plugin_check CHECK (meeting_plugin IN ('chyme', 'peer-programming', 'beacon')) NOT VALID;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mutual_time_events_slug ON mutual_time_events(slug);
 CREATE INDEX IF NOT EXISTS idx_mutual_time_events_creator ON mutual_time_events(created_by_user_id, created_at DESC);
 

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -6194,7 +6194,7 @@ CREATE TABLE IF NOT EXISTS mutual_time_events (
   created_by_user_id TEXT NOT NULL,
   title TEXT NULL,
   description TEXT NULL,
-  meeting_plugin TEXT NOT NULL CHECK (meeting_plugin IN ('chyme', 'peer-programming')),
+  meeting_plugin TEXT NOT NULL CHECK (meeting_plugin IN ('chyme', 'peer-programming', 'beacon')),
   window_start_date DATE NOT NULL,
   window_days INTEGER NOT NULL DEFAULT 7 CHECK (window_days BETWEEN 1 AND 14),
   opens_at TIMESTAMPTZ NULL,
@@ -6217,6 +6217,12 @@ ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS status TEXT NO
 ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS result_slot_start TIMESTAMPTZ;
 ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS result_can_make_it INTEGER;
 ALTER TABLE IF EXISTS mutual_time_events ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;
+-- "Where we'll meet" vocabulary. Beacon was added after the table shipped, so an existing database
+-- still carries the two-value check from the original CREATE TABLE. Drop + re-add keeps it idempotent
+-- and brings a legacy database up to date (same idiom as currencies_kind_check). NOT VALID so the ADD
+-- can never fail on an existing row and stop the rest of the file from being applied.
+ALTER TABLE IF EXISTS mutual_time_events DROP CONSTRAINT IF EXISTS mutual_time_events_meeting_plugin_check;
+ALTER TABLE IF EXISTS mutual_time_events ADD CONSTRAINT mutual_time_events_meeting_plugin_check CHECK (meeting_plugin IN ('chyme', 'peer-programming', 'beacon')) NOT VALID;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mutual_time_events_slug ON mutual_time_events(slug);
 CREATE INDEX IF NOT EXISTS idx_mutual_time_events_creator ON mutual_time_events(created_by_user_id, created_at DESC);
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105). Mutual Time is not on the Chyme keep-list, so there is no React Native surface to build.

**Waiting on owner review — auto-merge is deliberately off.** The first commit changes a database check constraint and a command contract, both on the risky list.

Five fixes to Mutual Time, all from phone screenshots. Two commits: the admin form, then the public shared link.

## Admin form at `/apps/mutual-time`

**Beacon is now a choice in "Where we'll meet".** The dropdown offered only Chyme and Peer Programming. Beacon is a live broadcast surface, so a chosen time can point at it the same way — the result link is `/apps/beacon`, the same `/apps/<slug>` shape, and Beacon already ships a real page there. Added to the plugin list and the display-name map, to the `meetingPlugin` enum in the command contract, to the target context in the audit contract, and to the `meeting_plugin` check on `mutual_time_events`.

On the database change: the inline check in `CREATE TABLE` only helps a fresh database — an existing one still carries the two-value check from when the table shipped and would reject the new value. So the constraint is also dropped and re-added by name (`mutual_time_events_meeting_plugin_check`), the same drop-and-re-add idiom used for `currencies_kind_check`, and added `NOT VALID` so it can never fail on an existing row and stop the rest of the file being applied. No row changes, nothing deleted. `schema.demo.sql` regenerated from `schema.sql`.

**The two date-and-time fields no longer run off the right edge.** A grid column sized `1fr` keeps a floor of the item's own minimum width, and a `datetime-local` control reports a minimum wider than the phone-width column, so the column grew and carried the field past the card. A percentage width on the input could not pull it back, because that percentage resolves against the column that had already grown. The column is now `minmax(0, 1fr)`, each wrapper carries `minWidth: 0`, and the shared input style carries `maxWidth: 100%`.

## Public shared link at `/mutual-time/<slug>`

No schema, contract, or API change here — everything shown was already in the public read.

**A visitor now sees the form before signing in.** Signed out or not yet approved, they used to get only a locked box. They now see the sign-in prompt with the real voting form below it, greyed out: the same day chips and one-hour windows a member picks from, under the line "Here are the times on offer — sign in to pick yours". The preview is inert — nothing responds to a tap, nothing takes keyboard focus, and screen readers skip it, since the prompt above already carries the message. The reason to sign in is visible instead of described.

**Where the meeting is, from the moment the link opens.** "We'll meet in Chyme", with a button straight to that plugin, now shows on every state of the link rather than only after the survey closes: the sign-in gate, the not-yet-open state, and the voting form. Someone who opens the link knows what they are being invited to, and can go look at it, before a time is picked. The button goes to the in-app route, so `/apps/chyme` on this host — `https://app.chargingthefuture.com/apps/chyme` in production.

**The clear-picks button stopped offering to clear nothing.** It read "Clear my picks" whenever nothing was selected, including on a first visit where there was nothing to clear. It now tracks what the server holds separately from what is selected on screen: "Save my picks" when there is a selection, "Clear my picks" only when the member has saved picks and has deselected them all, and switched off with the hint "Pick a time above, then save." when there is neither.

The day chips and slot grid moved into `components/mutual-time/mutual-time-slot-picker.tsx` so the voting form and the gate preview are one component rather than two that can drift apart.

## Docs

Mutual Time inventory updated (scope, user features, admin features, data model, delivery status, change log) and the test script updated: MT-1 and MT-2 now describe the preview instead of saying no picker is present, the core smoke step for the public link matches what it now shows, and four cases were added — the preview cannot be used (MT-1b), the clear button only appears when there is something to clear (MT-5b), the meeting place shows before close (MT-12), and the dropdown lists all three with no field running off (MT-A1b).

## Checked locally

Web typecheck, lint, full `next build`, `check-eof-format.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs` all pass, re-run after each commit and after rebasing onto the current `main`.