### PR TITLE
fix: link Commons Beacon notices to the full Beacon web address

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md
@@ -78,7 +78,9 @@ feed; when the event ends, Beacon auto-posts the recording to the Commons as a r
 - **Recording = Stream Video recording.** Recording is enabled on the call; when it is ready Stream
   delivers the URL via webhook. Beacon stores the URL and posts the replay to the Commons.
 - **Commons integration** reuses the existing feed/announcement path: a "🔴 Live now" entry on go-live
-  (linking to `/apps/beacon`) and a "▶️ Watch the replay" entry when the recording is ready.
+  and a "▶️ Watch the replay" entry when the recording is ready. Both carry the full web address
+  `https://app.chargingthefuture.com/apps/beacon`, so the reader can tap straight through instead of
+  having to work out the domain from a bare path.
 
 ## User Features (viewer surface, `/apps/beacon`)
 
@@ -258,6 +260,12 @@ stops. HLS is used for public viewers so scale does not multiply WebRTC cost.
 
 ## Change Log
 
+- 2026-08-12: **The Commons notices link straight to Beacon.** The auto-posted "🔴 Live now" and
+  "▶️ Watch the replay" entries said "at `/apps/beacon`" — a piece of a web address, which nobody can
+  tap and which only works for a reader who already knows the domain. Both now carry the full address
+  `https://app.chargingthefuture.com/apps/beacon`, matching the announcement link lines in
+  `lib/feed/repository.ts`. Copy-only change in `postBeaconLiveNotice` / `postBeaconReplayNotice`
+  (`lib/beacon/repository.ts`); no schema, contract, route, or API change.
 - 2026-08-10: **A broadcast run from a phone now reaches viewers and produces a replay.** The public
   HLS feed and the recording are started by `startBeaconBroadcastEgress`, reached through
   `POST /api/beacon/[id]/start-broadcast` — and the only thing that called it was the in-browser

--- a/ctf/docs/developer/test-scripts/beacon-test-script.md
+++ b/ctf/docs/developer/test-scripts/beacon-test-script.md
@@ -92,9 +92,10 @@ the member's real account.
 **Precondition:** an event has ended and its recording is ready.
 **Steps:**
 1. After the event ends, check the Commons feed.
-**Expected:** A "🔴 Live now" entry appeared on go-live (linking to `/apps/beacon`), and a
-"▶️ Watch the replay" entry appears once the recording is ready. The replay is posted only once
-(never double-posted).
+**Expected:** A "🔴 Live now" entry appeared on go-live, and a "▶️ Watch the replay" entry appears
+once the recording is ready. Both entries show the full web address
+`https://app.chargingthefuture.com/apps/beacon` — a tappable link, not a bare `/apps/beacon` path —
+and tapping it opens the Beacon viewer. The replay is posted only once (never double-posted).
 **Result:** web ☐ mobile ☐ — notes:
 
 ---

--- a/ctf/packages/web/lib/beacon/repository.ts
+++ b/ctf/packages/web/lib/beacon/repository.ts
@@ -224,7 +224,11 @@ export async function insertBeaconAudit(input: {
   );
 }
 
-const BEACON_APP_PATH = '/apps/beacon';
+// Commons notices carry the full web address, not a bare `/apps/beacon` path. A member reading the
+// post in the mobile feed or in Commons can tap it and land on the broadcast; a path fragment only
+// works if the reader already knows the domain and types it in. Same shape as the announcement link
+// lines in `lib/feed/repository.ts`.
+const BEACON_APP_URL = 'https://app.chargingthefuture.com/apps/beacon';
 
 // Auto-post a "live now" notice to the Commons on go-live. Idempotent: if the event already carries a
 // live-post id we skip. Returns the post id (or null when nothing was posted). A Commons failure is
@@ -234,7 +238,7 @@ export async function postBeaconLiveNotice(event: BeaconEvent): Promise<string |
     return event.commonsLivePostId;
   }
   try {
-    const body = `🔴 Live now: ${event.title}. Watch the broadcast at ${BEACON_APP_PATH} — no sign-in needed to watch; sign in to chat.`;
+    const body = `🔴 Live now: ${event.title}. Watch the broadcast at ${BEACON_APP_URL} — no sign-in needed to watch; sign in to chat.`;
     const post = await createFeedCommunityPost(event.hostUserId, { body, category: 'event' });
     await setBeaconLivePostId(event.id, post.postId);
     return post.postId;
@@ -253,7 +257,7 @@ export async function postBeaconReplayNotice(event: BeaconEvent): Promise<string
     return null;
   }
   try {
-    const body = `▶️ Watch the replay: ${event.title}. The recording is available at ${BEACON_APP_PATH}.`;
+    const body = `▶️ Watch the replay: ${event.title}. The recording is available at ${BEACON_APP_URL}.`;
     const post = await createFeedCommunityPost(event.hostUserId, { body, category: 'event' });
     await setBeaconRecordingPostId(event.id, post.postId);
     return post.postId;


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

The two notices Beacon auto-posts to the Commons pointed at `/apps/beacon` — a piece of a web address rather than a link. In the feed it reads as plain text: nothing to tap, and it only works for a reader who already knows which domain to put in front of it.

Both notices now carry the full address `https://app.chargingthefuture.com/apps/beacon`:

- "🔴 Live now: … Watch the broadcast at https://app.chargingthefuture.com/apps/beacon — no sign-in needed to watch; sign in to chat."
- "▶️ Watch the replay: … The recording is available at https://app.chargingthefuture.com/apps/beacon."

This is the same shape the announcement link lines already use (`lib/feed/repository.ts` builds `https://app.chargingthefuture.com<plugin route>`), and it matches the Chyme post shown in the report, which already links out in full.

## Files

- `ctf/packages/web/lib/beacon/repository.ts` — `BEACON_APP_PATH` becomes `BEACON_APP_URL`, used by `postBeaconLiveNotice` and `postBeaconReplayNotice`.
- `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-beacon-feature-inventory.md` — Commons integration line updated, change-log entry added.
- `ctf/docs/developer/test-scripts/beacon-test-script.md` — step BCN-4 now checks for the full tappable address.

No schema, contract, route, or API change. Message copy only.

## Checks run locally

Web build, typecheck, lint, `check-eof-format.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs` all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqHeMuYfK4ioSKhQQwEJBK)_