### PR TITLE
fix: opening Trust from the apps list lands on the account hub, not a debug page

### DIFF
--- a/ctf/config/plugin-parity-contracts.json
+++ b/ctf/config/plugin-parity-contracts.json
@@ -113,7 +113,7 @@
       "slug": "trust",
       "mobileFeatureDirs": [],
       "requiresMobileSurface": false,
-      "requiresExplicitWebShell": false
+      "requiresExplicitWebShell": true
     },
     {
       "slug": "what-works",

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -5,6 +5,12 @@
 - Plugin name: `Trust`
 - Plugin slug: `trust`
 - Owned surfaces: `/api/trust/*` routes, `trust_*` tables, `packages/mobile/src/features/trust` (Android), the trust evidence card embedded in profile/account/directory surfaces (web).
+- **Trust has no screen of its own.** The member-facing card lives inside the account hub, the
+  community right rail, and Directory profiles — there is no `/apps/trust` page to build, and one
+  should not be added without a reason the embedded card cannot serve. `/apps/trust` exists only as a
+  route: a signed-in member who opens Trust from the apps list is redirected to `/account`, where the
+  card is. A signed-out visitor or a not-yet-verified member is denied before that redirect and keeps
+  seeing the Trust public landing page.
 - Not owned: canonical user profile (Directory), identity (Clerk), moderation backend (handled out-of-plugin via Retool tooling), and all upstream engagement/participation data (owned by the plugins Trust reads from, e.g. SocketRelay, login/auth, and other activity sources).
 - Derived, read-mostly model: Trust owns no primary participation data. It derives a **qualitative** trust signal — never a numeric score — by aggregating engagement/contribution signals from across the platform's seeded plugins (not just Directory), and persists only the per-user extension (evidence) and the admin audit trail.
 - Humane-by-design: Trust deliberately avoids reducing a person to a number. It shows a plain list of what a member has actually done — no badge, no status, no ranked numeric score.
@@ -198,6 +204,24 @@ Trust has no dedicated seed script, and none is required. Trust is a derived plu
 
 ## Change Log
 
+- 2026-08-13: **Opening Trust from the apps list now lands on the account hub instead of a debug
+  page.** Trust is listed in the apps grid (`isVisible: true`, `implemented_shell`) but the dynamic
+  plugin route `app/apps/[pluginSlug]/page.tsx` had no branch for the `trust` slug, so a signed-in
+  member who tapped it fell through to `GenericPluginView` — the baseline-access check page showing
+  their user id, username handle, availability state, and a link home. That is a routing test, not a
+  product surface, and it exposed a raw identifier to the member for no reason.
+
+  Trust is the only visible plugin that hit this: `contributions`, `recurring-activity`, and
+  `mutual-time` also have no branch in the dynamic route, but each has its own static
+  `app/apps/<slug>/page.tsx` segment that takes precedence, so they were never affected.
+
+  Fixed by redirecting the `trust` slug to `/account`, where the member's trust card already ships.
+  The branch sits **after** the access gate on purpose: a signed-out visitor and a not-yet-verified
+  member are denied earlier and still get the Trust public landing page, which was already correct.
+  Flipped `requiresExplicitWebShell` to `true` for `trust` in `ctf/config/plugin-parity-contracts.json`
+  so the parity gate now holds the branch in place instead of letting it be dropped silently.
+  No new UI, no copy change, no schema change, no API change. Web-only; Trust is not on the Android
+  keep-list (rule 105).
 - 2026-08-12: **Second sign-in line: the member's current run of days, alongside the all-time count**
   (model `cross_plugin_engagement_v5`, owner request). "Active on 162 days" is cumulative — distinct
   sign-in days over a member's whole history — and on its own it cannot tell a reader whether that

--- a/ctf/docs/developer/test-scripts/trust-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-test-script.md
@@ -35,13 +35,26 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 2. **Widget renders on the right rail.** Sign in as admin, open a page that embeds the Trust right-rail card (e.g. account hub or community shell). `TrustWidgetCard` should render — ShieldCheck header visible, no crash, no blank white box. Each evidence row must read as a human sentence (the `summary`, e.g. "Accepted 1 SkillsHunt submission"), **never** a raw type slug like `demo_second_owner` or `Engagement-...`. Any date shown must be a real date — **never** the literal "Invalid Date". (Regression guard: the demo seed previously wrote evidence with no `summary`/`createdAt`, which produced both symptoms.)
    web ☐
 
-3. **Android Trust screen loads.** Open the app as admin. Navigate to the Trust screen. It should reach one of the four states (loading → then populated, empty, or public) without a crash.
-  
-
-4. **Unauthenticated call blocked.** Call `GET /api/trust/user/self` with no auth header. Expect HTTP 401 or 403, never 200.
+3. **Opening Trust from the apps list lands on the account hub.** Signed in as an approved member,
+   open the apps list and tap **Trust** (or go straight to `/apps/trust`). You should end up on
+   `/account` with your trust card on it. You must **not** see a page headed "Plugin baseline access
+   confirmed" listing your user id, username handle, and availability state — that is the generic
+   routing-check view and reaching it from Trust is the bug this step guards.
    web ☐
 
-5. **Public landing lists four signals — no verification claim.** Signed out, open the Trust public landing. The signal list reads exactly: How often you sign in, ServiceCredits activity, Community connections, Cohort completion record. Every line must map to a signal `buildTrustEvidence` really emits — "Quora social proof" was removed on 2026-08-10 because no such signal exists (the onboarding Quora check belongs to Unlock). "Admin-reviewed verification" does NOT appear either (removed 2026-07-19 — it read as the platform vetting people, a claim this plugin never makes).
+4. **Signed-out Trust still shows the public landing page.** In a private window with no session,
+   open `/apps/trust`. You should get the Trust public landing page, not a redirect to the account
+   page and not a sign-in wall. Repeat as a member who has not finished verification: they should
+   also get the landing page, with the "Finish verifying" action.
+   web ☐
+
+5. **Android Trust screen loads.** Open the app as admin. Navigate to the Trust screen. It should reach one of the four states (loading → then populated, empty, or public) without a crash.
+  
+
+6. **Unauthenticated call blocked.** Call `GET /api/trust/user/self` with no auth header. Expect HTTP 401 or 403, never 200.
+   web ☐
+
+7. **Public landing lists four signals — no verification claim.** Signed out, open the Trust public landing. The signal list reads exactly: How often you sign in, ServiceCredits activity, Community connections, Cohort completion record. Every line must map to a signal `buildTrustEvidence` really emits — "Quora social proof" was removed on 2026-08-10 because no such signal exists (the onboarding Quora check belongs to Unlock). "Admin-reviewed verification" does NOT appear either (removed 2026-07-19 — it read as the platform vetting people, a claim this plugin never makes).
    web ☐
 
 ---

--- a/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
+++ b/ctf/packages/web/app/apps/[pluginSlug]/page.tsx
@@ -258,6 +258,20 @@ function renderPluginShellC(
     return <MoodShell />;
   }
 
+  if (selectedPlugin.slug === 'trust') {
+    // Trust has no screen of its own. A member's trust card — their own signals, and under it the
+    // exact rows other members receive — is built into the account hub, and that is the only place
+    // it ships. Without this branch a signed-in member who tapped Trust in the apps list fell
+    // through to GenericPluginView below and got the baseline-access debug page: their user id, the
+    // availability state, and a link home. That page is a routing check, not a product surface.
+    //
+    // Deliberately placed AFTER the access gate rather than beside the knowledge redirect above.
+    // A signed-out visitor and a not-yet-verified member are denied before this point and keep
+    // getting the Trust public landing page, which is correct and is what they see today; only a
+    // member who actually passed the gate is sent to the hub, where they have a card to look at.
+    redirect('/account');
+  }
+
   if (selectedPlugin.slug === 'weekly-performance') {
     // Weekly Performance has no member view — the dashboard lives on the admin page only.
     // Non-admins never reach this branch (the admin-only gate above 404s them).


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## The bug

Tapping **Trust** in the apps list while signed in showed a page headed "Plugin baseline access confirmed", listing the member's raw user id, username handle, availability state, and a link home. That is the routing-check view, not a product surface, and it put a raw identifier in front of the member for no reason.

Trust is listed in the apps grid (`isVisible: true`, `implemented_shell`) but the dynamic plugin route `app/apps/[pluginSlug]/page.tsx` had no branch for the `trust` slug, so a signed-in member fell through to `GenericPluginView` at the bottom of the file.

This is not a recent regression — there has never been a branch for `trust`. Three other visible plugins also have no branch (`contributions`, `recurring-activity`, `mutual-time`), but each has its own static `app/apps/<slug>/page.tsx` segment that takes precedence over the dynamic route, so they were never affected. Trust is the only one that reached the generic view.

## The fix

`/apps/trust` now redirects a signed-in member to `/account`, where their trust card already ships — the member's own signals, and under them the exact rows other members receive. Trust has no screen of its own by design; the card is embedded in the account hub, the community right rail, and Directory profiles.

The branch sits **after** the access gate on purpose, not beside the `knowledge` redirect that runs before it. A signed-out visitor and a not-yet-verified member are denied earlier and keep getting the Trust public landing page, which was already correct — only a member who passed the gate is sent to the hub, where they have a card to look at.

Also flipped `requiresExplicitWebShell` to `true` for `trust` in `ctf/config/plugin-parity-contracts.json`, so the parity gate now holds that branch in place instead of letting it be dropped silently later.

No new UI, no copy change, no schema change, no API change.

## Checks run locally

Typecheck, lint, full web build, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-web-android-parity.mjs`, and `check-modularity-governance.sh` all pass.

Inventory and manual test script updated, including two smoke steps: that opening Trust from the apps list lands on the account hub and never on the baseline-access page, and that a signed-out visitor still gets the public landing page rather than a redirect or a sign-in wall.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YcKqD4UKMdjNSfSjQmMvdr)_