### PR TITLE
fix: split the Trust card into "Your trust" and "What members see"

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -16,19 +16,20 @@ Trust gives the community a privacy-respecting, **non-numeric** way to gauge how
 ## User Features
 
 1. View their trust badge (qualitative standing, not a number), evidence panel, and verification status on profile/directory surfaces.
-2. Choose who can see their own trust signals, from a labeled "Who can see your trust signals"
-   dropdown on their own Trust card (account hub, community right rail, own Directory profile).
-   Each choice states the outcome in plain words rather than naming a category, and names what is
-   being shared so the selected line still makes sense with the dropdown closed: **"Members see all
-   your trust signals"** — any signed-in member who opens your profile sees every signal; **"Members
-   see a summary of your trust signals"** — members see how active you are (sign-in days, how many
-   plugins you take part in, and any ServiceCredits counts) without the detail or the dates; **"Only
-   you see your trust signals"** — no other member can see them, though admins can, as they can for
-   every member. The member always
-   sees every signal on their own card whichever choice is active, and a "What members see" preview
-   under the dropdown shows exactly what a member would receive at the current choice. A "Saved"
-   confirmation appears when the choice is stored. The setting governs the trust panel only; it is
-   not a platform-wide visibility switch.
+2. Choose what other members see of their trust signals, on their own Trust card (account hub,
+   community right rail, own Directory profile). The card body is two labeled sections: **"Your
+   trust"** — every signal the member has, always all of them, whatever the choice is — then **"What
+   members see"**, which holds the choice and its result. The choice is three buttons, not a
+   dropdown, each completing the section heading: **"Everything"** (any signed-in member who opens
+   the profile sees every signal), **"A summary"** (members see how active you are — sign-in days,
+   how many plugins you take part in, and any ServiceCredits counts — without the detail or the
+   dates), **"Nothing"** (the Trust card does not appear on the profile for other members). Under the
+   buttons, the exact rows another member would receive are rendered with the same components their
+   screen uses, so the preview is the copy they get rather than a description of it; on "Nothing" a
+   single line stands in, because a member receives no card at all. A "Saved" confirmation appears
+   when the choice is stored. The card names no admin caveat — nothing in the app is end-to-end
+   encrypted, so admin access is a given everywhere and repeating it here only crowded the section.
+   The setting governs the trust card only; it is not a platform-wide visibility switch.
 3. Inspect their own trust signal snapshot via `GET /api/trust/user/self`.
 
 ## Admin Features
