### PR TITLE
fix: make the LevelUp admin and member sides count the same enrollment rows

### DIFF
--- a/ctf/docs/contracts/LEVEL_UP_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/LEVEL_UP_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -75,6 +75,32 @@ policies:
       - cohort_closed
 
   - pluginId: level-up
+    command: enrollment.list
+    version: 1.0.0
+    requiredRoles:
+      - member
+      - trainer
+      - admin
+    attributePolicies:
+      tenancy: same_workspace
+      # The read is filtered by the caller's own user id in the repository query; no id comes from
+      # the request, so an admin calling it still sees only their own enrollments.
+      scope: self_only
+    consentRequirements:
+      scopes:
+        - level_up_read
+      fallbackLawfulBasis: contract_performance
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: false
+    denyConditions:
+      - profile_not_approved
+
+  - pluginId: level-up
     command: milestone.validate
     version: 1.0.0
     requiredRoles:

--- a/ctf/docs/contracts/LEVEL_UP_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/LEVEL_UP_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -87,6 +87,27 @@ contracts:
     idempotency: true
 
   - pluginId: level-up
+    command: enrollment.list
+    version: 1.0.0
+    description: >-
+      List the calling member's own cohort enrollments with a per-enrollment milestone tally.
+      Read-only and always scoped to the caller — it takes no user id and can return no one else's
+      enrollments.
+    inputSchema: {}
+    outputSchema:
+      enrollments:
+        type: array
+    dataAccess:
+      - level_up_enrollments
+      - level_up_cohorts
+      - level_up_trainers
+      - level_up_enrollment_milestone_escrows
+      - level_up_milestone_validations
+    purpose: training_enrollment_self_view
+    retentionClass: derived_short_lived
+    idempotency: true
+
+  - pluginId: level-up
     command: milestone.validate
     version: 1.0.0
     description: Record trainer/admin validation for milestone completion.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
@@ -17,6 +17,7 @@
 6. Trainers directory (read-only browse): survivor-advocate trainer profiles with headline, bio, tracks, and active-cohort count.
 7. Achievements (grant-only badges): badge definitions with the signed-in user's earned status. Badges are awarded, never bought or spent.
 8. Credits Wallet (grant-only view): the signed-in user's ServiceCredits balance, total earned through LevelUp, escrow held, and a read-only history of credits earned/granted. Exposes no spend or transfer action.
+9. Your own cohorts, on every visit (2026-08-15). Browse shows **My Cohorts** — how many cohorts you are in right now — and Progress lists each one with its milestone count (for example "2/5") and your trainer's name; a cohort you have already joined shows "✓ Enrolled" instead of an Enroll button. Before this the member screen only remembered cohorts you joined during that same visit, so coming back later showed zero and an empty Progress tab. Finished cohorts read "Completed" and ones you left read "You left this cohort", so the count of cohorts you are in never quietly includes them. If the read fails, the count shows a dash and a note explains that it could not be read — it never shows a "0" that would look like you are not enrolled anywhere.
 
 ## Implemented Trainer Features
 
@@ -34,9 +35,10 @@
 
 1. Admin credit grant endpoint (`mint`/`adjustment` path), wired to a real admin UI on both web and Android. Owner decision (2026-06-06): the admin UI is grant-only — it only ever grants ServiceCredits to a member ("earn or earn nothing") and exposes no remove/negative path; the amount input accepts positive values only and submit is disabled client-side for non-positive amounts. (The backend endpoint still technically accepts a signed amount so a mistaken grant can be corrected later, but the UI never sends a negative.) Every grant requires a member user ID, an amount greater than zero, a reason, and a governance ticket ID, and goes behind an explicit in-screen confirm step that restates exactly what will change ("add N credits to member X") before submit. The mutation carries the `x-ctf-csrf: '1'` header and is written to the audit log.
 2. Dispute resolution endpoint with optional adjustment transfer.
