### PR TITLE
docs: add Intent and Outcome to Mood, LevelUp, and LightHouse, and bar money wording for credits

### DIFF
--- a/.claude/rules/120-plugin-feature-inventory-lifecycle-rules.mdc
+++ b/.claude/rules/120-plugin-feature-inventory-lifecycle-rules.mdc
@@ -81,8 +81,14 @@ Known generators and their grounding sources (keep this list current as generato
   2026-08-18 after the guide called Workforce a tracker of "job openings" members are "matched to":
   with only feature bullets and no sentence saying what the plugin IS, the model supplied a familiar
   frame of its own. So the first paragraph of Intent and Outcome now ships to a public page — write it
-  as a plain, true statement of what the plugin is, not as planning notes. An inventory with no Intent
-  and Outcome heading falls back to the other two blocks.
+  as a plain, true statement of what the plugin is, not as planning notes. Every member-facing plugin
+  inventory carries the heading as of 2026-08-18 — Mood, LevelUp, and LightHouse were the last three
+  without one, and their `/guide` sections were being written from feature bullets alone. A new
+  member-facing plugin must add the section with the rest of its inventory; one that somehow lacks it
+  falls back to the other two blocks, which is the setup that produced the wrong Workforce framing.
+  The section is capped at 2500 characters, cut at a paragraph break so a long one never reaches the
+  model as a half-sentence — put the plain statement of what the plugin is in the opening paragraph,
+  not after the planning notes.
 
 Rules for every generator-grounding section (at minimum **User Features**, **Intent and Outcome**,
 **Scope and Boundary**, and the test script's **Core smoke**):

--- a/ctf/docs/USER_GUIDE.md
+++ b/ctf/docs/USER_GUIDE.md
@@ -239,9 +239,9 @@ _Last updated: 2026-08-05_
 
 LevelUp is where you can enroll in skills training cohorts and track your progress and credits.
 
-Browse available cohorts by track, status, or start date. Each cohort shows its curriculum and milestones. When you find one that fits, you can enroll and set up a payment plan if one is required.
+Browse available cohorts by track, status, or start date. Each cohort shows its curriculum and milestones. When you find one that fits, you can join it. Some cohorts ask for a deposit in credits, which is held against the cohort's milestones and released as each one is validated.
 
-Your dashboard shows your current ServiceCredits balance, how much is held in escrow for active enrollments, and your recent transactions. You can view your earned achievements and your total credits earned through LevelUp.
+Your dashboard shows your current ServiceCredits balance, how much is being held for cohorts you are in, and your recent credit movements. You can view the badges you have earned and your total credits earned through LevelUp. Credits are an internal unit — there is no way to spend, transfer, or cash them out here.
 
 If a problem comes up with an enrollment, you can open a dispute and add comments or attachments to explain what happened. You can also browse trainer profiles to see who runs each cohort.
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-level-up-feature-inventory.md
@@ -7,6 +7,25 @@
 - Plugin name: `LevelUp`
 - Plugin slug: `level-up`
 
+## Intent and Outcome
+
+LevelUp is where skills training runs. A member browses the open cohorts, reads each one's
+curriculum and milestones, joins one, and follows their own progress — how many milestones are
+done, who the trainer is, and which cohorts they are in right now. Cohorts exist because Workforce
+shows the community is short of people in that occupation; an admin approves each one from that
+ranked list, so what LevelUp offers follows where the skills gaps actually are.
+
+ServiceCredits move through LevelUp, and credits are an internal, non-fiat unit — never money,
+never cash, never redeemable for anything outside the app. A cohort may ask for a deposit in
+credits, held against that cohort's milestones and released as each milestone is validated, with
+the trainer's share set as a percentage. A member's credits view inside LevelUp is read-only: it
+shows the balance, what is being held, and what was earned here, and offers no way to spend or
+transfer. Badges are awarded for reaching something, never bought and never spent.
+
+If something goes wrong with an enrollment, the member opens a dispute and writes what happened,
+with comments and attachments; an admin resolves it. Trainer profiles are browsable but read-only —
+a member reads who runs a cohort and cannot edit it.
+
 ## Implemented User Features
 
 1. Cohort listing with filters for `track`, `status`, and `startDate`.
@@ -245,6 +264,16 @@ that exist today.
 5. ~~Auto cohorts' trainer payout did not fire because enrollments had no `assigned_trainer_id`.~~ **Resolved (2026-06-29):** enrolling in a claimed auto cohort now sets `assigned_trainer_id` to the claiming trainer (the cohort's `created_by_user_id` once it is no longer the scheduler placeholder), and `claim-trainer` backfills that trainer onto any enrollments made before the claim. So a milestone release now settles the trainer split for auto cohorts. (Admin/human-built cohorts are unchanged — they only get an assigned trainer when one is passed in, since their `created_by_user_id` may be an admin, not the trainer.)
 
 ## Change Log
+
+- 2026-08-18: **Intent and Outcome statement added — it now ships to the public user guide.** As of
+  2026-08-18 the guide generator (`ctf/scripts/generate-user-guide.mjs`) reads each inventory's
+  "Intent and Outcome" section as its framing block; LevelUp had no such heading, so its `/guide`
+  section was written from feature bullets alone and described joining a cohort as setting up a
+  "payment plan" — credits are an internal, non-fiat unit and are never described in money terms. The
+  new section states what LevelUp is, where its cohorts come from (the Workforce skills gaps, admin
+  approved), and how credits work here in the approved wording: a deposit in credits held against the
+  cohort's milestones, a read-only credits view with no spend or transfer, badges awarded and never
+  bought. Documentation only; no schema, route, contract, or behavior change.
 
 - 2026-08-15: **The admin and the member now count the same enrollment rows (owner report: "admin
   says 3 people enrolled but the member side says 3 cohorts are open, not members").** Three separate

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-lighthouse-feature-inventory.md
@@ -9,6 +9,27 @@
 
 ---
 
+## Intent and Outcome
+
+LightHouse is where members offer places to stay and ask to stay in them. Browsing needs nothing at
+all: no LightHouse profile, no approval step — open it and the listings are there, each with its
+location, its rent, and its details. Listing a place is self-service, and the same member can be
+both a host and someone looking for a place at the same time.
+
+Asking to stay is the one action that needs the member's own details filled in first. The host
+accepts or rejects the request, and an accepted request opens a private chat between just those two
+people. An accepted match can also be recorded as an ongoing housing arrangement — how often it
+happens and how it is settled, confirmed by the other person in Recurring Activity. A rent
+arrangement records no amount, only that it happens and how often.
+
+Boundaries, stated in the words they should be repeated in: rent and terms are between the two
+members. LightHouse takes no part in the arrangement itself, has no approval step for a listing,
+and holds nothing on anyone's behalf. What it does carry is the product-wide member block — block
+someone and their listings leave the browse list, and neither person can request a stay from the
+other.
+
+---
+
 ## 1) User Features
 
 ### 1.1 Dashboard and Role-Based Entry
@@ -297,6 +318,16 @@ Android admin present (2026-06-06): `AdminLighthouse.tsx` + `admin-api.ts` added
    than guessed at.
 
 ## 9) Change Log
+
+- 2026-08-18: **Intent and Outcome statement added — it now ships to the public user guide.** As of
+  2026-08-18 the guide generator (`ctf/scripts/generate-user-guide.mjs`) reads each inventory's
+  "Intent and Outcome" section as its framing block; LightHouse had no such heading, so its `/guide`
+  section was written from feature bullets alone — the same setup that made the guide call Workforce
+  a list of "job openings". The new section states what LightHouse is (members offer places and ask
+  to stay in them, browsing gated by nothing, listing self-service, host and seeker at once) and what
+  it is not (rent and terms are between the two members; no approval step; nothing held on anyone's
+  behalf), plus the product-wide member block it honors. Documentation only; no schema, route,
+  contract, or behavior change.
 
 - 2026-08-03: **An accepted match can be recorded as ongoing without leaving LightHouse.** Housing is the
   clearest case of something that carries on month after month, and LightHouse only ever sees the moment

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-mood-feature-inventory.md
@@ -18,6 +18,23 @@ Scope decisions locked for this rewrite:
 
 ---
 
+## Intent and Outcome
+
+Mood is a private check-in on how a member is doing. Pick a number from 1 to 5, add a note if you
+want to, and that is the whole thing; the next check-in is available 7 days later. Each check is
+stored under a server-controlled pseudonym with no account id on the row, so no one — including an
+admin — can read one member's check-in or note.
+
+What comes back is a community pulse and nothing else: the average and the number of check-ins per
+day over the trailing week, withheld entirely until at least five check-ins exist in that window.
+
+Boundaries, stated in the words they should be repeated in: Mood does not respond to a low number,
+does not alert anyone, does not notify a helper, and has no in-app admin screen. It is a shared
+sense of how the community is doing — not a support, safety, or crisis service, and not a record
+anyone can look up about a person.
+
+---
+
 ## 1) User Features
 
 ### 1.1 Mood Check Submission
@@ -115,6 +132,14 @@ Seed script requirement: Provide a deterministic plugin seed script with dummy d
 2. Multi-device behavior (multiple `clientId`s for one authenticated user) is allowed by current schema; the cooldown is one-per-user via the pseudonym, so multiple devices share one cooldown. No UI affordance to reconcile or merge mood history across devices.
 
 ## 9) Change Log
+
+- 2026-08-18: **Intent and Outcome statement added — it now ships to the public user guide.** As of
+  2026-08-18 the guide generator (`ctf/scripts/generate-user-guide.mjs`) reads each inventory's
+  "Intent and Outcome" section as its framing block; Mood had no such heading, so its `/guide`
+  section was written from feature bullets alone — the same setup that made the guide call Workforce
+  a list of "job openings". The new section states what Mood is in plain words and, just as
+  importantly, what it is not: no response to a low number, no alert to anyone, no admin screen, not
+  a support or crisis service. Documentation only; no schema, route, contract, or behavior change.
 
 - 2026-08-02: **Deletion burn-down batch 1: defense-in-depth entry for `mood_submissions`.** The
   registry deleted only `mood_client_identities` (correct — v3 rows store `user_id` as `''` and

--- a/ctf/docs/developer/test-scripts/level-up-test-script.md
+++ b/ctf/docs/developer/test-scripts/level-up-test-script.md
@@ -29,6 +29,12 @@
 
 ## Core smoke (every session)
 
+LevelUp runs skills training: browse the open cohorts, join one, follow your own milestones. Credits
+are an internal, non-fiat unit — a cohort deposit is held in credits against that cohort's milestones
+and released as each is validated, and the member's credits view here is read-only with no spend or
+transfer action. Any screen that offers to spend, transfer, or cash out credits, or that describes a
+deposit in money terms, is a bug (inventory Intent and Outcome, added 2026-08-18).
+
 **Seed before starting:** `pnpm --dir ctf seed:level-up`
 
 1. Sign in as the seed **member** (trainee 1). Open the LevelUp app. The cohort browse screen loads without error and shows at least one cohort card.

--- a/ctf/docs/developer/test-scripts/lighthouse-test-script.md
+++ b/ctf/docs/developer/test-scripts/lighthouse-test-script.md
@@ -34,6 +34,11 @@
 
 ## Core smoke (every session)
 
+LightHouse is where members offer places to stay and ask to stay in them: browsing is gated by
+nothing, listing a place is self-service with no approval step, and one member can be both host and
+seeker. Rent and terms are between the two members — LightHouse holds nothing on anyone's behalf and
+records no amount for an ongoing arrangement (inventory Intent and Outcome, added 2026-08-18).
+
 Member role unless noted.
 
 1. **Opens straight to browse.** Open LightHouse. It lands on the property browse screen — no

--- a/ctf/docs/developer/test-scripts/mood-test-script.md
+++ b/ctf/docs/developer/test-scripts/mood-test-script.md
@@ -32,6 +32,10 @@ This is a personal-wellbeing surface. Individual check-ins are private — they 
 server-controlled pseudonym, never shown to anyone, and only an anonymous aggregate is displayed. Do
 not test for, or expect, any screen that surfaces one member's check-in to another person.
 
+Nor is Mood a support or crisis service: it does not respond to a low number, alert anyone, or notify
+a helper, and it has no in-app admin screen (see the inventory's Intent and Outcome section, added
+2026-08-18). A missing follow-up after a low check-in is the designed behavior, not a bug to file.
+
 ---
 
 ## Core smoke (every session)

--- a/ctf/packages/web/app/guide/guide-content.json
+++ b/ctf/packages/web/app/guide/guide-content.json
@@ -216,8 +216,8 @@
       "updated": "2026-08-05",
       "summary": "LevelUp is where you can enroll in skills training cohorts and track your progress and credits.",
       "body": [
-        "Browse available cohorts by track, status, or start date. Each cohort shows its curriculum and milestones. When you find one that fits, you can enroll and set up a payment plan if one is required.",
-        "Your dashboard shows your current ServiceCredits balance, how much is held in escrow for active enrollments, and your recent transactions. You can view your earned achievements and your total credits earned through LevelUp.",
+        "Browse available cohorts by track, status, or start date. Each cohort shows its curriculum and milestones. When you find one that fits, you can join it. Some cohorts ask for a deposit in credits, which is held against the cohort's milestones and released as each one is validated.",
+        "Your dashboard shows your current ServiceCredits balance, how much is being held for cohorts you are in, and your recent credit movements. You can view the badges you have earned and your total credits earned through LevelUp. Credits are an internal unit — there is no way to spend, transfer, or cash them out here.",
         "If a problem comes up with an enrollment, you can open a dispute and add comments or attachments to explain what happened. You can also browse trainer profiles to see who runs each cohort."
       ],
       "howTo": [

--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -117,6 +117,17 @@ function extractSection(md, headingRe) {
   return out.join('\n').trim();
 }
 
+// Trim `text` to at most `limit` characters, cutting at the last paragraph break inside the limit so
+// a truncated block never ends mid-sentence (the model reads a half-sentence as a finished claim).
+// Inventory prose is hard-wrapped, so a bare line break usually sits mid-sentence; fall back to one
+// only when there is no blank line to cut at, and to a hard slice when there is neither.
+function capAtParagraph(text, limit) {
+  if (text.length <= limit) return text;
+  const head = text.slice(0, limit);
+  const cut = Math.max(head.lastIndexOf('\n\n'), 0) || head.lastIndexOf('\n');
+  return (cut > 0 ? head.slice(0, cut) : head).trimEnd();
+}
+
 // Last commit date (YYYY-MM-DD) touching any of the given files; today when git is unavailable.
 function lastUpdated(paths) {
   const real = paths.filter(Boolean);
@@ -139,6 +150,7 @@ const GROUNDING = `GROUNDING — DO NOT FABRICATE (most important rule, override
 - The three source blocks below (this plugin's "What it is", its "User Features", and its "Core smoke" steps) are your ONLY facts. Every claim you write must trace to them. If they do not say it, you do not write it.
 - Invent no capability, number, date, rating, or outcome. When unsure what something does, say less — a vaguer true sentence beats a specific false one. A short section is fine.
 - Keep the frame the docs give you. Never swap a documented term for a familiar real-world one that means something different — a headcount worked out from a population model is not a "job opening", a list of skills is not a "job board", and a count is not a rating. If a plain word for it is not in the sources, describe what the screen shows instead of naming it.
+- ServiceCredits and every in-app credit are an internal, non-fiat unit — never money, cash, a currency, or redeemable for anything outside the app. Never write "payment", "payment plan", "price", "cost", "pay", "buy", "purchase", "refund", "cash out", or a currency symbol about credits. A credit movement is a send, transfer, or exchange; a cohort deposit is held in credits, not paid. Real money unrelated to credits (a listing's actual rent, a confirmed donation in dollars) is real money and is described as such.
 - The platform verifies NO ONE's identity, background, or work, and has no trust "score". Never write "verified", "verification", "vetted", "background check", or "trust score", even for Directory, Foundation, or Trust features. Foundation helpers are fellow community members, not a formally vetted service. Trust features are peer/social information only.
 - Describe MEMBER actions only. Skip anything admin-only.`;
 
@@ -233,10 +245,11 @@ for (const [slug, title] of ORDER) {
   const ts = tsPath ? readFileSync(tsPath, 'utf-8') : '';
   // "Intent and Outcome" states what the plugin IS. Without it the model has only feature bullets
   // and reaches for a familiar frame that may be wrong (see the Workforce note at the top of this
-  // file). A few inventories have no such heading — those sections fall back to the other two blocks.
-  // Capped because these sections carry developer planning notes the model does not need; only the
-  // longest of them (PeerProgramming) is anywhere near the cap today.
-  const whatItIs = extractSection(inv, /Intent (and|&) Outcome/i).slice(0, 2500);
+  // file). Every member-facing inventory carries the heading as of 2026-08-18; one that does not
+  // falls back to the other two blocks. Capped because these sections carry developer planning notes
+  // the model does not need — only the longest (PeerProgramming) is near the cap today — and the cap
+  // lands on a paragraph break so the block never ends mid-sentence and reads as a truncated claim.
+  const whatItIs = capAtParagraph(extractSection(inv, /Intent (and|&) Outcome/i), 2500);
   const features = extractSection(inv, /User Features/i);
   const coreSmoke = extractSection(ts, /Core smoke/i);
   const updated = lastUpdated([invPath, tsPath]);


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete
Android: out of scope (web-only per rule 105)

Follow-up to #2235, which made the user guide generator read each inventory's `Intent and Outcome` section as its framing block. Three member-facing inventories had no such heading — Mood, LevelUp, LightHouse — so their public `/guide` sections were still being written from feature bullets alone, the exact setup that made the guide call Workforce a list of "job openings".

## The three statements

Each says what the plugin is and, just as plainly, what it is not, since that is the half a model invents when it is missing:

- Mood — a private 1-to-5 check-in with an optional note, once every 7 days, stored under a server-controlled pseudonym with no account id on the row; what comes back is only the aggregate community pulse, withheld until at least five check-ins exist in the window. It does not respond to a low number, alert anyone, or notify a helper, and has no in-app admin screen. Not a support or crisis service.
- LevelUp — skills training cohorts that exist because Workforce shows a shortage in that occupation, each opened by an admin from that ranked list. Credits are an internal, non-fiat unit: a cohort may ask for a deposit in credits, held against its milestones and released as each is validated; the member's credits view here is read-only with no spend or transfer; badges are awarded, never bought.
- LightHouse — members offer places to stay and ask to stay in them. Browsing is gated by nothing, listing is self-service with no approval step, and one member can be host and seeker at once. Rent and terms are between the two members, nothing is held on anyone's behalf, and an ongoing arrangement records no amount. The product-wide member block is honored here.

Each plugin's manual test script gained the matching framing note, so the inventory and its runnable counterpart stay in step and a tester does not file the designed behavior (no follow-up after a low Mood check-in) as a bug.

## A second wrong frame, found on the way

The shipped LevelUp guide section described joining a cohort as "set up a payment plan if one is required", and its credits paragraph used "escrow". Credits are a non-fiat internal unit and are never described in money terms, so that is a rule violation sitting on a public page.

- The generator's grounding rules gained a line: credits are never money, never write "payment", "price", "pay", "buy", "refund", "cash out", or a currency symbol about them, and real money unrelated to credits (a listing's actual rent, a confirmed donation in dollars) is still described as real money.
- The two LevelUp paragraphs in `guide-content.json` and `docs/USER_GUIDE.md` are corrected by hand as a stopgap. Unlike #2235 this is temporary on purpose: these inventory edits change the three sections' dates, so the next scheduled run regenerates Mood, LevelUp, and LightHouse from the new grounding.

## One more generator fix

The Intent block is capped at 2500 characters and was being cut mid-sentence. It now cuts at a paragraph break, so a long section never reaches the model as a half-sentence that reads as a finished claim. PeerProgramming is the only section near the cap; it now ends at 2030 characters on a complete sentence.

Rule 120 records that every member-facing inventory now carries the heading, that a new plugin must add one, and that the plain statement belongs in the opening paragraph rather than after the planning notes.

## Checks run locally

`check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs` (which is what requires the matching test-script edits), `check-us-spelling.mjs`, `check-notice-formatting.mjs` all pass. The script parses, all 19 member-facing plugins now extract a non-empty Intent block, and a render check confirms `USER_GUIDE.md` still matches byte-for-byte what the generator would write from `guide-content.json`. Install-and-build gates not run: documentation, one node script outside every workspace package, and two string values in a JSON file whose shape is unchanged.

## Noted, not changed

PeerProgramming's Intent opens with "a persistent, async-first collaboration experience" — abstract product-speak of the kind rule 120 tells authors to avoid in a generator-grounding section, and it now ships as framing. Its current guide section is concrete and correct, so I left the approved wording alone rather than rewrite it uninvited. Worth a look when someone next touches that inventory.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E2RZzr6gxi8fPqanEAsf7Y)_