@@ -132,7 +133,7 @@ numeric score is ever computed or stored. The snapshot route never changes `trus
 
 ## Web and Android Delivery Status
 
-**Web: delivered (signal-only).** The live member-facing surface is the right-rail card `components/shared/trust/TrustRightRailCard.tsx`, which renders `components/trust/TrustWidgetCard.tsx` — an inline-styled widget aligned to `design/.../survivor-hub/Trust.tsx` (blue brand palette, ShieldCheck header, real `trustEvidence` list when present, an empty state with onboarding prompts, and the visibility control `components/trust/trust-visibility-control.tsx` — on self surfaces a labeled "Who can see your trust signals" dropdown whose choices name their audience, with a sentence stating the effect of the current choice and a "Saved" confirmation; it POSTs `/api/trust/visibility` and stays a read-only "Visible to: …" row when the card shows another member). It is consumed by `account-hub-shell.tsx`, `community-shell/shell-right-rail.tsx`, `directory-profile-detail.tsx` (editable on own profile), and `lighthouse-host.tsx`. The admin surface is `/admin/trust` (`app/admin/trust/page.tsx` + `components/trust/trust-admin-shell.tsx`), a verification-review form over `POST /api/trust/admin/verification`, linked from the `/admin` landing. The signed-out marketing view is `components/trust/trust-public-shell.tsx`. The header has no Verified/Unverified status chip: the platform does not verify members, so Trust is signal-only and shows derived evidence, not a status badge. Per the real-data-only rule the design's verified-state signal buckets are omitted. Removed in the signal-only cleanup (2026-06-21): `TrustDirectoryProfilePanel.tsx`, `TrustEvidencePanel.tsx`, `TrustStatusBadge.tsx`, `TrustVisibilityBadge.tsx`, and the unused re-export `components/trust/TrustRightRailCard.tsx` — all dead after verification was dropped from the UI (no importers).
+**Web: delivered (signal-only).** The live member-facing surface is the right-rail card `components/shared/trust/TrustRightRailCard.tsx`, which renders `components/trust/TrustWidgetCard.tsx` — an inline-styled widget aligned to `design/.../survivor-hub/Trust.tsx` (blue brand palette, ShieldCheck header, real `trustEvidence` list when present, an empty state with onboarding prompts, and the visibility control `components/trust/trust-visibility-control.tsx` — on self surfaces a "What members see" section holding three buttons (Everything / A summary / Nothing), a preview built from the real evidence rows, and a "Saved" confirmation; it POSTs `/api/trust/visibility` and stays a read-only one-line row when the card shows another member). The evidence row, the summary note, and the section label live in `components/trust/trust-evidence-row.tsx` so the card and the preview render the same components. It is consumed by `account-hub-shell.tsx`, `community-shell/shell-right-rail.tsx`, `directory-profile-detail.tsx` (editable on own profile), and `lighthouse-host.tsx`. The admin surface is `/admin/trust` (`app/admin/trust/page.tsx` + `components/trust/trust-admin-shell.tsx`), a verification-review form over `POST /api/trust/admin/verification`, linked from the `/admin` landing. The signed-out marketing view is `components/trust/trust-public-shell.tsx`. The header has no Verified/Unverified status chip: the platform does not verify members, so Trust is signal-only and shows derived evidence, not a status badge. Per the real-data-only rule the design's verified-state signal buckets are omitted. Removed in the signal-only cleanup (2026-06-21): `TrustDirectoryProfilePanel.tsx`, `TrustEvidencePanel.tsx`, `TrustStatusBadge.tsx`, `TrustVisibilityBadge.tsx`, and the unused re-export `components/trust/TrustRightRailCard.tsx` — all dead after verification was dropped from the UI (no importers).
 
 **Android: surface removed 2026-07-20 (rule 105, PR #1742)** — this feature is now web-only, served by the installable web app (PWA). Historical detail: `Trust.tsx` under `packages/mobile/src/features/trust` had been rewritten to align with `design/.../survivor-hub/MobileTrust.tsx`, `MobileTrustEmpty.tsx`, `MobileTrustLoading.tsx`, and `MobileTrustPublic.tsx`. A new `api.ts` binds to `GET /api/trust/user/self` for real data. The screen covers all four states: loading (branded taglines), public/unauthenticated (visitor marketing view), empty (no evidence yet), and populated (evidence list). `MockTrust.tsx` is retired. Real bindings: `trustStatus`, `trustVisibility`, `trustEvidence` array (type/summary/createdAt per item). Omissions per real-data-only rule: Last Active / Activity / Transactions / Active Plugins stats from the design's Trust Score card have no backing API field and are omitted; signal-progress percentage and hardcoded checklist items are omitted (snapshot route is a stub); visibility update dropdown rendered as display-only at the time of the pixel pass. The backend for signal derivation, visibility update, and admin verification is now implemented (2026-06-08); the web client is wired to the live visibility mutation as of 2026-08-04 (Android stays retired per rule 105).
 
@@ -167,6 +168,23 @@ Trust has no dedicated seed script, and none is required. Trust is a derived plu
    closing if the status is ever meant to stay admin-side.
 
 ## Change Log
+
+- 2026-08-09: **The card is two labeled sections and the dropdown is gone.** Owner direction: the
+  block read as three different ideas stacked with nothing separating them — a heading, a dropdown
+  whose closed line stood alone, an effect sentence, and a boxed preview with its own label. It is
+  now **"Your trust"** (the signals, always all of them) above **"What members see"** (the choice and
+  its result). The dropdown is replaced by three buttons that complete the heading — **Everything /
+  A summary / Nothing** — so the three read as amounts of one thing rather than three concepts. The
+  separate effect sentence is dropped: the two section labels carry what it said. The preview no
+  longer carries its own "WHAT MEMBERS SEE" label (that text never appears on a member's screen) and
+  no longer describes the result in prose — it renders the real evidence rows, and the summary note
+  for "A summary", using the same components another member's screen uses, so it is exactly the copy
+  they receive. The admin sentence is removed everywhere on this card per owner direction: nothing in
+  the app is end-to-end encrypted, so admin access is a given and does not belong in this choice. The
+  row shown on another member's card is unchanged. `TrustEvidenceRow`, the summary note, and the
+  section label moved to `components/trust/trust-evidence-row.tsx` so the card and the preview draw
+  the same components (rule 116). Presentation only: the stored values, routes, contracts, and schema
+  are unchanged.
 
 - 2026-08-09: **Each choice now names what is being shared.** Owner report: with the dropdown closed
   the selected line read "Only you see this" on its own, with the "Who sees your trust signals"

--- a/ctf/docs/developer/test-scripts/trust-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-test-script.md
@@ -178,28 +178,31 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 
 ---
 
-### TR-A5b — Visibility selector in the widget (self surfaces only)
+### TR-A5b — "What members see" choice in the widget (self surfaces only)
 
 **Role:** Admin acting as any authenticated user  
 **Surfaces:** Web (desktop + mobile-responsive)  
 **Precondition:** Admin signed in.
 
 **Steps:**
-1. Open the account hub (or the community shell right rail) and find the Trust widget's "Who sees your trust signals" control.
-2. Change the dropdown to "Only you see your trust signals", then reload the page.
-3. Open another member's Directory profile and find their Trust widget (member with `public` visibility).
-4. Reset your own choice to "Members see all your trust signals".
+1. Open the account hub (or the community shell right rail) and find the Trust widget's "What members see" section.
+2. Press "Nothing", then reload the page.
+3. Press "A summary" and compare the rows shown under the buttons with what TR-A4b returns for a peer.
+4. Open another member's Directory profile and find their Trust widget (member with `public` visibility).
+5. Reset your own choice to "Everything".
 
 **Expected:**
-- On your own widget the control has a heading ("Who sees your trust signals") above a full-width dropdown, so it reads as something you can change rather than a status line.
-- The choices are ordered most open to most private and each states the outcome in plain words — **"Members see all your trust signals"**, **"Members see a summary of your trust signals"**, **"Only you see your trust signals"**. No choice is named after a category ("Public"/"Restricted"/"Private" must not appear as option text), and every choice names what is being shared — no option may say only "everything" or "this", because a closed dropdown shows the selected line on its own.
-- Below the dropdown, a sentence states what the current choice does and that you always see everything on your own card whichever one you pick. On "Only you see your trust signals" that sentence must also say admins can read them — the label alone would otherwise overpromise.
-- Under that, a **"What members see"** preview shows the result of the current choice: on "Members see all your trust signals", "Every trust signal listed above, exactly as you see it."; on "Only you see your trust signals", "Nothing — your trust signals do not appear on your profile for them."; on "Members see a summary of your trust signals", the actual summary lines a member would receive.
+- Your own card body reads as two labeled sections: **"Your trust"** above your signal rows, then **"What members see"**. No third block sits between them — the old standalone effect sentence must not reappear.
+- The "Your trust" rows are your full list and do **not** change when the choice changes. That is correct; the section below is where the effect shows. Do not file the unchanged list as a bug.
+- The choice is three buttons in one row, ordered most open to most private, each completing the section heading: **"Everything"**, **"A summary"**, **"Nothing"**. It must not be a dropdown, and no button is named after a category ("Public"/"Restricted"/"Private" must not appear).
+- The selected button is visibly the selected one (accent fill and border), and the group is reachable by keyboard as a radio group labeled "What members see".
+- Under the buttons the result is rendered as the **actual rows another member receives**, not a description of them: on "Everything", your rows exactly as they appear above; on "A summary", the note "This member shares a summary of their participation, not the detail." followed by the summary rows. No "WHAT MEMBERS SEE" label appears inside that preview — that text is a section heading, and it never appears on a member's screen.
+- On "Nothing" the preview is the single line "Nothing. The Trust card does not appear on your profile for other members." — there is no card copy to show, so a sentence stands in.
+- No sentence anywhere in this section mentions admins. Admin access is a given across the app and must not be restated here.
 - The summary preview must match what the API returns for a peer (cross-check against TR-A4b) — both come from the same projection function, so any disagreement is a bug.
-- Changing it POSTs `/api/trust/visibility`, shows "Saving…" while in flight, then a "Saved" confirmation that clears itself after a few seconds. After reload the chosen value is still selected.
-- Your own evidence list above the control does **not** change when the setting changes — that is correct; the preview is where the effect shows. Do not file the unchanged list as a bug.
-- On failure (e.g. network cut), the dropdown reverts to the previous value and a short plain-language error appears under it, replacing the confirmation.
-- On **another member's** widget the row is plain text stating what they share ("This member shares all their trust signals"), never a dropdown, and no preview is shown — the route is self-scope only.
+- Pressing a button POSTs `/api/trust/visibility`, shows "Saving…" while in flight, then a "Saved" confirmation that clears itself after a few seconds. After reload the chosen button is still selected.
+- On failure (e.g. network cut), the selection reverts to the previous button and a short plain-language error appears under it, replacing the confirmation.
+- On **another member's** widget there is no "Your trust" / "What members see" split and no buttons — just plain text stating what they share ("This member shares all their trust signals") and no preview, because the route is self-scope only.
 
 **Result:** web ☐
 

--- a/ctf/packages/web/components/trust/TrustWidgetCard.tsx
+++ b/ctf/packages/web/components/trust/TrustWidgetCard.tsx
@@ -12,35 +12,24 @@
 // - The visibility control (`trust-visibility-control.tsx`) is live only on self
 //   surfaces (`editable`), because POST /api/trust/visibility is self-scope only;
 //   when the card shows another member's trust the row stays read-only.
+//
+// On the member's own card the body is two labelled sections — "Your trust" (these signals, always
+// all of them) then "What members see" (the choice and a preview of the result). Before the labels
+// the two ran together and read as one jumbled block, which is what made the setting hard to place.
 import React from "react";
-import { ShieldCheck, CheckCircle2, Eye } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import type { TrustUserExtension, TrustPeerView, TrustPeerEvidenceItem, TrustDisclosure } from "../../lib/trust/types";
 import { getTrustTokens } from "./trust-shared";
 import { TrustVisibilityControl } from "./trust-visibility-control";
+import { TrustEvidenceRow, TrustSummaryNote, TrustSectionLabel, TRUST_HAIRLINE } from "./trust-evidence-row";
 
-// Accent-with-alpha card tints and the 5% hairline have no exact shell-token equivalent
-// (the token helper carries solid values only), so they stay as the shipped literals.
+// Accent-with-alpha card tints have no exact shell-token equivalent (the token helper carries solid
+// values only), so they stay as the shipped literals.
 const CARD_BG = "rgba(14,165,233,0.06)";
 const CARD_BORDER = "rgba(14,165,233,0.18)";
-const HAIRLINE = "rgba(255,255,255,0.05)";
 
 const STEPS = ["Complete your profile", "Make your first transaction", "Use at least one plugin"];
-
-// Turn an internal evidence `type` slug (e.g. "engagement-login-frequency") into readable text. Only
-// used as a fallback when an item has no `summary` — a well-formed derived item always has one.
-function humanizeType(type: string): string {
-  const words = (type || "").replace(/[-_]+/g, " ").trim();
-  return words ? words.charAt(0).toUpperCase() + words.slice(1) : "Trust signal";
-}
-
-// Render the evidence date only when `createdAt` is a real, parseable timestamp — otherwise nothing,
-// never the literal "Invalid Date" a bad/missing value would produce.
-function formatEvidenceDate(value?: string): string | null {
-  if (!value) return null;
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? null : parsed.toLocaleDateString();
-}
 
 // Header is just the Trust label. There is no verified/unverified status chip: the platform does
 // not verify members, so showing a "Verified"/"Unverified" badge would promise something it cannot
@@ -61,7 +50,7 @@ function EmptyBody({ visibility, editable, evidence }: { visibility: string; edi
   const t = getTrustTokens(theme);
   return (
     <div style={{ padding: "4px 14px 14px" }}>
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "16px 0 14px", borderTop: `1px solid ${HAIRLINE}` }}>
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "16px 0 14px", borderTop: `1px solid ${TRUST_HAIRLINE}` }}>
         <div style={{ width: 48, height: 48, borderRadius: "50%", border: "2px dashed rgba(14,165,233,0.3)", display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 10 }}>
           <ShieldCheck size={22} style={{ color: "rgba(14,165,233,0.4)" }} />
         </div>
@@ -73,7 +62,7 @@ function EmptyBody({ visibility, editable, evidence }: { visibility: string; edi
 
       <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 12 }}>
         {STEPS.map((label) => (
-          <div key={label} style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 9px", background: "rgba(255,255,255,0.02)", borderRadius: 8, border: `1px solid ${HAIRLINE}` }}>
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 9px", background: "rgba(255,255,255,0.02)", borderRadius: 8, border: `1px solid ${TRUST_HAIRLINE}` }}>
             <div style={{ width: 16, height: 16, borderRadius: "50%", border: "1.5px solid rgba(255,255,255,0.12)", flexShrink: 0 }} />
             <span style={{ fontSize: 11, color: t.MUTED }}>{label}</span>
           </div>
@@ -85,53 +74,22 @@ function EmptyBody({ visibility, editable, evidence }: { visibility: string; edi
   );
 }
 
-function EvidenceItem({ item }: { item: TrustPeerEvidenceItem }) {
-  const { theme } = useTheme();
-  const t = getTrustTokens(theme);
-  return (
-    <div style={{ background: "rgba(255,255,255,0.03)", borderRadius: 8, padding: "8px 10px", border: `1px solid ${HAIRLINE}` }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        <CheckCircle2 size={12} style={{ color: "#38BDF8", flexShrink: 0 }} />
-        <span style={{ fontSize: 11, fontWeight: 600, color: "#E2E8F0", flex: 1, minWidth: 0 }}>
-          {item.summary && item.summary.trim() ? item.summary : humanizeType(item.type)}
-        </span>
-        {formatEvidenceDate(item.createdAt) && (
-          <span style={{ fontSize: 10, color: t.FAINT, flexShrink: 0 }}>{formatEvidenceDate(item.createdAt)}</span>
-        )}
-      </div>
-      {item.details && <div style={{ fontSize: 10, color: t.MUTED, marginTop: 3, lineHeight: 1.5 }}>{item.details}</div>}
-    </div>
-  );
-}
-
-// Shown above a summary projection so a viewer never mistakes the reduced list for the member's
-// whole record. Without it, "Took part in 6 plugins" reads as everything they have ever done.
-function SummaryNote() {
-  const { theme } = useTheme();
-  const t = getTrustTokens(theme);
-  return (
-    <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 12 }}>
-      <Eye size={11} style={{ color: t.FAINT, flexShrink: 0 }} />
-      <span style={{ fontSize: 10, color: t.MUTED, lineHeight: 1.5 }}>
-        This member shares a summary of their participation, not the detail.
-      </span>
-    </div>
-  );
-}
-
 function EvidenceBody({ evidence, visibility, editable, disclosure }: { evidence: TrustPeerEvidenceItem[]; visibility: string; editable?: boolean; disclosure: TrustDisclosure }) {
   return (
-    <div style={{ padding: "4px 14px 14px", borderTop: `1px solid ${HAIRLINE}` }}>
-      {disclosure === "summary" && <SummaryNote />}
-      <div style={{ display: "flex", flexDirection: "column", gap: 6, margin: "12px 0 10px" }}>
+    <div style={{ padding: "4px 14px 14px", borderTop: `1px solid ${TRUST_HAIRLINE}` }}>
+      {disclosure === "summary" && <div style={{ marginTop: 12 }}><TrustSummaryNote /></div>}
+      {/* The label only makes sense on your own card, where a second section follows it. On another
+          member's card there is one list and nothing to tell it apart from. */}
+      {editable && <div style={{ marginTop: 12 }}><TrustSectionLabel>Your trust</TrustSectionLabel></div>}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, margin: editable ? "7px 0 10px" : "12px 0 10px" }}>
         {evidence.map((item, idx) => (
-          <EvidenceItem key={idx} item={item} />
+          <TrustEvidenceRow key={idx} item={item} />
         ))}
       </div>
       {/* On a peer's summary card the note above already says the member shares a summary, so the
           read-only row would repeat it. Keep the row for a full peer card and for the owner. */}
       {(editable || disclosure === "full") && (
-        <div style={{ paddingTop: 7, borderTop: `1px solid ${HAIRLINE}` }}>
+        <div style={{ paddingTop: 7, borderTop: `1px solid ${TRUST_HAIRLINE}` }}>
           <TrustVisibilityControl visibility={visibility} bordered={false} editable={editable} evidence={evidence} />
         </div>
       )}

--- a/ctf/packages/web/components/trust/trust-evidence-row.tsx
+++ b/ctf/packages/web/components/trust/trust-evidence-row.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+// The pieces of the Trust card that both the card itself and the "What members see" preview draw.
+//
+// Split out (rule 116) for one reason: the preview on the owner's own card has to show the exact
+// rows another member receives, not a description of them. Rendering the same components with the
+// peer's data is the only way that stays true when either side changes — a hand-written imitation
+// drifts the moment a row grows a field.
+import React from "react";
+import { CheckCircle2, Eye } from "lucide-react";
+import { useTheme } from "@/hooks/useTheme";
+import type { TrustPeerEvidenceItem } from "../../lib/trust/types";
+import { getTrustTokens } from "./trust-shared";
+
+// The 5% hairline has no exact shell-token equivalent, so it stays as the shipped literal.
+export const TRUST_HAIRLINE = "rgba(255,255,255,0.05)";
+
+// Turn an internal evidence `type` slug (e.g. "engagement-login-frequency") into readable text. Only
+// used as a fallback when an item has no `summary` — a well-formed derived item always has one.
+function humanizeType(type: string): string {
+  const words = (type || "").replace(/[-_]+/g, " ").trim();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : "Trust signal";
+}
+
+// Render the evidence date only when `createdAt` is a real, parseable timestamp — otherwise nothing,
+// never the literal "Invalid Date" a bad/missing value would produce.
+function formatEvidenceDate(value?: string): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toLocaleDateString();
+}
+
+export function TrustEvidenceRow({ item }: { item: TrustPeerEvidenceItem }) {
+  const { theme } = useTheme();
+  const t = getTrustTokens(theme);
+  return (
+    <div style={{ background: "rgba(255,255,255,0.03)", borderRadius: 8, padding: "8px 10px", border: `1px solid ${TRUST_HAIRLINE}` }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <CheckCircle2 size={12} style={{ color: "#38BDF8", flexShrink: 0 }} />
+        <span style={{ fontSize: 11, fontWeight: 600, color: "#E2E8F0", flex: 1, minWidth: 0 }}>
+          {item.summary && item.summary.trim() ? item.summary : humanizeType(item.type)}
+        </span>
+        {formatEvidenceDate(item.createdAt) && (
+          <span style={{ fontSize: 10, color: t.FAINT, flexShrink: 0 }}>{formatEvidenceDate(item.createdAt)}</span>
+        )}
+      </div>
+      {item.details && <div style={{ fontSize: 10, color: t.MUTED, marginTop: 3, lineHeight: 1.5 }}>{item.details}</div>}
+    </div>
+  );
+}
+
+// Shown above a summary projection so a viewer never mistakes the reduced list for the member's
+// whole record. Without it, "Took part in 6 plugins" reads as everything they have ever done.
+export function TrustSummaryNote() {
+  const { theme } = useTheme();
+  const t = getTrustTokens(theme);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <Eye size={11} style={{ color: t.FAINT, flexShrink: 0 }} />
+      <span style={{ fontSize: 10, color: t.MUTED, lineHeight: 1.5 }}>
+        This member shares a summary of their participation, not the detail.
+      </span>
+    </div>
+  );
+}
+
+// The card is two things stacked — the member's own signals, then what everyone else gets — and
+// without a label on each the reader has to work out where one ends and the other starts. These
+// labels are the whole answer to that.
+export function TrustSectionLabel({ children }: { children: React.ReactNode }) {
+  const { theme } = useTheme();
+  const t = getTrustTokens(theme);
+  return (
+    <div style={{ fontSize: 10, fontWeight: 700, color: t.FAINT, textTransform: "uppercase", letterSpacing: "0.06em" }}>
+      {children}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/trust/trust-visibility-control.tsx
+++ b/ctf/packages/web/components/trust/trust-visibility-control.tsx
@@ -1,62 +1,52 @@
 "use client";
 
-// The "who can see my trust signals" control from the Trust widget card.
+// The "what members see" half of the Trust card.
 //
 // Split out of TrustWidgetCard (rule 116) so the card stays a rendering component and this file
 // owns the one piece of state and the one write call in it (POST /api/trust/visibility).
 //
-// Why the control spells out its own effect: the setting changes only what OTHER members see. The
-// owner's card always renders the full evidence list whatever the setting says, so a member who
-// changes it and watches their own card sees nothing move and reasonably concludes it does
-// nothing. So each choice states the outcome in plain words, the effect is restated underneath, a
-// live preview shows what a member would actually receive, and a short confirmation appears once
-// the change is stored.
+// The card reads as two labelled sections: the member's own signals under "Your trust", then this
+// one under "What members see". That split is what makes the setting legible. It changes only what
+// OTHER members get — the owner's own list never moves — so a member who changed it and watched
+// their own card used to conclude it did nothing.
+//
+// Two rules follow from that, and both matter more than they look:
+//   1. The choice is three words under the section heading — Everything / A summary / Nothing — not
+//      a dropdown whose closed state showed one sentence with no heading attached to it.
+//   2. The preview renders the REAL components with the peer's data, so it is the copy another
+//      member actually receives rather than a description of it. No admin caveat appears anywhere
+//      here: nothing in this app is end-to-end encrypted, so admin access is a given, and saying it
+//      on this card only crowded out the thing the member came to read.
 //
 // The three choices are three real outcomes at `GET /api/trust/user/[userId]`: `public` serves the
 // full panel to any signed-in member, `restricted` serves the summary projection, `private` refuses
 // with 403. The owner and admins always read the full panel.
 import React from "react";
-import { Eye, Check, CheckCircle2 } from "lucide-react";
+import { Eye, Check } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import type { TrustTokens } from "./trust-shared";
 import type { TrustPeerEvidenceItem, TrustVisibility } from "../../lib/trust/types";
 import { TRUST_VISIBILITY_VALUES } from "../../lib/trust/types";
 import { summarizeTrustEvidenceForPeer } from "../../lib/trust/peer-summary";
 import { getTrustTokens } from "./trust-shared";
+import { TrustEvidenceRow, TrustSummaryNote, TrustSectionLabel, TRUST_HAIRLINE } from "./trust-evidence-row";
 
-// Display order runs most open to most private, so the dropdown reads as a scale. The exported enum
+// Display order runs most open to most private, so the three read as one scale. The exported enum
 // keeps its own order for validation; this is presentation only.
 const VISIBILITY_ORDER: readonly TrustVisibility[] = ["public", "restricted", "private"];
 
-// The 5% hairline has no exact shell-token equivalent, so it stays as the shipped literal.
-const HAIRLINE = "rgba(255,255,255,0.05)";
-
-// Each choice states who sees what, in plain words, as a sentence about members rather than an
-// abstract label. "Public" / "Restricted" / "Private" named a category and left the reader to guess
-// the category's rules — which is how the three got read as kinds of transaction. These say the
-// outcome instead, so no guessing is required and the three read as one scale.
-//
-// Every choice names the thing being shared — "your trust signals" — instead of pointing at it with
-// "everything" or "this". A closed dropdown shows only the selected line, with the question above it
-// scrolled away or forgotten, so a label like "Only you see this" left the member with no idea what
-// "this" was.
+// Each choice completes the section heading — "What members see: Everything / A summary / Nothing" —
+// so it is one question with three amounts, not three separate ideas. The category names
+// ("Public" / "Restricted" / "Private") are deliberately not used: they named a bucket and left the
+// member to work out the bucket's rules.
 //
 // The stored values are still `public` / `restricted` / `private`; only what the member reads
 // changed. Nothing here is a promise about the rest of the app — this setting governs the trust
-// panel and nothing else.
+// card and nothing else.
 const OPTION_LABEL: Record<TrustVisibility, string> = {
-  public: "Members see all your trust signals",
-  restricted: "Members see a summary of your trust signals",
-  private: "Only you see your trust signals",
-};
-
-// Admins are named in the effect line rather than the label: they can read any member's panel, so
-// leaving it out would make "Only you see your trust signals" a claim the app does not keep.
-const OPTION_EFFECT: Record<TrustVisibility, string> = {
-  public: "Any signed-in member who opens your profile sees the signals listed above.",
-  restricted:
-    "Members see how active you are, without the detail or the dates. Enough to tell that you take part here.",
-  private: "No other member can see your trust signals. Admins can, as they can for every member.",
+  public: "Everything",
+  restricted: "A summary",
+  private: "Nothing",
 };
 
 // The same three outcomes described from a viewer's side, for the read-only row on another member's
@@ -70,7 +60,7 @@ const PEER_LABEL: Record<TrustVisibility, string> = {
 
 // A member's stored value should always be one of the three, but a row written before the column
 // was constrained (or by hand) could be anything; fall back to the column default rather than
-// rendering a blank select.
+// rendering a blank control.
 function normalize(value: string): TrustVisibility {
   return (TRUST_VISIBILITY_VALUES as readonly string[]).includes(value) ? (value as TrustVisibility) : "public";
 }
@@ -79,7 +69,7 @@ function wrapperStyle(bordered: boolean): React.CSSProperties {
   return {
     padding: bordered ? "9px 0 0" : 0,
     marginTop: bordered ? 0 : 4,
-    borderTop: bordered ? `1px solid ${HAIRLINE}` : "none",
+    borderTop: bordered ? `1px solid ${TRUST_HAIRLINE}` : "none",
   };
 }
 
@@ -97,14 +87,14 @@ function ReadOnlyRow({ current, bordered, t }: { current: TrustVisibility; borde
 
 function SaveStatus({ saving, saved, error, t }: { saving: boolean; saved: boolean; error: string | null; t: TrustTokens }) {
   if (error) {
-    return <div style={{ fontSize: 10, color: "#F87171", marginTop: 5, lineHeight: 1.4 }}>{error}</div>;
+    return <div style={{ fontSize: 10, color: "#F87171", marginTop: 6, lineHeight: 1.4 }}>{error}</div>;
   }
   if (saving) {
-    return <div style={{ fontSize: 10, color: t.FAINT, marginTop: 5 }}>Saving…</div>;
+    return <div style={{ fontSize: 10, color: t.FAINT, marginTop: 6 }}>Saving…</div>;
   }
   if (saved) {
     return (
-      <div style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 10, color: "#34D399", marginTop: 5 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 10, color: "#34D399", marginTop: 6 }}>
         <Check size={11} /> Saved
       </div>
     );
@@ -112,45 +102,54 @@ function SaveStatus({ saving, saved, error, t }: { saving: boolean; saved: boole
   return null;
 }
 
-// Shows the member exactly what a peer sees at the current setting. This is what makes the control
-// legible: the setting's whole effect is on other people's screens, so without a preview the member
-// changes it, watches their own unchanged card, and concludes it does nothing.
-//
-// The lines come from `summarizeTrustEvidenceForPeer` — the same function the cross-user route runs
-// — so the preview cannot promise something different from what peers actually receive.
+function choiceStyle(selected: boolean, disabled: boolean, t: TrustTokens): React.CSSProperties {
+  return {
+    flex: 1,
+    padding: "9px 4px",
+    borderRadius: 8,
+    fontSize: 11,
+    fontWeight: selected ? 700 : 500,
+    lineHeight: 1.3,
+    textAlign: "center",
+    cursor: disabled ? "default" : "pointer",
+    color: selected ? "#38BDF8" : t.MUTED,
+    background: selected ? "rgba(56,189,248,0.14)" : t.INPUT_BG,
+    border: `1px solid ${selected ? "rgba(56,189,248,0.55)" : t.BORDER_STRONG}`,
+    opacity: disabled && !selected ? 0.6 : 1,
+  };
+}
+
+// What another member gets at the current choice, drawn with the same components the other member's
+// screen uses. `public` shows the owner's own rows unchanged; `restricted` shows the projection from
+// `summarizeTrustEvidenceForPeer` — the same function the cross-user route runs, so the preview
+// cannot promise something different from what peers actually receive.
 function PeerPreview({ current, evidence, t }: { current: TrustVisibility; evidence: readonly TrustPeerEvidenceItem[]; t: TrustTokens }) {
-  const lines = current === "restricted" ? summarizeTrustEvidenceForPeer(evidence) : [];
+  const rows = current === "public" ? [...evidence] : current === "restricted" ? summarizeTrustEvidenceForPeer(evidence) : [];
+
+  // Nothing is rendered for `private` because nothing is what a member gets: the route refuses the
+  // read, so there is no copy to show and a sentence has to stand in for the absence.
+  if (current === "private") {
+    return (
+      <div style={{ marginTop: 8, fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
+        Nothing. The Trust card does not appear on your profile for other members.
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div style={{ marginTop: 8, fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
+        Nothing yet — signals appear here once you have taken part somewhere.
+      </div>
+    );
+  }
 
   return (
-    <div style={{ marginTop: 8, padding: "8px 10px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: `1px solid ${HAIRLINE}` }}>
-      <div style={{ fontSize: 10, fontWeight: 600, color: t.FAINT, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 6 }}>
-        What members see
-      </div>
-      {current === "public" && (
-        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
-          Every trust signal listed above, exactly as you see it.
-        </div>
-      )}
-      {current === "private" && (
-        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
-          Nothing — your trust signals do not appear on your profile for them.
-        </div>
-      )}
-      {current === "restricted" && lines.length === 0 && (
-        <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
-          Nothing yet — a summary appears here once you have taken part somewhere.
-        </div>
-      )}
-      {current === "restricted" && lines.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          {lines.map((line, idx) => (
-            <div key={idx} style={{ display: "flex", alignItems: "center", gap: 6 }}>
-              <CheckCircle2 size={11} style={{ color: "#38BDF8", flexShrink: 0 }} />
-              <span style={{ fontSize: 11, color: t.TEXT }}>{line.summary}</span>
-            </div>
-          ))}
-        </div>
-      )}
+    <div style={{ marginTop: 8, padding: "10px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: `1px solid ${TRUST_HAIRLINE}`, display: "flex", flexDirection: "column", gap: 6 }}>
+      {current === "restricted" && <TrustSummaryNote />}
+      {rows.map((item, idx) => (
+        <TrustEvidenceRow key={idx} item={item} />
+      ))}
     </div>
   );
 }
@@ -168,7 +167,6 @@ export interface TrustVisibilityControlProps {
 export function TrustVisibilityControl({ visibility, bordered, editable, evidence }: TrustVisibilityControlProps) {
   const { theme } = useTheme();
   const t = getTrustTokens(theme);
-  const selectId = React.useId();
   const [current, setCurrent] = React.useState<TrustVisibility>(normalize(visibility));
   const [saving, setSaving] = React.useState(false);
   const [saved, setSaved] = React.useState(false);
@@ -199,15 +197,13 @@ export function TrustVisibilityControl({ visibility, bordered, editable, evidenc
       if (!res.ok) {
         const body = (await res.json().catch(() => null)) as { message?: string } | null;
         setCurrent(previous);
-        setError(body?.message ?? `Could not save the visibility setting (status ${res.status}).`);
+        setError(body?.message ?? `Could not save what members see (status ${res.status}).`);
         return;
       }
       setSaved(true);
     } catch (err) {
       setCurrent(previous);
-      setError(
-        `Could not reach the server to save the visibility setting: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      setError(`Could not reach the server to save what members see: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setSaving(false);
     }
@@ -219,35 +215,26 @@ export function TrustVisibilityControl({ visibility, bordered, editable, evidenc
 
   return (
     <div style={wrapperStyle(bordered)}>
-      <label htmlFor={selectId} style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <Eye size={12} style={{ color: t.SUBTLE }} />
-        <span style={{ fontSize: 12, fontWeight: 600, color: t.SUBTLE }}>Who sees your trust signals</span>
-      </label>
-      <select
-        id={selectId}
-        value={current}
-        disabled={saving}
-        onChange={(e) => void updateVisibility(e.target.value as TrustVisibility)}
-        style={{
-          width: "100%",
-          padding: "9px 10px",
-          borderRadius: 8,
-          fontSize: 12,
-          color: t.TEXT,
-          background: t.INPUT_BG,
-          border: `1px solid ${t.BORDER_STRONG}`,
-          appearance: "auto",
-        }}
-      >
+      <TrustSectionLabel>What members see</TrustSectionLabel>
+      <div role="radiogroup" aria-label="What members see" style={{ display: "flex", gap: 6, marginTop: 7 }}>
         {VISIBILITY_ORDER.map((value) => (
-          <option key={value} value={value} style={{ color: t.BG }}>
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={value === current}
+            disabled={saving}
+            onClick={() => {
+              if (value !== current) {
+                void updateVisibility(value);
+              }
+            }}
+            style={choiceStyle(value === current, saving, t)}
+          >
             {OPTION_LABEL[value]}
-          </option>
+          </button>
         ))}
-      </select>
-      <p style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.5, margin: "6px 0 0" }}>
-        {OPTION_EFFECT[current]} You always see everything on your own card, whichever one you pick.
-      </p>
+      </div>
       <PeerPreview current={current} evidence={evidence ?? []} t={t} />
       <SaveStatus saving={saving} saved={saved} error={error} t={t} />
     </div>


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

## What was wrong

The bottom of the Trust card stacked several unrelated things with nothing separating them: a heading, a dropdown whose closed line stood on its own, a sentence describing the effect, and a boxed preview with its own "WHAT MEMBERS SEE" label. Reported as jumbled — three different ideas in one section — with two specific problems: the preview's label is text that never appears on another member's screen, and the preview described the result instead of showing it.

## What changed

The card body on your own card is now two labeled sections.

**"Your trust"** — your signal rows. Always all of them, whatever the choice is. Labeling it is what makes the next section make sense: the list above is yours and never moves, the section below is everyone else's and does.

**"What members see"** — the choice and its result:

- The dropdown is replaced by three buttons that complete the section heading: **Everything** / **A summary** / **Nothing**. That is one question with three amounts, rather than three sentences that read as three separate concepts. Keyboard-reachable as a radio group labeled "What members see".
- The standalone effect sentence is dropped. The two section labels carry what it said.
- The preview no longer has its own label and no longer describes the outcome in prose. It renders the real rows another member receives, using the same components their screen uses — `TrustEvidenceRow` for the rows and the summary note above them on "A summary". On "Nothing" a single line stands in, because a member receives no card at all and there is no copy to show.
- The admin sentence is removed. Nothing in this app is end-to-end encrypted, so admin access is a given across every surface; repeating it here only crowded out the thing the member came to read.

**Why three choices and not two.** The three are amounts of one thing, not three concepts — everything, a summary, or nothing. The middle one is a real tier added on 2026-08-07: `restricted` serves a coarse projection (sign-in days, how many plugins you take part in) so a member checking whether someone actually participates gets an answer without seeing the record. Dropping it would put that back to all-or-nothing. The new heading plus one-word buttons is what makes them read as a scale.

Another member's card is untouched: no section split, no buttons, just the one-line row saying what that member shares.

## Structure

`TrustEvidenceRow`, the summary note, and the section label moved out of `TrustWidgetCard.tsx` into `components/trust/trust-evidence-row.tsx` (rule 116), so the card and the preview draw the same components. A hand-written imitation of the peer rows would drift the first time either side changed.

Presentation only — the stored values (`public` / `restricted` / `private`), the routes, the contracts, and the schema are unchanged.

## Docs kept in step

- Trust feature inventory: User Features entry and the web delivery-status paragraph rewritten to the new structure, with a change log entry.
- Trust manual test script (TR-A5b) rewritten: steps now press the buttons, and the expectations pin the two section labels, the buttons over a dropdown, the preview being real rows rather than a description, no inner "WHAT MEMBERS SEE" label, and no admin sentence anywhere in the section.

## Checks run locally

`tsc --noEmit` (all packages), `pnpm --filter @ctf/web run lint`, `pnpm --filter @ctf/web run build`, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs` — all pass.

Follows #2185, which is already merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q7VzgoznjPmuWFwnueYsh)_