### PR TITLE
fix: give the code-review sweep the code and contracts it was missing

### DIFF
--- a/ctf/config/code-review-slice-manifest.json
+++ b/ctf/config/code-review-slice-manifest.json
@@ -1,0 +1,31 @@
+{
+  "$comment": [
+    "Explicit slice manifest for the code-review sweep (ctf/scripts/reviewCodebaseSlice.mjs).",
+    "The sweep names a slice after the folders that share a name across the source layers. Two things",
+    "cannot be derived from that name, so they are declared here instead of guessed:",
+    "",
+    "  contractPrefix — which ctf/docs/contracts/<PREFIX>_* files govern this slice. The default is the",
+    "    slice name upper-snake-cased, which is wrong wherever a surface is served by another plugin's",
+    "    contracts. Getting this wrong means the reviewer is handed NO contracts and then invents what",
+    "    the contract must say (that is what produced issue #2207, which asserted a plugin id the feed",
+    "    contracts pin the other way).",
+    "",
+    "  aliases — folder names this slice used to have. Findings are deduped against issues titled",
+    "    'Code review (<slice>): ...', so a rename hides every earlier decision and dismissed findings",
+    "    come back. #2207 is #1876 refiled 17 days later, purely because api/hub became api/commons.",
+    "",
+    "Only slices that need one of these appear here; everything else uses the derived default.",
+    "Add an entry when you rename a slice folder, or when a slice's contracts live under another name."
+  ],
+  "slices": {
+    "commons": {
+      "contractPrefix": "FEED",
+      "aliases": ["hub"],
+      "note": "Member-facing surface over the feed plugin: its routes call lib/feed and it is governed by the FEED_* contracts. `commons` is not a registered plugin slug."
+    },
+    "community-shell": {
+      "contractPrefix": "FEED",
+      "note": "The shell that renders the Commons/feed surfaces; no contracts of its own."
+    }
+  }
+}

