### PR TITLE
docs: retire the utility token term for ServiceCredits

### DIFF
--- a/ctf/docs/contracts/RECURRING_ACTIVITY_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/RECURRING_ACTIVITY_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -23,7 +23,7 @@ contracts:
       directory profile, a recorded sign-in, or the accounts table where it exists). A fiat
       (non-ServiceCredits) line MUST NOT carry an amount — the value firewall is enforced server-side,
       not just in the UI — so the platform never holds a summable recurring-fiat-payment total. Only
-      ServiceCredits (an internal utility token) may carry a declared value, and even that is a declared
+      ServiceCredits (an internal credits unit) may carry a declared value, and even that is a declared
       figure, never an executed transfer. No free-text is accepted; sector is a fixed enum. Callable
       both from this plugin's own form and from the inline "this happens regularly" control other apps
       render beside a finished arrangement, which passes originPlugin. Implemented by

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-recurring-activity-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-recurring-activity-feature-inventory.md
@@ -32,7 +32,7 @@ signal in Trust. It is emphatically NOT a ledger, NOT a bill, and carries NO fia
    "description."
 2. **No fiat amount, ever.** A fiat-denominated activity stores only the currency label + cadence, never
    a number. The platform therefore never holds a summable recurring-fiat-payment total — the thing that
