### PR TITLE
fix: give the Mutual Time survey link a way back

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mutual-time-feature-inventory.md
@@ -40,7 +40,11 @@ to the meeting surface; members who did not vote can still come listen in.
    before voting opens, while voting is open, for a signed-out visitor, and after the time is chosen —
    shows "We'll meet in <plugin>" with a button straight to that plugin (for example Chyme, at
    `/apps/chyme`). It no longer waits for the survey to close.
-6. **Copy the link.** Every surface has a Copy-link button (rule 130) for sharing the one event link.
+6. **A way back off the survey.** A signed-in member sees the standard top bar on the shared link —
+   back chevron, brand icon, "Mutual Time", and the bug / settings / account controls — the same bar
+   every other screen has. A signed-out visitor sees the shared back chevron next to the event name,
+   and only when there is somewhere in-app to go back to.
+7. **Copy the link.** Every surface has a Copy-link button (rule 130) for sharing the one event link.
 
 ## Admin Features
 
@@ -218,6 +222,18 @@ idempotent. Fixed candidate window (`2026-07-21`, 7 days) keeps the seed determi
   then save." when there is neither. The day chips and slot grid moved to
   `components/mutual-time/mutual-time-slot-picker.tsx` so the voting form and the gate preview share one
   component.
+- 2026-08-09: **The shared survey link now has a way back (rule 134).** `/mutual-time/<slug>` shipped
+  with no back control at all — on a phone, and especially in the installed web app where there is no
+  browser back button, a member who opened it was stranded. It is the one screen a signed-out stranger
+  can open, so the two viewers get different chrome. A signed-in member now gets the shared
+  `MobileScreenHeader` (back chevron, brand icon, "Mutual Time", and the bug / settings / account
+  cluster), the same bar as every other screen. A signed-out visitor gets the shared
+  `BackChevronButton` beside the event name instead, and only when `useSmartBack` reports in-app
+  history: the full bar would offer them an account menu and a settings link they cannot use, and the
+  one-level-up fallback would push them to the all-apps page, which needs an account. With no in-app
+  history there is nothing in-app behind them and their browser's own back still works. No hand-rolled
+  back control — both pieces are the shared ones. `MutualTimePublic` was also split into `EventHeader`
+  and `EventBody` to stay under the complexity limit.
 
 Ordered, dependency-based (no phases). Each item done in this initial build.
 

--- a/ctf/docs/developer/test-scripts/mutual-time-test-script.md
+++ b/ctf/docs/developer/test-scripts/mutual-time-test-script.md
@@ -293,6 +293,24 @@ Result: web ☐ mobile ☐
 
 ---
 
+### MT-13 — There is a way back off the survey
+
+**Role:** Member (`approved_full`), then none (signed out)
+**Surfaces:** Web, Mobile
+**Precondition:** An open event slug. Best run in the installed web app, where there is no browser back button.
+
+**Steps:**
+1. Signed in, open the app, go to any screen, then open `/mutual-time/<open-event-slug>`.
+2. Look at the top of the screen, then press the back chevron.
+3. Sign out. Paste the same link into a fresh tab so nothing in the app came before it, and look next to the event name.
+4. Still signed out, open the app first, then navigate to the link, and look next to the event name again.
+
+**Expected:** Signed in, the standard top bar is there — back chevron, calendar icon, "Mutual Time", and the bug / settings / account controls — and the chevron returns to the screen you came from. Signed out in a fresh tab, there is no back chevron (there is nowhere in the app to go back to) and the browser's own back still works. Signed out after moving through the app, the back chevron appears next to the event name and returns to the previous page. No screen shows two back controls.
+
+Result: web ☐ mobile ☐
+
+---
+
 ## Admin walkthrough
 
 ### MT-A1 — Create an event (Chyme, no close date)

--- a/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
+++ b/ctf/packages/web/components/mutual-time/mutual-time-public.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { CalendarClock, Copy, Check, Globe, ChevronDown, Clock, Lock, ArrowUpRight } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
+import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
+import { BackChevronButton, useSmartBack } from '@/lib/nav/back-history';
 import { MUTUAL_TIME_MAX_PICKS } from 'lib/mutual-time/constants';
 import type { MutualTimePublicEvent, MutualTimeViewerState } from 'lib/mutual-time/types';
 import { SlotPicker, PicksSummary } from './mutual-time-slot-picker';
