### PR TITLE
fix: start the Beacon broadcast when any publisher joins

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -135,8 +135,11 @@ feed; when the event ends, Beacon auto-posts the recording to the Commons as a r
   `deleteDraftBeaconEvent`. Both the deletion and a refused attempt are written to the audit trail.
 
 ### Webhook
-- `POST /api/beacon/stream-webhook` — Stream recording-ready (and call lifecycle) events; verifies the
-  Stream signature, stores `recording_url`, posts the replay to the Commons.
+- `POST /api/beacon/stream-webhook` — Stream call lifecycle events; verifies the Stream signature and
+  acts on two of them. On `call.session_participant_joined` it starts the public HLS feed and the
+  recording for the matching `live` event, which is what carries a phone-only RTMP broadcast. On
+  `call.recording_ready` it stores `recording_url` and posts the replay to the Commons. Every other
+  event is acknowledged without acting so Stream stops retrying.
 
 ## Data Model and Storage Contracts
 
@@ -217,16 +220,15 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 - Whether anonymous viewers see the live chat read-only or just a "sign in to chat" panel (lean
   read-only so the room feels alive).
 - Replay hosting: link to Stream's recording URL vs. re-hosting; start with the Stream URL.
-- **A phone-only (RTMP) broadcast may never start the public HLS feed or the recording.**
-  `POST /api/beacon/[id]/start-broadcast` is the only caller of `startBeaconBroadcastEgress`, and it
-  fires from one place: the in-browser screen-share control in `beacon-host-stage.tsx`, when a screen
-  share starts (`useHasOngoingScreenShare`). A phone pushing RTMP publishes an ordinary video track,
-  not a screen-share track, so it does not trigger that call. Whether viewers still see the broadcast
-  depends on the Stream `livestream` call-type setting for automatic HLS, which is not asserted
-  anywhere in this repo. Fallback for the admin today: open the live event on `/admin/beacon` from a
-  computer and click **Share screen** once, which starts HLS and recording for the whole call.
-  Proper fix (not implemented): start egress when RTMP ingest begins — from Stream's ingress webhook,
-  or a short retry after go-live that starts egress once media is present.
+- ~~**A phone-only (RTMP) broadcast may never start the public HLS feed or the recording.**~~ Closed
+  2026-08-10: the Stream webhook now starts egress on `call.session_participant_joined`, so any
+  publisher — RTMP from a phone or the in-browser screen-share — starts the public feed and the
+  recording. See the change log entry for that date.
+- **The phone-only path has not been exercised end to end against production Stream yet.** The fix
+  above is written against Stream's documented event name and is guarded so a non-`live` event is
+  never put back on air, but no one has yet run a broadcast from a phone with no browser involved and
+  confirmed video reaches `/apps/beacon` and a replay lands in the Commons. That run is step BCN-A2c
+  in the manual test script.
 
 ## Build Checklist (flat, ordered; dependency-named — no phases)
 
@@ -256,6 +258,27 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 
 ## Change Log
 
+- 2026-08-10: **A broadcast run from a phone now reaches viewers and produces a replay.** The public
+  HLS feed and the recording are started by `startBeaconBroadcastEgress`, reached through
+  `POST /api/beacon/[id]/start-broadcast` — and the only thing that called it was the in-browser
+  screen-share control, which fires on `useHasOngoingScreenShare`. A phone pushing RTMP publishes an
+  ordinary video track, not a screen-share track, so it never triggered that call: a broadcast run
+  entirely from a phone could leave viewers in front of an empty player, and recorded nothing, so no
+  `call.recording_ready` event ever arrived and no replay was posted to the Commons. The one input
+  path the plugin was designed around (owner-locked decision 8 — the admin demos the app by streaming
+  the phone screen) was the one that did not complete.
+  `POST /api/beacon/stream-webhook` now also acts on `call.session_participant_joined` and starts
+  egress for the matching event. Stream's RTMP ingress publishes into the call as a participant, so
+  that event is the first moment media exists and egress can start; it covers the browser host too, so
+  both input paths now start the broadcast the same way. Guarded three ways: only an event whose
+  status is `live` is acted on, so neither a draft nor an ended event can be put back on air by a
+  webhook; the signature check in front of the route is unchanged; and a start that Stream refuses
+  because egress is already running is reported (`op: 'start_egress_on_participant_joined'`) and
+  acknowledged rather than retried. Only publishers join this call — viewers watch over public HLS —
+  so the event arrives once or twice per broadcast, not once per viewer. No schema, no new route, no
+  contract change. Quota-impact note:
+  `ctf/docs/quota-impact/2026-08-10-beacon-egress-on-rtmp-publisher.md`. Not yet exercised against
+  production Stream from a real phone; that run is BCN-A2c in the test script.
 - 2026-08-10: **Wrote the phone streaming guide (owner request).** The admin screen hands out an RTMP
   URL and a stream key after "Go live", but nothing in the repo said what to do with them, so the
   admin had to remember the broadcaster-app setup from one broadcast to the next. Added

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -156,13 +156,9 @@ there too, with `policy_status = 'allow'`.
 3. For a desktop demo: use "Share screen" to capture a desktop screen/window in the browser.
 **Expected:** Go Live flips the event out of backstage to `live` and auto-posts the "live now" notice
 to the Commons. The host stage mounts after go-live; HLS + recording start once a host is actually
