### PR TITLE
fix: use US spelling in the Trust card comments

### DIFF
--- a/ctf/packages/web/components/trust/TrustWidgetCard.tsx
+++ b/ctf/packages/web/components/trust/TrustWidgetCard.tsx
@@ -13,7 +13,7 @@
 //   surfaces (`editable`), because POST /api/trust/visibility is self-scope only;
 //   when the card shows another member's trust the row stays read-only.
 //
-// On the member's own card the body is two labelled sections — "Your trust" (these signals, always
+// On the member's own card the body is two labeled sections — "Your trust" (these signals, always
 // all of them) then "What members see" (the choice and a preview of the result). Before the labels
 // the two ran together and read as one jumbled block, which is what made the setting hard to place.
 import React from "react";

--- a/ctf/packages/web/components/trust/trust-visibility-control.tsx
+++ b/ctf/packages/web/components/trust/trust-visibility-control.tsx
@@ -5,7 +5,7 @@
 // Split out of TrustWidgetCard (rule 116) so the card stays a rendering component and this file
 // owns the one piece of state and the one write call in it (POST /api/trust/visibility).
 //
-// The card reads as two labelled sections: the member's own signals under "Your trust", then this
+// The card reads as two labeled sections: the member's own signals under "Your trust", then this
 // one under "What members see". That split is what makes the setting legible. It changes only what
 // OTHER members get — the owner's own list never moves — so a member who changed it and watched
 // their own card used to conclude it did nothing.


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

Two code comments added in #2186 wrote "labelled". The US Spelling Gate flagged both, and that PR merged while the check was red, so `main` currently fails the gate.

Both are now "labeled":

- `ctf/packages/web/components/trust/TrustWidgetCard.tsx:16`
- `ctf/packages/web/components/trust/trust-visibility-control.tsx:8`

Comments only — no rendered copy, no behavior change.

`check-us-spelling.mjs` and `check-eof-format.sh` pass locally, as does the all-packages typecheck.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q7VzgoznjPmuWFwnueYsh)_