### PR TITLE
fix: delete the sign-in when a member deletes their account

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -60,7 +60,14 @@
     — no CSRF needed).
   - `DELETE /api/account/services/:slug` (one plugin) and `DELETE /api/account/full-account`
     (every plugin + ServiceCredits reclaim). Both are self-service (caller's own rows only) and
-    same-origin CSRF-guarded (`x-ctf-csrf: 1`).
+    same-origin CSRF-guarded (`x-ctf-csrf: 1`). The full-account route also removes the member's
+    **auth-provider identity** as its last step (`deleteAuthIdentity`, `lib/account/identity-deletion.ts`
+    — the same helper the operator route uses), so "delete my account" removes the sign-in and not just
+    the data. Best-effort by design: the data deletion has already committed, so a provider outage
+    reports itself in the response (`identityRemoved: false` plus `identityError`) and in the audit row
+    rather than failing a deletion that did happen; the account can then be cleared through the operator
+    route. The provider's own `user.deleted` webhook fires on success and skips, because the
+    `account_deletion_events` row written by this request already exists.
   - `GET /api/account/services/:slug/export` and `GET /api/account/full-account/export` (issue
     #1264) — download the member's own data as JSON, per service or whole account. Both gated by
     `requireAccountAccess`, read-only (no CSRF needed on GET), returned with
@@ -293,6 +300,23 @@ An owner-curated list of real community comments, shown two ways on the public (
 
 ## 5) Change Log
 
+- 2026-08-19: **Deleting your account now removes your sign-in, not just your data (owner report).**
+  `DELETE /api/account/full-account` deleted every plugin's rows and queued the ServiceCredits reclaim
+  but left the member's auth-provider identity in place, so someone who asked to be forgotten was still
+  an account: they could sign back in to an empty app, and every roster read from the provider kept
+  counting them (the Unlock admin's sign-up panel reads exactly that roster, so the leftovers showed up
+  there as people who never verified). Only the operator route
+  (`POST /api/internal/account/delete`) and the provider's own hosted delete removed the identity — the
+  Clerk webhook receiver's comment already assumed the self-service flow did too. The removal moved into
+  a shared `lib/account/identity-deletion.ts` (`deleteAuthIdentity`) that both routes now call, so they
+  cannot drift, and the self-service route calls it as its last step. Best-effort by design: the data
+  deletion has already committed when it runs, so a provider outage reports itself
+  (`identityRemoved: false` + `identityError` in the response, `identityRemoved` on the audit row) and
+  is sent to the error reporter, instead of failing a deletion that did happen. The provider's
+  `user.deleted` webhook fires on success and skips on its existing idempotency guard, so nothing runs
+  twice. The "Deletion queued" confirmation on web and Android now says the sign-in goes too. No schema,
+  contract, or route-surface change. Note: identities left behind by past self-service deletions are
+  still in the provider and must be cleared through the operator route.
 - 2026-08-18: **The user guide generator now reads each plugin's "Intent and Outcome" statement, and
   the Workforce section was corrected (owner report).** The `/guide` page described Workforce as a
   tracker of "job openings by sector and skill level" that members are "matched to". Workforce has no

--- a/ctf/docs/developer/test-scripts/account-data-test-script.md
+++ b/ctf/docs/developer/test-scripts/account-data-test-script.md
@@ -98,3 +98,22 @@ announcements from the operator stay exactly as they were. The second deletion f
 remove and changes nothing on screen. Replies and reactions that hung off the deleted posts are gone
 with them.
 **Result:** web ☐ — notes:
+
+## AD-7 · Full-account delete removes the sign-in too
+
+**Role:** member on a **throwaway account** · **Precondition:** a disposable account you are willing
+to lose permanently — this cannot be undone. Note its email before you start.
+**Steps:**
+1. Sign in as the throwaway account, open Account & Data, choose the full-account delete, type
+   `delete my account`, and confirm.
+2. Read the "Deletion queued" screen.
+3. Try to sign in again with that account's email.
+4. As an admin, open `/admin/unlock` and look at the "Sign-ups" panel.
+**Expected:** Step 2: the confirmation says the personal data is being removed across all services
+**and that the sign-in is removed with it**. Step 3: signing in is no longer possible — the account is
+gone from the auth provider, not merely emptied. Step 4: the account is not in the sign-up list at all
+(it no longer exists), so it is not sitting in the "No Quora URL" tab as if it were someone who never
+verified. If the auth provider is unreachable at the moment of deletion, the data deletion still
+succeeds and the response carries `identityRemoved: false` with the reason — the leftover account is
+then cleared through the operator `Delete Account (manual)` workflow.
+**Result:** web ☐ · android ☐ — notes:

--- a/ctf/packages/mobile/src/features/account-data/AccountData.tsx
+++ b/ctf/packages/mobile/src/features/account-data/AccountData.tsx
@@ -701,8 +701,9 @@ function ConfirmDelete({
         <Text style={s.doneTitle}>Deletion queued</Text>
         <Text style={s.doneSub}>
           Your request has been received. Your personal data is being removed across all services,
-          and your ServiceCredits balance will be settled through the standard process. Some audit
-          records are retained for platform integrity.
+          and your sign-in is removed with it — you will not be able to sign back in. Your
+          ServiceCredits balance will be settled through the standard process. Some audit records are
+          retained for platform integrity.
         </Text>
       </View>
     );

--- a/ctf/packages/web/app/api/account/full-account/route.ts
+++ b/ctf/packages/web/app/api/account/full-account/route.ts
@@ -3,6 +3,7 @@ import { markFullAccountDeletionRequested } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { CHYME_ERROR_CODE } from 'lib/chyme/constants';
 import { deleteAllAccountData } from 'lib/account/deletion-orchestrator';
+import { deleteAuthIdentity } from 'lib/account/identity-deletion';
 import { requireAccountAccess, ensureMutationCsrf } from '../_lib';
 import { reportError } from 'lib/observability/report';
 
@@ -33,6 +34,18 @@ export async function DELETE(request: Request) {
     // stamps completion separately.
     const deletion = await deleteAllAccountData(userId, reclaim.requestedAtIso);
 
+    // Finally remove the sign-in itself. Deleting the data does not delete the account — the auth
+    // provider holds that — so without this a member who asked to be forgotten stays an account they
+    // can sign back into, and every roster read from the provider keeps counting them. Runs last and
+    // best-effort: the data deletion has already committed, so a provider outage reports itself
+    // (`identityRemoved: false` + `identityError`) instead of failing a deletion that did happen. The
+    // provider's `user.deleted` webhook fires on success and skips, because the deletion event row
+    // written above already exists.
+    const identity = await deleteAuthIdentity(userId);
+    if (identity.error) {
+      reportError(new Error(identity.error), { area: 'account', op: 'full_account_identity_delete' });
+    }
+
     logChymeAudit({
       pluginId: 'chyme',
       command: 'account.profile.delete.full',
@@ -41,6 +54,7 @@ export async function DELETE(request: Request) {
       reason: 'account_deletion_requested',
       target: {
         scope: 'account',
+        identityRemoved: String(identity.deleted),
       },
       result: 'success',
       errorCategory: null,
@@ -54,6 +68,8 @@ export async function DELETE(request: Request) {
         requestedAtIso: deletion.requestedAtIso,
         completedAtIso: deletion.completedAtIso,
         tablesAffected: deletion.tables.length,
+        identityRemoved: identity.deleted,
+        identityError: identity.error,
       },
       { status: 200 },
     );

--- a/ctf/packages/web/app/api/internal/account/delete/route.ts
+++ b/ctf/packages/web/app/api/internal/account/delete/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
-import { createClerkClient } from '@clerk/backend';
 import { markFullAccountDeletionRequested } from 'lib/chyme/repository';
 import { logChymeAudit } from 'lib/chyme/audit';
 import { deleteAllAccountData } from 'lib/account/deletion-orchestrator';
+import { deleteAuthIdentity } from 'lib/account/identity-deletion';
 import { runWithForcedPool } from 'lib/db/postgres';
-import { getClerkSecretKey } from 'lib/auth/clerk-env';
 import { reportError } from 'lib/observability/report';
 import { failureReason } from 'lib/errors/failure';
 
@@ -87,7 +86,8 @@ async function parseDeleteRequest(request: Request): Promise<{ error: NextRespon
 
 // Optionally delete the Clerk identity after the DB deletion has already succeeded. Runs only when
 // requested; a Clerk failure is surfaced (clerkError) without failing the request so the operator can
-// retry just the Clerk side (e.g. the user was already removed there).
+// retry just the Clerk side (e.g. the user was already removed there). The removal itself is the
+// shared `deleteAuthIdentity` the self-service delete route also uses, so the two cannot drift.
 async function deleteClerkAccountIfRequested(
   userId: string,
   deleteClerk: boolean,
@@ -95,18 +95,8 @@ async function deleteClerkAccountIfRequested(
   if (!deleteClerk) {
     return { clerkDeleted: false, clerkError: null };
   }
-  const secretKey = getClerkSecretKey();
-  if (!secretKey) {
-    return { clerkDeleted: false, clerkError: 'clerk_secret_not_configured' };
-  }
-  try {
-    await createClerkClient({ secretKey }).users.deleteUser(userId);
-    return { clerkDeleted: true, clerkError: null };
-  } catch (error) {
-    // The DB deletion already succeeded; surface the Clerk failure without failing the request
-    // so the operator can retry just the Clerk side (e.g. the user was already removed there).
-    return { clerkDeleted: false, clerkError: error instanceof Error ? error.message : 'clerk_delete_failed' };
-  }
+  const outcome = await deleteAuthIdentity(userId);
+  return { clerkDeleted: outcome.deleted, clerkError: outcome.error };
 }
 
 export async function POST(request: Request) {

--- a/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
+++ b/ctf/packages/web/components/account-data/account-data-confirm-delete.tsx
@@ -88,7 +88,7 @@ export function AccountDataConfirmDelete({ serviceCount, onCancel, onConfirm }: 
           </div>
           <div style={{ fontSize: 22, fontWeight: 800, color: TEXT, marginBottom: 10 }}>Deletion queued</div>
           <div style={{ fontSize: 14, color: SUBTLE, lineHeight: 1.7 }}>
-            Your request has been received. Your personal data is being removed across all services. Your ServiceCredits are held for 7 days from now, then returned to the community treasury; if any are locked in an active escrow, the return waits until that escrow resolves. Some audit records are retained for platform integrity.
+            Your request has been received. Your personal data is being removed across all services, and your sign-in is removed with it — you will not be able to sign back in. Your ServiceCredits are held for 7 days from now, then returned to the community treasury; if any are locked in an active escrow, the return waits until that escrow resolves. Some audit records are retained for platform integrity.
           </div>
         </div>
       </div>

--- a/ctf/packages/web/lib/account/identity-deletion.ts
+++ b/ctf/packages/web/lib/account/identity-deletion.ts
@@ -1,0 +1,31 @@
+import { createClerkClient } from '@clerk/backend';
+import { getClerkSecretKey } from 'lib/auth/clerk-env';
+import { failureReason } from 'lib/errors/failure';
+
+// Removing the sign-in itself, which is the last thing a full account deletion has to do.
+//
+// Deleting a member's data does not remove their identity: the auth provider holds the account, not
+// us. Leaving it behind means someone who asked to be forgotten still exists as an account — they can
+// sign back in to an empty app, they are still counted in every roster read from the provider, and the
+// owner has to reconcile a sign-up list against a member list that no longer agrees with it.
+//
+// Deliberately best-effort. The data deletion has already committed by the time this runs, so a
+// provider outage must not turn a completed deletion into a failed request; the caller reports what
+// happened and the account can be cleared afterwards through the operator delete route. The provider
+// fires its own `user.deleted` webhook on success, which our receiver skips because the deletion event
+// row already exists — so this never double-runs the cleanup.
+export type IdentityDeletionOutcome = { deleted: boolean; error: string | null };
+
+export async function deleteAuthIdentity(userId: string): Promise<IdentityDeletionOutcome> {
+  const secretKey = getClerkSecretKey();
+  if (!secretKey) {
+    return { deleted: false, error: 'The auth provider secret key is not set in this runtime, so the sign-in could not be removed.' };
+  }
+
+  try {
+    await createClerkClient({ secretKey }).users.deleteUser(userId);
+    return { deleted: true, error: null };
+  } catch (error) {
+    return { deleted: false, error: failureReason(error) };
+  }
+}


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

The Android side is in scope here (account / settings is on the rule-105 keep-list) and is covered: the route is shared backend, and the Android "Deletion queued" copy is updated alongside the web one.

## The gap

`DELETE /api/account/full-account` — the "Delete my account" flow a member runs from Account & Data — removed every plugin's rows and queued the ServiceCredits reclaim, but never removed the member's auth-provider identity. The account is held by the provider, not by us, so deleting the data left the account itself alive.

That means someone who asked to be forgotten:

- can still sign back in, to an empty app;
- is still counted in every roster read from the provider.

The second one has a visible consequence: the Unlock admin's new sign-up panel reads that roster, so these accounts appear as people who signed up and never verified — the opposite of what happened.

Only the operator route (`POST /api/internal/account/delete`) and the provider's own hosted delete removed the identity. This is a gap, not an intended behavior: the Clerk webhook receiver's own comment already says "the app's own delete flow calls Clerk deleteUser".

## The change

- New `lib/account/identity-deletion.ts` (`deleteAuthIdentity`) holds the removal. Both the self-service route and the operator route call it now, so the two cannot drift — the operator route's private copy is gone.
- The self-service route calls it as its **last** step, after the data deletion has committed.
- **Best-effort by design.** The data deletion has already committed when this runs, so a provider outage must not turn a completed deletion into a failed request. A failure reports itself: `identityRemoved: false` plus `identityError` in the response, `identityRemoved` on the audit row, and a line to the error reporter. The account can then be cleared through the operator route.
- The provider's `user.deleted` webhook fires on success and **skips**, because the `account_deletion_events` row this request wrote already exists — its idempotency guard. The cleanup never runs twice.
- The "Deletion queued" confirmation on web and Android now says the sign-in is removed too, because it now is. One added sentence on each; nothing else in that copy is touched.

No schema change, no new route, no change to any route's surface beyond two added response fields.

## Left over from before

Identities from past self-service deletions are still sitting in the provider. This change only stops new ones. Clearing the existing ones is the `Delete Account (manual)` Actions workflow, one account at a time — I have not touched any live account.

Until they are cleared, they show up in the Unlock sign-up panel; PR #2258 identifies them from `account_deletion_events` and puts them under a "Left" tab so they are not counted as members or as onboarding failures.

## Checks run locally

typecheck · lint · a11y lint · modularity governance · web `build:ci` · unit tests · EOF/format · schema drift · deletion registry, deletion engine, export engine · inventory drift · orphan routes · error verbosity · US spelling · notice formatting · test-script drift · web/android parity — all pass.

## Review lane

Owner-review lane — this changes account deletion and touches the auth identity, so auto-merge is deliberately not enabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eeeus3t1nQs2Ld6ujxP4bB)_