### PR TITLE
fix: five code-review findings in the Commons shell

### DIFF
--- a/ctf/packages/web/components/community-shell/shell-format.ts
+++ b/ctf/packages/web/components/community-shell/shell-format.ts
@@ -2,8 +2,11 @@
 // Renders large counts as "4.9M" / "$300B" so a big member count or economy value stays readable in
 // a small stat block instead of a long digit string. Extracted here so the chat panel and the
 // sidebar format identically from one source.
-export function formatScaledValue(value: number | null, prefix = ''): string {
-  if (!value) return `${prefix}0`;
+// A missing value (not loaded yet) and a non-finite one both render as "0" — but they are checked
+// separately from a real 0 so the guard says what it means. A genuine 0 falls through to the normal
+// formatting path below rather than being caught by a truthiness test.
+export function formatScaledValue(value: number | null | undefined, prefix = ''): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return `${prefix}0`;
   if (value >= 1_000_000_000) return `${prefix}${(value / 1_000_000_000).toFixed(0)}B`;
   if (value >= 1_000_000) return `${prefix}${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${prefix}${(value / 1_000).toFixed(1)}K`;

--- a/ctf/packages/web/components/community-shell/shell-right-rail.tsx
+++ b/ctf/packages/web/components/community-shell/shell-right-rail.tsx
@@ -7,6 +7,28 @@ import type { ShellCurrentUser } from './shell-types';
 import { TrustRightRailCard } from '../shared/trust/TrustRightRailCard';
 import styles from './community-shell.module.css';
 
+// The avatar photo is drawn by writing the URL into a CSS `url("…")` string, so anything that could
+// close that quoted string early would be writing raw CSS into the page. Clerk's own image URLs are
+// plain https links and safe, but the value is checked rather than trusted. Parsing it and using the
+// parser's own output does the escaping: the URL parser percent-encodes quotes, turns backslashes
+// into slashes, and drops control characters, so the result cannot contain a string terminator.
+// (Percent-encoding it again here would corrupt any URL that already contains a %-escape.) Only
+// http(s) is accepted, and the quote/backslash check below is a cheap backstop. Returns null when
+// there is no usable photo, which falls back to the initial monogram.
+function safeImageUrl(rawUrl: string | undefined): string | null {
+  if (!rawUrl) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+  const normalized = parsed.toString();
+  if (normalized.includes('"') || normalized.includes('\\')) return null;
+  return normalized;
+}
+
 type ShellRightRailProps = {
   currentUser: ShellCurrentUser;
   trust: TrustUserExtension;
@@ -22,7 +44,7 @@ export function ShellRightRail({ currentUser, trust, isAuthenticated = false, si
   // profileAvatar sizing/border-radius/comic-theme border all still apply. Falls back to the initial
   // monogram when there is no photo or the user is signed out.
   const { user } = useUser();
-  const photoUrl = user?.imageUrl;
+  const photoUrl = safeImageUrl(user?.imageUrl);
   const avatar = photoUrl ? (
     <div
       className={styles.profileAvatar}

--- a/ctf/packages/web/components/community-shell/unlock-verify-banner.tsx
+++ b/ctf/packages/web/components/community-shell/unlock-verify-banner.tsx
@@ -157,9 +157,12 @@ export function UnlockVerifyBanner({
     setSubmitting(true);
     setError(null);
     try {
+      // The submission route gates on Origin today, not on this header, so the submit works without
+      // it. The header is sent so this keeps working if the route ever moves to the header-based
+      // check the rest of the Commons POSTs use.
       const res = await fetch('/api/unlock/submission', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
         body: JSON.stringify({ quoraProfileUrl: trimmed }),
       });
       if (!res.ok) {

--- a/ctf/packages/web/components/community-shell/use-home-chat.ts
+++ b/ctf/packages/web/components/community-shell/use-home-chat.ts
@@ -833,7 +833,13 @@ async function connectLiveWhenConfigured(
 // failure, fall back to the frequent poll.
 async function joinAndConnect(ctx: ChatBootstrapContext): Promise<void> {
   try {
-    const join = await requestJson<HubJoinResponse>('/api/hub/join', { method: 'POST' });
+    // The join route gates on Origin today, not on this header, so the call works without it. The
+    // header is sent so the join keeps working if the route ever moves to the header-based check
+    // that the rest of the Commons POSTs use, and so no Commons mutation is the odd one out.
+    const join = await requestJson<HubJoinResponse>('/api/hub/join', {
+      method: 'POST',
+      headers: { 'x-ctf-csrf': '1' },
+    });
     if (!ctx.controller.active) return;
     ctx.setters.setConnectionState('live');
     ctx.setters.setError(null);
@@ -1046,7 +1052,10 @@ export function useHomeChat(currentUser: ShellCurrentUser) {
       setters: settersRef.current,
     });
     return () => teardownBootstrap(controller, liveConnectionRef);
-  }, [currentUser.displayName, currentUser.userId, refreshHistory, refreshComic, refreshLastSeen, loadAroundDeepLink]);
+    // Deliberately keyed on userId only: nothing in the bootstrap reads the display name (incoming
+    // messages carry their own sender name from the server), so listing it here tore down the whole
+    // chat — cleared messages, re-joined, restarted the poll — every time a member edited their name.
+  }, [currentUser.userId, refreshHistory, refreshComic, refreshLastSeen, loadAroundDeepLink]);
 
   const routeToComic = useCallback(
     (questionText: string) => runRouteToComic(questionText, refreshComic, settersRef.current),


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Five open code-review findings on the Commons shell, each checked against the current code before anything was changed. One more was checked and found not to hold; it is closed rather than coded around.

## What changed

**Same-origin marker header on two Commons POSTs** — joining the home chat (`use-home-chat.ts`) and submitting a verification link from the Commons banner (`unlock-verify-banner.tsx`) were the only state-changing calls in the module not sending `x-ctf-csrf: 1`. They send it now, so every mutation in the module looks the same.

**Read this before "fixing" it back — the findings' stated reason is wrong.** Both issues claim the calls fail silently today because the server rejects them. They do not. `app/api/hub/join/route.ts` gates on `requireHubAccess()` and `app/api/unlock/submission/route.ts` on `requireUnlockUserAccess()`; neither one reads that header — the cross-site protection on both comes from the request origin check. So this changes no behavior now. What is load-bearing is that the header is sent so these two calls keep working if those routes ever move to the header-based check the rest of the Commons uses, and so nobody has to re-derive which Commons POSTs are exceptions. The reason is written into a comment above each call.

**No full chat rebuild on a display-name edit** (`use-home-chat.ts`) — the startup effect listed `currentUser.displayName` as a trigger, but nothing in that path reads it (incoming messages carry their own sender name from the server). Editing a first name in Clerk therefore cleared every loaded message, re-issued the join, and restarted polling. The trigger is now the user id alone.

**Profile photo link checked before it is written into CSS** (`shell-right-rail.tsx`) — the avatar photo is drawn by interpolating the link into a `url("…")` rule, so a link containing a quote could end that string early and inject styles. Clerk's links are plain https and safe in practice, but the value is now checked rather than trusted: only http(s) is accepted, and the link is run through the URL parser, whose output percent-encodes quotes, converts backslashes, and drops control characters. A quote/backslash check on the result is a cheap backstop; anything unusable falls back to the existing initial monogram.

Worth noting for a later reader: the obvious fix here — `encodeURI` — is the wrong tool. It escapes `%`, so it corrupts any link that already contains a percent-escape. The parser's own output does the escaping correctly without double-encoding.

**Number-shortening helper states its guard** (`shell-format.ts`) — `if (!value)` caught a real `0` alongside a missing value. Output was already correct in both cases, so this is a contract fix, not a behavior fix: a missing or non-numeric value is now checked directly and a genuine `0` falls through to normal formatting. `NaN` is handled explicitly so it still renders `0` instead of the literal text "NaN". Every output is unchanged.

## Closed as not real

`flashTarget` in `shell-chat-panel.tsx` does not leak a trailing retry. The finding says a scheduled retry stays pending after a later attempt succeeds, but `tryScroll` only ever runs from the initial call or from the timer firing — and a timer that has fired is already finished, with no new one scheduled before the early return. There is never a live handle at the moment of success, so no extra invocation happens and the existing cleanup is correct. Closed with that explanation; no code change.

## Verified locally

Typecheck, lint, and build on `@ctf/web`; `check-eof-format.sh`; `check-inventory-drift.mjs`; `check-test-script-drift.mjs`. All pass. No routes, schema, contracts, or delivery status changed, so no inventory section needed an update.

## Lane

Two of these are in the security category, so per the review rules this is opened for owner review rather than auto-merge — even though nothing here changes a server-side gate and no change can loosen one.

Closes #2170
Closes #2171
Closes #2172
Closes #2174
Closes #2156

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1WtaDtrrD3wvYkFxhHUdB)_