### PR TITLE
fix: recompute the trust card on the pages that render it, not just in the API

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-trust-feature-inventory.md
@@ -46,6 +46,12 @@ Trust still writes `trust_admin_audit_trail` rows for panel reads and snapshot r
 
 ## API Surface and Route Map
 
+- **Server-rendered self surfaces** (`app/account/page.tsx`, `app/page.tsx`, `app/apps/page.tsx`) — these
+  render the member's own trust card without going through the API, and they call
+  `readTrustSelfExtensionOrStored(userId)`, the same throttled recompute-then-fall-back path the self
+  route uses. They must never call `getTrustUserExtension` directly: that is a plain read of the last
+  written row, and using it froze the card at whatever some other surface last recomputed (see the
+  2026-08-13 change-log entry). One recompute per throttle window per member covers all of them.
 - `GET /api/trust/user/self` — Implemented. Recomputes the caller's trust signals before returning, so the panel reflects their current participation instead of a frozen snapshot that nothing refreshed. Calls `refreshTrustSignalSnapshot(userId)` (the same logic as `POST /api/trust/signal/snapshot`), persists a snapshot row, refreshes derived evidence, and returns the fresh `trust_user_extension`. Resilient: if the recompute throws, it falls back to the last stored extension so the member's own read never errors. Gated by server-side plugin authz (`evaluatePluginAccess`). The cross-user route stays a plain read (no recompute).
 - `GET /api/trust/user/[userId]` — Implemented. Returns another member's trust panel at one of two disclosure levels, reported on the response as `trustDisclosure`, and the level is decided here in code rather than by any member setting: the owner (self) and admins receive `full`; **every other member receives `summary`** — headline counts only, with every timestamp and supporting detail dropped and the per-plugin participation items collapsed to a single "Took part in N plugins" breadth line (`lib/trust/peer-summary.ts`). No read is refused; there is no `403` visibility path, because hiding a member's participation from other members would defeat the point of the panel.
 - `POST /api/trust/signal/snapshot` — Implemented. Recomputes the caller's trust signal (model `cross_plugin_engagement_v5`) from real cross-plugin engagement — sign-in history from `login_events` (all-time days plus the member's current unbroken run of days); SocketRelay trades/requests; ServiceCredits received (distinct payers + undisputed completed transfers); per-plugin participation COUNTs across LightHouse, TrustTransport, SkillsHunt, LevelUp, Chyme, Directory, WhatWorks, PeerProgramming, Contributions, and Foundation (provider side); and the count of DISTINCT members with a confirmed recurring activity (`recurring_activities`, either side). Coarse COUNTs only; privacy-sensitive plugins (ClickLog, Mood, GentlePulse, Unlock, and the Foundation seeker side) are excluded — see the Trust Signal Model section. Persists a `trust_signal_snapshot` row and refreshes the caller's derived evidence. CSRF-guarded; writes an audit row.
@@ -198,6 +204,30 @@ Trust has no dedicated seed script, and none is required. Trust is a derived plu
 
 ## Change Log
 
+- 2026-08-13: **The trust card on server-rendered pages was frozen — it now recomputes like the API
+  does.** Found on the owner's own account hub: every evidence row was dated 2026-08-06 and the
+  sign-in detail read "Most recent sign-in 2026-08-06", eight days later. The member had signed in
+  every day in between, so the card was not merely behind — it was another week's picture of their
+  participation, presented as current.
+
+  Cause: only `GET /api/trust/user/self` recomputed. The three pages that render the member's own
+  card server-side — the account hub, the home page, and the apps launcher — each called
+  `getTrustUserExtension`, a plain read of the last written row. Nothing on those pages triggered a
+  recompute, so the card showed whatever some other surface (Directory profile detail or the
+  LightHouse host view, the two that fetch the self API from the browser) had last written. A member
+  who does not open those two surfaces never refreshes, and the card can sit unchanged indefinitely.
+  This is also why the new sign-in-run line did not appear for a member signing in daily: the stored
+  snapshot predated the feature and nothing recomputed it.
+
+  Fixed with one shared helper rather than three page-level patches:
+  `readTrustSelfExtensionOrStored(userId)` in `lib/trust/repository.ts` does exactly what the self
+  route did — recompute on the existing throttle, fall back to the last stored extension if the
+  recompute throws — and the three pages plus the self route all call it, so the route and the pages
+  cannot drift into showing one member two different panels. Writes stay bounded: the throttle
+  allows at most one recompute per window per member no matter how many of those pages they open,
+  and each page render otherwise costs one indexed freshness lookup.
+
+  No UI change, no copy change, no schema change, no contract change.
 - 2026-08-12: **Second sign-in line: the member's current run of days, alongside the all-time count**
   (model `cross_plugin_engagement_v5`, owner request). "Active on 162 days" is cumulative — distinct
   sign-in days over a member's whole history — and on its own it cannot tell a reader whether that

