### PR TITLE
feat: edit a logged incident's note and tags in place

### DIFF
--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -32,6 +32,20 @@ policies:
         mustBeOwnedBy: authenticatedUserId
     consentRequirements: []
   - pluginId: click-log
+    command: click-log.incident.update
+    version: 1.0.0
+    # Deliberately no admin override: the note is the member's private content, so only the
+    # incident's owner may edit it (mirrors click-log.incident.share.set).
+    requiredRoles: [user]
+    attributePolicies:
+      - attribute: id
+        mustBeOwnedBy: authenticatedUserId
+      # The catch-all 'other-scheme' scheme tag may only be kept (already on the incident),
+      # never newly picked on edit — the suggestion intake it requires happens at create.
+      - attribute: schemeTag
+        conditionalRequirement: other_scheme_only_if_already_set
+    consentRequirements: []
+  - pluginId: click-log
     command: click-log.incident.share.set
     version: 1.0.0
     # Deliberately no admin override: whether an incident is shared with the owner is the

--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -21,6 +21,13 @@ auditEvents:
     dataClassesAccessed: [user_event]
     targetContext: user
   - pluginId: click-log
+    command: click-log.incident.update
+    commandVersion: 1.0.0
+    eventId: click-log.incident.update
+    policyDecision: allow
+    dataClassesAccessed: [user_event]
+    targetContext: user
+  - pluginId: click-log
     command: click-log.incident.share.set
     commandVersion: 1.0.0
     eventId: click-log.incident.share.set

--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -95,6 +95,51 @@ commands:
     purpose: Delete an incident by id
     retentionClass: user_event
   - pluginId: click-log
+    command: click-log.incident.update
+    version: 1.0.0
+    inputSchema:
+      type: object
+      properties:
+        id:
+          type: string
+        notes:
+          type:
+            - string
+            - 'null'
+        problemTag:
+          type:
+            - string
+            - 'null'
+        schemeTag:
+          type:
+            - string
+            - 'null'
+      required: [id]
+      # Edits an incident's note and tags in place (owner decision, 2026-08-13). The date
+      # (created_at) and location (metadata latitude/longitude) are IMMUTABLE — the body
+      # carries no coordinates and the SQL never touches them. Each field is nullable to
+      # clear it: notes null/empty removes the note, a null/empty tag untags.
+      # Tags follow the same rules as create: slugs validated against the canonical lists in
+      # packages/web/lib/click-log/tags.ts, and a tag may only be set on an incident that
+      # carries a location (tags-require-location, owner decision 2026-08-02). Since the
+      # location is immutable, an incident logged without one can never gain tags — only its
+      # note can be edited; the client explains this instead of showing pickers.
+      # The catch-all 'other-scheme' ("Not listed") may be KEPT or REMOVED on an incident that
+      # already carries it, but never newly picked on edit — its required description intake
+      # happens at logging time (click-log.incident.create); a 400 explains this.
+      # An edit whose resulting metadata duplicates another of the member's incidents violates
+      # the UNIQUE (user_id, metadata_hash) dedupe and returns a readable 409.
+    outputSchema:
+      type: object
+      properties:
+        success:
+          type: boolean
+    dataAccess:
+      - click_log_incidents (select, update — own row only; metadata notes key and the two tag
+        columns; never coordinates or created_at)
+    purpose: Edit the note and tags of an own incident after logging (date and location immutable)
+    retentionClass: user_event
+  - pluginId: click-log
     command: click-log.incident.share.set
     version: 1.0.0
     inputSchema:

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -33,6 +33,14 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   flow to the owner's private triage queue, and a real one becomes a pull request adding the
   scheme to the canonical list.
 - View incident count and history
+- Edit an own incident after logging (pencil icon on each history row): the note can be changed
+  or removed, and the problem/scheme tags can be added, changed, or removed — using the same
+  type-and-search pickers as the log form. The date and location cannot be changed: they anchor
+  the trend data, and a location can't be truthfully added after the fact. Because tags require
+  a location, an incident logged without one can never gain tags — the editor says so plainly
+  and offers only the note. The "Not listed" scheme can be kept or removed on an incident that
+  already carries it, but not newly picked on edit (its required description is written when
+  logging).
 - Delete own incidents
 - Choose whether an incident is shared with the owner for trend tracking: a global "share new
   incidents by default" setting plus a per-incident override (in the log form and on each history
