### PR TITLE
feat: raise the incident note limit from 200 to 2,000 characters

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -168,6 +168,17 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-08-13: **Incident note limit raised 200 → 2,000 characters (owner request).**
+  `MAX_NOTES_LENGTH` in `lib/click-log/constants.ts` — the single constant read by the log
+  form's textarea, the server-side length check on create, and (once the edit feature merges)
+  the editor and its server check. 200 characters forced summaries of multi-part incidents to
+  be too thin to be useful later; the owner's cross-country bus trip, which chained five
+  schemes in one journey, did not fit. Notes remain private to the member — the limit change
+  does not touch what is shared. The "Not listed" scheme-description cap
+  (`MAX_SCHEME_SUGGESTION_LENGTH`) stays at 200 on purpose: that text is shared with the owner
+  and drained into triage issues, where shorter is better. No schema change (`metadata` is
+  JSONB with no length constraint); no contract shape change.
+
 - 2026-08-13: **Five new scheme tags and two new problem tags from the owner's cross-country bus
   trip (owner-named).** Schemes: `engineered-delay` (The Engineered Delay — a driver or employee
   stalls on purpose so a connection is missed and hours are lost), `altered-ticket` (The Altered

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -226,3 +226,5 @@ of these, it is already tracked, not a new bug:
 > _Documentation note (2026-08-07): recorded an owner refinement in the pendulum comment — the recruit's windfall is arranged long in advance to read as merit-based, binding them to the network before they know anything. Comment only; no tag added, removed, or renamed, and no test steps changed._
 
 > _Tag list update (2026-08-13): added schemes "The Engineered Delay", "The Altered Ticket", "The Pretext Search", "The Planted Witness", and "The Replay", and problems "Trips sabotaged — delays, missed connections, canceled tickets" and "Falsely accused of violence / crimes to bystanders". List-data only — no test steps changed; CL-7/CL-8 cover tagging and suggestions generically._
+
+> _Limit change (2026-08-13): the incident note maximum length was raised from 200 to 2,000 characters (`MAX_NOTES_LENGTH`). CL-4's over-length note case still applies at the new limit — no test steps changed._

--- a/ctf/packages/web/lib/click-log/constants.ts
+++ b/ctf/packages/web/lib/click-log/constants.ts
@@ -1,4 +1,7 @@
-export const MAX_NOTES_LENGTH = 200;
+// Raised 200 -> 2000 (owner request, 2026-08-13): a note often has to recap a multi-part
+// incident (the owner's cross-country bus trip chained five schemes), and 200 characters
+// forced summaries too thin to be useful later. Notes stay private to the member either way.
+export const MAX_NOTES_LENGTH = 2000;
 // Max length of the "Not listed" scheme description a member writes when suggesting a new
 // scheme. Unlike notes, this text IS shared with the owner — the field says so explicitly.
 export const MAX_SCHEME_SUGGESTION_LENGTH = 200;


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

`MAX_NOTES_LENGTH` in `ctf/packages/web/lib/click-log/constants.ts` goes from 200 to 2,000. It is the single constant read by the log form's textarea `maxLength` and the server-side length check on create (and by the inline editor in #2213 once that merges), so this is a one-line behavior change.

Reason: 200 characters forced summaries of multi-part incidents to be too thin to be useful later — the owner's cross-country bus trip, which chained five schemes in one journey, did not fit.

Deliberately unchanged: `MAX_SCHEME_SUGGESTION_LENGTH` stays at 200 — that text is shared with the owner and drained into triage issues, where shorter is better. Notes remain private to the member; nothing about sharing changes. No schema change (`metadata` is JSONB with no length constraint) and no contract shape change.

Inventory changelog and test-script note included (CL-4's over-length case still applies at the new limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_