### PR TITLE
fix: hide the GDP "Estimate" chip while the Community Value Index is 0

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-gross-domestic-product-feature-inventory.md
@@ -78,6 +78,9 @@ The plugin ships on web (desktop + mobile-responsive). The former native Android
 2. Canonical-definition status indicator per KPI.
 3. Clear handling for unresolved/blocked metrics (not found/ambiguous).
 4. Human-readable metric definition panel (name, owner, formula summary).
+5. The "Estimate" chip beside the headline Community Value Index, shown only when the figure is
+   flagged an estimate **and** is above 0 — a 0 index has nothing rolled together to estimate, so the
+   chip is hidden rather than reading as doubt about the zero.
 
 ### 1.6 Value Waiting to Happen (projected figure)
 
@@ -355,6 +358,15 @@ GDP draws aggregated values from upstream plugin schemas; no dedicated seed scri
 ---
 
 ## 10) Change Log
+
+- 2026-08-18: **The "Estimate" chip is hidden while the Community Value Index is 0.** The flag that
+  drives the chip (`gdp_metric_snapshots.is_estimate`) is set on every Community Value Index row no
+  matter what the number is, so a brand-new community saw "0 Estimate" on the hero and in the sidebar
+  ticker — which reads as if the zero itself were in doubt, when in fact nothing has been rolled
+  together yet. `deriveIsEstimate` in `components/gdp/gdp-shell.tsx` now also requires the index value
+  to be above 0, so the chip disappears at 0 and returns as soon as the first exchange is recognized.
+  Both surfaces read that one derived flag, so they stay in step. No schema, route, contract, or copy
+  change; the chip label and footnote wording are untouched.
 
 - 2026-08-10: **Launch date moved to a platform-owned constant; no visible change to GDP.** Weekly
   Performance needed the same launch date to floor its week history, and a plugin must not import

--- a/ctf/docs/developer/test-scripts/gdp-test-script.md
+++ b/ctf/docs/developer/test-scripts/gdp-test-script.md
@@ -68,18 +68,20 @@ Result: web ☐
 
 **Role:** member
 **Surfaces:** web (desktop), web (mobile-responsive)
-**Precondition:** Seed run includes at least one `gdp_metric_snapshots` row with `is_estimate = true` for the headline metric (`gdp_total_revenue` or `gdp_value_index`).
+**Precondition:** Seed run includes at least one `gdp_metric_snapshots` row with `is_estimate = true` for the headline metric (`gdp_total_revenue` or `gdp_value_index`), and the recognized Community Value Index is above 0.
 
 **Steps:**
 1. On `/apps/gdp`, locate the main GDP headline value in the hero and in the sidebar Live Ticker.
 2. Check for an "Estimate" chip or badge next to each flagged figure.
 3. Read the footnote beneath the chip.
+4. On a community with nothing recognized yet (headline figure reads 0), look at the same two places again.
 
 **Expected:**
-- An understated "Estimate" chip appears on the headline figure (and in the sidebar Live Ticker) wherever `isEstimate` is true.
+- An understated "Estimate" chip appears on the headline figure (and in the sidebar Live Ticker) wherever `isEstimate` is true and the figure is above 0.
 - The footnote describes a community-wide normalized figure — not a per-user redemption value or a dollar balance.
 - No currency symbol appears alongside the index value.
 - If the seed has no estimate-flagged metric, the chip simply does not appear (no crash).
+- When the headline figure is 0, no chip appears next to it in either place — "0 Estimate" would read as doubt about the zero, and there is nothing rolled together to estimate yet.
 
 Result: web ☐
 

--- a/ctf/packages/web/components/gdp/gdp-shell.tsx
+++ b/ctf/packages/web/components/gdp/gdp-shell.tsx
@@ -60,10 +60,20 @@ function GdpContent({
 // is flagged a normalized estimate. Returns false unless the row actually carries that flag, so the
 // estimate treatment only renders where the data says it is an estimate. Never inspects per-user figures
 // — only the aggregate metric.
+//
+// A zero index also returns false. The flag is set on every Community Value Index row regardless of what
+// the number is, but nothing has been rolled together when the figure is 0, so there is nothing to call
+// an estimate — "0 Estimate" only reads as if the count itself were in doubt. The chip comes back as soon
+// as the index moves above 0.
 function deriveIsEstimate(rawMetrics: unknown): boolean {
   if (!Array.isArray(rawMetrics)) return false;
   return (rawMetrics as GdpMetricRow[]).some(
-    (m) => m && m.metricKey === COMMUNITY_VALUE_INDEX_METRIC_KEY && m.isEstimate === true,
+    (m) =>
+      m &&
+      m.metricKey === COMMUNITY_VALUE_INDEX_METRIC_KEY &&
+      m.isEstimate === true &&
+      Number.isFinite(m.metricValue) &&
+      m.metricValue > 0,
   );
 }
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

The small "Estimate" chip beside the headline Community Value Index is driven by
`gdp_metric_snapshots.is_estimate`. That flag is set to true on every Community Value Index row no
matter what the number is — both the live builder (`lib/gdp/repository.ts`) and the recognition job
(`scripts/recognizeGdp.mjs`) hardcode it.

So on a community with nothing recognized yet, the dashboard hero and the sidebar ticker read
"0 Estimate". That reads as if the zero itself were in doubt, when in fact nothing has been rolled
together and there is nothing to estimate.

## What changed

`deriveIsEstimate` in `components/gdp/gdp-shell.tsx` now also requires the index value to be above 0.
The chip is hidden at 0 and comes back as soon as the first exchange is recognized. Both the hero and
the sidebar ticker read that same derived flag, so they stay in step — no second code path.

Nothing else moved: the chip label and footnote wording are untouched, and there is no schema, route,
or contract change. The reason the index is an estimate at all — it folds money, crypto,
ServiceCredits, and barter through fixed weights — is unchanged and still disclosed wherever the
figure is above 0.

## Docs updated in the same commit

- Feature inventory (`ctf-gross-domestic-product-feature-inventory.md`): the chip is now listed under
  "Data Quality and Trust Cues" with its condition, plus a change-log entry.
- Manual test script (`gdp-test-script.md`): GDP-2 gains a step and an expected result for the
  zero case.

## Checks run locally

`check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, web typecheck, web
lint, and the web build all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_016xnf9sn5dCebB1WLssSbGC)_