### PR TITLE
feat: make every Skills Coverage value live, no hardcoded baseline

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
@@ -34,7 +34,7 @@ Workforce is a **read-only live tracker** of how the skills/talent of a populati
 
 ### 1.1 Workforce Dashboard and Drilldowns
 
-1. Live dashboard: Population, Workforce Total, Total Headcount Target, Recruited, Skills Coverage (the whole-number percentage of the 650-skill functioning-economy baseline covered by distinct active skills at least one active Directory member has listed, shown as "{listed} of 650 skills" — the same figure the weekly community-stats draft reports, never the size of the pick-list catalog), Recruitment Progress, Sector Gaps, Skill Level Breakdown, and Top Training Gaps.
+1. Live dashboard: Population, Workforce Total, Total Headcount Target, Recruited, Skills Coverage (the whole-number percentage of the skills taxonomy with at least one active Directory member behind it, shown as "{listed} of {catalog} skills" — both numbers are live: the numerator is the distinct active skills members have listed, the denominator is the current active-skill catalog count, so the tile tracks skills being added and removed), Recruitment Progress, Sector Gaps, Skill Level Breakdown, and Top Training Gaps.
 2. Demand is population-scale: `population × participation_rate` (workforce config), spread across sectors by each sector's Skills Taxonomy `workforce_share`, then split across the sector's job titles. Supply is read live from Directory: members = active profiles; recruited = the V2 aspirational 3-way match (profiles matching a bucket by sector, job title, or a skill registered under the job title), with the top-line recruited mirroring V2 as the count of all active profiles. Gap = demand − recruited. See section 5 for the exact definition.
 3. Drilldowns by sector, skill level, and occupation (the per-occupation training gaps).
 4. Deterministic loading/empty/error states for the core screens.
@@ -153,7 +153,7 @@ Note: there is no snapshot table — the dashboard, sector/skill/occupation brea
 
 ### 4.3 Storage and Derivation Rules
 
-1. The sector / skill-level / occupation breakdowns (the report routes) are derived live in `computeWorkforceModel()` from one read of the upstream sources; there is no stored snapshot, no inferred-event history, and no weekly bucketing. The **dashboard** top-line totals come from a separate lightweight read (`getDashboard()`): config + sector demand + three counts (active job titles, active profiles, distinct active skills listed by active members — the Skills Coverage numerator against the 650-skill baseline `WORKFORCE_SKILLS_ECONOMY_BASELINE`). It deliberately skips the expensive per-bucket supply match, because the dashboard returns only top-line numbers — `recruitedTotal` there is the count of all active profiles, identical to the full model, so the two never diverge.
+1. The sector / skill-level / occupation breakdowns (the report routes) are derived live in `computeWorkforceModel()` from one read of the upstream sources; there is no stored snapshot, no inferred-event history, and no weekly bucketing. The **dashboard** top-line totals come from a separate lightweight read (`getDashboard()`): config + sector demand + four counts (active job titles, active profiles, distinct active skills listed by active members, and all active taxonomy skills — the last two are the Skills Coverage numerator and denominator, both live so the figure moves as skills are added/removed). It deliberately skips the expensive per-bucket supply match, because the dashboard returns only top-line numbers — `recruitedTotal` there is the count of all active profiles, identical to the full model, so the two never diverge.
 2. **Demand** per sector = (sector `workforce_share` ÷ sum of shares) × `workforce_total`, where `workforce_total = population × participation_rate`. If no sector carries a positive share, demand is an even split across active sectors. Per-occupation demand = its sector's demand split evenly across the sector's active job titles.
 3. **Supply** is read from Directory: a profile's own sector resolves by spec precedence — taxonomy-derived signals first (the chosen occupation's sector via `job_title_id → sector_id`, else the sector the profile's skills map to through the taxonomy: plurality across the skills' occupations' sectors, ties broken by sector name), then the raw profile `sector_id` field. Only a profile with no occupation, no skills, and no sector lands in the `Unassigned` bucket (rendered only when non-empty; it carries no demand). Members = all active profiles. **Recruited** is the V2 aspirational match — a profile counts toward a sector/skill-level/occupation if it matches by sector, job title, or a skill registered under the job title (see section 5); the top-line recruited total is the count of all active profiles (V2 parity).
 4. **Skill level** is derived live from each job title's name using V2's keyword rule (`lib/workforce/skill-level.ts`) — Foundational / Intermediate / Advanced. No stored skill-level column.
