### PR TITLE
feat: show sign-ups and non-verifiers in the Unlock admin

### DIFF
--- a/ctf/docs/contracts/UNLOCK_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -49,6 +49,51 @@ policies:
       - insufficient_role
 
   - pluginId: unlock
+    command: unlock.admin.signups.read
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnlyQueueAccess: required
+    consentRequirements:
+      scopes:
+        - unlock_admin_read
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+
+  - pluginId: unlock
+    command: unlock.admin.signups.exclude
+    version: 1.0.0
+    requiredRoles:
+      - admin
+    attributePolicies:
+      adminOnlyQueueAccess: required
+      csrfConfirmationRequired: true
+    consentRequirements:
+      scopes:
+        - unlock_admin_write
+      fallbackLawfulBasis: legitimate_interest
+    regionRestrictions:
+      allowedTransferMechanisms:
+        - local_processing
+        - scc
+    highRiskFlags:
+      containsPHI: false
+      requiresAdditionalAudit: true
+    denyConditions:
+      - insufficient_role
+      - missing_csrf_confirmation
+      - cross_origin_mutation
+
+  - pluginId: unlock
     command: unlock.admin.experiment.read
     version: 1.0.0
     requiredRoles:

--- a/ctf/docs/contracts/UNLOCK_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -44,6 +44,28 @@ auditEvents:
     timestamp: rfc3339
     actorId: principal
     pluginId: unlock
+    command: unlock.admin.signups.exclude
+    commandVersion: 1.0.0
+    purpose: onboarding_funnel_measurement
+    policyDecision:
+      status: allow_or_deny
+      reason: policy_reason_code
+    dataClassesAccessed:
+      - unlock_excluded_accounts
+    targetContext:
+      adminUserId: user_identifier
+      userId: user_identifier
+      excluded: boolean_flag
+    requestId: request_identifier
+    traceId: trace_identifier
+    result:
+      status: success_or_failure
+      errorCategory: none_or_error_class
+
+  - eventId: uuid
+    timestamp: rfc3339
+    actorId: principal
+    pluginId: unlock
     command: unlock.admin.experiment.read
     commandVersion: 1.0.0
     purpose: experiment_measurement

--- a/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -137,6 +137,7 @@ contracts:
       - auth_provider_account_directory
       - unlock_verification_submissions
       - unlock_excluded_accounts
+      - account_deletion_events
     purpose: onboarding_funnel_measurement
     retentionClass: derived_short_lived
     idempotency: true

--- a/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -123,6 +123,55 @@ contracts:
     idempotency: true
 
   - pluginId: unlock
+    command: unlock.admin.signups.read
+    version: 1.0.0
+    description: >-
+      Read the Unlock admin sign-up panel: the full account roster from the auth provider joined to the
+      verification submissions, so an admin can see how many people signed up and which of them never
+      submitted a Quora URL. Read-only; performs no write.
+    inputSchema: {}
+    outputSchema:
+      signupOverview:
+        type: object
+    dataAccess:
+      - auth_provider_account_directory
+      - unlock_verification_submissions
+      - unlock_excluded_accounts
+    purpose: onboarding_funnel_measurement
+    retentionClass: derived_short_lived
+    idempotency: true
+
+  - pluginId: unlock
+    command: unlock.admin.signups.exclude
+    version: 1.0.0
+    description: >-
+      Mark one account as demo/test so the Unlock admin sign-up counters leave it out, or put it back in
+      the counts. Counter-only: it never changes the member's access tier, submission, or reward.
+    inputSchema:
+      userId:
+        type: string
+        required: true
+      excluded:
+        type: boolean
+        required: true
+      note:
+        type: string
+        required: false
+    outputSchema:
+      ok:
+        type: boolean
+      userId:
+        type: string
+      excluded:
+        type: boolean
+    dataAccess:
+      - unlock_excluded_accounts
+      - unlock_audit_log
+    purpose: onboarding_funnel_measurement
+    retentionClass: audit_long_lived
+    idempotency: true
+
+  - pluginId: unlock
     command: unlock.admin.submission.url.edit
     version: 1.0.0
     description: Admin correction of a submission's Quora profile URL (e.g. fixing a typo). Re-validates and re-normalizes the URL with the same rules as the member submit path. Does not change review status, access tier, or the verification window.

--- a/ctf/docs/contracts/UNLOCK_PROFILE_AND_DELETION_CONTRACT.md
+++ b/ctf/docs/contracts/UNLOCK_PROFILE_AND_DELETION_CONTRACT.md
@@ -51,6 +51,7 @@ Unlock uses canonical identity for authentication, submission ownership, and mod
 - `unlock_verification_submissions`
 - `unlock_audit_log`
 - `unlock_spam_quora_urls`
+- `unlock_excluded_accounts`
 
 Retention summary:
 
@@ -63,6 +64,11 @@ Retention summary:
    the flagged member deletes their data. As shipped, `unlock_verification_submissions` is hard-deleted
    on deletion (see the account deletion registry, which is the source of truth over the intent
    described in sections 5–6 below).
+5. `unlock_excluded_accounts` holds one row per account an admin marked as demo/test so the Unlock
+   admin's sign-up counters leave it out. It is keyed on `user_id` and is hard-deleted with the member's
+   other data (registered `del` in the account deletion registry): the account it names no longer
+   exists, so the row would count for nothing and there is no abuse-prevention reason to keep it. The
+   row grants and revokes nothing — it changes only what the admin sign-up numbers count.
 
 ## 5) Service-Scoped Deletion Contract
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -82,6 +82,22 @@ This plugin must:
 2. Audit service-credit governance event correlation for reward grants.
 3. Provide API contracts suitable for Retool-based admin queue UX.
 
+### 2.4 Sign-up Reading (who joined, and who never verified)
+
+1. See how many people have signed up, without opening the auth provider's dashboard. The Unlock
+   admin page reads the full account roster from the auth provider's backend API on load, because a
+   sign-up is an account and not a row of ours.
+2. See the members who signed up and never submitted a Quora URL — a count and a list with each
+   person's name, handle, email, sign-up date, and whether they have signed in since. Unlock's review
+   queue can never show these people: with no submission there is no queue row, so before this panel
+   they were invisible. A large number here is the signal to look at — either the Quora-URL step is
+   turning spam away as intended, or people are arriving from somewhere other than Quora and cannot
+   finish a step that assumes they came from there.
+3. Mark an account as demo / test so every sign-up number leaves it out, and unmark it to count it
+   again. Nothing on the account itself says it is not a real member, so the exclusion is recorded in
+   `unlock_excluded_accounts` by an admin. Marking changes only the counters — never the member's
+   access, submission, or reward.
+
 ## 3) API Surface and Route Map
 
 ### 3.1 Plugin Command Surface (Authoritative)
@@ -96,6 +112,8 @@ This plugin must:
 8. `unlock.admin.reward.grant`
 9. `unlock.admin.experiment.read`
 10. `unlock.admin.spam_denylist.remove`
+11. `unlock.admin.signups.read`
+12. `unlock.admin.signups.exclude`
 
 ### 3.2 HTTP Projection Routes
 
@@ -113,6 +131,7 @@ Admin routes:
 - `POST /api/unlock/admin/reconcile-rewards` — admin-session-gated (`requireUnlockAdminAccess`, no `CRON_SECRET`). Runs the same idempotent reward drain as the cron and returns `{ scanned, granted, alreadyGranted, withheld, failed }`. Lets an admin grant any approved-but-uncredited reward on demand from the Unlock admin screen (the "Retry pending rewards" button), independent of the GitHub cron. Audited as `unlock.admin.rewards.reconcile`.
 - `POST /api/unlock/admin/submissions/:submissionId/revoke` — admin-session-gated (`requireUnlockAdminAccess`) + CSRF (`x-ctf-csrf: '1'` + same-origin). Duplicate-identity determination "loser" path: claws a granted reward back (best-effort `burnCredits`, key `unlock-revoke-submission-<id>`) and sets the submission to `rejected` + `locked_support_only` with `reward_revoked_at`, so reconcile never re-grants it. Body `{ reviewNote? }`. Returns `{ ok, submission, creditsReclaimed, reclaimAmount }`; idempotent (a second call on an already-revoked submission is a no-op). Audited as `unlock.admin.submission.revoke` (+ `service-credits.governance.burn.unlock.revoke` when credits were reclaimed).
 - `POST /api/unlock/admin/submissions/:submissionId/grant-reward` — admin-session-gated + CSRF. Duplicate-identity determination "winner" path: clears the hold and grants the reward to the chosen account through the shared guard. Returns 409 `unlock_reward_still_held` (with `holderUserId`) if another account still holds the identity's reward (revoke that one first); 409 if the submission is not approved; otherwise `{ ok, submission }`. Idempotent if the reward already landed. Audited as `unlock.admin.reward.grant` (+ `service-credits.governance.mint.grant.unlock.determination` on a fresh grant).
+- `POST /api/unlock/admin/excluded-accounts` — admin-session-gated (`requireUnlockAdminAccess`) + CSRF (`x-ctf-csrf: '1'` + same-origin). Marks one account as demo / test so the sign-up counters leave it out, or puts it back. Body `{ userId, excluded, note? }` (`note` is capped at 200 characters); returns `{ ok: true, userId, excluded }`, 400 on a missing `userId` or a non-boolean `excluded`. Idempotent in both directions — re-marking refreshes the note, unmarking an account that was never marked is a no-op. Writes `unlock_excluded_accounts` only: it never touches the member's access tier, submission, or reward. Audited as `unlock.admin.signups.exclude`. The list itself is read server-side by the admin page (`getUnlockSignupOverview`) and shown in the admin shell's sign-up panel.
 - `POST /api/unlock/admin/spam-denylist/remove` — admin-session-gated (`requireUnlockAdminAccess`) + CSRF (`x-ctf-csrf: '1'`). Removes one normalized Quora URL from `unlock_spam_quora_urls`. Body `{ quoraProfileUrlNormalized }`; returns `{ ok: true }`, 400 if missing. Only stops future submissions of that URL from being auto-blocked — it does not lift the restriction on a member already blocked for it (re-review their submission to approved/rejected for that). The denylist itself is read server-side by the admin page (`listSpamQuoraUrls`) and shown in the admin shell's denylist panel. Audited as `unlock.admin.spam_denylist.remove`.
 
 Internal (cron) routes:
