### PR TITLE
fix: retire the Survivor Hub name and delete the SH avatar glyph

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -24,7 +24,7 @@
 > surfaces live in `ctf-feed-feature-inventory.md` /
 > `ctf-survivor-hub-chat-feature-inventory.md`.
 >
-> **`@comic` already exists** as a defined persona in the Survivor Hub inventory (a
+> **`@comic` already exists** as a defined persona in the Commons (Hub Home) inventory (a
 > hub-owned assistive bot that introduces survivor stories, gives onboarding nudges, and
 > routes users to plugins). This document **extends** that persona from a navigation
 > router into a **conversational Q&A assistant** backed by Rasa + Ollama. It does not
@@ -125,7 +125,7 @@ design that this plan unifies:
    client-side `getActionForText()` keyword→plugin navigation (`ctf-home-bot`, "I'm still
    learning…" fallback, localStorage history). **Navigation only, not Q&A.** The Hub
    consolidation already calls for replacing this hardcoded router with Feed-backed data.
-4. **`@comic` persona + `hub_bots` design** — defined in the Survivor Hub inventory
+4. **`@comic` persona + `hub_bots` design** — defined in the Commons (Hub Home) inventory
    (persona, `hub_bots` table, deterministic seed, DM wiring). **But** the consolidation
    dropped the `hub_*` tables and **none exist in schema** — so the persona is real, its
    backing tables are not.
@@ -133,7 +133,7 @@ design that this plan unifies:
 ## Scope and Boundary
 
 - Subsystem name: `comic`. Bot handle: `@comic`.
-- Surfaced inside: the unified Hub/Feed chat (web `/apps/feed` → Survivor Hub homepage;
+- Surfaced inside: the unified Hub/Feed chat (web `/apps/feed` → the Commons homepage;
   Android `packages/mobile/src/features/feed`).
 - Owned data layer: `comic_*` conversation/training/rating tables + (target) a Rasa tracker
   store. `llm_inference_log` and `feed_answer_ratings` are **not** reused (their FKs target the

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -79,7 +79,7 @@ Architecture decisions in effect:
 1. Community support posts for peer-to-peer engagement (general, peer support, resource sharing, events).
 2. Threaded replies on community posts.
 3. Content moderation and rate limiting on post creation. Members are capped at 1,200 characters and 3 links per post (anti-spam in the publicly-readable Commons); admins get a higher cap (4,000 characters, 20 links) so the owner's detailed welcome/help posts are not blocked. The raw-HTML (`<>`) block applies to everyone.
-4. The Commons (Survivor Hub home chat) now opens a live Stream connection to this channel's `ctf-feed-community` Stream channel for real-time updates and typing indicators. `POST /api/hub/join` mints the credentials via `getFeedStreamCredentials(userId, displayName, 'community')` — the same channel and Stream identity (`feed-<userId>`) the Questions/Community Stream surfaces use. The post data itself stays in `feed_community_posts` (our database); Stream is the real-time signal only. See the Commons live-layer entry in `ctf-survivor-hub-chat-feature-inventory.md` and the quota note `ctf/docs/quota-impact/2026-06-21-commons-live-stream-layer.md`.
+4. The Commons (the hub home chat) now opens a live Stream connection to this channel's `ctf-feed-community` Stream channel for real-time updates and typing indicators. `POST /api/hub/join` mints the credentials via `getFeedStreamCredentials(userId, displayName, 'community')` — the same channel and Stream identity (`feed-<userId>`) the Questions/Community Stream surfaces use. The post data itself stays in `feed_community_posts` (our database); Stream is the real-time signal only. See the Commons live-layer entry in `ctf-survivor-hub-chat-feature-inventory.md` and the quota note `ctf/docs/quota-impact/2026-06-21-commons-live-stream-layer.md`.
 
 ### 1.5 Membership-Aware Personalization
 
@@ -351,6 +351,19 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 ## 11) Change Log
 
+- 2026-08-09: **Official posts are signed with the operator's name, and the "SH" avatar is gone
+  (owner decision).** `hubMessageAuthor` in `app/api/hub/messages/route.ts` labeled every
+  non-community item "Survivor Hub" — an institution's name over first-person writing. It now reads
+  the shared `OFFICIAL_SENDER_LABEL` (`lib/hub/constants.ts`), which is **Farah**, the operator,
+  matching how Beacon already names her publicly. The same constant backs the
+  `shell-chat-panel.tsx` sender fallback and the Stream system user in
+  `lib/contributor-access/gated-channel.ts`, so the official identity cannot drift between them.
+  Whether a post is official is still carried by the shield badge on the announcement card, not by
+  the name. The hardcoded **"SH"** avatar is deleted rather than renamed: `avatarFromSender` and the
+  announcement card both take the first letter of whatever name they are given, so no house glyph
+  can disagree with the name printed beside it. AI answers are unaffected — they render through
+  their own card branch and never used this label. Copy-and-label only: no route, schema, or
+  contract change.
 - 2026-08-05: **Member blocks enforced on the Commons timeline (issue #809 task 4).**
   `listFeedTimeline` now leaves out community posts authored by a member who is blocked (either
   direction) relative to the viewer, and the replies batch-loader applies the same filter, so a

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-notifications-feature-inventory.md
@@ -144,7 +144,7 @@ No seed yet. A follow-up seed can insert a couple of sample notifications for a 
 - 2026-07-22: Deep links now reach messages older than the recent page. The Commons only loaded the
   recent page, so an "Open" to an older message landed without the flash. `GET /api/hub/messages` gained
   `aroundPost` / `aroundAnnouncement` params that return a page centered on the target, and the Commons
-  merges that window in alongside the recent page before scrolling to it. See the Survivor Hub / Commons
+  merges that window in alongside the recent page before scrolling to it. See the Commons
   inventory for the mechanism.
 - 2026-07-21: Deep links on "Open". Commons notifications now link to the exact message instead of the
   Commons home. A reply or @mention links to `/?post=<postId>` and an announcement reply to

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md
@@ -1,4 +1,4 @@
-# Survivor Hub Feature Inventory (CTF Rewrite)
+# Commons (Hub Home) Feature Inventory (CTF Rewrite)
 
 ## Consolidation Decision (2026-05-31): Survivor Hub absorbs Feed
 
@@ -49,7 +49,7 @@
 
 - Rewrite target only: `ctf/`. Legacy `platform/` is reference-only.
 - Plugin slug: `hub` (the homepage at `/`; not a separately navigable app tile).
-- Hub owns the unified Survivor Hub home/landing experience: app shell, the single blended
+- Hub owns the unified Commons home/landing experience: app shell, the single blended
   `community` channel, live hero stats, and the plugin grid.
 - Data layer: the Hub channel is backed by the Feed model (`feed_items` + `lib/feed/inference.ts`)
   as the single source of truth — see the Consolidation Decision above. The Hub does not own a
@@ -59,7 +59,7 @@
 
 ## Intent and Outcome
 
-The Survivor Hub is the primary entry point of CTF for both unauthenticated visitors and authenticated survivors. It provides the home shell, one blended publicly-viewable `community` channel (interleaving admin-only announcements, AI Q&A, and peer-to-peer community posts), the live hero stats, and the plugin grid. Hub is the canonical "home" route at `/`; opening a plugin moves the user into that plugin's own scope. This is deliberately not social media: peer-to-peer posting is the only user-authored surface, kept economy-scoped. Separate channels, direct messages, and system bots are deferred (see Gaps) — the MVP is one channel.
+The Commons is the primary entry point of CTF for both unauthenticated visitors and authenticated survivors. It provides the home shell, one blended publicly-viewable `community` channel (interleaving admin-only announcements, AI Q&A, and peer-to-peer community posts), the live hero stats, and the plugin grid. Hub is the canonical "home" route at `/`; opening a plugin moves the user into that plugin's own scope. This is deliberately not social media: peer-to-peer posting is the only user-authored surface, kept economy-scoped. Separate channels, direct messages, and system bots are deferred (see Gaps) — the MVP is one channel.
 
 ## User Features
 
@@ -68,7 +68,7 @@ The Survivor Hub is the primary entry point of CTF for both unauthenticated visi
 1. Four-column layout on `/apps`: icon rail (72px), left sidebar (240px), main content (flex), right rail (280px).
 2. Section toggle between **Chat** and **Apps** controlled by icon rail buttons; section state is shell-local.
 3. Right rail renders auth-provider username/display name for signed-in users and a sign-in CTA for unsigned visitors.
-4. Right rail "About Survivor Hub" section with chat-first copy that points members to ask in the chat (no plugin-count framing).
+4. Right rail "About Skills Economy" section with chat-first copy that points members to ask in the chat (no plugin-count framing).
 5. Right rail no longer shows a "Ready/Active Apps" list (removed 2026-06-18) — apps are reached via the Apps section; the "· N ready apps" line was also dropped from the signed-in profile card.
 6. Sign-in and Create-Account CTAs visible in icon rail and right rail for unsigned visitors.
 7. Hero banner ("Free to join · End-to-end encrypted") visible to unsigned visitors.
@@ -78,12 +78,12 @@ The Survivor Hub is the primary entry point of CTF for both unauthenticated visi
 ### Hub Chat (the blended `community` channel)
 
 1. Hero banner with live stats from the platform-owned GDP snapshot table: member count, GDP value (USD), opportunity value (target GDP minus current GDP).
-2. Hero banner copy adapts: "Welcome to Survivor Hub" for unsigned visitors; "Good morning, {displayName} — your network is active." for signed-in users.
+2. Hero banner copy adapts: "Welcome to Skills Economy" for unsigned visitors; "Good morning, {displayName} — your network is active." for signed-in users.
 3. One blended stream interleaving admin-only announcements, AI Q&A answers, and peer-to-peer community posts. History loaded via `GET /api/hub/messages` (backed by `listFeedTimeline` over `feed_items`), polled while the shell is mounted.
 4. Sending from the input creates a peer-to-peer community post via `POST /api/hub/messages` (backed by `createFeedCommunityPost`, CSRF-guarded); dedup on display by `(from, sender, text, time)` tuple.
 5. AI Q&A uses the Feed inference pipeline (`lib/feed/inference.ts`, consent-gated). The hardcoded `getActionForText()` keyword routing has been **removed** (2026-07-16): it was wrongly attaching an "Open <Plugin>" action button to any peer post whose body happened to contain a keyword like "economy"/"housing", making it look as if the author had linked a plugin. Action buttons now come only from an explicit source — the local concierge reply sets its own `actionLabel`/`actionSlug`; a peer community post never carries an inferred action, and members cannot attach one.
 6. One-tap suggestion chips render persistently above the composer (whether or not the chat already has messages). Each chip's behavior is explicit (`lib/concierge/hub-suggestions.ts`), so a tap always does the right thing and never merely pre-fills the composer (#471): a **navigate** chip ("Show housing options" → LightHouse, "Open the provider directory" → Foundation, "Browse the skills directory" → Directory, "Check my Service Credits" → ServiceCredits) opens that plugin directly (`/apps/<slug>`) — it is an action, not a question; an **ask** chip ("What is the GDP tracker showing this week?") routes the question to the `@comic` AI assistant via `askComic`, which prepends the `@comic` mention (the server only routes a mentioned body) and shows the "Reviewing for safety" pending card immediately, then the human-approved answer when it is ready. The local keyword concierge (`lib/concierge/resolver`, `sendConciergeAsk`) remains available for free-text asks but no longer backs the visible chip row.
-7. Announcements render as official Survivor Hub items; community posts render with their author.
+7. Announcements render as official items on their own card, signed with the operator's name (Farah, `OFFICIAL_SENDER_LABEL` in `lib/hub/constants.ts`) and marked official by the shield badge — the name says who wrote it, the badge says it is official. Community posts render with their author. Every avatar glyph, official or peer, is the first letter of that sender's name; there is no fixed house glyph.
 8. Connection state visible as footer status (connecting, live, fallback).
 9. Unsigned visitors see a sign-in gate in place of the input; the channel itself is publicly readable when `feed_render_config.is_public` is TRUE (public read enforcement is a tracked follow-up). The gate is one short line under the posts explaining that signing in — free — is what lets you post, reply, and reach housing, work, and safety resources. It carries no button of its own: signing in is the "Sign in" button in the top bar (and the outline "Sign In" in the right rail on wide screens), so the hero, the posts, and that line fit on one screen (2026-08-03).
 10. Signal-style quoted reply: each peer message shows a small "Reply" affordance. Tapping it sets the composer's "Replying to …" banner (a one-line quote preview + cancel X); sending while it is set posts the message with `replyToPostId` so it stores and renders a compact quoted block (author + ~120-char snippet) above its body. Backed by `feed_community_posts.reply_to_post_id`; the quote is resolved server-side into `HubMessage.quotedMessage`.
@@ -141,7 +141,7 @@ Feed routes that own the data layer remain under `/api/feed/*` (timeline, announ
 
 Web entry routes:
 
-- `GET /` — Survivor Hub home page (Next.js `app/page.tsx`, `CommunityShell` chat section).
+- `GET /` — Commons home page (Next.js `app/page.tsx`, `CommunityShell` chat section).
 - `GET /apps` — Hub home, Apps section (`app/apps/page.tsx`).
 
 ## Data Model and Storage Contracts
@@ -181,7 +181,7 @@ The previously-specified `hub_channels` / `hub_bots` / `hub_bot_routes` / `hub_d
   channel from `GET /api/hub/messages` (the same feed-backed timeline the web Hub uses, flattened to
   the `HubMessage` shape) and sends a peer-to-peer community post via `POST /api/hub/messages` with
   the `x-ctf-csrf: 1` header, mirroring the web CSRF handling. `HubHome` is the default surface in
-  the mobile app shell. Announcements render with the official Survivor Hub treatment; community
+  the mobile app shell. Announcements render with the official announcement treatment; community
   posts render with their author. The dead GetStream-based survivor-hub-chat mobile fixtures were
   removed. The single AI Assistant (`@comic`) surfaces — answer cards, the "Reviewing for safety"
   pending card, the `@comic` composer, consent, and ratings — are delivered separately in the comic
@@ -212,6 +212,26 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
 
 ## Change Log
 
+- 2026-08-09 (latest): **"Survivor Hub" retired as a name, and the "SH" avatar glyph is gone
+  (owner decision).** The name was doing two unrelated jobs and was wrong at both. As the signature
+  on official posts it was an institution's name over first-person writing ("I will be hosting a
+  live Q&A"), which reads as an institution performing a personal voice. As a stand-in for the
+  product — "unlock full access to Survivor Hub", "one identity across Survivor Hub", "Survivor Hub
+  apps", "self-hosted inside Survivor Hub" — it named something that is not in the brand hierarchy
+  at all; the product is Skills Economy.
+  Official posts are now signed **Farah**, the operator, from the single shared
+  `OFFICIAL_SENDER_LABEL` in `lib/hub/constants.ts` (used by `app/api/hub/messages/route.ts`, the
+  `shell-chat-panel.tsx` fallback, and the Stream system user in
+  `lib/contributor-access/gated-channel.ts`), matching how Beacon already names her publicly.
+  Whether a post is official stays with the shield badge, not the name. Product-name copy became
+  **Skills Economy** across the account-data, Unlock, account hub, AI-consent and Chyme
+  lock-screen surfaces on both web and mobile.
+  The hardcoded **"SH"** avatar is deleted rather than renamed: both `avatarFromSender` and the
+  announcement card now take the first letter of whatever name they are given, so the avatar can
+  never disagree with the name beside it and there is no house glyph left to go out of date.
+  AI answers are untouched — they render through their own card and keep their own identity, so a
+  person is never credited with text a bot wrote. No route, schema, or contract change (the
+  `schema.sql` edits are comment-only, with `schema.demo.sql` regenerated).
 - 2026-08-09: **All Apps sort had nothing to sort by, so Recent and Most Used both showed A-Z
   (owner report).** The two counters that drive those orderings were only written by
   `handleAppSelect`, which fires when a member taps a card body — and a card tap only highlights
@@ -389,7 +409,7 @@ There is no `seedHub.mjs`; the Hub channel's data layer is seeded by the Feed se
 ### Scope
 
 - Rewrite target: `ctf/packages/web`, `ctf/packages/mobile`, `ctf/schema.sql`, `ctf/docs/contracts`.
-- Surface: Survivor Hub home experience (`community-shell` + supporting APIs and schema).
+- Surface: Commons home experience (`community-shell` + supporting APIs and schema).
 - Canonical spec: `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-survivor-hub-chat-feature-inventory.md`.
 - Hub has no cross-plugin runtime dependency. See [112-platform-architecture-rules.mdc](../../../../.claude/rules/112-platform-architecture-rules.mdc).
 - 100% web↔Android parity is the baseline. See [105-web-android-feature-parity-rules.mdc](../../../../.claude/rules/105-web-android-feature-parity-rules.mdc). No phased rollouts.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -199,6 +199,11 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 
 ## 9) Change Log
 
+- 2026-08-09: **"Survivor Hub" retired from the Unlock copy (owner decision).** The web submission
+  view said "To unlock full access to Survivor Hub", and the mobile screen said "Survivor Hub uses
+  Quora profile verification". Both now say **Skills Economy** — the product's actual name in the
+  brand hierarchy, which "Survivor Hub" never was. This finishes the sweep the 2026-08-03 approved-
+  card fix started on this surface. Copy only; no route, schema, or contract change.
 - 2026-08-03: **Approved card drops "Hub" (owner report).** The verification approved card said
   "Welcome to the Survivor Hub!" with a "Continue to Hub" button. Per the brand lexicon, the card
   title now reads "Welcome to Skills Economy (SE)" (the first-meeting form of the product name,

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -26,7 +26,7 @@
 
 1. **Seed is clean.** Run `pnpm --dir ctf seed:demo`. Confirm the command exits without errors and the app starts. web ☐
 
-2. **Commons home loads.** Sign in as a member. Navigate to the Survivor Hub home. The feed timeline renders with at least one item (announcement, question, or community post) and no unhandled error is shown. web ☐
+2. **Commons home loads.** Sign in as a member. Navigate to the Commons home. The feed timeline renders with at least one item (announcement, question, or community post) and no unhandled error is shown. web ☐
 
 3. **Admin page loads.** Sign in as an admin. Navigate to `/admin/feed-announcements`. The page renders with a feed config panel and an announcement list. No 404 or 500. web ☐
 
@@ -44,7 +44,7 @@
 **Precondition:** Signed in as a member. Seed has run (`pnpm --dir ctf seed:demo`).
 
 **Steps:**
-1. Navigate to the Survivor Hub home (the Commons).
+1. Navigate to the Commons home.
 2. Observe the default feed — all channels.
 3. Use the channel filter to switch to **Announcements**.
 4. Switch to **Questions**.
@@ -96,6 +96,8 @@
 2. Confirm the card uses the accent color `#84CC16` and Lucide icons (Megaphone or equivalent), not emoji icons.
 3. Confirm there is no "GetStream ⚡" badge anywhere on the card.
 4. If the announcement has a linked plugin slug, confirm the card body contains an "Open \<Plugin\>:" link pointing to `https://app.chargingthefuture.com/apps/<slug>`.
+5. Confirm the name on the card reads **Farah** — not "Survivor Hub" — and that the shield "Official" badge still sits beside it (added 2026-08-09). The name says who wrote it, the badge says it is official; both must be present.
+6. Confirm the round avatar on the card reads **F**, the first letter of that name, and that no card anywhere in the stream shows the old fixed **SH** glyph. Scroll a peer post into view and confirm its avatar is likewise the first letter of its author's handle.
 
 **Expected:**
 - Card matches the design spec: `#84CC16` accent, Lucide icons, no badge.
@@ -405,7 +407,7 @@
 **Precondition:** Signed out completely.
 
 **Steps:**
-1. Navigate to the Survivor Hub home (or call `GET /api/feed/public/community`).
+1. Navigate to the Commons home (or call `GET /api/feed/public/community`).
 2. Observe what is shown.
 3. Send more than 30 requests to `GET /api/feed/public/community` within one minute from the same IP.
 

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -119,6 +119,9 @@ not see this banner. On android the client Unlock gate lets a treatment member t
    home page (`/`), not the plugin navigator (`/apps`).
 4. On android, confirm the same "Welcome to Skills Economy (SE)" title (that card has no continue
    button).
+5. Before approval, on the submission screen: confirm the explanation says "To unlock full access to
+   Skills Economy" on web, and "Skills Economy uses Quora profile verification" on android — neither
+   should say "Survivor Hub" (name retired 2026-08-09).
 **Expected:** The approved card welcomes the member to Skills Economy (SE) and the web continue
 button goes to the Commons home so the label matches the destination. No "Hub" wording anywhere on
 the card.

--- a/ctf/packages/mobile/src/features/account-data/AccountData.tsx
+++ b/ctf/packages/mobile/src/features/account-data/AccountData.tsx
@@ -600,7 +600,7 @@ function EmptyState({ s, hasRetained }: { s: Styles; hasRetained: boolean }) {
       </View>
       <Text style={s.emptyTitle}>No personal data stored yet</Text>
       <Text style={s.emptySub}>
-        As you use Survivor Hub apps, any personal data they hold will appear here for you to see
+        As you use Skills Economy apps, any personal data they hold will appear here for you to see
         and delete.
       </Text>
       {hasRetained ? (

--- a/ctf/packages/mobile/src/features/unlock/Unlock.tsx
+++ b/ctf/packages/mobile/src/features/unlock/Unlock.tsx
@@ -89,7 +89,7 @@ function PublicView({ s, t, accent }: { s: Styles; t: ThemeTokens; accent: strin
         <Text style={{ color: accent }}>the verification process</Text>
       </Text>
       <Text style={[s.bodyText, { marginBottom: 20 }]}>
-        Survivor Hub uses Quora profile verification to confirm members are real people. This protects the community.
+        Skills Economy uses Quora profile verification to confirm members are real people. This protects the community.
       </Text>
       {[
         { n: '1', title: 'Create a free account', desc: 'Sign up in 60 seconds.' },

--- a/ctf/packages/web/app/api/hub/messages/route.ts
+++ b/ctf/packages/web/app/api/hub/messages/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { reportError } from 'lib/observability/report';
 import type { HubMessagesResponse, HubMessage } from 'lib/hub/types';
+import { OFFICIAL_SENDER_LABEL } from 'lib/hub/constants';
 import type { FeedTimelineItem } from 'lib/feed/types';
 import {
   FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH,
@@ -21,9 +22,9 @@ import { requireHubAccess } from '../_lib';
 import { ensureMutationCsrf } from '../../feed/_lib';
 import { failureReason } from 'lib/errors/failure';
 
-// Survivor Hub consolidation: the Hub home channel is backed by the Feed model
-// (feed_items) as the single source of truth. The channel is one blended stream
-// interleaving admin announcements, AI Q&A, and peer-to-peer community posts.
+// The Commons home channel is backed by the Feed model (feed_items) as the single source of truth.
+// The channel is one blended stream interleaving admin announcements, AI Q&A, and peer-to-peer
+// community posts.
 
 function hubMessageAuthor(
   item: FeedTimelineItem,
@@ -32,10 +33,10 @@ function hubMessageAuthor(
   const userId = isCommunity ? item.community?.authorUserId ?? 'hub-system' : 'hub-system';
   // This route is gated to signed-in members, so a peer post leads with the
   // author's @username when we captured it at post time. Posts created before
-  // usernames were stored (and official announcements/AI answers) fall back to
-  // the pseudonymous "Community member" / "Survivor Hub" labels.
+  // usernames were stored fall back to the pseudonymous "Community member" label; official
+  // announcements are signed with the operator's name (see OFFICIAL_SENDER_LABEL).
   const username = isCommunity ? item.community?.authorUsername ?? null : null;
-  const displayName = isCommunity ? feedAuthorHandle(username, userId) : 'Survivor Hub';
+  const displayName = isCommunity ? feedAuthorHandle(username, userId) : OFFICIAL_SENDER_LABEL;
   return { userId, username, displayName };
 }
 

--- a/ctf/packages/web/components/account-data/account-data-desktop.tsx
+++ b/ctf/packages/web/components/account-data/account-data-desktop.tsx
@@ -84,7 +84,7 @@ export function AccountDataDesktop({
           <Shield size={18} color={BRAND} />
           <div style={{ flex: 1 }}>
             <div style={{ fontSize: 15, fontWeight: 600, color: TEXT }}>Your Data &amp; Privacy</div>
-            <div style={{ fontSize: 12, color: SUBTLE }}>See and delete the data Survivor Hub holds across all services</div>
+            <div style={{ fontSize: 12, color: SUBTLE }}>See and delete the data Skills Economy holds across all services</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
             <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', color: SUBTLE, textTransform: 'uppercase' }}>Theme</span>
@@ -208,7 +208,7 @@ function EmptyState({ retained, tokens }: { retained: AccountService[]; tokens: 
       </div>
       <div style={{ fontSize: 22, fontWeight: 800, color: TEXT, marginBottom: 8 }}>No personal data stored yet</div>
       <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7, maxWidth: 480, marginBottom: 28 }}>
-        As you use Survivor Hub apps, any personal data they hold will appear here — where you can see it and delete it on your own terms.
+        As you use Skills Economy apps, any personal data they hold will appear here — where you can see it and delete it on your own terms.
       </div>
       {retained.length > 0 ? (
         <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 16px', borderRadius: 12, background: `${BRAND}05`, border: `1px solid ${BRAND}15`, maxWidth: 560, width: '100%', textAlign: 'left' }}>

--- a/ctf/packages/web/components/account-data/account-data-mobile.tsx
+++ b/ctf/packages/web/components/account-data/account-data-mobile.tsx
@@ -246,7 +246,7 @@ function MobileEmpty({ retained, tokens }: { retained: AccountService[]; tokens:
       </div>
       <div style={{ fontSize: 19, fontWeight: 800, color: TEXT, marginBottom: 8 }}>No personal data stored yet</div>
       <div style={{ fontSize: 13, color: SUBTLE, lineHeight: 1.6, marginBottom: 20 }}>
-        As you use Survivor Hub apps, any personal data they hold will appear here for you to see and delete.
+        As you use Skills Economy apps, any personal data they hold will appear here for you to see and delete.
       </div>
       {retained.length > 0 ? (
         <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '12px', borderRadius: 12, background: `${BRAND}05`, border: `1px solid ${BRAND}15`, width: '100%', textAlign: 'left' }}>

--- a/ctf/packages/web/components/account/account-hub-shell.tsx
+++ b/ctf/packages/web/components/account/account-hub-shell.tsx
@@ -43,7 +43,7 @@ export function AccountHubShell({ username, trust }: { username: string | null; 
           <header style={{ marginBottom: 24 }}>
           <h1 style={{ fontSize: 24, fontWeight: 800, margin: '0 0 6px' }}>Your account</h1>
           <p style={{ fontSize: 14, color: tok.SUBTLE, lineHeight: 1.6, margin: 0 }}>
-            You have one identity across Survivor Hub. Here is everywhere it shows up — update each part where it lives.
+            You have one identity across Skills Economy. Here is everywhere it shows up — update each part where it lives.
           </p>
         </header>
 

--- a/ctf/packages/web/components/chyme/use-audio-call-keep-alive.ts
+++ b/ctf/packages/web/components/chyme/use-audio-call-keep-alive.ts
@@ -73,7 +73,7 @@ export function useAudioCallKeepAlive(active: boolean, title = 'Chyme audio room
     const mediaSession = typeof navigator !== 'undefined' ? navigator.mediaSession : undefined;
     if (mediaSession && typeof MediaMetadata !== 'undefined') {
       try {
-        mediaSession.metadata = new MediaMetadata({ title, artist: 'Survivor Hub' });
+        mediaSession.metadata = new MediaMetadata({ title, artist: 'Skills Economy' });
         mediaSession.playbackState = 'playing';
       } catch {
         // Some browsers throw on unsupported metadata fields — ignore.

--- a/ctf/packages/web/components/community-shell/announcement-card.tsx
+++ b/ctf/packages/web/components/community-shell/announcement-card.tsx
@@ -11,8 +11,9 @@ import styles from './community-shell.module.css';
 import { NoticeParagraphs } from './notice-paragraphs';
 
 type AnnouncementCardProps = {
-  // The posting authority — almost always "Survivor Hub". Passed in so the card matches whatever
-  // label the stream resolved rather than hardcoding it.
+  // Who posted it — the operator's name for an official announcement. Passed in so the card matches
+  // whatever label the stream resolved rather than hardcoding it. Whether the post is official is
+  // carried by the shield badge, not by this name.
   senderName: string;
   // The announcement heading, shown bold above the body. Null when the announcement has no title.
   title: string | null;
@@ -198,7 +199,14 @@ function AnnouncementEngagement({
   );
 }
 
-// Official Survivor Hub announcement, rendered as a distinct card (emerald treatment, shield
+// First letter of whoever posted the announcement, for the card's round avatar.
+function announcementAvatarGlyph(senderName: string): string {
+  const trimmed = senderName.trim();
+  const handle = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
+  return handle.charAt(0).toUpperCase() || '?';
+}
+
+// Official announcement, rendered as a distinct card (emerald treatment, shield
 // "Official" badge) so it stands out from peer chat bubbles and AI answers instead of blending into
 // the purple stream. Members can react to an announcement with the same fixed emoji quick set as a
 // peer post, and reply to it — the replies group under the announcement as a thread (loaded on
@@ -284,7 +292,9 @@ export function AnnouncementCard({
       data-announcement-id={announcementId ?? undefined}
     >
       <div className={styles.announcementHead}>
-        <div className={styles.announcementAvatar} aria-hidden="true">SH</div>
+        {/* Derived from the sender's name rather than a fixed pair of letters, so the avatar can
+            never disagree with the name printed beside it (it used to read a hardcoded "SH"). */}
+        <div className={styles.announcementAvatar} aria-hidden="true">{announcementAvatarGlyph(senderName)}</div>
         <div className={styles.announcementHeadText}>
           <div className={styles.announcementTitleRow}>
             <span className={styles.announcementName}>{senderName}</span>

--- a/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
+++ b/ctf/packages/web/components/community-shell/comic-consent-modal.tsx
@@ -14,7 +14,7 @@ type ComicConsentModalProps = {
 // First-use AI-processing consent (the llm_consent_granted gate). Translated from the locked
 // design's AIConsent mockup into the app's CSS-module approach. Self-hosted, no third parties.
 const POINTS = [
-  { icon: Server, title: 'Runs on our own servers', desc: 'The AI Assistant is self-hosted inside Survivor Hub. Your questions never leave our infrastructure.' },
+  { icon: Server, title: 'Runs on our own servers', desc: 'The AI Assistant is self-hosted inside Skills Economy. Your questions never leave our infrastructure.' },
   { icon: EyeOff, title: 'No third parties', desc: "We don't send your messages to outside AI companies, advertisers, or data brokers — ever." },
   { icon: ShieldCheck, title: 'A teammate reviews answers', desc: 'Sensitive answers are checked by a trained human before they reach you.' },
   { icon: Lock, title: 'Your safety comes first', desc: 'The assistant will never reveal your location or identity, or ask you to.' },

--- a/ctf/packages/web/components/community-shell/community-shell.module.css
+++ b/ctf/packages/web/components/community-shell/community-shell.module.css
@@ -527,7 +527,7 @@
   background: rgba(14, 165, 233, 0.18);
 }
 
-/* Official Survivor Hub announcement card. Emerald treatment + a left accent + a shield "Official"
+/* Official announcement card. Emerald treatment + a left accent + a shield "Official"
    badge so an official post reads as a distinct, must-see message instead of blending into the
    purple peer bubbles or the cyan AI card. Mirrors the comic card's header structure. */
 .announcementCard {
@@ -2105,7 +2105,7 @@
 }
 
 /* ─── AI Assistant (@comic) — answered card ──────────────────────────────── */
-/* Translated from the locked Survivor Hub design (cyan #0EA5E9 accent, Sparkles, AI Q&A badge). */
+/* Translated from the locked Commons design (cyan #0EA5E9 accent, Sparkles, AI Q&A badge). */
 .comicCard {
   margin-bottom: 16px;
   padding: 20px;

--- a/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
+++ b/ctf/packages/web/components/community-shell/shell-chat-panel.tsx
@@ -27,14 +27,16 @@ import type { HubSuggestionChip } from '../../lib/concierge/hub-suggestions';
 import styles from './community-shell.module.css';
 import { feedPostLength } from '../../lib/feed/normalize';
 import { FEED_ADMIN_MAX_COMMUNITY_POST_LENGTH, FEED_MAX_COMMUNITY_POST_LENGTH } from '../../lib/feed/constants';
+import { OFFICIAL_SENDER_LABEL } from '../../lib/hub/constants';
 
-// Avatar glyph for a chat sender: "SH" for the Survivor Hub system/AI, otherwise the first letter of
-// the member's handle. Keeps each post attributable instead of every row reading as the same "SH".
+// Avatar glyph for a chat sender: the first letter of the sender's name, whoever they are. The
+// official house account used to get a hardcoded "SH" here; now that official posts are signed with
+// the operator's own name, there is no special case left to make — the same rule covers every row
+// and keeps each post attributable (owner decision, 2026-08-09).
 function avatarFromSender(label: string): string {
   const trimmed = label.trim();
-  if (!trimmed || trimmed.toLowerCase() === 'survivor hub') return 'SH';
   const handle = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
-  return handle.charAt(0).toUpperCase() || 'SH';
+  return handle.charAt(0).toUpperCase() || '?';
 }
 
 // One unified stream entry: either a peer/hub chat message or an AI Assistant (@comic) Q&A item.
@@ -690,7 +692,7 @@ function StreamEntryView({ entry, showDivider, ownHandle, currentUser, inputRef,
   // The author shown above the bubble. Your own messages are attributed to you (handle when we have
   // it) so every message has a visible author, not just other people's — peer posts were rendering
   // with no name on the sender's own side.
-  const senderName = msg.from === 'user' ? ownHandle : (msg.senderLabel ?? 'Survivor Hub');
+  const senderName = msg.from === 'user' ? ownHandle : (msg.senderLabel ?? OFFICIAL_SENDER_LABEL);
 
   // An official announcement renders as its own distinct card (badge + optional title), not a chat
   // bubble, so it stands apart from peer posts and AI answers.

--- a/ctf/packages/web/components/unlock/unlock-submission-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-submission-view.tsx
@@ -49,7 +49,7 @@ export function UnlockSubmissionView({
           <div style={{ marginBottom: 28 }}>
             <div style={{ fontSize: 26, fontWeight: 800, color: tok.TITLE, marginBottom: 10 }}>Submit your Quora profile URL</div>
             <div style={{ fontSize: 14, color: tok.MUTED, lineHeight: 1.7 }}>
-              To unlock full access to Survivor Hub, submit your Quora profile URL for manual verification. This helps us confirm you are a real person and reduces infiltration risk from bad actors.
+              To unlock full access to Skills Economy, submit your Quora profile URL for manual verification. This helps us confirm you are a real person and reduces infiltration risk from bad actors.
             </div>
           </div>
 

--- a/ctf/packages/web/lib/contributor-access/gated-channel.ts
+++ b/ctf/packages/web/lib/contributor-access/gated-channel.ts
@@ -6,6 +6,7 @@ import {
   GATED_STREAM_CHANNEL_ID,
   GATED_STREAM_CHANNEL_TYPE,
 } from './gated-channel-shared';
+import { OFFICIAL_SENDER_LABEL } from 'lib/hub/constants';
 
 // Server-side Stream helpers for the single gated contributor channel. Mirrors lib/feed/stream.ts
 // exactly (same credential resolver — demo mode selects the *_STAGING app — same create/watch
@@ -61,7 +62,7 @@ export async function ensureGatedChannel(): Promise<boolean> {
   const streamConfig = await resolveStreamCredentials();
   if (!streamConfig) return false;
   const streamClient = new StreamChat(streamConfig.apiKey, streamConfig.apiSecret);
-  await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: 'Survivor Hub' });
+  await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: OFFICIAL_SENDER_LABEL });
   await createOrWatchGatedChannel(streamClient);
   return true;
 }
@@ -79,7 +80,7 @@ export async function syncGatedChannelMembership(): Promise<GatedChannelSyncResu
   if (!streamConfig) return null;
   const targets = await listChannelMembershipTargets();
   const streamClient = new StreamChat(streamConfig.apiKey, streamConfig.apiSecret);
-  await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: 'Survivor Hub' });
+  await streamClient.upsertUser({ id: GATED_SYSTEM_USER_ID, name: OFFICIAL_SENDER_LABEL });
   const channel = await createOrWatchGatedChannel(streamClient);
 
   const eligibleIds = targets.eligibleUserIds.map(streamMemberId);

--- a/ctf/packages/web/lib/feed/repository.ts
+++ b/ctf/packages/web/lib/feed/repository.ts
@@ -2487,7 +2487,7 @@ export async function toggleAnnouncementReaction(
       throw new Error('announcement_not_found');
     }
     // Same rule as peer posts: you may not react to an announcement you authored. Members are never
-    // the author of a Survivor Hub announcement, so this only guards the owner reacting to their own.
+    // the author of an official announcement, so this only guards the owner reacting to their own.
     if (announcement.rows[0].created_by_user_id === userId) {
       throw new Error('cannot_react_to_own_post');
     }

--- a/ctf/packages/web/lib/feed/types.ts
+++ b/ctf/packages/web/lib/feed/types.ts
@@ -92,7 +92,7 @@ export type FeedCommunityDetail = {
   reactions: FeedReactionSummary[];
 };
 
-// One reply on an official announcement. Members can reply to a Survivor Hub announcement; the
+// One reply on an official announcement. Members can reply to an official announcement; the
 // replies group under it as a thread. author_username is captured at reply time so the thread can
 // render the member's handle without a second lookup.
 export type FeedAnnouncementReply = {

--- a/ctf/packages/web/lib/hub/constants.ts
+++ b/ctf/packages/web/lib/hub/constants.ts
@@ -1,0 +1,16 @@
+// The name shown on official posts in the Commons — announcements and anything else the operator
+// sends as the house account.
+//
+// It is a person's name, not an institution's, because the posts are written in the first person
+// ("I will be hosting a live Q&A"). Signed with a product or department name, that "I" has no
+// referent and reads as an institution performing a personal voice — the opposite of how this
+// product talks. The operator is already named on a shipped surface: Beacon says "Live one-way
+// broadcasts from Farah" (owner decision, 2026-08-09, replacing the old "Survivor Hub" label).
+//
+// Who wrote it and whether it is official are two separate facts, carried by two separate things:
+// this name, and the shield "Official" badge the announcement card draws. Do not fold the authority
+// back into the name.
+//
+// This is deliberately NOT the AI Assistant's name. AI answers render through their own card and
+// keep their own identity, so a person is never credited with text a bot wrote.
+export const OFFICIAL_SENDER_LABEL = 'Farah';

--- a/ctf/packages/web/lib/hub/types.ts
+++ b/ctf/packages/web/lib/hub/types.ts
@@ -31,7 +31,7 @@ export type HubMessage = {
   displayName: string;
   avatarUrl: string | null;
   // Which feed channel this message came from. `community` for peer posts (the common case),
-  // `announcement` for official Survivor Hub posts, `question` for AI Q&A items.
+  // `announcement` for official operator posts, `question` for AI Q&A items.
   kind: HubMessageKind;
   // The announcement's own title, rendered as a heading above the body on the official card.
   // Null for peer posts and AI answers (their `text` is the whole message).

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -827,7 +827,7 @@ CREATE TABLE IF NOT EXISTS feed_render_config (
   render_mode TEXT NOT NULL,
   max_timeline_page_size INTEGER NOT NULL DEFAULT 100,
   enabled_channels JSONB NOT NULL DEFAULT '["announcements", "questions", "community"]'::jsonb,
-  -- Survivor Hub consolidation: the blended channel is publicly viewable (read-only)
+  -- Commons consolidation: the blended channel is publicly viewable (read-only)
   -- to unauthenticated visitors when TRUE. Public-read enforcement route is tracked
   -- as a follow-up; this flag is the canonical config the admin/seed sets.
   is_public BOOLEAN NOT NULL DEFAULT TRUE,
@@ -2341,7 +2341,7 @@ CREATE INDEX IF NOT EXISTS idx_announcement_reactions_announcement
   ON announcement_reactions(announcement_id);
 
 -- Replies on official announcements. Mirrors feed_community_replies but keyed on the announcement:
--- a member can reply to an official Survivor Hub announcement, and the replies group under that
+-- a member can reply to an official announcement, and the replies group under that
 -- announcement as a thread. author_username is captured at reply time so the thread can show the
 -- member's handle without a second lookup. Deleting the announcement cascades its replies.
 CREATE TABLE IF NOT EXISTS announcement_replies (
@@ -2472,7 +2472,7 @@ ON CONFLICT (plugin_slug) DO UPDATE SET
   is_visible         = EXCLUDED.is_visible,
   updated_at         = NOW();
 
--- Feed + Announcements was consolidated into the Survivor Hub and is no longer a
+-- Feed + Announcements was consolidated into the Commons and is no longer a
 -- navigable app: its data layer (the feed_* tables + /api/feed/*) and its admin
 -- page at /admin/feed-announcements remain, but it is not a plugin tile/route.
 -- Remove any registry row left from when it was seeded as a visible app so the

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -829,7 +829,7 @@ CREATE TABLE IF NOT EXISTS feed_render_config (
   render_mode TEXT NOT NULL,
   max_timeline_page_size INTEGER NOT NULL DEFAULT 100,
   enabled_channels JSONB NOT NULL DEFAULT '["announcements", "questions", "community"]'::jsonb,
-  -- Survivor Hub consolidation: the blended channel is publicly viewable (read-only)
+  -- Commons consolidation: the blended channel is publicly viewable (read-only)
   -- to unauthenticated visitors when TRUE. Public-read enforcement route is tracked
   -- as a follow-up; this flag is the canonical config the admin/seed sets.
   is_public BOOLEAN NOT NULL DEFAULT TRUE,
@@ -2343,7 +2343,7 @@ CREATE INDEX IF NOT EXISTS idx_announcement_reactions_announcement
   ON announcement_reactions(announcement_id);
 
 -- Replies on official announcements. Mirrors feed_community_replies but keyed on the announcement:
--- a member can reply to an official Survivor Hub announcement, and the replies group under that
+-- a member can reply to an official announcement, and the replies group under that
 -- announcement as a thread. author_username is captured at reply time so the thread can show the
 -- member's handle without a second lookup. Deleting the announcement cascades its replies.
 CREATE TABLE IF NOT EXISTS announcement_replies (
@@ -2474,7 +2474,7 @@ ON CONFLICT (plugin_slug) DO UPDATE SET
   is_visible         = EXCLUDED.is_visible,
   updated_at         = NOW();
 
--- Feed + Announcements was consolidated into the Survivor Hub and is no longer a
+-- Feed + Announcements was consolidated into the Commons and is no longer a
 -- navigable app: its data layer (the feed_* tables + /api/feed/*) and its admin
 -- page at /admin/feed-announcements remain, but it is not a plugin tile/route.
 -- Remove any registry row left from when it was seeded as a visible app so the


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

The React Native app is touched here too — the Unlock and account-data screens carried the same copy, and both are updated in this PR.

## What was wrong

"Survivor Hub" was doing two unrelated jobs and was wrong at both.

**As the signature on official posts** it put an institution's name over first-person writing. The announcement in the report reads "I will be hosting a live virtual Q&A" — signed by a product name, that "I" has no referent, and it reads as an institution performing a personal voice.

**As a stand-in for the product** it named something that is not in the brand hierarchy at all: "unlock full access to Survivor Hub", "one identity across Survivor Hub", "Survivor Hub apps", "self-hosted inside Survivor Hub". The product is Skills Economy.

Separately, the avatar next to official posts was a hardcoded **SH** in two places.

## What changed

**Sender label → Farah.** Official posts are signed with the operator's own name, matching how Beacon already names her publicly ("Live one-way broadcasts from Farah"). The name comes from one shared `OFFICIAL_SENDER_LABEL` in the new `lib/hub/constants.ts`, read by all three places that render it — `app/api/hub/messages/route.ts`, the `shell-chat-panel.tsx` fallback, and the Stream system user in `lib/contributor-access/gated-channel.ts` — so the official identity cannot drift between them.

Who wrote it and whether it is official stay separate: the name carries the first, the shield "Official" badge carries the second. The badge is unchanged.

**Product name → Skills Economy**, across the account-data, Unlock, account hub, AI-consent and Chyme lock-screen surfaces on both web and mobile.

**SH deleted, not renamed.** `avatarFromSender` and the announcement card now both take the first letter of whatever name they are handed, so the avatar can never disagree with the name printed beside it and there is no house glyph left to go out of date. The special case is gone rather than re-pointed.

**AI answers are untouched.** They render through their own card branch (`entry.kind === 'comic'`) and never used this label, so no person is credited with text a bot wrote.

## Scope notes

- `schema.sql` edits are comment-only; `schema.demo.sql` was regenerated from it. The schema drift gate reports no database-impacting change.
- Dated change-log entries and the 2026-05-31 consolidation-decision blocks keep the old name — they record what shipped at the time, and rewriting them would falsify the history.
- The inventory file `ctf-survivor-hub-chat-feature-inventory.md` keeps its filename (its title is updated). Renaming the file means updating cross-references in four other docs; happy to do it as its own change if you want it.

## Docs

- Hub inventory retitled, current-state lines corrected (several were already behind the code), and the announcement-rendering entry now describes the name, the badge, and the derived avatar. Change-log entry added.
- Feed and Unlock inventories each get a change-log entry, with matching updates to `feed-test-script.md` (new steps checking the name reads Farah, the badge is present, and no SH glyph appears anywhere) and `unlock-test-script.md`.
- Comic and notifications inventories: cross-references updated.

## Checks run locally

`typecheck` (all 6 workspace projects), web + mobile `lint`, web `build`, `check-eof-format.sh`, `check-schema-drift.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-us-spelling.mjs`, `check-modularity-governance.sh`, `check-web-android-parity.mjs`, `check-notice-formatting.mjs` — all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyQEw5NhiJuzqeKQWmVh2R)_