@@ -225,17 +225,17 @@ Profile read + compliance-delete surface: the profile is read-only (owner decisi
 ## 10) Change Log
 
 - 2026-08-16: **Added the Skills Coverage tile to the dashboard overview (fourth hero card).** Shows
-  the whole-number percentage of the 650-skill functioning-economy baseline that has at least one
-  active Directory member behind it (e.g. "24%" with "156 of 650 skills" beneath) — the same
-  coverage figure the weekly community-stats draft reports (`generate-community-stats.mjs`), and the
-  same distinct-listed-skills query: `COUNT(DISTINCT skill_id)` over `directory_profile_skills`
-  joined to active `directory_profiles` and active `skills_taxonomy_skills` (both join sides cast to
-  text — production `directory_profiles.id` is varchar). Deliberately NOT the size of the skills
-  catalog, which already holds all 650 options and would always read 100%. `getDashboard()` gained
-  that one count in its existing lightweight read, and `WorkforceDashboard` gained
-  `skillsListedTotal` + `skillsBaseline` (the new `WORKFORCE_SKILLS_ECONOMY_BASELINE = 650` constant
-  in `lib/workforce/constants.ts`, kept in sync with the script's `FULL_ECONOMY_SKILL_BASELINE`).
-  Percentage is computed in the tile, capped at 100. The dashboard command contract is unchanged —
+  the whole-number percentage of the skills taxonomy with at least one active Directory member
+  behind it (e.g. "24%" with "156 of 650 skills" beneath). Every value is live (owner directive,
+  2026-08-16 — skills may be added and removed, so nothing is hardcoded): the numerator is
+  `COUNT(DISTINCT skill_id)` over `directory_profile_skills` joined to active `directory_profiles`
+  and active `skills_taxonomy_skills` (both join sides cast to text — production
+  `directory_profiles.id` is varchar; the same distinct-listed count the weekly community-stats
+  draft reports), and the denominator is the current `COUNT(*)` of active `skills_taxonomy_skills`.
+  The numerator filters to the same active-skill population as the denominator, so coverage can
+  never exceed 100%. `getDashboard()` gained the two counts in its existing lightweight read, and
+  `WorkforceDashboard` gained `skillsListedTotal` + `skillsCatalogTotal`. Percentage is computed in
+  the tile (0% on an empty catalog, capped at 100). The dashboard command contract is unchanged —
   its `dataAccess` already lists `directory_profile_skills` and `skills_taxonomy_skills`, and its
   output schema is the opaque `dashboard` object. No schema, route, or contract change; web-only
   (the Android Workforce surface was removed per rule 105).

--- a/ctf/docs/developer/test-scripts/workforce-test-script.md
+++ b/ctf/docs/developer/test-scripts/workforce-test-script.md
@@ -17,7 +17,7 @@
 | **Surfaces** | web (desktop) · web (mobile-responsive, ~390px) |
 | **Seed first** | `pnpm --dir ctf seed:workforce` |
 | **Source inventory** | `ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md` |
-| **Generated** | 2026-06-28 (initial authoring; regenerate via CI to stamp the commit) · 2026-07-16 manual update: added WF-10 Community Planning · 2026-07-17 manual update: WF-10 gap figure removed (team + per-occupation), team sector names corrected to live taxonomy names, member names link to Directory profile (web) · 2026-08-04 manual updates: WF-A2 now tests the shipped Audit trail panel; WF-7 points at the real `/account/data` delete control; region row removed (field dropped) · 2026-08-16 manual update: Skills Coverage hero card added (fourth tile — percent of the 650-skill baseline, "{n} of 650 skills") |
+| **Generated** | 2026-06-28 (initial authoring; regenerate via CI to stamp the commit) · 2026-07-16 manual update: added WF-10 Community Planning · 2026-07-17 manual update: WF-10 gap figure removed (team + per-occupation), team sector names corrected to live taxonomy names, member names link to Directory profile (web) · 2026-08-04 manual updates: WF-A2 now tests the shipped Audit trail panel; WF-7 points at the real `/account/data` delete control; region row removed (field dropped) · 2026-08-16 manual update: Skills Coverage hero card added (fourth tile — percent of the live active-skill catalog, "{listed} of {catalog} skills", all values dynamic) |
 
 ## How to run this
 
@@ -57,9 +57,10 @@ Workforce is a read-only live tracker — these are the can't-ship-broken checks
 2. Read the four hero cards (Population, Workforce Total, Recruited, Skills Coverage) and the Recruitment Progress.
 **Expected:** All four cards show numbers. Workforce Total = population × participation rate.
 Recruited = the count of all active Directory members. Skills Coverage shows a whole-number percent
-of the 650-skill functioning-economy baseline with "{n} of 650 skills" beneath, where n = the count
-of DIFFERENT skills at least one active Directory member has listed — never the size of the skills
-pick-list catalog (which would always read 100%), and never above 100%. Recruitment Progress reads as a percent of
+with "{listed} of {catalog} skills" beneath — both numbers live: listed = the count of DIFFERENT
+skills at least one active Directory member has listed; catalog = the current count of ALL active
+skills in the Skills Taxonomy (not a hardcoded figure — adding or removing a taxonomy skill moves
+it). The percent is listed ÷ catalog, never above 100%. Recruitment Progress reads as a percent of
 the recruitment goal (recruited ÷ min recruitable, the 2,000,000 target) and shows the recruited
 count plus "Remaining to the 2,000,000 goal", which counts down as members are recruited. There is
 no "Remaining capacity" line (the max-recruitable ceiling is config, not progress).

--- a/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
+++ b/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
@@ -12,11 +12,13 @@ export function WorkforceHeroStats({ dashboard }: WorkforceHeroStatsProps) {
   const { theme } = useTheme();
   const t = getWorkforceTokens(theme);
   const participationPct = Math.round(dashboard.participationRate * 100);
-  // Skills coverage toward the 650-skill functioning-economy baseline — the same whole-number
-  // percentage the weekly community-stats draft reports. Capped at 100 so a taxonomy larger than
-  // the baseline can never read as more than fully covered.
-  const skillsBaseline = Math.max(1, dashboard.skillsBaseline);
-  const skillsCoveragePct = Math.min(100, Math.round((dashboard.skillsListedTotal / skillsBaseline) * 100));
+  // Skills coverage: every value is live — the numerator is the distinct active skills members have
+  // listed, and the denominator is the current active-skill catalog count, so both move as skills
+  // are added and removed from the taxonomy. 0% when the catalog is empty; capped at 100 as a
+  // guard, though the numerator counts only catalog skills so it cannot exceed the denominator.
+  const skillsCoveragePct = dashboard.skillsCatalogTotal > 0
+    ? Math.min(100, Math.round((dashboard.skillsListedTotal / dashboard.skillsCatalogTotal) * 100))
+    : 0;
 
   const stats = [
     {
@@ -46,10 +48,9 @@ export function WorkforceHeroStats({ dashboard }: WorkforceHeroStatsProps) {
     {
       label: 'Skills Coverage',
       // How much of the skills taxonomy has someone behind it: DIFFERENT skills at least one active
-      // Directory member has listed, against the 650-skill functioning-economy baseline (the same
-      // figure the weekly community-stats draft reports) — not the size of the pick-list catalog.
+      // Directory member has listed, out of the live active-skill catalog total.
       value: `${skillsCoveragePct}%`,
-      delta: `${dashboard.skillsListedTotal.toLocaleString()} of ${skillsBaseline.toLocaleString()} skills`,
+      delta: `${dashboard.skillsListedTotal.toLocaleString()} of ${dashboard.skillsCatalogTotal.toLocaleString()} skills`,
       color: '#A855F7',
     },
   ];

--- a/ctf/packages/web/lib/workforce/constants.ts
+++ b/ctf/packages/web/lib/workforce/constants.ts
@@ -23,10 +23,3 @@ export const WORKFORCE_DEFAULT_POPULATION = 5_000_000;
 export const WORKFORCE_DEFAULT_PARTICIPATION_RATE = 0.5;
 export const WORKFORCE_DEFAULT_MIN_RECRUITABLE = 2_000_000;
 export const WORKFORCE_DEFAULT_MAX_RECRUITABLE = 5_000_000;
-
-// The number of documented skills a functioning economy needs — the point at which the community can
-// meet its own needs. Coverage toward it is the count of DIFFERENT skills at least one active
-// Directory member has listed, NOT the size of the skills catalog (the catalog already holds all 650
-// options and would always read 100%). Same baseline the weekly community-stats draft uses
-// (ctf/scripts/generate-community-stats.mjs, FULL_ECONOMY_SKILL_BASELINE) — keep the two in sync.
-export const WORKFORCE_SKILLS_ECONOMY_BASELINE = 650;

--- a/ctf/packages/web/lib/workforce/repository.ts
+++ b/ctf/packages/web/lib/workforce/repository.ts
@@ -14,7 +14,6 @@ import {
   WORKFORCE_DEFAULT_PARTICIPATION_RATE,
   WORKFORCE_DEFAULT_POPULATION,
   WORKFORCE_MAX_PAGE_SIZE,
-  WORKFORCE_SKILLS_ECONOMY_BASELINE,
 } from './constants';
 import type {
   WorkforceConfig,
@@ -686,7 +685,7 @@ export async function getDashboard(): Promise<WorkforceDashboard> {
   const config = await getWorkforceConfig();
   const workforceTotal = Math.max(0, Math.round(config.population * config.participationRate));
 
-  const [sectorsRes, occupationsCountRes, membersCountRes, skillsListedCountRes] = await Promise.all([
+  const [sectorsRes, occupationsCountRes, membersCountRes, skillsListedCountRes, skillsCatalogCountRes] = await Promise.all([
     queryDb<SectorModelRow>(
       `SELECT id::text AS id, name, workforce_share::text AS workforce_share
        FROM skills_taxonomy_sectors
@@ -700,9 +699,8 @@ export async function getDashboard(): Promise<WorkforceDashboard> {
        FROM directory_profiles
        WHERE is_active = TRUE AND deleted_at IS NULL`,
     ),
-    // Skills coverage: DIFFERENT active skills at least one active member has listed — the same
-    // count the weekly community-stats draft reports against the 650-skill functioning-economy
-    // baseline. directory_profiles.id is varchar on the production (v2-cloned) database while
+    // Skills coverage numerator: DIFFERENT active skills at least one active member has listed.
+    // directory_profiles.id is varchar on the production (v2-cloned) database while
     // directory_profile_skills.profile_id is uuid, so the join casts both sides to text.
     queryDb<CountRow>(
       `SELECT COUNT(DISTINCT dps.skill_id)::text AS total
@@ -710,6 +708,12 @@ export async function getDashboard(): Promise<WorkforceDashboard> {
        JOIN directory_profiles p ON dps.profile_id::text = p.id::text
        JOIN skills_taxonomy_skills s ON s.id = dps.skill_id
        WHERE p.is_active = TRUE AND p.deleted_at IS NULL AND s.is_active = TRUE`,
+    ),
+    // Skills coverage denominator: the live count of ALL active skills in the taxonomy — never a
+    // fixed baseline, so the tile tracks the catalog as skills are added and removed. The numerator
+    // filters to the same active-skill population, so coverage can never exceed 100%.
+    queryDb<CountRow>(
+      `SELECT COUNT(*)::text AS total FROM skills_taxonomy_skills WHERE is_active = TRUE`,
     ),
   ]);
 
@@ -719,6 +723,7 @@ export async function getDashboard(): Promise<WorkforceDashboard> {
   const totalMembers = Math.max(0, Number.parseInt(membersCountRes.rows[0]?.total ?? '0', 10) || 0);
   const occupationsTotal = Math.max(0, Number.parseInt(occupationsCountRes.rows[0]?.total ?? '0', 10) || 0);
   const skillsListedTotal = Math.max(0, Number.parseInt(skillsListedCountRes.rows[0]?.total ?? '0', 10) || 0);
+  const skillsCatalogTotal = Math.max(0, Number.parseInt(skillsCatalogCountRes.rows[0]?.total ?? '0', 10) || 0);
   // Top-line recruited mirrors V2 exactly: the count of all active Directory profiles.
   const recruitedTotal = totalMembers;
 
@@ -736,7 +741,7 @@ export async function getDashboard(): Promise<WorkforceDashboard> {
     sectorsTotal: sectors.length,
     occupationsTotal,
     skillsListedTotal,
-    skillsBaseline: WORKFORCE_SKILLS_ECONOMY_BASELINE,
+    skillsCatalogTotal,
     generatedAtIso: new Date().toISOString(),
   };
 }

--- a/ctf/packages/web/lib/workforce/repository.ts
+++ b/ctf/packages/web/lib/workforce/repository.ts
@@ -673,6 +673,12 @@ function percentRecruited(recruited: number, target: number): number {
   return Math.round(((recruited / target) * 100 + Number.EPSILON) * 100) / 100;
 }
 
+// Parse a `COUNT(*)::text AS total` result into a non-negative integer, treating a missing row or
+// an unparseable value as 0.
+function parseCountTotal(result: { rows: CountRow[] }): number {
+  return Math.max(0, Number.parseInt(result.rows[0]?.total ?? '0', 10) || 0);
+}
+
 // The dashboard returns only top-line totals — it has no per-bucket supply breakdown — so it does NOT
 // need the expensive V2 supply-match work the full model does (the per-member expansion across every
 // occupation in a member's sector, and the DISTINCT profile-skill -> job-title join). Running the full
@@ -720,10 +726,10 @@ export async function getDashboard(): Promise<WorkforceDashboard> {
   const sectors = sectorsRes.rows;
   const sectorDemand = buildSectorDemand(sectors, workforceTotal);
   const totalHeadcountTarget = Array.from(sectorDemand.values()).reduce((sum, n) => sum + n, 0);
-  const totalMembers = Math.max(0, Number.parseInt(membersCountRes.rows[0]?.total ?? '0', 10) || 0);
-  const occupationsTotal = Math.max(0, Number.parseInt(occupationsCountRes.rows[0]?.total ?? '0', 10) || 0);
-  const skillsListedTotal = Math.max(0, Number.parseInt(skillsListedCountRes.rows[0]?.total ?? '0', 10) || 0);
-  const skillsCatalogTotal = Math.max(0, Number.parseInt(skillsCatalogCountRes.rows[0]?.total ?? '0', 10) || 0);
+  const totalMembers = parseCountTotal(membersCountRes);
+  const occupationsTotal = parseCountTotal(occupationsCountRes);
+  const skillsListedTotal = parseCountTotal(skillsListedCountRes);
+  const skillsCatalogTotal = parseCountTotal(skillsCatalogCountRes);
   // Top-line recruited mirrors V2 exactly: the count of all active Directory profiles.
   const recruitedTotal = totalMembers;
 

--- a/ctf/packages/web/lib/workforce/types.ts
+++ b/ctf/packages/web/lib/workforce/types.ts
@@ -23,7 +23,7 @@ export type WorkforceDashboard = {
   sectorsTotal: number; // active Skills Taxonomy sectors
   occupationsTotal: number; // active Skills Taxonomy job titles
   skillsListedTotal: number; // distinct active skills at least one active Directory member has listed
-  skillsBaseline: number; // the 650-skill functioning-economy baseline coverage is measured against
+  skillsCatalogTotal: number; // ALL active Skills Taxonomy skills — live count, moves as skills are added/removed
   generatedAtIso: string;
 };
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

## What changed

Follow-up to #2225 (owner directive): every value on the Workforce **Skills Coverage** tile is now live — skills may be added and removed, so nothing is hardcoded.

- The denominator is now the current count of ALL active skills in the Skills Taxonomy (one more `COUNT(*)` in the dashboard's existing lightweight read) instead of the fixed 650-skill constant, which is removed (`WORKFORCE_SKILLS_ECONOMY_BASELINE` deleted from `lib/workforce/constants.ts`).
- The tile reads "{listed} of {catalog} skills"; the numerator already filters to the same active-skill population, so coverage can never exceed 100% (0% on an empty catalog).
- `WorkforceDashboard.skillsBaseline` is renamed `skillsCatalogTotal`.
- Feature inventory and manual test script updated to match.

#2225 auto-merged while this follow-up was being prepared, so it ships as its own PR on a fresh branch off `main`.

No schema, route-surface, or contract change — the dashboard command contract's `dataAccess` already lists `skills_taxonomy_skills`, and its output schema is the opaque `dashboard` object.

## Verified locally

Typecheck, lint, EOF format, inventory-drift, and test-script-drift checks pass; the pre-push hook ran the web build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvD5gKWivfDiAExbnEChBo)_