### PR TITLE
fix: name what the trust visibility choices actually share

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -18,11 +18,13 @@ Trust gives the community a privacy-respecting, **non-numeric** way to gauge how
 1. View their trust badge (qualitative standing, not a number), evidence panel, and verification status on profile/directory surfaces.
 2. Choose who can see their own trust signals, from a labeled "Who can see your trust signals"
    dropdown on their own Trust card (account hub, community right rail, own Directory profile).
-   Each choice states the outcome in plain words rather than naming a category: **"Members see
-   everything"** — any signed-in member who opens your profile sees every signal; **"Members see a
-   summary"** — members see how active you are (sign-in days, how many plugins you take part in, and
-   any ServiceCredits counts) without the detail or the dates; **"Only you see this"** — no other
-   member can open the panel, though admins can, as they can for every member. The member always
+   Each choice states the outcome in plain words rather than naming a category, and names what is
+   being shared so the selected line still makes sense with the dropdown closed: **"Members see all
+   your trust signals"** — any signed-in member who opens your profile sees every signal; **"Members
+   see a summary of your trust signals"** — members see how active you are (sign-in days, how many
+   plugins you take part in, and any ServiceCredits counts) without the detail or the dates; **"Only
+   you see your trust signals"** — no other member can see them, though admins can, as they can for
+   every member. The member always
    sees every signal on their own card whichever choice is active, and a "What members see" preview
    under the dropdown shows exactly what a member would receive at the current choice. A "Saved"
    confirmation appears when the choice is stored. The setting governs the trust panel only; it is
@@ -165,6 +167,18 @@ Trust has no dedicated seed script, and none is required. Trust is a derived plu
    closing if the status is ever meant to stay admin-side.
 
 ## Change Log
