### PR TITLE
feat: report daily active members on the Weekly Performance dashboard

### DIFF
--- a/ctf/config/canonical_metrics.yaml
+++ b/ctf/config/canonical_metrics.yaml
@@ -2019,6 +2019,34 @@ canonical_metrics:
     allowed_thresholds:
       min: 0
 
+  - id: wp_adoption_daily_active_members
+    name: Weekly Daily Active Members
+    description: Average number of distinct members active on a day of the week window — the dashboard's daily-active-members reading. login_events holds at most one row per member per UTC day, so one row is one member-day; the distinct count is used anyway so a database cloned before the once-per-day unique index existed cannot inflate the average. The divisor is the number of days of the window that have already started (1-7), so the live current week averages over the days it has actually had and every past week divides by the full 7. Aggregate only — never a per-member figure. Adoption, not value; signing in is not a plugin's defining action and carries no positive weight in value scoring.
+    owner: analytics-owner@chargingthefuture.org
+    data_type: number
+    unit: per day
+    calculation: |
+      SELECT ROUND(
+               COUNT(DISTINCT (user_id, (created_at AT TIME ZONE 'UTC')::date))::numeric
+                 / GREATEST(LEAST(7, (CURRENT_DATE - :week_start) + 1), 1),
+               2) AS v
+      FROM login_events
+      WHERE created_at >= :week_start
+        AND created_at < :week_end;
+    inputs:
+      - name: login_events.user_id
+        type: string
+      - name: login_events.created_at
+        type: datetime
+    example_values:
+      - 12.43
+      - 18
+    last_updated: "2026-08-15T00:00:00Z"
+    update_cadence: weekly
+    retention: 24 months
+    allowed_thresholds:
+      min: 0
+
   - id: wp_adoption_directory_findable_members
     name: Weekly Directory Findable Members
     description: Cumulative state count — claimed, active, non-deleted Directory profiles holding at least one skill, created by the end of the week window. Claim time is not stored, so the count reflects each profile's CURRENT claimed/active/skilled state, not its state at the time.

--- a/ctf/docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -85,6 +85,7 @@ contracts:
       - directory_profile_skills
       - mood_submissions
       - click_log_incidents
+      - login_events
     purpose: operational_metrics_review
     retentionClass: derived_short_lived
     idempotency: true
@@ -134,6 +135,7 @@ contracts:
       - directory_profile_skills
       - mood_submissions
       - click_log_incidents