@@ -66,6 +74,7 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 - `POST /api/click-log` — Create incident. Accepts optional `sharedWithOwner` boolean (falls back to the member's stored global default) and optional `problemTag` / `schemeTag` strings (each validated against the canonical slug lists in `lib/click-log/tags.ts`; an unknown slug is a 400). When either or both tags are present, `metadata.latitude`/`metadata.longitude` are required (400 otherwise). When `schemeTag` is `other-scheme` ("Not listed"): `schemeSuggestion` is required (1–200 chars after trim), `schemeQuoraUrl` is optional (must be an https quora.com link), the caller must hold the Weavers badge (403 otherwise), and the suggestion is stored in `click_log_scheme_suggestions`; suggestion fields with any other `schemeTag` are a 400. Returns the created incident flat (a `ClickLogIncident`, not wrapped under `{ incident }`), matching the command contract's `outputSchema`.
 - `DELETE /api/click-log/[id]` — Delete incident by id. Returns `{ success: true }`.
 - `PATCH /api/click-log/[id]` — Toggle owner-sharing on a single incident. Body `{ sharedWithOwner }`; only the incident's owner may call it (no admin override — consent is the member's alone). Returns `{ success, sharedWithOwner }`.
+- `PUT /api/click-log/[id]` — Edit an incident's note and tags in place. Body `{ notes, problemTag, schemeTag }`, each nullable to clear. Only the incident's owner may call it (no admin override — the note is the member's private content). The date and location are immutable: the body carries no coordinates and the SQL never touches them. Tags follow the create rules (canonical slugs; tags require the incident to carry a location — since location is immutable, a location-less incident can only edit its note, 400 otherwise). `other-scheme` ("Not listed") may be kept or removed but not newly picked on edit (400 — its description intake happens at create). An edit whose metadata duplicates another of the member's incidents returns a readable 409 (the `metadata_hash` dedupe). Returns `{ success: true }`.
 - `GET /api/click-log/preferences` — Read the member's global owner-share default (`{ shareWithOwner }`).
 - `PUT /api/click-log/preferences` — Set the member's global owner-share default. Body `{ shareWithOwner }`.
 - `GET /api/click-log/admin/trends` — Admin-only aggregate trends over shared incidents from the last 90 days: `{ buckets, tagTrends }` — `buckets` of day / ~11 km location cell / count, plus `tagTrends` of tag kind (`problem` | `scheme`) / tag slug / count.
@@ -103,6 +112,10 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 
 - Auth required for all actions
 - Users can only view/delete their own incidents; admins can view/delete any incident
+- Editing an incident (`click-log.incident.update`) is owner-only with no admin override
+  (`canEditIncident` — the note is the member's private content, mirroring the share toggle).
+  Only the note and tags are editable; the date and location are immutable by contract and by
+  the SQL itself (the UPDATE replaces only the metadata `notes` key and the two tag columns).
 - The "Not listed" scheme-suggestion text is the one deliberate exception to "tags carry no free
   text": it is a separate field explicitly labeled as shared with the owner (submission is the
   consent act), stored apart from `metadata.notes` (which keeps its absolute never-shared
@@ -167,6 +180,21 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 - No advanced search/filtering on incident history.
 
 ## Change Log
+
+- 2026-08-13: **Incidents are editable after logging: note and tags only, date and location
+  immutable (owner request).** New `PUT /api/click-log/[id]` (command
+  `click-log.incident.update` 1.0.0) plus a pencil icon on each history row opening an inline
+  editor with the same type-and-search tag pickers as the log form. Rules: owner-only with no
+  admin override (`canEditIncident` — the note is private member content); the date and
+  location never change (the SQL replaces only the metadata `notes` key and the two tag
+  columns, so the coordinates and `created_at` are untouchable); tags still require a location,
+  and since location is immutable an incident logged without one can only edit its note (the
+  editor explains this instead of showing pickers); "Not listed" can be kept or removed but not
+  newly picked on edit, because its required description intake happens at logging time; an
+  edit that makes the metadata identical to another of the member's incidents hits the
+  `metadata_hash` dedupe and returns a readable 409. Contracts updated (command, access policy
+  with `other_scheme_only_if_already_set`, audit event). No schema change — the generated
+  `metadata_hash` column recomputes on update. Android: out of scope (web-only per rule 105).
 
 - 2026-08-13: **Five new scheme tags and two new problem tags from the owner's cross-country bus
   trip (owner-named).** Schemes: `engineered-delay` (The Engineered Delay — a driver or employee

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -136,6 +136,24 @@ non-quora.com link. After submitting, the incident logs with the "Not listed" sc
 description is stored for the owner's scheme-naming queue, not shown in the trends dashboard.
 **Result:** web ☐ mobile ☐ — notes:
 
+### CL-9 · Edit an incident's note and tags (date and location immutable)
+**Role:** member · **Surfaces:** all
+**Steps:**
+1. On a history row of an incident logged WITH a location, tap the pencil icon.
+2. Change the note, change or remove the problem/scheme tags with the pickers, save.
+3. Open the editor again on an incident logged WITHOUT a location.
+4. Try to add a tag to it (there should be no way to).
+**Expected:** The editor opens inline in place of the row, stating that the date and location
+stay as logged — there is no way to change either. Saving updates the note and tag chips on the
+row and the change survives a refresh. On the location-less incident the editor shows no tag
+pickers at all and explains that tags need a location and the location can't be changed after
+logging; only the note is editable. The scheme picker never offers "Not listed" unless the
+incident already carries it (keeping or removing it is allowed). The server enforces all of it:
+a tag on a location-less incident, or newly picking "Not listed", is rejected with a specific
+message, and an edit that duplicates another incident's exact note returns a readable
+"change the note slightly" error.
+**Result:** web ☐ mobile ☐ — notes:
+
 ### CL-5 · Refresh the incident list
 **Role:** member · **Surfaces:** all
 **Steps:**

--- a/ctf/packages/web/app/api/click-log/[id]/_edit.ts
+++ b/ctf/packages/web/app/api/click-log/[id]/_edit.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { updateIncident } from 'lib/click-log/repository';
+import { canEditIncident } from 'lib/click-log/policy';
+import { MAX_NOTES_LENGTH } from 'lib/click-log/constants';
+import { isValidProblemTag, isValidSchemeTag, NOT_LISTED_SCHEME_SLUG } from 'lib/click-log/tags';
+import type { ClickLogIncident } from 'lib/click-log/types';
+import { failureReason } from 'lib/errors/failure';
+
+// Validation and update helpers for PUT /api/click-log/[id] (edit an incident's note and tags).
+// Split from route.ts so each function stays under the rule-116 complexity limit.
+
+export type IncidentEditFields = {
+  notes: string | null;
+  problemTag: string | null;
+  schemeTag: string | null;
+};
+
+function badRequest(error: string): NextResponse {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+// Normalize one tag field of the edit body: absent, null, or "" all mean "no tag"; anything
+// else must be a known slug from the canonical list.
+function parseEditTag(
+  raw: unknown,
+  isValid: (slug: string) => boolean,
+  fieldName: string,
+): { error: NextResponse } | { data: string | null } {
+  if (raw === undefined || raw === null || raw === '') {
+    return { data: null };
+  }
+  if (typeof raw !== 'string' || !isValid(raw)) {
+    return { error: badRequest(`Invalid ${fieldName}`) };
+  }
+  return { data: raw };
+}
+
+// Normalize the note field of the edit body: absent, null, or whitespace-only all clear the
+// note; a non-empty note is trimmed and length-checked like on create.
+function parseEditNotes(raw: unknown): { error: NextResponse } | { data: string | null } {
+  if (raw === undefined || raw === null) {
+    return { data: null };
+  }
+  if (typeof raw !== 'string') {
+    return { error: badRequest('Invalid notes') };
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > MAX_NOTES_LENGTH) {
+    return { error: badRequest('Notes too long') };
+  }
+  return { data: trimmed.length > 0 ? trimmed : null };
+}
+
+// Reads and validates the PUT body: { notes, problemTag, schemeTag }. The date and location are
+// immutable by design (owner decision, 2026-08-13), so the body carries no metadata beyond the
+// note — a client sending coordinates here is simply ignored by the field list.
+export async function parseEditBody(
+  request: NextRequest,
+): Promise<{ error: NextResponse } | { data: IncidentEditFields }> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (caught) {
+    return { error: NextResponse.json({ error: 'Invalid JSON body', reason: failureReason(caught) }, { status: 400 }) };
+  }
+  const notesResult = parseEditNotes((body as { notes?: unknown })?.notes);
+  if ('error' in notesResult) {
+    return notesResult;
+  }
+  const problemResult = parseEditTag((body as { problemTag?: unknown })?.problemTag, isValidProblemTag, 'problemTag');
+  if ('error' in problemResult) {
+    return problemResult;
+  }
+  const schemeResult = parseEditTag((body as { schemeTag?: unknown })?.schemeTag, isValidSchemeTag, 'schemeTag');
+  if ('error' in schemeResult) {
+    return schemeResult;
+  }
+  return { data: { notes: notesResult.data, problemTag: problemResult.data, schemeTag: schemeResult.data } };
+}
+
+// Authorization for the edit: the incident must belong to the caller. No admin override — the
+// note is the member's private content (mirrors canToggleIncidentShare). The route has already
+// 404ed a missing incident before calling this.
+export function authorizeEdit(userId: string, incident: ClickLogIncident): NextResponse | null {
+  if (!incident.user_id || !canEditIncident(userId, incident.user_id)) {
+    return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+  }
+  return null;
+}
+
+// The edit rules that depend on the stored incident:
+// - Tags still require a location (same rule as create), and the location is immutable — so an
+//   incident logged without one can never gain tags, only edit its note.
+// - "Not listed" is a logging-time flow (its required description is written at create); an
+//   edit may keep or remove it on an incident that already carries it, but never newly pick it.
+export function validateEditRules(
+  incident: ClickLogIncident,
+  fields: IncidentEditFields,
+): NextResponse | null {
+  const tagged = fields.problemTag !== null || fields.schemeTag !== null;
+  const hasLocation = incident.metadata.latitude !== undefined && incident.metadata.longitude !== undefined;
+  if (tagged && !hasLocation) {
+    return badRequest('Location is required when tagging an incident, and this incident was logged without one');
+  }
+  if (fields.schemeTag === NOT_LISTED_SCHEME_SLUG && incident.scheme_tag !== NOT_LISTED_SCHEME_SLUG) {
+    return badRequest('Pick "Not listed" when logging a new incident — the scheme description is written at logging time');
+  }
+  return null;
+}
+
+// Runs the update and maps the outcomes the route cares about. 'conflict' is the generated
+// metadata_hash dedupe: the edited note made this row's metadata identical to another of the
+// member's incidents, violating UNIQUE (user_id, metadata_hash).
+export async function applyIncidentEdit(
+  id: string,
+  userId: string,
+  fields: IncidentEditFields,
+): Promise<'ok' | 'conflict' | 'failed'> {
+  try {
+    const updated = await updateIncident({ id, userId, ...fields });
+    return updated ? 'ok' : 'failed';
+  } catch (caught) {
+    if ((caught as { code?: string })?.code === '23505') {
+      return 'conflict';
+    }
+    throw caught;
+  }
+}

--- a/ctf/packages/web/app/api/click-log/[id]/route.ts
+++ b/ctf/packages/web/app/api/click-log/[id]/route.ts
@@ -4,6 +4,7 @@ import { canDeleteIncident, canToggleIncidentShare } from 'lib/click-log/policy'
 import { logClickLogAudit } from 'lib/click-log/audit';
 import { ensureMutationCsrf, requireClickLogAccess } from '../_lib';
 import { failureReason } from 'lib/errors/failure';
+import { applyIncidentEdit, authorizeEdit, parseEditBody, validateEditRules } from './_edit';
 
 export async function DELETE(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const csrfDenied = ensureMutationCsrf(request);
@@ -112,4 +113,61 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
     target: { incidentId: id, sharedWithOwner: String(shared) },
   });
   return NextResponse.json({ success: true, sharedWithOwner: shared });
+}
+
+// Edits an incident's note and tags (owner decision, 2026-08-13). The date and location are
+// immutable — they anchor the trend data and a location cannot be truthfully added after the
+// fact — so the body carries only { notes, problemTag, schemeTag }, each nullable to clear.
+// Only the member who logged the incident may edit it (authorizeEdit — no admin override).
+export async function PUT(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const csrfDenied = ensureMutationCsrf(request);
+  if (csrfDenied) {
+    return csrfDenied;
+  }
+  const gate = await requireClickLogAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id param' }, { status: 400 });
+  }
+  const parsed = await parseEditBody(request);
+  if ('error' in parsed) {
+    return parsed.error;
+  }
+  const incident = await getIncidentById(id);
+  if (!incident) {
+    return NextResponse.json({ error: 'Incident not found' }, { status: 404 });
+  }
+  const authDenied = authorizeEdit(gate.auth.userId, incident);
+  if (authDenied) {
+    return authDenied;
+  }
+  const ruleDenied = validateEditRules(incident, parsed.data);
+  if (ruleDenied) {
+    return ruleDenied;
+  }
+  const outcome = await applyIncidentEdit(id, gate.auth.userId, parsed.data);
+  if (outcome !== 'ok') {
+    logClickLogAudit({
+      actorId: gate.auth.userId,
+      command: 'click-log.incident.update',
+      result: 'failure',
+      target: { incidentId: id },
+    });
+    return outcome === 'conflict'
+      ? NextResponse.json(
+          { error: 'Another of your incidents already has this exact note and location — change the note slightly' },
+          { status: 409 },
+        )
+      : NextResponse.json({ error: 'Update failed' }, { status: 500 });
+  }
+  logClickLogAudit({
+    actorId: gate.auth.userId,
+    command: 'click-log.incident.update',
+    result: 'success',
+    target: { incidentId: id },
+  });
+  return NextResponse.json({ success: true });
 }

