### PR TITLE
fix: give the signed-out Knowledge library page a way back

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -178,7 +178,10 @@ its plugin-routing role (today's hardcoded `getActionForText`) becomes Rasa-back
    contributor's Quora account and seeing a real person writing real things, which is the same look
    Unlock asks for — so gating it behind Unlock would review the same account twice. A **signed-out
    visitor gets a public landing page**, because this is the URL the invitation post links to from
-   Quora and most people opening it have no account yet.
+   Quora and most people opening it have no account yet. Both the signed-in and signed-out versions
+   carry the shared back control (rule 134): the signed-in shell through `MobileScreenHeader`, and
+   the public shell through the standalone `BackChevronButton` in its own header, since that
+   header's signed-in chrome would mean nothing to a visitor with no account.
    The path is `/knowledge`, deliberately **not**
    `/contribute` — the Contributions plugin is a different thing entirely (the fundraiser and donation
    surface), and two member-facing paths a word apart would be a standing source of confusion (owner
@@ -697,7 +700,20 @@ buckets are not reproduced — only real provenance (engine / intent / safety ca
 
 ## Change Log
 
-- 2026-08-05 (latest): **Knowledge-base curation admin shipped (closes the manual-curation gap).**
+- 2026-08-09 (latest): **The signed-out Knowledge library page had no way back (owner report).**
+  `comic-knowledge-public-shell.tsx` builds its own header — the BookOpen mark and the title — and
+  carried no back control at all, so a visitor who reached `/knowledge` from inside the app was
+  stranded there at phone width, where there is no browser back button in the installed web app.
+  This is the case rule 134 names outright as forbidden. The signed-in shell was never affected; it
+  gets its back control from `MobileScreenHeader`. Fixed by adding the shared `BackChevronButton`
+  to the left of the icon and title, tinted to the plugin accent and sized to match the header —
+  the same placement `mutual-time-public.tsx` already uses for a public shell with its own header.
+  `MobileScreenHeader` would have been the wrong piece here: its right-hand cluster is report-a-bug,
+  account settings, and the account menu, all of which are signed-in chrome a visitor with no
+  account cannot use. Back resolves through the shared `useSmartBack` — the previous in-app page
+  when there is one, the all-apps grid otherwise, and that grid renders for a signed-out visitor
+  too, so the fallback lands somewhere real. No route, schema, or contract change.
+- 2026-08-05: **Knowledge-base curation admin shipped (closes the manual-curation gap).**
   New page `/admin/comic/knowledge` (`comic-knowledge-admin.tsx`, linked from the `/admin` landing
   as "AI Knowledge Base") lists `comic_knowledge_entries` newest-first with source, type,
   title/question, a content snippet, and the active flag, filterable all/active/inactive with

--- a/ctf/docs/developer/test-scripts/comic-test-script.md
+++ b/ctf/docs/developer/test-scripts/comic-test-script.md
@@ -27,7 +27,11 @@ the tests worth running slowly.
 - Step 1 → the **public landing page**, not a redirect to sign-in. It says what the library is, what
   happens to your writing, that you can take it back, and that contributing also verifies you. This
   is the page the invitation post links to from Quora, so a visitor with no account has to be able to
-  read it and decide.
+  read it and decide. The page also carries the standard back chevron to the left of the title
+  (added 2026-08-09) — it looks and behaves like the one on every other screen, and on a phone it is
+  the only way back, since the installed web app has no browser back button. Reach the page from
+  inside the app and it returns you to the page you came from; open it cold from the Quora link and
+  it goes to the apps grid, which a signed-out visitor can also see.
 - Step 2 → the form loads. An unverified member is **not** turned away — contributing is the way in,
   not something behind the gate.
 - Step 3 → send is blocked until the profile field is filled; the receipt then says the Quora profile

--- a/ctf/packages/web/components/comic/comic-knowledge-public-shell.tsx
+++ b/ctf/packages/web/components/comic/comic-knowledge-public-shell.tsx
@@ -2,6 +2,7 @@
 
 import { BookOpen, ShieldCheck, PenLine, KeyRound } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
+import { BackChevronButton } from '@/lib/nav/back-history';
 import { getComicTokens } from './comic-shared';
 
 // The signed-out landing page for the knowledge library.
@@ -21,7 +22,15 @@ export function ComicKnowledgePublicShell({ signInUrl }: { signInUrl: string }) 
   return (
     <main style={{ minHeight: '100dvh', background: t.BG, color: t.TITLE, fontFamily: "'Inter',system-ui,sans-serif" }}>
       <div style={{ maxWidth: 720, margin: '0 auto', padding: '32px 16px 56px' }}>
+        {/* This shell builds its own header rather than using MobileScreenHeader, whose right-hand
+            cluster (report a bug, account settings, the account menu) is all signed-in chrome that
+            means nothing to a visitor with no account. So the way back is the shared standalone
+            chevron, which is what rule 134 prescribes for exactly this shape of screen — never a
+            hand-rolled arrow or "Back to …" link. It returns to the previous in-app page when there
+            is one, and to the all-apps grid otherwise; that grid renders for a signed-out visitor
+            too, so the fallback lands somewhere real. */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+          <BackChevronButton accent={t.ACCENT} size={34} />
           <BookOpen size={22} color={t.ACCENT} />
           <h1 style={{ fontSize: 24, fontWeight: 800, margin: 0 }}>Knowledge library</h1>
         </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

The signed-out `/knowledge` page had no back control at all. `comic-knowledge-public-shell.tsx` builds its own header — the book mark and the "Knowledge library" title — and nothing else was in that row, so a visitor who reached the page from inside the app was stranded on it at phone width, where the installed web app has no browser back button. Rule 134 names a screen with no way back as forbidden outright.

The signed-in shell was never affected — it gets its back control from `MobileScreenHeader`. Only the public shell was missing one.

## What changed

Added the shared `BackChevronButton` to the left of the icon and title, tinted to the plugin accent and sized to match the header. This is the placement `mutual-time-public.tsx` already uses for a public shell that builds its own header, so the control looks and sits where members find it on every other screen.

`MobileScreenHeader` would have been the wrong shared piece here: its right-hand cluster is report-a-bug, account settings and the account menu, all of which are signed-in chrome that a visitor with no account cannot use. Rule 134 prescribes the standalone chevron for exactly this shape of screen.

Back resolves through the shared `useSmartBack`, so nothing about the destination is hand-rolled: the previous in-app page when there is one, the all-apps grid otherwise. That grid renders for a signed-out visitor too, so the fallback lands somewhere real rather than bouncing an account-less visitor into a sign-in form.

No route, schema, or contract change. The page's copy, cards, and join button are untouched.

## Docs

- `ctf-comic-feature-inventory.md`: the `/knowledge` entry now records that both versions of the page carry the shared back control and which piece each uses, plus a change-log entry.
- `comic-test-script.md`: step 1 of CMC-C0 now checks for the back chevron and states where it goes in each of the two arrival cases.

## Checks run locally

`typecheck` (all 6 workspace projects), web `lint`, web `build`, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-us-spelling.mjs`, `check-modularity-governance.sh` — all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyQEw5NhiJuzqeKQWmVh2R)_