### PR TITLE
fix: start the Weekly Performance week history at the launch week

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -34,8 +34,11 @@ The plugin ships on web (desktop + mobile-responsive). The former native Android
 2. An as-of anchor under the headline Community Value Index: "Cumulative since June 12, 2026" — the
    soft launch date (owner decision, 2026-08-06; the Render production deploy came slightly earlier,
    2026-05-25). The index sums all recognized exchanges from launch onward and never resets to a
-   calendar year. The date is one constant (`COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` in
-   `ctf/packages/web/components/gdp/gdp-shared.ts`) so a corrected launch date changes in one place.
+   calendar year. The date is one platform-owned constant, `PLATFORM_LAUNCH_DATE_ISO` in
+   `ctf/packages/web/lib/platform/launch.ts` (GDP's `COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` in
+   `ctf/packages/web/components/gdp/gdp-shared.ts` re-exports it), so a corrected launch date
+   changes in one place and every surface that counts from launch — GDP here, the Weekly
+   Performance week history — follows together.
 3. Current annual `Total GDP`, `Service GDP`, `Goods/Local GDP` with plain-language explanations.
 3. Per-capita indicators based on population baseline and selected period.
 4. Progress-to-target indicators for $300B total and $210B services goals.
@@ -353,6 +356,12 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 
 ## 10) Change Log
 
+- 2026-08-10: **Launch date moved to a platform-owned constant; no visible change to GDP.** Weekly
+  Performance needed the same launch date to floor its week history, and a plugin must not import
+  another plugin's code, so `2026-06-12` now lives in `ctf/packages/web/lib/platform/launch.ts` as
+  `PLATFORM_LAUNCH_DATE_ISO`. GDP's `COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` re-exports it, so the
+  on-screen line still reads "Cumulative since June 12, 2026" and the two surfaces cannot drift
+  apart. No schema, route, or contract change.
 - 2026-08-06: **As-of anchor corrected to the soft launch date: "Cumulative since June 12, 2026"
   (owner decision).** The first pass anchored to the Render production deploy (2026-05-25); the
   owner identified 2026-06-12 as the actual soft launch, so the constant in `gdp-shared.ts` now

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
@@ -59,7 +59,7 @@ actually exist are listed here).
 
 Read routes (admin or approved user). Each writes a `weekly_performance_audit_trail` row on an allow decision:
 
-- `GET /api/weekly-performance/weeks` — a continuous run of weeks, newest first: every week from the current week (an ISO Monday start) back to the earliest of one year ago or the oldest tracked week, so the list never skips a week. Stored weeks keep their real status; generated weeks with no row are `open` and read live per window. Audits `weekly-performance.week.list`.
+- `GET /api/weekly-performance/weeks` — a continuous run of weeks, newest first: every week from the current week (an ISO Monday start) back to the earliest of one year ago or the oldest tracked week, so the list never skips a week. The run stops at the week containing the platform launch date (`PLATFORM_LAUNCH_DATE_ISO` = 2026-06-12, `ctf/packages/web/lib/platform/launch.ts`), so the oldest week in the list is the week of Jun 8–14, 2026 and no pre-launch week is offered — the floor applies to stored rows too, so demo/seed data cannot pull the list back past launch. Stored weeks keep their real status; generated weeks with no row are `open` and read live per window. Audits `weekly-performance.week.list`.
 - `GET /api/weekly-performance/weeks/[weekStart]` — canonical window metadata for an arbitrary week start date (`{weekStart, weekEnd, isCurrentWeek, status}`); this is the full `weekly-performance.week.get` surface (accepts any `weekStart`, validated as an ISO `YYYY-MM-DD` date), audits `weekly-performance.week.get`.
 - `GET /api/weekly-performance/current-week` — convenience read of the **current** week plus active-user count (last 7 days); also audits `weekly-performance.week.get` (it is the current-week-only projection of that command, not the parameterized surface).
 - `GET /api/weekly-performance/metrics?weekStartDate=...[&compareWeekStartDate=...]` — week metrics, or a week-over-week comparison when `compareWeekStartDate` is supplied; audits `weekly-performance.metrics.get` or `weekly-performance.comparison.get` per branch.