--- a/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
+++ b/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import type { ClickLogIncident } from "../../lib/click-log/types";
+import { MAX_NOTES_LENGTH } from "../../lib/click-log/constants";
+import { CLICK_LOG_PROBLEM_TAGS, CLICK_LOG_SCHEME_TAGS, NOT_LISTED_SCHEME_SLUG } from "../../lib/click-log/tags";
+import { formatIncidentTime, hasLocation, type ClickLogTokens } from "./click-log-shared";
+import { ClickLogTagPicker } from "./click-log-tag-picker";
+
+// What an edit can change. Tags use "" for "no tag" (picker convention); the shell converts to
+// null for the API.
+export type IncidentEditFields = { notes: string; problemTag: string; schemeTag: string };
+
+// The tag pickers of the edit form, or — on an incident logged without a location — the
+// explanation of why there are none. Extracted so the editor stays under the complexity limit.
+function EditorTagSection({
+  incident,
+  problemTag,
+  schemeTag,
+  tokens,
+  onProblemTagChange,
+  onSchemeTagChange,
+}: {
+  incident: ClickLogIncident;
+  problemTag: string;
+  schemeTag: string;
+  tokens: ClickLogTokens;
+  onProblemTagChange: (value: string) => void;
+  onSchemeTagChange: (value: string) => void;
+}) {
+  const t = tokens;
+  if (!hasLocation(incident)) {
+    // Tags require a location (same rule as logging), and the location is fixed once logged —
+    // so this incident can never gain tags. Say so instead of showing disabled pickers.
+    return (
+      <div style={{ marginTop: 10, fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
+        This incident was logged without a location, so tags can&apos;t be added — tags need a
+        location, and the location can&apos;t be changed after logging. The note can still be
+        edited.
+      </div>
+    );
+  }
+  // "Not listed" is a logging-time flow (its required description is written when logging), so
+  // editing offers it only on an incident that already carries it — keep it or remove it, but
+  // never newly pick it here. The server enforces the same rule.
+  const schemeOptions =
+    incident.scheme_tag === NOT_LISTED_SCHEME_SLUG
+      ? CLICK_LOG_SCHEME_TAGS
+      : CLICK_LOG_SCHEME_TAGS.filter((tag) => tag.slug !== NOT_LISTED_SCHEME_SLUG);
+  return (
+    <>
+      <ClickLogTagPicker
+        label="Which problem happened? (optional)"
+        searchPlaceholder="Search problems…"
+        value={problemTag}
+        options={CLICK_LOG_PROBLEM_TAGS}
+        tokens={t}
+        onChange={onProblemTagChange}
+      />
+      <ClickLogTagPicker
+        label="Which scheme was used? (optional)"
+        searchPlaceholder="Search schemes…"
+        value={schemeTag}
+        options={schemeOptions}
+        tokens={t}
+        onChange={onSchemeTagChange}
+      />
+    </>
+  );
+}
+
+// Inline editor for one history row (owner decision, 2026-08-13): the note and the two tags can
+// be changed after logging; the date and location cannot — they anchor the trend data, and a
+// location can't be truthfully added after the fact.
+export function ClickLogIncidentEditor({
+  incident,
+  tokens,
+  busy,
+  onSave,
+  onCancel,
+}: {
+  incident: ClickLogIncident;
+  tokens: ClickLogTokens;
+  busy: boolean;
+  onSave: (fields: IncidentEditFields) => void;
+  onCancel: () => void;
+}) {
+  const t = tokens;
+  const [notes, setNotes] = useState(incident.metadata.notes ?? "");
+  const [problemTag, setProblemTag] = useState(incident.problem_tag ?? "");
+  const [schemeTag, setSchemeTag] = useState(incident.scheme_tag ?? "");
+  return (
+    <div style={{ padding: "14px 16px", borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.ACCENT}40` }}>
+      {/* The immutable half of the row, shown so it is clear what editing covers. */}
+      <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 8 }}>
+        Editing the incident from {formatIncidentTime(incident.created_at)} — the date and
+        location stay as logged.
+      </div>
+      <textarea
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        maxLength={MAX_NOTES_LENGTH}
+        rows={3}
+        aria-label="Edit incident note"
+        placeholder="What happened? (private — never shared)"
+        style={{ width: "100%", padding: "8px 12px", background: t.INPUT_BG, border: `1px solid ${t.BORDER_SOLID}`, borderRadius: 8, fontSize: 13, color: t.TITLE, outline: "none", resize: "vertical", boxSizing: "border-box", fontFamily: "inherit" }}
+      />
+      <EditorTagSection
+        incident={incident}
+        problemTag={problemTag}
+        schemeTag={schemeTag}
+        tokens={t}
+        onProblemTagChange={setProblemTag}
+        onSchemeTagChange={setSchemeTag}
+      />
+      <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+        <button
+          onClick={() => onSave({ notes, problemTag, schemeTag })}
+          disabled={busy}
+          style={{ padding: "8px 16px", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: busy ? "default" : "pointer", background: t.ACCENT, border: "none", color: "#fff", opacity: busy ? 0.6 : 1 }}
+        >
+          {busy ? "Saving…" : "Save changes"}
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={busy}
+          style={{ padding: "8px 16px", borderRadius: 8, fontSize: 13, cursor: busy ? "default" : "pointer", background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/click-log/click-log-incident-list.tsx
+++ b/ctf/packages/web/components/click-log/click-log-incident-list.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { AlertTriangle, MapPin, Trash2 } from "lucide-react";
+import { AlertTriangle, MapPin, Pencil, Trash2 } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import type { ClickLogIncident } from "../../lib/click-log/types";
 import { problemTagLabel, schemeTagLabel } from "../../lib/click-log/tags";
 import { formatIncidentTime, getClickLogTokens, hasLocation, type ClickLogTokens } from "./click-log-shared";
+import { ClickLogIncidentEditor, type IncidentEditFields } from "./click-log-incident-editor";
 
 // The problem/scheme tag chips on one history row. Renders nothing on an untagged incident.
 // Extracted so the row component stays under the complexity limit.
@@ -34,11 +35,13 @@ function ClickLogIncidentRow({
   tokens,
   onDelete,
   onToggleShare,
+  onEdit,
 }: {
   incident: ClickLogIncident;
   tokens: ClickLogTokens;
   onDelete: (id: string) => void;
   onToggleShare: (id: string, shared: boolean) => void;
+  onEdit: (id: string) => void;
 }) {
   const t = tokens;
   return (
@@ -67,6 +70,15 @@ function ClickLogIncidentRow({
           {incident.shared_with_owner ? "Shared with owner" : "Private"}
         </button>
       </div>
+      {/* Edit opens the inline editor for this row: note and tags only — date and location
+          are immutable once logged. */}
+      <button
+        onClick={() => onEdit(incident.id)}
+        aria-label="Edit incident"
+        style={{ width: 28, height: 28, borderRadius: 6, background: "transparent", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", color: t.MUTED, flexShrink: 0 }}
+      >
+        <Pencil size={13} />
+      </button>
       <button
         onClick={() => onDelete(incident.id)}
         aria-label="Delete incident"
@@ -80,12 +92,23 @@ function ClickLogIncidentRow({
 
 export function ClickLogIncidentList({
   incidents,
+  editingId,
+  editBusy,
   onDelete,
   onToggleShare,
+  onEdit,
+  onSaveEdit,
+  onCancelEdit,
 }: {
   incidents: ClickLogIncident[];
+  // Id of the incident currently open in the inline editor, or null.
+  editingId: string | null;
+  editBusy: boolean;
   onDelete: (id: string) => void;
   onToggleShare: (id: string, shared: boolean) => void;
+  onEdit: (id: string) => void;
+  onSaveEdit: (id: string, fields: IncidentEditFields) => void;
+  onCancelEdit: () => void;
 }) {
   const { theme } = useTheme();
   const t = getClickLogTokens(theme);
@@ -93,15 +116,27 @@ export function ClickLogIncidentList({
     <div>
       <div style={{ fontSize: 14, fontWeight: 600, color: t.TITLE, marginBottom: 14 }}>Recent Incidents</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {incidents.map((incident) => (
-          <ClickLogIncidentRow
-            key={incident.id}
-            incident={incident}
-            tokens={t}
-            onDelete={onDelete}
-            onToggleShare={onToggleShare}
-          />
-        ))}
+        {incidents.map((incident) =>
+          incident.id === editingId ? (
+            <ClickLogIncidentEditor
+              key={incident.id}
+              incident={incident}
+              tokens={t}
+              busy={editBusy}
+              onSave={(fields) => onSaveEdit(incident.id, fields)}
+              onCancel={onCancelEdit}
+            />
+          ) : (
+            <ClickLogIncidentRow
+              key={incident.id}
+              incident={incident}
+              tokens={t}
+              onDelete={onDelete}
+              onToggleShare={onToggleShare}
+              onEdit={onEdit}
+            />
+          ),
+        )}
       </div>
     </div>
   );

--- a/ctf/packages/web/components/click-log/click-log-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-shell.tsx
@@ -14,6 +14,7 @@ import { AlertTriangle } from "lucide-react";
 import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
 import { useOwnerShare } from "./click-log-use-owner-share";
+import { useIncidentEdit } from "./click-log-use-incident-edit";
 
 type Geo = { latitude?: number; longitude?: number };
 
@@ -59,6 +60,32 @@ function buildCreateBody(args: {
     ...(notListed && args.schemeSuggestion.trim() ? { schemeSuggestion: args.schemeSuggestion.trim() } : {}),
     ...(notListed && args.schemeQuoraUrl.trim() ? { schemeQuoraUrl: args.schemeQuoraUrl.trim() } : {}),
   };
+}
+
+// Global share default. Opt-in and member-controlled; a new incident starts from this setting
+// and can be overridden per incident in the log form or the history list. Module-level to keep
+// ClickLogShell under the function-length limit.
+function ShareDefaultToggle({
+  checked,
+  tokens,
+  onChange,
+}: {
+  checked: boolean;
+  tokens: ReturnType<typeof getClickLogTokens>;
+  onChange: (next: boolean) => void;
+}) {
+  const t = tokens;
+  return (
+    <label style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 24, padding: "10px 14px", borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, fontSize: 12, color: t.MUTED, cursor: "pointer" }}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        style={{ accentColor: t.ACCENT }}
+      />
+      Share new incidents with the owner by default (only trend data — never your notes)
+    </label>
+  );
 }
 
 export function ClickLogShell() {
@@ -107,6 +134,9 @@ export function ClickLogShell() {
 
   // Owner-share consent (global default + per-incident choice) — see click-log-use-owner-share.
   const share = useOwnerShare({ onError: setError, onBusy: setBusy, refresh: fetchIncidents });
+  // Inline per-incident edit (note + tags; date and location immutable) — see
+  // click-log-use-incident-edit.
+  const edit = useIncidentEdit({ onError: setError, onBusy: setBusy, refresh: fetchIncidents });
 
   useEffect(() => {
     void fetchIncidents(true);
@@ -243,23 +273,22 @@ export function ClickLogShell() {
         onCancel={() => { setShowForm(false); setNote(""); setProblemTag(""); setSchemeTag(""); setSchemeSuggestion(""); setSchemeQuoraUrl(""); setGeo({}); setGeoStatus("idle"); setGeoError(null); share.setFormShare(share.shareDefault); }}
       />
 
-      {/* Global share default. Opt-in and member-controlled; a new incident starts from this
-          setting and can be overridden per incident in the log form or the list below. */}
-      <label style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 24, padding: "10px 14px", borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, fontSize: 12, color: t.MUTED, cursor: "pointer" }}>
-        <input
-          type="checkbox"
-          checked={share.shareDefault}
-          onChange={(e) => void share.setDefault(e.target.checked)}
-          style={{ accentColor: t.ACCENT }}
-        />
-        Share new incidents with the owner by default (only trend data — never your notes)
-      </label>
+      <ShareDefaultToggle
+        checked={share.shareDefault}
+        tokens={t}
+        onChange={(next) => void share.setDefault(next)}
+      />
 
       {incidents.length > 0 && (
         <ClickLogIncidentList
           incidents={incidents}
+          editingId={edit.editingId}
+          editBusy={busy}
           onDelete={(id) => void handleDelete(id)}
           onToggleShare={(id, next) => void share.toggleIncident(id, next)}
+          onEdit={edit.start}
+          onSaveEdit={(id, fields) => void edit.save(id, fields)}
+          onCancelEdit={edit.cancel}
         />
       )}
     </>

--- a/ctf/packages/web/components/click-log/click-log-use-incident-edit.ts
+++ b/ctf/packages/web/components/click-log/click-log-use-incident-edit.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import type { IncidentEditFields } from "./click-log-incident-editor";
+
+// Per-incident edit state and the PUT call, extracted from the shell (mirroring
+// click-log-use-owner-share) so ClickLogShell stays under the rule-116 function-length limit.
+// Only the note and tags are sent — the date and location are immutable, so the body never
+// carries coordinates. "" tags from the pickers become null (= untagged) for the API.
+export function useIncidentEdit({
+  onError,
+  onBusy,
+  refresh,
+}: {
+  onError: (message: string | null) => void;
+  onBusy: (busy: boolean) => void;
+  refresh: () => Promise<void>;
+}) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  async function save(id: string, fields: IncidentEditFields): Promise<void> {
+    onBusy(true);
+    onError(null);
+    try {
+      const res = await fetch(`/api/click-log/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
+        body: JSON.stringify({
+          notes: fields.notes,
+          problemTag: fields.problemTag || null,
+          schemeTag: fields.schemeTag || null,
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? "Failed to update incident");
+      }
+      setEditingId(null);
+      await refresh();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : "Failed to update incident");
+    } finally {
+      onBusy(false);
+    }
+  }
+
+  return {
+    editingId,
+    start: (id: string) => setEditingId(id),
+    cancel: () => setEditingId(null),
+    save,
+  };
+}

--- a/ctf/packages/web/lib/click-log/audit.ts
+++ b/ctf/packages/web/lib/click-log/audit.ts
@@ -12,6 +12,7 @@ type ClickLogCommand =
   | 'click-log.incident.create'
   | 'click-log.incident.list'
   | 'click-log.incident.delete'
+  | 'click-log.incident.update'
   | 'click-log.incident.share.set'
   | 'click-log.preferences.fetch'
   | 'click-log.preferences.update'

--- a/ctf/packages/web/lib/click-log/policy.ts
+++ b/ctf/packages/web/lib/click-log/policy.ts
@@ -19,6 +19,14 @@ export function canToggleIncidentShare(userId: string | null, incidentOwnerId: s
   return userId === incidentOwnerId;
 }
 
+// Only the member who logged an incident may edit its note and tags. Deliberately no admin
+// override: the note is the member's private content. The date and location are immutable —
+// editing covers note and tags only (owner decision, 2026-08-13).
+export function canEditIncident(userId: string | null, incidentOwnerId: string): boolean {
+  if (!userId) return false;
+  return userId === incidentOwnerId;
+}
+
 // The aggregate trends view is owner/admin-only.
 export function canViewSharedTrends(isAdmin: boolean): boolean {
   return isAdmin;

--- a/ctf/packages/web/lib/click-log/repository.ts
+++ b/ctf/packages/web/lib/click-log/repository.ts
@@ -6,6 +6,7 @@ import {
   CreateSchemeSuggestionInput,
   SharedIncidentTagTrend,
   SharedIncidentTrendBucket,
+  UpdateIncidentInput,
 } from './types';
 
 export async function getIncidentById(id: string): Promise<ClickLogIncident | null> {
@@ -25,6 +26,29 @@ export async function createIncident(input: CreateIncidentInput): Promise<ClickL
     [userId, metadata, sharedWithOwner, problemTag ?? null, schemeTag ?? null]
   );
   return result.rows[0];
+}
+
+// Edits an incident's note and tags in place. Owner-scoped only (the user_id condition — no
+// admin variant: the note is the member's private content). The date (created_at) and location
+// (metadata latitude/longitude) are immutable by design, so the SQL only replaces the 'notes'
+// key inside metadata and never touches the coordinate keys. A null note removes the key; the
+// generated metadata_hash column recomputes automatically, so an edit that makes this row's
+// metadata identical to another of the member's rows violates UNIQUE (user_id, metadata_hash) —
+// the route maps that to a readable 409.
+export async function updateIncident(input: UpdateIncidentInput): Promise<boolean> {
+  const { id, userId, notes, problemTag, schemeTag } = input;
+  const result = await queryDb(
+    `UPDATE click_log_incidents
+     SET metadata = CASE
+           WHEN $3::text IS NULL THEN metadata - 'notes'
+           ELSE jsonb_set(metadata, '{notes}', to_jsonb($3::text), true)
+         END,
+         problem_tag = $4,
+         scheme_tag = $5
+     WHERE id = $1 AND user_id = $2`,
+    [id, userId, notes, problemTag, schemeTag]
+  );
+  return (result.rowCount ?? 0) > 0;
 }
 
 // Flips the owner-share flag on a single incident. Owner-scoped only: the member who logged the

--- a/ctf/packages/web/lib/click-log/types.ts
+++ b/ctf/packages/web/lib/click-log/types.ts
@@ -25,6 +25,17 @@ export type CreateIncidentInput = {
   schemeTag?: string;
 };
 
+// Edit of an existing incident (owner decision, 2026-08-13): the note and the two tags may be
+// changed after logging; the date and location are immutable, so they are absent here. null
+// clears a field (note removed / tag removed).
+export type UpdateIncidentInput = {
+  id: string;
+  userId: string;
+  notes: string | null;
+  problemTag: string | null;
+  schemeTag: string | null;
+};
+
 // Per-member ClickLog preferences (click_log_preferences). shareWithOwner is the global default
 // applied when a new incident is logged without an explicit per-incident choice.
 export type ClickLogPreferences = {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Owner request: incidents can now be edited after logging. Each history row gains a pencil icon that opens an inline editor for the note and the two tags, using the same type-and-search pickers as the log form. The date and location are immutable — they anchor the trend data and a location can't be truthfully added after the fact.

What the server enforces (and the editor mirrors):

- Owner-only, no admin override (`canEditIncident`) — the note is the member's private content, same stance as the share toggle.
- The SQL replaces only the metadata `notes` key and the two tag columns; coordinates and `created_at` are untouchable by construction.
- Tags still require a location (same rule as create). Since location is immutable, an incident logged without one can never gain tags — the editor explains this and offers only the note; the server returns a specific 400.
- "Not listed" (`other-scheme`) can be kept or removed on an incident that already carries it, but never newly picked on edit — its required description intake happens at logging time. Specific 400 otherwise.
- An edit that makes the metadata identical to another of the member's incidents violates the generated `metadata_hash` dedupe (`UNIQUE (user_id, metadata_hash)`); mapped to a readable 409 telling the member to change the note slightly.

Surface:

- `PUT /api/click-log/[id]` — body `{ notes, problemTag, schemeTag }`, each nullable to clear. Validation helpers live in `[id]/_edit.ts` to stay under the complexity gate.
- New command contract `click-log.incident.update` 1.0.0, access policy entry (with `other_scheme_only_if_already_set`), and audit event; audit union type extended.
- Inventory (User Features, API Surface, Security controls, changelog) and manual test script (new CL-9 case) updated.
- No schema change — the generated `metadata_hash` column recomputes on update.

Owner-review lane (new API contract): auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_