### PR TITLE
feat: incidents hold several problem and scheme tags, not one of each

### DIFF
--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -1,16 +1,17 @@
 policies:
   - pluginId: click-log
     command: click-log.incident.create
-    version: 1.1.0
+    version: 2.0.0
     requiredRoles: [user]
     attributePolicies:
       - attribute: userId
         mustMatch: authenticatedUserId
-      # The "Not listed" scheme flow (schemeTag = 'other-scheme') additionally requires the
-      # Weavers of the Commons badge (contributor_access_eligibility: eligible and not revoked)
-      # — spam control on the scheme-suggestion intake. Enforced in the create route; members
-      # without the badge get a 403 and the client hides the option.
-      - attribute: schemeTag
+      # The "Not listed" scheme flow (schemeTags contains 'other-scheme') additionally requires
+      # the Weavers of the Commons badge (contributor_access_eligibility: eligible and not
+      # revoked) — spam control on the scheme-suggestion intake. Enforced in the create route;
+      # members without the badge get a 403 and the client hides the option. (2.0.0: schemeTags
+      # is a list — see the command contract.)
+      - attribute: schemeTags
         conditionalRequirement: weavers_badge_when_other_scheme
     # The schemeSuggestion text is member content explicitly shared with the owner; the field
     # states this in the form, so submission is the consent act.
@@ -33,7 +34,7 @@ policies:
     consentRequirements: []
   - pluginId: click-log
     command: click-log.incident.update
-    version: 1.0.0
+    version: 2.0.0
     # Deliberately no admin override: the note is the member's private content, so only the
     # incident's owner may edit it (mirrors click-log.incident.share.set).
     requiredRoles: [user]
@@ -42,7 +43,8 @@ policies:
         mustBeOwnedBy: authenticatedUserId
       # The catch-all 'other-scheme' scheme tag may only be kept (already on the incident),
       # never newly picked on edit — the suggestion intake it requires happens at create.
-      - attribute: schemeTag
+      # (2.0.0: schemeTags is a list — see the command contract.)
+      - attribute: schemeTags
         conditionalRequirement: other_scheme_only_if_already_set
     consentRequirements: []
   - pluginId: click-log

--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -1,7 +1,7 @@
 commands:
   - pluginId: click-log
     command: click-log.incident.create
-    version: 1.3.0
+    version: 2.0.0
     inputSchema:
       type: object
       properties:
@@ -9,10 +9,16 @@ commands:
           $ref: '#/definitions/IncidentMetadata'
         sharedWithOwner:
           type: boolean
-        problemTag:
-          type: string
-        schemeTag:
-          type: string
+        problemTags:
+          type: array
+          items:
+            type: string
+          maxItems: 10
+        schemeTags:
+          type: array
+          items:
+            type: string
+          maxItems: 10
         schemeSuggestion:
           type: string
         schemeQuoraUrl:
@@ -20,16 +26,20 @@ commands:
       # metadata is not required, matches implementation.
       # sharedWithOwner is optional: when omitted, the member's stored global default
       # (click_log_preferences.share_with_owner, itself defaulting to false) is applied.
-      # problemTag / schemeTag are optional coarse tags — one, both, or neither may be sent.
-      # Each is validated against the canonical slug list in packages/web/lib/click-log/tags.ts
-      # (problems mirror the landing-page 50+ problems list; schemes started from the owner's
-      # "A post for each gang stalker game" Discourse thread — now deprecated, so tags.ts is
-      # the living canonical scheme list); an unknown slug is a 400.
-      # When either or both tags are present, metadata.latitude and metadata.longitude are
-      # required (owner decision, 2026-08-02: tagged trend data needs location to be detailed
-      # enough); a tagged request without a location is a 400.
-      # schemeSuggestion is REQUIRED (1–200 chars after trim) when schemeTag is the catch-all
-      # 'other-scheme' ("Not listed") and rejected with any other schemeTag. It is member text
+      # problemTags / schemeTags are optional coarse tag LISTS (2.0.0, owner decision
+      # 2026-08-13: a real incident routinely chains several schemes, so the singular
+      # problemTag/schemeTag fields of 1.x never fit — this is the breaking change). Either,
+      # both, or neither may be sent; absent/null/[] all mean untagged. Every slug is
+      # validated against the canonical list in packages/web/lib/click-log/tags.ts (problems
+      # mirror the landing-page 50+ problems list; schemes started from the owner's "A post
+      # for each gang stalker game" Discourse thread — now deprecated, so tags.ts is the
+      # living canonical scheme list); an unknown slug is a 400, duplicates are collapsed,
+      # and more than 10 of a kind (MAX_TAGS_PER_KIND) is a 400.
+      # When either list is non-empty, metadata.latitude and metadata.longitude are required
+      # (owner decision, 2026-08-02: tagged trend data needs location to be detailed enough);
+      # a tagged request without a location is a 400.
+      # schemeSuggestion is REQUIRED (1–200 chars after trim) when schemeTags contains the
+      # catch-all 'other-scheme' ("Not listed") and rejected otherwise. It is member text
       # EXPLICITLY shared with the owner (the form says so; metadata.notes stays never-shared)
       # and is stored in click_log_scheme_suggestions for the scheme-naming pipeline.
       # schemeQuoraUrl is optional with 'other-scheme' only: an https quora.com link to the
@@ -41,13 +51,15 @@ commands:
     dataAccess:
       - click_log_incidents (insert)
       - click_log_preferences (select)
-      - click_log_scheme_suggestions (insert — only when schemeTag is 'other-scheme')
-      - contributor_access_eligibility (select — Weavers badge check, only when schemeTag is 'other-scheme')
+      - click_log_scheme_suggestions (insert — only when schemeTags contains 'other-scheme')
+      - contributor_access_eligibility (select — Weavers badge check, only when schemeTags contains 'other-scheme')
     purpose: Log a new incident for the authenticated user
     retentionClass: user_event
   - pluginId: click-log
     command: click-log.incident.list
-    version: 1.1.0
+    version: 2.0.0
+    # 2.0.0: the ClickLogIncident items now carry problem_tags/scheme_tags arrays instead of
+    # the singular problem_tag/scheme_tag (owner decision, 2026-08-13).
     inputSchema:
       type: object
       properties:
@@ -96,7 +108,7 @@ commands:
     retentionClass: user_event
   - pluginId: click-log
     command: click-log.incident.update
-    version: 1.0.0
+    version: 2.0.0
     inputSchema:
       type: object
       properties:
@@ -106,21 +118,30 @@ commands:
           type:
             - string
             - 'null'
-        problemTag:
+        problemTags:
           type:
-            - string
+            - array
             - 'null'
-        schemeTag:
+          items:
+            type: string
+          maxItems: 10
+        schemeTags:
           type:
-            - string
+            - array
             - 'null'
+          items:
+            type: string
+          maxItems: 10
       required: [id]
-      # Edits an incident's note and tags in place (owner decision, 2026-08-13). The date
+      # Edits an incident's note and tag lists in place (owner decision, 2026-08-13). The date
       # (created_at) and location (metadata latitude/longitude) are IMMUTABLE — the body
-      # carries no coordinates and the SQL never touches them. Each field is nullable to
-      # clear it: notes null/empty removes the note, a null/empty tag untags.
+      # carries no coordinates and the SQL never touches them. notes null/empty removes the
+      # note; problemTags/schemeTags absent/null/[] untags that kind (2.0.0, owner decision
+      # 2026-08-13: tag lists replace the singular problemTag/schemeTag of 1.0.0 — the
+      # breaking change; same validation as create: canonical slugs, duplicates collapsed,
+      # at most 10 of a kind).
       # Tags follow the same rules as create: slugs validated against the canonical lists in
-      # packages/web/lib/click-log/tags.ts, and a tag may only be set on an incident that
+      # packages/web/lib/click-log/tags.ts, and tags may only be set on an incident that
       # carries a location (tags-require-location, owner decision 2026-08-02). Since the
       # location is immutable, an incident logged without one can never gain tags — only its
       # note can be edited; the client explains this instead of showing pickers.
@@ -136,8 +157,8 @@ commands:
           type: boolean
     dataAccess:
       - click_log_incidents (select, update — own row only; metadata notes key and the two tag
-        columns; never coordinates or created_at)
-    purpose: Edit the note and tags of an own incident after logging (date and location immutable)
+        array columns; never coordinates or created_at)
+    purpose: Edit the note and tag lists of an own incident after logging (date and location immutable)
     retentionClass: user_event
   - pluginId: click-log
     command: click-log.incident.share.set
@@ -237,18 +258,23 @@ definitions:
         $ref: '#/definitions/IncidentMetadata'
       shared_with_owner:
         type: boolean
-      # Optional coarse tags; slugs from packages/web/lib/click-log/tags.ts, null when untagged.
-      problem_tag:
-        type:
-          - string
-          - 'null'
-      scheme_tag:
-        type:
-          - string
-          - 'null'
+      # Optional coarse tag lists; slugs from packages/web/lib/click-log/tags.ts, [] when
+      # untagged. Arrays since 2026-08-13 (owner decision: a real incident routinely chains
+      # several schemes). The superseded singular problem_tag/scheme_tag DB columns are kept
+      # for history but no longer surface in API responses' typed shape.
+      problem_tags:
+        type: array
+        items:
+          type: string
+        maxItems: 10
+      scheme_tags:
+        type: array
+        items:
+          type: string
+        maxItems: 10
       created_at:
         type: string
-    required: [id, user_id, metadata, shared_with_owner, problem_tag, scheme_tag, created_at]
+    required: [id, user_id, metadata, shared_with_owner, problem_tags, scheme_tags, created_at]
   ClickLogPreferences:
     type: object
     properties:

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -14,16 +14,18 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 ## 3. User Features
 
 - Log incident (with optional location/notes)