+      - login_events
     purpose: operational_metrics_comparison
     retentionClass: derived_short_lived
     idempotency: true

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md
@@ -127,22 +127,47 @@ Weekly performance metrics are derived from upstream plugin tables (feed, login 
 
 Live numbers: weekly numbers are **always** computed live, matching the V2 dashboard, which aggregated on read for any selected week. There is no "close the week" step and no stored snapshot to wait for. `getWeekMetrics` returns `computeLiveWeekMetrics` (`lib/weekly-performance/live-metrics.ts`) for every week, counting the week window directly from upstream tables. The current week is labeled "Live" and keeps moving (silent 60s polling + focus refetch on web); every earlier week is a settled historical window with no "closed" state. The `weekly_performance_metrics` table and the `weekly-performance.metrics.get` route are unchanged; the read is simply always live (the table is no longer consulted for the dashboard).
 
-The metric set mirrors what V2 captured, **minus everything revenue/financial** (revenue, MRR, ARR, CLV) — V3 is free to end users, so those have no meaning. All metrics are non-financial, scoped to `[week_start, week_start + 7 days)`, and each query is table-existence-guarded so a missing table contributes 0 rather than failing the read:
+The shipped metric set is the one locked on 2026-07-18 in `ctf/docs/developer/PLUGIN_VALUE_METRICS.md`, plus the
+daily-active-members adoption row added 2026-08-15. Nothing revenue/financial is included (revenue, MRR, ARR, CLV)
+— V3 is free to end users, so those have no meaning. Every metric is scoped to
+`[week_start, week_start + 7 days)` unless noted, and each query is table-existence-guarded so a missing table
+contributes 0 rather than failing the read. Card order on the dashboard is the order below.
 
-- `members.total` — distinct members seen up to end of week (cumulative, from `login_events`).
-- `members.new` — members whose first recorded activity falls in the week (`login_events` first-seen).
-- `engagement.active_members` — distinct members active during the week (WAU, `login_events`).
-- `engagement.daily_active` — average daily active over the week's 7 days (DAU, `login_events`).
-- `engagement.monthly_active` — distinct members active in the 30 days ending at week end (MAU, `login_events`).
-- `retention.lapsed_members` — churn proxy: members active the prior week who did not return this week (`login_events`).
-- `engagement.questions_asked` — `feed_questions` created in the week.
-- `engagement.answers_posted` — `feed_answers` created in the week.
-- `community.posts_created` — accepted `feed_community_posts` created in the week.
-- `learning.enrollments_started` — `level_up_enrollments` created in the week.
-- `wellbeing.mood_checkins` — `mood_submissions` in the week (aggregate count only).
-- `wellbeing.mood_average` — average `mood_value` in the week (aggregate only — never an individual reading).
+Goals (state metrics — the current-week read stores a snapshot, past weeks report their stored row):
 
-V2's "verified" and "approved" member counts are intentionally omitted: V3's `users` table is the Clerk mirror with no dependable verification/approval timestamp, so a time-correct per-week value can't be computed (real-data-only). Metric card labels are humanized from the key (the namespace dot is treated as a separator, so `engagement.active_members` reads "Engagement Active Members").
+- `goal.gdp_value_index` — Community Value Index, toward the 300B goal (from the GDP plugin's live report).
+- `goal.workforce_recruited` — active, non-deleted Directory profiles, toward the 2,000,000 goal.
+
+Value delivered (each plugin's defining action, windowed on the event's own timestamp):
+
+- `value.foundation_calls_answered` — answered Foundation calls with at least one block charged (aggregate only, rule 132).
+- `value.socket_relay_requests_fulfilled` — SocketRelay fulfillments the requester closed as successful.
+- `value.trust_transport_trips_completed` — trips both sides confirmed complete.
+- `value.lighthouse_stays_completed` — Lighthouse matches now in `completed`.
+- `value.chyme_tips_sent` — completed ServiceCredits transfers originated by Chyme (never self-to-self).
+- `value.service_credits_peer_sends` — completed direct peer sends originated by ServiceCredits.
+- `value.contributions_confirmed_usd` — confirmed real dollars this week (a sum, not a row count).
+- `value.skills_hunt_nominations_accepted` — nominations a moderator accepted.
+- `value.what_works_tools_approved` / `value.what_works_endorsements_given` — approved tools and endorsements given.
+- `value.level_up_completions` / `value.level_up_trainer_payouts` — completed enrollments and trainer payouts.
+- `value.recurring_ties_confirmed` — ties the counterparty confirmed.
+- `value.peer_programming_active_posters` — distinct members who posted in their cohort.
+- `value.beacon_broadcast_engagement` — distinct (member, broadcast) pairs that reacted or replied on a broadcast's Commons replay post.
+
+Adoption (honest non-value rows):
+
+- `adoption.daily_active_members` — average number of distinct members active on a day of the week, from
+  `login_events`. That table holds at most one row per member per UTC day, so one row is one member-day; the
+  count is still taken as distinct (member, day) pairs so an older database without the once-per-day unique
+  index cannot inflate the average. The divisor is the number of days of the window that have already started
+  (1–7), so the live current week averages over the days it has actually had and every past week divides by 7.
+  Aggregate only — never a per-member figure. This is adoption, not value: signing in is not a plugin's defining
+  action and carries no positive weight in value scoring.
+- `adoption.directory_findable_members` — claimed, active, skilled Directory profiles by week end (cumulative).
+- `adoption.mood_checkins` / `adoption.mood_average` — Mood check-ins and their average (aggregate only — never an individual reading).
+- `adoption.click_log_incidents` / `adoption.click_log_active_loggers` — ClickLog incidents and distinct loggers (aggregate only).
+
+V2's "verified" and "approved" member counts are intentionally omitted: V3's `users` table is the Clerk mirror with no dependable verification/approval timestamp, so a time-correct per-week value can't be computed (real-data-only). Metric card labels are humanized from the key: the group prefix is dropped and the rest is title-cased, so `adoption.daily_active_members` reads "Daily Active Members".
 
 ## 7) Gaps and Known Technical Debt
 
@@ -153,6 +178,23 @@ V2's "verified" and "approved" member counts are intentionally omitted: V3's `us
 
 ## 8) Change Log
 
+- 2026-08-15: **The dashboard reports daily active members again (owner report: "Weekly performance
+  does not have a state on daily active users").** The 2026-07-18 rebuild dropped every sign-in
+  number, so the dashboard could say what members had done but not how many of them turned up, and
+  the only active-user figure left in the plugin was a rolling last-7-days count the
+  `/current-week` route returns and no screen renders. A new adoption row,
+  `adoption.daily_active_members`, is computed per selected week in
+  `lib/weekly-performance/live-metrics.ts` from `login_events`: the average number of distinct
+  members active on a day of that week, divided by the days of the window that have already started
+  so the live current week is not watered down by days that have not happened yet. It reads as
+  "Daily Active Members" in the Adoption section, joins the week-over-week comparison like every
+  other row, and is aggregate only — never a per-member figure. It sits under Adoption rather than
+  Value on purpose: logging in is not a plugin's defining action and still carries no weight in
+  value scoring. Registered as `wp_adoption_daily_active_members` in
+  `ctf/config/canonical_metrics.yaml`, and `login_events` is added to the `dataAccess` lists of
+  `weekly-performance.metrics.get` and `weekly-performance.comparison.get`. No schema, route, or
+  access-policy change. Section 6's metric list, which still described the pre-2026-07-18 set, is
+  replaced with the shipped one.
 - 2026-08-10: **The week history now starts at the launch week (owner report).** The picker listed
   weeks going back a year, so it offered windows from before the platform existed (Apr 2026 and
   earlier) that could only ever read zero. `listWeeks` (`lib/weekly-performance/repository.ts`) now

--- a/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
+++ b/ctf/docs/developer/test-scripts/weekly-performance-test-script.md
@@ -108,10 +108,13 @@ is no "set active week" action and no per-week status.
    Lighthouse completed stays, Chyme tips, ServiceCredits direct peer sends, Contributions confirmed
    USD, SkillsHunt accepted nominations, WhatWorks approved tools + endorsements, LevelUp
    completions + trainer payouts, Recurring Activity confirmed ties, PeerProgramming distinct
-   posters, Beacon engagement per unique broadcast); **Adoption** — Directory findable members, Mood
-   check-ins + average, ClickLog incidents + distinct loggers. There are NO login/engagement cards,
-   NO feed cards, NO LevelUp enrollments-started card, and nothing for GentlePulse or Skills
-   Taxonomy. No revenue/MRR/ARR/CLV.
+   posters, Beacon engagement per unique broadcast); **Adoption** — Daily Active Members, Directory
+   findable members, Mood check-ins + average, ClickLog incidents + distinct loggers. The Daily
+   Active Members card reads "N per day": the average number of distinct members active on a day of
+   the selected week, from `login_events`; on the current week it divides by the days of the week so
+   far, on a past week by the full 7. It is an aggregate — no member is ever named. There are NO
+   other login/engagement cards, NO feed cards, NO LevelUp enrollments-started card, and nothing for
+   GentlePulse or Skills Taxonomy. No revenue/MRR/ARR/CLV.
 2. Supply a compare week so the route returns a comparison
    (`GET /api/weekly-performance/metrics?weekStartDate=...&compareWeekStartDate=...`).
 3. On the current week, leave the dashboard open: it silently re-fetches about every 60s and on tab

--- a/ctf/packages/web/lib/weekly-performance/live-metrics.ts
+++ b/ctf/packages/web/lib/weekly-performance/live-metrics.ts
@@ -13,13 +13,16 @@ import { buildLiveGdpReport } from 'lib/shared/gdp-interface';
 //   2. The per-plugin VALUE EVENTS — each plugin's defining action, the event that means the
 //      plugin was used as intended (a completed trip, a hosted stay, a confirmed contribution…).
 //      These are windowed on the event's own timestamp, so any week reports its real count.
-//   3. Honest ADOPTION rows for the no-value-to-others plugins the owner wants visible:
-//      Directory (findable members), Mood (check-ins + average, aggregate only), ClickLog
-//      (aggregate incidents + distinct loggers — never per-member detail).
+//   3. Honest ADOPTION rows: how many members are actually turning up (daily active members) plus
+//      the no-value-to-others plugins the owner wants visible: Directory (findable members), Mood
+//      (check-ins + average, aggregate only), ClickLog (aggregate incidents + distinct loggers —
+//      never per-member detail).
 //
-// Dropped from the old set (owner decision): login/engagement counts (logins are downstream of
-// value, not value), feed counts, and LevelUp enrollments-started (intent, not delivered value —
-// replaced by completions). Skills Taxonomy carries no dashboard stats at all.
+// Dropped from the old set (owner decision): feed counts and LevelUp enrollments-started (intent,
+// not delivered value — replaced by completions). Skills Taxonomy carries no dashboard stats at
+// all. Sign-in activity is still not VALUE — logging in is not a plugin's defining action — but the
+// dashboard has to answer "how many people showed up this week", so daily active members is carried
+// as an adoption row (owner report, 2026-08-15).
 //
 // The Foundation row is an aggregate count on this admin-only surface; per rule 132 the underlying
 // participation is sensitive (wellbeing/payment), so it must never appear on a public surface or as
@@ -188,6 +191,25 @@ const beaconBroadcastEngagement = (weekStart: string) =>
 
 // ── Adoption rows (honest non-value metrics) ──────────────────────────────────
 
+// Daily active members: the average number of distinct members active on a day of this week.
+// `login_events` holds at most one row per member per UTC day, so one row is one member-day;
+// COUNT(DISTINCT (member, day)) is used anyway so a database cloned before the once-per-day unique
+// index existed cannot inflate the average with duplicate rows. The divisor is the number of days
+// of the window that have already started (1–7), so the live current week reports the average of
+// the days it has actually had instead of a figure watered down by days that have not happened yet;
+// every past week divides by the full 7. Aggregate only — never a per-member figure.
+const dailyActiveMembers = (weekStart: string) =>
+  guardedScalar(
+    'login_events',
+    `SELECT ROUND(
+              COUNT(DISTINCT (user_id, (created_at AT TIME ZONE 'UTC')::date))::numeric
+                / GREATEST(LEAST(7, (CURRENT_DATE - $1::date) + 1), 1),
+              2)::text AS v
+     FROM login_events
+     WHERE created_at >= $1::date AND created_at < $1::date + INTERVAL '7 days'`,
+    weekStart,
+  );
+
 // Directory: findable members — claimed, active, non-deleted profiles holding at least one skill.
 // Claim time is not stored, so this is the cumulative count of such profiles created by week end
 // (their CURRENT claimed/active state) — the same cumulative pattern the old members.total used.
@@ -327,6 +349,7 @@ const METRIC_SPECS: MetricSpec[] = [
   { metricKey: 'value.recurring_ties_confirmed', metricUnit: 'ties', sourcePlugin: 'recurring-activity', compute: recurringTiesConfirmed },
   { metricKey: 'value.peer_programming_active_posters', metricUnit: 'members', sourcePlugin: 'peer-programming', compute: peerProgrammingActivePosters },
   { metricKey: 'value.beacon_broadcast_engagement', metricUnit: 'engagements', sourcePlugin: 'beacon', compute: beaconBroadcastEngagement },
+  { metricKey: 'adoption.daily_active_members', metricUnit: 'per day', sourcePlugin: 'platform', compute: dailyActiveMembers },
   { metricKey: 'adoption.directory_findable_members', metricUnit: 'members', sourcePlugin: 'directory', compute: directoryFindableMembers },
   { metricKey: 'adoption.mood_checkins', metricUnit: 'check-ins', sourcePlugin: 'mood', compute: moodCheckins },
   { metricKey: 'adoption.mood_average', metricUnit: '', sourcePlugin: 'mood', compute: moodAverage },


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

Weekly Performance had no reading for daily active users. The 2026-07-18 metric rebuild dropped every sign-in number, so the dashboard could say what members had *done* that week but not how many of them turned up. The only active-user figure left in the plugin was a rolling last-7-days count that `GET /api/weekly-performance/current-week` returns and no screen renders.

## What changed

One new adoption row, `adoption.daily_active_members`, computed per selected week in `ctf/packages/web/lib/weekly-performance/live-metrics.ts` from `login_events`:

- **What it is:** the average number of distinct members active on a day of that week. It shows in the **Adoption** section as "Daily Active Members" and reads e.g. `12.43 per day`.
- **Counting:** `login_events` holds at most one row per member per UTC day, so one row is one member-day. The count is still taken as distinct (member, day) pairs so a database cloned before the once-per-day unique index existed cannot inflate the average with duplicate rows.
- **Divisor:** the number of days of the week window that have already started (1–7). The live current week averages over the days it has actually had rather than being watered down by days that have not happened yet; every past week divides by the full 7.
- **Adoption, not value:** signing in is not a plugin's defining action, so it carries no weight in value scoring — it sits under Adoption on purpose, alongside the other honest non-value rows.
- **Privacy:** aggregate only. No member is ever named, and the query is table-existence-guarded like every other metric, so a missing table reads 0 rather than breaking the dashboard.

It joins the week-over-week comparison like every other row, so a week's figure gets a delta against the prior week.

## Supporting updates

- `ctf/config/canonical_metrics.yaml` — registers `wp_adoption_daily_active_members` with its formula and inputs.
- `ctf/docs/contracts/WEEKLY_PERFORMANCE_PLUGIN_COMMAND_CONTRACTS.yaml` — adds `login_events` to the `dataAccess` lists of `weekly-performance.metrics.get` and `weekly-performance.comparison.get`.
- `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-weekly-performance-feature-inventory.md` — new change-log entry, and section 6's metric list is replaced: it still described the pre-2026-07-18 set (`members.total`, `engagement.daily_active`, feed counts…) and no longer matched the code.
- `ctf/docs/developer/test-scripts/weekly-performance-test-script.md` — the WP-A3 metric walkthrough now covers the new card.

No schema change, no new route, no access-policy change.

## Checks run locally

Typecheck (all packages), lint, `pnpm --filter @ctf/web build`, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs` — all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EhzGx36SFkWhd4srAvfa9t)_