### PR TITLE
fix: stop calling spam members support-only, and split the stuck from the bounced

### DIFF
--- a/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/UNLOCK_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -128,7 +128,9 @@ contracts:
     description: >-
       Read the Unlock admin sign-up panel: the full account roster from the auth provider joined to the
       verification submissions, so an admin can see how many people signed up and which of them never
-      submitted a Quora URL. Read-only; performs no write.
+      submitted a Quora URL — and, of those, how many never came back versus how many returned to the
+      Unlock screen and still could not finish (counted from unlock.status.get audit rows). Read-only;
+      performs no write.
     inputSchema: {}
     outputSchema:
       signupOverview:
@@ -138,6 +140,7 @@ contracts:
       - unlock_verification_submissions
       - unlock_excluded_accounts
       - account_deletion_events
+      - unlock_audit_log
     purpose: onboarding_funnel_measurement
     retentionClass: derived_short_lived
     idempotency: true

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -47,6 +47,13 @@ This plugin must:
 
 ### 2.1 Moderation Queue
 
+0. **Spam is not "support-only access" (2026-08-19).** A spam decision drops the tier to
+   `locked_support_only` *and* places a platform-wide (`all`-scope) account restriction, and the
+   restriction is what decides — the member reaches nothing, the Commons included. The Support-only
+   counter, the Support-only queue tab, and the per-row Support-only pill therefore all exclude spam;
+   listing them there reported the opposite of their real access. Rejected members are still counted and
+   listed, because they genuinely do keep the support surface and can correct their URL. A member's
+   past support-only access remains readable in `unlock_audit_log`.
 1. List submissions by status/access-tier filters.
 2. Review with decisions: `approved`, `rejected`, `spam`.
 3. Capture reviewer and optional moderation note.
@@ -97,7 +104,15 @@ This plugin must:
    again. Nothing on the account itself says it is not a real member, so the exclusion is recorded in
    `unlock_excluded_accounts` by an admin. Marking changes only the counters — never the member's
    access, submission, or reward.
-4. See who left. An account with an account-scope row in `account_deletion_events` asked to be
+4. **Tell a bounce from a person who is stuck.** The sign-up panel breaks the "No Quora URL" number
+   into how many never signed in again after the day they signed up, how many came back and still did
+   not submit, and how many times a typical one of them loaded the Unlock screen (counted from
+   `unlock.status.get` audit rows). Those two groups need different answers — one is a discovery or
+   first-impression problem, the other is the Quora step being too hard — so the panel separates them
+   rather than leaving an admin to read it off row by row. The view count is the firmer of the two
+   signals: a sign-in date only moves on a fresh sign-in, so a member with a live session can come back
+   repeatedly without it changing. Each row carries its own view count.
+5. See who left. An account with an account-scope row in `account_deletion_events` asked to be
    forgotten; their Unlock submission was deleted with the rest of their data, so counting them as
    "signed up, never gave a Quora URL" would say the opposite of what happened. They get their own
    count, their own tab, and a line on the row saying when they asked, and they are subtracted from the
@@ -261,6 +276,20 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
    `Delete Account (manual)` Actions workflow, one account at a time.
 
 ## 9) Change Log