@@ -153,6 +153,17 @@ V2's "verified" and "approved" member counts are intentionally omitted: V3's `us
 
 ## 8) Change Log
 
+- 2026-08-10: **The week history now starts at the launch week (owner report).** The picker listed
+  weeks going back a year, so it offered windows from before the platform existed (Apr 2026 and
+  earlier) that could only ever read zero. `listWeeks` (`lib/weekly-performance/repository.ts`) now
+  floors both the generated run and the stored rows at the week containing the launch date, so the
+  oldest entry is the week of Jun 8–14, 2026. The launch date moved out of the GDP shell into a
+  platform-owned constant, `PLATFORM_LAUNCH_DATE_ISO` in `ctf/packages/web/lib/platform/launch.ts`;
+  GDP's `COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` now reads that constant, so its on-screen line
+  ("Cumulative since June 12, 2026") is unchanged and both surfaces can never disagree about the
+  date. Selecting the launch week shows no week-over-week comparison, because there is no earlier
+  week to compare against — the shell already handles the oldest week that way. No schema, route,
+  or contract change.
 - 2026-07-19: **Fixed the week picker's skipped weeks and ugly mobile labels; deleted the export feature (owner report).** (1) *Week list skipped weeks.* `listWeeks` (`lib/weekly-performance/repository.ts`) previously returned only stored weeks plus the synthesized current week, so the picker jumped straight from an old stored week to the current one. It now generates a continuous run of weeks — the current week (ISO Monday start) back to the earliest of one year ago or the oldest tracked week — unioned with stored weeks so none is dropped; generated weeks with no row read `open` and compute live per window. Both web and Android benefit (shared `/weeks` route). The week **start day is unchanged** (ISO Monday, per owner: v3 does not need the V2 Saturday boundary). (2) *Ugly mobile labels.* The mobile-responsive web week selector showed the raw ISO date (`Week of 2026-07-13`); it now shows the friendly range (`Week of Jul 13–19, 2026`) via `formatWeekRange`, matching desktop. (3) *Deleted the export feature.* Removed the `GET /api/weekly-performance/export` route, every Export button/hint (desktop header, desktop sidebar "Admin Controls" box, mobile-web header button, right-rail "Export available to admins" note, Android history "CSV export is admin-only" hint), the `weekly-performance.report.export` command/access/audit contract entries, and the now-unused `WEEKLY_PERFORMANCE_EXPORT_ENABLED` flag. With export gone the shell's `isAdmin` prop had no remaining UI effect and was dropped (the page still gates admin-only). No schema change.
 - 2026-07-18: **Consolidated to a single admin surface (owner directive: "the member view should
   now be removed. Only an admin page for weekly performance").** `/admin/weekly-performance` now

--- a/ctf/docs/developer/test-scripts/gdp-test-script.md
+++ b/ctf/docs/developer/test-scripts/gdp-test-script.md
@@ -58,7 +58,7 @@
 - One hero tile labeled "Members" shows a whole number greater than zero.
 - The weekly-active-members tile is absent.
 - No mock or placeholder numbers (e.g. "1,234,567") appear — the count matches what the Directory shows for total active members.
-- The line "Cumulative since June 12, 2026" appears directly under the headline Community Value Index figure (added 2026-08-06: the index is all-time from the soft launch date, never a yearly figure).
+- The line "Cumulative since June 12, 2026" appears directly under the headline Community Value Index figure (added 2026-08-06: the index is all-time from the soft launch date, never a yearly figure). The date now comes from the platform-wide launch constant (`PLATFORM_LAUNCH_DATE_ISO`), so check it still reads June 12, 2026 here and matches the oldest week offered in Weekly Performance ("Jun 8–14, 2026").
 
 Result: web ☐
 

--- a/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
+++ b/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
@@ -82,13 +82,19 @@ admits `admin` or the `operations` role, matching `requiredRoles: [admin, operat
 **Role:** admin / operations · **Surfaces:** web (desktop), web (mobile-responsive)
 **Steps:**
 1. Read the week history (current week back through prior weeks) and the current week.
-2. Pick a week to review (web admin picker, or the History tab on Android).
+2. Scroll the list to the bottom and read the oldest week it offers.
+3. Pick a week to review (web admin picker, or the History tab on Android).
+4. Pick the oldest week — the launch week — and look for the comparison chart.
 **Expected:** Weeks use an ISO Monday start. The list is **continuous — it never skips a week**:
 every week from the current one back to the earliest tracked week (or a year, whichever is longer)
-appears, newest first, even for weeks with no activity (they read zero). Labels are a friendly range
-(e.g. "Jul 13–19, 2026") on desktop **and** the mobile-responsive week selector — never a raw ISO
-date. Picking a week shows that week's live metrics; the current week is marked **Live**. There is no
-"set active week" action and no per-week status.
+appears, newest first, even for weeks with no activity (they read zero). The list **stops at the
+launch week**: the oldest entry is "Jun 8–14, 2026" (the week containing the 12 June 2026 launch),
+and no earlier week — Apr or May 2026, or anything from 2025 — is offered on either the desktop
+sidebar or the mobile week selector. Labels are a friendly range (e.g. "Jul 13–19, 2026") on
+desktop **and** the mobile-responsive week selector — never a raw ISO date. Picking a week shows
+that week's live metrics; the current week is marked **Live**. The launch week shows its own
+numbers but no week-over-week comparison, since there is no earlier week to compare against. There
+is no "set active week" action and no per-week status.
 **Result:** web ☐ mobile ☐ — notes:
 
 ### WP-A3 · Metrics and week-over-week comparison

--- a/ctf/packages/web/components/gdp/gdp-shared.ts
+++ b/ctf/packages/web/components/gdp/gdp-shared.ts
@@ -1,6 +1,7 @@
 // Shared constants and types for the GDP web shell.
 // Palette/layout derive from design/.../survivor-hub/GDP.tsx.
 
+import { PLATFORM_LAUNCH_DATE_ISO } from "@/lib/platform/launch";
 import { getAppAccent, type ThemeName } from "@/lib/theme/theme-tokens";
 import { getPluginShellTokens, type PluginShellTokens } from "@/components/shared/plugin-shell-theme";
 
@@ -102,12 +103,11 @@ export const COMMUNITY_VALUE_INDEX_DISCLAIMER =
   "Community Value is one measure of all the value exchanged in this community — money, crypto, ServiceCredits, and barter — combined through a fixed set of weights. It's a relative index for transparency, in the spirit of GDP. It isn't money, a price, or an exchange or redemption value for any currency or token.";
 
 // The date the index counts from. The index is cumulative — every recognition source sums its full
-// table history with no time window (lib/gdp/recognition.ts), so the honest anchor is the launch
-// date: 2026-06-12, the soft launch (owner decision, 2026-08-06). The Render production deploy came
-// slightly earlier (2026-05-25, PRs #98–#117), but the announced launch is the date members count
-// from. If the owner fixes a different date later, change it here only — every surface reads this
-// one constant.
-export const COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO = "2026-06-12";
+// table history with no time window (lib/gdp/recognition.ts), so the honest anchor is the platform
+// launch date. That date now lives in the platform-owned constant `PLATFORM_LAUNCH_DATE_ISO`
+// (lib/platform/launch.ts) because Weekly Performance needs the same value; change it there and
+// every surface follows.
+export const COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO = PLATFORM_LAUNCH_DATE_ISO;
 export const COMMUNITY_VALUE_INDEX_SINCE_LABEL = "Cumulative since June 12, 2026";
 
 // The projected figure: what the posts already on the board would add IF every one of them closed

--- a/ctf/packages/web/lib/platform/launch.ts
+++ b/ctf/packages/web/lib/platform/launch.ts
@@ -1,0 +1,12 @@
+// The date the platform launched, as one platform-owned constant.
+//
+// 2026-06-12 is the soft launch (owner decision, 2026-08-06). The Render production deploy came
+// slightly earlier (2026-05-25, PRs #98–#117), but the announced launch is the date members count
+// from. Nothing on the platform has real history before this date, so any surface that shows a
+// running total or a run of time periods starts here rather than inventing empty pre-launch
+// windows.
+//
+// This file is platform-owned, not plugin-owned: it lives outside every plugin directory so that
+// GDP, Weekly Performance, and anything added later all read the same value. If the owner fixes a
+// different launch date, change it here only.
+export const PLATFORM_LAUNCH_DATE_ISO = "2026-06-12";

--- a/ctf/packages/web/lib/weekly-performance/repository.ts
+++ b/ctf/packages/web/lib/weekly-performance/repository.ts
@@ -1,4 +1,5 @@
 import { queryDb } from 'lib/db/postgres';
+import { PLATFORM_LAUNCH_DATE_ISO } from 'lib/platform/launch';
 import { computeLiveWeekMetrics } from 'lib/weekly-performance/live-metrics';
 
 type WeekRow = {
@@ -23,19 +24,36 @@ function mapWeek(row: WeekRow) {
 // stored row are shown as 'open'; their numbers are computed live per window, so an empty week
 // simply reads zero rather than being missing from the list. Nothing is persisted here — a week
 // gets a row only when an admin sets it active (see selectWeek).
+//
+// The run stops at the week containing the platform launch date (owner report, 2026-08-10): the
+// platform did not exist before then, so an earlier week is not a week that read zero — it is a
+// week that never happened, and listing it invites a reader to compare against a window with no
+// meaning. The floor covers stored rows too, so a pre-launch row seeded by demo data cannot pull
+// the list back past launch. `LEAST(current_start, ...)` keeps the generated run non-empty even if
+// a clock ever reads a date before launch.
 export async function listWeeks() {
   const result = await queryDb<WeekRow>(
-    `WITH current_week AS (
-       SELECT DATE_TRUNC('week', NOW())::date AS current_start
+    `WITH bounds AS (
+       SELECT DATE_TRUNC('week', NOW())::date AS current_start,
+              DATE_TRUNC('week', $1::date)::date AS launch_start
      ),
      span AS (
        SELECT
-         cw.current_start,
+         b.current_start,
          LEAST(
-           (cw.current_start - INTERVAL '51 weeks')::date,
-           COALESCE((SELECT MIN(week_start_date) FROM weekly_performance_weeks), cw.current_start)
+           b.current_start,
+           GREATEST(
+             b.launch_start,
+             LEAST(
+               (b.current_start - INTERVAL '51 weeks')::date,
+               COALESCE(
+                 (SELECT MIN(week_start_date) FROM weekly_performance_weeks WHERE week_start_date >= b.launch_start),
+                 b.current_start
+               )
+             )
+           )
          ) AS earliest_start
-       FROM current_week cw
+       FROM bounds b
      ),
      series AS (
        SELECT generate_series(sp.current_start, sp.earliest_start, INTERVAL '-1 week')::date AS week_start_date
@@ -43,6 +61,7 @@ export async function listWeeks() {
      ),
      combined AS (
        SELECT week_start_date, status FROM weekly_performance_weeks
+       WHERE week_start_date >= (SELECT launch_start FROM bounds)
        UNION
        SELECT s.week_start_date, 'open' AS status
        FROM series s
@@ -56,6 +75,7 @@ export async function listWeeks() {
      FROM combined
      ORDER BY week_start_date DESC
      LIMIT 260`,
+    [PLATFORM_LAUNCH_DATE_ISO],
   );
 
   return result.rows.map(mapWeek);


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

The Weekly Performance week picker listed weeks going back a year, so it offered windows from before the platform existed — the oldest entry read "Week of Apr 6–12, 2026", while the app launched on 12 June 2026. Those weeks can only ever read zero, and offering them invites a reader to compare the current week against a window that never happened.

The launch date was already recorded in the codebase: GDP shows "Cumulative since June 12, 2026" from the constant `COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` in `components/gdp/gdp-shared.ts` (owner decision, 2026-08-06). Weekly Performance was not reading it.

## What changed

- **`lib/weekly-performance/repository.ts`** — `listWeeks` now floors the week run at the week containing the launch date, so the oldest entry is the week of **Jun 8–14, 2026** (ISO Monday start, unchanged). The floor covers stored rows too, so a pre-launch row left behind by demo or seed data cannot pull the list back past launch. A `LEAST(current_start, …)` guard keeps the generated run non-empty if a clock ever reads a date before launch.
- **`lib/platform/launch.ts`** (new) — the launch date is now the platform-owned constant `PLATFORM_LAUNCH_DATE_ISO`. It had to move out of the GDP shell because a plugin must not import another plugin's code (`check-plugin-boundaries.mjs`), and both surfaces need the same value.
- **`components/gdp/gdp-shared.ts`** — `COMMUNITY_VALUE_INDEX_SINCE_DATE_ISO` now reads that constant. The on-screen line is unchanged and still reads "Cumulative since June 12, 2026"; the two surfaces can no longer disagree about the date.

Selecting the launch week shows its own numbers with no week-over-week comparison, because there is no earlier week to compare against — `priorWeekStart` in the shell already returns nothing for the oldest week in the list, so no UI change was needed.

No schema, route, or contract change. Both feature inventories and both manual test scripts were updated to match.

## How it was checked

The new query was run against a scratch Postgres 16 instance with a stand-in table:

- Today's window returns Aug 10 back to Jun 8 and nothing earlier (10 weeks).
- Stored week statuses (`locked`, `published`) survive the floor.
- A stored pre-launch row (2026-03-02) is dropped from the list.
- With no stored rows at all, the run is still Jun 8 through Aug 10.
- A clock set before launch still returns a non-empty list rather than a runaway or empty series.

Also run locally and green: web typecheck, web lint, web build, `check-eof-format.sh`, `check-plugin-boundaries.mjs`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-us-spelling.mjs`, `check-modularity-governance.sh`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YSGmosV9gMC6yRugsJkpHn)_