+
+- 2026-08-09: **Each choice now names what is being shared.** Owner report: with the dropdown closed
+  the selected line read "Only you see this" on its own, with the "Who sees your trust signals"
+  heading above it easily scrolled past, so the member had no way to tell what "this" was. The three
+  labels now name the subject — **"Members see all your trust signals"** / **"Members see a summary
+  of your trust signals"** / **"Only you see your trust signals"** — and the same pointing words are
+  removed from the private effect line ("No other member can see your trust signals"), the preview
+  lines ("Every trust signal listed above, exactly as you see it." / "Nothing — your trust signals do
+  not appear on your profile for them."), and the read-only row on another member's card ("This
+  member shares all their trust signals" / "…a summary of their trust signals" / "…keeps their trust
+  signals private"). Wording only: the stored enum values, routes, contracts, and schema are
+  unchanged.
 
 - 2026-08-08: **Plain-language names for the three choices.** Owner direction: the labels named a
   category and left the member to work out the category's rules, which is how the three were read as

--- a/ctf/docs/developer/test-scripts/trust-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-test-script.md
@@ -186,20 +186,20 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 
 **Steps:**
 1. Open the account hub (or the community shell right rail) and find the Trust widget's "Who sees your trust signals" control.
-2. Change the dropdown to "Only you see this", then reload the page.
+2. Change the dropdown to "Only you see your trust signals", then reload the page.
 3. Open another member's Directory profile and find their Trust widget (member with `public` visibility).
-4. Reset your own choice to "Members see everything".
+4. Reset your own choice to "Members see all your trust signals".
 
 **Expected:**
 - On your own widget the control has a heading ("Who sees your trust signals") above a full-width dropdown, so it reads as something you can change rather than a status line.
-- The choices are ordered most open to most private and each states the outcome in plain words — **"Members see everything"**, **"Members see a summary"**, **"Only you see this"**. No choice is named after a category ("Public"/"Restricted"/"Private" must not appear as option text).
-- Below the dropdown, a sentence states what the current choice does and that you always see everything on your own card whichever one you pick. On "Only you see this" that sentence must also say admins can read the panel — the label alone would otherwise overpromise.
-- Under that, a **"What members see"** preview shows the result of the current choice: on "Members see everything", "Everything listed above, exactly as you see it."; on "Only you see this", "Nothing — this panel does not appear on your profile for them."; on "Members see a summary", the actual summary lines a member would receive.
+- The choices are ordered most open to most private and each states the outcome in plain words — **"Members see all your trust signals"**, **"Members see a summary of your trust signals"**, **"Only you see your trust signals"**. No choice is named after a category ("Public"/"Restricted"/"Private" must not appear as option text), and every choice names what is being shared — no option may say only "everything" or "this", because a closed dropdown shows the selected line on its own.
+- Below the dropdown, a sentence states what the current choice does and that you always see everything on your own card whichever one you pick. On "Only you see your trust signals" that sentence must also say admins can read them — the label alone would otherwise overpromise.
+- Under that, a **"What members see"** preview shows the result of the current choice: on "Members see all your trust signals", "Every trust signal listed above, exactly as you see it."; on "Only you see your trust signals", "Nothing — your trust signals do not appear on your profile for them."; on "Members see a summary of your trust signals", the actual summary lines a member would receive.
 - The summary preview must match what the API returns for a peer (cross-check against TR-A4b) — both come from the same projection function, so any disagreement is a bug.
 - Changing it POSTs `/api/trust/visibility`, shows "Saving…" while in flight, then a "Saved" confirmation that clears itself after a few seconds. After reload the chosen value is still selected.
 - Your own evidence list above the control does **not** change when the setting changes — that is correct; the preview is where the effect shows. Do not file the unchanged list as a bug.
 - On failure (e.g. network cut), the dropdown reverts to the previous value and a short plain-language error appears under it, replacing the confirmation.
-- On **another member's** widget the row is plain text stating what they share ("This member shares everything"), never a dropdown, and no preview is shown — the route is self-scope only.
+- On **another member's** widget the row is plain text stating what they share ("This member shares all their trust signals"), never a dropdown, and no preview is shown — the route is self-scope only.
 
 **Result:** web ☐
 

--- a/ctf/packages/web/components/trust/trust-visibility-control.tsx
+++ b/ctf/packages/web/components/trust/trust-visibility-control.tsx
@@ -36,31 +36,36 @@ const HAIRLINE = "rgba(255,255,255,0.05)";
 // the category's rules — which is how the three got read as kinds of transaction. These say the
 // outcome instead, so no guessing is required and the three read as one scale.
 //
+// Every choice names the thing being shared — "your trust signals" — instead of pointing at it with
+// "everything" or "this". A closed dropdown shows only the selected line, with the question above it
+// scrolled away or forgotten, so a label like "Only you see this" left the member with no idea what
+// "this" was.
+//
 // The stored values are still `public` / `restricted` / `private`; only what the member reads
 // changed. Nothing here is a promise about the rest of the app — this setting governs the trust
 // panel and nothing else.
 const OPTION_LABEL: Record<TrustVisibility, string> = {
-  public: "Members see everything",
-  restricted: "Members see a summary",
-  private: "Only you see this",
+  public: "Members see all your trust signals",
+  restricted: "Members see a summary of your trust signals",
+  private: "Only you see your trust signals",
 };
 
 // Admins are named in the effect line rather than the label: they can read any member's panel, so
-// leaving it out would make "Only you see this" a claim the app does not keep.
+// leaving it out would make "Only you see your trust signals" a claim the app does not keep.
 const OPTION_EFFECT: Record<TrustVisibility, string> = {
   public: "Any signed-in member who opens your profile sees the signals listed above.",
   restricted:
     "Members see how active you are, without the detail or the dates. Enough to tell that you take part here.",
-  private: "No other member can open this panel. Admins can, as they can for every member.",
+  private: "No other member can see your trust signals. Admins can, as they can for every member.",
 };
 
 // The same three outcomes described from a viewer's side, for the read-only row on another member's
 // card. `private` is listed for completeness; that card is never rendered, because the route refuses
 // the read before there is anything to draw.
 const PEER_LABEL: Record<TrustVisibility, string> = {
-  public: "This member shares everything",
-  restricted: "This member shares a summary",
-  private: "This member keeps this to themselves",
+  public: "This member shares all their trust signals",
+  restricted: "This member shares a summary of their trust signals",
+  private: "This member keeps their trust signals private",
 };
 
 // A member's stored value should always be one of the three, but a row written before the column
@@ -122,10 +127,14 @@ function PeerPreview({ current, evidence, t }: { current: TrustVisibility; evide
         What members see
       </div>
       {current === "public" && (
-        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>Everything listed above, exactly as you see it.</div>
+        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
+          Every trust signal listed above, exactly as you see it.
+        </div>
       )}
       {current === "private" && (
-        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>Nothing — this panel does not appear on your profile for them.</div>
+        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
+          Nothing — your trust signals do not appear on your profile for them.
+        </div>
       )}
       {current === "restricted" && lines.length === 0 && (
         <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

## What was wrong

On the Trust card, the visibility dropdown showed its selected value as **"Only you see this"**. With the dropdown closed that line sits on its own — the "Who sees your trust signals" heading above it scrolls out of view — so there was nothing on screen telling the member what "this" referred to. Reported from the account hub screen.

## What changed

Every choice now names the thing being shared instead of pointing at it:

| Before | After |
|---|---|
| Members see everything | Members see all your trust signals |
| Members see a summary | Members see a summary of your trust signals |
| Only you see this | Only you see your trust signals |

The same pointing words are removed from the three other places on the card that had them:

- The effect line under the dropdown on the private choice: "No other member can open this panel" → "No other member can see your trust signals" (the admin sentence after it is unchanged).
- The two fixed preview lines: "Everything listed above, exactly as you see it." → "Every trust signal listed above, exactly as you see it."; "Nothing — this panel does not appear on your profile for them." → "Nothing — your trust signals do not appear on your profile for them."
- The read-only row on another member's card: "This member shares everything" / "…a summary" / "This member keeps this to themselves" → "This member shares all their trust signals" / "…a summary of their trust signals" / "This member keeps their trust signals private".

Wording only. The stored values (`public` / `restricted` / `private`), the routes, the contracts, and the schema are untouched, and no layout or color changed.

## Docs kept in step

- Trust feature inventory: User Features entry rewritten to the new labels, with a change log entry.
- Trust manual test script (TR-A5b): step and expectation text updated, plus a new expectation that no option may say only "everything" or "this" — the closed dropdown shows the selected line alone.

## Checks run locally

`tsc --noEmit` (all packages, via the pre-commit gate), `pnpm --filter @ctf/web run lint`, `pnpm --filter @ctf/web run build`, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs` — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q7VzgoznjPmuWFwnueYsh)_