### PR TITLE
fix: count a plugin open so the All Apps sort has something to order by

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -112,8 +112,8 @@ The Survivor Hub is the primary entry point of CTF for both unauthenticated visi
 3. Sort modes: **recent**, **alphabetical**, **most-used**. Selection persists in `localStorage` (`ctf.communityShell.pluginSortMode`).
 4. Recent-use tracking persists in `localStorage` (`ctf.communityShell.recentPluginSlugs`); capped at 12 entries.
 5. Most-used tracking persists in `localStorage` (`ctf.communityShell.pluginUsageCounts`).
-6. Sidebar in apps mode shows a flat searchable plugin list; selection sets the active app and updates recent/used counters.
-7. Search filters by name and summary.
+6. Both counters are recorded when the member opens a plugin from a card's "Open plugin →" link. Tapping the card body only highlights it and is not counted as a use.
+7. Search filters by name and summary. The search box sits in the apps grid header, not the sidebar.
 8. Cards link to `/apps/[slug]` for each plugin.
 
 ## Admin Features
@@ -212,6 +212,19 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
 
 ## Change Log
 
+- 2026-08-09: **All Apps sort had nothing to sort by, so Recent and Most Used both showed A-Z
+  (owner report).** The two counters that drive those orderings were only written by
+  `handleAppSelect`, which fires when a member taps a card body — and a card tap only highlights
+  the card, it does not open anything. The control a member actually uses, the card's
+  "Open plugin →" link, called `stopPropagation()` and recorded nothing. So
+  `ctf.communityShell.pluginUsageCounts` and `ctf.communityShell.recentPluginSlugs` stayed empty in
+  normal use, both modes fell through to their alphabetical tie-break, and all three sort options
+  produced the same order — the sort control looked dead even though it was applying. Recording now
+  happens on the link, in a new `handleAppOpen` passed down to `ShellAppsPanel` as `onAppOpen`;
+  `handleAppSelect` is left as highlight-only so a tap no longer inflates a plugin's count. The two
+  `localStorage` writes also moved out of the `setState` updater callbacks they were nested in, so
+  a double-invoked updater under React strict mode in development cannot write the count twice. No
+  route, schema, or contract change; web-only (the native app has no apps grid).
 - 2026-08-09: **Even spacing across the phone top bar, and the product name is back on it for
   signed-in members (owner report, follow-up to the icon tabs below).** Three different gaps ran
   across one row of identical squares: `.mobileBar` used 5px, `.mobileBarSections` used 4px between

