### PR TITLE
docs: drop filler "only" from the Skills Economy Summary line

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
@@ -39,7 +39,7 @@ Workforce is a **read-only live tracker** of how the skills/talent of a populati
 3. Drilldowns by sector, skill level, and occupation (the per-occupation training gaps).
 4. Deterministic loading/empty/error states for the core screens.
 5. Skills Economy Summary: a fixed positive statement on the overview with live numbers — "With
-   only {recruited} people recruited, we have reached {skills coverage}% of the skills potential of
+   {recruited} people recruited, we have reached {skills coverage}% of the skills potential of
    an independent nation state like Finland, Estonia, or Singapore — equating to ${GDP potential}
    in GDP potential. That means each individual contributing ${per person} in GDP, and earning
    upwards of ${earnings}." Followed by the disclaimer that the figures are speculative, not
@@ -232,6 +232,11 @@ Profile read + compliance-delete surface: the profile is read-only (owner decisi
 
 ## 10) Change Log
 
+- 2026-08-17: **Dropped the word "only" from the Skills Economy Summary opening line** (owner
+  direction — it read as filler). The statement now opens "With {recruited} people recruited, we
+  have reached …". Copy-only change in `workforce-hero-stats.tsx`; no numbers, layout, or
+  behaviour changed. The disclaimer paragraph's "the only place in the app where GDP is stated in
+  US dollars" is unchanged — that "only" carries meaning.
 - 2026-08-16: **Replaced the Recruitment Progress bar with the Skills Economy Summary statement
   (owner direction — at 94 recruited against a 2,000,000 goal the bar sat at 0% and repeated the
   hero card's numbers; the owner wants a positive summary instead).** The card

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md
@@ -235,7 +235,7 @@ Profile read + compliance-delete surface: the profile is read-only (owner decisi
 - 2026-08-17: **Dropped the word "only" from the Skills Economy Summary opening line** (owner
   direction — it read as filler). The statement now opens "With {recruited} people recruited, we
   have reached …". Copy-only change in `workforce-hero-stats.tsx`; no numbers, layout, or
-  behaviour changed. The disclaimer paragraph's "the only place in the app where GDP is stated in
+  behavior changed. The disclaimer paragraph's "the only place in the app where GDP is stated in
   US dollars" is unchanged — that "only" carries meaning.
 - 2026-08-16: **Replaced the Recruitment Progress bar with the Skills Economy Summary statement
   (owner direction — at 94 recruited against a 2,000,000 goal the bar sat at 0% and repeated the

--- a/ctf/docs/developer/test-scripts/workforce-test-script.md
+++ b/ctf/docs/developer/test-scripts/workforce-test-script.md
@@ -64,7 +64,9 @@ skills in the Skills Taxonomy (not a hardcoded figure — adding or removing a t
 it). The percent is listed ÷ catalog, never above 100%. The Skills Economy Summary is a fixed
 statement with live numbers: the recruited count, the Skills Coverage percent, a speculative GDP
 potential in US dollars (recruited × the $142,500 per-person modeling benchmark), the per-person
-GDP contribution, and the per-person earnings (half the benchmark). Its disclaimer paragraph says
+GDP contribution, and the per-person earnings (half the benchmark). It opens "With {recruited}
+people recruited, we have reached …" — there is no "only" before the recruited count. Its
+disclaimer paragraph says
 the figures are speculative, not actuals, that this is the only place in the app where GDP is
 stated in US dollars, and that the Skills Economy has no intention of forming a nation state.
 There is no progress bar, no "Remaining to the goal" countdown, and no "Remaining capacity" line.

--- a/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
+++ b/ctf/packages/web/components/workforce/workforce-hero-stats.tsx
@@ -150,7 +150,7 @@ function WorkforceEconomySummary({ dashboard }: WorkforceHeroStatsProps) {
         Skills Economy Summary
       </div>
       <p style={{ fontSize: 13, color: t.SUBTLE, lineHeight: 1.7, margin: 0 }}>
-        With only <span style={strong}>{recruited.toLocaleString()}</span> people recruited, we have
+        With <span style={strong}>{recruited.toLocaleString()}</span> people recruited, we have
         reached <span style={strong}>{skillsCoveragePct}%</span> of the skills potential of an
         independent nation state like Finland, Estonia, or Singapore — equating to{' '}
         <span style={strong}>${gdpPotentialLabel}</span> in GDP potential. That means each individual


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

The Skills Economy Summary card on the Workforce overview opened with:

> With **only** 97 people recruited, we have reached 24% of the skills potential of an independent nation state…

The word "only" reads as filler there, so the line now opens:

> With **97** people recruited, we have reached 24% of the skills potential of an independent nation state…

## Why

Owner direction: the word adds nothing to the sentence.

## Scope

- One word removed in `ctf/packages/web/components/workforce/workforce-hero-stats.tsx`. Numbers, layout, styling, and behaviour are unchanged.
- The disclaimer paragraph below it keeps its "only" — "this summary is the **only** place in the app where GDP is stated in US dollars" — because that word carries meaning rather than filling space.
- The Workforce feature inventory quotes the statement word for word, so its copy and its change log are updated to match (`ctf/docs/developer/ctf-plugin-feature-inventories/ctf-workforce-feature-inventory.md`).

## Checks run locally

Web typecheck, web lint, web build, `check-eof-format.sh`, `check-inventory-drift.mjs`, and `check-test-script-drift.mjs` all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EEC8jzvZDrVviTLiSVqA2o)_