--- a/ctf/scripts/lib/sliceImports.mjs
+++ b/ctf/scripts/lib/sliceImports.mjs
@@ -1,0 +1,382 @@
+// Resolve what a code-review slice imports from OUTSIDE itself, and pull just enough of that
+// code in as read-only reference.
+//
+// Why this exists: the sweep defines a slice as the folders sharing a name across the source
+// layers (app/api/<name>, components/<name>, lib/<name>, mobile features). That is wrong for any
+// surface built on another plugin's server code. The clearest case is the Commons: its slice is
+// `app/api/commons` + `lib/commons`, but `lib/commons` holds only constants, types, and the
+// live-stream helper — every function its routes call lives in `lib/feed/`, a different slice. The
+// reviewer therefore read route handlers calling functions it could not open, guessed what they
+// did, and filed confident, wrong findings (issues #2205, #2206, #2208 were all this).
+//
+// Whole dependency files do not fit: lib/feed/repository.ts alone is ~110 KB against a 200 KB
+// per-run source budget. So a large dependency contributes only the declarations the slice
+// actually imports, plus the file-local helpers those declarations call — which is exactly the
+// evidence the reviewer was missing (e.g. `updateCommonsLastSeen` and the `isValidIsoDatetime`
+// check inside it). Small files are included whole, since the surrounding code is cheap context.
+
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const RESOLVE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+// How many file-local helpers one round of the "what does this declaration call?" pass may add per
+// dependency file. Bounded so a densely-cross-referenced module cannot pull in most of itself.
+const MAX_LOCAL_HELPERS = 12;
+
+// Identifiers that appear in extracted code but are never a file-local helper worth chasing.
+const IDENTIFIER_STOPWORDS = new Set([
+  'if', 'else', 'for', 'while', 'do', 'switch', 'case', 'break', 'continue', 'return', 'throw',
+  'try', 'catch', 'finally', 'new', 'typeof', 'instanceof', 'in', 'of', 'delete', 'void', 'await',
+  'async', 'function', 'const', 'let', 'var', 'class', 'extends', 'implements', 'interface', 'type',
+  'enum', 'export', 'import', 'from', 'as', 'default', 'null', 'undefined', 'true', 'false', 'this',
+  'super', 'yield', 'string', 'number', 'boolean', 'object', 'symbol', 'bigint', 'unknown', 'never',
+  'any', 'Promise', 'Array', 'Map', 'Set', 'Date', 'Math', 'JSON', 'Object', 'String', 'Number',
+  'Boolean', 'Error', 'console', 'process', 'require', 'module', 'exports', 'globalThis',
+]);
+
+function isFile(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sizeOf(path) {
+  try {
+    return statSync(path).size;
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+// Try a resolved path as-is, then with each source extension, then as a directory index.
+function probe(basePath) {
+  if (isFile(basePath)) {
+    return basePath;
+  }
+  for (const ext of RESOLVE_EXTENSIONS) {
+    if (isFile(`${basePath}${ext}`)) {
+      return `${basePath}${ext}`;
+    }
+  }
+  for (const ext of RESOLVE_EXTENSIONS) {
+    if (isFile(join(basePath, `index${ext}`))) {
+      return join(basePath, `index${ext}`);
+    }
+  }
+  return null;
+}
+
+// The nearest ancestor directory holding a package.json — the root a bare, non-npm specifier like
+// `lib/feed/repository` is written against (both web and mobile set baseUrl to their package root).
+function packageRootOf(fileAbs, repoRoot) {
+  let dir = dirname(fileAbs);
+  const stop = resolve(repoRoot);
+  while (dir.startsWith(stop) && dir !== stop) {
+    if (isFile(join(dir, 'package.json'))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+// Resolve one import specifier to an absolute file path, or null when it is an npm/node module or
+// cannot be found. Handles relative imports, package-root-absolute imports (`lib/...`, `@/...`),
+// and workspace imports (`@ctf/<pkg>/...`).
+export function resolveSpecifier(specifier, fromFileAbs, repoRoot) {
+  if (!specifier || specifier.startsWith('node:')) {
+    return null;
+  }
+  if (specifier.startsWith('.')) {
+    return probe(resolve(dirname(fromFileAbs), specifier));
+  }
+  if (specifier.startsWith('@ctf/')) {
+    const [, pkg, ...rest] = specifier.split('/');
+    const pkgRoot = join(repoRoot, 'ctf/packages', pkg);
+    const tail = rest.join('/');
+    return probe(join(pkgRoot, 'src', tail)) || probe(join(pkgRoot, tail));
+  }
+  const pkgRoot = packageRootOf(fromFileAbs, repoRoot);
+  if (!pkgRoot) {
+    return null;
+  }
+  if (specifier.startsWith('@/')) {
+    return probe(join(pkgRoot, specifier.slice(2)));
+  }
+  // A bare specifier is only package-root-absolute when it actually resolves there; anything else
+  // (next/server, react, @clerk/nextjs) falls through to null and is skipped.
+  return probe(join(pkgRoot, specifier));
+}
+
+// Every `import ... from '<specifier>'` / `export ... from '<specifier>'` in one file, with the
+// names each pulls in. A namespace or default import records no names, which makes the whole file
+// the unit of interest for that dependency.
+export function parseImports(text) {
+  const results = [];
+  const statementRe = /(?:^|\n)\s*(?:import|export)\s+([\s\S]*?)\s*from\s*['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = statementRe.exec(text)) !== null) {
+    const clause = match[1];
+    const specifier = match[2];
+    const names = [];
+    let wantsWholeModule = false;
+    const braced = clause.match(/\{([\s\S]*)\}/);
+    if (braced) {
+      for (const part of braced[1].split(',')) {
+        const name = part.replace(/\btype\b/g, '').trim().split(/\s+as\s+/)[0].trim();
+        if (name) {
+          names.push(name);
+        }
+      }
+    }
+    const outsideBraces = clause.replace(/\{[\s\S]*\}/, '').replace(/\btype\b/g, '').trim();
+    if (/\*\s+as\s+/.test(outsideBraces) || /^[A-Za-z_$][\w$]*$/.test(outsideBraces.replace(/,$/, '').trim())) {
+      wantsWholeModule = true;
+    }
+    results.push({ specifier, names, wantsWholeModule });
+  }
+  return results;
+}
+
+// Walk forward from `startIdx` to the end of one top-level declaration, tracking bracket depth and
+// skipping strings, template literals, and comments. A declaration with a body ends at the `}` that
+// returns depth to 0; one without (`export const X = 1;`) ends at its `;`.
+function declarationEnd(text, startIdx) {
+  let depth = 0;
+  let entered = false;
+  let i = startIdx;
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (ch === '/' && next === '/') {
+      const nl = text.indexOf('\n', i);
+      i = nl === -1 ? text.length : nl;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const close = text.indexOf('*/', i + 2);
+      i = close === -1 ? text.length : close + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const quote = ch;
+      i += 1;
+      while (i < text.length) {
+        if (text[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (text[i] === quote) {
+          break;
+        }
+        i += 1;
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === '{' || ch === '(' || ch === '[') {
+      depth += 1;
+      entered = true;
+    } else if (ch === '}' || ch === ')' || ch === ']') {
+      depth -= 1;
+      if (depth <= 0 && entered && ch === '}') {
+        return i + 1;
+      }
+    } else if (ch === ';' && depth <= 0) {
+      return i + 1;
+    }
+    i += 1;
+  }
+  return text.length;
+}
+
+// Walk backward over the comment block directly above a declaration. The "why" comments in this
+// repo carry the deliberate-design reasoning a reviewer needs (e.g. "clamped to server NOW()"),
+// so they travel with the code.
+function commentStart(text, declIdx) {
+  const lines = text.slice(0, declIdx).split('\n');
+  let i = lines.length - 1;
+  if (i >= 0 && lines[i].trim() === '') {
+    i -= 1;
+  }
+  let firstCommentLine = -1;
+  while (i >= 0) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+      firstCommentLine = i;
+      i -= 1;
+      continue;
+    }
+    break;
+  }
+  if (firstCommentLine === -1) {
+    return declIdx;
+  }
+  return lines.slice(0, firstCommentLine).join('\n').length + (firstCommentLine > 0 ? 1 : 0);
+}
+
+// Locate one top-level declaration of `name`, exported or not. Returns [start, end) or null.
+function findDeclaration(text, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const patterns = [
+    new RegExp(`^export\\s+(?:async\\s+)?(?:function|const|let|var|class|type|interface|enum)\\s+${escaped}\\b`, 'm'),
+    new RegExp(`^(?:async\\s+)?(?:function|const|let|var|class|type|interface|enum)\\s+${escaped}\\b`, 'm'),
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    if (match) {
+      return [commentStart(text, match.index), declarationEnd(text, match.index)];
+    }
+  }
+  return null;
+}
+
+// Identifiers referenced by already-extracted code that have a top-level declaration in the same
+// file. Without this hop the reviewer sees a call to a validation helper but not the helper.
+function localHelpersIn(extractedText, fileText, alreadyTaken) {
+  const helpers = [];
+  const seen = new Set(alreadyTaken);
+  const identifierRe = /\b([A-Za-z_$][\w$]*)\b/g;
+  let match;
+  while ((match = identifierRe.exec(extractedText)) !== null && helpers.length < MAX_LOCAL_HELPERS) {
+    const name = match[1];
+    if (seen.has(name) || IDENTIFIER_STOPWORDS.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    if (findDeclaration(fileText, name)) {
+      helpers.push(name);
+    }
+  }
+  return helpers;
+}
+
+// The declarations named by `names`, plus the file-local helpers they call, in source order.
+export function extractSymbols(fileText, names) {
+  const spans = [];
+  const taken = new Set();
+  for (const name of names) {
+    const span = findDeclaration(fileText, name);
+    if (span) {
+      spans.push(span);
+      taken.add(name);
+    }
+  }
+  if (spans.length === 0) {
+    return { text: '', names: [] };
+  }
+  const firstPass = spans.map(([s, e]) => fileText.slice(s, e)).join('\n');
+  for (const helper of localHelpersIn(firstPass, fileText, taken)) {
+    const span = findDeclaration(fileText, helper);
+    if (span) {
+      spans.push(span);
+      taken.add(helper);
+    }
+  }
+  // Source order, with overlapping spans merged so a helper declared inside a captured range is
+  // not emitted twice.
+  spans.sort((a, b) => a[0] - b[0]);
+  const merged = [];
+  for (const span of spans) {
+    const last = merged[merged.length - 1];
+    if (last && span[0] <= last[1]) {
+      last[1] = Math.max(last[1], span[1]);
+      continue;
+    }
+    merged.push([...span]);
+  }
+  const text = merged.map(([s, e]) => fileText.slice(s, e).trim()).join('\n\n');
+  return { text, names: [...taken] };
+}
+
+// Build the read-only dependency reference block for one slice.
+//
+// `fileList` is the slice's own files ([{abs, rel}]). Returns the reference text, the dependency
+// files it covers, and how many were dropped for budget, so the caller can log an honest count
+// rather than implying full coverage.
+export function collectDependencyContext(fileList, options) {
+  // Files at or under `wholeFileMaxBytes` come in whole (surrounding code is cheap context); bigger
+  // ones contribute only what the slice imports. Kept low deliberately: a mid-size module asking for
+  // its full text buys far less per byte than the same budget spread over several files' relevant
+  // declarations, and crowding out a small type definition is what loses an argument outright.
+  const { repoRoot, maxBytes, wholeFileMaxBytes = 12_000 } = options;
+  const sliceFiles = new Set(fileList.map((f) => f.rel));
+  const wanted = new Map();
+
+  for (const { abs } of fileList) {
+    let text;
+    try {
+      text = readFileSync(abs, 'utf8');
+    } catch {
+      continue; // no-trace: an unreadable slice file is already the caller's problem, not ours.
+    }
+    for (const { specifier, names, wantsWholeModule } of parseImports(text)) {
+      const resolved = resolveSpecifier(specifier, abs, repoRoot);
+      if (!resolved) {
+        continue;
+      }
+      const rel = relative(repoRoot, resolved);
+      if (rel.startsWith('..') || sliceFiles.has(rel)) {
+        continue; // outside the repo, or part of the slice and already under review
+      }
+      const entry = wanted.get(rel) || { rel, abs: resolved, names: new Set(), whole: false, importers: 0 };
+      for (const name of names) {
+        entry.names.add(name);
+      }
+      if (wantsWholeModule) {
+        entry.whole = true;
+      }
+      entry.importers += 1;
+      wanted.set(rel, entry);
+    }
+  }
+
+  // Most-depended-on first, then smallest first, then path for a stable order. Plain alphabetical
+  // ordering let one large module spend the budget and push out small, high-value files — the type
+  // definitions that settle a question outright are usually the cheapest bytes in the set.
+  const ordered = [...wanted.values()]
+    .map((entry) => ({ ...entry, size: sizeOf(entry.abs) }))
+    .sort((a, b) => (
+      b.importers - a.importers
+      || a.size - b.size
+      || (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0)
+    ));
+  let text = '';
+  const files = [];
+  let skipped = 0;
+
+  for (const entry of ordered) {
+    let body;
+    try {
+      body = readFileSync(entry.abs, 'utf8');
+    } catch {
+      continue; // no-trace: a dependency we cannot read is simply not offered as reference.
+    }
+    let note = '';
+    if (body.length > wholeFileMaxBytes && !entry.whole && entry.names.size > 0) {
+      const extracted = extractSymbols(body, [...entry.names]);
+      if (extracted.text.length === 0) {
+        skipped += 1;
+        continue;
+      }
+      body = extracted.text;
+      note = ` (only the declarations this slice imports, plus their local helpers: ${extracted.names.join(', ')})`;
+    } else if (body.length > wholeFileMaxBytes) {
+      // Wanted whole (namespace/default import) but too big to afford in full.
+      body = `${body.slice(0, wholeFileMaxBytes)}\n... (truncated) ...`;
+      note = ' (truncated)';
+    }
+    const header = `\n----- IMPORTED BY THIS SLICE: ${entry.rel}${note} -----\n`;
+    if (text.length + header.length + body.length > maxBytes) {
+      skipped += 1;
+      continue;
+    }
+    text += header + body;
+    files.push(entry.rel);
+  }
+
+  return { text, files, skipped };
+}

--- a/ctf/scripts/reviewCodebaseSlice.mjs
+++ b/ctf/scripts/reviewCodebaseSlice.mjs
@@ -14,9 +14,17 @@
 //   2. Pick the slice to review: an in-progress (partial) slice first, then any
 //      never-reviewed slice, then the least-recently-reviewed one. This guarantees every
 //      slice gets at least one pass before any gets a second.
-//   3. Send that slice's source to Claude (up to a per-run byte budget), along with the
-//      plugin's declared contracts as read-only reference, and ask for concrete, high-signal
-//      findings — including mismatches between the layers and code that violates a contract.
+//   3. Send that slice's source to Claude (up to a per-run byte budget), along with two read-only
+//      references — the plugin's declared contracts, and the code the slice imports from OUTSIDE
+//      itself — and ask for concrete, high-signal findings, including mismatches between the layers
+//      and code that violates a contract.
+//
+//      The imported-code reference matters because a slice is a set of same-named folders, which
+//      does not hold for a surface built on another plugin's server code: the Commons slice is
+//      app/api/commons + lib/commons, while every function its routes call lives in lib/feed. The
+//      reviewer used to read those call sites with no way to open the implementations, and filed
+//      confident, wrong findings about validation and error handling that were present one layer
+//      down (issues #2205, #2206, #2208). See ctf/scripts/lib/sliceImports.mjs.
 //   4. File one GitHub issue per finding, labeled `code-review`. Findings the model judges
 //      to have a small, safe, self-contained fix also get `code-review:actionable`, which
 //      the implement workflow can turn into a pull request.
@@ -38,6 +46,7 @@
 //   CODE_REVIEW_MAX_ISSUES Most issues to file in one run (default: 8). Highest severity first.
 //   CODE_REVIEW_MAX_BYTES  Per-run source byte budget (default: 200000 ≈ most whole plugins).
 //   CODE_REVIEW_CONTRACTS_MAX_BYTES  Cap on contract reference bytes (default: 60000).
+//   CODE_REVIEW_DEPS_MAX_BYTES  Cap on imported-code reference bytes (default: 70000; 0 disables).
 //   CODE_REVIEW_DRY_RUN    "1" to print findings without filing issues or touching the ledger.
 
 import { execFileSync } from 'node:child_process';
@@ -45,10 +54,12 @@ import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { collectDependencyContext } from './lib/sliceImports.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '../..');
 const ledgerPath = join(repoRoot, 'ctf/config/code-review-ledger.json');
+const manifestPath = join(repoRoot, 'ctf/config/code-review-slice-manifest.json');
 
 const REPO = (process.env.GITHUB_REPOSITORY || 'chargingthefuture/chargingthefuture').trim();
 const MODEL = (process.env.CODE_REVIEW_MODEL || 'claude-sonnet-4-6').trim();
@@ -56,6 +67,10 @@ const FORCED_SLICE = (process.env.CODE_REVIEW_SLICE || '').trim();
 const MAX_ISSUES = Number(process.env.CODE_REVIEW_MAX_ISSUES || '8');
 const MAX_BYTES = Number(process.env.CODE_REVIEW_MAX_BYTES || '200000');
 const CONTRACTS_MAX_BYTES = Number(process.env.CODE_REVIEW_CONTRACTS_MAX_BYTES || '60000');
+// Budget for code the slice imports from OUTSIDE itself, sent as read-only reference. Separate from
+// the source budget so pulling in a dependency never costs the slice its own coverage. Set to 0 to
+// turn the dependency context off.
+const DEPS_MAX_BYTES = Number(process.env.CODE_REVIEW_DEPS_MAX_BYTES || '70000');
 // The model's findings JSON must fit in one response. 4000 was too small for a whole-plugin
 // review: the JSON truncated mid-string and JSON.parse threw, failing the whole run. Give it ample
 // room (Sonnet allows far more), overridable for cost tuning.
@@ -69,9 +84,10 @@ const DRY_RUN = process.env.CODE_REVIEW_DRY_RUN === '1';
 const WONTFIX_REVISIT_DAYS = Number(process.env.CODE_REVIEW_WONTFIX_DAYS || '90');
 
 // A plugin's declared contracts are sent as read-only reference so the reviewer can check
-// the code against them. Looked up by exact filename (prefix = SLICE_NAME upper-snake);
-// modules without contracts simply get none. Sent on every run for the slice, separate from
-// the code byte budget, and capped so they don't crowd out the code.
+// the code against them. Looked up by exact filename; the prefix defaults to the slice name
+// upper-snake-cased, but a slice whose contracts live under another name declares the real prefix
+// in the slice manifest. Modules with genuinely no contracts simply get none. Sent on every run for
+// the slice, separate from the code byte budget, and capped so they don't crowd out the code.
 const CONTRACTS_DIR = 'ctf/docs/contracts';
 const CONTRACT_SUFFIXES = [
   '_PLUGIN_COMMAND_CONTRACTS.yaml',
@@ -104,6 +120,48 @@ if (!process.env.GH_TOKEN && !DRY_RUN) {
 
 function gh(args, options = {}) {
   return execFileSync('gh', args, { encoding: 'utf8', ...options });
+}
+
+// The explicit slice manifest: contract prefixes and former folder names that cannot be derived
+// from the slice name. Missing or malformed, every slice falls back to the derived default, which
+// is what the sweep did before the manifest existed — a bad manifest degrades the review, it does
+// not fail the run.
+function loadSliceManifest() {
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    return parsed && typeof parsed.slices === 'object' && parsed.slices !== null ? parsed.slices : {};
+  } catch {
+    return {};
+  }
+}
+
+const SLICE_MANIFEST = loadSliceManifest();
+
+// Which `ctf/docs/contracts/<PREFIX>_*` files govern this slice. Default: the slice name
+// upper-snake-cased. A slice served by another plugin's contracts declares the real prefix, because
+// silently finding none leaves the reviewer to invent what the contract says.
+function contractPrefixFor(sliceName) {
+  const declared = SLICE_MANIFEST[sliceName]?.contractPrefix;
+  return (typeof declared === 'string' && declared.trim().length > 0
+    ? declared.trim()
+    : sliceName
+  ).toUpperCase().replace(/-/g, '_');
+}
+
+// Every name this slice's issues may be titled with: its current name plus any former folder names.
+// Without the aliases a rename hides all earlier decisions, and findings dismissed under the old
+// name are filed again as new.
+function sliceTitleNames(sliceName) {
+  const aliases = SLICE_MANIFEST[sliceName]?.aliases;
+  const names = [sliceName];
+  if (Array.isArray(aliases)) {
+    for (const alias of aliases) {
+      if (typeof alias === 'string' && alias.trim() && !names.includes(alias.trim())) {
+        names.push(alias.trim());
+      }
+    }
+  }
+  return names;
 }
 
 function isDir(path) {
@@ -284,7 +342,7 @@ function gatherChunk(fileList, cursor, budget) {
 
 // A plugin's declared contracts (by exact filename), as read-only reference text.
 function gatherContracts(sliceName) {
-  const prefix = sliceName.toUpperCase().replace(/-/g, '_');
+  const prefix = contractPrefixFor(sliceName);
   let text = '';
   const files = [];
   for (const suffix of CONTRACT_SUFFIXES) {
@@ -370,7 +428,7 @@ function loadPlainLanguageRules() {
   }
 }
 
-async function askClaude(slice, source, chunkNote, contractsText, existingFindings = []) {
+async function askClaude(slice, source, chunkNote, contractsText, existingFindings = [], depsText = '') {
   const layers = slice.paths.join('\n  ');
   const system = [
     'You are a senior engineer doing a code review of one plugin/module of "Charging the',
@@ -393,6 +451,21 @@ async function askClaude(slice, source, chunkNote, contractsText, existingFindin
     'Also report within-file problems: real bugs, security/correctness issues, missing error',
     'handling, clear dead code, obvious simplifications, and TypeScript type-safety violations',
     '(no `any` without an eslint-disable + reason).',
+    '',
+    'IMPORTED CODE, when shown below, is the code this slice calls that lives outside it — often the',
+    'repository/server functions its routes depend on. It is REFERENCE, not under review:',
+    '  - Read it before claiming a call is unchecked, unvalidated, or unguarded. Much of this slice\'s',
+    '    validation, clamping, and error handling lives in the function being called, not at the call',
+    '    site, and a wrapper that already catches its own errors cannot throw at the caller.',
+    '  - Do NOT file a finding whose fix belongs in an imported file — that file is reviewed as part',
+    '    of its own slice. Report only problems in the slice\'s own files.',
+    '  - Large imported files show only the declarations this slice uses. Absence of code you were not',
+    '    shown is not evidence: if you cannot see the definition you need, do not guess what it does —',
+    '    leave the finding out.',
+    '',
+    'Before reporting any missing check, missing validation, or missing error handling, confirm from',
+    'the code you were actually shown that it is missing everywhere, not just at the line you are',
+    'looking at. A finding that is wrong costs more than a finding that is never filed.',
     '',
     'You may be given an ALREADY-TRACKED list of findings previously raised for this slice. These are',
     'already tracked elsewhere — do NOT report them again, with two narrow exceptions:',
@@ -418,6 +491,14 @@ async function askClaude(slice, source, chunkNote, contractsText, existingFindin
           '',
           'DECLARED CONTRACTS for this plugin (reference — the source of truth for what it may do; not under review):',
           contractsText,
+        ]
+      : []),
+    ...(depsText
+      ? [
+          '',
+          'IMPORTED CODE this slice calls from outside itself (reference — not under review; check the',
+          'slice against it before claiming something is unchecked or unhandled):',
+          depsText,
         ]
       : []),
     ...buildAlreadyTrackedBlock(existingFindings),
@@ -563,7 +644,10 @@ function ensureLabel(name, color, description) {
 // rewrites the title every run, so a text fingerprint would miss a reworded re-flag. The embedded
 // fingerprint is kept only as a cheap exact-match fast path.
 function existingSliceIssues(sliceName) {
-  const titlePrefix = `Code review (${sliceName}):`;
+  // Match this slice's current name AND any former folder name it declares, so a rename does not
+  // hide the decisions already made (issue #2207 was #1876 refiled after api/hub became
+  // api/commons — the code had not changed and the finding had already been rejected).
+  const titlePrefixes = sliceTitleNames(sliceName).map((name) => `Code review (${name}):`);
   try {
     const raw = gh([
       'issue', 'list', '--repo', REPO, '--label', 'code-review', '--state', 'all',
@@ -571,11 +655,13 @@ function existingSliceIssues(sliceName) {
     ]);
     const issues = [];
     for (const issue of JSON.parse(raw)) {
-      if (!(issue.title || '').startsWith(titlePrefix)) continue;
+      const title = issue.title || '';
+      const titlePrefix = titlePrefixes.find((prefix) => title.startsWith(prefix));
+      if (!titlePrefix) continue;
       const fpMatch = (issue.body || '').match(/code-review-fingerprint:\s*([a-f0-9]+)/);
       issues.push({
         number: issue.number,
-        title: (issue.title || '').slice(titlePrefix.length).trim(),
+        title: title.slice(titlePrefix.length).trim(),
         summary: extractWhat(issue.body || ''),
         state: String(issue.state || '').toLowerCase(),
         stateReason: String(issue.stateReason || '').toLowerCase(),
@@ -754,12 +840,22 @@ async function main() {
 
   const contracts = gatherContracts(slice.name);
   const contractNote = contracts.files.length ? ` + ${contracts.files.length} contract file(s)` : '';
+  // The code this slice calls from outside itself. Without it the reviewer reads call sites whose
+  // implementations it cannot open and guesses at them, which is where its wrong findings come from.
+  const deps = DEPS_MAX_BYTES > 0
+    ? collectDependencyContext(fileList, { repoRoot, maxBytes: DEPS_MAX_BYTES })
+    : { text: '', files: [], skipped: 0 };
+  const depNote = deps.files.length
+    ? ` + ${deps.files.length} imported file(s)${deps.skipped ? ` (${deps.skipped} dropped for budget)` : ''}`
+    : '';
   // The findings already raised for this slice (open + closed). Passed to the reviewer so it doesn't
   // re-report a concern already tracked or already fixed (the main source of re-run churn), and reused
   // below for substance-based dedup. One fetch serves both.
   const sliceIssues = existingSliceIssues(slice.name);
-  console.log(`reviewCodebaseSlice: reviewing ${slice.type} ${slice.name} — ${covered}${contractNote} with ${MODEL} (${sliceIssues.length} already-tracked).`);
-  const findings = parseFindings(await askClaude(slice, chunk.text, chunkNote, contracts.text, sliceIssues));
+  console.log(`reviewCodebaseSlice: reviewing ${slice.type} ${slice.name} — ${covered}${contractNote}${depNote} with ${MODEL} (${sliceIssues.length} already-tracked).`);
+  const findings = parseFindings(
+    await askClaude(slice, chunk.text, chunkNote, contracts.text, sliceIssues, deps.text),
+  );
 
   if (findings.length === 0) {
     console.log(`reviewCodebaseSlice: no findings for ${slice.name} (${covered}).`);


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## Why

Every one of the four findings the sweep filed for the Commons on 2026-08-11 (#2205, #2206, #2207, #2208) was wrong, and all four failed the same way. This fixes the cause rather than the findings.

The sweep reviews one slice per run, where a slice is the folders sharing a name across the source layers. That assumption breaks for any surface built on another plugin's server code. The Commons slice is `app/api/commons` + `lib/commons`, but `lib/commons` holds only constants, types, and the live-stream helper — every function its routes call lives in `lib/feed`, a different slice. The reviewer read call sites whose implementations it could not open, and guessed:

| Finding | What it claimed | What the code does |
|---|---|---|
| #2206 | A database call could throw and become a 500 | `markFirstVisitNoticeSeen` catches its own errors and never rejects |
| #2208 | A timestamp is passed on without checking | `updateCommonsLastSeen` runs exactly the proposed check on its first line |
| #2205 | The quoted-post id reads the wrong field | The field is correct by construction; the suggested replacement does not exist on the type |
| #2207 | The audit plugin id should be `commons` | All three `FEED_*` contracts pin this event to `feed`, and `commons` is not a registered plugin slug |

## What changed

**The reviewer now sees the code its slice imports from outside itself**, as read-only reference. Whole dependency files do not fit — `lib/feed/repository.ts` alone is ~110 KB against a 200 KB source budget — so a large file contributes only the declarations the slice imports, plus the file-local helpers those declarations call. That is precisely the missing evidence: `updateCommonsLastSeen` now arrives with the `isValidIsoDatetime` check inside it, and with the comment explaining the clamping. Dependencies are ordered most-depended-on first, then smallest first, so one large module cannot spend the budget and crowd out a small type definition — during development that was the difference between seeing and not seeing `FeedQuotedPost`, which settles #2205 outright.

The prompt now tells the reviewer to read that reference before claiming a call is unchecked, not to file findings whose fix belongs in an imported file (that file is reviewed as part of its own slice), and not to guess about code it was not shown.

**Contracts are looked up by a declared prefix** instead of the uppercased slice name. There are no `COMMONS_*` contract files, so the reviewer was handed none and invented what the contract must say.

**Findings are matched against issues filed under a slice's former folder names** as well as its current one. A rename hid every earlier decision: #2207 is #1876 refiled seventeen days later, purely because `api/hub` became `api/commons`. The code had not changed and the finding had already been rejected.

New files:

- `ctf/scripts/lib/sliceImports.mjs` — resolves what a slice imports and extracts the relevant declarations.
- `ctf/config/code-review-slice-manifest.json` — the two things that cannot be derived from a slice name: contract prefix and former names. Only slices that need an entry have one.

A missing or malformed manifest falls back to the previous derived behaviour rather than failing the run, and the dependency context can be turned off with `CODE_REVIEW_DEPS_MAX_BYTES=0`.

## Verified

Ran against the real `commons` slice:

```
before: commons — files 1–11 of 11 with claude-sonnet-4-6 (0 already-tracked)
after:  commons — files 1–11 of 11 + 4 contract file(s) + 16 imported file(s) ... (2 already-tracked)
```

Contract files 0 → 4, imported files 0 → 16, and with a stubbed issue list an issue titled for the old `hub` folder is now matched while an unrelated slice's issue is not. Confirmed the extracted text contains `updateCommonsLastSeen`, `isValidIsoDatetime`, `markFirstVisitNoticeSeen`, and `FeedQuotedPost`.

Gates run locally: syntax check on both scripts, manifest JSON parse, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-error-verbosity.mjs`, `check-modularity-governance.sh` — all pass. Lint, typecheck, and build are each scoped to package source directories (`src`, `app`, `components`, `lib`), so none of them cover `ctf/scripts`; the local lint run fails only because this container has no `node_modules`.

## Note on scope

This does not close #2205–#2208 — those were closed as not planned after checking each against the code. This removes the cause so the same class of wrong finding stops being filed.

One limitation left alone: the helper hop is one level deep, so a private function called by another private function inside a large dependency is still not shown. The prompt now tells the reviewer to leave a finding out rather than guess when it cannot see a definition, which is the safe behaviour for that case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrUkaA2ftw65v6RoakXLD6)_