--- a/ctf/docs/developer/test-scripts/trust-test-script.md
+++ b/ctf/docs/developer/test-scripts/trust-test-script.md
@@ -35,13 +35,28 @@ These checks confirm the plugin is alive. If any fail, stop and file a bug befor
 2. **Widget renders on the right rail.** Sign in as admin, open a page that embeds the Trust right-rail card (e.g. account hub or community shell). `TrustWidgetCard` should render — ShieldCheck header visible, no crash, no blank white box. Each evidence row must read as a human sentence (the `summary`, e.g. "Accepted 1 SkillsHunt submission"), **never** a raw type slug like `demo_second_owner` or `Engagement-...`. Any date shown must be a real date — **never** the literal "Invalid Date". (Regression guard: the demo seed previously wrote evidence with no `summary`/`createdAt`, which produced both symptoms.)
    web ☐
 
-3. **Android Trust screen loads.** Open the app as admin. Navigate to the Trust screen. It should reach one of the four states (loading → then populated, empty, or public) without a crash.
-  
-
-4. **Unauthenticated call blocked.** Call `GET /api/trust/user/self` with no auth header. Expect HTTP 401 or 403, never 200.
+3. **The card on the account hub is current, not a frozen snapshot.** Sign in, then open
+   `/account`. The evidence rows' dates should be today's — not a date from a previous week. Open
+   the sign-in row's detail: "Most recent sign-in" should be today or yesterday for a member who has
+   been signing in. A card whose every row carries the same old date, on a member who has used the
+   app since, means the recompute is not running on this page (the 2026-08-13 regression). Check the
+   home page and the apps launcher the same way; all three render the member's own card and all
+   three must agree with each other and with `GET /api/trust/user/self`.
    web ☐
 
-5. **Public landing lists four signals — no verification claim.** Signed out, open the Trust public landing. The signal list reads exactly: How often you sign in, ServiceCredits activity, Community connections, Cohort completion record. Every line must map to a signal `buildTrustEvidence` really emits — "Quora social proof" was removed on 2026-08-10 because no such signal exists (the onboarding Quora check belongs to Unlock). "Admin-reviewed verification" does NOT appear either (removed 2026-07-19 — it read as the platform vetting people, a claim this plugin never makes).
+4. **Repeat renders do not write a snapshot each time.** Reload `/account` several times inside a
+   five-minute window and count `trust_signal_snapshot` rows for that member before and after. The
+   count should rise by at most one — the recompute is throttled, so opening the page repeatedly (or
+   opening account, home, and the apps launcher in turn) must not append a row per render.
+   web ☐
+
+5. **Android Trust screen loads.** Open the app as admin. Navigate to the Trust screen. It should reach one of the four states (loading → then populated, empty, or public) without a crash.
+  
+
+6. **Unauthenticated call blocked.** Call `GET /api/trust/user/self` with no auth header. Expect HTTP 401 or 403, never 200.
+   web ☐
+
+7. **Public landing lists four signals — no verification claim.** Signed out, open the Trust public landing. The signal list reads exactly: How often you sign in, ServiceCredits activity, Community connections, Cohort completion record. Every line must map to a signal `buildTrustEvidence` really emits — "Quora social proof" was removed on 2026-08-10 because no such signal exists (the onboarding Quora check belongs to Unlock). "Admin-reviewed verification" does NOT appear either (removed 2026-07-19 — it read as the platform vetting people, a claim this plugin never makes).
    web ☐
 
 ---

--- a/ctf/packages/web/app/account/page.tsx
+++ b/ctf/packages/web/app/account/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getTrustUserExtension } from 'lib/trust/repository';
+import { readTrustSelfExtensionOrStored } from 'lib/trust/repository';
 import type { TrustUserExtension } from 'lib/trust/types';
 import { AccountHubShell } from '@/components/account/account-hub-shell';
 
@@ -37,7 +37,10 @@ export default async function AccountPage() {
     );
   }
 
