### PR TITLE
fix: use US spelling in the Commons service label notes

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -298,7 +298,7 @@ An owner-curated list of real community comments, shown two ways on the public (
   `GET /api/account/services`) still read "Feed & Announcements" — the internal name of the tables —
   even though the surface those tables belong to is called the Commons everywhere a member sees it.
   The row now reads **"Commons: Feed & Announcements"**, keeping the old wording after the colon so
-  a member who remembers the previous label still recognises the row, and its one-line summary now
+  a member who remembers the previous label still recognizes the row, and its one-line summary now
   says "Your Commons posts…" instead of "Your community posts…". Copy-only, in the `name` and
   `dataSummary` fields of the `feed-announcements` entry in `lib/account/deletion-registry.ts`; the
   slug, the table list, and every delete/export behavior are unchanged.

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -201,7 +201,7 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
     slug: 'feed-announcements',
     // The member-facing name of this service is the Commons — the home screen these tables feed.
     // The old "Feed & Announcements" wording is kept after the colon so a member who remembers the
-    // old label still recognises the row.
+    // old label still recognizes the row.
     name: 'Commons: Feed & Announcements',
     dataSummary: 'Your Commons posts, replies, questions, answers, ratings, and read/dismiss state.',
     serviceScopeSupported: true,


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — comment and documentation text only.

## What changed

#2189 merged while its US Spelling Gate run was still red, so `main` carries the British "recognises" in two places:

- a code comment in `ctf/packages/web/lib/account/deletion-registry.ts`
- the matching change-log entry in `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md`

Both now read "recognizes", so the gate passes on `main` again and future PRs are not blocked by it.

No behavior change — the service label itself, the slug, the tables, and every delete and export path are untouched.

## Checks run locally

`node ctf/scripts/check-us-spelling.mjs` passes; the pre-commit typecheck gate passes across all workspace packages.

Follow-up to #2189.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCEFCQQktSmW8Ggw52J5qK)_