### PR TITLE
fix: repair the ClickLog signed-out chip pairing

### DIFF
--- a/ctf/packages/web/components/click-log/click-log-public-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-public-shell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AlertTriangle, Lock, ShieldCheck, Clock, FileText, UserPlus, Pointer, MapPin } from 'lucide-react';
+import { AlertTriangle, Lock, ShieldCheck, Clock, FileText, UserPlus, Pointer, PenLine } from 'lucide-react';
 import { PublicShellBackLink } from '@/components/plugins/public-shell-back-link';
 import type { PublicVisitorShellProps } from '@/components/plugins/public-visitor-registry';
 import { useTheme } from '@/hooks/useTheme';
@@ -68,9 +68,12 @@ function MobileClickLogPublic({ signInUrl, verifyUrl }: { signInUrl: string; ver
 
         <div style={{ display: 'flex', gap: 8, width: '100%' }}>
           {[
+            // Reads as a sequence: log it fast, add detail if you want, and it stays yours.
+            // "Private" sat next to "Location" here, which pitched privacy and location capture
+            // in the same breath. Ending on "Private" keeps the reassurance last.
             { Icon: Pointer, label: 'One tap' },
+            { Icon: PenLine, label: 'Add a note' },
             { Icon: ShieldCheck, label: 'Private' },
-            { Icon: MapPin, label: 'Location' },
           ].map(({ Icon, label }) => (
             <div key={label} style={{ flex: 1, padding: '12px 8px', borderRadius: 12, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, textAlign: 'center' }}>
               <Icon size={18} color={t.ACCENT} style={{ marginBottom: 6, opacity: 0.75 }} />


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

The signed-out ClickLog screen showed three chips under the "Create free account" button: **One tap**, **Private**, **Location**. The last two sat side by side, which reads as a contradiction — the screen promises the log is yours alone and in the same breath advertises that it records where you were. A visitor deciding whether to trust a personal safety log reads those two boxes together, not separately.

The row now reads as a sequence instead:

| Before | After |
|---|---|
| One tap · Private · Location | One tap · Add a note · Private |

- **One tap** — unchanged; logging really is one tap.
- **Add a note** — the optional detail members most often add, and it matches the wording already shipped on the signed-in empty state (`click-log-empty-state.tsx`, "Add context — optionally add notes or location to any log"), so the two screens agree.
- **Private** — moves to the end so the privacy promise closes the row rather than sitting next to location capture.

Location is untouched in the app itself; it just is no longer the headline next to a privacy claim. Nothing else on the screen changed — the heading, the subline, the button, and the locked bottom bar all ship as they were.

## Files

- `ctf/packages/web/components/click-log/click-log-public-shell.tsx` — chip trio and the `MapPin` → `PenLine` icon swap, plus a short comment recording why the pairing changed so it does not get put back.

## Checks run locally

`tsc --noEmit` across the workspace, eslint on the changed file, `pnpm --filter @ctf/web build`, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs` — all pass. No schema, route, or contract change, so no inventory or test-script update is required (neither document names these chip labels).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JTEZpL2TfayyfwLeEVUfUK)_