### PR TITLE
feat: Workforce Skills Economy Summary and goal wording

### DIFF
--- a/ctf/docs/BRAND_VOICE_LEXICON.md
+++ b/ctf/docs/BRAND_VOICE_LEXICON.md
@@ -115,6 +115,11 @@ This document is the canonical source of truth for brand language across:
   "never redeemable for cash"). Real fiat amounts unrelated to credits — a LightHouse listing's
   actual rent and its currency, Contributions' confirmed USD donations — are real money and are
   described as such. Any money-framing of credits anywhere in the repo is an error, not a claim.
+- Do not state GDP in US dollars anywhere in the app except the Workforce overview's Skills
+  Economy Summary card (owner directive, 2026-08-16). That card is the single allowed USD GDP
+  reference, and only as an explicitly speculative baseline — its copy must keep saying the figures
+  are speculative, not actuals, and that the Skills Economy has no intention of forming a nation
+  state. The GDP plugin's Community Value Index stays a unitless index, never a dollar figure.
 
 ## Canonical Capability Names (Public Surfaces)
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
@@ -34,10 +34,18 @@ Workforce is a **read-only live tracker** of how the skills/talent of a populati
 
 ### 1.1 Workforce Dashboard and Drilldowns
 
-1. Live dashboard: Population, Workforce Total, Recruited (with "% of goal" progress), Skills Coverage (the whole-number percentage of the skills taxonomy with at least one active Directory member behind it, shown as "{listed} of {catalog} skills" — both numbers are live: the numerator is the distinct active skills members have listed, the denominator is the current active-skill catalog count, so the tile tracks skills being added and removed), Recruitment Progress, Sector Gaps, Skill Level Breakdown, and Top Training Gaps.
+1. Live dashboard: Population, Workforce Total, Recruited (with "% of goal" progress), Skills Coverage (the whole-number percentage of the skills taxonomy with at least one active Directory member behind it, shown as "{listed} of {catalog} skills" — both numbers are live: the numerator is the distinct active skills members have listed, the denominator is the current active-skill catalog count, so the tile tracks skills being added and removed), the Skills Economy Summary statement (below), Sector Gaps, Skill Level Breakdown, and Top Training Gaps.
 2. Demand is population-scale: `population × participation_rate` (workforce config), spread across sectors by each sector's Skills Taxonomy `workforce_share`, then split across the sector's job titles. Supply is read live from Directory: members = active profiles; recruited = the V2 aspirational 3-way match (profiles matching a bucket by sector, job title, or a skill registered under the job title), with the top-line recruited mirroring V2 as the count of all active profiles. Gap = demand − recruited. See section 5 for the exact definition.
 3. Drilldowns by sector, skill level, and occupation (the per-occupation training gaps).
 4. Deterministic loading/empty/error states for the core screens.
+5. Skills Economy Summary: a fixed positive statement on the overview with live numbers — "With
+   only {recruited} people recruited, we have reached {skills coverage}% of the skills potential of
+   an independent nation state like Finland, Estonia, or Singapore — equating to ${GDP potential}
+   in GDP potential. That means each individual contributing ${per person} in GDP, and earning
+   upwards of ${earnings}." Followed by the disclaimer that the figures are speculative, not
+   actuals, that this is the only place in the app where GDP is stated in US dollars, and that the
+   Skills Economy has no intention of forming a nation state — it is a baseline for understanding
+   economics at the scale of upwards of 5 million people.
 
 ### 1.2 Workforce Directory-Coupled Profile Experience
 
@@ -204,7 +212,7 @@ Delivery: **web + mobile-responsive complete**. **Android (React Native) surface
 
 | Surface | Status | Notes |
 |---|---|---|