@@ -121,7 +140,13 @@ Internal (cron) routes:
 
 Admin page:
 
-- `GET /admin/unlock`
+- `GET /admin/unlock` — also assembles the sign-up reading server-side via `getUnlockSignupOverview()`
+  (`lib/unlock/signups.ts`): the account roster from the auth provider's backend API, joined to
+  `unlock_verification_submissions` and `unlock_excluded_accounts`. Command `unlock.admin.signups.read`.
+  It never throws — when the provider secret is absent from the runtime or the call fails, the overview
+  comes back `available: false` with the reason in plain words and the panel prints it, so the rest of
+  the admin page still renders. The roster read is capped at 5,000 accounts per load and says so when it
+  truncates.
 
 ## 4) Data Model and Storage Contracts
 
@@ -137,6 +162,13 @@ Admin page:
    so it is retained through account/data deletion (registered `retain` in the account deletion
    registry). Written when a submission is marked spam; a row is removed when the same URL is later
    approved or rejected (the spam mark is reversible).
+
+5. `unlock_excluded_accounts` — the demo / test accounts the sign-up counters leave out. Keyed on
+   `user_id` (primary key); also stores `note` (free text, why it is excluded), `excluded_by_user_id`
+   (the admin who marked it), `created_at`, `updated_at`. Read only by the Unlock admin's sign-up panel;
+   it grants and revokes nothing. Registered `del` in the account deletion registry — if an excluded
+   account deletes their data, the marker goes with it (the account it names no longer exists, so the
+   row would count for nothing).
 
 Multi-currency (issue #120): `unlock_runtime_config` carries `incentive_currency` (FK → `currencies.code`),
 naming the currency of `incentive_amount`. It defaults to ServiceCredits (code `SC`) — the approval
@@ -170,6 +202,15 @@ Index `idx_unlock_verification_submissions_url_normalized` on `quora_profile_url
 9. **Duplicate-identity guard (one Quora profile, one reward).** A normalized Quora URL earns the verification reward on a single account. The shared reward grant (`grantUnlockRewardForSubmission`, used by the approval handler, the hourly reconcile, and the admin determination) checks `getUnlockRewardHolderForUrl` before minting: if another non-revoked account already holds the identity's reward, the reward is **held** (`reward_withheld_at`) for an admin determination rather than auto-minting a second reward for the same person. The admin then awards the chosen account (`grant-reward`) and/or revokes the others (`revoke`, which burns the credits back and locks the account). This blocks both honest cross-account reuse and a perp who pastes a victim's Quora URL onto an impersonation account. The reward verbs are admin-gated + CSRF-guarded and fully audited.
 10. **A `spam` decision is a whole-app block, not just a tier drop (2026-07-30).** `rejected` and `spam` both drop the Unlock tier to `locked_support_only`, which by itself still lets a member into the Commons/Hub support surface and every `any_authenticated` route. To make `spam` mean "removed from the app", the review handler (`POST /api/unlock/admin/submissions/[submissionId]/review`) additionally places a platform-wide (`all`-scope) `account_restrictions` record with reason `unlock:spam`. The central auth gate (`evaluatePluginAccess`) denies every `support_only` and `approved_full` route for an `all`-scope restriction (reason `account_restricted`), so a spammed member is shut out of the Commons and all plugins — only their own status and account/data-deletion (`any_authenticated`) routes stay reachable, preserving the right to be forgotten. A subsequent `approved` or `rejected` decision lifts the restriction **only** when the stored reason is the `unlock:spam` marker, so it never clears an unrelated admin restriction; this makes a mistaken spam mark fully reversible. The restriction upsert and its audit row are written by `restrictAccount` / `unrestrictAccount` (tables `account_restrictions`, `account_restrictions_audit`).
 
+11. **The sign-up panel reads member identity from the auth provider, admin-only (2026-08-19).** The
+    roster read returns each account's name, handle, email address, sign-up time, and last sign-in time.
+    It is reachable only from `/admin/unlock`, which is gated by `evaluatePluginAccess({ requiredRoles:
+    ['admin'] })`, and the email is there for a working reason: a member who never submitted a Quora URL
+    has no Directory profile and no submission row, so the account is the only place their identity
+    exists. Nothing from this panel is rendered on any member-facing surface, and it is never used as
+    trust evidence. The exclusion write is CSRF-guarded and audited as `unlock.admin.signups.exclude`
+    with the target account id; the roster read itself performs no write.
+
 ## 6) Web and Android Delivery Strategy
 
 1. Backend-first delivery with web admin moderation shell.
@@ -183,6 +224,8 @@ Index `idx_unlock_verification_submissions_url_normalized` on `quora_profile_url
    previously shipped 2026-06-07): added `ctf/packages/mobile/src/features/unlock/AdminUnlock.tsx` (new `unlock-admin` App.tsx key) and `admin-api.ts`. The screen lists the pending verification queue and adds per-submission Approve / Reject actions, mirroring the web admin's review action and the `MobileUnlockAdmin.tsx` mockup. Binds only existing endpoints — `GET /api/unlock/admin/submissions?reviewStatus=pending` and `POST /api/unlock/admin/submissions/:submissionId/review` (with `x-ctf-csrf: '1'`). Admin-gated server-side (`requireUnlockAdminAccess`); a 401/403 shows an "admins only" notice. Each decision is confirm-gated via `Alert.alert`. Reject sends `reviewStatus: 'rejected'` with no free-text reason (the route's `reviewNote` is optional and `Alert.prompt` is iOS-only); the `spam` decision the route also accepts is not surfaced, matching the web admin and the mockup's two-button Grant/Deny.
 7. Android A/B experiment readout (admin) — **removed 2026-07-20 (rule 105, PR #1742)** along with the
    rest of the Android Unlock admin surface (web-only now). Historical detail (#1602): the mobile Unlock admin (`AdminUnlock.tsx` + `admin-api.ts`) showed the same "Early Commons access — A/B experiment" panel the web shell renders — per-bucket treatment vs control with completion %, "N of M submitted", and the same Unleash-rollout empty state. The web reads the split server-side in the admin page component, so a new read-only admin-gated route `GET /api/unlock/admin/experiment-split` was added to expose it over HTTP; the mobile client (`fetchExperimentSplit`) fetches it alongside the queue (best-effort — a failure never blocks the queue). Read-only; no new mutation.
+8. Sign-up panel (2026-08-19) is **web-only**, like the rest of the Unlock admin surface — Android carries
+   only the member access-wall/status screen (rule 105). No React Native screen was added.
 
 ## 7) Seed Coverage Status
 
@@ -196,9 +239,32 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 4. Reminder scheduler and cadence delivery worker are pending implementation.
 5. Duplicate-identity guard: the holder check + mint are not wrapped in a per-URL advisory lock, so two brand-new accounts with the same URL approved in the same instant could in theory both be granted before either is recorded as the holder. With serialized reconcile and the per-submission idempotency this is negligible in practice; the admin revoke path cleans up any stray. A per-URL `pg_advisory_xact_lock` around the grant would close it fully.
 6. Duplicate-identity guard is web + backend only. The React Native Unlock **admin** screen (`AdminUnlock.tsx`) was **removed 2026-07-20 (rule 105, PR #1742)** — all Unlock admin (queue review, grant/revoke determination, badges) is now web-only; the earlier "Android parity follow-up" for the per-row withheld/revoked badges and grant/revoke actions no longer applies.
+7. The sign-up roster is fetched from the auth provider on every load of `/admin/unlock` and is not
+   cached. At the current scale that is one provider call per page load; if the roster grows enough for
+   that to matter, cache it for a few minutes rather than dropping the reading.
+8. An account the auth provider no longer holds (the member deleted it) drops out of the sign-up counts
+   on the next load, so the totals are "accounts that exist now", not "accounts ever created". The
+   provider dashboard's all-time sign-up chart counts differently and can read higher.
 
 ## 9) Change Log
 
+- 2026-08-19: **Sign-up reading added to the Unlock admin (owner request).** Two numbers were missing
+  from `/admin/unlock`: how many people have signed up, and how many of them never submitted a Quora
+  URL. The first lived only in the auth provider's dashboard, because a sign-up creates an account and
+  not a row of ours; the second was invisible to every surface, because Unlock's queue is built from
+  submissions and someone who never submitted has no row in it. New `lib/unlock/signups.ts` reads the
+  account roster from the auth provider's backend API (paged, capped at 5,000 per load) and joins it to
+  `unlock_verification_submissions`, and the admin page renders it in a new sign-up panel
+  (`unlock-signups-panel.tsx` + `unlock-signup-row.tsx`) with tabs for "No Quora URL", all sign-ups, and
+  demo / test. New table `unlock_excluded_accounts` plus `POST /api/unlock/admin/excluded-accounts`
+  (admin + CSRF + audited as `unlock.admin.signups.exclude`) let an admin mark the owner's demo and
+  recording accounts so every sign-up number subtracts them — nothing on the account itself says it is
+  not a real member. The exclusion is counter-only: it never changes access, submissions, or rewards.
+  The roster read never throws — a missing provider secret or a failed call comes back as an unavailable
+  overview carrying the reason, and the rest of the admin page still renders. New commands
+  `unlock.admin.signups.read` and `unlock.admin.signups.exclude` added to the command, access-policy,
+  and audit contracts; the new table registered `del` in the account deletion registry and documented in
+  the deletion contract.
 - 2026-08-09: **"Survivor Hub" retired from the Unlock copy (owner decision).** The web submission
   view said "To unlock full access to Survivor Hub", and the mobile screen said "Survivor Hub uses
   Quora profile verification". Both now say **Skills Economy** — the product's actual name in the

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -97,6 +97,11 @@ This plugin must:
    again. Nothing on the account itself says it is not a real member, so the exclusion is recorded in
    `unlock_excluded_accounts` by an admin. Marking changes only the counters — never the member's
    access, submission, or reward.
+4. See who left. An account with an account-scope row in `account_deletion_events` asked to be
+   forgotten; their Unlock submission was deleted with the rest of their data, so counting them as
+   "signed up, never gave a Quora URL" would say the opposite of what happened. They get their own
+   count, their own tab, and a line on the row saying when they asked, and they are subtracted from the
+   member count. A demo / test mark wins over a deletion mark, so no account is subtracted twice.
 
 ## 3) API Surface and Route Map
 
@@ -142,7 +147,9 @@ Admin page:
 
 - `GET /admin/unlock` — also assembles the sign-up reading server-side via `getUnlockSignupOverview()`
   (`lib/unlock/signups.ts`): the account roster from the auth provider's backend API, joined to
-  `unlock_verification_submissions` and `unlock_excluded_accounts`. Command `unlock.admin.signups.read`.
+  `unlock_verification_submissions`, `unlock_excluded_accounts`, and the account-scope rows of
+  `account_deletion_events` (retained through deletion, so it is the only remaining record that an
+  account is a former member rather than someone who never got started). Command `unlock.admin.signups.read`.
   It never throws — when the provider secret is absent from the runtime or the call fails, the overview
   comes back `available: false` with the reason in plain words and the panel prints it, so the rest of
   the admin page still renders. The roster read is capped at 5,000 accounts per load and says so when it
@@ -242,9 +249,15 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
 7. The sign-up roster is fetched from the auth provider on every load of `/admin/unlock` and is not
    cached. At the current scale that is one provider call per page load; if the roster grows enough for
    that to matter, cache it for a few minutes rather than dropping the reading.
-8. An account the auth provider no longer holds (the member deleted it) drops out of the sign-up counts
-   on the next load, so the totals are "accounts that exist now", not "accounts ever created". The
-   provider dashboard's all-time sign-up chart counts differently and can read higher.
+8. The totals are "accounts the auth provider holds now", not "accounts ever created", so the provider
+   dashboard's all-time sign-up chart counts differently and can read higher.
+9. **The app's own Delete Account flow (`DELETE /api/account/full-account`) deletes the member's data
+   but leaves their auth-provider identity in place** — only the operator route
+   (`POST /api/internal/account/delete`) and the provider's own hosted delete remove the identity. So a
+   member who left through the app is still an account in the roster. The sign-up panel identifies them
+   from `account_deletion_events` and subtracts them from the member count, which keeps the numbers
+   honest, but the identity itself is a leftover the panel cannot clear. Closing that is a separate
+   change to the deletion route.
 
 ## 9) Change Log
 
@@ -261,7 +274,11 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
   recording accounts so every sign-up number subtracts them — nothing on the account itself says it is
   not a real member. The exclusion is counter-only: it never changes access, submissions, or rewards.
   The roster read never throws — a missing provider secret or a failed call comes back as an unavailable
-  overview carrying the reason, and the rest of the admin page still renders. New commands
+  overview carrying the reason, and the rest of the admin page still renders. Accounts that asked to be
+  forgotten are identified from the account-scope rows of `account_deletion_events` (retained through
+  deletion) and get their own count and tab: their submission was deleted with the rest of their data,
+  so counting them among "never gave a Quora URL" would read as an onboarding failure when it was
+  someone leaving. New commands
   `unlock.admin.signups.read` and `unlock.admin.signups.exclude` added to the command, access-policy,
   and audit contracts; the new table registered `del` in the account deletion registry and documented in
   the deletion contract.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -251,13 +251,14 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
    that to matter, cache it for a few minutes rather than dropping the reading.
 8. The totals are "accounts the auth provider holds now", not "accounts ever created", so the provider
    dashboard's all-time sign-up chart counts differently and can read higher.
-9. **The app's own Delete Account flow (`DELETE /api/account/full-account`) deletes the member's data
-   but leaves their auth-provider identity in place** — only the operator route
-   (`POST /api/internal/account/delete`) and the provider's own hosted delete remove the identity. So a
-   member who left through the app is still an account in the roster. The sign-up panel identifies them
-   from `account_deletion_events` and subtracts them from the member count, which keeps the numbers
-   honest, but the identity itself is a leftover the panel cannot clear. Closing that is a separate
-   change to the deletion route.
+9. **Auth-provider accounts left behind by deletions made before 2026-08-19 are still in the roster.**
+   Until PR #2259, the app's own Delete Account flow (`DELETE /api/account/full-account`) deleted the
+   member's data but left their auth-provider identity in place; only the operator route
+   (`POST /api/internal/account/delete`) and the provider's own hosted delete removed it. That is fixed
+   for every deletion from now on, but the accounts already stranded there are still counted in the
+   roster this panel reads. It identifies them from `account_deletion_events` and puts them under
+   "Left", so the member count is right, but it cannot clear the account itself — that is the
+   `Delete Account (manual)` Actions workflow, one account at a time.
 
 ## 9) Change Log
 

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -334,18 +334,21 @@ The readout is read-only — no action buttons. A read failure never blocks the 
 **Precondition:** signed in as an admin; the auth provider secret is set in the app runtime.
 **Steps:**
 1. Open `/admin/unlock` and find the "Sign-ups" panel, above the A/B experiment panel.
-2. Read the four numbers — Members, Gave a Quora URL, No Quora URL, Demo / test — and the line above
-   them saying how many accounts there are in total.
-3. Open the **No Quora URL** tab and read the list.
+2. Read the five numbers — Members, Gave a Quora URL, No Quora URL, Demo / test, Left — and the line
+   above them saying how many accounts there are in total.
+3. Open the **No Quora URL** tab and read the list, then open the **Left** tab.
 4. On any row, click **Mark as demo / test**, then watch the four numbers.
 5. Open the **Demo / test** tab, find that row, and click **Count this account again**.
 6. Type part of a name, handle, or email into the search box.
 7. Compare the "Members" number against the sign-up total in the auth provider's own dashboard, minus
    however many accounts you have marked demo / test.
-**Expected:** Step 2: Members = total accounts minus demo/test; Gave a Quora URL + No Quora URL = Members.
-Step 3: every person listed signed up and has no submission — they are not in the review queue below,
-because there is nothing to review. Each row shows a name or handle, the email, the sign-up date, and
-whether they have signed in since. Step 4: `POST /api/unlock/admin/excluded-accounts` records the
+**Expected:** Step 2: Members = total accounts minus demo/test minus Left; Gave a Quora URL + No Quora
+URL = Members. Step 3: on **No Quora URL**, every person listed signed up and has no submission — they
+are not in the review queue below, because there is nothing to review. Each row shows a name or handle,
+the email, the sign-up date, and whether they have signed in since. On **Left**, every row says when
+that person asked to be forgotten; nobody appears on both tabs, and nobody on **Left** is counted as a
+member (their submission was deleted with the rest of their data, so they are not an onboarding
+failure). Step 4: `POST /api/unlock/admin/excluded-accounts` records the
 account (audited `unlock.admin.signups.exclude`); Members and Demo / test both move by one immediately,
 and the row is no longer counted. The member's access, submission, and reward are untouched — check
 their status if you marked someone with a submission. Step 5: the numbers move back. Step 6: the list
@@ -382,5 +385,9 @@ tracked, not a new bug:
   grant/revoke determination actions.
 - The sign-up roster is re-read from the auth provider on every load of `/admin/unlock` and is not
   cached, so the panel is the slowest part of the page to appear.
-- An account someone deleted stops being counted on the next load, so "Members" is accounts that exist
-  now — the auth provider's all-time sign-up chart counts differently and can read higher.
+- "Members" counts accounts the auth provider holds now, so the provider's all-time sign-up chart
+  counts differently and can read higher.
+- Deleting your account through the app removes your data but leaves the auth-provider identity behind
+  (only the operator delete route and the provider's own hosted delete remove it). The sign-up panel
+  labels those accounts "Left" and subtracts them, so the numbers are right, but the leftover identity
+  is not something the panel can clear.

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -387,7 +387,7 @@ tracked, not a new bug:
   cached, so the panel is the slowest part of the page to appear.
 - "Members" counts accounts the auth provider holds now, so the provider's all-time sign-up chart
   counts differently and can read higher.
-- Deleting your account through the app removes your data but leaves the auth-provider identity behind
-  (only the operator delete route and the provider's own hosted delete remove it). The sign-up panel
-  labels those accounts "Left" and subtracts them, so the numbers are right, but the leftover identity
-  is not something the panel can clear.
+- Accounts stranded in the auth provider by deletions made before 2026-08-19, when the app's own delete
+  flow started removing the sign-in as well as the data (PR #2259). The sign-up panel labels them "Left"
+  and subtracts them, so the numbers are right, but clearing the account itself is the
+  `Delete Account (manual)` workflow, not something the panel can do.

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -329,6 +329,31 @@ completion % and "N of M submitted". Android reads it from `GET /api/unlock/admi
 The readout is read-only — no action buttons. A read failure never blocks the queue below it.
 **Result:** web ☐ · android ☐ — notes:
 
+### UNLOCK-A9 · Sign-ups — total, and who never gave a Quora URL
+**Role:** admin / reviewer · **Surfaces:** web (admin surface) — web-only, no Android admin (rule 105)
+**Precondition:** signed in as an admin; the auth provider secret is set in the app runtime.
+**Steps:**
+1. Open `/admin/unlock` and find the "Sign-ups" panel, above the A/B experiment panel.
+2. Read the four numbers — Members, Gave a Quora URL, No Quora URL, Demo / test — and the line above
+   them saying how many accounts there are in total.
+3. Open the **No Quora URL** tab and read the list.
+4. On any row, click **Mark as demo / test**, then watch the four numbers.
+5. Open the **Demo / test** tab, find that row, and click **Count this account again**.
+6. Type part of a name, handle, or email into the search box.
+7. Compare the "Members" number against the sign-up total in the auth provider's own dashboard, minus
+   however many accounts you have marked demo / test.
+**Expected:** Step 2: Members = total accounts minus demo/test; Gave a Quora URL + No Quora URL = Members.
+Step 3: every person listed signed up and has no submission — they are not in the review queue below,
+because there is nothing to review. Each row shows a name or handle, the email, the sign-up date, and
+whether they have signed in since. Step 4: `POST /api/unlock/admin/excluded-accounts` records the
+account (audited `unlock.admin.signups.exclude`); Members and Demo / test both move by one immediately,
+and the row is no longer counted. The member's access, submission, and reward are untouched — check
+their status if you marked someone with a submission. Step 5: the numbers move back. Step 6: the list
+filters and says so when nothing matches. Step 7: the two totals agree. A non-admin cannot reach the
+page or the route. If the auth provider secret is missing from the runtime, the panel prints the reason
+in plain words and the rest of the admin page still loads.
+**Result:** web ☐ — notes:
+
 ---
 
 ## Parity check (web ↔ android)
@@ -355,3 +380,7 @@ tracked, not a new bug:
 - The duplicate-identity guard is web + backend only; the android admin screen has status tabs and
   shows withheld/error counts but does not yet surface the per-row withheld/revoked badges or the
   grant/revoke determination actions.
+- The sign-up roster is re-read from the auth provider on every load of `/admin/unlock` and is not
+  cached, so the panel is the slowest part of the page to appear.
+- An account someone deleted stops being counted on the next load, so "Members" is accounts that exist
+  now — the auth provider's all-time sign-up chart counts differently and can read higher.

--- a/ctf/packages/web/app/admin/unlock/page.tsx
+++ b/ctf/packages/web/app/admin/unlock/page.tsx
@@ -4,6 +4,7 @@ import {
   getUnlockExperimentSplit,
   listUnlockSubmissions,
 } from 'lib/unlock/repository';
+import { getUnlockSignupOverview } from 'lib/unlock/signups';
 import { listSpamQuoraUrls } from 'lib/unlock/spam-denylist';
 import { redirect } from 'next/navigation';
 import { UnlockAdminShell } from '@/components/unlock/unlock-admin-shell';
@@ -16,11 +17,15 @@ export default async function UnlockAdminPage() {
     redirect('/');
   }
 
-  const [dashboard, submissions, experimentSplit, spamDenylist] = await Promise.all([
+  const [dashboard, submissions, experimentSplit, spamDenylist, signupOverview] = await Promise.all([
     getUnlockDashboardSnapshot(),
     listUnlockSubmissions({ limit: 50 }),
     getUnlockExperimentSplit(),
     listSpamQuoraUrls(),
+    // Reads the account roster from the auth provider, so the whole sign-up reading is on this page and
+    // the owner does not have to open the provider dashboard. Never throws — a provider failure comes
+    // back as an unavailable overview carrying the reason.
+    getUnlockSignupOverview(),
   ]);
 
   return (
@@ -29,6 +34,7 @@ export default async function UnlockAdminPage() {
       submissions={submissions}
       experimentSplit={experimentSplit}
       spamDenylist={spamDenylist}
+      signupOverview={signupOverview}
     />
   );
 }

--- a/ctf/packages/web/app/api/unlock/admin/excluded-accounts/route.ts
+++ b/ctf/packages/web/app/api/unlock/admin/excluded-accounts/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { ensureUnlockMutationCsrf, requireUnlockAdminAccess, resolveUnlockRequestId, unlockErrorResponse } from 'lib/unlock/_lib';
+import { addUnlockExcludedAccount, removeUnlockExcludedAccount } from 'lib/unlock/excluded-accounts';
+import { insertUnlockAudit } from 'lib/unlock/repository';
+import { failureResponse } from 'lib/errors/failure';
+
+const MAX_NOTE_LENGTH = 200;
+
+type ExcludeBody = {
+  userId?: string;
+  excluded?: boolean;
+  note?: string;
+};
+
+type ParsedBody = { userId: string; excluded: boolean; note: string | null };
+
+// Read and validate the request body. Keeps the branching out of POST so it stays inside the rule-116
+// complexity gate.
+function parseExcludeBody(raw: ExcludeBody): { ok: true; body: ParsedBody } | { ok: false; message: string } {
+  const userId = raw.userId?.trim();
+  if (!userId) {
+    return { ok: false, message: 'userId is required.' };
+  }
+  if (typeof raw.excluded !== 'boolean') {
+    return { ok: false, message: 'excluded must be true (mark as demo/test) or false (put back in the counts).' };
+  }
+  const note = raw.note?.trim();
+  if (note && note.length > MAX_NOTE_LENGTH) {
+    return { ok: false, message: `note must be ${MAX_NOTE_LENGTH} characters or fewer.` };
+  }
+  return { ok: true, body: { userId, excluded: raw.excluded, note: note && note.length > 0 ? note : null } };
+}
+
+// Admin action: mark an account as a demo/test account (or put it back). This only changes the sign-up
+// counters on the Unlock admin page — it does not touch the member's access, their submission, or any
+// reward. Admin-gated, CSRF-guarded, and audited.
+export async function POST(request: Request) {
+  const csrfDeny = ensureUnlockMutationCsrf(request);
+  if (csrfDeny) {
+    return csrfDeny;
+  }
+
+  const gate = await requireUnlockAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+
+  const requestId = resolveUnlockRequestId(request);
+
+  let raw: ExcludeBody;
+  try {
+    raw = (await request.json()) as ExcludeBody;
+  } catch {
+    return unlockErrorResponse('Invalid JSON payload.', 400);
+  }
+
+  const parsed = parseExcludeBody(raw);
+  if (!parsed.ok) {
+    return unlockErrorResponse(parsed.message, 400);
+  }
+  const { userId, excluded, note } = parsed.body;
+
+  try {
+    if (excluded) {
+      await addUnlockExcludedAccount({ userId, note, actorUserId: gate.auth.userId });
+    } else {
+      await removeUnlockExcludedAccount(userId);
+    }
+
+    await insertUnlockAudit({
+      actorUserId: gate.auth.userId,
+      command: 'unlock.admin.signups.exclude',
+      policyStatus: 'allow',
+      reason: 'ok',
+      targetUserId: userId,
+      requestId,
+      metadata: { excluded, hasNote: note !== null },
+    });
+
+    return NextResponse.json({ ok: true, userId, excluded });
+  } catch (error) {
+    return failureResponse({
+      summary: 'The demo/test account list could not be updated',
+      error,
+      code: 'unlock_excluded_accounts_update_failed',
+      area: 'unlock',
+      op: 'admin_excluded_accounts_update',
+      extra: { excluded },
+    });
+  }
+}

--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -6,9 +6,16 @@ import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import { PluginUserShellButton } from '@/components/shared/plugin-user-shell-button';
 import { Unlock } from 'lucide-react';
 import { UNLOCK_REWARD_SLA_HOURS } from 'lib/unlock/constants';
-import type { SpamQuoraUrlEntry, UnlockDashboardSnapshot, UnlockExperimentBucketStat, UnlockSubmission } from 'lib/unlock/types';
+import type {
+  SpamQuoraUrlEntry,
+  UnlockDashboardSnapshot,
+  UnlockExperimentBucketStat,
+  UnlockSignupOverview,
+  UnlockSubmission,
+} from 'lib/unlock/types';
 import { useTheme } from '@/hooks/useTheme';
 import { getUnlockTokens } from './unlock-shared';
+import { UnlockSignupsPanel } from './unlock-signups-panel';
 import { UnlockSpamDenylistPanel } from './unlock-spam-denylist-panel';
 import {
   grantReward,
@@ -45,11 +52,13 @@ export function UnlockAdminShell({
   submissions: initialSubmissions,
   experimentSplit = [],
   spamDenylist = [],
+  signupOverview,
 }: {
   dashboard: UnlockDashboardSnapshot;
   submissions: UnlockSubmission[];
   experimentSplit?: UnlockExperimentBucketStat[];
   spamDenylist?: SpamQuoraUrlEntry[];
+  signupOverview?: UnlockSignupOverview;
 }) {
   const router = useRouter();
   const { theme } = useTheme();
@@ -163,6 +172,8 @@ export function UnlockAdminShell({
           <StatBlock label="Spam" value={dashboard.spamCount} />
           <StatBlock label="Support-only" value={dashboard.lockedSupportOnlyCount} />
         </div>
+
+        {signupOverview ? <UnlockSignupsPanel overview={signupOverview} /> : null}
 
         <UnlockExperimentPanel experimentSplit={experimentSplit} />
 

--- a/ctf/packages/web/components/unlock/unlock-signup-row.tsx
+++ b/ctf/packages/web/components/unlock/unlock-signup-row.tsx
@@ -4,7 +4,7 @@ import type { UnlockSignupAccount } from 'lib/unlock/types';
 import { useTheme } from '@/hooks/useTheme';
 import { getUnlockTokens } from './unlock-shared';
 
-// Colour and wording for what happened to this person's Quora URL, including the case this panel exists
+// Color and wording for what happened to this person's Quora URL, including the case this panel exists
 // for: they signed up and never submitted one.
 function statusChip(account: UnlockSignupAccount): { label: string; color: string } {
   if (!account.hasSubmission) return { label: 'No Quora URL', color: '#F59E0B' };

--- a/ctf/packages/web/components/unlock/unlock-signup-row.tsx
+++ b/ctf/packages/web/components/unlock/unlock-signup-row.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type { UnlockSignupAccount } from 'lib/unlock/types';
+import { useTheme } from '@/hooks/useTheme';
+import { getUnlockTokens } from './unlock-shared';
+
+// Colour and wording for what happened to this person's Quora URL, including the case this panel exists
+// for: they signed up and never submitted one.
+function statusChip(account: UnlockSignupAccount): { label: string; color: string } {
+  if (!account.hasSubmission) return { label: 'No Quora URL', color: '#F59E0B' };
+  if (account.reviewStatus === 'approved') return { label: 'Approved', color: '#22C55E' };
+  if (account.reviewStatus === 'rejected' || account.reviewStatus === 'spam') {
+    return { label: account.reviewStatus === 'spam' ? 'Spam' : 'Rejected', color: '#EF4444' };
+  }
+  return { label: 'Awaiting review', color: '#F59E0B' };
+}
+
+function shortDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toLocaleDateString();
+}
+
+// The heading for the row: the most human identifier the account carries, falling back to the raw id so
+// a row is never blank. The handle is repeated on its own line only when it is not already the heading.
+function identityOf(account: UnlockSignupAccount): { title: string; handle: string | null } {
+  if (account.name) return { title: account.name, handle: account.username };
+  if (account.username) return { title: `@${account.username}`, handle: null };
+  return { title: account.email ?? account.userId, handle: null };
+}
+
+// "Signed up 3 Aug 2026 · has never signed in since" — one line, built here so the row itself stays
+// inside the rule-116 complexity limit.
+function timingLine(account: UnlockSignupAccount): string {
+  const signedUp = shortDate(account.createdAt);
+  const lastSignIn = shortDate(account.lastSignInAt);
+  const joined = signedUp ? `Signed up ${signedUp}` : 'Sign-up date unknown';
+  return `${joined} · ${lastSignIn ? `last signed in ${lastSignIn}` : 'has never signed in since'}`;
+}
+
+// One muted detail line under the row heading. Renders nothing when there is nothing to say, so the row
+// itself carries no per-line conditional.
+function DetailLine({ text, breakAll = false }: { text: string | null; breakAll?: boolean }) {
+  const { theme } = useTheme();
+  const t = getUnlockTokens(theme);
+  if (!text) return null;
+  return (
+    <div style={{ fontSize: 11, color: t.MUTED, marginTop: 2, wordBreak: breakAll ? 'break-all' : 'normal' }}>
+      {text}
+    </div>
+  );
+}
+
+// One signed-up account in the Unlock admin's sign-up list: who they are, when they joined, whether they
+// ever came back, what happened to their Quora URL, and the button that takes them out of (or puts them
+// back into) the sign-up counts.
+export function UnlockSignupRow({
+  account,
+  busy,
+  onToggleExcluded,
+}: {
+  account: UnlockSignupAccount;
+  busy: boolean;
+  onToggleExcluded: (userId: string, excluded: boolean) => void;
+}) {
+  const { theme } = useTheme();
+  const t = getUnlockTokens(theme);
+  const chip = statusChip(account);
+  const { title, handle } = identityOf(account);
+
+  return (
+    <div style={{ padding: '10px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, wordBreak: 'break-word' }}>{title}</div>
+        <span style={{ fontSize: 11, fontWeight: 700, color: chip.color }}>{chip.label}</span>
+        {account.excluded ? (
+          <span style={{ fontSize: 11, fontWeight: 700, color: t.MUTED }}>Demo / test — not counted</span>
+        ) : null}
+      </div>
+
+      <DetailLine text={handle ? `@${handle}` : null} />
+      <DetailLine text={account.email} breakAll />
+      <DetailLine text={timingLine(account)} />
+      <DetailLine text={account.excludedNote ? `Note: ${account.excludedNote}` : null} />
+
+      <button
+        type="button"
+        onClick={() => onToggleExcluded(account.userId, !account.excluded)}
+        disabled={busy}
+        style={{
+          marginTop: 8,
+          padding: '5px 10px',
+          borderRadius: 8,
+          background: t.SURFACE_CARD,
+          border: `1px solid ${t.BORDER_SOLID}`,
+          color: t.MUTED,
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: busy ? 'not-allowed' : 'pointer',
+          opacity: busy ? 0.6 : 1,
+        }}
+      >
+        {account.excluded ? 'Count this account again' : 'Mark as demo / test'}
+      </button>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/unlock/unlock-signup-row.tsx
+++ b/ctf/packages/web/components/unlock/unlock-signup-row.tsx
@@ -7,6 +7,7 @@ import { getUnlockTokens } from './unlock-shared';
 // Color and wording for what happened to this person's Quora URL, including the case this panel exists
 // for: they signed up and never submitted one.
 function statusChip(account: UnlockSignupAccount): { label: string; color: string } {
+  if (account.deletedTheirData) return { label: 'Deleted their data', color: '#6B7280' };
   if (!account.hasSubmission) return { label: 'No Quora URL', color: '#F59E0B' };
   if (account.reviewStatus === 'approved') return { label: 'Approved', color: '#22C55E' };
   if (account.reviewStatus === 'rejected' || account.reviewStatus === 'spam') {
@@ -36,6 +37,16 @@ function timingLine(account: UnlockSignupAccount): string {
   const lastSignIn = shortDate(account.lastSignInAt);
   const joined = signedUp ? `Signed up ${signedUp}` : 'Sign-up date unknown';
   return `${joined} · ${lastSignIn ? `last signed in ${lastSignIn}` : 'has never signed in since'}`;
+}
+
+// Said only for someone who asked to be forgotten: their submission was deleted with the rest of their
+// data, so the row would otherwise read as "never gave a Quora URL" with nothing to explain it.
+function departureLine(account: UnlockSignupAccount): string | null {
+  if (!account.deletedTheirData) return null;
+  const on = shortDate(account.deletedAt);
+  return on
+    ? `Asked to be forgotten on ${on} — their data, this submission included, was deleted. Not counted.`
+    : 'Asked to be forgotten — their data, this submission included, was deleted. Not counted.';
 }
 
 // One muted detail line under the row heading. Renders nothing when there is nothing to say, so the row
@@ -81,6 +92,7 @@ export function UnlockSignupRow({
       <DetailLine text={handle ? `@${handle}` : null} />
       <DetailLine text={account.email} breakAll />
       <DetailLine text={timingLine(account)} />
+      <DetailLine text={departureLine(account)} />
       <DetailLine text={account.excludedNote ? `Note: ${account.excludedNote}` : null} />
 
       <button

--- a/ctf/packages/web/components/unlock/unlock-signups-panel.tsx
+++ b/ctf/packages/web/components/unlock/unlock-signups-panel.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Users } from 'lucide-react';
+import type { UnlockSignupAccount, UnlockSignupOverview } from 'lib/unlock/types';
+import { failureText } from 'lib/errors/client-failure';
+import { useTheme } from '@/hooks/useTheme';
+import { getUnlockTokens } from './unlock-shared';
+import { UnlockSignupRow } from './unlock-signup-row';
+
+type SignupTab = 'not-submitted' | 'all' | 'excluded';
+
+const TAB_LABEL: Record<SignupTab, string> = {
+  'not-submitted': 'No Quora URL',
+  all: 'All sign-ups',
+  excluded: 'Demo / test',
+};
+
+// The four numbers the panel leads with. Derived from the loaded accounts (not from the server's copy of
+// the counts) so marking an account demo/test moves every number at once.
+function summarize(accounts: UnlockSignupAccount[]) {
+  const counted = accounts.filter((account) => !account.excluded);
+  const submitted = counted.filter((account) => account.hasSubmission).length;
+  return {
+    totalAccounts: accounts.length,
+    excludedCount: accounts.length - counted.length,
+    memberCount: counted.length,
+    submittedCount: submitted,
+    notSubmittedCount: counted.length - submitted,
+  };
+}
+
+function matchesSearch(account: UnlockSignupAccount, query: string): boolean {
+  return [account.name, account.username, account.email, account.userId].some(
+    (field) => field != null && field.toLowerCase().includes(query),
+  );
+}
+
+function SignupStat({ label, value, accent }: { label: string; value: number; accent?: string }) {
+  const { theme } = useTheme();
+  const t = getUnlockTokens(theme);
+  return (
+    <div style={{ flex: 1, minWidth: 92, padding: '10px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ fontSize: 18, fontWeight: 800, color: accent ?? t.TITLE }}>{value}</div>
+      <div style={{ fontSize: 11, color: t.MUTED, marginTop: 2 }}>{label}</div>
+    </div>
+  );
+}
+
+// Admin panel: how many people have signed up, and which of them never gave us a Quora URL.
+//
+// Unlock only ever sees someone once they submit a Quora URL, so before this panel the total sign-up
+// number lived only in the auth provider's dashboard and the people who stopped before verifying were
+// invisible. Both readings are here now. A large "No Quora URL" number is the signal to look at: either
+// the Quora step is turning spam away as intended, or people are arriving from somewhere other than
+// Quora and cannot finish a step that assumes they came from there.
+//
+// Demo and test accounts are marked from this panel and subtracted from every number above, since
+// nothing on the account itself says it is not a real member.
+export function UnlockSignupsPanel({ overview }: { overview: UnlockSignupOverview }) {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const t = getUnlockTokens(theme);
+  const [accounts, setAccounts] = useState(overview.accounts);
+  const [tab, setTab] = useState<SignupTab>('not-submitted');
+  const [search, setSearch] = useState('');
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const counts = useMemo(() => summarize(accounts), [accounts]);
+  const query = search.trim().toLowerCase();
+  const visible = useMemo(() => {
+    const byTab =
+      tab === 'not-submitted'
+        ? accounts.filter((account) => !account.excluded && !account.hasSubmission)
+        : tab === 'excluded'
+          ? accounts.filter((account) => account.excluded)
+          : accounts;
+    return query ? byTab.filter((account) => matchesSearch(account, query)) : byTab;
+  }, [accounts, tab, query]);
+
+  async function toggleExcluded(userId: string, excluded: boolean) {
+    setBusyUserId(userId);
+    setError(null);
+    try {
+      const res = await fetch('/api/unlock/admin/excluded-accounts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-ctf-csrf': '1' },
+        body: JSON.stringify({ userId, excluded }),
+      });
+      const data = (await res.json().catch(() => null)) as { ok?: boolean; message?: string; code?: string } | null;
+      if (!res.ok) {
+        setError(data?.message ?? data?.code ?? `Update failed (${res.status}).`);
+        return;
+      }
+      setAccounts((prev) =>
+        prev.map((account) => (account.userId === userId ? { ...account, excluded, excludedNote: null } : account)),
+      );
+      router.refresh();
+    } catch (caught) {
+      setError(failureText(caught, { area: 'unlock', op: 'exclude_account', fallback: 'Network error. Try again.' }));
+    } finally {
+      setBusyUserId(null);
+    }
+  }
+
+  return (
+    <div style={{ marginBottom: 16, padding: '12px 14px', borderRadius: 12, background: t.HEADER, border: `1px solid ${t.BORDER_SOLID}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+        <Users size={15} color={t.ACCENT} />
+        <div style={{ fontSize: 13, fontWeight: 700, color: t.TITLE }}>Sign-ups</div>
+      </div>
+
+      {!overview.available ? (
+        <div style={{ fontSize: 12, color: t.MUTED, lineHeight: 1.6, marginTop: 6 }}>
+          {overview.unavailableReason ?? 'The sign-up list could not be read.'}
+        </div>
+      ) : (
+        <>
+          <div style={{ fontSize: 11, color: t.MUTED, marginBottom: 10, lineHeight: 1.6 }}>
+            {counts.totalAccounts} account{counts.totalAccounts === 1 ? '' : 's'} in total, {counts.excludedCount}{' '}
+            marked demo / test. Someone who signs up and never gives a Quora URL never reaches the review
+            queue, so they are listed here instead.
+            {overview.truncated ? ' Only the most recent accounts were read, so these numbers are a floor.' : ''}
+          </div>
+
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}>
+            <SignupStat label="Members" value={counts.memberCount} />
+            <SignupStat label="Gave a Quora URL" value={counts.submittedCount} accent="#22C55E" />
+            <SignupStat label="No Quora URL" value={counts.notSubmittedCount} accent="#F59E0B" />
+            <SignupStat label="Demo / test" value={counts.excludedCount} />
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+            {(['not-submitted', 'all', 'excluded'] as const).map((tabKey) => (
+              <button
+                key={tabKey}
+                type="button"
+                onClick={() => setTab(tabKey)}
+                aria-pressed={tab === tabKey}
+                style={{ padding: '6px 14px', borderRadius: 8, background: tab === tabKey ? t.ACCENT : t.SURFACE, border: `1px solid ${tab === tabKey ? t.ACCENT : t.BORDER_SOLID}`, color: tab === tabKey ? '#fff' : t.MUTED, fontSize: 12, fontWeight: 600, cursor: 'pointer' }}
+              >
+                {TAB_LABEL[tabKey]}
+              </button>
+            ))}
+          </div>
+
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search sign-ups by name, handle, email, or user id"
+            aria-label="Search sign-ups"
+            style={{ width: '100%', boxSizing: 'border-box', padding: '8px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}`, color: t.TITLE, fontSize: 13, marginBottom: 10 }}
+          />
+
+          {error ? (
+            <div role="alert" style={{ fontSize: 12, color: '#EF4444', marginBottom: 10 }}>{error}</div>
+          ) : null}
+
+          {visible.length === 0 ? (
+            <div style={{ fontSize: 12, color: t.MUTED }}>
+              {query ? 'No sign-up matches that search.' : 'Nothing to show on this tab.'}
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {visible.map((account) => (
+                <UnlockSignupRow
+                  key={account.userId}
+                  account={account}
+                  busy={busyUserId === account.userId}
+                  onToggleExcluded={(userId, excluded) => void toggleExcluded(userId, excluded)}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/ctf/packages/web/components/unlock/unlock-signups-panel.tsx
+++ b/ctf/packages/web/components/unlock/unlock-signups-panel.tsx
@@ -9,26 +9,42 @@ import { useTheme } from '@/hooks/useTheme';
 import { getUnlockTokens } from './unlock-shared';
 import { UnlockSignupRow } from './unlock-signup-row';
 
-type SignupTab = 'not-submitted' | 'all' | 'excluded';
+type SignupTab = 'not-submitted' | 'all' | 'excluded' | 'deleted';
 
 const TAB_LABEL: Record<SignupTab, string> = {
   'not-submitted': 'No Quora URL',
   all: 'All sign-ups',
   excluded: 'Demo / test',
+  deleted: 'Left',
 };
+
+// Whether this account counts as a member: not a demo/test account, and not someone who deleted their
+// data. A demo/test mark wins over a deletion mark so nobody is subtracted twice.
+function isCounted(account: UnlockSignupAccount): boolean {
+  return !account.excluded && !account.deletedTheirData;
+}
 
 // The four numbers the panel leads with. Derived from the loaded accounts (not from the server's copy of
 // the counts) so marking an account demo/test moves every number at once.
 function summarize(accounts: UnlockSignupAccount[]) {
-  const counted = accounts.filter((account) => !account.excluded);
+  const counted = accounts.filter(isCounted);
   const submitted = counted.filter((account) => account.hasSubmission).length;
   return {
     totalAccounts: accounts.length,
-    excludedCount: accounts.length - counted.length,
+    excludedCount: accounts.filter((account) => account.excluded).length,
+    deletedCount: accounts.filter((account) => !account.excluded && account.deletedTheirData).length,
     memberCount: counted.length,
     submittedCount: submitted,
     notSubmittedCount: counted.length - submitted,
   };
+}
+
+// Which accounts each tab shows. Kept out of the component so its own decision count stays small.
+function accountsForTab(accounts: UnlockSignupAccount[], tab: SignupTab): UnlockSignupAccount[] {
+  if (tab === 'not-submitted') return accounts.filter((account) => isCounted(account) && !account.hasSubmission);
+  if (tab === 'excluded') return accounts.filter((account) => account.excluded);
+  if (tab === 'deleted') return accounts.filter((account) => !account.excluded && account.deletedTheirData);
+  return accounts;
 }
 
 function matchesSearch(account: UnlockSignupAccount, query: string): boolean {
@@ -71,12 +87,7 @@ export function UnlockSignupsPanel({ overview }: { overview: UnlockSignupOvervie
   const counts = useMemo(() => summarize(accounts), [accounts]);
   const query = search.trim().toLowerCase();
   const visible = useMemo(() => {
-    const byTab =
-      tab === 'not-submitted'
-        ? accounts.filter((account) => !account.excluded && !account.hasSubmission)
-        : tab === 'excluded'
-          ? accounts.filter((account) => account.excluded)
-          : accounts;
+    const byTab = accountsForTab(accounts, tab);
     return query ? byTab.filter((account) => matchesSearch(account, query)) : byTab;
   }, [accounts, tab, query]);
 
@@ -120,8 +131,8 @@ export function UnlockSignupsPanel({ overview }: { overview: UnlockSignupOvervie
         <>
           <div style={{ fontSize: 11, color: t.MUTED, marginBottom: 10, lineHeight: 1.6 }}>
             {counts.totalAccounts} account{counts.totalAccounts === 1 ? '' : 's'} in total, {counts.excludedCount}{' '}
-            marked demo / test. Someone who signs up and never gives a Quora URL never reaches the review
-            queue, so they are listed here instead.
+            marked demo / test and {counts.deletedCount} who deleted their data. Someone who signs up and
+            never gives a Quora URL never reaches the review queue, so they are listed here instead.
             {overview.truncated ? ' Only the most recent accounts were read, so these numbers are a floor.' : ''}
           </div>
 
@@ -130,10 +141,11 @@ export function UnlockSignupsPanel({ overview }: { overview: UnlockSignupOvervie
             <SignupStat label="Gave a Quora URL" value={counts.submittedCount} accent="#22C55E" />
             <SignupStat label="No Quora URL" value={counts.notSubmittedCount} accent="#F59E0B" />
             <SignupStat label="Demo / test" value={counts.excludedCount} />
+            <SignupStat label="Left" value={counts.deletedCount} />
           </div>
 
           <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
-            {(['not-submitted', 'all', 'excluded'] as const).map((tabKey) => (
+            {(['not-submitted', 'all', 'excluded', 'deleted'] as const).map((tabKey) => (
               <button
                 key={tabKey}
                 type="button"

--- a/ctf/packages/web/lib/account/deletion-registry.ts
+++ b/ctf/packages/web/lib/account/deletion-registry.ts
@@ -574,6 +574,9 @@ export const accountDeletionRegistry: readonly PluginDeletionEntry[] = [
         'unlock_spam_quora_urls',
         'Spam Quora-URL denylist; keyed on the URL (holds no member id), retained for abuse prevention so a URL an admin flagged as spam is not lost when the flagged member deletes their data.',
       ),
+      // Counter-only marker: it says "leave this account out of the admin sign-up numbers" and grants
+      // nothing. Once the account is gone the row counts for nothing, so it goes with the rest.
+      del('unlock_excluded_accounts', 'user_id', 'The admin marker that left your account out of the sign-up counts.'),
       // unlock_runtime_config is global.
     ],
   },

--- a/ctf/packages/web/lib/unlock/excluded-accounts.ts
+++ b/ctf/packages/web/lib/unlock/excluded-accounts.ts
@@ -1,0 +1,59 @@
+import { queryDb } from 'lib/db/postgres';
+import type { UnlockExcludedAccount } from './types';
+
+// The accounts the Unlock admin's sign-up counters leave out: the owner's demo/recording accounts and
+// any other test account. Nothing on the account itself says "this is not a real member", so an admin
+// marks it here and every sign-up number on the Unlock admin page subtracts it. Keyed on the auth
+// provider's user id, one row per excluded account.
+
+type UnlockExcludedAccountRow = {
+  user_id: string;
+  note: string | null;
+  excluded_by_user_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function mapExcludedAccount(row: UnlockExcludedAccountRow): UnlockExcludedAccount {
+  return {
+    userId: row.user_id,
+    note: row.note,
+    excludedByUserId: row.excluded_by_user_id,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+}
+
+// Every excluded account, newest mark first.
+export async function listUnlockExcludedAccounts(): Promise<UnlockExcludedAccount[]> {
+  const result = await queryDb<UnlockExcludedAccountRow>(
+    `SELECT user_id, note, excluded_by_user_id, created_at, updated_at
+       FROM unlock_excluded_accounts
+      ORDER BY created_at DESC`,
+  );
+
+  return result.rows.map(mapExcludedAccount);
+}
+
+// Mark an account as demo/test so the sign-up counters stop counting it. Idempotent: re-marking an
+// account already on the list refreshes its note and who marked it rather than failing.
+export async function addUnlockExcludedAccount(input: {
+  userId: string;
+  note: string | null;
+  actorUserId: string;
+}): Promise<void> {
+  await queryDb(
+    `INSERT INTO unlock_excluded_accounts (user_id, note, excluded_by_user_id, created_at, updated_at)
+     VALUES ($1, $2, $3, NOW(), NOW())
+     ON CONFLICT (user_id) DO UPDATE
+     SET note = EXCLUDED.note,
+         excluded_by_user_id = EXCLUDED.excluded_by_user_id,
+         updated_at = NOW()`,
+    [input.userId, input.note, input.actorUserId],
+  );
+}
+
+// Put an account back in the counts. Idempotent: removing an account that was never marked is a no-op.
+export async function removeUnlockExcludedAccount(userId: string): Promise<void> {
+  await queryDb(`DELETE FROM unlock_excluded_accounts WHERE user_id = $1`, [userId]);
+}

--- a/ctf/packages/web/lib/unlock/signups.ts
+++ b/ctf/packages/web/lib/unlock/signups.ts
@@ -86,6 +86,22 @@ async function listProviderAccounts(): Promise<{ accounts: ProviderAccount[]; tr
   }
 }
 
+// The accounts that asked to be forgotten. Their plugin data — the Unlock submission included — is
+// gone, but `account_deletion_events` is retained as the accountability record, so it is the one place
+// left that says this account is a former member rather than someone who never got started. Without
+// this read they would land in the "signed up, never gave a Quora URL" list, which is the opposite of
+// what happened and would make the onboarding signal read worse than it is.
+async function listDeletedAccountDates(): Promise<Map<string, string>> {
+  const result = await queryDb<{ user_id: string; deleted_at: Date }>(
+    `SELECT user_id, MIN(requested_at) AS deleted_at
+       FROM account_deletion_events
+      WHERE scope = 'account'
+      GROUP BY user_id`,
+  );
+
+  return new Map(result.rows.map((row) => [row.user_id, row.deleted_at.toISOString()]));
+}
+
 // Which of those accounts have a Quora URL on file, and what happened to it.
 async function listSubmissionFacts(): Promise<Map<string, SubmissionFact>> {
   const result = await queryDb<{ user_id: string; review_status: UnlockReviewStatus; created_at: Date }>(
@@ -109,6 +125,7 @@ function emptyOverview(unavailableReason: string): UnlockSignupOverview {
     truncated: false,
     totalAccounts: 0,
     excludedCount: 0,
+    deletedCount: 0,
     memberCount: 0,
     submittedCount: 0,
     notSubmittedCount: 0,
@@ -130,10 +147,16 @@ export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
 
   let submissions: Map<string, SubmissionFact>;
   let excludedUserIds: Map<string, string | null>;
+  let deletedDates: Map<string, string>;
   try {
-    const [facts, excluded] = await Promise.all([listSubmissionFacts(), listUnlockExcludedAccounts()]);
+    const [facts, excluded, deleted] = await Promise.all([
+      listSubmissionFacts(),
+      listUnlockExcludedAccounts(),
+      listDeletedAccountDates(),
+    ]);
     submissions = facts;
     excludedUserIds = new Map(excluded.map((entry) => [entry.userId, entry.note]));
+    deletedDates = deleted;
   } catch (error) {
     return emptyOverview(`The verification records could not be read from the database — ${failureReason(error)}`);
   }
@@ -144,13 +167,18 @@ export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
       ...account,
       excluded: excludedUserIds.has(account.userId),
       excludedNote: excludedUserIds.get(account.userId) ?? null,
+      deletedTheirData: deletedDates.has(account.userId),
+      deletedAt: deletedDates.get(account.userId) ?? null,
       hasSubmission: submission !== null,
       reviewStatus: submission?.reviewStatus ?? null,
       submittedAt: submission?.submittedAt ?? null,
     };
   });
 
-  const counted = accounts.filter((account) => !account.excluded);
+  // A demo/test mark wins over a deletion mark, so an account is only ever taken out of the member
+  // count once.
+  const deletedCount = accounts.filter((account) => !account.excluded && account.deletedTheirData).length;
+  const counted = accounts.filter((account) => !account.excluded && !account.deletedTheirData);
   const submittedCount = counted.filter((account) => account.hasSubmission).length;
 
   return {
@@ -158,7 +186,8 @@ export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
     unavailableReason: null,
     truncated: roster.truncated,
     totalAccounts: accounts.length,
-    excludedCount: accounts.length - counted.length,
+    excludedCount: accounts.filter((account) => account.excluded).length,
+    deletedCount,
     memberCount: counted.length,
     submittedCount,
     notSubmittedCount: counted.length - submittedCount,

--- a/ctf/packages/web/lib/unlock/signups.ts
+++ b/ctf/packages/web/lib/unlock/signups.ts
@@ -1,0 +1,167 @@
+import { createClerkClient } from '@clerk/backend';
+import { queryDb } from 'lib/db/postgres';
+import { getClerkSecretKey } from 'lib/auth/clerk-env';
+import { failureReason } from 'lib/errors/failure';
+import { listUnlockExcludedAccounts } from './excluded-accounts';
+import type { UnlockReviewStatus, UnlockSignupAccount, UnlockSignupOverview } from './types';
+
+// Who has signed up, and which of those people never gave us a Quora URL.
+//
+// Unlock only ever sees a member once they submit a Quora profile URL, so its review queue cannot answer
+// the two questions the owner actually asks of it: how many people have joined, and how many joined and
+// then stopped before verifying. The first number lives only in the auth provider (the sign-up is an
+// account, not a row of ours), so this module reads the full account roster from the provider's backend
+// API and joins it to the submissions table. That way the whole reading is on the Unlock admin page and
+// nobody has to open the provider dashboard to get it.
+//
+// A large gap between sign-ups and submissions is the signal: either the Quora-URL step is doing its job
+// and turning spam away, or people are arriving from somewhere other than Quora and cannot complete a
+// step that assumes they came from there.
+
+// One page of the provider's account list. 500 is the provider's maximum page size.
+const PAGE_SIZE = 500;
+// Stop after this many accounts so a much larger future roster cannot turn one admin page load into a
+// long series of provider calls. The overview says so when it truncates.
+const MAX_ACCOUNTS = 5000;
+
+type ProviderAccount = {
+  userId: string;
+  name: string | null;
+  username: string | null;
+  email: string | null;
+  createdAt: string;
+  lastSignInAt: string | null;
+};
+
+type SubmissionFact = {
+  reviewStatus: UnlockReviewStatus;
+  submittedAt: string;
+};
+
+function toIso(epochMs: number | null | undefined): string | null {
+  if (typeof epochMs !== 'number' || !Number.isFinite(epochMs)) return null;
+  return new Date(epochMs).toISOString();
+}
+
+function fullName(user: { firstName: string | null; lastName: string | null }): string | null {
+  const joined = [user.firstName, user.lastName].filter((part) => part && part.trim().length > 0).join(' ').trim();
+  return joined.length > 0 ? joined : null;
+}
+
+function primaryEmail(user: {
+  primaryEmailAddressId: string | null;
+  emailAddresses: { id: string; emailAddress: string }[];
+}): string | null {
+  const primary = user.emailAddresses.find((address) => address.id === user.primaryEmailAddressId);
+  return primary?.emailAddress ?? user.emailAddresses[0]?.emailAddress ?? null;
+}
+
+// Every account the auth provider holds, newest sign-up first. Throws when the provider is not
+// configured or the call fails — the caller turns that into the "why this reading is missing" message.
+async function listProviderAccounts(): Promise<{ accounts: ProviderAccount[]; truncated: boolean }> {
+  const secretKey = getClerkSecretKey();
+  if (!secretKey) {
+    throw new Error('the auth provider secret key is not set in this runtime, so the account list cannot be read');
+  }
+
+  const client = createClerkClient({ secretKey });
+  const accounts: ProviderAccount[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const page = await client.users.getUserList({ limit: PAGE_SIZE, offset, orderBy: '-created_at' });
+    for (const user of page.data) {
+      accounts.push({
+        userId: user.id,
+        name: fullName(user),
+        username: user.username,
+        email: primaryEmail(user),
+        createdAt: new Date(user.createdAt).toISOString(),
+        lastSignInAt: toIso(user.lastSignInAt),
+      });
+    }
+    offset += page.data.length;
+    if (page.data.length < PAGE_SIZE) return { accounts, truncated: false };
+    if (accounts.length >= MAX_ACCOUNTS) return { accounts, truncated: true };
+  }
+}
+
+// Which of those accounts have a Quora URL on file, and what happened to it.
+async function listSubmissionFacts(): Promise<Map<string, SubmissionFact>> {
+  const result = await queryDb<{ user_id: string; review_status: UnlockReviewStatus; created_at: Date }>(
+    `SELECT user_id, review_status, created_at FROM unlock_verification_submissions`,
+  );
+
+  const byUser = new Map<string, SubmissionFact>();
+  for (const row of result.rows) {
+    byUser.set(row.user_id, {
+      reviewStatus: row.review_status,
+      submittedAt: row.created_at.toISOString(),
+    });
+  }
+  return byUser;
+}
+
+function emptyOverview(unavailableReason: string): UnlockSignupOverview {
+  return {
+    available: false,
+    unavailableReason,
+    truncated: false,
+    totalAccounts: 0,
+    excludedCount: 0,
+    memberCount: 0,
+    submittedCount: 0,
+    notSubmittedCount: 0,
+    accounts: [],
+  };
+}
+
+// The sign-up reading behind the Unlock admin's top panel: total accounts, the demo/test accounts an
+// admin has taken out, and the members who never submitted a Quora URL. Never throws — a provider
+// failure comes back as `available: false` with the reason in plain words, so the rest of the admin page
+// still renders.
+export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
+  let roster: { accounts: ProviderAccount[]; truncated: boolean };
+  try {
+    roster = await listProviderAccounts();
+  } catch (error) {
+    return emptyOverview(`The sign-up list could not be read from the auth provider — ${failureReason(error)}`);
+  }
+
+  let submissions: Map<string, SubmissionFact>;
+  let excludedUserIds: Map<string, string | null>;
+  try {
+    const [facts, excluded] = await Promise.all([listSubmissionFacts(), listUnlockExcludedAccounts()]);
+    submissions = facts;
+    excludedUserIds = new Map(excluded.map((entry) => [entry.userId, entry.note]));
+  } catch (error) {
+    return emptyOverview(`The verification records could not be read from the database — ${failureReason(error)}`);
+  }
+
+  const accounts: UnlockSignupAccount[] = roster.accounts.map((account) => {
+    const submission = submissions.get(account.userId) ?? null;
+    return {
+      ...account,
+      excluded: excludedUserIds.has(account.userId),
+      excludedNote: excludedUserIds.get(account.userId) ?? null,
+      hasSubmission: submission !== null,
+      reviewStatus: submission?.reviewStatus ?? null,
+      submittedAt: submission?.submittedAt ?? null,
+    };
+  });
+
+  const counted = accounts.filter((account) => !account.excluded);
+  const submittedCount = counted.filter((account) => account.hasSubmission).length;
+
+  return {
+    available: true,
+    unavailableReason: null,
+    truncated: roster.truncated,
+    totalAccounts: accounts.length,
+    excludedCount: accounts.length - counted.length,
+    memberCount: counted.length,
+    submittedCount,
+    notSubmittedCount: counted.length - submittedCount,
+    accounts,
+  };
+}

--- a/ctf/packages/web/lib/unlock/types.ts
+++ b/ctf/packages/web/lib/unlock/types.ts
@@ -130,6 +130,11 @@ export type UnlockSignupAccount = {
   // True when an admin has marked this as a demo/test account, so the sign-up counters leave it out.
   excluded: boolean;
   excludedNote: string | null;
+  // True when this account has an account-scope row in account_deletion_events: the person asked to be
+  // forgotten and their data is gone. Their submission row went with it, so without this they would be
+  // counted as "signed up, never gave a Quora URL" — the opposite of what happened.
+  deletedTheirData: boolean;
+  deletedAt: string | null;
   hasSubmission: boolean;
   reviewStatus: UnlockReviewStatus | null;
   submittedAt: string | null;
@@ -147,7 +152,9 @@ export type UnlockSignupOverview = {
   totalAccounts: number;
   // How many of those an admin has marked demo/test.
   excludedCount: number;
-  // totalAccounts - excludedCount: the people we treat as real sign-ups.
+  // How many of the rest deleted their data (an account-scope row in account_deletion_events).
+  deletedCount: number;
+  // totalAccounts - excludedCount - deletedCount: the people we treat as real sign-ups.
   memberCount: number;
   // Of memberCount, how many have a Quora URL on file, in any review state.
   submittedCount: number;

--- a/ctf/packages/web/lib/unlock/types.ts
+++ b/ctf/packages/web/lib/unlock/types.ts
@@ -104,3 +104,54 @@ export type UnlockStatus = {
   // (not the repository) from the Unleash rollout; defaults to false (control).
   earlyCommonsAccess: boolean;
 };
+
+// One account on the Unlock admin's demo/test exclusion list (unlock_excluded_accounts). Marking an
+// account here takes it out of every sign-up number on that page; it changes nothing about the member's
+// access or their submission.
+export type UnlockExcludedAccount = {
+  userId: string;
+  note: string | null;
+  excludedByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+// One signed-up account as the Unlock admin's sign-up panel shows it: who they are, when they joined,
+// and whether they ever gave us a Quora URL. Identity comes from the auth provider (an account that
+// never submitted has no row of ours to read a name from); the submission fields come from
+// unlock_verification_submissions.
+export type UnlockSignupAccount = {
+  userId: string;
+  name: string | null;
+  username: string | null;
+  email: string | null;
+  createdAt: string;
+  lastSignInAt: string | null;
+  // True when an admin has marked this as a demo/test account, so the sign-up counters leave it out.
+  excluded: boolean;
+  excludedNote: string | null;
+  hasSubmission: boolean;
+  reviewStatus: UnlockReviewStatus | null;
+  submittedAt: string | null;
+};
+
+// The sign-up reading on the Unlock admin page. `available: false` means the roster could not be read
+// (the auth provider is not configured in this runtime, or the call failed) and `unavailableReason` says
+// why in plain words; every count is 0 in that case rather than pretending nobody signed up.
+export type UnlockSignupOverview = {
+  available: boolean;
+  unavailableReason: string | null;
+  // True when the roster hit the per-load account cap, so the counts cover only the accounts read.
+  truncated: boolean;
+  // Every account the auth provider holds, demo/test accounts included.
+  totalAccounts: number;
+  // How many of those an admin has marked demo/test.
+  excludedCount: number;
+  // totalAccounts - excludedCount: the people we treat as real sign-ups.
+  memberCount: number;
+  // Of memberCount, how many have a Quora URL on file, in any review state.
+  submittedCount: number;
+  // memberCount - submittedCount: signed up, never submitted a Quora URL.
+  notSubmittedCount: number;
+  accounts: UnlockSignupAccount[];
+};

--- a/ctf/schema.demo.sql
+++ b/ctf/schema.demo.sql
@@ -1469,6 +1469,24 @@ ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS first_flag
 ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS last_flagged_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
+-- Accounts the Unlock admin's sign-up counters leave out: the owner's own demo/recording accounts and
+-- any other test account. The Unlock admin reads the full sign-up roster from the auth provider so the
+-- owner does not have to open the provider dashboard to see how many people have joined; those totals
+-- are only useful once the handful of accounts that are not real members are taken out, and there is no
+-- marker on the account itself that says so. An admin marks them here, one row per excluded account, and
+-- every sign-up counter on that page subtracts them.
+CREATE TABLE IF NOT EXISTS unlock_excluded_accounts (
+  user_id TEXT PRIMARY KEY,
+  note TEXT,
+  excluded_by_user_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS note TEXT;
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS excluded_by_user_id TEXT;
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 -- Add prod unlock audit/config tables if missing.
 -- `user_id` and `action` are nullable: the current writer (insertUnlockAudit) records the
 -- actor_user_id/command/policy_status/reason columns and does NOT populate the legacy user_id/action

--- a/ctf/schema.sql
+++ b/ctf/schema.sql
@@ -1471,6 +1471,24 @@ ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS first_flag
 ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS last_flagged_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 ALTER TABLE IF EXISTS unlock_spam_quora_urls ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
+-- Accounts the Unlock admin's sign-up counters leave out: the owner's own demo/recording accounts and
+-- any other test account. The Unlock admin reads the full sign-up roster from the auth provider so the
+-- owner does not have to open the provider dashboard to see how many people have joined; those totals
+-- are only useful once the handful of accounts that are not real members are taken out, and there is no
+-- marker on the account itself that says so. An admin marks them here, one row per excluded account, and
+-- every sign-up counter on that page subtracts them.
+CREATE TABLE IF NOT EXISTS unlock_excluded_accounts (
+  user_id TEXT PRIMARY KEY,
+  note TEXT,
+  excluded_by_user_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS note TEXT;
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS excluded_by_user_id TEXT;
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS unlock_excluded_accounts ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 -- Add prod unlock audit/config tables if missing.
 -- `user_id` and `action` are nullable: the current writer (insertUnlockAudit) records the
 -- actor_user_id/command/policy_status/reason columns and does NOT populate the legacy user_id/action


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — the Unlock admin surface is web-only; Android carries only the member access-wall/status screen).

## What this fixes

The Unlock admin could not answer two questions the owner asks of it:

1. **How many people have signed up?** That number lived only in the auth provider's dashboard, because signing up creates an account and not a row of ours.
2. **How many signed up and then stopped before giving a Quora URL?** That was invisible everywhere. Unlock's review queue is built from submissions, so someone who never submitted has nothing in it — they do not appear on any surface at all.

The second one is the useful signal: a large number there means either the Quora-URL step is turning spam away as intended, or people are arriving from somewhere other than Quora and cannot finish a step that assumes they came from there.

## What was added

A **Sign-ups** panel on `/admin/unlock`, above the A/B experiment panel:

- Five numbers — Members, Gave a Quora URL, No Quora URL, Demo / test, Left — plus a line saying how many accounts there are in total.
- Four tabs: **No Quora URL** (the list this exists for — name or handle, email, sign-up date, and whether they have signed in since), **All sign-ups**, **Demo / test**, and **Left**. A search box filters by name, handle, email, or user id.
- A per-row button to mark an account demo / test, or to count it again.

Nothing on an account itself says it is not a real member, so the demo and recording accounts are marked by hand once and every number above subtracts them from then on. The mark is counter-only: it never touches the member's access tier, submission, or reward.

## Members who left are not onboarding failures

An account with an account-scope row in `account_deletion_events` asked to be forgotten, and their Unlock submission was deleted with the rest of their data. Read naively they look identical to someone who signed up and never verified — the opposite of what happened.

`account_deletion_events` is retained through deletion (it is the accountability record), so it is the one place left that says an account is a former member. Those accounts get the **Left** count and tab, a line on the row saying when they asked, and they come out of the member count — so `Gave a Quora URL + No Quora URL = Members` still holds. A demo / test mark wins over a deletion mark, so nobody is subtracted twice.

This matters right now because the app's own Delete Account flow deletes a member's data but leaves their auth-provider identity behind, so every past in-app deletion is still an account in the roster. #2259 closes that for future deletions; this PR keeps the numbers honest either way, including for the ones already there.

## How it is put together

- `lib/unlock/signups.ts` reads the account roster from the auth provider's backend API (paged, capped at 5,000 accounts per load) and joins it to `unlock_verification_submissions`, `unlock_excluded_accounts`, and the account-scope rows of `account_deletion_events`. It never throws — a missing provider secret in the runtime, or a failed call, comes back as an unavailable overview carrying the reason in plain words, which the panel prints; the rest of the admin page still renders.
- New table `unlock_excluded_accounts` (`user_id` primary key, `note`, `excluded_by_user_id`, timestamps), registered `del` in the account deletion registry — once the account is gone the marker counts for nothing.
- New route `POST /api/unlock/admin/excluded-accounts` — admin-gated, CSRF-guarded, audited as `unlock.admin.signups.exclude`, idempotent in both directions.
- New commands `unlock.admin.signups.read` and `unlock.admin.signups.exclude` added to the command, access-policy, and audit contracts.
- Feature inventory, deletion contract, and the manual test script (new step `UNLOCK-A9`) updated to match.

## Privacy note

The panel shows each account's name, handle, and email. It is reachable only from `/admin/unlock`, which is admin-role gated, and the email is load-bearing: a member who never submitted a Quora URL has no Directory profile and no submission row, so the account is the only place their identity exists. Nothing here is rendered on any member-facing surface and it is never used as trust evidence.

## Not automatic

The 7 demo accounts have to be marked once from the panel — there is no marker on the account to read, and putting the ids in a secret would still mean opening the provider dashboard to find them, which is the thing this change removes.

## Checks run locally

typecheck · lint · a11y lint · modularity and complexity governance · web `build:ci` · unit tests · EOF/format · schema drift (base…head) · deletion registry, deletion engine, export engine · inventory drift · orphan routes · error verbosity · US spelling · notice formatting · test-script drift · web/android parity — all pass. The `web.jsBytes` performance budget is over its limit both before and after this change (6.96 MB → 6.97 MB), so it is pre-existing, not introduced here.

## Review lane

Owner-review lane — this adds a table, a migration, and a new API contract, so auto-merge is deliberately not enabled. Waiting on the owner's review.