-  const trust = await getTrustUserExtension(decision.userId).catch(() => buildFallbackTrust(decision.userId));
+  // Recompute before rendering (throttled, with a fallback to the last stored evidence) so the card
+  // shows the member's participation as it is now. A plain read froze this page's card at whatever
+  // the last self-API call had written, which could be weeks earlier.
+  const trust = await readTrustSelfExtensionOrStored(decision.userId).catch(() => buildFallbackTrust(decision.userId));
   const username = decision.username && decision.username !== 'guest' ? decision.username : null;
 
   return <AccountHubShell username={username} trust={trust} />;

--- a/ctf/packages/web/app/api/trust/user/self/route.ts
+++ b/ctf/packages/web/app/api/trust/user/self/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { evaluatePluginAccess } from 'lib/auth/server-authz';
-import { getTrustUserExtension, readTrustSelfExtension } from 'lib/trust/repository';
-import type { TrustUserExtension } from 'lib/trust/types';
+import { readTrustSelfExtensionOrStored } from 'lib/trust/repository';
 import { logTrustAuditEvent } from 'lib/trust/audit';
 import { resolveRequestId } from 'lib/trust/_lib';
 import { reportError } from 'lib/observability/report';
@@ -27,13 +26,11 @@ export async function GET(request: Request) {
   // Resilience: if the recompute throws (an upstream table is briefly unavailable, the DB hiccups,
   // etc.) fall back to the last stored extension so the panel still renders the most recent good
   // evidence instead of erroring. A failed refresh must never break the member's own read.
-  let extension: TrustUserExtension;
-  try {
-    ({ extension } = await readTrustSelfExtension(decision.userId));
-  } catch (error) {
-    reportError(error, { area: 'trust', op: 'self_refresh' });
-    extension = await getTrustUserExtension(decision.userId);
-  }
+  //
+  // Both the throttle and that fallback live in readTrustSelfExtensionOrStored, which the
+  // server-rendered self surfaces (account hub, home, apps launcher) call too — so this route and
+  // those pages cannot drift into showing the same member two different panels.
+  const extension = await readTrustSelfExtensionOrStored(decision.userId);
 
   // Record the trust.summary.read audit event required by the audit contract. A failed audit write
   // must never break the member's own read, so log-and-continue on error.

--- a/ctf/packages/web/app/apps/page.tsx
+++ b/ctf/packages/web/app/apps/page.tsx
@@ -4,7 +4,7 @@ import type { TrustUserExtension } from '../../lib/trust/types';
 import { evaluatePluginAccess } from '../../lib/auth/server-authz';
 import { getGdpShellStats } from '../../lib/gdp/repository';
 import { listPluginRegistry, filterPluginsForViewer } from '../../lib/plugins/repository';
-import { getTrustUserExtension } from '../../lib/trust/repository';
+import { readTrustSelfExtensionOrStored } from '../../lib/trust/repository';
 import { getHostedSignInUrl } from '../../lib/auth/provider-env';
 
 function buildShellUser(userId: string, username: string | null): ShellCurrentUser {
@@ -51,7 +51,7 @@ export default async function AppsPage() {
     : buildShellUser('guest', null);
 
   const trust = authDecision && authDecision.allowed
-    ? await getTrustUserExtension(authDecision.userId).catch(() => buildFallbackTrust(authDecision.userId))
+    ? await readTrustSelfExtensionOrStored(authDecision.userId).catch(() => buildFallbackTrust(authDecision.userId))
     : buildFallbackTrust(currentUser.userId);
 
   const signInUrl = getHostedSignInUrl() ?? '/sign-in';

--- a/ctf/packages/web/app/page.tsx
+++ b/ctf/packages/web/app/page.tsx
@@ -8,7 +8,7 @@ import { getUnlockStatusForUser } from '../lib/unlock/repository';
 import type { UnlockAccessTier } from '../lib/unlock/types';
 import { getGdpShellStats } from '../lib/gdp/repository';
 import { listPluginRegistry, filterPluginsForViewer } from '../lib/plugins/repository';
-import { getTrustUserExtension } from '../lib/trust/repository';
+import { readTrustSelfExtensionOrStored } from '../lib/trust/repository';
 import { getHostedSignInUrl } from '../lib/auth/provider-env';
 
 function buildShellUser(userId: string, username: string | null): ShellCurrentUser {
@@ -109,7 +109,9 @@ async function resolveTrust(
   if (!userId) {
     return buildFallbackTrust(fallbackUserId);
   }
-  return getTrustUserExtension(userId).catch(() => buildFallbackTrust(userId));
+  // Recomputes on the shared throttle rather than reading whatever was last written, so the card
+  // here agrees with the account hub instead of showing an older snapshot of the same member.
+  return readTrustSelfExtensionOrStored(userId).catch(() => buildFallbackTrust(userId));
 }
 
 export default async function HomePage() {

--- a/ctf/packages/web/lib/trust/repository.ts
+++ b/ctf/packages/web/lib/trust/repository.ts
@@ -3,6 +3,7 @@ import type {
   TrustSignalMetrics,
   TrustUserExtension,
 } from './types';
+import { reportError } from 'lib/observability/report';
 import {
   buildTrustEvidence,
   computeTrustSignalMetrics,
@@ -42,6 +43,32 @@ export async function readTrustSelfExtension(
   }
   const { extension } = await refreshTrustSignalSnapshot(userId);
   return { extension, refreshed: true };
+}
+
+// Read the caller's own panel for a surface that renders it directly, rather than fetching
+// `/api/trust/user/self` from the browser.
+//
+// Why this exists: the account hub, the home page, and the apps launcher all render the member's
+// trust card server-side, and each of them used to call `getTrustUserExtension` — a plain read of
+// whatever was last written. Nothing on those pages recomputed, so the card froze at the moment
+// some other surface last hit the self API. In production that showed as a card whose every row was
+// dated over a week earlier, still reporting a sign-in from that same day: not an out-of-date
+// number, a snapshot of a member's participation from another week. A signal nothing refreshes is
+// worse than no signal, because it reads as current.
+//
+// So the fix is not per-page: it is this one function, doing exactly what the self API route does —
+// recompute on the same throttle, fall back to the last stored extension if the recompute throws —
+// so every self surface stays in step and no future page can quietly reintroduce the frozen read.
+// The throttle is what keeps it cheap: at most one recompute per window per member, no matter how
+// many of these pages they open.
+export async function readTrustSelfExtensionOrStored(userId: string): Promise<TrustUserExtension> {
+  try {
+    const { extension } = await readTrustSelfExtension(userId);
+    return extension;
+  } catch (error) {
+    reportError(error, { area: 'trust', op: 'self_refresh' });
+    return getTrustUserExtensionDb(userId);
+  }
 }
 
 export interface TrustSnapshotResult {


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## The bug

Found on the owner's own account hub: every evidence row was dated 2026-08-06 and the sign-in detail read "Most recent sign-in 2026-08-06" — eight days later, on a member who had signed in every day in between. The card was not merely behind. It was another week's picture of that member's participation, presented as current, with no way for a reader to tell.

## Cause

Only `GET /api/trust/user/self` recomputed. The three pages that render a member's own card server-side — the account hub, the home page, and the apps launcher — each called `getTrustUserExtension`, a plain read of the last written row. Nothing on those pages triggered a recompute, so the card showed whatever some other surface had last written.

Only two surfaces fetch the self API from the browser (Directory profile detail and the LightHouse host view). A member who does not open either never refreshes, and the card can sit unchanged indefinitely.

This is also why the sign-in-run line added in #2211 did not appear for a member signing in daily: their stored snapshot predated the feature, and nothing recomputed it.

## The fix

One shared helper rather than three page-level patches. `readTrustSelfExtensionOrStored(userId)` in `lib/trust/repository.ts` does exactly what the self route already did — recompute on the existing throttle, fall back to the last stored extension if the recompute throws — and the three pages plus the self route now all call it. The route and the pages therefore cannot drift into showing one member two different panels, and a future self surface cannot quietly reintroduce the frozen read.

## On writing during a page render

The recompute writes (a snapshot row plus the evidence rewrite), so this makes three page GETs capable of a write where before only the API GET was. The existing throttle is what bounds that, and it is unchanged: at most one recompute per window per member however many of these pages they open, with each render otherwise costing one indexed freshness lookup. A forced cross-site GET of `/account` can at most cause the victim's own snapshot to refresh on that same schedule — nothing an attacker supplies, controls, or reads. That is the same reasoning the self route already documents for being a write-on-GET, applied to the pages that render the same panel.

No UI change, no copy change, no schema change, no contract change.

## Checks run locally

Typecheck, lint, full web build, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-web-android-parity.mjs`, and `check-modularity-governance.sh` all pass, along with the 20 trust unit tests.

Inventory and manual test script updated, including a smoke step that the card's dates are current rather than a frozen snapshot, and one that repeat renders inside the throttle window do not append a snapshot row each time.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YcKqD4UKMdjNSfSjQmMvdr)_