-| Web dashboard | ✅ Delivered | `workforce-shell.tsx` + `workforce-hero-stats` (incl. Recruitment Progress), `workforce-sector-gaps`, `workforce-skill-distribution`, `workforce-training-gaps`, sidebar, profile panel. Bound to `/dashboard`, `/reports/sector/all`, `/reports/skill-level/all`, `/reports/occupations`, `/profile`. |
+| Web dashboard | ✅ Delivered | `workforce-shell.tsx` + `workforce-hero-stats` (incl. the Skills Economy Summary), `workforce-sector-gaps`, `workforce-skill-distribution`, `workforce-training-gaps`, sidebar, profile panel. Bound to `/dashboard`, `/reports/sector/all`, `/reports/skill-level/all`, `/reports/occupations`, `/profile`. |
 | Web admin | ✅ Delivered | `workforce-admin-shell.tsx` — snapshot counts + the population-model config (population, participation rate, min/max recruitable). |
 | Android dashboard | ➖ Removed (web-only per rule 105 / #1742) | `WorkforceDashboard` with StatGrid (Population / Workforce Total / Headcount Target / Recruited / Directory Members), Sector Gaps, Top Training Gaps; `WorkforceLoading`, `WorkforceEmpty`, `WorkforcePublic`, `WorkforceStatCard`, `WorkforceProfileCard`. |
 | Android admin | ➖ Removed (web-only per rule 105 / #1742) | `AdminWorkforce.tsx` + `admin-api.ts`; mirrors `/admin/workforce` (snapshot + population-model config) against `GET /dashboard`, `GET/PUT /admin/config` only. |
@@ -224,7 +232,24 @@ Profile read + compliance-delete surface: the profile is read-only (owner decisi
 
 ## 10) Change Log
 
-- 2026-08-16: **Replaced the word "target" with "goal" across all rendered Workforce copy (owner
+- 2026-08-16: **Replaced the Recruitment Progress bar with the Skills Economy Summary statement
+  (owner direction — at 94 recruited against a 2,000,000 goal the bar sat at 0% and repeated the
+  hero card's numbers; the owner wants a positive summary instead).** The card
+  (`WorkforceEconomySummary` in `workforce-hero-stats.tsx`) renders a fixed statement whose numbers
+  are live: recruited count (`recruitedTotal`), skills-coverage percent (same live calculation as
+  the hero tile, now shared via `computeSkillsCoveragePct`), speculative GDP potential
+  (recruited × `WORKFORCE_BENCHMARK_GDP_PER_PERSON_USD`, a $142,500 modeling constant in
+  `lib/workforce/constants.ts` approximating Singapore's per-person GDP on a purchasing-power
+  basis, the upper benchmark of the three reference economies), per-person GDP contribution (the
+  benchmark itself), and per-person earnings (benchmark × `WORKFORCE_EARNINGS_SHARE_OF_GDP` = 0.5,
+  the lower bound of the compensation share in advanced economies, backing "earning upwards of").
+  The card's second paragraph is the standing disclaimer: figures are speculative, not actuals;
+  this is the only place in the app where GDP is stated in US dollars (owner directive, recorded in
+  `ctf/docs/BRAND_VOICE_LEXICON.md` Prohibited Patterns); the Skills Economy has no intention of
+  forming a nation state — it is a baseline for understanding economics at the scale of upwards of
+  5 million people. Display-only: the dashboard API payload, schema, routes, and contracts are
+  unchanged; `minRecruitable` is no longer read by this card. Web-only (rule 105). Test script
+  WF-1 and the core smoke updated to match.
   direction — in this product "target" refers only to a person subjected to Specterati harassment;
   the lexicon already reserved it, `ctf/docs/BRAND_VOICE_LEXICON.md`).** Overview hero "% of target"
   → "% of goal"; Skill Level Breakdown subtitle "Target shown for context" → "Goal shown for

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
@@ -34,7 +34,7 @@ Workforce is a **read-only live tracker** of how the skills/talent of a populati
 
 ### 1.1 Workforce Dashboard and Drilldowns
 
-1. Live dashboard: Population, Workforce Total, Total Headcount Target, Recruited, Skills Coverage (the whole-number percentage of the skills taxonomy with at least one active Directory member behind it, shown as "{listed} of {catalog} skills" — both numbers are live: the numerator is the distinct active skills members have listed, the denominator is the current active-skill catalog count, so the tile tracks skills being added and removed), Recruitment Progress, Sector Gaps, Skill Level Breakdown, and Top Training Gaps.
+1. Live dashboard: Population, Workforce Total, Recruited (with "% of goal" progress), Skills Coverage (the whole-number percentage of the skills taxonomy with at least one active Directory member behind it, shown as "{listed} of {catalog} skills" — both numbers are live: the numerator is the distinct active skills members have listed, the denominator is the current active-skill catalog count, so the tile tracks skills being added and removed), Recruitment Progress, Sector Gaps, Skill Level Breakdown, and Top Training Gaps.
 2. Demand is population-scale: `population × participation_rate` (workforce config), spread across sectors by each sector's Skills Taxonomy `workforce_share`, then split across the sector's job titles. Supply is read live from Directory: members = active profiles; recruited = the V2 aspirational 3-way match (profiles matching a bucket by sector, job title, or a skill registered under the job title), with the top-line recruited mirroring V2 as the count of all active profiles. Gap = demand − recruited. See section 5 for the exact definition.
 3. Drilldowns by sector, skill level, and occupation (the per-occupation training gaps).
 4. Deterministic loading/empty/error states for the core screens.
@@ -61,7 +61,7 @@ Workforce is a **read-only live tracker** of how the skills/talent of a populati
 ### 2.1 Workforce Admin Operations
 
 1. Admin route for the workforce config (the population model) plus the read-only dashboard snapshot.
-2. Admin audit-trail viewer: the admin screen's "Audit trail" panel loads `GET /api/workforce/admin/audit-events` on demand and pages through events newest-first (command, allow/deny, reason, target, actor, timestamp).
+2. Admin audit-trail viewer: the admin screen's "Audit trail" panel loads `GET /api/workforce/admin/audit-events` on demand and pages through events newest-first (command, allow/deny, reason, the record acted on, actor, timestamp).
 3. No occupation/announcement/export/sync/recompute admin surface — those were removed in the read-only model.
 
 ### 2.2 Workforce Configuration Governance
@@ -224,6 +224,18 @@ Profile read + compliance-delete surface: the profile is read-only (owner decisi
 
 ## 10) Change Log
 
+- 2026-08-16: **Replaced the word "target" with "goal" across all rendered Workforce copy (owner
+  direction — in this product "target" refers only to a person subjected to Specterati harassment;
+  the lexicon already reserved it, `ctf/docs/BRAND_VOICE_LEXICON.md`).** Overview hero "% of target"
+  → "% of goal"; Skill Level Breakdown subtitle "Target shown for context" → "Goal shown for
+  context" and the per-bar "{n} target" → "{n} goal"; sector/skill-level drilldown rows "recruited /
+  {n} target" → "{n} goal"; Sector Opportunities legend "Target (opportunity)" → "Goal
+  (opportunity)"; occupation detail "Headcount target (demand)" / "Annual training target" and the
+  how-computed explainer → goal wording; sidebar Quick Stats "Headcount Target" → "Headcount Goal";
+  admin "Headcount target" stat → "Headcount goal"; the admin audit-trail line's "target
+  {type}/{id}" (the record acted on) → "record {type}/{id}". Display-only — code identifiers, API
+  fields (`target`, `totalHeadcountTarget`, `annualTrainingTarget`, `target_type`/`target_id`), and
+  contracts are unchanged; no schema or route change.
 - 2026-08-16: **Added the Skills Coverage tile to the dashboard overview (fourth hero card).** Shows
   the whole-number percentage of the skills taxonomy with at least one active Directory member
   behind it (e.g. "24%" with "156 of 650 skills" beneath). Every value is live (owner directive,

--- a/ctf/docs/developer/test-scripts/workforce-test-script.md
+++ b/ctf/docs/developer/test-scripts/workforce-test-script.md
@@ -40,7 +40,8 @@ Workforce is a read-only live tracker — these are the can't-ship-broken checks
    2026-07-19, web and android); per-sector targets live in the Sectors view. On android the
    screen subtitle reads "{recruited} recruited · {goal} goal". → web ☐ mobile ☐
 2. **Top-line numbers reconcile.** Recruited equals the count of all active Directory members, and
-   the Recruitment Progress shows a percent of target, not a repeated count. → web ☐ mobile ☐
+   the Skills Economy Summary statement uses that same recruited count and the Skills Coverage
+   percent — no progress bar, no repeated card. → web ☐ mobile ☐
 3. **No write controls on the profile.** Open the Workforce profile view. There is no profile editor
    — it is read-only (the only member write is the service-scoped delete). → web ☐ mobile ☐
 4. **Empty state is handled.** If there are no sectors/occupations and no Directory members, the
@@ -54,16 +55,19 @@ Workforce is a read-only live tracker — these are the can't-ship-broken checks
 **Role:** member · **Surfaces:** all · **Seed:** `seed:workforce`
 **Steps:**
 1. Open the Workforce dashboard for a signed-in member.
-2. Read the four hero cards (Population, Workforce Total, Recruited, Skills Coverage) and the Recruitment Progress.
+2. Read the four hero cards (Population, Workforce Total, Recruited, Skills Coverage) and the Skills Economy Summary card beneath them.
 **Expected:** All four cards show numbers. Workforce Total = population × participation rate.
 Recruited = the count of all active Directory members. Skills Coverage shows a whole-number percent
 with "{listed} of {catalog} skills" beneath — both numbers live: listed = the count of DIFFERENT
 skills at least one active Directory member has listed; catalog = the current count of ALL active
 skills in the Skills Taxonomy (not a hardcoded figure — adding or removing a taxonomy skill moves
-it). The percent is listed ÷ catalog, never above 100%. Recruitment Progress reads as a percent of
-the recruitment goal (recruited ÷ min recruitable, the 2,000,000 target) and shows the recruited
-count plus "Remaining to the 2,000,000 goal", which counts down as members are recruited. There is
-no "Remaining capacity" line (the max-recruitable ceiling is config, not progress).
+it). The percent is listed ÷ catalog, never above 100%. The Skills Economy Summary is a fixed
+statement with live numbers: the recruited count, the Skills Coverage percent, a speculative GDP
+potential in US dollars (recruited × the $142,500 per-person modeling benchmark), the per-person
+GDP contribution, and the per-person earnings (half the benchmark). Its disclaimer paragraph says
+the figures are speculative, not actuals, that this is the only place in the app where GDP is
+stated in US dollars, and that the Skills Economy has no intention of forming a nation state.
+There is no progress bar, no "Remaining to the goal" countdown, and no "Remaining capacity" line.
 **Result:** web ☐ mobile ☐ — notes:
 
 ### WF-2 · Sector opportunities

--- a/ctf/packages/web/components/workforce/workforce-admin-shell.tsx
+++ b/ctf/packages/web/components/workforce/workforce-admin-shell.tsx
@@ -178,7 +178,7 @@ function AuditTrailPanel() {
                 <span style={{ fontSize: 11, color: t.MUTED, marginLeft: 'auto' }}>{new Date(event.createdAtIso).toLocaleString()}</span>
               </div>
               <div style={{ fontSize: 11, color: t.MUTED, marginTop: 4 }}>
-                {event.reason} · target {event.targetType}/{event.targetId} · actor {event.actorId}
+                {event.reason} · record {event.targetType}/{event.targetId} · actor {event.actorId}
               </div>
             </div>
           ))}
@@ -265,7 +265,7 @@ export function WorkforceAdminShell({
         {/* Snapshot */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 20 }}>
           <StatBlock label="Workforce total" value={dashboard.workforceTotal} accent={t.ACCENT} />
-          <StatBlock label="Headcount target" value={dashboard.totalHeadcountTarget} accent="#EF4444" />
+          <StatBlock label="Headcount goal" value={dashboard.totalHeadcountTarget} accent="#EF4444" />
           <StatBlock label="Recruited" value={dashboard.recruitedTotal} accent="#22C55E" />
           <StatBlock label="Directory members" value={dashboard.totalMembers} />
         </div>

--- a/ctf/packages/web/components/workforce/workforce-bucket-drilldown.tsx
+++ b/ctf/packages/web/components/workforce/workforce-bucket-drilldown.tsx
@@ -68,7 +68,7 @@ function BucketRow({ kind, item }: { kind: DrilldownKind; item: WorkforceGrouped
           {item.bucket}
         </span>
         <span style={{ fontSize: 12, color: t.MUTED }}>
-          {item.recruited.toLocaleString()} recruited / {item.target.toLocaleString()} target
+          {item.recruited.toLocaleString()} recruited / {item.target.toLocaleString()} goal
         </span>
         <span
           style={{

--- a/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
+++ b/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
@@ -3,22 +3,30 @@
 import type { WorkforceDashboard } from '../../lib/workforce/types';
 import { useTheme } from '@/hooks/useTheme';
 import { getWorkforceTokens } from './workforce-shared';
+import {
+  WORKFORCE_BENCHMARK_GDP_PER_PERSON_USD,
+  WORKFORCE_EARNINGS_SHARE_OF_GDP,
+} from '../../lib/workforce/constants';
 
 interface WorkforceHeroStatsProps {
   dashboard: WorkforceDashboard;
+}
+
+// Skills coverage: every value is live — the numerator is the distinct active skills members have
+// listed, and the denominator is the current active-skill catalog count, so both move as skills
+// are added and removed from the taxonomy. 0% when the catalog is empty; capped at 100 as a
+// guard, though the numerator counts only catalog skills so it cannot exceed the denominator.
+function computeSkillsCoveragePct(dashboard: WorkforceDashboard): number {
+  return dashboard.skillsCatalogTotal > 0
+    ? Math.min(100, Math.round((dashboard.skillsListedTotal / dashboard.skillsCatalogTotal) * 100))
+    : 0;
 }
 
 export function WorkforceHeroStats({ dashboard }: WorkforceHeroStatsProps) {
   const { theme } = useTheme();
   const t = getWorkforceTokens(theme);
   const participationPct = Math.round(dashboard.participationRate * 100);
-  // Skills coverage: every value is live — the numerator is the distinct active skills members have
-  // listed, and the denominator is the current active-skill catalog count, so both move as skills
-  // are added and removed from the taxonomy. 0% when the catalog is empty; capped at 100 as a
-  // guard, though the numerator counts only catalog skills so it cannot exceed the denominator.
-  const skillsCoveragePct = dashboard.skillsCatalogTotal > 0
-    ? Math.min(100, Math.round((dashboard.skillsListedTotal / dashboard.skillsCatalogTotal) * 100))
-    : 0;
+  const skillsCoveragePct = computeSkillsCoveragePct(dashboard);
 
   const stats = [
     {
@@ -103,25 +111,31 @@ export function WorkforceHeroStats({ dashboard }: WorkforceHeroStatsProps) {
           </div>
         ))}
       </div>
-      <WorkforceRecruitmentProgress dashboard={dashboard} />
+      <WorkforceEconomySummary dashboard={dashboard} />
     </div>
   );
 }
 
-function WorkforceRecruitmentProgress({ dashboard }: WorkforceHeroStatsProps) {
+// Replaced the Recruitment Progress bar (owner direction, 2026-08-16): with recruitment at a
+// fraction of a percent the bar repeated the hero card's numbers and read as failure. The card is
+// now a positive summary statement. The statement text is fixed; only the numbers are live. This
+// is the ONLY place in the app where GDP is stated in US dollars, and only as an explicitly
+// speculative baseline — see the constants for the derivation.
+function WorkforceEconomySummary({ dashboard }: WorkforceHeroStatsProps) {
   const { theme } = useTheme();
   const t = getWorkforceTokens(theme);
-  // Progress is toward the recruitment goal (min recruitable, the owner's 2,000,000 target — the
-  // same goal Weekly Performance tracks), not toward theoretical sector capacity. The card shows
-  // the recruited count and the countdown to the goal; "remaining capacity" (max recruitable minus
-  // recruited) is a config ceiling, not progress, and confused the read.
-  const goal = Math.max(0, dashboard.minRecruitable);
   const recruited = Math.max(0, dashboard.recruitedTotal);
-  const goalPct = goal > 0 ? Math.round(((recruited / goal) * 100 + Number.EPSILON) * 100) / 100 : 0;
-  const pct = Math.min(100, Math.max(0, goalPct));
-  // Most of the bar is the gap to fill — the signal that tells LevelUp where to recruit and train.
-  const barPct = pct < 0.5 && pct > 0 ? 0.5 : pct;
-  const remainingToGoal = Math.max(0, goal - recruited);
+  const skillsCoveragePct = computeSkillsCoveragePct(dashboard);
+  const gdpPerPerson = WORKFORCE_BENCHMARK_GDP_PER_PERSON_USD;
+  const gdpPotential = recruited * gdpPerPerson;
+  const earningsPerPerson = Math.round(gdpPerPerson * WORKFORCE_EARNINGS_SHARE_OF_GDP);
+  // "$13.4 million" style for the headline figure so the scale reads at a glance.
+  const gdpPotentialLabel = new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    compactDisplay: 'long',
+    maximumFractionDigits: 1,
+  }).format(gdpPotential);
+  const strong = { color: t.TEXT, fontWeight: 700 as const };
 
   return (
     <div
@@ -132,25 +146,23 @@ function WorkforceRecruitmentProgress({ dashboard }: WorkforceHeroStatsProps) {
         border: '1px solid rgba(255,255,255,0.06)',
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 10 }}>
-        <div style={{ fontSize: 14, fontWeight: 700, color: t.TITLE }}>Recruitment Progress</div>
-        <div style={{ fontSize: 13, color: t.ACCENT, fontWeight: 700 }}>
-          {goalPct.toLocaleString(undefined, { maximumFractionDigits: 2 })}%
-        </div>
+      <div style={{ fontSize: 14, fontWeight: 700, color: t.TITLE, marginBottom: 10 }}>
+        Skills Economy Summary
       </div>
-      <div style={{ height: 8, background: 'rgba(255,255,255,0.05)', borderRadius: 4, overflow: 'hidden', marginBottom: 10 }}>
-        <div style={{ height: '100%', width: `${barPct}%`, background: '#22C55E', borderRadius: 4 }} />
-      </div>
-      <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap', fontSize: 12, color: t.SUBTLE }}>
-        <span>
-          Recruited:{' '}
-          <span style={{ color: t.TEXT, fontWeight: 600 }}>{recruited.toLocaleString()}</span>
-        </span>
-        <span>
-          Remaining to the {goal.toLocaleString()} goal:{' '}
-          <span style={{ color: t.TEXT, fontWeight: 600 }}>{remainingToGoal.toLocaleString()}</span>
-        </span>
-      </div>
+      <p style={{ fontSize: 13, color: t.SUBTLE, lineHeight: 1.7, margin: 0 }}>
+        With only <span style={strong}>{recruited.toLocaleString()}</span> people recruited, we have
+        reached <span style={strong}>{skillsCoveragePct}%</span> of the skills potential of an
+        independent nation state like Finland, Estonia, or Singapore — equating to{' '}
+        <span style={strong}>${gdpPotentialLabel}</span> in GDP potential. That means each individual
+        contributing <span style={strong}>${gdpPerPerson.toLocaleString()}</span> in GDP, and earning
+        upwards of <span style={strong}>${earningsPerPerson.toLocaleString()}</span>.
+      </p>
+      <p style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.6, margin: '10px 0 0' }}>
+        These figures are speculative, not actuals, and this summary is the only place in the app
+        where GDP is stated in US dollars. The Skills Economy has no intention of forming a nation
+        state — this is a baseline for understanding economics at the scale of upwards of 5 million
+        people.
+      </p>
     </div>
   );
 }

--- a/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
+++ b/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
@@ -42,7 +42,7 @@ export function WorkforceHeroStats({ dashboard }: WorkforceHeroStatsProps) {
       value: dashboard.recruitedTotal.toLocaleString(),
       // Recruited mirrors V2 (all active Directory profiles), so it equals the directory headcount;
       // show progress toward the target instead of repeating the same number.
-      delta: `${dashboard.percentRecruited.toLocaleString(undefined, { maximumFractionDigits: 1 })}% of target`,
+      delta: `${dashboard.percentRecruited.toLocaleString(undefined, { maximumFractionDigits: 1 })}% of goal`,
       color: '#22C55E',
     },
     {

--- a/ctf/packages/web/components/workforce/workforce-occupations.tsx
+++ b/ctf/packages/web/components/workforce/workforce-occupations.tsx
@@ -124,8 +124,8 @@ function OccupationDetail({ id, onBack }: { id: string; onBack: () => void }) {
             </div>
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 12 }}>
-            <Stat label="Headcount target (demand)" value={occ.target.toLocaleString()} />
-            <Stat label="Annual training target" value={occ.annualTrainingTarget.toLocaleString()} />
+            <Stat label="Headcount goal (demand)" value={occ.target.toLocaleString()} />
+            <Stat label="Annual training goal" value={occ.annualTrainingTarget.toLocaleString()} />
             {/* No "Members" (declared-occupation) card: members join jobless but skilled, so the
                 declared count is ~always 0 and reads as an error. Recruited (matched) carries the
                 story; occ.members stays in the API for consumers that need the declared count. */}
@@ -147,13 +147,13 @@ function OccupationDetail({ id, onBack }: { id: string; onBack: () => void }) {
               border: '1px solid rgba(255,255,255,0.06)',
             }}
           >
-            How these are computed: the <strong>headcount target</strong> is this occupation&apos;s share of
+            How these are computed: the <strong>headcount goal</strong> is this occupation&apos;s share of
             its sector&apos;s demand — population × participation rate, split across sectors by each
             sector&apos;s workforce share, then divided evenly among the sector&apos;s job titles. The{' '}
-            <strong>annual training target</strong> is a share of that target by skill level (Foundational
+            <strong>annual training goal</strong> is a share of that goal by skill level (Foundational
             10%, Intermediate 15%, Advanced 25%). <strong>Recruited</strong> is the distinct Directory
             members who match this occupation by sector, job title, or a registered skill. The{' '}
-            <strong>training gap</strong> is the target minus recruited.
+            <strong>training gap</strong> is the goal minus recruited.
           </div>
         </>
       )}