+
+- 2026-08-19: **Spam no longer counts as support-only access, and the sign-up panel separates a bounce
+  from a stuck member (owner report).** The Support-only counter, queue tab, and per-row pill were
+  keyed on `access_tier = 'locked_support_only'` alone, which a spam decision also sets — but a spam
+  decision additionally places an `all`-scope `account_restrictions` record, and that restriction is
+  what actually decides: the member reaches nothing, Commons included. So the admin reported the exact
+  opposite of a spammed member's real access. All three now exclude `review_status = 'spam'`. Rejected
+  members are deliberately unchanged: they keep the support surface and can correct their URL, so the
+  tag is accurate for them (owner decision, 2026-08-19). Past support-only access stays readable in
+  `unlock_audit_log`. Separately, the sign-up panel now breaks "No Quora URL" into never-came-back
+  versus came-back-and-still-did-not-submit, with the median number of Unlock-screen loads
+  (`unlock.status.get` audit rows, a new `unlockScreenViews` field per account and a per-row line), so
+  that reading happens in the app instead of by scrolling rows. `unlock_audit_log` added to the
+  `unlock.admin.signups.read` contract's dataAccess. No schema change; admin-only surfaces.
 
 - 2026-08-19: **Sign-up reading added to the Unlock admin (owner request).** Two numbers were missing
   from `/admin/unlock`: how many people have signed up, and how many of them never submitted a Quora

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -329,6 +329,23 @@ completion % and "N of M submitted". Android reads it from `GET /api/unlock/admi
 The readout is read-only — no action buttons. A read failure never blocks the queue below it.
 **Result:** web ☐ · android ☐ — notes:
 
+### UNLOCK-A8c · Spam is not listed as support-only access
+**Role:** admin / reviewer · **Surfaces:** web (admin surface)
+**Precondition:** at least one submission marked spam and one marked rejected.
+**Steps:**
+1. On `/admin/unlock`, read the **Support-only** counter at the top.
+2. Open the **Support-only** tab and read the list.
+3. Find the spam member on the **All submissions** tab and look at their pills.
+4. Find the rejected member on the **Support-only** tab.
+**Expected:** Steps 1–2: the spam member is in neither the counter nor the list. A spam decision also
+places a platform-wide account restriction, and that restriction is what decides — they reach nothing,
+Commons included — so calling them "support-only access" said the opposite of the truth. Step 3: their
+row still shows the **spam** status pill, just not the Support-only pill. Step 4: the rejected member
+**is** counted and listed, because they really do keep the support surface and can correct their URL.
+The counter and the list agree with each other. Their earlier support-only access is still readable in
+`unlock_audit_log` if you need it.
+**Result:** web ☐ — notes:
+
 ### UNLOCK-A9 · Sign-ups — total, and who never gave a Quora URL
 **Role:** admin / reviewer · **Surfaces:** web (admin surface) — web-only, no Android admin (rule 105)
 **Precondition:** signed in as an admin; the auth provider secret is set in the app runtime.
@@ -336,7 +353,8 @@ The readout is read-only — no action buttons. A read failure never blocks the 
 1. Open `/admin/unlock` and find the "Sign-ups" panel, above the A/B experiment panel.
 2. Read the five numbers — Members, Gave a Quora URL, No Quora URL, Demo / test, Left — and the line
    above them saying how many accounts there are in total.
-3. Open the **No Quora URL** tab and read the list, then open the **Left** tab.
+3. Read the breakdown line under the numbers, then open the **No Quora URL** tab and read the list,
+   then open the **Left** tab.
 4. On any row, click **Mark as demo / test**, then watch the four numbers.
 5. Open the **Demo / test** tab, find that row, and click **Count this account again**.
 6. Type part of a name, handle, or email into the search box.
@@ -345,7 +363,11 @@ The readout is read-only — no action buttons. A read failure never blocks the 
 **Expected:** Step 2: Members = total accounts minus demo/test minus Left; Gave a Quora URL + No Quora
 URL = Members. Step 3: on **No Quora URL**, every person listed signed up and has no submission — they
 are not in the review queue below, because there is nothing to review. Each row shows a name or handle,
-the email, the sign-up date, and whether they have signed in since. On **Left**, every row says when
+the email, the sign-up date, whether they have signed in since, and how many times they opened the
+Unlock screen. The breakdown line above splits the same group into how many never signed in again after
+sign-up day and how many came back and still did not submit, with the typical number of Unlock-screen
+loads — the two groups need different answers, and the view count is the firmer signal because a
+sign-in date only moves on a fresh sign-in. On **Left**, every row says when
 that person asked to be forgotten; nobody appears on both tabs, and nobody on **Left** is counted as a
 member (their submission was deleted with the rest of their data, so they are not an onboarding
 failure). Step 4: `POST /api/unlock/admin/excluded-accounts` records the

--- a/ctf/packages/web/components/unlock/unlock-admin-card.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-card.tsx
@@ -100,7 +100,9 @@ function CardBadges({ s }: { s: UnlockSubmission }) {
   return (
     <>
       <StatusPill status={s.reviewStatus} />
-      {s.accessTier === 'locked_support_only' ? (
+      {/* Never shown for spam: that decision also places a platform-wide account restriction, so the
+          member reaches nothing — the stored tier says support-only but the restriction overrules it. */}
+      {s.accessTier === 'locked_support_only' && s.reviewStatus !== 'spam' ? (
         <span title="This member is on support-only access — they can reach support surfaces but not the full app" style={pill('rgba(148,163,184,0.14)', '#94A3B8', 'rgba(148,163,184,0.32)')}>
           Support-only
         </span>

--- a/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
+++ b/ctf/packages/web/components/unlock/unlock-admin-shell.tsx
@@ -127,15 +127,19 @@ export function UnlockAdminShell({
     toggle: (userId) => void toggleHistory(ctx, userId, historyOpenUser, historyByUser),
   };
 
-  // Which slice of the loaded submissions the list shows. 'support-only' filters on access tier (not
-  // review status): a member lands there from more than one route (rejected, spam, or a lapsed pending
-  // window swept by supportOnlyAfterExpiry), and the tier is the one thing all of those share — which
-  // is also exactly what the Support-only counter above counts, so the number and the list agree.
+  // Which slice of the loaded submissions the list shows. 'support-only' filters on access tier rather
+  // than review status, because a member lands there from more than one route — rejected, or a lapsed
+  // pending window swept by supportOnlyAfterExpiry — and the tier is the one thing those share.
+  //
+  // Spam is the exception and is excluded. A spam decision drops the tier to locked_support_only AND
+  // places a platform-wide account restriction; the restriction is what decides, so the member reaches
+  // nothing at all. Listing them under "support-only access" said the opposite of their real access.
+  // The dashboard counter excludes them the same way, so the number and the list still agree.
   const visible =
     tab === 'pending'
       ? submissions.filter((s) => s.reviewStatus === 'pending')
       : tab === 'support-only'
-        ? submissions.filter((s) => s.accessTier === 'locked_support_only')
+        ? submissions.filter((s) => s.accessTier === 'locked_support_only' && s.reviewStatus !== 'spam')
         : submissions;
   const searchQuery = search.trim().toLowerCase();
   const filteredVisible = searchQuery

--- a/ctf/packages/web/components/unlock/unlock-signup-row.tsx
+++ b/ctf/packages/web/components/unlock/unlock-signup-row.tsx
@@ -39,6 +39,16 @@ function timingLine(account: UnlockSignupAccount): string {
   return `${joined} · ${lastSignIn ? `last signed in ${lastSignIn}` : 'has never signed in since'}`;
 }
 
+// How many times they loaded the Unlock screen. Said only for a member with no submission, where it is
+// the difference between seeing the ask once and coming back to it repeatedly without finishing.
+function screenViewLine(account: UnlockSignupAccount): string | null {
+  if (account.hasSubmission) return null;
+  if (account.unlockScreenViews === 0) return 'Has not opened the Unlock screen since it started being recorded';
+  return account.unlockScreenViews === 1
+    ? 'Opened the Unlock screen once'
+    : `Opened the Unlock screen ${account.unlockScreenViews} times`;
+}
+
 // Said only for someone who asked to be forgotten: their submission was deleted with the rest of their
 // data, so the row would otherwise read as "never gave a Quora URL" with nothing to explain it.
 function departureLine(account: UnlockSignupAccount): string | null {
@@ -92,6 +102,7 @@ export function UnlockSignupRow({
       <DetailLine text={handle ? `@${handle}` : null} />
       <DetailLine text={account.email} breakAll />
       <DetailLine text={timingLine(account)} />
+      <DetailLine text={screenViewLine(account)} />
       <DetailLine text={departureLine(account)} />
       <DetailLine text={account.excludedNote ? `Note: ${account.excludedNote}` : null} />
 

--- a/ctf/packages/web/components/unlock/unlock-signups-panel.tsx
+++ b/ctf/packages/web/components/unlock/unlock-signups-panel.tsx
@@ -26,16 +26,32 @@ function isCounted(account: UnlockSignupAccount): boolean {
 
 // The four numbers the panel leads with. Derived from the loaded accounts (not from the server's copy of
 // the counts) so marking an account demo/test moves every number at once.
+// Has this member never signed in again since the day they signed up? A hint, not proof — the provider
+// stamps the last sign-in on a fresh sign-in, not on every visit. The Unlock-screen view count beside it
+// is the firmer reading.
+function neverReturned(account: UnlockSignupAccount): boolean {
+  if (!account.lastSignInAt) return true;
+  return account.lastSignInAt.slice(0, 10) === account.createdAt.slice(0, 10);
+}
+
 function summarize(accounts: UnlockSignupAccount[]) {
   const counted = accounts.filter(isCounted);
   const submitted = counted.filter((account) => account.hasSubmission).length;
+  const notSubmitted = counted.filter((account) => !account.hasSubmission);
+  const neverBack = notSubmitted.filter(neverReturned).length;
+  const views = notSubmitted.map((account) => account.unlockScreenViews).sort((a, b) => a - b);
   return {
     totalAccounts: accounts.length,
     excludedCount: accounts.filter((account) => account.excluded).length,
     deletedCount: accounts.filter((account) => !account.excluded && account.deletedTheirData).length,
     memberCount: counted.length,
     submittedCount: submitted,
-    notSubmittedCount: counted.length - submitted,
+    notSubmittedCount: notSubmitted.length,
+    neverReturnedCount: neverBack,
+    returnedAnywayCount: notSubmitted.length - neverBack,
+    // Median rather than mean: one member who reloaded the screen twenty times would drag an average
+    // and make the whole group look like it kept trying.
+    medianScreenViews: views.length === 0 ? 0 : views[Math.floor(views.length / 2)],
   };
 }
 
@@ -143,6 +159,22 @@ export function UnlockSignupsPanel({ overview }: { overview: UnlockSignupOvervie
             <SignupStat label="Demo / test" value={counts.excludedCount} />
             <SignupStat label="Left" value={counts.deletedCount} />
           </div>
+
+          {/* What the "No Quora URL" number is actually made of. Someone who signed up and never came
+              back is a different problem from someone who returned to the Unlock screen and still could
+              not finish, and the fix for one does nothing for the other. */}
+          {counts.notSubmittedCount > 0 ? (
+            <div style={{ fontSize: 11, color: t.MUTED, lineHeight: 1.7, marginBottom: 12, padding: '10px 12px', borderRadius: 10, background: t.SURFACE, border: `1px solid ${t.BORDER_SOLID}` }}>
+              Of the {counts.notSubmittedCount} with no Quora URL:{' '}
+              <strong style={{ color: t.TITLE }}>{counts.neverReturnedCount}</strong> have not signed in
+              again since the day they signed up, and{' '}
+              <strong style={{ color: t.TITLE }}>{counts.returnedAnywayCount}</strong> came back and still
+              did not submit. Typically they loaded the Unlock screen{' '}
+              <strong style={{ color: t.TITLE }}>{counts.medianScreenViews}</strong>{' '}
+              time{counts.medianScreenViews === 1 ? '' : 's'}. A sign-in date only moves on a fresh
+              sign-in, so the view count is the firmer of the two.
+            </div>
+          ) : null}
 
           <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
             {(['not-submitted', 'all', 'excluded', 'deleted'] as const).map((tabKey) => (

--- a/ctf/packages/web/lib/unlock/repository.ts
+++ b/ctf/packages/web/lib/unlock/repository.ts
@@ -643,7 +643,13 @@ export async function getUnlockDashboardSnapshot(): Promise<UnlockDashboardSnaps
        COUNT(*) FILTER (WHERE review_status = 'approved')::text AS approved_count,
        COUNT(*) FILTER (WHERE review_status = 'rejected')::text AS rejected_count,
        COUNT(*) FILTER (WHERE review_status = 'spam')::text AS spam_count,
-       COUNT(*) FILTER (WHERE access_tier = 'locked_support_only')::text AS locked_support_only_count
+       -- Spam is excluded on purpose. A spam decision drops the tier to locked_support_only AND places
+       -- a platform-wide account restriction, and the restriction is what actually decides: the member
+       -- reaches nothing, Commons included. Counting them as "support-only access" reported the
+       -- opposite of their real access. Rejected members are counted, because they genuinely do keep
+       -- the support surface and can correct their URL.
+       COUNT(*) FILTER (WHERE access_tier = 'locked_support_only' AND review_status <> 'spam')::text
+         AS locked_support_only_count
      FROM unlock_verification_submissions`,
   );
 

