### PR TITLE
feat: add the Commons section to the user guide generator

### DIFF
--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -44,6 +44,10 @@ const OUT_MD = join(ctfRoot, 'docs/USER_GUIDE.md');
 // Reading order for the guide — people/connection first, then the ways to contribute, then the
 // quieter tools and stats. Each entry: [slug, display name]. Only member-facing plugins appear.
 const ORDER = [
+  // Commons is the home page and the app list itself, so earlier passes left it out of the guide;
+  // members still need it explained (owner decision, 2026-08-18) — it leads the reading order as
+  // the surface everyone lands on first.
+  ['commons', 'Commons'],
   ['directory', 'Directory'],
   ['foundation', 'Foundation'],
   ['chyme', 'Chyme'],


### PR DESCRIPTION
The guide at app.chargingthefuture.com/guide has no Commons section: the generator's plugin list skipped it because Commons is the home page and the app list itself. Members still need it explained (owner decision, 2026-08-18), so Commons now leads the reading order as the surface everyone lands on first.

The section text generates from `ctf-commons-feature-inventory.md` (Intent and Outcome + User Features, both present and concrete) on the next guide run. After this merges, the `generate-user-guide` workflow gets a manual dispatch so `#commons` appears without waiting for the weekly schedule.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwwWBMAXMAdtZTskWfbFZD)_