--- a/ctf/packages/web/components/workforce/workforce-sector-gaps.tsx
+++ b/ctf/packages/web/components/workforce/workforce-sector-gaps.tsx
@@ -90,7 +90,7 @@ export function WorkforceSectorGaps({ sectorItems }: WorkforceSectorGapsProps) {
             >
               {g.bucket}
               <div style={{ fontSize: 11, color: t.MUTED }}>
-                {g.recruited.toLocaleString()} recruited / {g.target.toLocaleString()} target
+                {g.recruited.toLocaleString()} recruited / {g.target.toLocaleString()} goal
               </div>
             </div>
             <div style={{ flex: '1 1 0', minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -155,7 +155,7 @@ export function WorkforceSectorGaps({ sectorItems }: WorkforceSectorGapsProps) {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
           <div style={{ width: 12, height: 4, background: t.ACCENT, borderRadius: 2 }} />
-          <span style={{ fontSize: 12, color: t.MUTED }}>Target (opportunity)</span>
+          <span style={{ fontSize: 12, color: t.MUTED }}>Goal (opportunity)</span>
         </div>
       </div>
     </div>

--- a/ctf/packages/web/components/workforce/workforce-sidebar.tsx
+++ b/ctf/packages/web/components/workforce/workforce-sidebar.tsx
@@ -154,7 +154,7 @@ export function WorkforceSidebar({
                 Quick Stats
               </div>
               {[
-                { l: 'Headcount Target', v: dashboard.totalHeadcountTarget.toLocaleString() },
+                { l: 'Headcount Goal', v: dashboard.totalHeadcountTarget.toLocaleString() },
                 { l: 'Recruited', v: dashboard.recruitedTotal.toLocaleString() },
                 { l: 'Skill Gaps', v: gapCount > 0 ? `${gapCount} sectors` : 'None' },
               ].map(({ l, v }) => (

--- a/ctf/packages/web/components/workforce/workforce-skill-distribution.tsx
+++ b/ctf/packages/web/components/workforce/workforce-skill-distribution.tsx
@@ -36,7 +36,7 @@ export function WorkforceSkillDistribution({ skillItems }: WorkforceSkillDistrib
         Skill Level Breakdown
       </div>
       <div style={{ fontSize: 12, color: t.MUTED, marginBottom: 16 }}>
-        Members recruited at each skill level (bar height = people). Target shown for context.
+        Members recruited at each skill level (bar height = people). Goal shown for context.
       </div>
       <div style={{ display: 'flex', gap: 16 }}>
         {skillItems.map((item) => {
@@ -75,7 +75,7 @@ export function WorkforceSkillDistribution({ skillItems }: WorkforceSkillDistrib
               </div>
               <div style={{ fontSize: 11, color: t.MUTED }}>recruited</div>
               <div style={{ fontSize: 11, color: t.ACCENT, marginTop: 4 }}>
-                {item.target.toLocaleString()} target
+                {item.target.toLocaleString()} goal
               </div>
               <div style={{ fontSize: 11, color: t.MUTED }}>
                 gap {item.gap.toLocaleString()}

--- a/ctf/packages/web/lib/workforce/constants.ts
+++ b/ctf/packages/web/lib/workforce/constants.ts
@@ -23,3 +23,15 @@ export const WORKFORCE_DEFAULT_POPULATION = 5_000_000;
 export const WORKFORCE_DEFAULT_PARTICIPATION_RATE = 0.5;
 export const WORKFORCE_DEFAULT_MIN_RECRUITABLE = 2_000_000;
 export const WORKFORCE_DEFAULT_MAX_RECRUITABLE = 5_000_000;
+
+// Skills Economy summary modeling constants (owner directive, 2026-08-16). The overview's summary
+// statement is the ONLY place in the app where GDP is stated in US dollars, and it is explicitly
+// speculative, not actuals. The reference economies are small advanced nation states (Finland,
+// Estonia, Singapore); the per-person figure is the upper benchmark of the three — Singapore's GDP
+// per person (purchasing-power basis, ~$141k IMF 2024), rounded to a clean modeling constant.
+// Speculative GDP potential = recruited × this benchmark (94 recruited ≈ $13.4 million).
+export const WORKFORCE_BENCHMARK_GDP_PER_PERSON_USD = 142_500;
+// Share of a person's GDP contribution that reaches them as earnings. Advanced economies pay out
+// roughly half to two-thirds of GDP as compensation; the lower bound backs the statement's
+// "earning upwards of" phrasing.
+export const WORKFORCE_EARNINGS_SHARE_OF_GDP = 0.5;


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

## What changed

Two owner-directed changes to the Workforce plugin, both display-only — no schema, route, API payload, or contract change.

**1. The word "target" no longer appears anywhere on the Workforce screens.** In this product that word refers only to a person subjected to Specterati harassment (`ctf/docs/BRAND_VOICE_LEXICON.md` already reserves it), so every rendered use in the goal sense now says "goal": the overview hero card ("% of goal"), the Skill Level Breakdown subtitle and per-bar figures, the sector and skill-level drilldown rows, the Sector Opportunities legend, the occupation detail labels and explainer, the sidebar quick stats, and the admin stat. The admin audit-trail line labels the record acted on as "record". Code identifiers and API field names (`target`, `totalHeadcountTarget`, `annualTrainingTarget`, `target_type`) keep their names.

**2. The Recruitment Progress bar is replaced by the Skills Economy Summary.** At 94 recruited against a 2,000,000 goal the bar sat at 0% and repeated the hero card's numbers. The card is now a fixed positive statement with live numbers: recruited count, skills-coverage percent, a speculative GDP potential in US dollars (recruited × a $142,500 per-person modeling benchmark documented in `lib/workforce/constants.ts`), the per-person GDP contribution, and per-person earnings (half the benchmark). Its second paragraph is the standing disclaimer: the figures are speculative, not actuals; this card is the only place in the app where GDP is stated in US dollars; the Skills Economy has no intention of forming a nation state — the statement is a baseline for understanding economics at the scale of upwards of 5 million people. That USD rule is now recorded in the brand lexicon's Prohibited Patterns so it holds product-wide.

Docs kept in step: Workforce feature inventory (User Features, delivery table, change log) and the Workforce manual test script.

## Verification

Web lint, typecheck, and build pass; EOF formatting, inventory-drift, and test-script-drift gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7Xmx7aeu8vbuR7HLvz4Mw

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7Xmx7aeu8vbuR7HLvz4Mw)_