### PR TITLE
feat: link the ClickLog tag pickers to the full problems and schemes lists

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -26,6 +26,14 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   requires a location — the form disables Submit (with an explanation) until location is added,
   and the server enforces the same rule — because tagged trend data needs location to be
   detailed enough. Tags show as chips on the history rows and feed trend reporting.
+- Read the full problems list and the full schemes list while tagging: each picker carries a
+  "Full list" link beside its question — the problems picker points at
+  `https://www.chargingthefuture.com/look-ma`, the schemes picker at
+  `https://www.chargingthefuture.com/schemes`. Both open in the shared share-link popup (the same
+  control used everywhere else in the app), which shows the whole address, opens it in a new tab,
+  or copies it — so reading the long description of a problem or a scheme never replaces the page
+  and never loses the incident the member is part-way through logging. The same links appear in
+  the pickers of the after-the-fact edit form.
 - Suggest a new scheme via the "Not listed" scheme tag (Weavers of the Commons badge holders
   only — members without the badge do not see the option). Picking it requires a written
   description of the scheme (up to 200 characters) that is explicitly shared with the owner —
@@ -185,6 +193,14 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 
 ## Change Log
 
+- 2026-08-14: **Both tag pickers now link to the public list that describes their tags in full
+  (owner request).** The chip labels are short by necessity, so a member who does not recognize
+  one had nowhere to read the long version. Each picker question now carries a "Full list" link:
+  problems → `https://www.chargingthefuture.com/look-ma`, schemes →
+  `https://www.chargingthefuture.com/schemes`. Both go through the shared `ShareLink` popup
+  (rule 130) rather than a plain link, so the page opens in a new tab or the address is copied —
+  the incident being logged is never replaced. Applied in the log form and the history editor;
+  UI only, no schema, API, or contract change.
 - 2026-08-13: **Incidents now hold several tags of each kind: `problem_tags` / `scheme_tags`
   arrays replace the singular columns (owner decision).** The owner's cross-country bus trip
   chained five schemes in one incident, and no real incident is ever just one tag — so the

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -154,6 +154,24 @@ message, and an edit that duplicates another incident's exact note returns a rea
 "change the note slightly" error.
 **Result:** web ☐ mobile ☐ — notes:
 
+### CL-10 · Open the full problems / schemes list from the tag pickers
+**Role:** member · **Surfaces:** all
+**Steps:**
+1. Open the log form and half-fill it: write a note and pick a tag or two, but do not submit.
+2. Tap the "Full list" link beside "Which problems happened?".
+3. Read the address shown, tap "Copy link", then tap "Open in new tab".
+4. Come back to the ClickLog tab and do the same with the "Full list" link beside
+   "Which schemes were used?".
+5. Repeat step 2 inside the edit form of an existing incident that has a location.
+**Expected:** Each link opens the shared share-link popup, not the page itself. The popup shows
+the whole address as selectable text — `https://www.chargingthefuture.com/look-ma` for problems,
+`https://www.chargingthefuture.com/schemes` for schemes — with "Copy link" (which confirms
+"Copied!") and "Open in new tab". Opening the page leaves the ClickLog tab as it was: the note
+you wrote and the tags you picked are still there, and nothing was submitted. Escape or a tap
+outside closes the popup and returns focus to the link. The same two links appear in the edit
+form's pickers.
+**Result:** web ☐ mobile ☐ — notes:
+
 ### CL-5 · Refresh the incident list
 **Role:** member · **Surfaces:** all
 **Steps:**

--- a/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
+++ b/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
@@ -4,7 +4,13 @@ import { useState } from "react";
 import type { ClickLogIncident } from "../../lib/click-log/types";
 import { MAX_NOTES_LENGTH, MAX_TAGS_PER_KIND } from "../../lib/click-log/constants";
 import { CLICK_LOG_PROBLEM_TAGS, CLICK_LOG_SCHEME_TAGS, NOT_LISTED_SCHEME_SLUG } from "../../lib/click-log/tags";
-import { formatIncidentTime, hasLocation, type ClickLogTokens } from "./click-log-shared";
+import {
+  CLICK_LOG_PROBLEM_REFERENCE,
+  CLICK_LOG_SCHEME_REFERENCE,
+  formatIncidentTime,
+  hasLocation,
+  type ClickLogTokens,
+} from "./click-log-shared";
 import { ClickLogTagPicker } from "./click-log-tag-picker";
 
 // What an edit can change. Tag lists use [] for untagged (picker convention).