-- Optionally tag an incident with which known problem happened ("Which problem happened?" — the
-  50+ problems list published on the public landing page) and/or which named scheme was used
-  ("Which scheme was used?" — schemes named in the owner's now-deprecated "A post for each gang
-  stalker game" Discourse thread plus schemes described in the owner's archived posts;
-  `lib/click-log/tags.ts` is the living canonical list). One, both, or neither tag may be picked.
-  Both pickers are type-and-search filtered chip pickers (mimicking the Directory / SkillsHunt
-  skill pickers). A tagged incident requires a location — the form disables Submit (with an
-  explanation) until location is added, and the server enforces the same rule — because tagged
-  trend data needs location to be detailed enough. Tags show as chips on the history rows and
-  feed trend reporting.
+- Optionally tag an incident with which known problems happened ("Which problems happened?" —
+  the 50+ problems list published on the public landing page) and/or which named schemes were
+  used ("Which schemes were used?" — schemes named in the owner's now-deprecated "A post for
+  each gang stalker game" Discourse thread plus schemes described in the owner's archived
+  posts; `lib/click-log/tags.ts` is the living canonical list). Several of each may be picked —
+  up to 10 problems and 10 schemes per incident (owner decision, 2026-08-13: a real incident
+  routinely chains several schemes, so one tag per kind never fit). Both pickers are
+  type-and-search filtered multi-select chip pickers (mimicking the Directory / SkillsHunt
+  skill pickers): tapping a chip adds it, tapping it again removes it. A tagged incident
+  requires a location — the form disables Submit (with an explanation) until location is added,
+  and the server enforces the same rule — because tagged trend data needs location to be
+  detailed enough. Tags show as chips on the history rows and feed trend reporting.
 - Suggest a new scheme via the "Not listed" scheme tag (Weavers of the Commons badge holders
   only — members without the badge do not see the option). Picking it requires a written
   description of the scheme (up to 200 characters) that is explicitly shared with the owner —
@@ -34,8 +36,8 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   scheme to the canonical list.
 - View incident count and history
 - Edit an own incident after logging (pencil icon on each history row): the note can be changed
-  or removed, and the problem/scheme tags can be added, changed, or removed — using the same
-  type-and-search pickers as the log form. The date and location cannot be changed: they anchor
+  or removed, and the problem/scheme tag lists can be added to, changed, or emptied — using the
+  same type-and-search multi-select pickers as the log form. The date and location cannot be changed: they anchor
   the trend data, and a location can't be truthfully added after the fact. Because tags require
   a location, an incident logged without one can never gain tags — the editor says so plainly
   and offers only the note. The "Not listed" scheme can be kept or removed on an incident that
@@ -71,10 +73,10 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 ## 5. API Surface and Route Map
 
 - `GET /api/click-log` — List incidents for authenticated user. Returns `{ incidents, count, canSuggestScheme }` (`canSuggestScheme` = whether this member holds the Weavers of the Commons badge and so may pick "Not listed"). The user is always derived from the authenticated token (no caller-supplied `userId`); the access policy (`canViewIncidents`) is applied before the query.