--- a/ctf/packages/web/lib/unlock/signups.ts
+++ b/ctf/packages/web/lib/unlock/signups.ts
@@ -102,6 +102,31 @@ async function listDeletedAccountDates(): Promise<Map<string, string>> {
   return new Map(result.rows.map((row) => [row.user_id, row.deleted_at.toISOString()]));
 }
 
+// How many times each member has loaded the Unlock screen, from the `unlock.status.get` audit rows.
+//
+// This is the number that separates "saw the ask once and left" from "came back to it and still could
+// not finish", and the two want different answers — the first is a discovery or first-impression
+// problem, the second is the Quora step itself being too hard. Sign-in timestamps cannot tell them
+// apart: they only move on a fresh sign-in, so somebody with a live session can return again and again
+// without the dates changing.
+//
+// Best-effort: a failure here leaves every count at 0 rather than taking the whole panel down, since
+// this is a supporting reading and not the panel's reason for existing.
+async function countUnlockScreenViews(): Promise<Map<string, number>> {
+  try {
+    const result = await queryDb<{ user_id: string; views: string }>(
+      `SELECT actor_user_id AS user_id, COUNT(*)::text AS views
+         FROM unlock_audit_log
+        WHERE command = 'unlock.status.get' AND actor_user_id IS NOT NULL
+        GROUP BY actor_user_id`,
+    );
+    return new Map(result.rows.map((row) => [row.user_id, Number(row.views)]));
+  } catch (error) {
+    console.error('[unlock] Unlock-screen view counts unavailable; showing 0', error);
+    return new Map();
+  }
+}
+
 // Which of those accounts have a Quora URL on file, and what happened to it.
 async function listSubmissionFacts(): Promise<Map<string, SubmissionFact>> {
   const result = await queryDb<{ user_id: string; review_status: UnlockReviewStatus; created_at: Date }>(
@@ -118,6 +143,14 @@ async function listSubmissionFacts(): Promise<Map<string, SubmissionFact>> {
   return byUser;
 }
 
+// Has this member never signed in again since the day they signed up? Only ever a hint: the provider
+// stamps the last sign-in on a fresh sign-in, not on every visit, so a member with a live session can
+// return without moving it. The Unlock-screen view count is the firmer reading of the same question.
+function neverReturned(account: { createdAt: string; lastSignInAt: string | null }): boolean {
+  if (!account.lastSignInAt) return true;
+  return account.lastSignInAt.slice(0, 10) === account.createdAt.slice(0, 10);
+}
+
 function emptyOverview(unavailableReason: string): UnlockSignupOverview {
   return {
     available: false,
@@ -129,6 +162,7 @@ function emptyOverview(unavailableReason: string): UnlockSignupOverview {
     memberCount: 0,
     submittedCount: 0,
     notSubmittedCount: 0,
+    notSubmittedNeverReturnedCount: 0,
     accounts: [],
   };
 }
@@ -148,15 +182,18 @@ export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
   let submissions: Map<string, SubmissionFact>;
   let excludedUserIds: Map<string, string | null>;
   let deletedDates: Map<string, string>;
+  let screenViews: Map<string, number>;
   try {
-    const [facts, excluded, deleted] = await Promise.all([
+    const [facts, excluded, deleted, views] = await Promise.all([
       listSubmissionFacts(),
       listUnlockExcludedAccounts(),
       listDeletedAccountDates(),
+      countUnlockScreenViews(),
     ]);
     submissions = facts;
     excludedUserIds = new Map(excluded.map((entry) => [entry.userId, entry.note]));
     deletedDates = deleted;
+    screenViews = views;
   } catch (error) {
     return emptyOverview(`The verification records could not be read from the database — ${failureReason(error)}`);
   }
@@ -172,6 +209,7 @@ export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
       hasSubmission: submission !== null,
       reviewStatus: submission?.reviewStatus ?? null,
       submittedAt: submission?.submittedAt ?? null,
+      unlockScreenViews: screenViews.get(account.userId) ?? 0,
     };
   });
 
@@ -180,6 +218,7 @@ export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
   const deletedCount = accounts.filter((account) => !account.excluded && account.deletedTheirData).length;
   const counted = accounts.filter((account) => !account.excluded && !account.deletedTheirData);
   const submittedCount = counted.filter((account) => account.hasSubmission).length;
+  const notSubmitted = counted.filter((account) => !account.hasSubmission);
 
   return {
     available: true,
@@ -190,7 +229,8 @@ export async function getUnlockSignupOverview(): Promise<UnlockSignupOverview> {
     deletedCount,
     memberCount: counted.length,
     submittedCount,
-    notSubmittedCount: counted.length - submittedCount,
+    notSubmittedCount: notSubmitted.length,
+    notSubmittedNeverReturnedCount: notSubmitted.filter((account) => neverReturned(account)).length,
     accounts,
   };
 }

--- a/ctf/packages/web/lib/unlock/types.ts
+++ b/ctf/packages/web/lib/unlock/types.ts
@@ -138,6 +138,11 @@ export type UnlockSignupAccount = {
   hasSubmission: boolean;
   reviewStatus: UnlockReviewStatus | null;
   submittedAt: string | null;
+  // How many times this member has loaded the Unlock screen (`unlock.status.get` audit rows). This is
+  // the honest "did they try" number: sign-in timestamps only move on a fresh sign-in, so a member with
+  // a live session can come back repeatedly without the dates changing. 1 means they saw the ask once
+  // and left; several means they came back to it and still could not finish.
+  unlockScreenViews: number;
 };
 
 // The sign-up reading on the Unlock admin page. `available: false` means the roster could not be read
@@ -160,5 +165,9 @@ export type UnlockSignupOverview = {
   submittedCount: number;
   // memberCount - submittedCount: signed up, never submitted a Quora URL.
   notSubmittedCount: number;
+  // Of notSubmittedCount, how many have not signed in again since the day they signed up. The rest
+  // came back and still did not submit — the two groups need different answers, so they are counted
+  // separately rather than read off a list of rows one at a time.
+  notSubmittedNeverReturnedCount: number;
   accounts: UnlockSignupAccount[];
 };


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105 — every surface here is the Unlock admin, which is web-only).

## Spam was tagged as having access it does not have

The Support-only counter, the Support-only queue tab, and the per-row Support-only pill were all keyed on `access_tier = 'locked_support_only'`. A spam decision sets that tier — which is where the tag came from — but it *also* places a platform-wide (`all`-scope) `account_restrictions` record, and **the restriction is what decides**. A spammed member reaches nothing, the Commons included.

So the admin reported the exact opposite of their real access. All three now exclude `review_status = 'spam'`. The spam status pill on the row stays; only the Support-only pill goes.

**Rejected members are deliberately unchanged.** You asked to drop them too, on the basis that they no longer reach the Commons — but they do: rejection sets the tier without any restriction, and the review route's own comment spells out why the two decisions differ. You confirmed keeping their access, so the tag stays accurate for them and reject remains a distinct outcome from spam rather than collapsing into it. Anyone's past support-only access is still readable in `unlock_audit_log`, as you noted.

The counter and the list are filtered identically, so they still agree with each other.

## "No Quora URL" was one number covering two different problems

Someone who signed up and never came back is a discovery or first-impression problem. Someone who returned to the Unlock screen and still could not finish is the Quora step being too hard. The fix for one does nothing for the other, and the single number hid which you had.

The panel now says, above the tabs:

> Of the 46 with no Quora URL: **38** have not signed in again since the day they signed up, and **8** came back and still did not submit. Typically they loaded the Unlock screen **1** time.

Each row carries its own count too. The Unlock-screen figure comes from `unlock.status.get` audit rows — a new `unlockScreenViews` field per account.

**Why the view count and not just the dates:** a sign-in timestamp only moves on a fresh sign-in, so a member with a live session can come back repeatedly without any date changing. The view count is the firmer reading of the same question; the sign-in split is kept beside it as the coarser one and labeled as such. Median rather than mean, so one member who reloaded twenty times cannot make the whole group look like it kept trying.

This is the reading that decides whether the Unlock help path is the right fix or only an improvement — and it now happens in the app, with no member data leaving it.

## Scope

`unlock_audit_log` added to the `unlock.admin.signups.read` contract's `dataAccess`. No schema change. Every surface here is admin-only, and nothing about any member's actual access changes — this is what the admin *reports*.

## Checks run locally

typecheck · lint · a11y lint · modularity governance · web `build:ci` · unit tests · EOF/format · inventory drift · orphan routes · error verbosity · US spelling · notice formatting · test-script drift · deletion registry · web/android parity — all pass.

## Review lane

Owner-review lane — it changes a contract's `dataAccess`. Nothing else here is risky; it is admin display only, so it should read quickly.

## Note on ordering

Independent of #2260, which is still open. Both touch `unlock-admin-shell.tsx` and `lib/unlock/types.ts` in different places; whichever merges second I will bring up to date.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eeeus3t1nQs2Ld6ujxP4bB)_