### PR TITLE
fix: name the Commons service by its member-facing name on Account &amp; Data

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -293,6 +293,15 @@ An owner-curated list of real community comments, shown two ways on the public (
 
 ## 5) Change Log
 
+- 2026-08-10: **Account & Data names the Commons service by its member-facing name (owner report).**
+  The service row on `/account/data` (web and the Android screen, both fed by
+  `GET /api/account/services`) still read "Feed & Announcements" — the internal name of the tables —
+  even though the surface those tables belong to is called the Commons everywhere a member sees it.
+  The row now reads **"Commons: Feed & Announcements"**, keeping the old wording after the colon so
+  a member who remembers the previous label still recognises the row, and its one-line summary now
+  says "Your Commons posts…" instead of "Your community posts…". Copy-only, in the `name` and
+  `dataSummary` fields of the `feed-announcements` entry in `lib/account/deletion-registry.ts`; the
+  slug, the table list, and every delete/export behavior are unchanged.
 - 2026-08-03: **The member block now has a real starting point and a first enforcing surface (§1.6).**
   The reusable `BlockMemberButton` had been built, exported, and attached to nothing, so the only way
   to block anyone was the manage-list at `/account/blocks` — which needs you to already know who you

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -199,8 +199,11 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
   },
   {
     slug: 'feed-announcements',
-    name: 'Feed & Announcements',
-    dataSummary: 'Your community posts, replies, questions, answers, ratings, and read/dismiss state.',
+    // The member-facing name of this service is the Commons — the home screen these tables feed.
+    // The old "Feed & Announcements" wording is kept after the colon so a member who remembers the
+    // old label still recognises the row.
+    name: 'Commons: Feed & Announcements',
+    dataSummary: 'Your Commons posts, replies, questions, answers, ratings, and read/dismiss state.',
     serviceScopeSupported: true,
     tables: [
       del('feed_answer_ratings', 'user_id', 'Your ratings on answers.'),


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — the Android Account & Data screen reads the same `GET /api/account/services` response, so it picks up the new label with no app change.

## What changed

The service row on `/account/data` read **"Feed & Announcements"** — the internal name of the tables — while the surface those tables belong to is called the **Commons** everywhere a member actually looks. Reported from the Account & Data screen.

The row now reads **"Commons: Feed & Announcements"**. The old wording is kept after the colon so a member who remembers the previous label still recognises the row. Its one-line summary changes from "Your community posts, replies, …" to "Your Commons posts, replies, …".

Copy only — the `name` and `dataSummary` fields of the `feed-announcements` entry in `ctf/packages/web/lib/account/deletion-registry.ts`. The slug, the table list, and every delete and export behavior are untouched.

Both surfaces are covered by the one change: the web shell and the React Native Account & Data screen both render the names returned by `GET /api/account/services`, which is built from this registry.

## Documentation

Change-log entry added to `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md`, which is the inventory that owns the Account & Data surface.

## Checks run locally

`pnpm --filter @ctf/web typecheck`, `lint`, and `build`; `check-eof-format.sh`; `check-deletion-registry.mjs`, `check-deletion-engine.mjs`, `check-export-engine.mjs`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs` — all pass.

## Not changed (would need your approval)

Two admin-facing labels still say "Feed Announcements": the `/admin` landing tile and the `Feed & Announcements Admin` header on `/admin/feed-announcements`. Left as shipped since the report was about member-facing copy — say the word if you want those renamed too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCEFCQQktSmW8Ggw52J5qK)_