-- `POST /api/click-log` — Create incident. Accepts optional `sharedWithOwner` boolean (falls back to the member's stored global default) and optional `problemTag` / `schemeTag` strings (each validated against the canonical slug lists in `lib/click-log/tags.ts`; an unknown slug is a 400). When either or both tags are present, `metadata.latitude`/`metadata.longitude` are required (400 otherwise). When `schemeTag` is `other-scheme` ("Not listed"): `schemeSuggestion` is required (1–200 chars after trim), `schemeQuoraUrl` is optional (must be an https quora.com link), the caller must hold the Weavers badge (403 otherwise), and the suggestion is stored in `click_log_scheme_suggestions`; suggestion fields with any other `schemeTag` are a 400. Returns the created incident flat (a `ClickLogIncident`, not wrapped under `{ incident }`), matching the command contract's `outputSchema`.
+- `POST /api/click-log` — Create incident. Accepts optional `sharedWithOwner` boolean (falls back to the member's stored global default) and optional `problemTags` / `schemeTags` string arrays (each slug validated against the canonical lists in `lib/click-log/tags.ts` — an unknown slug is a 400; duplicates collapsed; at most 10 per kind, `MAX_TAGS_PER_KIND`). When either list is non-empty, `metadata.latitude`/`metadata.longitude` are required (400 otherwise). When `schemeTags` contains `other-scheme` ("Not listed"): `schemeSuggestion` is required (1–200 chars after trim), `schemeQuoraUrl` is optional (must be an https quora.com link), the caller must hold the Weavers badge (403 otherwise), and the suggestion is stored in `click_log_scheme_suggestions`; suggestion fields without `other-scheme` are a 400. Returns the created incident flat (a `ClickLogIncident`, not wrapped under `{ incident }`), matching the command contract's `outputSchema`.
 - `DELETE /api/click-log/[id]` — Delete incident by id. Returns `{ success: true }`.
 - `PATCH /api/click-log/[id]` — Toggle owner-sharing on a single incident. Body `{ sharedWithOwner }`; only the incident's owner may call it (no admin override — consent is the member's alone). Returns `{ success, sharedWithOwner }`.
-- `PUT /api/click-log/[id]` — Edit an incident's note and tags in place. Body `{ notes, problemTag, schemeTag }`, each nullable to clear. Only the incident's owner may call it (no admin override — the note is the member's private content). The date and location are immutable: the body carries no coordinates and the SQL never touches them. Tags follow the create rules (canonical slugs; tags require the incident to carry a location — since location is immutable, a location-less incident can only edit its note, 400 otherwise). `other-scheme` ("Not listed") may be kept or removed but not newly picked on edit (400 — its description intake happens at create). An edit whose metadata duplicates another of the member's incidents returns a readable 409 (the `metadata_hash` dedupe). Returns `{ success: true }`.
+- `PUT /api/click-log/[id]` — Edit an incident's note and tag lists in place. Body `{ notes, problemTags, schemeTags }`: a null note clears it, an absent/null/empty tag array untags that kind. Only the incident's owner may call it (no admin override — the note is the member's private content). The date and location are immutable: the body carries no coordinates and the SQL never touches them. Tag lists follow the create rules (canonical slugs, duplicates collapsed, at most 10 per kind; tags require the incident to carry a location — since location is immutable, a location-less incident can only edit its note, 400 otherwise). `other-scheme` ("Not listed") may be kept or removed but not newly picked on edit (400 — its description intake happens at create). An edit whose metadata duplicates another of the member's incidents returns a readable 409 (the `metadata_hash` dedupe). Returns `{ success: true }`.
 - `GET /api/click-log/preferences` — Read the member's global owner-share default (`{ shareWithOwner }`).
 - `PUT /api/click-log/preferences` — Set the member's global owner-share default. Body `{ shareWithOwner }`.
 - `GET /api/click-log/admin/trends` — Admin-only aggregate trends over shared incidents from the last 90 days: `{ buckets, tagTrends }` — `buckets` of day / ~11 km location cell / count, plus `tagTrends` of tag kind (`problem` | `scheme`) / tag slug / count.
@@ -86,8 +88,9 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   - `user_id TEXT`
   - `metadata JSONB NOT NULL DEFAULT '{}'` (latitude, longitude, notes)
   - `shared_with_owner BOOLEAN NOT NULL DEFAULT FALSE` — member's per-incident owner-share opt-in; a real column (not metadata) so it is excluded from the `metadata_hash` dedupe
-  - `problem_tag TEXT` (nullable) — optional coarse tag: which of the 50+ known problems happened; slug validated against `lib/click-log/tags.ts` (mirrors the landing-page problems list). Real column, excluded from the `metadata_hash` dedupe.
-  - `scheme_tag TEXT` (nullable) — optional coarse tag: which named scheme was used; slug validated against `lib/click-log/tags.ts` (schemes started from the owner's "A post for each gang stalker game" Discourse thread, now deprecated — `tags.ts` is the living canonical list and grows there; slugs are never renamed or reused so trend history stays comparable). Real column, excluded from the `metadata_hash` dedupe.
+  - `problem_tags TEXT[] NOT NULL DEFAULT '{}'` — optional coarse tag list: which of the 50+ known problems happened; each slug validated against `lib/click-log/tags.ts` (mirrors the landing-page problems list); at most 10 (`MAX_TAGS_PER_KIND`, enforced in the API). Real column, excluded from the `metadata_hash` dedupe. Arrays since 2026-08-13 (owner decision: one tag per kind never fit a real incident).
+  - `scheme_tags TEXT[] NOT NULL DEFAULT '{}'` — optional coarse tag list: which named schemes were used; each slug validated against `lib/click-log/tags.ts` (schemes started from the owner's "A post for each gang stalker game" Discourse thread, now deprecated — `tags.ts` is the living canonical list and grows there; slugs are never renamed or reused so trend history stays comparable); at most 10. Real column, excluded from the `metadata_hash` dedupe.
+  - `problem_tag TEXT` / `scheme_tag TEXT` (nullable) — the superseded singular tag columns (2026-08-02 → 2026-08-13): backfilled into the arrays by guarded `UPDATE`s in `schema.sql`, kept for history, no longer read or written by the app.
   - `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
   - Indexes: `user_id`, `created_at DESC`, partial `created_at DESC WHERE shared_with_owner` (for the trends aggregate)
 - Table: `click_log_preferences`
@@ -114,8 +117,9 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 - Users can only view/delete their own incidents; admins can view/delete any incident
 - Editing an incident (`click-log.incident.update`) is owner-only with no admin override
   (`canEditIncident` — the note is the member's private content, mirroring the share toggle).
-  Only the note and tags are editable; the date and location are immutable by contract and by
-  the SQL itself (the UPDATE replaces only the metadata `notes` key and the two tag columns).
+  Only the note and tag lists are editable; the date and location are immutable by contract and
+  by the SQL itself (the UPDATE replaces only the metadata `notes` key and the two tag array
+  columns).
 - The "Not listed" scheme-suggestion text is the one deliberate exception to "tags carry no free
   text": it is a separate field explicitly labeled as shared with the owner (submission is the
   consent act), stored apart from `metadata.notes` (which keeps its absolute never-shared
@@ -167,9 +171,9 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 - See [scripts/seedClickLog.mjs](../../../scripts/seedClickLog.mjs)
 - 3–5 sample incidents with varied metadata
-- Tag coverage: one incident tagged with both a problem and a scheme, one problem-only, one
-  scheme-only, and untagged incidents; every tagged seed incident carries a location, matching
-  the tags-require-location rule
+- Tag coverage: one incident tagged with a problem and two schemes (exercising the multi-tag
+  arrays), one problem-only, one scheme-only, and untagged incidents; every tagged seed incident
+  carries a location, matching the tags-require-location rule
 - One "Not listed" incident plus a matching `click_log_scheme_suggestions` row (status `new`,
   with a Quora self-link) so a demo run of the suggestion pipeline has something to drain
 
@@ -180,6 +184,27 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 - No advanced search/filtering on incident history.
 
 ## Change Log
+
+- 2026-08-13: **Incidents now hold several tags of each kind: `problem_tags` / `scheme_tags`
+  arrays replace the singular columns (owner decision).** The owner's cross-country bus trip
+  chained five schemes in one incident, and no real incident is ever just one tag — so the
+  single-select shape was wrong. Schema: new `problem_tags TEXT[]` / `scheme_tags TEXT[]`
+  columns (`NOT NULL DEFAULT '{}'`) with guarded one-time backfill `UPDATE`s from the singular
+  columns (idempotent — only fills a still-empty array), in both `schema.sql` and
+  `schema.demo.sql`; the singular `problem_tag`/`scheme_tag` columns are kept for history but
+  no longer read or written. API: `POST /api/click-log` and `PUT /api/click-log/[id]` take
+  `problemTags`/`schemeTags` string arrays (unknown slug 400, duplicates collapsed, at most 10
+  per kind — `MAX_TAGS_PER_KIND` in `lib/click-log/constants.ts`); command contracts
+  `click-log.incident.create` and `.update` bumped to 2.0.0 (breaking field rename), `.list`
+  to 2.0.0 (incident shape now carries the arrays), access-policy attributes follow the rename.
+  Rules unchanged in spirit: any non-empty tag list still requires a location; `other-scheme`
+  ("Not listed") still requires the Weavers badge + description at create and can only be kept
+  or removed (never newly picked) on edit — now keyed on list membership instead of equality.
+  UI: both pickers are multi-select (tap adds, tap again removes, selected chips row with per-
+  chip X, cap hint at 10); history rows and the editor render every tag as its own chip. Trends:
+  `getSharedIncidentTagTrends` unnests the arrays, so each tag on a shared incident counts once
+  in "Top problems"/"Top schemes" — buckets and privacy boundary unchanged. Seed: one demo
+  incident now carries two schemes. Android: out of scope (web-only per rule 105).
 
 - 2026-08-13: **Incidents are editable after logging: note and tags only, date and location
   immutable (owner request).** New `PUT /api/click-log/[id]` (command

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -246,3 +246,5 @@ of these, it is already tracked, not a new bug:
 > _Tag list update (2026-08-13): added schemes "The Engineered Delay", "The Altered Ticket", "The Pretext Search", "The Planted Witness", and "The Replay", and problems "Trips sabotaged — delays, missed connections, canceled tickets" and "Falsely accused of violence / crimes to bystanders". List-data only — no test steps changed; CL-7/CL-8 cover tagging and suggestions generically._
 
 > _Limit change (2026-08-13): the incident note maximum length was raised from 200 to 2,000 characters (`MAX_NOTES_LENGTH`). CL-4's over-length note case still applies at the new limit — no test steps changed._
+
+> _Multi-tag change (2026-08-13): incidents now hold up to 10 problem tags and 10 scheme tags (arrays replace the single tag per kind). CL-7 and CL-9 below: the pickers are multi-select — pick two or more problems and two or more schemes in one incident, confirm every pick shows as its own chip in the selected row, on the history row, and in the editor, and confirm the 11th pick of a kind is refused with the "up to 10" hint. All other rules (tags need a location; "Not listed" keep-or-remove-only on edit) are unchanged._

--- a/ctf/packages/web/app/api/click-log/[id]/_edit.ts
+++ b/ctf/packages/web/app/api/click-log/[id]/_edit.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { updateIncident } from 'lib/click-log/repository';
 import { canEditIncident } from 'lib/click-log/policy';
-import { MAX_NOTES_LENGTH } from 'lib/click-log/constants';
+import { MAX_NOTES_LENGTH, MAX_TAGS_PER_KIND } from 'lib/click-log/constants';
 import { isValidProblemTag, isValidSchemeTag, NOT_LISTED_SCHEME_SLUG } from 'lib/click-log/tags';
 import type { ClickLogIncident } from 'lib/click-log/types';
 import { failureReason } from 'lib/errors/failure';
@@ -11,28 +11,36 @@ import { failureReason } from 'lib/errors/failure';
 
 export type IncidentEditFields = {
   notes: string | null;
-  problemTag: string | null;
-  schemeTag: string | null;
+  problemTags: string[];
+  schemeTags: string[];
 };
 
 function badRequest(error: string): NextResponse {
   return NextResponse.json({ error }, { status: 400 });
 }
 
-// Normalize one tag field of the edit body: absent, null, or "" all mean "no tag"; anything
-// else must be a known slug from the canonical list.
-function parseEditTag(
+// Normalize one tag-list field of the edit body: absent, null, or [] all mean untagged;
+// otherwise every entry must be a known slug from the canonical list, duplicates are
+// collapsed, and each kind is capped at MAX_TAGS_PER_KIND (same rules as create).
+function parseEditTagList(
   raw: unknown,
   isValid: (slug: string) => boolean,
   fieldName: string,
-): { error: NextResponse } | { data: string | null } {
-  if (raw === undefined || raw === null || raw === '') {
-    return { data: null };
+): { error: NextResponse } | { data: string[] } {
+  if (raw === undefined || raw === null) {
+    return { data: [] };
   }
-  if (typeof raw !== 'string' || !isValid(raw)) {
-    return { error: badRequest(`Invalid ${fieldName}`) };
+  if (!Array.isArray(raw)) {
+    return { error: badRequest(`Invalid ${fieldName}: expected a list of tag slugs`) };
   }
-  return { data: raw };
+  const unique = [...new Set(raw)];
+  if (unique.some((slug) => typeof slug !== 'string' || !isValid(slug))) {
+    return { error: badRequest(`Invalid ${fieldName}: unknown tag slug`) };
+  }
+  if (unique.length > MAX_TAGS_PER_KIND) {
+    return { error: badRequest(`Invalid ${fieldName}: at most ${MAX_TAGS_PER_KIND} tags`) };
+  }
+  return { data: unique as string[] };
 }
 
 // Normalize the note field of the edit body: absent, null, or whitespace-only all clear the
@@ -51,7 +59,7 @@ function parseEditNotes(raw: unknown): { error: NextResponse } | { data: string 
   return { data: trimmed.length > 0 ? trimmed : null };
 }
 
-// Reads and validates the PUT body: { notes, problemTag, schemeTag }. The date and location are
+// Reads and validates the PUT body: { notes, problemTags, schemeTags }. The date and location are
 // immutable by design (owner decision, 2026-08-13), so the body carries no metadata beyond the
 // note — a client sending coordinates here is simply ignored by the field list.
 export async function parseEditBody(
@@ -67,15 +75,15 @@ export async function parseEditBody(
   if ('error' in notesResult) {
     return notesResult;
   }
-  const problemResult = parseEditTag((body as { problemTag?: unknown })?.problemTag, isValidProblemTag, 'problemTag');
+  const problemResult = parseEditTagList((body as { problemTags?: unknown })?.problemTags, isValidProblemTag, 'problemTags');
   if ('error' in problemResult) {
     return problemResult;
   }
-  const schemeResult = parseEditTag((body as { schemeTag?: unknown })?.schemeTag, isValidSchemeTag, 'schemeTag');
+  const schemeResult = parseEditTagList((body as { schemeTags?: unknown })?.schemeTags, isValidSchemeTag, 'schemeTags');
   if ('error' in schemeResult) {
     return schemeResult;
   }
-  return { data: { notes: notesResult.data, problemTag: problemResult.data, schemeTag: schemeResult.data } };
+  return { data: { notes: notesResult.data, problemTags: problemResult.data, schemeTags: schemeResult.data } };
 }
 
 // Authorization for the edit: the incident must belong to the caller. No admin override — the
@@ -97,12 +105,12 @@ export function validateEditRules(
   incident: ClickLogIncident,
   fields: IncidentEditFields,
 ): NextResponse | null {
-  const tagged = fields.problemTag !== null || fields.schemeTag !== null;
+  const tagged = fields.problemTags.length > 0 || fields.schemeTags.length > 0;
   const hasLocation = incident.metadata.latitude !== undefined && incident.metadata.longitude !== undefined;
   if (tagged && !hasLocation) {
     return badRequest('Location is required when tagging an incident, and this incident was logged without one');
   }
-  if (fields.schemeTag === NOT_LISTED_SCHEME_SLUG && incident.scheme_tag !== NOT_LISTED_SCHEME_SLUG) {
+  if (fields.schemeTags.includes(NOT_LISTED_SCHEME_SLUG) && !incident.scheme_tags.includes(NOT_LISTED_SCHEME_SLUG)) {
     return badRequest('Pick "Not listed" when logging a new incident — the scheme description is written at logging time');
   }
   return null;

--- a/ctf/packages/web/app/api/click-log/[id]/route.ts
+++ b/ctf/packages/web/app/api/click-log/[id]/route.ts
@@ -117,7 +117,8 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
 
 // Edits an incident's note and tags (owner decision, 2026-08-13). The date and location are
 // immutable — they anchor the trend data and a location cannot be truthfully added after the
-// fact — so the body carries only { notes, problemTag, schemeTag }, each nullable to clear.
+// fact — so the body carries only { notes, problemTags, schemeTags }; a null note clears it
+// and an absent/empty tag list untags that kind.
 // Only the member who logged the incident may edit it (authorizeEdit — no admin override).
 export async function PUT(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const csrfDenied = ensureMutationCsrf(request);

--- a/ctf/packages/web/app/api/click-log/route.ts
+++ b/ctf/packages/web/app/api/click-log/route.ts
@@ -6,7 +6,7 @@ import {
   getIncidentCount,
   getPreferences,
 } from 'lib/click-log/repository';
-import { MAX_NOTES_LENGTH, MAX_SCHEME_SUGGESTION_LENGTH } from 'lib/click-log/constants';
+import { MAX_NOTES_LENGTH, MAX_SCHEME_SUGGESTION_LENGTH, MAX_TAGS_PER_KIND } from 'lib/click-log/constants';
 import { canViewIncidents } from 'lib/click-log/policy';
 import { logClickLogAudit } from 'lib/click-log/audit';
 import type { IncidentMetadata } from 'lib/click-log/types';
@@ -103,21 +103,29 @@ function buildMetadata(
   };
 }
 
-// Validate an optional incident tag against its canonical slug list (lib/click-log/tags.ts).
-// Absent means untagged; an unknown slug is rejected so trend reporting only ever aggregates
-// known values. Returns a discriminated result so the caller keeps TypeScript narrowing.
-function parseTag(
+// Validate an optional incident tag list against its canonical slug list
+// (lib/click-log/tags.ts). Absent/null/[] all mean untagged; an unknown slug is rejected so
+// trend reporting only ever aggregates known values; duplicates are collapsed; each kind is
+// capped at MAX_TAGS_PER_KIND. Returns a discriminated result so the caller keeps narrowing.
+function parseTagList(
   raw: unknown,
   isValid: (slug: string) => boolean,
   fieldName: string,
-): { error: NextResponse } | { data: string | undefined } {
+): { error: NextResponse } | { data: string[] } {
   if (raw === undefined || raw === null) {
-    return { data: undefined };
+    return { data: [] };
   }
-  if (typeof raw !== 'string' || !isValid(raw)) {
-    return { error: badRequest(`Invalid ${fieldName}`) };
+  if (!Array.isArray(raw)) {
+    return { error: badRequest(`Invalid ${fieldName}: expected a list of tag slugs`) };
   }
-  return { data: raw };
+  const unique = [...new Set(raw)];
+  if (unique.some((slug) => typeof slug !== 'string' || !isValid(slug))) {
+    return { error: badRequest(`Invalid ${fieldName}: unknown tag slug`) };
+  }
+  if (unique.length > MAX_TAGS_PER_KIND) {
+    return { error: badRequest(`Invalid ${fieldName}: at most ${MAX_TAGS_PER_KIND} tags`) };
+  }
+  return { data: unique as string[] };
 }
 
 // Validate the optional per-incident owner-share choice. undefined means the caller left the
@@ -132,35 +140,36 @@ function parseSharedFlag(raw: unknown): { error: NextResponse } | { data: boolea
   return { data: raw };
 }
 
-// Validate both optional tags plus the tags-require-location rule (owner decision, 2026-08-02):
-// a tagged incident must carry a location, because without it the trend data a tag feeds is not
-// detailed enough. Applies when either or both tags are set.
+// Validate both optional tag lists plus the tags-require-location rule (owner decision,
+// 2026-08-02): a tagged incident must carry a location, because without it the trend data a
+// tag feeds is not detailed enough. Applies when either list is non-empty. Lists since
+// 2026-08-13: a real incident routinely chains several schemes, so each kind takes up to
+// MAX_TAGS_PER_KIND slugs.
 function parseIncidentTags(
   body: unknown,
   metadata: IncidentMetadata,
-): { error: NextResponse } | { data: { problemTag?: string; schemeTag?: string } } {
-  const problemResult = parseTag(
-    (body as { problemTag?: unknown })?.problemTag,
+): { error: NextResponse } | { data: { problemTags: string[]; schemeTags: string[] } } {
+  const problemResult = parseTagList(
+    (body as { problemTags?: unknown })?.problemTags,
     isValidProblemTag,
-    'problemTag',
+    'problemTags',
   );
   if ('error' in problemResult) {
     return problemResult;
   }
-  const schemeResult = parseTag(
-    (body as { schemeTag?: unknown })?.schemeTag,
+  const schemeResult = parseTagList(
+    (body as { schemeTags?: unknown })?.schemeTags,
     isValidSchemeTag,
-    'schemeTag',
+    'schemeTags',
   );
   if ('error' in schemeResult) {
     return schemeResult;
   }
-  const tagged = problemResult.data !== undefined || schemeResult.data !== undefined;
+  const tagged = problemResult.data.length > 0 || schemeResult.data.length > 0;
   if (tagged && (metadata.latitude === undefined || metadata.longitude === undefined)) {
     return { error: badRequest('Location is required when tagging an incident') };
   }
-  // An absent tag stays undefined here; createIncident stores undefined as NULL.
-  return { data: { problemTag: problemResult.data, schemeTag: schemeResult.data } };
+  return { data: { problemTags: problemResult.data, schemeTags: schemeResult.data } };
 }
 
 // Resolve the effective owner-share flag: an explicit per-incident choice wins; otherwise the
@@ -212,7 +221,7 @@ function parseSuggestionText(raw: unknown): { error: NextResponse } | { data: st
 // any other scheme tag are rejected so nothing shared can ride along unnoticed.
 async function parseSchemeSuggestion(
   body: unknown,
-  schemeTag: string | undefined,
+  schemeTags: string[],
   userId: string,
 ): Promise<{ error: NextResponse } | { data: { suggestion: string; quoraUrl: string | undefined } | undefined }> {
   const rawSuggestion = (body as { schemeSuggestion?: unknown })?.schemeSuggestion;
@@ -220,7 +229,7 @@ async function parseSchemeSuggestion(
   if ('error' in urlResult) {
     return urlResult;
   }
-  if (schemeTag !== NOT_LISTED_SCHEME_SLUG) {
+  if (!schemeTags.includes(NOT_LISTED_SCHEME_SLUG)) {
     if (rawSuggestion !== undefined || urlResult.data !== undefined) {
       return { error: badRequest('Scheme suggestions are only accepted with the "Not listed" scheme tag') };
     }
@@ -267,14 +276,14 @@ export async function POST(req: NextRequest) {
   if ('error' in sharedResult) {
     return sharedResult.error;
   }
-  // Optional tags: which known problem happened and/or which named scheme was used. One or
-  // both may be present; both are optional; a tagged incident must carry a location.
+  // Optional tag lists: which known problems happened and/or which named schemes were used.
+  // Either, both, or neither may be non-empty; a tagged incident must carry a location.
   const tagsResult = parseIncidentTags(body, metadata);
   if ('error' in tagsResult) {
     return tagsResult.error;
   }
   // "Not listed" scheme suggestion: required description + optional Quora link, Weavers-only.
-  const suggestionResult = await parseSchemeSuggestion(body, tagsResult.data.schemeTag, userId);
+  const suggestionResult = await parseSchemeSuggestion(body, tagsResult.data.schemeTags, userId);
   if ('error' in suggestionResult) {
     return suggestionResult.error;
   }

--- a/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
+++ b/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
@@ -2,31 +2,30 @@
 
 import { useState } from "react";
 import type { ClickLogIncident } from "../../lib/click-log/types";
-import { MAX_NOTES_LENGTH } from "../../lib/click-log/constants";
+import { MAX_NOTES_LENGTH, MAX_TAGS_PER_KIND } from "../../lib/click-log/constants";
 import { CLICK_LOG_PROBLEM_TAGS, CLICK_LOG_SCHEME_TAGS, NOT_LISTED_SCHEME_SLUG } from "../../lib/click-log/tags";
 import { formatIncidentTime, hasLocation, type ClickLogTokens } from "./click-log-shared";
 import { ClickLogTagPicker } from "./click-log-tag-picker";
 
-// What an edit can change. Tags use "" for "no tag" (picker convention); the shell converts to
-// null for the API.
-export type IncidentEditFields = { notes: string; problemTag: string; schemeTag: string };
+// What an edit can change. Tag lists use [] for untagged (picker convention).
+export type IncidentEditFields = { notes: string; problemTags: string[]; schemeTags: string[] };
 
 // The tag pickers of the edit form, or — on an incident logged without a location — the
 // explanation of why there are none. Extracted so the editor stays under the complexity limit.
 function EditorTagSection({
   incident,
-  problemTag,
-  schemeTag,
+  problemTags,
+  schemeTags,
   tokens,
-  onProblemTagChange,
-  onSchemeTagChange,
+  onProblemTagsChange,
+  onSchemeTagsChange,
 }: {
   incident: ClickLogIncident;
-  problemTag: string;
-  schemeTag: string;
+  problemTags: string[];
+  schemeTags: string[];
   tokens: ClickLogTokens;
-  onProblemTagChange: (value: string) => void;
-  onSchemeTagChange: (value: string) => void;
+  onProblemTagsChange: (values: string[]) => void;
+  onSchemeTagsChange: (values: string[]) => void;
 }) {
   const t = tokens;
   if (!hasLocation(incident)) {
@@ -44,32 +43,34 @@ function EditorTagSection({
   // editing offers it only on an incident that already carries it — keep it or remove it, but
   // never newly pick it here. The server enforces the same rule.
   const schemeOptions =
-    incident.scheme_tag === NOT_LISTED_SCHEME_SLUG
+    incident.scheme_tags.includes(NOT_LISTED_SCHEME_SLUG)
       ? CLICK_LOG_SCHEME_TAGS
       : CLICK_LOG_SCHEME_TAGS.filter((tag) => tag.slug !== NOT_LISTED_SCHEME_SLUG);
   return (
     <>
       <ClickLogTagPicker
-        label="Which problem happened? (optional)"
+        label="Which problems happened? (optional — pick all that apply)"
         searchPlaceholder="Search problems…"
-        value={problemTag}
+        values={problemTags}
         options={CLICK_LOG_PROBLEM_TAGS}
+        maxSelected={MAX_TAGS_PER_KIND}
         tokens={t}
-        onChange={onProblemTagChange}
+        onChange={onProblemTagsChange}
       />
       <ClickLogTagPicker
-        label="Which scheme was used? (optional)"
+        label="Which schemes were used? (optional — pick all that apply)"
         searchPlaceholder="Search schemes…"
-        value={schemeTag}
+        values={schemeTags}
         options={schemeOptions}
+        maxSelected={MAX_TAGS_PER_KIND}
         tokens={t}
-        onChange={onSchemeTagChange}
+        onChange={onSchemeTagsChange}
       />
     </>
   );
 }
 
-// Inline editor for one history row (owner decision, 2026-08-13): the note and the two tags can
+// Inline editor for one history row (owner decision, 2026-08-13): the note and the tag lists can
 // be changed after logging; the date and location cannot — they anchor the trend data, and a
 // location can't be truthfully added after the fact.
 export function ClickLogIncidentEditor({
@@ -87,8 +88,8 @@ export function ClickLogIncidentEditor({
 }) {
   const t = tokens;
   const [notes, setNotes] = useState(incident.metadata.notes ?? "");
-  const [problemTag, setProblemTag] = useState(incident.problem_tag ?? "");
-  const [schemeTag, setSchemeTag] = useState(incident.scheme_tag ?? "");
+  const [problemTags, setProblemTags] = useState<string[]>(incident.problem_tags);
+  const [schemeTags, setSchemeTags] = useState<string[]>(incident.scheme_tags);
   return (
     <div style={{ padding: "14px 16px", borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.ACCENT}40` }}>
       {/* The immutable half of the row, shown so it is clear what editing covers. */}
@@ -107,15 +108,15 @@ export function ClickLogIncidentEditor({
       />
       <EditorTagSection
         incident={incident}
-        problemTag={problemTag}
-        schemeTag={schemeTag}
+        problemTags={problemTags}
+        schemeTags={schemeTags}
         tokens={t}
-        onProblemTagChange={setProblemTag}
-        onSchemeTagChange={setSchemeTag}
+        onProblemTagsChange={setProblemTags}
+        onSchemeTagsChange={setSchemeTags}
       />
       <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
         <button
-          onClick={() => onSave({ notes, problemTag, schemeTag })}
+          onClick={() => onSave({ notes, problemTags, schemeTags })}
           disabled={busy}
           style={{ padding: "8px 16px", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: busy ? "default" : "pointer", background: t.ACCENT, border: "none", color: "#fff", opacity: busy ? 0.6 : 1 }}
         >

--- a/ctf/packages/web/components/click-log/click-log-incident-list.tsx
+++ b/ctf/packages/web/components/click-log/click-log-incident-list.tsx
@@ -11,19 +11,19 @@ import { ClickLogIncidentEditor, type IncidentEditFields } from "./click-log-inc
 // Extracted so the row component stays under the complexity limit.
 function IncidentTagChips({ incident, tokens }: { incident: ClickLogIncident; tokens: ClickLogTokens }) {
   const t = tokens;
-  if (!incident.problem_tag && !incident.scheme_tag) return null;
+  if (incident.problem_tags.length === 0 && incident.scheme_tags.length === 0) return null;
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginBottom: 4 }}>
-      {incident.problem_tag && (
-        <span style={{ padding: "2px 8px", borderRadius: 999, fontSize: 10, background: `${t.ACCENT}12`, border: `1px solid ${t.ACCENT}25`, color: t.ACCENT }}>
-          {problemTagLabel(incident.problem_tag)}
+      {incident.problem_tags.map((slug) => (
+        <span key={slug} style={{ padding: "2px 8px", borderRadius: 999, fontSize: 10, background: `${t.ACCENT}12`, border: `1px solid ${t.ACCENT}25`, color: t.ACCENT }}>
+          {problemTagLabel(slug)}
         </span>
-      )}
-      {incident.scheme_tag && (
-        <span style={{ padding: "2px 8px", borderRadius: 999, fontSize: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED }}>
-          Scheme: {schemeTagLabel(incident.scheme_tag)}
+      ))}
+      {incident.scheme_tags.map((slug) => (
+        <span key={slug} style={{ padding: "2px 8px", borderRadius: 999, fontSize: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.MUTED }}>
+          Scheme: {schemeTagLabel(slug)}
         </span>
-      )}
+      ))}
     </div>
   );
 }

--- a/ctf/packages/web/components/click-log/click-log-log-panel.tsx
+++ b/ctf/packages/web/components/click-log/click-log-log-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertTriangle, MapPin } from "lucide-react";
-import { MAX_NOTES_LENGTH } from "../../lib/click-log/constants";
+import { MAX_NOTES_LENGTH, MAX_TAGS_PER_KIND } from "../../lib/click-log/constants";
 import { CLICK_LOG_PROBLEM_TAGS, CLICK_LOG_SCHEME_TAGS, NOT_LISTED_SCHEME_SLUG } from "../../lib/click-log/tags";
 import { useTheme } from "@/hooks/useTheme";
 import { getClickLogTokens, type ClickLogTokens } from "./click-log-shared";
@@ -27,34 +27,34 @@ export type SchemeSuggestionProps = {
 // Module-level so the form component stays under the complexity limit.
 function isSubmitDisabled(
   submitting: boolean,
-  problemTag: string,
-  schemeTag: string,
+  problemTags: string[],
+  schemeTags: string[],
   locationAdded: boolean,
   suggestion: string,
 ): boolean {
   if (submitting) return true;
-  if (Boolean(problemTag || schemeTag) && !locationAdded) return true;
-  return schemeTag === NOT_LISTED_SCHEME_SLUG && suggestion.trim().length === 0;
+  if ((problemTags.length > 0 || schemeTags.length > 0) && !locationAdded) return true;
+  return schemeTags.includes(NOT_LISTED_SCHEME_SLUG) && suggestion.trim().length === 0;
 }
 
 // The two optional tag pickers plus the tags-need-location hint and the "Not listed"
 // suggestion fields. Extracted so the note form stays under the complexity limit.
 function ClickLogTagFields({
-  problemTag,
-  schemeTag,
+  problemTags,
+  schemeTags,
   locationAdded,
   schemeSuggestion,
   tokens,
-  onProblemTagChange,
-  onSchemeTagChange,
+  onProblemTagsChange,
+  onSchemeTagsChange,
 }: {
-  problemTag: string;
-  schemeTag: string;
+  problemTags: string[];
+  schemeTags: string[];
   locationAdded: boolean;
   schemeSuggestion: SchemeSuggestionProps;
   tokens: ClickLogTokens;
-  onProblemTagChange: (value: string) => void;
-  onSchemeTagChange: (value: string) => void;
+  onProblemTagsChange: (values: string[]) => void;
+  onSchemeTagsChange: (values: string[]) => void;
 }) {
   const t = tokens;
   // Non-Weavers never see the catch-all option — picking a named scheme stays open to everyone.
@@ -64,22 +64,24 @@ function ClickLogTagFields({
   return (
     <>
       <ClickLogTagPicker
-        label="Which problem happened? (optional)"
+        label="Which problems happened? (optional — pick all that apply)"
         searchPlaceholder="Search problems…"
-        value={problemTag}
+        values={problemTags}
         options={CLICK_LOG_PROBLEM_TAGS}
+        maxSelected={MAX_TAGS_PER_KIND}
         tokens={t}
-        onChange={onProblemTagChange}
+        onChange={onProblemTagsChange}
       />
       <ClickLogTagPicker
-        label="Which scheme was used? (optional)"
+        label="Which schemes were used? (optional — pick all that apply)"
         searchPlaceholder="Search schemes…"
-        value={schemeTag}
+        values={schemeTags}
         options={schemeOptions}
+        maxSelected={MAX_TAGS_PER_KIND}
         tokens={t}
-        onChange={onSchemeTagChange}
+        onChange={onSchemeTagsChange}
       />
-      {schemeTag === NOT_LISTED_SCHEME_SLUG && (
+      {schemeTags.includes(NOT_LISTED_SCHEME_SLUG) && (
         <ClickLogSchemeSuggestionFields
           suggestion={schemeSuggestion.suggestion}
           quoraUrl={schemeSuggestion.quoraUrl}
@@ -90,7 +92,7 @@ function ClickLogTagFields({
       )}
       {/* A tagged incident must carry a location — without it the trend data a tag feeds is not
           detailed enough (owner decision, 2026-08-02). The server enforces the same rule. */}
-      {(problemTag || schemeTag) && !locationAdded && (
+      {(problemTags.length > 0 || schemeTags.length > 0) && !locationAdded && (
         <div style={{ marginTop: 8, fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
           Tags need a location: add your location below before submitting, so the trend data is
           detailed enough.
@@ -137,15 +139,15 @@ function ClickLogNoteForm({
   geoStatus,
   geoError,
   shareWithOwner,
-  problemTag,
-  schemeTag,
+  problemTags,
+  schemeTags,
   schemeSuggestion,
   tokens,
   onNoteChange,
   onAddLocation,
   onShareChange,
-  onProblemTagChange,
-  onSchemeTagChange,
+  onProblemTagsChange,
+  onSchemeTagsChange,
   onSubmit,
   onCancel,
 }: {
@@ -155,15 +157,15 @@ function ClickLogNoteForm({
   geoStatus: GeoStatus;
   geoError: string | null;
   shareWithOwner: boolean;
-  problemTag: string;
-  schemeTag: string;
+  problemTags: string[];
+  schemeTags: string[];
   schemeSuggestion: SchemeSuggestionProps;
   tokens: ClickLogTokens;
   onNoteChange: (value: string) => void;
   onAddLocation: () => void;
   onShareChange: (value: boolean) => void;
-  onProblemTagChange: (value: string) => void;
-  onSchemeTagChange: (value: string) => void;
+  onProblemTagsChange: (values: string[]) => void;
+  onSchemeTagsChange: (values: string[]) => void;
   onSubmit: () => void;
   onCancel: () => void;
 }) {
@@ -172,8 +174,8 @@ function ClickLogNoteForm({
   // matching the server rules), so Submit waits for them.
   const submitDisabled = isSubmitDisabled(
     submitting,
-    problemTag,
-    schemeTag,
+    problemTags,
+    schemeTags,
     locationAdded,
     schemeSuggestion.suggestion,
   );
@@ -192,13 +194,13 @@ function ClickLogNoteForm({
           used. One, both, or neither may be picked; both feed trend reporting. Type-and-search
           filtered pickers, mimicking the Directory / SkillsHunt skill pickers. */}
       <ClickLogTagFields
-        problemTag={problemTag}
-        schemeTag={schemeTag}
+        problemTags={problemTags}
+        schemeTags={schemeTags}
         locationAdded={locationAdded}
         schemeSuggestion={schemeSuggestion}
         tokens={t}
-        onProblemTagChange={onProblemTagChange}
-        onSchemeTagChange={onSchemeTagChange}
+        onProblemTagsChange={onProblemTagsChange}
+        onSchemeTagsChange={onSchemeTagsChange}
       />
       {/* Per-incident owner-share choice, seeded from the member's global default. Only coarse
           trend data (day + rounded location + tags + count) is ever shared — never notes. */}
@@ -240,12 +242,12 @@ export function ClickLogLogPanel({
   geoStatus,
   geoError,
   shareWithOwner,
-  problemTag,
-  schemeTag,
+  problemTags,
+  schemeTags,
   schemeSuggestion,
   onShareChange,
-  onProblemTagChange,
-  onSchemeTagChange,
+  onProblemTagsChange,
+  onSchemeTagsChange,
   onToggleForm,
   onNoteChange,
   onAddLocation,
@@ -260,12 +262,12 @@ export function ClickLogLogPanel({
   geoStatus: GeoStatus;
   geoError: string | null;
   shareWithOwner: boolean;
-  problemTag: string;
-  schemeTag: string;
+  problemTags: string[];
+  schemeTags: string[];
   schemeSuggestion: SchemeSuggestionProps;
   onShareChange: (value: boolean) => void;
-  onProblemTagChange: (value: string) => void;
-  onSchemeTagChange: (value: string) => void;
+  onProblemTagsChange: (values: string[]) => void;
+  onSchemeTagsChange: (values: string[]) => void;
   onToggleForm: () => void;
   onNoteChange: (value: string) => void;
   onAddLocation: () => void;
@@ -296,15 +298,15 @@ export function ClickLogLogPanel({
           geoStatus={geoStatus}
           geoError={geoError}
           shareWithOwner={shareWithOwner}
-          problemTag={problemTag}
-          schemeTag={schemeTag}
+          problemTags={problemTags}
+          schemeTags={schemeTags}
           schemeSuggestion={schemeSuggestion}
           tokens={t}
           onNoteChange={onNoteChange}
           onAddLocation={onAddLocation}
           onShareChange={onShareChange}
-          onProblemTagChange={onProblemTagChange}
-          onSchemeTagChange={onSchemeTagChange}
+          onProblemTagsChange={onProblemTagsChange}
+          onSchemeTagsChange={onSchemeTagsChange}
           onSubmit={onSubmit}
           onCancel={onCancel}
         />

--- a/ctf/packages/web/components/click-log/click-log-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-shell.tsx
@@ -46,17 +46,17 @@ async function throwIfNotOk(res: Response, fallback: string): Promise<void> {
 function buildCreateBody(args: {
   metadata: Record<string, unknown>;
   sharedWithOwner: boolean;
-  problemTag: string;
-  schemeTag: string;
+  problemTags: string[];
+  schemeTags: string[];
   schemeSuggestion: string;
   schemeQuoraUrl: string;
 }): Record<string, unknown> {
-  const notListed = args.schemeTag === NOT_LISTED_SCHEME_SLUG;
+  const notListed = args.schemeTags.includes(NOT_LISTED_SCHEME_SLUG);
   return {
     metadata: args.metadata,
     sharedWithOwner: args.sharedWithOwner,
-    ...(args.problemTag ? { problemTag: args.problemTag } : {}),
-    ...(args.schemeTag ? { schemeTag: args.schemeTag } : {}),
+    ...(args.problemTags.length > 0 ? { problemTags: args.problemTags } : {}),
+    ...(args.schemeTags.length > 0 ? { schemeTags: args.schemeTags } : {}),
     ...(notListed && args.schemeSuggestion.trim() ? { schemeSuggestion: args.schemeSuggestion.trim() } : {}),
     ...(notListed && args.schemeQuoraUrl.trim() ? { schemeQuoraUrl: args.schemeQuoraUrl.trim() } : {}),
   };
@@ -96,9 +96,9 @@ export function ClickLogShell() {
   const [totalCount, setTotalCount] = useState<number | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [note, setNote] = useState("");
-  // Optional tags for the incident being logged ("" = untagged). Slugs from lib/click-log/tags.
-  const [problemTag, setProblemTag] = useState("");
-  const [schemeTag, setSchemeTag] = useState("");
+  // Optional tags for the incident being logged ([] = untagged). Slugs from lib/click-log/tags.
+  const [problemTags, setProblemTags] = useState<string[]>([]);
+  const [schemeTags, setSchemeTags] = useState<string[]>([]);
   // "Not listed" scheme-suggestion state. canSuggestScheme comes from GET /api/click-log
   // (Weavers of the Commons badge holders only); when false the option is hidden entirely.
   const [canSuggestScheme, setCanSuggestScheme] = useState(false);
@@ -183,8 +183,8 @@ export function ClickLogShell() {
           buildCreateBody({
             metadata,
             sharedWithOwner: share.formShare,
-            problemTag,
-            schemeTag,
+            problemTags,
+            schemeTags,
             schemeSuggestion,
             schemeQuoraUrl,
           }),
@@ -193,8 +193,8 @@ export function ClickLogShell() {
       await throwIfNotOk(res, "Failed to log incident");
       setShowForm(false);
       setNote("");
-      setProblemTag("");
-      setSchemeTag("");
+      setProblemTags([]);
+      setSchemeTags([]);
       setSchemeSuggestion("");
       setSchemeQuoraUrl("");
       setGeo({});
@@ -254,8 +254,8 @@ export function ClickLogShell() {
         geoStatus={geoStatus}
         geoError={geoError}
         shareWithOwner={share.formShare}
-        problemTag={problemTag}
-        schemeTag={schemeTag}
+        problemTags={problemTags}
+        schemeTags={schemeTags}
         schemeSuggestion={{
           canSuggestScheme,
           suggestion: schemeSuggestion,
@@ -264,13 +264,13 @@ export function ClickLogShell() {
           onQuoraUrlChange: setSchemeQuoraUrl,
         }}
         onShareChange={share.setFormShare}
-        onProblemTagChange={setProblemTag}
-        onSchemeTagChange={setSchemeTag}
+        onProblemTagsChange={setProblemTags}
+        onSchemeTagsChange={setSchemeTags}
         onToggleForm={() => setShowForm((s) => !s)}
         onNoteChange={setNote}
         onAddLocation={addLocation}
         onSubmit={() => void postIncident({ ...geo, notes: note })}
-        onCancel={() => { setShowForm(false); setNote(""); setProblemTag(""); setSchemeTag(""); setSchemeSuggestion(""); setSchemeQuoraUrl(""); setGeo({}); setGeoStatus("idle"); setGeoError(null); share.setFormShare(share.shareDefault); }}
+        onCancel={() => { setShowForm(false); setNote(""); setProblemTags([]); setSchemeTags([]); setSchemeSuggestion(""); setSchemeQuoraUrl(""); setGeo({}); setGeoStatus("idle"); setGeoError(null); share.setFormShare(share.shareDefault); }}
       />
 
       <ShareDefaultToggle

--- a/ctf/packages/web/components/click-log/click-log-tag-picker.tsx
+++ b/ctf/packages/web/components/click-log/click-log-tag-picker.tsx
@@ -5,12 +5,13 @@ import { Search, X } from "lucide-react";
 import type { ClickLogTag } from "../../lib/click-log/tags";
 import type { ClickLogTokens } from "./click-log-shared";
 
-// Single-select tag picker for the log form (problem or scheme), mimicking the Directory /
-// SkillsHunt picker style: a type-and-search keyword box that filters a flat chip list, a
-// removable selected chip, and "✓"-marked active chips. Both lists are long (51 problems,
-// a growing scheme list), so search-first beats a giant dropdown. Unlike the skills pickers
-// this is single-select: picking a chip replaces the previous pick; the X (or tapping the
-// active chip) clears it.
+// Multi-select tag picker for the log form (problems or schemes), mimicking the Directory /
+// SkillsHunt picker style: a type-and-search keyword box that filters a flat chip list, a row
+// of removable selected chips, and "✓"-marked active chips. Both lists are long (50+ problems,
+// a growing scheme list), so search-first beats a giant dropdown. Multi-select since
+// 2026-08-13 (owner decision: a real incident routinely chains several schemes): tapping a
+// chip adds it, tapping an active chip (or its X in the selected row) removes it, up to
+// MAX_TAGS_PER_KIND of each kind.
 
 // One selectable tag chip — shared by the filtered list and the search results.
 function TagChip({ tag, active, tokens, onToggle }: {
@@ -38,22 +39,24 @@ function TagChip({ tag, active, tokens, onToggle }: {
   );
 }
 
-// The removable selected pick, shown above the search box. Renders nothing while unpicked.
-function SelectedTagChip({ selected, tokens, onClear }: {
-  selected: ClickLogTag | undefined;
+// The removable selected picks, shown above the search box. Renders nothing while unpicked.
+function SelectedTagChips({ selected, tokens, onRemove }: {
+  selected: ClickLogTag[];
   tokens: ClickLogTokens;
-  onClear: () => void;
+  onRemove: (slug: string) => void;
 }) {
   const t = tokens;
-  if (!selected) return null;
+  if (selected.length === 0) return null;
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
-      <span style={{ display: "flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 20, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}40`, fontSize: 12, color: t.ACCENT, fontWeight: 600 }}>
-        {selected.label}
-        <button type="button" aria-label={`Remove ${selected.label}`} onClick={onClear} style={{ background: "none", border: "none", color: t.ACCENT, cursor: "pointer", padding: 0, lineHeight: 1, display: "flex" }}>
-          <X size={11} />
-        </button>
-      </span>
+      {selected.map((tag) => (
+        <span key={tag.slug} style={{ display: "flex", alignItems: "center", gap: 4, padding: "4px 10px", borderRadius: 20, background: `${t.ACCENT}20`, border: `1px solid ${t.ACCENT}40`, fontSize: 12, color: t.ACCENT, fontWeight: 600 }}>
+          {tag.label}
+          <button type="button" aria-label={`Remove ${tag.label}`} onClick={() => onRemove(tag.slug)} style={{ background: "none", border: "none", color: t.ACCENT, cursor: "pointer", padding: 0, lineHeight: 1, display: "flex" }}>
+            <X size={11} />
+          </button>
+        </span>
+      ))}
     </div>
   );
 }
@@ -61,32 +64,43 @@ function SelectedTagChip({ selected, tokens, onClear }: {
 export function ClickLogTagPicker({
   label,
   searchPlaceholder,
-  value,
+  values,
   options,
+  maxSelected,
   tokens,
   onChange,
 }: {
   label: string;
   searchPlaceholder: string;
-  // Selected slug, or "" for unpicked.
-  value: string;
+  // Selected slugs, in pick order; [] for unpicked.
+  values: string[];
   options: readonly ClickLogTag[];
+  // Cap on picks of this kind (MAX_TAGS_PER_KIND); adding past it is ignored and a hint shows.
+  maxSelected: number;
   tokens: ClickLogTokens;
-  onChange: (value: string) => void;
+  onChange: (values: string[]) => void;
 }) {
   const t = tokens;
   const [search, setSearch] = useState("");
   const query = search.trim().toLowerCase();
-  const selected = useMemo(() => options.find((o) => o.slug === value), [options, value]);
+  const selected = useMemo(
+    () => values.map((slug) => options.find((o) => o.slug === slug)).filter((o): o is ClickLogTag => o !== undefined),
+    [options, values],
+  );
   const matches = useMemo(
     () => (query ? options.filter((o) => o.label.toLowerCase().includes(query)) : options),
     [options, query],
   );
+  const atCap = values.length >= maxSelected;
 
-  // Single-select toggle: picking replaces the previous pick; picking the active chip clears it.
-  // A pick also clears the search so the list is back to full for the other picker/next log.
+  // Multi-select toggle: tapping adds the chip (until the cap), tapping an active chip removes
+  // it. A pick also clears the search so the list is back to full for the next pick.
   function toggle(slug: string) {
-    onChange(slug === value ? "" : slug);
+    if (values.includes(slug)) {
+      onChange(values.filter((v) => v !== slug));
+    } else if (!atCap) {
+      onChange([...values, slug]);
+    }
     setSearch("");
   }
 
@@ -94,7 +108,12 @@ export function ClickLogTagPicker({
     <div style={{ marginTop: 12 }}>
       <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 6 }}>{label}</div>
 
-      <SelectedTagChip selected={selected} tokens={t} onClear={() => onChange("")} />
+      <SelectedTagChips selected={selected} tokens={t} onRemove={(slug) => onChange(values.filter((v) => v !== slug))} />
+      {atCap && (
+        <div style={{ fontSize: 11, color: t.MUTED, marginBottom: 6 }}>
+          Up to {maxSelected} — remove one to pick another.
+        </div>
+      )}
 
       <div style={{ position: "relative", marginBottom: 8 }}>
         <Search size={14} style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: t.MUTED, pointerEvents: "none" }} />
@@ -119,7 +138,7 @@ export function ClickLogTagPicker({
         ) : (
           <div style={{ display: "flex", flexWrap: "wrap", gap: 7 }}>
             {matches.map((tag) => (
-              <TagChip key={tag.slug} tag={tag} active={tag.slug === value} tokens={t} onToggle={toggle} />
+              <TagChip key={tag.slug} tag={tag} active={values.includes(tag.slug)} tokens={t} onToggle={toggle} />
             ))}
           </div>
         )}

--- a/ctf/packages/web/components/click-log/click-log-use-incident-edit.ts
+++ b/ctf/packages/web/components/click-log/click-log-use-incident-edit.ts
@@ -5,8 +5,8 @@ import type { IncidentEditFields } from "./click-log-incident-editor";
 
 // Per-incident edit state and the PUT call, extracted from the shell (mirroring
 // click-log-use-owner-share) so ClickLogShell stays under the rule-116 function-length limit.
-// Only the note and tags are sent — the date and location are immutable, so the body never
-// carries coordinates. "" tags from the pickers become null (= untagged) for the API.
+// Only the note and tag lists are sent — the date and location are immutable, so the body
+// never carries coordinates. Empty picker arrays mean untagged.
 export function useIncidentEdit({
   onError,
   onBusy,
@@ -27,8 +27,8 @@ export function useIncidentEdit({
         headers: { "Content-Type": "application/json", "x-ctf-csrf": "1" },
         body: JSON.stringify({
           notes: fields.notes,
-          problemTag: fields.problemTag || null,
-          schemeTag: fields.schemeTag || null,
+          problemTags: fields.problemTags,
+          schemeTags: fields.schemeTags,
         }),
       });
       if (!res.ok) {

--- a/ctf/packages/web/lib/click-log/constants.ts
+++ b/ctf/packages/web/lib/click-log/constants.ts
@@ -5,4 +5,8 @@ export const MAX_NOTES_LENGTH = 2000;
 // Max length of the "Not listed" scheme description a member writes when suggesting a new
 // scheme. Unlike notes, this text IS shared with the owner — the field says so explicitly.
 export const MAX_SCHEME_SUGGESTION_LENGTH = 200;
+// Max tags of each kind (problems / schemes) on one incident. Arrays since 2026-08-13 (owner
+// decision: a real incident routinely chains several schemes, so one tag per kind never fit).
+// The cap bounds the trend aggregates and the picker UI, not the member's honesty.
+export const MAX_TAGS_PER_KIND = 10;
 export const DEFAULT_METADATA: Readonly<Record<string, never>> = Object.freeze({});

--- a/ctf/packages/web/lib/click-log/repository.ts
+++ b/ctf/packages/web/lib/click-log/repository.ts
@@ -18,12 +18,12 @@ export async function getIncidentById(id: string): Promise<ClickLogIncident | nu
 }
 
 export async function createIncident(input: CreateIncidentInput): Promise<ClickLogIncident> {
-  const { userId, metadata, sharedWithOwner, problemTag, schemeTag } = input;
+  const { userId, metadata, sharedWithOwner, problemTags, schemeTags } = input;
   const result = await queryDb<ClickLogIncident>(
-    `INSERT INTO click_log_incidents (id, user_id, metadata, shared_with_owner, problem_tag, scheme_tag, created_at)
-     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, NOW())
+    `INSERT INTO click_log_incidents (id, user_id, metadata, shared_with_owner, problem_tags, scheme_tags, created_at)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4::text[], $5::text[], NOW())
      RETURNING *`,
-    [userId, metadata, sharedWithOwner, problemTag ?? null, schemeTag ?? null]
+    [userId, metadata, sharedWithOwner, problemTags ?? [], schemeTags ?? []]
   );
   return result.rows[0];
 }
@@ -36,17 +36,17 @@ export async function createIncident(input: CreateIncidentInput): Promise<ClickL
 // metadata identical to another of the member's rows violates UNIQUE (user_id, metadata_hash) —
 // the route maps that to a readable 409.
 export async function updateIncident(input: UpdateIncidentInput): Promise<boolean> {
-  const { id, userId, notes, problemTag, schemeTag } = input;
+  const { id, userId, notes, problemTags, schemeTags } = input;
   const result = await queryDb(
     `UPDATE click_log_incidents
      SET metadata = CASE
            WHEN $3::text IS NULL THEN metadata - 'notes'
            ELSE jsonb_set(metadata, '{notes}', to_jsonb($3::text), true)
          END,
-         problem_tag = $4,
-         scheme_tag = $5
+         problem_tags = $4::text[],
+         scheme_tags = $5::text[]
      WHERE id = $1 AND user_id = $2`,
-    [id, userId, notes, problemTag, schemeTag]
+    [id, userId, notes, problemTags, schemeTags]
   );
   return (result.rowCount ?? 0) > 0;
 }
@@ -145,19 +145,17 @@ export async function createSchemeSuggestion(input: CreateSchemeSuggestionInput)
 // member identity. Untagged incidents are simply absent from this aggregate.
 export async function getSharedIncidentTagTrends(days = 90): Promise<SharedIncidentTagTrend[]> {
   const result = await queryDb<{ tag_type: 'problem' | 'scheme'; tag: string; count: string }>(
-    `SELECT 'problem' AS tag_type, problem_tag AS tag, COUNT(*) AS count
-     FROM click_log_incidents
+    `SELECT 'problem' AS tag_type, tag, COUNT(*) AS count
+     FROM click_log_incidents, unnest(problem_tags) AS tag
      WHERE shared_with_owner
-       AND problem_tag IS NOT NULL
        AND created_at >= NOW() - make_interval(days => $1)
-     GROUP BY problem_tag
+     GROUP BY tag
      UNION ALL
-     SELECT 'scheme' AS tag_type, scheme_tag AS tag, COUNT(*) AS count
-     FROM click_log_incidents
+     SELECT 'scheme' AS tag_type, tag, COUNT(*) AS count
+     FROM click_log_incidents, unnest(scheme_tags) AS tag
      WHERE shared_with_owner
-       AND scheme_tag IS NOT NULL
        AND created_at >= NOW() - make_interval(days => $1)
-     GROUP BY scheme_tag
+     GROUP BY tag
      ORDER BY count DESC, tag ASC`,
     [days]
   );

--- a/ctf/packages/web/lib/click-log/types.ts
+++ b/ctf/packages/web/lib/click-log/types.ts
@@ -10,10 +10,12 @@ export type ClickLogIncident = {
   metadata: IncidentMetadata;
   // Whether the member opted to share this incident with the owner for aggregate trends.
   shared_with_owner: boolean;
-  // Optional coarse tags: which known problem happened / which named scheme was used.
-  // Values are slugs from lib/click-log/tags.ts (validated on create); null when untagged.
-  problem_tag: string | null;
-  scheme_tag: string | null;
+  // Optional coarse tags: which known problems happened / which named schemes were used.
+  // Arrays (owner decision, 2026-08-13): a real incident routinely chains several schemes, so
+  // one tag per kind never fit. Values are slugs from lib/click-log/tags.ts (each validated on
+  // create/edit, capped at MAX_TAGS_PER_KIND per kind); empty arrays when untagged.
+  problem_tags: string[];
+  scheme_tags: string[];
   created_at: string;
 };
 
@@ -21,19 +23,19 @@ export type CreateIncidentInput = {
   userId: string;
   metadata: IncidentMetadata;
   sharedWithOwner: boolean;
-  problemTag?: string;
-  schemeTag?: string;
+  problemTags?: string[];
+  schemeTags?: string[];
 };
 
-// Edit of an existing incident (owner decision, 2026-08-13): the note and the two tags may be
-// changed after logging; the date and location are immutable, so they are absent here. null
-// clears a field (note removed / tag removed).
+// Edit of an existing incident (owner decision, 2026-08-13): the note and the tag lists may be
+// changed after logging; the date and location are immutable, so they are absent here. A null
+// note removes it; an empty tag array means untagged.
 export type UpdateIncidentInput = {
   id: string;
   userId: string;
   notes: string | null;
-  problemTag: string | null;
-  schemeTag: string | null;
+  problemTags: string[];
+  schemeTags: string[];
 };
 
 // Per-member ClickLog preferences (click_log_preferences). shareWithOwner is the global default

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -39,21 +39,25 @@ CREATE TABLE IF NOT EXISTS click_log_incidents (
   -- column (not metadata) so it is excluded from the metadata_hash dedupe and toggling share state
   -- never collides with the UNIQUE (user_id, metadata_hash) constraint.
   shared_with_owner BOOLEAN NOT NULL DEFAULT FALSE,
-  -- Optional incident tags (2026-08-02): a member may say which of the 50+ known problems
-  -- happened (problem_tag — slugs mirror the landing-page problems list) and/or which named
-  -- scheme was used (scheme_tag — slugs from the owner's "A post for each gang stalker game"
-  -- Discourse thread). Canonical slug lists live in packages/web/lib/click-log/tags.ts; the API
-  -- validates against them. Real columns (not metadata) so they are excluded from the
-  -- metadata_hash dedupe — mirroring shared_with_owner — and so the shared-trends aggregate can
-  -- project them as coarse categorical values without touching the metadata JSON.
+  -- Optional incident tags (2026-08-02; arrays since 2026-08-13 — see schema.sql for the full
+  -- note). The singular problem_tag/scheme_tag columns are superseded by the arrays: backfilled,
+  -- kept for history, no longer read or written by the app.
   problem_tag TEXT,
   scheme_tag TEXT,
+  problem_tags TEXT[] NOT NULL DEFAULT '{}',
+  scheme_tags TEXT[] NOT NULL DEFAULT '{}',
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (user_id, metadata_hash)
 );
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS shared_with_owner BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS problem_tag TEXT;
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS scheme_tag TEXT;
+ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS problem_tags TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS scheme_tags TEXT[] NOT NULL DEFAULT '{}';
+UPDATE click_log_incidents SET problem_tags = ARRAY[problem_tag]
+  WHERE problem_tag IS NOT NULL AND problem_tags = '{}';
+UPDATE click_log_incidents SET scheme_tags = ARRAY[scheme_tag]
+  WHERE scheme_tag IS NOT NULL AND scheme_tags = '{}';
 CREATE INDEX IF NOT EXISTS idx_click_log_incidents_user_id ON click_log_incidents(user_id);
 CREATE INDEX IF NOT EXISTS idx_click_log_incidents_created_at ON click_log_incidents(created_at DESC);
 -- Partial index for the admin trends aggregate, which only ever reads shared rows.

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -24,21 +24,36 @@ CREATE TABLE IF NOT EXISTS click_log_incidents (
   -- column (not metadata) so it is excluded from the metadata_hash dedupe and toggling share state
   -- never collides with the UNIQUE (user_id, metadata_hash) constraint.
   shared_with_owner BOOLEAN NOT NULL DEFAULT FALSE,
-  -- Optional incident tags (2026-08-02): a member may say which of the 50+ known problems
-  -- happened (problem_tag — slugs mirror the landing-page problems list) and/or which named
-  -- scheme was used (scheme_tag — slugs from the owner's "A post for each gang stalker game"
-  -- Discourse thread). Canonical slug lists live in packages/web/lib/click-log/tags.ts; the API
-  -- validates against them. Real columns (not metadata) so they are excluded from the
-  -- metadata_hash dedupe — mirroring shared_with_owner — and so the shared-trends aggregate can
-  -- project them as coarse categorical values without touching the metadata JSON.
+  -- Optional incident tags (2026-08-02; arrays since 2026-08-13): a member may say which of the
+  -- 50+ known problems happened (problem_tags — slugs mirror the landing-page problems list)
+  -- and/or which named schemes were used (scheme_tags — slugs from the owner's "A post for each
+  -- gang stalker game" Discourse thread). Arrays because a real incident routinely chains
+  -- several schemes at once (owner decision, 2026-08-13); the API caps each list at 10.
+  -- Canonical slug lists live in packages/web/lib/click-log/tags.ts; the API validates against
+  -- them. Real columns (not metadata) so they are excluded from the metadata_hash dedupe —
+  -- mirroring shared_with_owner — and so the shared-trends aggregate can unnest them as coarse
+  -- categorical values without touching the metadata JSON. The singular problem_tag/scheme_tag
+  -- columns are superseded: backfilled into the arrays below, kept for history, no longer
+  -- read or written by the app.
   problem_tag TEXT,
   scheme_tag TEXT,
+  problem_tags TEXT[] NOT NULL DEFAULT '{}',
+  scheme_tags TEXT[] NOT NULL DEFAULT '{}',
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (user_id, metadata_hash)
 );
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS shared_with_owner BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS problem_tag TEXT;
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS scheme_tag TEXT;
+ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS problem_tags TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS scheme_tags TEXT[] NOT NULL DEFAULT '{}';
+-- One-time backfill of the superseded singular tag columns into the arrays. Idempotent: only
+-- touches rows whose array is still empty while the singular column has a value, so re-running
+-- schema.sql never overwrites a member's later multi-tag edits.
+UPDATE click_log_incidents SET problem_tags = ARRAY[problem_tag]
+  WHERE problem_tag IS NOT NULL AND problem_tags = '{}';
+UPDATE click_log_incidents SET scheme_tags = ARRAY[scheme_tag]
+  WHERE scheme_tag IS NOT NULL AND scheme_tags = '{}';
 CREATE INDEX IF NOT EXISTS idx_click_log_incidents_user_id ON click_log_incidents(user_id);
 CREATE INDEX IF NOT EXISTS idx_click_log_incidents_created_at ON click_log_incidents(created_at DESC);
 -- Partial index for the admin trends aggregate, which only ever reads shared rows.

--- a/ctf/scripts/seedClickLog.mjs
+++ b/ctf/scripts/seedClickLog.mjs
@@ -29,7 +29,7 @@ const SEED_USER_IDS = [
   'user-00000003',
 ];
 
-// problem_tag / scheme_tag are optional coarse tags; slugs must exist in
+// problem_tags / scheme_tags are optional coarse tag lists; slugs must exist in
 // packages/web/lib/click-log/tags.ts. Coverage: tagged-with-both, problem-only,
 // scheme-only, and untagged incidents. Every tagged incident carries a location,
 // matching the API rule that tags require latitude/longitude.
@@ -37,40 +37,40 @@ const INCIDENTS = [
   {
     user_id: SEED_USER_IDS[0],
     metadata: { latitude: 37.7749, longitude: -122.4194, notes: 'Test incident with location and notes' },
-    problem_tag: 'parked-cars-outside-home',
-    scheme_tag: 'scapegoating-by-proxy',
+    problem_tags: ['parked-cars-outside-home'],
+    scheme_tags: ['scapegoating-by-proxy', 'staged-public-scenes'],
   },
   {
     user_id: SEED_USER_IDS[1],
     metadata: { latitude: 40.7128, longitude: -74.0060 },
-    problem_tag: 'mail-tampering',
-    scheme_tag: null,
+    problem_tags: ['mail-tampering'],
+    scheme_tags: [],
   },
   {
     user_id: SEED_USER_IDS[2],
     metadata: { latitude: 34.0522, longitude: -118.2437, notes: 'Incident with notes and location' },
-    problem_tag: null,
-    scheme_tag: 'mail-mirage',
+    problem_tags: [],
+    scheme_tags: ['mail-mirage'],
   },
   {
     user_id: SEED_USER_IDS[0],
     metadata: {},
-    problem_tag: null,
-    scheme_tag: null,
+    problem_tags: [],
+    scheme_tags: [],
   },
   {
     user_id: SEED_USER_IDS[1],
     metadata: { latitude: 51.5074, longitude: -0.1278, notes: 'London incident' },
-    problem_tag: null,
-    scheme_tag: null,
+    problem_tags: [],
+    scheme_tags: [],
   },
   // "Not listed" scheme with a suggestion (see SUGGESTIONS below): the suggestion row is what
   // the proposeSchemeSuggestions pipeline drains into a private triage issue.
   {
     user_id: SEED_USER_IDS[2],
     metadata: { latitude: 41.8781, longitude: -87.6298 },
-    problem_tag: null,
-    scheme_tag: 'other-scheme',
+    problem_tags: [],
+    scheme_tags: ['other-scheme'],
   },
 ];
 
@@ -96,10 +96,10 @@ async function seed() {
     for (const incident of INCIDENTS) {
       const id = deterministicId(incident.user_id, incident.metadata);
       await queryDb(
-        `INSERT INTO click_log_incidents (id, user_id, metadata, problem_tag, scheme_tag, created_at)
+        `INSERT INTO click_log_incidents (id, user_id, metadata, problem_tags, scheme_tags, created_at)
          VALUES ($1, $2, $3, $4, $5, NOW())
          ON CONFLICT (id) DO NOTHING`,
-        [id, incident.user_id, JSON.stringify(incident.metadata), incident.problem_tag, incident.scheme_tag]
+        [id, incident.user_id, JSON.stringify(incident.metadata), incident.problem_tags, incident.scheme_tags]
       );
     }
     for (const s of SUGGESTIONS) {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Owner observation: no real incident is ever just one tag — the cross-country bus trip chained five schemes in a single journey, and the single-select shape forced a false choice. Incidents now carry several tags of each kind.

What changed:

- Schema: new `problem_tags TEXT[]` / `scheme_tags TEXT[]` columns (`NOT NULL DEFAULT '{}'`) in `schema.sql` and `schema.demo.sql`, with guarded one-time backfill `UPDATE`s from the singular columns — idempotent, only fills a still-empty array, so re-running never overwrites a later multi-tag edit. The singular `problem_tag`/`scheme_tag` columns are kept for history but no longer read or written.
- API: `POST /api/click-log` and `PUT /api/click-log/[id]` take `problemTags`/`schemeTags` string arrays. Unknown slug 400, duplicates collapsed, at most 10 per kind (`MAX_TAGS_PER_KIND`). Contracts `click-log.incident.create` and `.update` bumped to 2.0.0 (breaking field rename), `.list` to 2.0.0 (incident output shape now carries the arrays); access-policy attributes follow the rename.
- Rules unchanged in spirit: any non-empty tag list still requires a location; "Not listed" (`other-scheme`) still requires the Weavers badge and description at create, and can only be kept or removed (never newly picked) on edit — now keyed on list membership instead of equality.
- UI: both pickers are multi-select — tap adds, tap again removes, selected chips row with per-chip X, "up to 10" hint at the cap. History rows and the editor render every tag as its own chip.
- Trends: `getSharedIncidentTagTrends` unnests the arrays, so each tag on a shared incident counts once in "Top problems" / "Top schemes". Buckets and the privacy boundary (shared rows only, slugs and counts only) are unchanged.
- Seed: one demo incident now carries two schemes. Inventory and manual test script updated.

Owner-review lane (schema + breaking contract change): auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_