### PR TITLE
ci: stop the Stream quota gate firing on documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,8 +281,18 @@ jobs:
           # ctf/scripts/changed-files.mjs — it drops dialect-only files and nothing else.
           changed_files=$(node ctf/scripts/changed-files.mjs --base "$base_sha")
 
-          if echo "$changed_files" | grep -Eiq '^ctf/.*(stream|getstream)'; then
-            echo "Detected Stream-related code changes in this PR."
+          # Documentation is excluded from the trigger for the same reason: a markdown file consumes
+          # no Stream quota, whatever its name says. The trigger matches file paths, so a document
+          # whose title merely contains the word — ctf/docs/developer/BEACON_PHONE_STREAMING_GUIDE.md
+          # is the one that exposed this — was read as a Stream code change and demanded a quota note
+          # describing a change in consumption that had not happened. Quota notes themselves live
+          # under ctf/docs/quota-impact/ and are the answer to this gate, never the thing that fires
+          # it. Code under ctf/ is unaffected: every real Stream change still has to carry its note.
+          stream_changes=$(echo "$changed_files" | grep -Ev '^ctf/docs/' | grep -Ei '^ctf/.*(stream|getstream)' || true)
+
+          if [ -n "$stream_changes" ]; then
+            echo "Detected Stream-related code changes in this PR:"
+            echo "$stream_changes"
 
             quota_notes=$(echo "$changed_files" | grep -E '^ctf/docs/quota-impact/.+\.md$' | grep -Ev '^ctf/docs/quota-impact/TEMPLATE\.md$' || true)
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

The **Stream Quota Impact Note** gate decides a change is Stream-related by matching changed file *paths* against `^ctf/.*(stream|getstream)`, case-insensitively. That reads a document whose title merely contains the word as a Stream code change.

It went red on #2201 for `ctf/docs/developer/BEACON_PHONE_STREAMING_GUIDE.md` and demanded a quota note describing a change in consumption that had not happened — a markdown file consumes no Stream quota whatever it is called.

Documentation is now filtered out of the trigger before the match runs:

```sh
stream_changes=$(echo "$changed_files" | grep -Ev '^ctf/docs/' | grep -Ei '^ctf/.*(stream|getstream)' || true)
```

The failing path also prints which files it matched, instead of only saying it found some.

## Why excluding `ctf/docs/` is safe

- Quota notes live under `ctf/docs/quota-impact/` and are the **answer** to this gate, never the thing that fires it.
- Code under `ctf/` is untouched — every real Stream change still has to carry its note.
- The heading validation further down the job is unchanged.

This follows the reasoning already in the job for dialect-only changes (`ctf/scripts/changed-files.mjs`): do not weaken the gate, answer its question honestly. A file that cannot change Stream consumption should not be read as changing it.

## Checks run locally

Exercised the new expression against the cases that matter:

| Changed files | Gate |
|---|---|
| `ctf/docs/developer/BEACON_PHONE_STREAMING_GUIDE.md` | quiet |
| `ctf/packages/web/lib/beacon/stream.ts` | fires |
| that code file **and** the doc together | fires |
| `ctf/packages/web/app/api/beacon/stream-webhook/route.ts` | fires |
| `ctf/docs/quota-impact/2026-06-21-beacon-livestream-video.md` alone | quiet |
| unrelated code, empty list, non-`ctf/` paths | quiet |

`check-eof-format.sh` passes and the workflow YAML parses.

## Lane

Low-risk (CI configuration, no product surface) — auto-merge enabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPDkZxhMio1fkjjN3RXUAU)_