@@ -38,7 +40,6 @@ export function MutualTimePublic({ initialEvent, initialViewer, isSignedIn, sign
   const [picks, setPicks] = useState<string[]>(initialViewer.picks);
   const [tz, setTz] = useState<string>('UTC');
   const [showTz, setShowTz] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   // Detect the viewer's timezone on mount (client-only, so SSR stays deterministic).
   useEffect(() => {
@@ -46,6 +47,51 @@ export function MutualTimePublic({ initialEvent, initialViewer, isSignedIn, sign
   }, []);
 
   const [canVote, setCanVote] = useState(initialViewer.canVote);
+
+  return (
+    <div style={{ background: t.BG, minHeight: '100vh', color: t.TITLE }}>
+      {/* Way back (rule 134). A signed-in member gets the standard top bar every other screen has —
+          back chevron, brand icon, title, and the bug/settings/account cluster — so the way back sits
+          where they expect it. A signed-out visitor does not: that bar would offer them an account
+          menu and a settings link they cannot use. Their back control lives in the page header below. */}
+      {isSignedIn && (
+        <MobileScreenHeader title="Mutual Time" accent={t.ACCENT} icon={<CalendarClock size={18} color={t.ACCENT} />} />
+      )}
+      <div style={{ maxWidth: 780, margin: '0 auto', padding: isSignedIn ? '20px 20px 32px' : '32px 20px' }}>
+        <EventHeader event={event} isSignedIn={isSignedIn} t={t} />
+        <EventBody
+          event={event}
+          setEvent={setEvent}
+          tz={tz}
+          setTz={setTz}
+          showTz={showTz}
+          setShowTz={setShowTz}
+          picks={picks}
+          setPicks={setPicks}
+          canVote={canVote}
+          setCanVote={setCanVote}
+          isSignedIn={isSignedIn}
+          signInUrl={signInUrl}
+          verifyUrl={verifyUrl}
+          t={t}
+        />
+      </div>
+    </div>
+  );
+}
+
+// The page's own header: the event name, the Copy-link button, and — for a signed-out visitor only —
+// the shared back chevron.
+//
+// That chevron shows only when there is somewhere in-app to go back to. A visitor usually arrives here
+// from a link pasted somewhere else entirely, so there is nothing in-app behind them; the one-level-up
+// fallback would push them to the all-apps page, which needs an account. Their browser's own back still
+// returns them to wherever the link came from. A signed-in member never needs it here — they already
+// have the standard top bar above.
+function EventHeader({ event, isSignedIn, t }: { event: MutualTimePublicEvent; isSignedIn: boolean; t: Tokens }) {
+  const [copied, setCopied] = useState(false);
+  const { hasHistory } = useSmartBack();
+  const showVisitorBack = !isSignedIn && hasHistory;
 
   const onCopy = useCallback(async () => {
     const ok = await copyToClipboard(eventShareUrl(event.slug));
@@ -55,9 +101,10 @@ export function MutualTimePublic({ initialEvent, initialViewer, isSignedIn, sign
     }
   }, [event.slug]);
 
-  const header = (
+  return (
     <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 14 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        {showVisitorBack && <BackChevronButton accent={t.ACCENT} size={34} />}
         <CalendarClock size={22} style={{ color: t.ACCENT }} />
         <h1 style={{ fontSize: 22, fontWeight: 700, margin: 0 }}>{event.title || 'Meeting time'}</h1>
       </div>
@@ -70,38 +117,69 @@ export function MutualTimePublic({ initialEvent, initialViewer, isSignedIn, sign
       </button>
     </div>
   );
+}
 
+// Picks the one view the visitor should see: the result (closed), the not-yet-open notice, the vote
+// grid (open + an approved member), or the sign-in / listen-in gate.
+function EventBody({
+  event,
+  setEvent,
+  tz,
+  setTz,
+  showTz,
+  setShowTz,
+  picks,
+  setPicks,
+  canVote,
+  setCanVote,
+  isSignedIn,
+  signInUrl,
+  verifyUrl,
+  t,
+}: {
+  event: MutualTimePublicEvent;
+  setEvent: (next: MutualTimePublicEvent) => void;
+  tz: string;
+  setTz: (v: string) => void;
+  showTz: boolean;
+  setShowTz: (v: boolean) => void;
+  picks: string[];
+  setPicks: (next: string[]) => void;
+  canVote: boolean;
+  setCanVote: (v: boolean) => void;
+  isSignedIn: boolean;
+  signInUrl: string;
+  verifyUrl?: string;
+  t: Tokens;
+}) {
   const closesLabel = event.closesAtIso ? formatSlotDate(event.closesAtIso, tz) : null;
 
   return (
-    <div style={{ background: t.BG, minHeight: '100vh', color: t.TITLE }}>
-      <div style={{ maxWidth: 780, margin: '0 auto', padding: '32px 20px' }}>
-        {header}
-        {event.description && <p style={{ color: t.SUBTLE, fontSize: 14, margin: '0 0 16px' }}>{event.description}</p>}
+    <>
+      {event.description && <p style={{ color: t.SUBTLE, fontSize: 14, margin: '0 0 16px' }}>{event.description}</p>}
 
-        {event.effectiveState === 'closed' ? (
-          <ResultView event={event} tz={tz} canVote={canVote} t={t} />
-        ) : event.effectiveState === 'scheduled' ? (
-          <ScheduledView event={event} tz={tz} t={t} />
-        ) : canVote ? (
-          <VoteView
-            event={event}
-            tz={tz}
-            picks={picks}
-            setPicks={setPicks}
-            setEvent={setEvent}
-            setCanVote={setCanVote}
-            showTz={showTz}
-            setShowTz={setShowTz}
-            setTz={setTz}
-            closesLabel={closesLabel}
-            t={t}
-          />
-        ) : (
-          <GateView event={event} tz={tz} isSignedIn={isSignedIn} signInUrl={signInUrl} verifyUrl={verifyUrl} closesLabel={closesLabel} t={t} />
-        )}
-      </div>
-    </div>
+      {event.effectiveState === 'closed' ? (
+        <ResultView event={event} tz={tz} canVote={canVote} t={t} />
+      ) : event.effectiveState === 'scheduled' ? (
+        <ScheduledView event={event} tz={tz} t={t} />
+      ) : canVote ? (
+        <VoteView
+          event={event}
+          tz={tz}
+          picks={picks}
+          setPicks={setPicks}
+          setEvent={setEvent}
+          setCanVote={setCanVote}
+          showTz={showTz}
+          setShowTz={setShowTz}
+          setTz={setTz}
+          closesLabel={closesLabel}
+          t={t}
+        />
+      ) : (
+        <GateView event={event} tz={tz} isSignedIn={isSignedIn} signInUrl={signInUrl} verifyUrl={verifyUrl} closesLabel={closesLabel} t={t} />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105). Mutual Time is not on the Chyme keep-list, so there is no React Native surface to build. The native app also carries its own top navigator on every screen, so rule 134 already treats that side as covered.

`/mutual-time/<slug>` shipped with no back control at all. On a phone — and especially in the installed web app, where there is no browser back button — a member who opened the survey was stranded on it. Rule 134 says every screen must offer a way back, using the shared controls and never a hand-rolled one.

## Two viewers, because this screen is unusual

This is the one screen a signed-out stranger can open, arriving from a link pasted somewhere else entirely. So the chrome differs:

**Signed in** → the shared `MobileScreenHeader`: back chevron, brand icon, "Mutual Time", and the bug / settings / account controls. The same bar as every other screen, so the way back sits where they expect it.

**Signed out** → the shared `BackChevronButton` beside the event name, and only when `useSmartBack` reports in-app history. The full bar would offer them an account menu and a settings link they cannot use, and the one-level-up fallback (`resolveBackTarget` → all apps) would push them to a page that needs an account. With no in-app history there is genuinely nothing in-app behind them, and their browser's own back still returns them to wherever the link came from.

Both are the shared controls from rule 134 — nothing hand-rolled, no second back control on any state, no `router.back()` called directly.

`MutualTimePublic` was also split into `EventHeader` and `EventBody`; adding the header pushed it past the complexity limit of 10.

## Docs

Inventory updated (user features and change log) and the test script gets MT-13, covering all three cases: signed in, signed out in a fresh tab, and signed out after moving through the app.

## Checked locally

Web typecheck, lint, full `next build`, `check-eof-format.sh`, `check-us-spelling.mjs`, `check-modularity-governance.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs` all pass — re-run after merging the current `main` (which now includes #2178), so the diff here is this change alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115PUZFv4JbFU4zWhWGamYh)_