### PR TITLE
fix: name the admin announcements surface after the Commons

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-feed-feature-inventory.md
@@ -99,7 +99,10 @@ Architecture decisions in effect:
 
 ### 2.1 Central Admin Surface
 
-1. Single admin page at `/admin/feed-announcements` for Feed + Announcements controls.
+1. Single admin page at `/admin/feed-announcements` for Feed + Announcements controls. It is titled
+   **Commons: Feed & Announcements Admin**, and the `/admin` landing tile that opens it is named
+   **Commons: Feed & Announcements** — the same name the Account & Data screen gives this service,
+   so every surface calls it after the Commons.
 2. Role-gated create/edit/publish/archive actions.
 3. Moderation and publish-state controls with auditability.
 
@@ -356,6 +359,16 @@ All three feed channels (announcements, questions, community) are shipped on web
 
 ## 11) Change Log
 
+- 2026-08-10: **The admin surface is named after the Commons too (owner request, follow-on from the
+  Account & Data rename in #2189).** The `/admin` landing tile read "Feed Announcements" and the
+  screen header read "Feed & Announcements Admin" — neither named the surface those announcements
+  land on. The tile is now **Commons: Feed & Announcements** (matching the Account & Data service
+  row exactly) and the header is **Commons: Feed & Announcements Admin**. It still sits beside
+  **Commons Moderation**, which is the separate power over member-authored posts. Copy only —
+  `app/admin/page.tsx` and `components/feed-announcements/feed-announcements-admin-shell.tsx`; no
+  route, schema, or contract change. Test step FD-A1 updated to check the new header (and to drop
+  the "ADMIN badge" it told the tester to look for, which the shared header has not rendered since
+  the surface moved to `MobileScreenHeader`).
 - 2026-08-09: **Account deletion now deletes Commons posts instead of leaving them under a generic
   name (owner report).** Deleting an account removed `feed_community_posts` / `feed_questions` but
   the Commons reads `feed_items`, which holds a copy of every post and question carrying the same

--- a/ctf/docs/developer/test-scripts/feed-test-script.md
+++ b/ctf/docs/developer/test-scripts/feed-test-script.md
@@ -477,8 +477,9 @@
 **Precondition:** Signed in as an admin. Seed has run.
 
 **Steps:**
-1. Navigate to `/admin/feed-announcements`.
-2. Observe the header (should include an icon + ADMIN badge).
+1. Navigate to `/admin/feed-announcements`. Reach it from `/admin` — the tile is named
+   **Commons: Feed & Announcements**.
+2. Observe the header. It reads **Commons: Feed & Announcements Admin** and includes an icon.
 3. Confirm the feed config panel shows current values from the database (render mode, enabled channels, `is_public` flag).
 4. Confirm an announcement list is shown.
 

--- a/ctf/packages/web/app/admin/page.tsx
+++ b/ctf/packages/web/app/admin/page.tsx
@@ -30,11 +30,13 @@ const ADMIN_AREAS: { href: string; name: string }[] = [
   { href: '/admin/contributions', name: 'Contributions' },
   { href: '/admin/contributor-access', name: 'Contributor Access' },
   { href: '/admin/directory', name: 'Directory' },
-  // Moderating member-authored Commons posts and replies (hide / put back). Kept separate from Feed
-  // Announcements, which is an authoring tool for the owner's own announcements — this one carries a
-  // different power, over someone else's words.
+  // Moderating member-authored Commons posts and replies (hide / put back). Kept separate from the
+  // announcements area below, which is an authoring tool for the owner's own announcements — this
+  // one carries a different power, over someone else's words.
   { href: '/admin/commons', name: 'Commons Moderation' },
-  { href: '/admin/feed-announcements', name: 'Feed Announcements' },
+  // Named for the Commons, the member-facing surface these announcements land on — the same name
+  // the Account & Data screen uses for this service.
+  { href: '/admin/feed-announcements', name: 'Commons: Feed & Announcements' },
   // Review of member-contributed writing for the assistant's library. Its own area rather than a tab
   // inside AI Assistant: it has its own queue, and a contribution waiting to be read should show up
   // in the admin directory on its own.

--- a/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
+++ b/ctf/packages/web/components/feed-announcements/feed-announcements-admin-shell.tsx
@@ -348,7 +348,7 @@ export function FeedAnnouncementsAdminShell({
         fontFamily: "'Inter',system-ui,sans-serif",
       }}
     >
-      <MobileScreenHeader title="Feed & Announcements Admin" accent={t.ACCENT} icon={<Megaphone size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/" accent={t.ACCENT} label="Commons" />} />
+      <MobileScreenHeader title="Commons: Feed & Announcements Admin" accent={t.ACCENT} icon={<Megaphone size={18} color={t.ACCENT} />} actions={<PluginUserShellButton href="/" accent={t.ACCENT} label="Commons" />} />
       <div style={{ maxWidth: 880, margin: '0 auto', padding: '24px 16px 48px' }}>
         {/* No in-page title card here: MobileScreenHeader above already names the screen and
             carries the icon, back control, and Member view. Repeating it cost a screen of phone


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105) — admin surfaces are web-only.

## What changed

Follow-on to #2189, which renamed the member-facing Account & Data row to "Commons: Feed & Announcements". The two admin labels still used the internal name:

| Where | Before | After |
|---|---|---|
| `/admin` landing tile (`app/admin/page.tsx`) | Feed Announcements | **Commons: Feed & Announcements** |
| Screen header (`components/feed-announcements/feed-announcements-admin-shell.tsx`) | Feed & Announcements Admin | **Commons: Feed & Announcements Admin** |

The tile name now matches the Account & Data service row exactly, so all three surfaces call this one thing by the same name. It still sits beside **Commons Moderation**, which is the separate power over member-authored posts — the comment there is reworded so it no longer refers to the old name.

Copy only. No route, schema, or contract change.

## Documentation and test script

- Inventory §2.1 and the change log in `ctf-feed-feature-inventory.md` record both names.
- Test step FD-A1 in `feed-test-script.md` now checks the new header, and reaches the page from the renamed `/admin` tile. It also no longer tells the tester to look for an "ADMIN badge" — the shared `MobileScreenHeader` this surface uses does not render one, so that step was checking something that is not there.

## Checks run locally

`pnpm --filter @ctf/web` typecheck / lint / build; `check-eof-format.sh`; `check-us-spelling.mjs`; `check-inventory-drift.mjs`; `check-test-script-drift.mjs` — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCEFCQQktSmW8Ggw52J5qK)_