@@ -54,6 +60,7 @@ function EditorTagSection({
         values={problemTags}
         options={CLICK_LOG_PROBLEM_TAGS}
         maxSelected={MAX_TAGS_PER_KIND}
+        reference={CLICK_LOG_PROBLEM_REFERENCE}
         tokens={t}
         onChange={onProblemTagsChange}
       />
@@ -63,6 +70,7 @@ function EditorTagSection({
         values={schemeTags}
         options={schemeOptions}
         maxSelected={MAX_TAGS_PER_KIND}
+        reference={CLICK_LOG_SCHEME_REFERENCE}
         tokens={t}
         onChange={onSchemeTagsChange}
       />

--- a/ctf/packages/web/components/click-log/click-log-log-panel.tsx
+++ b/ctf/packages/web/components/click-log/click-log-log-panel.tsx
@@ -4,7 +4,12 @@ import { AlertTriangle, MapPin } from "lucide-react";
 import { MAX_NOTES_LENGTH, MAX_TAGS_PER_KIND } from "../../lib/click-log/constants";
 import { CLICK_LOG_PROBLEM_TAGS, CLICK_LOG_SCHEME_TAGS, NOT_LISTED_SCHEME_SLUG } from "../../lib/click-log/tags";
 import { useTheme } from "@/hooks/useTheme";
-import { getClickLogTokens, type ClickLogTokens } from "./click-log-shared";
+import {
+  CLICK_LOG_PROBLEM_REFERENCE,
+  CLICK_LOG_SCHEME_REFERENCE,
+  getClickLogTokens,
+  type ClickLogTokens,
+} from "./click-log-shared";
 import { ClickLogTagPicker } from "./click-log-tag-picker";
 import { ClickLogSchemeSuggestionFields } from "./click-log-scheme-suggestion-fields";
 
@@ -69,6 +74,7 @@ function ClickLogTagFields({
         values={problemTags}
         options={CLICK_LOG_PROBLEM_TAGS}
         maxSelected={MAX_TAGS_PER_KIND}
+        reference={CLICK_LOG_PROBLEM_REFERENCE}
         tokens={t}
         onChange={onProblemTagsChange}
       />
@@ -78,6 +84,7 @@ function ClickLogTagFields({
         values={schemeTags}
         options={schemeOptions}
         maxSelected={MAX_TAGS_PER_KIND}
+        reference={CLICK_LOG_SCHEME_REFERENCE}
         tokens={t}
         onChange={onSchemeTagsChange}
       />

--- a/ctf/packages/web/components/click-log/click-log-shared.ts
+++ b/ctf/packages/web/components/click-log/click-log-shared.ts
@@ -23,6 +23,37 @@ export function getClickLogTokens(theme: ThemeName): ClickLogTokens {
   return getPluginShellTokens(accent, theme);
 }
 
+// The two public pages that describe every problem and every scheme in full, in the owner's own
+// words. The tag pickers link out to them (owner request, 2026-08-14) so a member who does not
+// recognize a short chip label can read the long version before picking. Both are opened through
+// the shared ShareLink popup — open in a new tab or copy the link — so reading the list never
+// replaces the page of an incident the member is part-way through logging.
+export const CLICK_LOG_PROBLEMS_PAGE_URL = "https://www.chargingthefuture.com/look-ma";
+export const CLICK_LOG_SCHEMES_PAGE_URL = "https://www.chargingthefuture.com/schemes";
+
+// A link to the public page that describes one list of tags in full. Shown next to the picker
+// question and opened through the shared ShareLink popup (rule 130).
+export type ClickLogTagReference = {
+  url: string;
+  // Short text on the trigger, sitting beside the picker question.
+  label: string;
+  // Heading inside the popup, naming the page the link goes to.
+  title: string;
+};
+
+// Shared by the log form and the history editor so both pickers offer the same link and wording.
+export const CLICK_LOG_PROBLEM_REFERENCE: ClickLogTagReference = {
+  url: CLICK_LOG_PROBLEMS_PAGE_URL,
+  label: "Full list",
+  title: "The full problems list on chargingthefuture.com",
+};
+
+export const CLICK_LOG_SCHEME_REFERENCE: ClickLogTagReference = {
+  url: CLICK_LOG_SCHEMES_PAGE_URL,
+  label: "Full list",
+  title: "The full schemes list on chargingthefuture.com",
+};
+
 export const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
 
 // Monday-based weekday index (Mon=0 … Sun=6).

--- a/ctf/packages/web/components/click-log/click-log-tag-picker.tsx
+++ b/ctf/packages/web/components/click-log/click-log-tag-picker.tsx
@@ -3,7 +3,8 @@
 import { useMemo, useState } from "react";
 import { Search, X } from "lucide-react";
 import type { ClickLogTag } from "../../lib/click-log/tags";
-import type { ClickLogTokens } from "./click-log-shared";
+import { ShareLink } from "../shared/share-link";
+import type { ClickLogTagReference, ClickLogTokens } from "./click-log-shared";
 
 // Multi-select tag picker for the log form (problems or schemes), mimicking the Directory /
 // SkillsHunt picker style: a type-and-search keyword box that filters a flat chip list, a row
@@ -61,12 +62,38 @@ function SelectedTagChips({ selected, tokens, onRemove }: {
   );
 }
 
+// The picker question with its optional "read the full list" link on the right. The link always
+// goes through the shared ShareLink popup (rule 130) — so the member reads the page in a new tab
+// (or copies the link for later) instead of losing the incident they are mid-way through logging.
+function TagPickerHeader({ label, reference, tokens }: {
+  label: string;
+  reference: ClickLogTagReference | undefined;
+  tokens: ClickLogTokens;
+}) {
+  const t = tokens;
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: 6 }}>
+      <div style={{ fontSize: 12, color: t.MUTED }}>{label}</div>
+      {reference && (
+        <ShareLink
+          url={reference.url}
+          label={reference.label}
+          title={reference.title}
+          iconSize={12}
+          triggerStyle={{ flexShrink: 0, fontSize: 11, fontWeight: 600, color: t.ACCENT, whiteSpace: "nowrap" }}
+        />
+      )}
+    </div>
+  );
+}
+
 export function ClickLogTagPicker({
   label,
   searchPlaceholder,
   values,
   options,
   maxSelected,
+  reference,
   tokens,
   onChange,
 }: {
@@ -77,6 +104,8 @@ export function ClickLogTagPicker({
   options: readonly ClickLogTag[];
   // Cap on picks of this kind (MAX_TAGS_PER_KIND); adding past it is ignored and a hint shows.
   maxSelected: number;
+  // Link to the public page listing these tags in full; omit to show no link.
+  reference?: ClickLogTagReference;
   tokens: ClickLogTokens;
   onChange: (values: string[]) => void;
 }) {
@@ -106,7 +135,7 @@ export function ClickLogTagPicker({
 
   return (
     <div style={{ marginTop: 12 }}>
-      <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 6 }}>{label}</div>
+      <TagPickerHeader label={label} reference={reference} tokens={t} />
 
       <SelectedTagChips selected={selected} tokens={t} onRemove={(slug) => onChange(values.filter((v) => v !== slug))} />
       {atCap && (


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

The two tag pickers in ClickLog use short chip labels, so a member who does not recognize one had
nowhere to read the long version. Each picker question now carries a "Full list" link beside it:

- "Which problems happened?" → `https://www.chargingthefuture.com/look-ma`
- "Which schemes were used?" → `https://www.chargingthefuture.com/schemes`

Both links open through the shared `ShareLink` popup (rule 130) rather than a plain link. The popup
shows the whole address, opens it in a new tab, or copies it — so reading the list never replaces
the page, and a half-written incident (note plus picked tags) is still there when the member comes
back.

The picker is shared, so the links appear in the log form and in the after-the-fact incident
editor.

## Files

- `components/click-log/click-log-shared.ts` — the two public page addresses plus the shared link
  wording, so the log form and the editor offer the same thing.
- `components/click-log/click-log-tag-picker.tsx` — optional `reference` prop; the picker question
  is now a header row with the `ShareLink` trigger on the right.
- `components/click-log/click-log-log-panel.tsx`, `click-log-incident-editor.tsx` — pass the
  problems link and the schemes link.
- Feature inventory: new User Features bullet and a change-log entry.
- Manual test script: new case CL-10 — open both links from a half-filled form, confirm the popup
  shows the address, copies it, opens a new tab, and leaves the form untouched.

UI only — no schema, API, or contract change.

## Checks run locally

`pnpm --filter @ctf/web typecheck`, `lint`, `build`, `lint:a11y`, `check-eof-format.sh`,
`check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-modularity-governance.sh`,
`check-us-spelling.mjs` — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgTEkfRbQ4pwp4m96wJ81R)_