### PR TITLE
fix: ClickLog Trends Member view uses the standard header pill button

### DIFF
--- a/ctf/packages/web/components/click-log/click-log-admin-trends.tsx
+++ b/ctf/packages/web/components/click-log/click-log-admin-trends.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { AlertTriangle, MapPin } from "lucide-react";
-import Link from "next/link";
+import { PluginUserShellButton } from "@/components/shared/plugin-user-shell-button";
 import { MobileScreenHeader } from "@/components/shared/mobile-screen-header";
 import type { SharedIncidentTagTrend, SharedIncidentTrendBucket } from "../../lib/click-log/types";
 import { problemTagLabel, schemeTagLabel } from "../../lib/click-log/tags";
@@ -93,7 +93,7 @@ export function ClickLogAdminTrends() {
         icon={<AlertTriangle size={18} color={ACCENT} />}
         accent={ACCENT}
         backHref="/admin"
-        actions={<Link href="/apps/click-log" style={{ fontSize: 12, color: SUBTLE, textDecoration: "none" }}>Member view</Link>}
+        actions={<PluginUserShellButton href="/apps/click-log" accent={ACCENT} />}
       />
       <div style={{ padding: 16, maxWidth: 560, margin: "0 auto" }}>
         {loading && <div style={{ color: SUBTLE, fontSize: 13, padding: "32px 0", textAlign: "center" }}>Loading trends…</div>}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Owner report (screenshot comparison with Unlock Admin): the ClickLog Trends header rendered "Member view" as plain grey text. Every other admin surface uses the shared `PluginUserShellButton` — the accent-tinted pill that also navigates with replace semantics, so the back button does not bounce between the admin and member views. Swapped the plain `Link` for the shared button with the ClickLog accent. One file changed, no behavior beyond the header control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_