-   would look like money transmission. Only ServiceCredits (an internal utility token with no third-party
+   would look like money transmission. Only ServiceCredits (an internal credits unit with no third-party
    reporting duty) carries a declared value, and even that is a declared figure, never an executed
    transfer, so it never touches real balances or the SC ledger.
 

--- a/ctf/docs/developer/specs/multi-currency-value-field-spec.md
+++ b/ctf/docs/developer/specs/multi-currency-value-field-spec.md
@@ -8,7 +8,7 @@ Type: cross-cutting schema + library + contract/inventory work. Non-UI foundatio
 
 ## 1. Why
 
-ServiceCredits is a utility token. It is non-fiat, non-cash, non-withdrawable, and has no fiat
+ServiceCredits is an internal credits unit. It is non-fiat, non-cash, non-withdrawable, and has no fiat
 redemption path (already policy in the ServiceCredits inventory: "enforce non-fiat, non-cash,
 non-withdrawable credit behavior"; "fiat redemption paths are out of scope and explicitly denied").
 Showing ServiceCredits at a fiat equivalent (e.g. "≈ $242 USD", "real monetary value", "credits ≈

--- a/ctf/docs/developer/test-scripts/recurring-activity-test-script.md
+++ b/ctf/docs/developer/test-scripts/recurring-activity-test-script.md
@@ -486,3 +486,5 @@ web ☐
 
 **2.** As member B, confirm the activity. Sign in as member A, open the 🔔 tab, and confirm a "Your recurring activity was confirmed." item appears. (Repeat with decline to confirm the "…was declined." item.)
 web ☐
+
+> _Documentation note (2026-08-18): the inventory's ServiceCredits wording changed from "utility token" to "internal credits unit" per the credits rule. Comment and prose only — no behavior, no route, and no test steps changed._

--- a/ctf/packages/web/components/service-credits/sc-shared.ts
+++ b/ctf/packages/web/components/service-credits/sc-shared.ts
@@ -1,7 +1,7 @@
 // Shared constants, types, and helpers for the ServiceCredits web shell.
 // Palette/layout derive from design/.../survivor-hub/ServiceCredits.tsx.
 //
-// Brand rules (critical): "ServiceCredits" is one word and a utility token —
+// Brand rules (critical): "ServiceCredits" is one word and an internal credits unit —
 // it must NEVER be shown at a fiat / dollar equivalent. Balances render as
 // "credits" only.
 

--- a/ctf/packages/web/lib/currency/assert.ts
+++ b/ctf/packages/web/lib/currency/assert.ts
@@ -1,6 +1,6 @@
 // No-fiat-parity guard (issue #120 — the legal line).
 //
-// ServiceCredits is a utility token with no fiat redemption path. A *single* ServiceCredits value
+// ServiceCredits is an internal credits unit with no fiat redemption path. A *single* ServiceCredits value
 // must NEVER be rendered as a fiat equivalent (e.g. "2,420 credits ≈ $242 USD", "purchasing power",
 // "real monetary value"). This guard detects that pattern in a single value/label string.
 //

--- a/ctf/packages/web/lib/currency/types.ts
+++ b/ctf/packages/web/lib/currency/types.ts
@@ -1,5 +1,5 @@
 // Currency model shared across value-bearing plugins (issue #120).
-// ServiceCredits is the platform utility token. Its technical code is 'SC', but UI must always
+// ServiceCredits is the platform credits unit. Its technical code is 'SC', but UI must always
 // render the label 'ServiceCredits' and must never show a ServiceCredits amount at a fiat equivalent.
 
 export type CurrencyKind = 'token' | 'fiat' | 'crypto' | 'barter' | 'free';
@@ -16,7 +16,7 @@ export interface Currency {
   sortOrder: number;
 }
 
-/** Technical code of the platform utility token. Internal only — never render it in UI. */
+/** Technical code of the platform credits unit. Internal only — never render it in UI. */
 export const SERVICE_CREDITS_CODE = 'SC';
 /** The only user-facing name for the token. */
 export const SERVICE_CREDITS_LABEL = 'ServiceCredits';

--- a/ctf/packages/web/lib/gdp/recognition.ts
+++ b/ctf/packages/web/lib/gdp/recognition.ts
@@ -351,7 +351,7 @@ export const RECURRING_ACTIVITY_COUNT_UNIT = 'RACT';
  *     MONTHLY figure by the line's cadence (`CADENCE_MONTHLY_FACTOR`) so a weekly arrangement and a
  *     monthly one moving the same credits over a year count the same. Before that scaling, a weekly 50
  *     and a monthly 50 both contributed 50, which read a weekly arrangement as a twelfth of what it is.
- *     ServiceCredits is an internal utility token with no third-party reporting duty. This is a DECLARED
+ *     ServiceCredits is an internal credits unit with no third-party reporting duty. This is a DECLARED
  *     figure, never an executed transfer, so it never touches real balances and never double-counts the
  *     direct ServiceCredits transfer source (which reads `service_credits_transfers`, a different
  *     table). Fiat lines are unaffected: they are counted by NUMBER of relationships, not by period.

--- a/ctf/packages/web/lib/recurring-activity/repository.ts
+++ b/ctf/packages/web/lib/recurring-activity/repository.ts
@@ -110,7 +110,7 @@ function resolveParticipants(input: CreateRecurringActivityInput): {
 function resolveScValue(currency: Currency, scValue: number | null | undefined): number | null {
   const isServiceCredits = currency.isServiceCredits || currency.code === SERVICE_CREDITS_CODE;
   if (isServiceCredits) {
-    // ServiceCredits is an internal utility token, so a declared value is allowed here (still not an
+    // ServiceCredits is an internal credits unit, so a declared value is allowed here (still not an
     // executed transfer). Optional — a member may leave it blank.
     if (scValue !== undefined && scValue !== null) {
       // Reject zero as well as negatives: a declared value of 0 is meaningless and only useful to

--- a/ctf/packages/web/lib/recurring-activity/types.ts
+++ b/ctf/packages/web/lib/recurring-activity/types.ts
@@ -2,7 +2,7 @@
 //
 // A recurring activity is a member's self-declared, counterparty-confirmed ONGOING relationship with
 // one other member. It is deliberately NOT a ledger and NOT a payment record: no value moves, fiat
-// carries no amount, and only ServiceCredits (an internal utility token) carries a declared value.
+// carries no amount, and only ServiceCredits (an internal credits unit) carries a declared value.
 
 // Fixed sector dropdown — this doubles as the "brief description" so there is no free-text field a
 // member could over-disclose in. Keep in sync with the schema CHECK on recurring_activities.sector.

--- a/ctf/scripts/lib/gdpValueIndex.mjs
+++ b/ctf/scripts/lib/gdpValueIndex.mjs
@@ -133,7 +133,7 @@ export const RECOGNITION_SOURCES = [
     // scaled to a MONTHLY figure by the line's cadence so a weekly arrangement and a monthly one moving
     // the same credits over a year count the same (mirrors CADENCE_MONTHLY_FACTOR in
     // packages/web/lib/recurring-activity/types.ts — keep the two in step). ServiceCredits is an
-    // internal utility token with no third-party reporting duty. This is a declared figure, never an
+    // internal credits unit with no third-party reporting duty. This is a declared figure, never an
     // executed transfer, so it never touches balances and never double-counts the direct ServiceCredits
     // transfer source (a different table). Only active (confirmed) rows count.
     pluginSlug: 'recurring-activity',

--- a/ctf/scripts/seedRecurringActivityPhase0.mjs
+++ b/ctf/scripts/seedRecurringActivityPhase0.mjs
@@ -92,7 +92,7 @@ async function main() {
       },
       {
         // Confirmed ServiceCredits service tie (member A pays member C 50 SC/month). ServiceCredits is
-        // an internal utility token, so a declared value is allowed — it feeds GDP by value (50 SC),
+        // an internal credits unit, so a declared value is allowed — it feeds GDP by value (50 SC),
         // never as an executed transfer.
         id: ACTIVE_SC_SERVICE,
         ownerUserId: memberA,


### PR DESCRIPTION
Owner directive, 2026-08-18, paired with the landing-page copy fix (chargingthefuture/landing-page#40). "Utility token" reads as a tradeable asset, which is exactly the framing the Credits Are Not Money rule forbids. Every internal use now says internal credits unit.

Files changed (comments, type docs, and prose only — no code identifiers, no behavior change):

- `packages/web/components/service-credits/sc-shared.ts` — brand-rules comment
- `packages/web/lib/currency/types.ts` (×2), `lib/currency/assert.ts`
- `packages/web/lib/recurring-activity/types.ts`, `lib/recurring-activity/repository.ts`
- `packages/web/lib/gdp/recognition.ts`
- `scripts/seedRecurringActivityPhase0.mjs`, `scripts/lib/gdpValueIndex.mjs`
- `docs/developer/specs/multi-currency-value-field-spec.md`
- `docs/developer/ctf-plugin-feature-inventories/ctf-recurring-activity-feature-inventory.md`
- `docs/contracts/RECURRING_ACTIVITY_PLUGIN_COMMAND_CONTRACTS.yaml`

Left alone deliberately: `docs/developer/design-audit-2026-05-29.md` keeps the old wording in two places — it is a dated record of questions asked that day (one of which was literally whether "utility token" framing is allowed), not current copy.

Gates run locally before pushing: EOF formatting, inventory drift, test-script drift, typecheck (all packages), and the web build in the pre-push hook — all clean.

Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwwWBMAXMAdtZTskWfbFZD)_