--- a/ctf/packages/web/components/community-shell/community-shell.tsx
+++ b/ctf/packages/web/components/community-shell/community-shell.tsx
@@ -355,6 +355,7 @@ type ShellMainContentProps = {
   currentUser: ShellCurrentUser;
   activeApp: string | null;
   onAppSelect: (slug: string | null) => void;
+  onAppOpen: (slug: string) => void;
   sortMode: PluginSortMode;
   onSortModeChange: (mode: PluginSortMode) => void;
   query: string;
@@ -376,6 +377,7 @@ function ShellMainContent({
   currentUser,
   activeApp,
   onAppSelect,
+  onAppOpen,
   sortMode,
   onSortModeChange,
   query,
@@ -416,6 +418,7 @@ function ShellMainContent({
           plugins={filteredPlugins}
           activeApp={activeApp}
           onAppSelect={onAppSelect}
+          onAppOpen={onAppOpen}
           sortMode={sortMode}
           onSortModeChange={onSortModeChange}
           query={query}
@@ -607,21 +610,28 @@ export function CommunityShell(props: CommunityShellProps) {
     );
   }, [normalizedQuery, orderedPlugins]);
 
+  // Tapping a card only highlights it — it does not open anything — so it must not count as a use.
+  // Counting it did, which is why Most Used and Recent had no real data to order by: the link that
+  // actually opens a plugin stops propagation, so nothing was ever recorded and both modes fell
+  // back to the alphabetical tie-break, making the sort control look broken.
   const handleAppSelect = (slug: string | null) => {
     setActiveApp(slug);
-    if (!slug || typeof window === 'undefined') return;
+  };
 
-    setRecentPluginSlugs((previous) => {
-      const next = [slug, ...previous.filter((item) => item !== slug)].slice(0, MAX_RECENT_PLUGINS);
-      window.localStorage.setItem(RECENT_PLUGIN_STORAGE_KEY, JSON.stringify(next));
-      return next;
-    });
+  // Fired by the card's "Open plugin →" link — the real signal that a member used a plugin. The
+  // localStorage writes sit outside the state updaters so a double-invoked updater (React strict
+  // mode in development) cannot write twice and inflate the count.
+  const handleAppOpen = (slug: string) => {
+    setActiveApp(slug);
+    if (typeof window === 'undefined') return;
 
-    setPluginUsageCounts((previous) => {
-      const next = { ...previous, [slug]: (previous[slug] ?? 0) + 1 };
-      window.localStorage.setItem(PLUGIN_USAGE_COUNTS_STORAGE_KEY, JSON.stringify(next));
-      return next;
-    });
+    const nextRecent = [slug, ...recentPluginSlugs.filter((item) => item !== slug)].slice(0, MAX_RECENT_PLUGINS);
+    setRecentPluginSlugs(nextRecent);
+    window.localStorage.setItem(RECENT_PLUGIN_STORAGE_KEY, JSON.stringify(nextRecent));
+
+    const nextCounts = { ...pluginUsageCounts, [slug]: (pluginUsageCounts[slug] ?? 0) + 1 };
+    setPluginUsageCounts(nextCounts);
+    window.localStorage.setItem(PLUGIN_USAGE_COUNTS_STORAGE_KEY, JSON.stringify(nextCounts));
   };
 
   // Escape closes the contributor-channel explainer; listener attached only while open.
@@ -684,6 +694,7 @@ export function CommunityShell(props: CommunityShellProps) {
           currentUser={currentUser}
           activeApp={activeApp}
           onAppSelect={handleAppSelect}
+          onAppOpen={handleAppOpen}
           sortMode={sortMode}
           onSortModeChange={handleSortModeChange}
           query={query}

--- a/ctf/packages/web/components/community-shell/shell-apps-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-apps-panel.tsx
@@ -24,6 +24,10 @@ type ShellAppsPanelProps = {
   plugins: PluginRegistryItem[];
   activeApp: string | null;
   onAppSelect: (slug: string | null) => void;
+  // Called when the member actually opens a plugin (the "Open plugin →" link), as opposed to
+  // tapping the card to highlight it. This is the event the Recent and Most Used orderings are
+  // counted from, so it has to fire on the link — the card tap alone is not a use.
+  onAppOpen: (slug: string) => void;
   sortMode: PluginSortMode;
   onSortModeChange: (mode: PluginSortMode) => void;
   // Search now lives here (it used to be in the nav drawer). The grid is the single
@@ -32,7 +36,7 @@ type ShellAppsPanelProps = {
   onQueryChange: (q: string) => void;
 };
 
-export function ShellAppsPanel({ plugins, activeApp, onAppSelect, sortMode, onSortModeChange, query, onQueryChange }: ShellAppsPanelProps) {
+export function ShellAppsPanel({ plugins, activeApp, onAppSelect, onAppOpen, sortMode, onSortModeChange, query, onQueryChange }: ShellAppsPanelProps) {
   const { theme } = useTheme();
 
   return (
@@ -112,7 +116,12 @@ export function ShellAppsPanel({ plugins, activeApp, onAppSelect, sortMode, onSo
                 href={pluginHref}
                 className={styles.appCardAction}
                 style={{ color, borderColor: `${color}35`, background: `${color}15` }}
-                onClick={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  // Stop the card's own click handler from also toggling the highlight, but still
+                  // record the open so Recent and Most Used have something to order by.
+                  e.stopPropagation();
+                  onAppOpen(plugin.slug);
+                }}
               >
                 Open plugin →
               </Link>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

On the All Apps page, picking Recent, A-Z, or Most Used all produced the same alphabetical order, so the sort control looked dead. It was not — it was applying, but two of the three modes had nothing to order by.

Recent reads `ctf.communityShell.recentPluginSlugs` and Most Used reads `ctf.communityShell.pluginUsageCounts`. Both were written in one place only: `handleAppSelect`, which fires when a member taps a card body. A card tap only highlights the card — it does not open anything, and `activeApp` is used for nothing else. The control a member actually uses to open a plugin, the card's "Open plugin →" link, called `stopPropagation()` and recorded nothing.

So in normal use both stores stayed empty, and each mode fell through to its alphabetical tie-break. The screenshot that reported this shows Most Used selected with Beacon, Chyme, ClickLog listed — straight A-Z, exactly what an empty counter produces.

## What changed

- `shell-apps-panel.tsx`: a new `onAppOpen` prop. The "Open plugin →" link still stops propagation so it does not toggle the card highlight, but now also reports the open.
- `community-shell.tsx`: recording moved out of `handleAppSelect` into a new `handleAppOpen`, threaded down through `ShellMainContent`. `handleAppSelect` is now highlight-only, so a tap no longer inflates a plugin's count — a highlight is not a use.
- The two `localStorage` writes also moved out of the `setState` updater callbacks they were nested in. A double-invoked updater under React strict mode in development would otherwise write the count twice.

No route, schema, or contract change. The sort control, its three options, and the card layout are all untouched.

## Docs

`ctf-survivor-hub-chat-feature-inventory.md`: the Hub Apps list now states which event the counters record from, and a change-log entry records the fix. Two neighboring lines in that list were also out of date and corrected — they described a searchable plugin list in the sidebar, but the search box has moved into the apps grid header.

## Checks run locally

`typecheck` (all 6 workspace projects), web `lint`, web `build`, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-us-spelling.mjs`, `check-modularity-governance.sh`, `check-credits-money-language.mjs` — all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyQEw5NhiJuzqeKQWmVh2R)_