-publishing (the in-browser screen-share triggers `start-broadcast`). Only the host can publish —
-viewers never can. On error, the underlying Stream message is surfaced, not a generic text.
-Watch the phone-only path specifically: a phone pushing RTMP publishes an ordinary video track, not a
-screen-share track, so it does **not** trigger `start-broadcast`. If the broadcaster app reports it is
-sending and `/apps/beacon` stays empty for more than a minute, that gap (recorded under Gaps in the
-Beacon inventory) is what you are seeing; clicking "Share screen" once from a computer on the same
-live event starts HLS + recording for the whole call and video should then appear.
+publishing — either the in-browser screen-share posting to `start-broadcast`, or Stream's
+`call.session_participant_joined` webhook when a phone's RTMP feed joins the call. Only the host can
+publish — viewers never can. On error, the underlying Stream message is surfaced, not a generic text.
 Opening the call must succeed on the first press: Beacon asks Stream to record at 720p, and a
 missing recording size is what previously made every Go Live come back with `(400)` and
 `recording quality is required when audio_only is false and recording is enabled`. Seeing that
@@ -185,6 +181,28 @@ is not configured." No banner ever shows a bare "Broadcast input unavailable." w
 API key or stream key appears in it. A Stream Chat problem alone (the host's chat registration) must
 not stop the broadcast: the event still goes live and only the host's chat name/moderator role is
 missing.
+**Result:** web ☐ mobile ☐ — notes:
+
+### BCN-A2c · A phone-only broadcast reaches viewers and produces a replay
+**Role:** admin · **Surfaces:** web (admin surface + public viewer)
+**Precondition:** a phone with a broadcaster app set up per
+`ctf/docs/developer/BEACON_PHONE_STREAMING_GUIDE.md`. **No computer touches the broadcast** — this
+case exists to prove the phone path completes on its own, so do not click "Share screen" anywhere
+during it.
+**Steps:**
+1. Create an event and press Go Live on the phone.
+2. Copy the RTMP URL + stream key into the broadcaster app and start sending.
+3. Open `/apps/beacon` signed out, on a different device, and wait up to a minute.
+4. Stop the broadcaster app and press End broadcast.
+5. Check the Commons after the recording is delivered.
+**Expected:** Video appears for the signed-out viewer without anyone sharing a screen. Behind it,
+Stream's `call.session_participant_joined` webhook fires when the phone's RTMP feed joins, the route
+starts HLS and the recording for that `live` event, and `GET /api/beacon/current` begins returning an
+`hlsPlaybackUrl`. After the event ends, `call.recording_ready` arrives and the replay is posted to the
+Commons. An empty player after a minute means egress never started — check that the webhook is
+reaching the app and that `call.session_participant_joined` is enabled in the Stream dashboard, which
+is the setting this case is really testing. Before 2026-08-10 this case failed by design: only an
+in-browser screen-share started egress.
 **Result:** web ☐ mobile ☐ — notes:
 
 ### BCN-A3 · Moderate the chat

--- a/ctf/docs/quota-impact/2026-08-10-beacon-egress-on-rtmp-publisher.md
+++ b/ctf/docs/quota-impact/2026-08-10-beacon-egress-on-rtmp-publisher.md
@@ -1,0 +1,89 @@
+# Stream Quota Impact Note — Beacon starts egress when any publisher joins
+
+## Summary
+
+- Feature/Change: Start the public HLS feed and the recording when a publisher actually joins the
+  Beacon call, instead of only when the in-browser screen-share starts. The existing
+  `POST /api/beacon/[id]/start-broadcast` route is the only thing that starts HLS and recording, and
+  its only caller was the browser screen-share control, which fires on a screen-share track. A phone
+  pushing RTMP publishes an ordinary video track, so a broadcast run entirely from a phone started
+  neither: viewers could sit in front of an empty player, and nothing was recorded, so no replay was
+  posted to the Commons. The Stream webhook route now also acts on
+  `call.session_participant_joined` and starts egress for the matching live event.
+- PR: opened from branch `fix/beacon-start-egress-on-rtmp-publisher`.
+- Owner: chargingthefuture
+- Date: 2026-08-10
+
+## Stream Surfaces Affected
+
+- Chat / Activity Feeds / Video / AI Moderation: **Video only.** This changes *what triggers* the
+  start of HLS and recording on a call that has already gone live. It adds no call, no new API poll,
+  and no new participant. No change to Chat, Activity Feeds, or AI Moderation.
+
+## Estimated Monthly Impact
+
+- Chat MAU impact estimate: no change (the event chat channel and its members are untouched).
+- Activity Feed API calls estimate: no change. The replay notice posted to the Commons is unchanged —
+  it was already written on `call.recording_ready`. In the phone-only case that notice previously never
+  fired at all, so this is at most one Feed write per phone broadcast that should already have
+  happened.
+- Video participant-minutes / HLS / recording estimate: **unchanged for the browser path, and up by
+  the intended amount for the phone path.** For a browser-hosted broadcast the egress start now has
+  two possible triggers instead of one, but egress can only start once per call, so consumption is
+  identical. For a phone-only broadcast, HLS distribution and one recording now happen where before
+  they did not — that is the feature working as designed, not new overhead. No new polling and no
+  per-interval traffic is introduced: the trigger is a webhook Stream already sends.
+- Webhook volume: `call.session_participant_joined` is delivered for publishers only. Viewers watch
+  over public HLS and never join the call, so this is one or two deliveries per broadcast, not one per
+  viewer. Webhook deliveries are not a metered Stream surface.
+- AI Moderation credits estimate: no change.
+
+## Budget Threshold Risk
+
+- Expected threshold after rollout (Green/Yellow/Orange/Red): **Green-to-Yellow**, the same band the
+  feature already sat in. Beacon runs a single one-way livestream at a time, so HLS distribution and
+  recording scale with broadcast duration and viewer count. This change does not raise the ceiling; it
+  makes the phone input path reach the ceiling the browser path already could.
+- Peak scenario estimate: a long, well-attended broadcast (HLS to many viewers plus one recording).
+  Unchanged by this PR — the peak driver is viewer count and duration, not the trigger.
+- Newly consuming case to be aware of: a phone broadcast that previously produced no HLS and no
+  recording now produces both. If a phone broadcast is started and left running unattended, it draws
+  Video quota where it previously drew none. Ending the event remains the stop control.
+
+## Fallback and Degradation Plan
+
+- What degrades first: if Stream is not configured, `startBeaconBroadcastEgress` returns false and the
+  handler acknowledges the webhook with `handled: false`; nothing throws and no broadcast state
+  changes. If Stream refuses the start because egress is already running, the error is reported and
+  acknowledged — the broadcast is already on air, so there is nothing to recover.
+- User-visible messaging behavior: unchanged. The public viewer stays in its starting/idle state until
+  the HLS playlist URL appears, and the admin surfaces are untouched by this PR.
+- Kill switch / feature flag: unchanged. Demo-mode sessions are routed to the dedicated **staging**
+  Stream app via `resolveStreamCredentials`, so demo and recording sessions never draw on the
+  production Maker-tier quota. To cut HLS and recording quickly, ending the event
+  (`POST /api/beacon/[id]/end`) stops the call, HLS distribution, and recording — that remains the one
+  stop control, and it now matters more for phone broadcasts because they consume quota where they
+  previously consumed none.
+- Guard against a webhook putting an event back on air: the handler starts egress only for an event
+  whose status is `live`. A draft that has not gone live, and an ended event still receiving a
+  straggling join, are both ignored.
+
+## Observability
+
+- Metrics and alerts added/updated: none added. A failed or duplicate start is reported through
+  `reportError` with `op: 'start_egress_on_participant_joined'` and carries the event id and call id,
+  so the phone path is now visible in error reporting instead of failing silently. The pre-existing
+  `op: 'stream_webhook'` catch now also records the event type it was handling. Stream's own dashboard
+  remains the source of truth for HLS and recording usage.
+
+## Validation
+
+- Tests added for degraded mode: none automated. The degraded paths are the false-return branch in
+  `startBeaconBroadcastEgress` (Stream unconfigured), the non-`live` event guard, and the caught
+  duplicate-start error. Typecheck, lint, and build pass for the changed files.
+- Manual check: run a broadcast from a phone only, with no browser screen-share anywhere, and confirm
+  video reaches `/apps/beacon` signed out and a replay is posted to the Commons after the event ends.
+  This is recorded as a step in `ctf/docs/developer/test-scripts/beacon-test-script.md`.
+- Rollback strategy: revert the branch. Beacon returns to its prior state — egress starts only from
+  the in-browser screen-share, and phone-only broadcasts again produce no public feed and no replay.
+  No data migration is involved.

--- a/ctf/packages/web/app/api/beacon/stream-webhook/route.ts
+++ b/ctf/packages/web/app/api/beacon/stream-webhook/route.ts
@@ -5,33 +5,77 @@ import {
   postBeaconReplayNotice,
   recordBeaconRecording,
 } from 'lib/beacon/repository';
-import { verifyBeaconWebhookSignature } from 'lib/beacon/stream';
+import { startBeaconBroadcastEgress, verifyBeaconWebhookSignature } from 'lib/beacon/stream';
 import { reportError } from 'lib/observability/report';
 import { failureReason } from 'lib/errors/failure';
 
 export const dynamic = 'force-dynamic';
 
-// Pull the call id and recording URL out of the payload defensively. `call_cid` looks like
-// "livestream:beacon-<id>"; strip the type prefix to get the call id. Missing/odd values yield empty
-// strings, which the caller treats as "nothing to do". We never fabricate a URL.
-function extractRecordingInfo(payload: Record<string, unknown>): { callId: string; recordingUrl: string } {
+// Every call event carries `call_cid`, which looks like "livestream:beacon-<id>"; strip the type
+// prefix to get the call id. A missing/odd value yields an empty string, which every caller treats as
+// "nothing to do".
+function extractCallId(payload: Record<string, unknown>): string {
   const callCid = typeof payload.call_cid === 'string' ? payload.call_cid : '';
-  const callId = callCid.includes(':') ? callCid.split(':').slice(1).join(':') : callCid;
-  const recording = (payload.call_recording ?? {}) as Record<string, unknown>;
-  const recordingUrl = typeof recording.url === 'string' ? recording.url : '';
-  return { callId, recordingUrl };
+  return callCid.includes(':') ? callCid.split(':').slice(1).join(':') : callCid;
 }
 
-// Handle the recording-ready payload: store the URL and post the replay. Non-recording-ready events,
-// and recording-ready events missing a call id / URL / matching event, are acknowledged without
-// acting so Stream stops retrying.
-async function handleRecordingReady(payload: Record<string, unknown>): Promise<NextResponse> {
-  const type = typeof payload.type === 'string' ? payload.type : '';
-  if (type !== 'call.recording_ready') {
-    // Acknowledge other lifecycle events so Stream stops retrying; only recording-ready acts.
+// Pull the call id and recording URL out of the payload defensively. Missing/odd values yield empty
+// strings, which the caller treats as "nothing to do". We never fabricate a URL.
+function extractRecordingInfo(payload: Record<string, unknown>): { callId: string; recordingUrl: string } {
+  const recording = (payload.call_recording ?? {}) as Record<string, unknown>;
+  const recordingUrl = typeof recording.url === 'string' ? recording.url : '';
+  return { callId: extractCallId(payload), recordingUrl };
+}
+
+// Start the public broadcast as soon as a publisher is actually present.
+//
+// "Go live" only flips the call out of backstage. The public HLS feed and the recording are started
+// separately by startBeaconBroadcastEgress, because Stream refuses to start either while no one is
+// publishing. Until now the only caller was the in-browser screen-share control, which fires on
+// `useHasOngoingScreenShare`. A phone pushing RTMP publishes an ordinary video track, not a
+// screen-share track, so a broadcast run entirely from a phone started neither: viewers could sit in
+// front of an empty player, and nothing was recorded, so no recording-ready event ever arrived and no
+// replay was posted to the Commons. This handler closes that path, and covers the browser host too.
+//
+// Source: Stream Video webhook events (getstream.io/video/docs/api/webhooks/events/), confirmed
+// 2026-08-10. `call.session_participant_joined` fires when a participant joins the call session, and
+// Stream's RTMP ingress publishes into the call as a participant — so this is the first moment media
+// exists and egress can be started.
+//
+// Only publishers ever join this call: viewers watch over public HLS and never join it, so this
+// arrives once or twice per broadcast, not once per viewer.
+async function handleParticipantJoined(payload: Record<string, unknown>): Promise<NextResponse> {
+  const callId = extractCallId(payload);
+  if (callId.length === 0) {
     return NextResponse.json({ ok: true, handled: false }, { status: 200 });
   }
 
+  const event = await getBeaconEventByCallId(callId);
+  // Only a live event has anything to broadcast. A draft that has not gone live, or an ended event
+  // still receiving a straggling join, must never be put back on air by a webhook.
+  if (!event || event.status !== 'live') {
+    return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+  }
+
+  try {
+    const started = await startBeaconBroadcastEgress(event.id);
+    return NextResponse.json({ ok: true, handled: started }, { status: 200 });
+  } catch (error) {
+    // Reaching here usually means egress was already running — the browser screen-share control got
+    // there first, or a second publisher joined — and Stream refused to start it twice. Either way the
+    // broadcast is already on air, so this is recorded and acknowledged rather than retried.
+    reportError(error, {
+      area: 'beacon',
+      op: 'start_egress_on_participant_joined',
+      extra: { eventId: event.id, callId },
+    });
+    return NextResponse.json({ ok: true, handled: false }, { status: 200 });
+  }
+}
+
+// Handle the recording-ready payload: store the URL and post the replay. A payload missing a call id
+// / URL / matching event is acknowledged without acting so Stream stops retrying.
+async function handleRecordingReady(payload: Record<string, unknown>): Promise<NextResponse> {
   const { callId, recordingUrl } = extractRecordingInfo(payload);
 
   if (callId.length === 0 || recordingUrl.length === 0) {
@@ -54,14 +98,25 @@ async function handleRecordingReady(payload: Record<string, unknown>): Promise<N
   return NextResponse.json({ ok: true, handled: true }, { status: 200 });
 }
 
-// Stream Video webhook. Verifies the signature, and on a recording-ready event stores the recording
-// URL and posts the replay to the Commons. Idempotent: the recording URL and the Commons post id are
-// each written only when still null, so a redelivered webhook never double-posts the replay.
+// Stream Video webhook. Verifies the signature, then acts on two events:
+//
+//   - `call.session_participant_joined` — a publisher is now on the call, so start the public HLS
+//     feed and the recording. This is what carries a phone-only RTMP broadcast, which otherwise
+//     starts neither.
+//   - `call.recording_ready` — store the recording URL and post the replay to the Commons.
+//
+// Every other event is acknowledged without acting so Stream stops retrying.
+//
+// Idempotent in both directions: the recording URL and the Commons post id are each written only when
+// still null, so a redelivered webhook never double-posts the replay, and a repeated participant-join
+// is reported and ignored rather than starting a second broadcast.
 //
 // Source: Stream Video recording docs (getstream.io/video/docs/react/advanced/recording/), confirmed
-// 2026-06-21. The event name is `call.recording_ready` (fired ~30s+ after the recording stops). The
-// payload carries `call_cid` (e.g. "livestream:beacon-<id>") identifying the call and the recording
-// URL at `call_recording.url`. We read those defensively and never fabricate a URL.
+// 2026-06-21, and Stream Video webhook events (getstream.io/video/docs/api/webhooks/events/),
+// confirmed 2026-08-10. `call.recording_ready` fires ~30s+ after the recording stops and carries the
+// URL at `call_recording.url`; `call.session_participant_joined` fires when a participant joins the
+// session. Both carry `call_cid` (e.g. "livestream:beacon-<id>") identifying the call. We read those
+// defensively and never fabricate a URL.
 export async function POST(request: Request) {
   const rawBody = await request.text();
   const signature = request.headers.get('x-signature');
@@ -81,10 +136,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, code: BEACON_ERROR_CODE.invalidJson, message: 'Invalid JSON body.', reason: failureReason(error) }, { status: 400 });
   }
 
+  const type = typeof payload.type === 'string' ? payload.type : '';
+
   try {
-    return await handleRecordingReady(payload);
+    if (type === 'call.session_participant_joined') {
+      return await handleParticipantJoined(payload);
+    }
+    if (type === 'call.recording_ready') {
+      return await handleRecordingReady(payload);
+    }
+    // Acknowledge every other lifecycle event so Stream stops retrying.
+    return NextResponse.json({ ok: true, handled: false }, { status: 200 });
   } catch (error) {
-    reportError(error, { area: 'beacon', op: 'stream_webhook' });
+    reportError(error, { area: 'beacon', op: 'stream_webhook', extra: { type } });
     // Return 200 so Stream does not hammer retries on our transient failure; we logged it.
     return NextResponse.json({ ok: true, handled: false }, { status: 200 });
   }


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**Waiting on owner review — auto-merge deliberately not enabled.** It changes a webhook route and the broadcast lifecycle, which the repo's lanes put in the review lane.

## The problem

A Beacon broadcast run from a phone could leave viewers in front of an empty player, and produced no replay at all.

The public HLS feed and the recording are started by `startBeaconBroadcastEgress`, reached through `POST /api/beacon/[id]/start-broadcast`. The only thing that called it was the in-browser screen-share control in `beacon-host-stage.tsx`, which fires on `useHasOngoingScreenShare`. A phone pushing RTMP publishes an **ordinary video track, not a screen-share track**, so it never triggered that call.

The recording half is unambiguous: the call is created with `recording: { mode: 'available' }`, meaning recording has to be started explicitly. Phone-only, it never was — so no `call.recording_ready` event ever arrived, and no replay was posted to the Commons. The live-feed half depended on a Stream call-type setting for automatic HLS that is not asserted anywhere in this repo.

That left the one input path the plugin was designed around — owner-locked decision 8, the admin demos the app by streaming the phone screen — as the one that did not complete.

## The fix

`POST /api/beacon/stream-webhook` now also acts on `call.session_participant_joined` and starts egress for the matching event. Stream's RTMP ingress publishes into the call as a participant, so that event is the first moment media exists and egress can be started. It covers the in-browser host too, so both input paths now start the broadcast the same way.

The route already existed, already verified Stream's signature, and already acknowledged every non-recording-ready event without acting — this adds one branch to it. No new endpoint, no schema change, no contract change.

## Guards

- **Only a `live` event is acted on.** Neither a draft that has not gone live nor an ended event still receiving a straggling join can be put back on air by a webhook.
- **The signature check in front of the route is unchanged** — an unsigned request still gets a 401 and never reaches the handler.
- **A duplicate start is absorbed.** If Stream refuses because egress is already running (the browser control got there first, or a second publisher joined), it is reported with `op: 'start_egress_on_participant_joined'` and acknowledged rather than retried.
- **Volume is publisher-scale, not viewer-scale.** Viewers watch over public HLS and never join the call, so this arrives once or twice per broadcast.

## Review notes

- The event name comes from Stream's webhook events documentation, cited in a source comment beside the handler as this file already does for `call.recording_ready`. It has **not** been exercised against production Stream from a real phone — recorded honestly in the inventory Gaps section, and added as **BCN-A2c** in the test script for that run.
- `call.session_participant_joined` must be enabled for the app in the Stream dashboard. BCN-A2c calls that out as the setting it is really testing.

## Also updated

- `ctf/docs/quota-impact/2026-08-10-beacon-egress-on-rtmp-publisher.md` — required by the Stream quota gate. Video only; no new call, poll, or participant. Browser path consumption is identical; the phone path now consumes what it was always meant to. Flags the newly consuming case: a phone broadcast left running unattended now draws Video quota where it previously drew none.
- Beacon inventory — webhook route description, the Gaps entry closed and replaced with the honest "not yet run against production" one, and a change-log entry.
- `beacon-test-script.md` — BCN-A2's expectation now names both egress triggers, plus the new BCN-A2c.

## Checks run locally

`pnpm --filter @ctf/web run typecheck`, `lint`, and `build` all pass, as do `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-us-spelling.mjs`, `check-error-verbosity.mjs`, `check-orphan-routes.mjs`, `check-plugin-boundaries.mjs`, and `check-modularity-governance.sh`. The Stream quota gate was simulated against the changed-file list: it fires on the route and is satisfied by the note, with all seven required headings present.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPDkZxhMio1fkjjN3RXUAU)_