-3. Admin panel with operational KPIs (enrollments, completions, avg days to first trainer payout) plus a read-only cohort overview (title, track, status, seats open, required deposit, trainer split, completion bonus) from `GET /api/level-up/cohorts`.
+3. Admin panel with operational KPIs plus a read-only cohort overview (title, track, status, seats open, required deposit, trainer split, completion bonus) from `GET /api/level-up/cohorts`.
 4. Cohort proposal queue (issue #904, proposal-queue model — owner decision 2026-07-23): a ranked, sector-diverse list of proposed cohorts derived from the Workforce talent gaps. Each row shows the occupation, sector, and gap, with a 1/3/5-month **term** selector and **Approve & open** / **Dismiss** actions; a **Refresh proposals** button re-reads the current gaps. Approving opens a real cohort (the admin picks the term); dismissing removes the proposal. The admin cohort overview shows `auto` and `needs trainer` badges on cohorts opened from proposals that have no human trainer yet.
 5. Review queues on the admin panel — **actionable since 2026-08-05** (`lu-review-actions.tsx`): **Open disputes** (`level_up_disputes` `status='open'`, newest first, with title, description, opener name, and time) each carry a **Resolve…** control (a written resolution posted to `POST /api/level-up/disputes/:id/resolve`; credit adjustments deliberately stay out of the form — an adjustment case goes through the ServiceCredits admin). **Pending milestone validations** (`level_up_milestone_validations` `status='pending'`, newest first) each carry **Validate** and **Release credits** buttons calling the live milestone routes (the server stays the referee on ordering; a row missing its cohort id shows a handle-via-API note instead of a broken button). Cohorts flagged `needs trainer` carry a **Claim as trainer** button (`POST /api/level-up/cohorts/:id/claim-trainer`). Both queue lists are server-rendered from `getAdminPanelData()` and drive the admin-landing "new to review" dot; a completed action re-pulls them via `router.refresh()`.
+6. KPI cards that each say which question they answer (2026-08-15). The panel shows **Members in a cohort now** (distinct people holding a live enrollment), **Active enrollments** (the live enrollment rows themselves — one member in three cohorts is three of these), **Enrollments, all time** (every enrollment row ever written, including left and finished ones), **Completions**, and **Avg days to first trainer credit grant**. All the enrollment numbers come from one pass over `level_up_enrollments` in `getAdminPanelData()`, so they cannot disagree with each other. Before this there was a single card labeled "Enrollments" carrying the all-time row count, which was read as a headcount of people.
 
 ## Cohort Proposals from Workforce Gaps (issue #904)
 
@@ -99,6 +101,7 @@ deferred. That future model is where `max_concurrent` becomes load-bearing again
 - `POST /api/level-up/admin/cohort-proposals/[proposalId]/approve` — admin-only; opens a cohort from a pending proposal with a chosen term of 1/3/5 months; CSRF-guarded (per `cohort.proposal_approve` contract).
 - `POST /api/level-up/admin/cohort-proposals/[proposalId]/dismiss` — admin-only; removes a pending proposal from the queue; CSRF-guarded (per `cohort.proposal_dismiss` contract).
 - `POST /api/level-up/enroll` — member or admin only; trainer-only accounts are blocked (per `enrollment.create` contract).
+- `GET /api/level-up/enrollments` — the calling member's own enrollments, each with cohort title/track, assigned trainer name, status, an `isCurrent` flag (true while the status is `enrolled` or `active`), and a milestone tally (`milestoneTotal` / `milestoneCompleted`, counting `validated` and `released` validations). Read-only, capped at 50, newest first. Scoped to the caller inside the repository query — it accepts no user id, so an admin calling it still gets only their own rows (per `enrollment.list` contract).
 - `POST /api/level-up/milestones/[milestoneId]/validate`
 - `POST /api/level-up/milestones/[milestoneId]/release`
 - `POST /api/level-up/transfers` — self-transfer (recipient equals actor) is rejected with 400.
@@ -118,7 +121,7 @@ Core tables:
 1. `level_up_cohorts`
 2. `level_up_curriculum_items`
 3. `level_up_milestones`
-4. `level_up_enrollments`
+4. `level_up_enrollments` — one row per member per cohort (unique on `(cohort_id, user_id)`). Columns: `id` (PK), `cohort_id`, `user_id`, `status`, `credits_deposited`, `assigned_trainer_id`, `enrolled_at`, `progress_percent`, `created_at`, `updated_at`. `status` is `enrolled` on insert (`active` on rows written before the value changed) and moves to `completed` or `dropped`; every read that means "a live enrollment" matches `('enrolled', 'active')`, and both `enrolled` and `pending` are in the check constraint. `enrolled_at` was corrected into `ctf/schema.sql` on 2026-08-15 — it had always existed on the long-running database but a freshly built one lacked it while three reads order or measure by it.
 5. `level_up_enrollment_milestone_escrows`
 6. `level_up_milestone_validations`
 7. `level_up_disbursements`
@@ -189,7 +192,9 @@ the design mockup (`MobileLevelUp.tsx` / `MobileLevelUpEmpty.tsx` / `MobileLevel
 `MobileLevelUpPublic.tsx`), covering loading / empty / main states. Real-data-only: binds
 `GET /api/level-up/cohorts` and `GET /api/service-credits/wallet`; `MockLevelUp.tsx` retired.
 Unbacked mockup elements omitted: `trainerName`, `tags`, `milestoneCount` (not returned by cohorts
-list endpoint); active-enrollment banner (no user-enrollment GET endpoint yet).
+list endpoint); active-enrollment banner (no user-enrollment GET endpoint at the time). The web shell
+gained that read on 2026-08-15 (`GET /api/level-up/enrollments`); the Android screen still does not
+call it — LevelUp is off the Android keep-list per rule 105, so the web app is its only surface.
 
 Trainers / Achievements / Credits Wallet (2026-06-07): the three former "coming soon" sidebar sections
 are now real, backed surfaces on web and Android. Web: `lu-trainers.tsx`, `lu-achievements.tsx`,
@@ -228,12 +233,10 @@ that exist today.
 
 0. **The member has no in-app way to OPEN a dispute, and a non-admin trainer has no in-app
    validate/release/claim surface.** (History-checked 2026-08-05: never built on any platform.)
-   The admin side became actionable 2026-08-05 (see Admin Features #5), but the member-side dispute
-   form is blocked on a missing own-enrollments read endpoint — the member shell only knows about
-   enrollments made in the current session (the same missing `GET` noted in the delivery-status
-   "active-enrollment banner" line), so a member who enrolled earlier has no enrollment to attach a
-   dispute to. Order of work when built: add the own-enrollments read route (+ contract), then the
-   dispute form on the Progress tab, then the trainer surface (which can reuse
+   The admin side became actionable 2026-08-05 (see Admin Features #5). The blocker named here — a
+   missing own-enrollments read — was cleared on 2026-08-15 by `GET /api/level-up/enrollments`, which
+   gives the Progress tab a real `enrollmentId` per row to attach a dispute to. Remaining order of
+   work: the dispute form on the Progress tab, then the trainer surface (which can reuse
    `getTrainerDashboardData` behind a trainer-gated read route).
 1. Dispute attachment storage uses URL metadata only (no secure file storage backend). This is a known limitation; full storage integration is a future optimization.
 2. No admin KPI read endpoint exists; the web admin page renders KPIs from server-side `getAdminPanelData()` and the Android admin screen has no KPI cards (no GET route to call). Add a `GET /api/level-up/admin/kpis` route to give the mobile screen the same KPI cards as web.
@@ -243,6 +246,34 @@ that exist today.
 
 ## Change Log
 
+- 2026-08-15: **The admin and the member now count the same enrollment rows (owner report: "admin
+  says 3 people enrolled but the member side says 3 cohorts are open, not members").** Three separate
+  causes, all fixed here.
+  (1) *The member side could not see its own enrollments at all.* No route returned them, so the shell
+  held them in React state only: the Browse count and the Progress tab were correct for a cohort you
+  joined in that same visit and empty on every later visit, and a cohort you were already in still
+  offered an Enroll button. New read `GET /api/level-up/enrollments` (`listMemberEnrollments`, scoped
+  to the caller by user id, capped at 50, newest first) returns each enrollment with its cohort title
+  and track, the assigned trainer's name, the status, an `isCurrent` flag, and a milestone tally. The
+  shell loads it with the cohorts and seeds the already-enrolled set from it; a failure there shows a
+  dash and a plain note instead of a "0". New `enrollment.list` command and access-policy contracts.
+  (2) *The one admin number was labeled ambiguously and counted every row of any status.* The panel's
+  "Enrollments" card was `COUNT(*)` over `level_up_enrollments`, so left and finished enrollments were
+  in it and one member in three cohorts counted three times — a row count that reads as a headcount.
+  `getAdminPanelData()` now does one pass over the table and returns `membersEnrolled` (distinct people
+  with a live enrollment), `activeEnrollments`, `enrollments` (all time), and `completions`; the panel
+  shows each under a label that says which it is. The single pass also means the numbers cannot drift
+  apart from each other.
+  (3) *The member's "Enrolled" card sat under a people icon next to a site-wide "Open Cohorts" count,*
+  which invited reading it as everyone enrolled. It reads **My Cohorts** with a bookmark icon and counts
+  only cohorts you are in right now.
+  Also fixed in `ctf/schema.sql`, both affecting a freshly built database only: `level_up_enrollments`
+  gains the `enrolled_at` column (it exists on the long-running database, came over with the legacy
+  `levelup_enrollments` table, but was never declared here — three live reads order or measure by it),
+  and its `status` check now allows `enrolled`, the value the enrollment insert actually writes (a fresh
+  database rejected every enrollment). The long-running database is unchanged by both: the column is
+  already there and the check lives in the `CREATE TABLE` block that a table which already exists never
+  runs. Web-only; LevelUp has no Android surface to match (rule 105).
 - 2026-08-05: **The admin review queues act (closes "read-only lists" scope, part of the inventory
   audit).** The history check found five live, hardened LevelUp routes with zero UI callers on any
   platform, ever. The admin panel's queues are now actionable via the new `lu-review-actions.tsx`

--- a/ctf/docs/developer/test-scripts/level-up-test-script.md
+++ b/ctf/docs/developer/test-scripts/level-up-test-script.md
@@ -119,7 +119,31 @@ Result: web ☐
 **Expected:**
 - Enrollment succeeds — the button flips to "✓ Enrolled" and **no** "Invalid LevelUp payload." error banner appears.
 - Wallet balance is unchanged and no escrow is held (a free cohort deposits nothing).
-- The Enrolled stat count increases by one.
+- The **My Cohorts** stat count increases by one.
+
+Result: web ☐
+
+---
+
+### LU-3c — Your cohorts survive leaving and coming back
+
+**Role:** member · **Surfaces:** web
+**Precondition:** Signed in as a member who is already enrolled in at least one cohort (complete LU-3 or LU-3b first, then navigate away from LevelUp entirely).
+
+**Steps:**
+1. Open `/apps/level-up` fresh (a full page reload, not a tab switch).
+2. Read the **My Cohorts** card on Browse.
+3. Find the cohort you enrolled in earlier in the cohort list.
+4. Open the **Progress** tab.
+
+**Steps to check the failure case:**
+5. Block or fail `GET /api/level-up/enrollments` (offline, or block the request in the browser tools) and reload.
+
+**Expected:**
+- **My Cohorts** shows the number of cohorts you are in — not 0. It counts only live ones: a cohort you completed or left is not in it.
+- The cohort you already joined shows "✓ Enrolled" and offers no Enroll button.
+- Progress lists each cohort with its milestone count (for example "2/5") and your trainer's name; it does not say "Not enrolled yet". A finished cohort with no milestones reads "Completed" and one you left reads "You left this cohort".
+- In the failure case: **My Cohorts** shows a dash (—) and a note says the cohorts you are in could not be read and to refresh. It never shows "0", which would look like you are not enrolled anywhere.
 
 Result: web ☐
 
@@ -338,7 +362,9 @@ Result: web ☐
 3. Inspect the cohort overview table below.
 
 **Expected:**
-- KPI cards show enrollments, completions, and avg days to first trainer payout (values may be 0 for a fresh seed; they must not be blank or "undefined").
+- KPI cards show **Members in a cohort now**, **Active enrollments**, **Enrollments, all time**, **Completions**, and **Avg days to first trainer credit grant** (values may be 0 for a fresh seed; they must not be blank or "undefined").
+- The three enrollment numbers agree with each other: "Members in a cohort now" is never larger than "Active enrollments", and "Active enrollments" is never larger than "Enrollments, all time".
+- Cross-check against the member side: enroll one member in two cohorts, then reload this page. "Active enrollments" goes up by two and "Members in a cohort now" goes up by one — a row count and a headcount, not the same number under two names.
 - Cohort overview table shows title, track, status, seats open, required deposit, trainer split, and completion bonus for the seed cohort.
 - The page uses the shared dark admin design system (dark tokens, icon header with ADMIN badge).
 

--- a/ctf/packages/web/app/api/level-up/enrollments/route.ts
+++ b/ctf/packages/web/app/api/level-up/enrollments/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { listMemberEnrollments } from 'lib/level-up/repository';
+import { levelUpErrorResponse, requireLevelUpReadAccess } from 'lib/level-up/_lib';
+import { reportError } from 'lib/observability/report';
+
+// The signed-in member's own cohort enrollments. Scoped to the caller by user id inside the
+// repository read — there is no way to ask for anyone else's, and no id is accepted from the request.
+// Read-only: it moves no ServiceCredits and changes no row.
+export async function GET() {
+  const gate = await requireLevelUpReadAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  try {
+    const enrollments = await listMemberEnrollments(gate.auth.userId);
+    return NextResponse.json({ ok: true, enrollments });
+  } catch (error) {
+    reportError(error, { area: 'level-up', op: 'enrollments' });
+    return levelUpErrorResponse(error, 'Your enrollments are unavailable.');
+  }
+}

--- a/ctf/packages/web/components/level-up/level-up-shell.tsx
+++ b/ctf/packages/web/components/level-up/level-up-shell.tsx
@@ -39,6 +39,16 @@ async function fetchCohorts(track: string, signal: AbortSignal): Promise<Cohort[
   return Array.isArray(data) ? data : (data.cohorts ?? []);
 }
 
+// The signed-in member's own enrollments. Without this read the shell knew only about enrollments
+// made in the current visit, so a member who enrolled yesterday saw "0" on Browse and an empty
+// Progress tab while the admin panel counted those same rows.
+async function fetchEnrollments(signal: AbortSignal): Promise<Enrollment[]> {
+  const res = await fetch("/api/level-up/enrollments", { signal });
+  if (!res.ok) throw new Error("Failed to load your enrollments");
+  const data = (await res.json()) as { enrollments?: Enrollment[] };
+  return data.enrollments ?? [];
+}
+
 async function fetchWallet(signal: AbortSignal): Promise<Wallet | null> {
   const res = await fetch("/api/service-credits/wallet", { signal });
   if (!res.ok) return null;
@@ -150,6 +160,7 @@ export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: b
   const [enrollingId, setEnrollingId] = useState<string | null>(null);
   const [enrolledIds, setEnrolledIds] = useState<Set<string>>(new Set());
   const [enrollError, setEnrollError] = useState<string | null>(null);
+  const [enrollmentsError, setEnrollmentsError] = useState<string | null>(null);
   const [trainers, setTrainers] = useState<Trainer[]>([]);
   const [achievements, setAchievements] = useState<Achievement[]>([]);
   const [walletView, setWalletView] = useState<WalletView | null>(null);
@@ -162,6 +173,21 @@ export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: b
     // display instead of flashing the loading state.
     if (!background) setLoading(true);
     setError(null);
+    setEnrollmentsError(null);
+    // The member's own enrollments load alongside the cohorts, but a failure there does not blank the
+    // screen: browsing still works, and the Browse count reports that it could not be read instead of
+    // showing a "0" that would be indistinguishable from genuinely not being enrolled anywhere.
+    const enrollmentsPromise = fetchEnrollments(signal).then(
+      (rows) => {
+        if (signal.aborted) return;
+        setEnrollments(rows);
+        setEnrolledIds(new Set(rows.filter((row) => row.isCurrent).map((row) => row.cohortId)));
+      },
+      (e: unknown) => {
+        if (signal.aborted) return;
+        setEnrollmentsError(e instanceof Error ? e.message : "Failed to load your enrollments.");
+      },
+    );
     try {
       const [cohortsData, walletData] = await Promise.all([fetchCohorts(track, signal), fetchWallet(signal)]);
       if (signal.aborted) return;
@@ -171,6 +197,7 @@ export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: b
       if (signal.aborted) return;
       setError(e instanceof Error ? e.message : "Failed to load LevelUp.");
     } finally {
+      await enrollmentsPromise;
       if (!signal.aborted && !background) setLoading(false);
     }
   }, [track]);
@@ -229,8 +256,24 @@ export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: b
         const d = (await res.json()) as { error?: string; message?: string };
         throw new Error(d.error ?? d.message ?? "Enrollment failed");
       }
+      const created = (await res.json()) as { enrollment?: { enrollmentId?: string } };
       setEnrolledIds((prev) => new Set([...prev, cohort.id]));
-      setEnrollments((prev) => [...prev, { cohortId: cohort.id, title: cohort.title, track: cohort.track, trainerName: cohort.trainerName, milestones: [], completedCount: 0 }]);
+      // Optimistic row so the count and the Progress tab move immediately; the next load replaces it
+      // with the server's version, including the milestone tally the response does not carry.
+      setEnrollments((prev) => [
+        ...prev,
+        {
+          enrollmentId: created.enrollment?.enrollmentId ?? cohort.id,
+          cohortId: cohort.id,
+          status: "enrolled",
+          isCurrent: true,
+          title: cohort.title,
+          track: cohort.track,
+          trainerName: cohort.trainerName,
+          milestoneTotal: 0,
+          milestoneCompleted: 0,
+        },
+      ]);
     } catch (e: unknown) {
       setEnrollError(e instanceof Error ? e.message : "Enrollment failed.");
     } finally {
@@ -254,7 +297,8 @@ export function LevelUpShell({ isAdmin = false }: { userId?: string; isAdmin?: b
           <LevelUpBrowse
             cohorts={filtered}
             openCount={openCount}
-            enrolledCount={enrollments.length}
+            enrolledCount={enrollments.filter((enr) => enr.isCurrent).length}
+            enrolledCountError={enrollmentsError}
             escrow={escrow}
             search={search}
             onSearch={setSearch}

--- a/ctf/packages/web/components/level-up/lu-admin-shared.ts
+++ b/ctf/packages/web/components/level-up/lu-admin-shared.ts
@@ -57,8 +57,14 @@ export type AdminProposal = {
 export const PROPOSAL_TERM_MONTHS = [1, 3, 5] as const;
 export type ProposalTermMonths = (typeof PROPOSAL_TERM_MONTHS)[number];
 
+// Headline numbers on the admin panel. `enrollments` counts every enrollment row ever written (a
+// member in three cohorts contributes three), `activeEnrollments` counts only the live ones, and
+// `membersEnrolled` counts the distinct people behind those live rows — three different questions
+// that a single "Enrollments" number used to be asked to answer at once.
 export type AdminKpis = {
   enrollments: number;
+  activeEnrollments: number;
+  membersEnrolled: number;
   completions: number;
   avgDaysToFirstTrainerPayout: number;
 };

--- a/ctf/packages/web/components/level-up/lu-admin-shell.tsx
+++ b/ctf/packages/web/components/level-up/lu-admin-shell.tsx
@@ -810,7 +810,13 @@ export function LevelUpAdminShell({
             height for no new information (owner report, 2026-07-27). */}
         {/* KPIs */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 24 }}>
-          <StatBlock label="Enrollments" value={String(kpis.enrollments)} />
+          {/* "Enrollments" on its own was read as a headcount, but it counts enrollment rows — one
+              member in three cohorts is three of them (owner report). Each number now says which
+              question it answers: people currently in a cohort, live enrollments, and every
+              enrollment ever written. */}
+          <StatBlock label="Members in a cohort now" value={String(kpis.membersEnrolled)} />
+          <StatBlock label="Active enrollments" value={String(kpis.activeEnrollments)} />
+          <StatBlock label="Enrollments, all time" value={String(kpis.enrollments)} />
           <StatBlock label="Completions" value={String(kpis.completions)} />
           <StatBlock label="Avg days to first trainer credit grant" value={`${kpis.avgDaysToFirstTrainerPayout} days`} />
         </div>

--- a/ctf/packages/web/components/level-up/lu-browse.tsx
+++ b/ctf/packages/web/components/level-up/lu-browse.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, CheckCircle, Search, Users } from "lucide-react";
+import { BookMarked, BookOpen, CheckCircle, Search } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { getLevelUpTokens, type Cohort } from "./lu-shared";
 import { LevelUpCohortCard } from "./lu-cohort-card";
@@ -9,6 +9,7 @@ export function LevelUpBrowse({
   cohorts,
   openCount,
   enrolledCount,
+  enrolledCountError,
   escrow,
   search,
   onSearch,
@@ -20,6 +21,7 @@ export function LevelUpBrowse({
   cohorts: Cohort[];
   openCount: number;
   enrolledCount: number;
+  enrolledCountError: string | null;
   escrow: number;
   search: string;
   onSearch: (value: string) => void;
@@ -30,9 +32,13 @@ export function LevelUpBrowse({
 }) {
   const { theme } = useTheme();
   const t = getLevelUpTokens(theme);
+  // All three cards are about you, not about the whole site: how many cohorts are open to join, how
+  // many you are in, and how many of your credits are held. The middle card used to read just
+  // "Enrolled" next to a people icon, which invited reading it as a count of everyone enrolled
+  // site-wide (owner report). It is your own count, so it says so.
   const stats = [
     { label: "Open Cohorts", value: String(openCount), icon: BookOpen, color: t.ACCENT },
-    { label: "Enrolled", value: String(enrolledCount), icon: Users, color: "#3B82F6" },
+    { label: "My Cohorts", value: enrolledCountError ? "—" : String(enrolledCount), icon: BookMarked, color: "#3B82F6" },
     { label: "In Escrow", value: `${escrow.toLocaleString()} SC`, icon: CheckCircle, color: "#F59E0B" },
   ];
 
@@ -63,6 +69,13 @@ export function LevelUpBrowse({
             style={{ background: "transparent", border: "none", outline: "none", fontSize: 12, color: t.TEXT_BODY, width: 140 }} />
         </div>
       </div>
+
+      {enrolledCountError && (
+        <div style={{ marginBottom: 16, padding: "10px 14px", borderRadius: 10, background: "rgba(245,158,11,0.08)", border: "1px solid rgba(245,158,11,0.25)", fontSize: 13, color: "#F59E0B" }}>
+          Could not read the cohorts you are in ({enrolledCountError}), so &ldquo;My Cohorts&rdquo; shows a dash and a
+          cohort you already joined may still offer an Enroll button. Refresh to try again.
+        </div>
+      )}
 
       {enrollError && (
         <div style={{ marginBottom: 16, padding: "10px 14px", borderRadius: 10, background: "rgba(239,68,68,0.08)", border: "1px solid rgba(239,68,68,0.25)", fontSize: 13, color: "#EF4444" }}>

--- a/ctf/packages/web/components/level-up/lu-progress.tsx
+++ b/ctf/packages/web/components/level-up/lu-progress.tsx
@@ -6,6 +6,14 @@ import { getLevelUpTokens, type Enrollment, enrollmentPct } from "./lu-shared";
 
 const STEPS = ["Choose a cohort", "Pay credits into escrow", "Complete milestones", "Trainer validates & credits release"];
 
+// What to say on a cohort that has no milestones to show a bar for. The default line assumes the
+// cohort simply has not started; a finished or left cohort needs its own line so it is not described
+// as still waiting to begin.
+const PLACEHOLDER_NOTE: Record<string, string> = {
+  completed: "Completed",
+  dropped: "You left this cohort",
+};
+
 function EmptyProgress({ onBrowse }: { onBrowse: () => void }) {
   const { theme } = useTheme();
   const t = getLevelUpTokens(theme);
@@ -43,21 +51,21 @@ export function LevelUpProgress({ enrollments, onBrowse }: { enrollments: Enroll
       {enrollments.map((enr) => {
         const pct = enrollmentPct(enr);
         return (
-          <div key={enr.cohortId} style={{ background: t.SURFACE, borderRadius: 12, padding: "18px", border: `1px solid ${t.BORDER_SOLID}` }}>
+          <div key={enr.enrollmentId} style={{ background: t.SURFACE, borderRadius: 12, padding: "18px", border: `1px solid ${t.BORDER_SOLID}` }}>
             <div style={{ fontSize: 15, fontWeight: 600, color: t.TEXT_BODY, marginBottom: 4 }}>{enr.title}</div>
             {enr.trainerName && <div style={{ fontSize: 12, color: t.TEXT_SUBTLE, marginBottom: 12 }}>with {enr.trainerName}</div>}
-            {enr.milestones.length > 0 ? (
+            {enr.milestoneTotal > 0 ? (
               <div>
                 <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, color: t.TEXT_SUBTLE, marginBottom: 4 }}>
                   <span>Milestones</span>
-                  <span style={{ color: pct === 100 ? t.ACCENT : t.TEXT_BODY }}>{enr.completedCount}/{enr.milestones.length}</span>
+                  <span style={{ color: pct === 100 ? t.ACCENT : t.TEXT_BODY }}>{enr.milestoneCompleted}/{enr.milestoneTotal}</span>
                 </div>
                 <div style={{ height: 6, background: t.BORDER_SOLID, borderRadius: 99 }}>
                   <div style={{ width: `${pct}%`, height: "100%", background: pct === 100 ? t.ACCENT : "#3B82F6", borderRadius: 99 }} />
                 </div>
               </div>
             ) : (
-              <div style={{ fontSize: 12, color: t.TEXT_SUBTLE }}>Enrolled — awaiting cohort start</div>
+              <div style={{ fontSize: 12, color: t.TEXT_SUBTLE }}>{PLACEHOLDER_NOTE[enr.status] ?? "Enrolled — awaiting cohort start"}</div>
             )}
           </div>
         );

--- a/ctf/packages/web/components/level-up/lu-shared.ts
+++ b/ctf/packages/web/components/level-up/lu-shared.ts
@@ -88,21 +88,20 @@ export interface Cohort {
   startDate?: string;
 }
 
-export interface Milestone {
-  id: string;
-  name?: string;
-  percentRelease?: number;
-  requiredTask?: string;
-  status?: string;
-}
-
+// One of the signed-in member's own enrollments, exactly as GET /api/level-up/enrollments returns it.
+// `isCurrent` is true while the enrollment is live (server statuses `enrolled` / `active`) and false
+// once it is completed or dropped, so the Browse count can say how many cohorts you are in right now
+// rather than how many you have ever joined.
 export interface Enrollment {
+  enrollmentId: string;
   cohortId: string;
+  status: string;
+  isCurrent: boolean;
   title: string;
   track?: string;
-  trainerName?: string;
-  milestones: Milestone[];
-  completedCount: number;
+  trainerName?: string | null;
+  milestoneTotal: number;
+  milestoneCompleted: number;
 }
 
 export interface Wallet {
@@ -156,5 +155,5 @@ export function idempotencyKey(): string {
 }
 
 export function enrollmentPct(enr: Enrollment): number {
-  return enr.milestones.length > 0 ? Math.round((enr.completedCount / enr.milestones.length) * 100) : 0;
+  return enr.milestoneTotal > 0 ? Math.round((enr.milestoneCompleted / enr.milestoneTotal) * 100) : 0;
 }

--- a/ctf/packages/web/lib/level-up/repository.ts
+++ b/ctf/packages/web/lib/level-up/repository.ts
@@ -1274,6 +1274,63 @@ export async function getUserDashboardData(userId: string) {
   };
 }
 
+// The signed-in member's own enrollments, with a milestone tally per row.
+//
+// Why this exists: the member shell used to hold enrollments only in React state, so it knew about an
+// enrollment only if you made it in that same visit. On a fresh page load the member saw "0 enrolled"
+// and an empty Progress tab while the admin panel counted the very same rows — the mismatch the owner
+// reported. This is the read that lets the member side count from the same table the admin counts.
+//
+// `enrolled`/`active` are the two statuses a live enrollment carries (`enrolled` is what
+// `createEnrollmentDraftTx` writes; `active` is the legacy value); `completed` and `dropped` are the
+// terminal ones. All are returned — the caller decides what to show — and `isCurrent` marks the live
+// ones so a count of "cohorts I am in" never quietly includes one I dropped.
+export async function listMemberEnrollments(userId: string) {
+  const result = await queryDb<{
+    enrollment_id: string;
+    cohort_id: string;
+    status: string;
+    title: string;
+    track: string;
+    trainer_name: string | null;
+    milestone_total: number;
+    milestone_completed: number;
+  }>(
+    `SELECT
+       n.id::text AS enrollment_id,
+       n.cohort_id::text AS cohort_id,
+       n.status,
+       c.title,
+       c.track,
+       t.display_name AS trainer_name,
+       COUNT(e.milestone_id)::int AS milestone_total,
+       COUNT(*) FILTER (WHERE v.status IN ('validated', 'released'))::int AS milestone_completed
+     FROM level_up_enrollments n
+     JOIN level_up_cohorts c ON c.id = n.cohort_id
+     LEFT JOIN level_up_trainers t ON t.user_id = n.assigned_trainer_id
+     LEFT JOIN level_up_enrollment_milestone_escrows e ON e.enrollment_id = n.id
+     LEFT JOIN level_up_milestone_validations v
+       ON v.enrollment_id = e.enrollment_id AND v.milestone_id = e.milestone_id
+     WHERE n.user_id = $1
+     GROUP BY n.id, n.cohort_id, n.status, n.enrolled_at, c.title, c.track, t.display_name
+     ORDER BY n.enrolled_at DESC
+     LIMIT 50`,
+    [userId],
+  );
+
+  return result.rows.map((row) => ({
+    enrollmentId: row.enrollment_id,
+    cohortId: row.cohort_id,
+    status: row.status,
+    isCurrent: row.status === 'enrolled' || row.status === 'active',
+    title: row.title,
+    track: row.track,
+    trainerName: row.trainer_name,
+    milestoneTotal: Number(row.milestone_total),
+    milestoneCompleted: Number(row.milestone_completed),
+  }));
+}
+
 export async function getTrainerDashboardData(trainerUserId: string) {
   const [cohorts, pendingValidations, trainees, payouts] = await Promise.all([
     queryDb<{ id: string; title: string; status: string; track: string }>(
@@ -1430,9 +1487,20 @@ export async function listPendingMilestoneValidations(limit = 100): Promise<Leve
 }
 
 export async function getAdminPanelData() {
-  const [enrollments, completions, avgLeadDays, openDisputes, pendingValidations] = await Promise.all([
-    queryDb<{ total: string }>(`SELECT COUNT(*)::text AS total FROM level_up_enrollments`),
-    queryDb<{ total: string }>(`SELECT COUNT(*)::text AS total FROM level_up_enrollments WHERE status = 'completed'`),
+  const [enrollmentCounts, avgLeadDays, openDisputes, pendingValidations] = await Promise.all([
+    // One pass over the enrollment rows for every headline number, so the counts can never disagree
+    // with each other. `enrollments` is every row ever written (a member who joins three cohorts
+    // contributes three), `membersEnrolled` is how many distinct people are in a cohort right now —
+    // those are different questions and the panel used to answer only the first while labeling it
+    // ambiguously, which is how a row count got read as a headcount.
+    queryDb<{ total: string; current_total: string; current_members: string; completed_total: string }>(
+      `SELECT
+         COUNT(*)::text AS total,
+         COUNT(*) FILTER (WHERE status IN ('enrolled', 'active'))::text AS current_total,
+         COUNT(DISTINCT user_id) FILTER (WHERE status IN ('enrolled', 'active'))::text AS current_members,
+         COUNT(*) FILTER (WHERE status = 'completed')::text AS completed_total
+       FROM level_up_enrollments`,
+    ),
     queryDb<{ avg_days: string }>(
       `WITH first_trainer_payout AS (
          SELECT enrollment_id, MIN(created_at) AS first_payout_at
@@ -1451,8 +1519,10 @@ export async function getAdminPanelData() {
 
   return {
     kpis: {
-      enrollments: Number(enrollments.rows[0]?.total ?? '0'),
-      completions: Number(completions.rows[0]?.total ?? '0'),
+      enrollments: Number(enrollmentCounts.rows[0]?.total ?? '0'),
+      activeEnrollments: Number(enrollmentCounts.rows[0]?.current_total ?? '0'),
+      membersEnrolled: Number(enrollmentCounts.rows[0]?.current_members ?? '0'),
+      completions: Number(enrollmentCounts.rows[0]?.completed_total ?? '0'),
       avgDaysToFirstTrainerPayout: roundCurrency(Number(avgLeadDays.rows[0]?.avg_days ?? '0')),
     },
     openDisputes,

--- a/ctf/packages/web/lib/level-up/repository.ts
+++ b/ctf/packages/web/lib/level-up/repository.ts
@@ -1486,6 +1486,25 @@ export async function listPendingMilestoneValidations(limit = 100): Promise<Leve
   }));
 }
 
+type AdminEnrollmentCountRow = {
+  total: string;
+  current_total: string;
+  current_members: string;
+  completed_total: string;
+};
+
+// Shapes the counted row into the panel's KPI numbers. Split out of getAdminPanelData so that
+// function stays inside the rule-116 complexity limit; every missing value reads as 0.
+function mapAdminEnrollmentKpis(row: AdminEnrollmentCountRow | undefined, avgLeadDays: string | undefined) {
+  return {
+    enrollments: Number(row?.total ?? '0'),
+    activeEnrollments: Number(row?.current_total ?? '0'),
+    membersEnrolled: Number(row?.current_members ?? '0'),
+    completions: Number(row?.completed_total ?? '0'),
+    avgDaysToFirstTrainerPayout: roundCurrency(Number(avgLeadDays ?? '0')),
+  };
+}
+
 export async function getAdminPanelData() {
   const [enrollmentCounts, avgLeadDays, openDisputes, pendingValidations] = await Promise.all([
     // One pass over the enrollment rows for every headline number, so the counts can never disagree
@@ -1493,7 +1512,7 @@ export async function getAdminPanelData() {
     // contributes three), `membersEnrolled` is how many distinct people are in a cohort right now —
     // those are different questions and the panel used to answer only the first while labeling it
     // ambiguously, which is how a row count got read as a headcount.
-    queryDb<{ total: string; current_total: string; current_members: string; completed_total: string }>(
+    queryDb<AdminEnrollmentCountRow>(
       `SELECT
          COUNT(*)::text AS total,
          COUNT(*) FILTER (WHERE status IN ('enrolled', 'active'))::text AS current_total,
@@ -1518,13 +1537,7 @@ export async function getAdminPanelData() {
   ]);
 
   return {
-    kpis: {
-      enrollments: Number(enrollmentCounts.rows[0]?.total ?? '0'),
-      activeEnrollments: Number(enrollmentCounts.rows[0]?.current_total ?? '0'),
-      membersEnrolled: Number(enrollmentCounts.rows[0]?.current_members ?? '0'),
-      completions: Number(enrollmentCounts.rows[0]?.completed_total ?? '0'),
-      avgDaysToFirstTrainerPayout: roundCurrency(Number(avgLeadDays.rows[0]?.avg_days ?? '0')),
-    },
+    kpis: mapAdminEnrollmentKpis(enrollmentCounts.rows[0], avgLeadDays.rows[0]?.avg_days),
     openDisputes,
     pendingValidations,
   };

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -39,9 +39,17 @@ CREATE TABLE IF NOT EXISTS click_log_incidents (
   -- column (not metadata) so it is excluded from the metadata_hash dedupe and toggling share state
   -- never collides with the UNIQUE (user_id, metadata_hash) constraint.
   shared_with_owner BOOLEAN NOT NULL DEFAULT FALSE,
-  -- Optional incident tags (2026-08-02; arrays since 2026-08-13 — see schema.sql for the full
-  -- note). The singular problem_tag/scheme_tag columns are superseded by the arrays: backfilled,
-  -- kept for history, no longer read or written by the app.
+  -- Optional incident tags (2026-08-02; arrays since 2026-08-13): a member may say which of the
+  -- 50+ known problems happened (problem_tags — slugs mirror the landing-page problems list)
+  -- and/or which named schemes were used (scheme_tags — slugs from the owner's "A post for each
+  -- gang stalker game" Discourse thread). Arrays because a real incident routinely chains
+  -- several schemes at once (owner decision, 2026-08-13); the API caps each list at 10.
+  -- Canonical slug lists live in packages/web/lib/click-log/tags.ts; the API validates against
+  -- them. Real columns (not metadata) so they are excluded from the metadata_hash dedupe —
+  -- mirroring shared_with_owner — and so the shared-trends aggregate can unnest them as coarse
+  -- categorical values without touching the metadata JSON. The singular problem_tag/scheme_tag
+  -- columns are superseded: backfilled into the arrays below, kept for history, no longer
+  -- read or written by the app.
   problem_tag TEXT,
   scheme_tag TEXT,
   problem_tags TEXT[] NOT NULL DEFAULT '{}',
@@ -54,6 +62,9 @@ ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS problem_tag T
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS scheme_tag TEXT;
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS problem_tags TEXT[] NOT NULL DEFAULT '{}';
 ALTER TABLE IF EXISTS click_log_incidents ADD COLUMN IF NOT EXISTS scheme_tags TEXT[] NOT NULL DEFAULT '{}';
+-- One-time backfill of the superseded singular tag columns into the arrays. Idempotent: only
+-- touches rows whose array is still empty while the singular column has a value, so re-running
+-- schema.sql never overwrites a member's later multi-tag edits.
 UPDATE click_log_incidents SET problem_tags = ARRAY[problem_tag]
   WHERE problem_tag IS NOT NULL AND problem_tags = '{}';
 UPDATE click_log_incidents SET scheme_tags = ARRAY[scheme_tag]
@@ -1534,9 +1545,15 @@ CREATE TABLE IF NOT EXISTS level_up_enrollments (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   cohort_id UUID NOT NULL,
   user_id TEXT NOT NULL,
-  status TEXT NOT NULL CHECK (status IN ('active', 'completed', 'dropped', 'pending')),
+  -- 'enrolled' is the value the enrollment insert actually writes; it was missing from this list, so
+  -- on a brand-new database every enrollment failed the check while the long-running database (whose
+  -- table predates this block) accepted them. 'active' stays for the rows written before the value
+  -- changed — both count as a live enrollment everywhere in the code.
+  status TEXT NOT NULL CHECK (status IN ('enrolled', 'active', 'completed', 'dropped', 'pending')),
   credits_deposited INTEGER NOT NULL DEFAULT 0,
   assigned_trainer_id TEXT,
+  enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  progress_percent NUMERIC NOT NULL DEFAULT 0,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (cohort_id, user_id)
@@ -1547,6 +1564,11 @@ ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS user_id TEXT
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS status TEXT;
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS credits_deposited INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS assigned_trainer_id TEXT;
+-- enrolled_at: when the member joined. It exists on the long-running database (it came over with the
+-- legacy `levelup_enrollments` table) but was never declared here, so a database built from this file
+-- lacked it while three live reads order or measure by it — the admin lead-time number, the trainer
+-- trainee list, and the member's own enrollment list.
+ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 -- Add unique constraint if not exists (Postgres 15+)

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1547,9 +1547,15 @@ CREATE TABLE IF NOT EXISTS level_up_enrollments (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   cohort_id UUID NOT NULL,
   user_id TEXT NOT NULL,
-  status TEXT NOT NULL CHECK (status IN ('active', 'completed', 'dropped', 'pending')),
+  -- 'enrolled' is the value the enrollment insert actually writes; it was missing from this list, so
+  -- on a brand-new database every enrollment failed the check while the long-running database (whose
+  -- table predates this block) accepted them. 'active' stays for the rows written before the value
+  -- changed — both count as a live enrollment everywhere in the code.
+  status TEXT NOT NULL CHECK (status IN ('enrolled', 'active', 'completed', 'dropped', 'pending')),
   credits_deposited INTEGER NOT NULL DEFAULT 0,
   assigned_trainer_id TEXT,
+  enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  progress_percent NUMERIC NOT NULL DEFAULT 0,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (cohort_id, user_id)
@@ -1560,6 +1566,11 @@ ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS user_id TEXT
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS status TEXT;
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS credits_deposited INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS assigned_trainer_id TEXT;
+-- enrolled_at: when the member joined. It exists on the long-running database (it came over with the
+-- legacy `levelup_enrollments` table) but was never declared here, so a database built from this file
+-- lacked it while three live reads order or measure by it — the admin lead-time number, the trainer
+-- trainee list, and the member's own enrollment list.
+ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS level_up_enrollments ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 -- Add unique constraint if not exists (Postgres 15+)


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**Waiting on your review — please do not merge until you have looked at it.** Auto-merge is deliberately off: this adds a new API route and contracts and edits `schema.sql`, which is the owner-review lane.

## What you reported

"Admin says 3 people enrolled but member side says 3 sessions are open, not members."

That is right, and there were three separate causes behind it.

## 1. The member side could not see its own enrollments at all

No route ever returned them. The member screen kept enrollments in browser memory only, so it knew about a cohort **only if you joined it during that same visit**. Come back the next day and Browse showed 0, the Progress tab said "Not enrolled yet", and a cohort you were already in still offered an Enroll button. So the only "3" a member could see was the count of open cohorts — exactly what you saw.

New read `GET /api/level-up/enrollments`. It returns your own enrollments with the cohort title and track, your trainer's name, the status, whether the enrollment is still live, and a milestone tally. It is scoped to the caller inside the query — it takes no user id, so an admin calling it still gets only their own rows. Read-only, capped at 50, newest first. New `enrollment.list` command and access-policy contracts.

The screen now loads it alongside the cohorts and seeds the already-enrolled set from it. If that read fails, the count shows a dash and a note says it could not be read — it never shows a "0", which would look like you are not enrolled anywhere.

## 2. The one admin number was labeled ambiguously and counted every row of any status

The panel's "Enrollments" card was a plain row count over `level_up_enrollments`. Left and finished enrollments were in it, and one member in three cohorts counted as three. A row count under that label reads as a headcount of people.

`getAdminPanelData()` now makes one pass over the table and returns four numbers, and the panel labels each for the question it answers:

- **Members in a cohort now** — distinct people holding a live enrollment
- **Active enrollments** — the live rows themselves
- **Enrollments, all time** — every row ever written
- **Completions**

One pass means they cannot drift apart from each other.

## 3. The member's "Enrolled" card sat under a people icon

It was next to a site-wide "Open Cohorts" count, which invited reading it as everyone enrolled. It now reads **My Cohorts** with a bookmark icon and counts only cohorts you are in right now — a finished or left cohort is not in it.

## Two schema corrections found while checking this

Both affect a **freshly built** database only; the long-running database is unchanged by either.

- `level_up_enrollments` was missing the `enrolled_at` column in `ctf/schema.sql`. It exists on the long-running database (it came over with the legacy `levelup_enrollments` table) but was never written into this file, while three live reads order or measure by it — the admin lead-time number, the trainer trainee list, and the new member enrollment list.
- Its `status` check allowed `active/completed/dropped/pending` but not `enrolled`, which is the value the enrollment insert actually writes. A database built from this file rejected every enrollment. Both values now count as a live enrollment everywhere in the code.

`schema.demo.sql` is regenerated from `schema.sql`. Its diff also picks up some comment text an earlier change left unregenerated — that part is incidental, not from this work.

## Checked locally

typecheck, lint, a11y lint, build, EOF format, US spelling, inventory drift, test-script drift, schema drift, orphan routes, error verbosity, web/Android parity — all green.

Feature inventory, manual test script (new case LU-3c for coming back to your cohorts, plus the reworked admin KPI case LU-A1), and both contract files updated in the same commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ni3CfLsUQNUZgpsyLQkpjg)_