### PR TITLE
feat: show where ClickLog activity is, who is behind it, and save the report as one image

### DIFF
--- a/ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md
+++ b/ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md
@@ -24,6 +24,13 @@ them.
 
 - Sharing is **off** unless the member turns it on. There is a global default (off) and a
   per-incident choice.
+- **The member is told the grouped totals may be published.** Every share control says so at the
+  moment the choice is made — the global default, the per-incident checkbox, the history-row
+  tooltip, and the notice shown before an edit turns sharing on. This report is posted publicly and
+  given to people outside the project, so consenting to share and consenting to publication are one
+  decision, and the app describes them as one decision. What is published is the aggregate only:
+  the notes, the exact locations, and the member identities behind these numbers are excluded by
+  the queries themselves (section 3).
 - An untagged incident stays entirely private if the member leaves sharing off. It never reaches
   the aggregate.
 - Tagging an incident **requires** sharing its trend data, and the app says so in plain words before
@@ -93,9 +100,9 @@ The report can be opened and saved as a single image for posting. That image lea
 coordinates out unless they are explicitly asked for, and the reason is not caution for its own
 sake: at low counts,
 an area roughly 11 km across combined with a specific date can point at one person for anyone who
-already knows them. Members consented to their trend data reaching the project. Publishing an area
-and a date is a wider disclosure than that, so it is a decision made deliberately each time rather
-than a default.
+already knows them. Members are told the grouped totals may be published, and that is what they
+agreed to: totals. An area cell paired with a date is closer to a location for one person than to a
+total, so it is a decision made deliberately each time rather than a default.
 
 Anyone requesting the underlying area detail for an investigation should ask for it directly rather
 than take it from a public copy.

--- a/ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md
+++ b/ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md
@@ -89,8 +89,9 @@ change to the display cannot widen what the report can see.
 
 ## 6. Why the area cells are usually left out of a shared copy
 
-The report can be saved as a single image for posting. That image leaves the area coordinates out
-unless they are explicitly asked for, and the reason is not caution for its own sake: at low counts,
+The report can be opened and saved as a single image for posting. That image leaves the area
+coordinates out unless they are explicitly asked for, and the reason is not caution for its own
+sake: at low counts,
 an area roughly 11 km across combined with a specific date can point at one person for anyone who
 already knows them. Members consented to their trend data reaching the project. Publishing an area
 and a date is a wider disclosure than that, so it is a decision made deliberately each time rather

--- a/ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md
+++ b/ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md
@@ -1,0 +1,166 @@
+# ClickLog trend report — method, limits, and what an investigation would still need
+
+This document travels with the ClickLog trend report. It is written to be read on its own, by
+someone who has never used this app: a journalist, a lawyer, or a human-rights body looking at the
+numbers for the first time. Every claim about how the data is collected can be checked against the
+code named at the end.
+
+The short version of the method is drawn into the report image itself, so a copy of the image
+posted anywhere carries its own provenance. This file is the long version.
+
+---
+
+## 1. What the report is
+
+Members of Charging The Future record incidents in a feature called ClickLog — one entry at a time,
+on the day it happens. Each entry can carry a written note, a location, and tags chosen from two
+fixed lists: known problems ("what happened to you") and named schemes ("what was used on you").
+
+The report counts **only** the incidents members chose to share. It is an aggregate: counts by day,
+counts by approximate area, counts by tag, and counts of how many different members are behind
+them.
+
+## 2. How a member's consent works
+
+- Sharing is **off** unless the member turns it on. There is a global default (off) and a
+  per-incident choice.
+- An untagged incident stays entirely private if the member leaves sharing off. It never reaches
+  the aggregate.
+- Tagging an incident **requires** sharing its trend data, and the app says so in plain words before
+  the member saves. Tags exist to feed the aggregate; an incident tagged in private would be a tag
+  that does nothing.
+- A member can turn sharing off again on any untagged incident at any time, and can delete any
+  incident, which removes it from every future report.
+
+## 3. What is counted, and what is never counted
+
+Counted:
+
+| Field | Precision |
+|---|---|
+| Date | The UTC day. No time of day. |
+| Location | Latitude and longitude rounded to one decimal place — an area roughly 11 km across. |
+| Problems | Which items the member picked from a fixed list of known problems. |
+| Schemes | Which items the member picked from a fixed list of named schemes. |
+| Member count | How many **different** members are behind a set of incidents. |
+
+Never counted, and never visible to anyone including the project's owner:
+
+- The member's written note. It is stored for the member and is excluded from every report query.
+- The member's exact location. Only the rounded cell above is ever read.
+- Who the member is. Member identity appears in the reporting queries only inside
+  `COUNT(DISTINCT …)` — as a number of people, never as a list of people.
+- The incident's identifier, so no two figures in the report can be joined back to one entry.
+
+This is enforced in the database queries themselves, not in the screen that displays them. A future
+change to the display cannot widen what the report can see.
+
+## 4. How to read the counts
+
+- **A count is the number of times members reported something, not the number of times it
+  happened.** Most incidents in anyone's life are never logged.
+- **Incidents and people are different numbers.** Seven incidents from one member and seven from
+  seven members describe very different situations. The report always shows both.
+- **Repeat reporting matters more than volume.** The number of members who logged more than one
+  incident is the figure that separates a sustained pattern from isolated events.
+- **Scheme counts are not comparable to each other.** Some named schemes describe a condition that
+  runs continuously in the background and can be reported almost any day; others describe a single
+  operation with a start and an end. The report labels each row with which kind it is. A larger
+  count on a continuous one does not make it more frequent or more serious than a smaller count on
+  an operation.
+- **Categories count each incident once.** An incident carrying three problems from the same
+  category adds one to that category, not three.
+
+## 5. What the report cannot show
+
+- **It is not verified.** These are first-hand accounts recorded by the people they happened to.
+  Nothing here has been checked against police reports, medical records, video, or any other
+  outside source. The report is a record of what members say happened, which is exactly what it
+  claims to be and no more.
+- **It is not a sample of any population.** The people logging chose to join this app and chose to
+  share. No rate, prevalence, or per-capita figure can be calculated from it, and none is offered.
+- **It cannot see outside its own lists.** Anything that is not on the fixed problem list or the
+  fixed scheme list is not counted at all. Both lists grow, through a member suggestion process, so
+  a term appearing for the first time can mean the term is new rather than the conduct.
+- **Location coverage is partial.** An untagged incident can be logged with no location, so some
+  incidents are counted in every figure except the area breakdown. The report states how many.
+- **The window is 90 days.** Older incidents still exist for the member; they are outside the
+  report.
+
+## 6. Why the area cells are usually left out of a shared copy
+
+The report can be saved as a single image for posting. That image leaves the area coordinates out
+unless they are explicitly asked for, and the reason is not caution for its own sake: at low counts,
+an area roughly 11 km across combined with a specific date can point at one person for anyone who
+already knows them. Members consented to their trend data reaching the project. Publishing an area
+and a date is a wider disclosure than that, so it is a decision made deliberately each time rather
+than a default.
+
+Anyone requesting the underlying area detail for an investigation should ask for it directly rather
+than take it from a public copy.
+
+## 7. What an investigation would still need, and what to build for it
+
+The report answers *what kind of thing is being reported, by how many people, over what days, in
+roughly what places*. A human-rights body assessing whether it has a mandate and what to do next
+would still ask for the following. None of it exists yet. Each item is a change to what members are
+asked when they log, so each is a product decision for the owner, not a reporting change.
+
+In order, with the blocking dependencies stated:
+
+1. **Country and region on each shared incident.** The single largest gap. Today an outside reader
+   has to look up coordinate cells by hand, and incidents with no location have no place at all. A
+   country field derived from the location at logging time — coarse, stored alongside the cell —
+   makes the report readable by anyone and makes cross-border patterns visible. Nothing else in this
+   list depends on it, so it can be done first and on its own.
+2. **Who the member says was involved.** Whether the conduct is attributed to state actors, private
+   parties, or is unknown, as a coarse choice with "unknown" as a real and common answer. This
+   decides which body has a mandate at all, and no aggregate can be acted on without it. Blocked by
+   nothing technical; blocked on the owner deciding the wording, because a badly worded question
+   here produces confident answers to something the member cannot actually know.
+3. **What the member did about it, and what happened.** Whether the incident was reported to police,
+   an employer, a regulator, or a doctor, and what came of it. Complaint procedures ask whether
+   domestic remedies were tried before anything international is considered, and a pattern of
+   reports that went nowhere is itself a finding. Depends on item 2 only in that both are answered
+   in the same place in the form; either order works.
+4. **A coarse severity or consequence field.** Whether the incident cost the member a job, housing,
+   money, medical treatment, liberty, or physical injury. Counts of conduct without consequence
+   read as a nuisance log; consequence is what makes it a rights question. Independent of the
+   others.
+5. **Whether corroborating material exists.** Whether the member holds video, documents, messages,
+   or a witness — as a yes/no, with the material never uploaded. It lets an investigator ask for
+   the small number of incidents worth following up instead of asking everyone for everything.
+   Independent of the others.
+6. **Consent to individual follow-up.** A separate, explicit opt-in, distinct from trend sharing:
+   whether the member is willing to be contacted about their own case by a named body. No Special
+   Procedure can act on aggregate numbers alone; it acts on individual cases with the consent of
+   the person concerned. This is the item that converts the report from context into something that
+   can be acted on, and it is blocked by items 1–5, because a member should know what they are
+   consenting to being contacted about before being asked.
+7. **A written statement of the sample.** How many members the app has, how many use ClickLog, and
+   how many share — so a reader can see what fraction of the community the report covers. Blocked
+   by nothing; it is a reporting change, not a collection change, and it is the cheapest of the
+   seven.
+
+Two things that are deliberately **not** on this list. Demographic data about members is not
+collected and should not be added merely because an analysis would be richer for it. And the note a
+member writes stays private permanently; if free-text accounts are ever needed for a submission,
+they should be collected fresh with their own consent, not taken from what members wrote for
+themselves.
+
+---
+
+## Where this is implemented
+
+| Concern | File |
+|---|---|
+| Fixed problem and scheme lists | `ctf/packages/web/lib/click-log/tags.ts` |
+| Harm categories and scheme kinds | `ctf/packages/web/lib/click-log/tag-categories.ts` |
+| Reporting queries (the privacy boundary) | `ctf/packages/web/lib/click-log/report-repository.ts` |
+| Report assembly | `ctf/packages/web/lib/click-log/report.ts` |
+| The words in the report and the image | `ctf/packages/web/lib/click-log/trend-report-view.ts` |
+| The shareable image | `ctf/packages/web/lib/click-log/report-image.tsx` |
+| Access control | `ctf/packages/web/lib/click-log/policy.ts`, `ctf/packages/web/app/api/click-log/_lib.ts` |
+
+The plugin's full feature record is
+`ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md`.

--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml
@@ -86,7 +86,15 @@ policies:
     command: click-log.trends.fetch
     version: 1.0.0
     # Owner/admin-only aggregate view. Reads only member-opted-in rows, and only as coarse
-    # buckets (day + ~11 km location cell + count).
+    # buckets (day + ~11 km location cell + count + distinct-member counts + tag slugs).
+    requiredRoles: [admin]
+    attributePolicies: []
+    consentRequirements: [owner_share_opt_in]
+  - pluginId: click-log
+    command: click-log.trends.image
+    version: 1.0.0
+    # Same gate and same data as click-log.trends.fetch — the image is drawn from that report and
+    # reads nothing else. Area coordinates are left out of the image unless explicitly requested.
     requiredRoles: [admin]
     attributePolicies: []
     consentRequirements: [owner_share_opt_in]

--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_AUDIT_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_AUDIT_CONTRACTS.yaml
@@ -55,3 +55,12 @@ auditEvents:
     policyDecision: allow
     dataClassesAccessed: [user_event]
     targetContext: admin
+  - pluginId: click-log
+    command: click-log.trends.image
+    commandVersion: 1.0.0
+    eventId: click-log.trends.image
+    policyDecision: allow
+    dataClassesAccessed: [user_event]
+    # Records whether the produced image carried the ~11 km area coordinates. That is the one
+    # choice on this route that widens what a posted copy reveals, so it belongs in the log.
+    targetContext: admin

--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -225,27 +225,66 @@ commands:
     retentionClass: user_event
   - pluginId: click-log
     command: click-log.trends.fetch
-    version: 1.1.0
+    version: 1.2.0
     inputSchema:
       type: object
       properties: {}
     outputSchema:
       type: object
       properties:
+        summary:
+          $ref: '#/definitions/SharedIncidentReportSummary'
         buckets:
           type: array
           items:
             $ref: '#/definitions/SharedIncidentTrendBucket'
+        areas:
+          type: array
+          items:
+            $ref: '#/definitions/SharedIncidentArea'
         tagTrends:
           type: array
           items:
             $ref: '#/definitions/SharedIncidentTagTrend'
+        categories:
+          type: array
+          items:
+            $ref: '#/definitions/SharedIncidentCategoryTrend'
+        pairs:
+          type: array
+          items:
+            $ref: '#/definitions/SharedIncidentTagPair'
     dataAccess:
       - click_log_incidents (select, aggregate only — shared_with_owner rows; the SQL projects
-        only day buckets, 1-decimal location cells, counts, and per-tag counts over the
-        canonical problem/scheme tag slugs, never notes, precise coordinates, incident ids,
-        or member identity)
+        only day buckets, 1-decimal location cells, counts, distinct-member counts, and per-tag
+        counts over the canonical problem/scheme tag slugs, never notes, precise coordinates,
+        incident ids, or member identity; user_id appears only inside COUNT(DISTINCT …))
     purpose: Owner/admin-only aggregate trends over incidents members opted to share
+    retentionClass: user_event
+  - pluginId: click-log
+    command: click-log.trends.image
+    version: 1.0.0
+    inputSchema:
+      type: object
+      properties:
+        areas:
+          type: string
+          enum: ['1']
+          description: >-
+            Pass '1' to include the ~11 km area coordinates in the image. Omitted by default: an
+            area cell plus a date can point at one person at small counts, and members opted into
+            sharing trend data with the project rather than into being placed on a public map.
+    outputSchema:
+      type: string
+      contentMediaType: image/png
+      description: >-
+        The whole report drawn as one tall PNG, carrying the same numbers as click-log.trends.fetch
+        plus the method statement (how the data was collected, what is never counted, and what the
+        counts cannot show) so a reposted copy is never numbers without provenance.
+    dataAccess:
+      - click_log_incidents (select, aggregate only — identical queries to click-log.trends.fetch;
+        the image is drawn from that report and reads nothing else)
+    purpose: Owner/admin-only shareable image of the aggregate trends report
     retentionClass: user_event
 
 definitions:
@@ -322,3 +361,85 @@ definitions:
       count:
         type: integer
     required: [tagType, tag, count]
+  SharedIncidentReportSummary:
+    type: object
+    properties:
+      days:
+        type: integer
+      sharedIncidents:
+        type: integer
+      reporters:
+        type: integer
+        description: Distinct members behind the shared incidents (COUNT(DISTINCT user_id) only).
+      repeatReporters:
+        type: integer
+        description: Members with more than one shared incident in the window.
+      areas:
+        type: integer
+        description: >-
+          Distinct ~11 km cells in the window. Counted in SQL rather than taken from the length of
+          the areas array, which is capped at 200.
+      taggedIncidents:
+        type: integer
+      withLocation:
+        type: integer
+      withoutLocation:
+        type: integer
+      firstDay:
+        type:
+          - string
+          - 'null'
+      lastDay:
+        type:
+          - string
+          - 'null'
+    required:
+      - days
+      - sharedIncidents
+      - reporters
+      - repeatReporters
+      - areas
+      - taggedIncidents
+      - withLocation
+      - withoutLocation
+      - firstDay
+      - lastDay
+  SharedIncidentArea:
+    type: object
+    properties:
+      latitudeCell:
+        type: number
+      longitudeCell:
+        type: number
+      incidents:
+        type: integer
+      reporters:
+        type: integer
+      firstDay:
+        type: string
+      lastDay:
+        type: string
+    required: [latitudeCell, longitudeCell, incidents, reporters, firstDay, lastDay]
+  SharedIncidentCategoryTrend:
+    type: object
+    properties:
+      category:
+        type: string
+        description: A harm-category slug from lib/click-log/tag-categories.ts.
+      incidents:
+        type: integer
+      reporters:
+        type: integer
+    required: [category, incidents, reporters]
+  SharedIncidentTagPair:
+    type: object
+    properties:
+      problemTag:
+        type: string
+      schemeTag:
+        type: string
+      incidents:
+        type: integer
+      reporters:
+        type: integer
+    required: [problemTag, schemeTag, incidents, reporters]

--- a/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
+++ b/ctf/docs/contracts/CLICK_LOG_PLUGIN_COMMAND_CONTRACTS.yaml
@@ -274,6 +274,12 @@ commands:
             Pass '1' to include the ~11 km area coordinates in the image. Omitted by default: an
             area cell plus a date can point at one person at small counts, and members opted into
             sharing trend data with the project rather than into being placed on a public map.
+        download:
+          type: string
+          enum: ['1']
+          description: >-
+            Pass '1' to send the image as a file download. Without it the image is served inline so
+            it opens in the browser, which is how it is saved or shared from a phone.
     outputSchema:
       type: string
       contentMediaType: image/png

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -82,9 +82,45 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 ## 4. Admin Features
 
 - ClickLog Trends dashboard (`/admin/click-log`): aggregate counts over incidents members opted to
-  share — shared total, days with activity, per-day counts, area-cluster count (each area is a
-  ~11 km cell), and "Top problems" / "Top schemes" tag breakdowns (per-tag counts over the
-  canonical tag slugs). No notes, precise coordinates, incident ids, or member identity are visible.
+  share. Headline figures — shared incidents, members reporting (distinct members, not incidents),
+  members who logged more than one, days with activity, number of areas, tagged incidents — then
+  per-day counts, the area breakdown, a harm-category rollup, "Top problems" / "Top schemes" tag
+  breakdowns, problem-and-scheme pairs, and the method statement. No notes, precise coordinates,
+  incident ids, or member identity are visible; member identity reaches the queries only inside
+  `COUNT(DISTINCT …)`.
+- Area breakdown (added 2026-08-19): every ~11 km cell with its coordinates, how many incidents and
+  how many different members sit in it, and the span of dates it covers. The screen previously
+  counted the clusters and stopped, which said activity had a location without ever saying where.
+  Incidents logged without a location are absent from this list by construction and counted in
+  every other figure; the summary states how many.
+- Harm categories (added 2026-08-19): the 53 problem tags rolled up into six categories defined in
+  `lib/click-log/tag-categories.ts` — watched and followed, body and health, threats and
+  intimidation, blocked from work/money/services, set up to be blamed, cut off from people. Counted
+  once per incident per category (array overlap in SQL), so an incident carrying three problems from
+  one category adds one, not three. A ranked list of 53 individual problems is readable only to
+  someone who already knows the subject; the rollup is what an outside reader can follow.
+- Scheme kind labels (added 2026-08-19): each scheme row says whether it is an operation with a
+  start and an end, something that runs continuously in the background, a shape over weeks or
+  months, or not yet classified. This closes the taxonomy gap recorded in `tags.ts`, on the trigger
+  that file names — the first time a tag ranking on real data would mislead a reader. No slug is
+  renamed, removed, or reordered; the kinds live in `tag-categories.ts` beside the harm categories.
+- Problem-and-scheme pairs (added 2026-08-19): how often a named scheme was tagged on the same
+  incident as a given problem. Two separate rankings say what happened and what was used; the pair
+  list says which method was attached to which harm.
+- Shareable report image (added 2026-08-19): `GET /api/click-log/admin/trends/image` draws the whole
+  report — every section plus the method statement — as one tall PNG, so it can be posted somewhere
+  that takes an image without stitching phone screenshots together and losing rows at the seams.
+  Built from the same aggregate as the screen, so there is no second data path. Area coordinates are
+  left out unless `?areas=1` is passed and the download control's checkbox is ticked: at small
+  counts an ~11 km cell plus a date can point at one person, and members opted into sharing trend
+  data with the project rather than into being placed on a public map. Which variant was produced is
+  recorded in the audit log.
+- Method statement (added 2026-08-19): the words under the numbers on the screen and drawn into the
+  image — where the figures come from, what is never counted, how to read a count, what the data
+  cannot show, why scheme totals are not comparable, and location coverage. It is built from the
+  report in `lib/click-log/trend-report-view.ts` so the screen and the image can never say different
+  things. The long version, written for a reader outside the project, is
+  `ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md`.
 - Scheme-naming pipeline (scheduled, outside the app): `.github/workflows/clicklog-scheme-suggestions.yml`
   runs `ctf/scripts/proposeSchemeSuggestions.mjs` twice a day. It (a) drains new "Not listed"
   suggestions into one issue per distinct text in the private triage repo
@@ -106,7 +142,8 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 - `PUT /api/click-log/[id]` — Edit an incident's note and tag lists in place. Body `{ notes, problemTags, schemeTags }`: a null note clears it, an absent/null/empty tag array untags that kind. Only the incident's owner may call it (no admin override — the note is the member's private content). The date and location are immutable: the body carries no coordinates and the SQL never touches them. Tag lists follow the create rules (canonical slugs, duplicates collapsed, at most 10 per kind; tags require the incident to carry a location — since location is immutable, a location-less incident can only edit its note, 400 otherwise). Saving with a non-empty tag list sets `shared_with_owner` to true in the same update (owner decision, 2026-08-18: tags require trend sharing; the editor states this before save); saving with both lists empty leaves the share flag as it stands. `other-scheme` ("Not listed") may be kept or removed but not newly picked on edit (400 — its description intake happens at create). An edit whose metadata duplicates another of the member's incidents returns a readable 409 (the `metadata_hash` dedupe). Returns `{ success: true }`.
 - `GET /api/click-log/preferences` — Read the member's global owner-share default (`{ shareWithOwner }`).
 - `PUT /api/click-log/preferences` — Set the member's global owner-share default. Body `{ shareWithOwner }`.
-- `GET /api/click-log/admin/trends` — Admin-only aggregate trends over shared incidents from the last 90 days: `{ buckets, tagTrends }` — `buckets` of day / ~11 km location cell / count, plus `tagTrends` of tag kind (`problem` | `scheme`) / tag slug / count.
+- `GET /api/click-log/admin/trends` — Admin-only aggregate trends over shared incidents from the last 90 days: `{ summary, buckets, areas, tagTrends, categories, pairs }`. `summary` carries the window, shared-incident total, distinct member count, repeat-reporter count, tagged total, location coverage, and first/last day; `buckets` are day / ~11 km location cell / count (unchanged); `areas` are ~11 km cells with incident count, distinct member count, and date span; `tagTrends` are tag kind (`problem` | `scheme`) / tag slug / count (unchanged); `categories` are harm-category rollups counted once per incident; `pairs` are the top problem-and-scheme combinations on the same incident. Every figure comes from a grouped query in `lib/click-log/report-repository.ts`; member identity appears only inside `COUNT(DISTINCT …)`.
+- `GET /api/click-log/admin/trends/image` — Admin-only PNG of the whole report, built from the same aggregate as the endpoint above. Optional `?areas=1` includes the ~11 km area coordinates; omitted by default. Responds with `Content-Disposition: attachment` and a dated filename, and `Cache-Control: no-store`. The image carries the method statement with the numbers so a reposted copy is never counts without provenance.
 
 ## 6. Data Model and Storage Contracts
 
@@ -183,6 +220,20 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   so an authorized request is audited regardless of the storage outcome.
 - See [CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml](../../contracts/CLICK_LOG_PLUGIN_ACCESS_POLICY_CONTRACTS.yaml)
 
+- The trend-reporting queries are the privacy boundary, and it is enforced in SQL rather than in
+  the screen that displays the result (`lib/click-log/report-repository.ts`). Every one filters on
+  `shared_with_owner`, and projects only counts, UTC day strings, 1-decimal location cells, and
+  canonical tag slugs. `user_id` never appears in a projection — only inside `COUNT(DISTINCT …)`,
+  which yields a number of people and never a list of them. A later change to the display therefore
+  cannot widen what the report can see.
+- The shareable report image is a wider disclosure than the screen, and is treated as one. Members
+  consented to their trend data reaching the owner; an image is made to be posted. So the area
+  coordinates — the most re-identifying element at low counts, where an ~11 km cell plus a date can
+  point at one person to anyone who knows them — are omitted unless the owner explicitly asks for
+  them, the download control says why in plain words, and the audit log records which variant was
+  produced. The image also carries the method statement with the numbers, so a copy that travels
+  without any surrounding text still states what the counts are and are not.
+
 ## 8. Web and Android Delivery Status
 
 - Web (desktop + mobile-responsive): Implemented shell, complete
@@ -215,9 +266,38 @@ Android pixel pass to `MobileClickLog.tsx` remains tracked in `PRODUCTION_READIN
 - No admin UI for global view/delete; admin access is via direct DB tooling.
 - No rate limiting on incident creation beyond shared platform defaults.
 - No advanced search/filtering on incident history.
+- The trend report cannot answer what an outside investigation would ask next: which country an
+  incident happened in, who the member says was involved, what they did about it and what came of
+  it, what it cost them, whether corroborating material exists, and whether they consent to being
+  contacted about their own case. Each needs a new question in the log form, so each is a product
+  decision rather than a reporting change. The seven items, in order and with their blocking
+  dependencies, are in `ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md` section 7. Nothing on that list is
+  built.
+- The report window is fixed at 90 days with no way to ask for another span, and the day list is
+  uncapped — at a high logging rate the shareable image becomes very tall.
 
 ## Change Log
 
+- 2026-08-19: **Trend reporting rebuilt so it says where, who, and what kind — and can be saved as
+  one image.** The screen showed a count of area clusters and never the areas themselves; it is now
+  a full breakdown of every ~11 km cell with its coordinates, incident count, distinct member count,
+  and date span, and the summary states how many shared incidents carry no location at all. Added
+  alongside it: distinct member and repeat-reporter counts (seven incidents from one member and
+  seven from seven members are different situations, and the old view could not tell them apart), a
+  rollup of the 53 problem tags into six harm categories, kind labels on scheme rows closing the
+  taxonomy gap `tags.ts` records, and a problem-and-scheme pair list. New endpoint
+  `GET /api/click-log/admin/trends/image` (`click-log.trends.image` 1.0.0) draws the whole report as
+  one tall PNG for posting; area coordinates are left out of it unless explicitly requested, because
+  members consented to sharing trend data with the project, not to an area and a date being
+  published. `click-log.trends.fetch` goes to 1.2.0 (additive — `buckets` and `tagTrends` are
+  unchanged). The method statement — how the data is collected, what is never counted, and what the
+  counts cannot show — is built once in `lib/click-log/trend-report-view.ts` and rendered by both the
+  screen and the image, so a copy of the image posted anywhere carries its own provenance; the long
+  version for readers outside the project is `ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md`, which also
+  lists the seven things an investigation would still need and which are not built. No change to
+  what members are asked, to what is stored, or to the privacy boundary: every new figure is a
+  grouped query over rows members already opted to share, and member identity reaches those queries
+  only inside `COUNT(DISTINCT …)`. Android: out of scope (web-only per rule 105).
 - 2026-08-18: **Tagging now requires trend sharing, not just a location (owner directive —
   correcting the 2026-08-18 guide copy, which had restated sharing as opt-in even for tagged
   incidents).** The three rules as the owner states them: tags (problems or schemes) require a

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -19,6 +19,14 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   incident does not need a location; (3) tagging problems or schemes requires both a location
   and trend sharing — a tagged incident always shares its trend data with the owner, and only
   shared incidents feed the global trends.
+- Every share control says the grouped totals may be published (owner directive, 2026-08-19). The
+  trend report is posted publicly and given to people outside the project, so sharing and
+  publication are one decision for the member and the copy states them together, at the moment the
+  choice is made: the global default, the per-incident checkbox in the log form, the history-row
+  pill tooltip and its screen-reader label, and the notice shown before an edit turns sharing on.
+  The wording lives once in `lib/click-log/share-copy.ts` so the four surfaces cannot drift apart.
+  What may be published is the aggregate only — notes, exact locations, and member identity are
+  excluded by the report queries themselves, not by the screen.
 - Log incident (with optional location/notes)
 - Optionally tag an incident with which known problems happened ("Which problems happened?" —
   the 50+ problems list published on the public landing page) and/or which named schemes were
@@ -76,8 +84,8 @@ ClickLog provides a simple, auditable incident counter and logging system for us
   tagged incident with the same explanation. Shared incidents contribute only grouped trend data
   (day, approximate area, tags, count) — never the note or exact location. The member-facing
   copy says so in plain words: the global default reads "only trend data — never your notes" and
-  the per-incident checkbox reads "only the date, rough area, and tags". Neither uses the word
-  "coarse".
+  the per-incident checkbox reads "only the date, rough area, and tags", and both close with
+  "Grouped totals may be published." Neither uses the word "coarse".
 
 ## 4. Admin Features
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-click-log-feature-inventory.md
@@ -110,6 +110,10 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 - Shareable report image (added 2026-08-19): `GET /api/click-log/admin/trends/image` draws the whole
   report — every section plus the method statement — as one tall PNG, so it can be posted somewhere
   that takes an image without stitching phone screenshots together and losing rows at the seams.
+  The trends screen offers it two ways: "Show the report as one image" opens it in the browser, which
+  is the phone path (hold the picture to save it to photos or send it into another app), and "Save it
+  as a file instead" (`?download=1`) downloads it, which is the computer path. A file download on a
+  phone lands in the files app, one step away from anywhere the image is actually going.
   Built from the same aggregate as the screen, so there is no second data path. Area coordinates are
   left out unless `?areas=1` is passed and the download control's checkbox is ticked: at small
   counts an ~11 km cell plus a date can point at one person, and members opted into sharing trend
@@ -143,7 +147,7 @@ ClickLog provides a simple, auditable incident counter and logging system for us
 - `GET /api/click-log/preferences` — Read the member's global owner-share default (`{ shareWithOwner }`).
 - `PUT /api/click-log/preferences` — Set the member's global owner-share default. Body `{ shareWithOwner }`.
 - `GET /api/click-log/admin/trends` — Admin-only aggregate trends over shared incidents from the last 90 days: `{ summary, buckets, areas, tagTrends, categories, pairs }`. `summary` carries the window, shared-incident total, distinct member count, repeat-reporter count, tagged total, location coverage, and first/last day; `buckets` are day / ~11 km location cell / count (unchanged); `areas` are ~11 km cells with incident count, distinct member count, and date span; `tagTrends` are tag kind (`problem` | `scheme`) / tag slug / count (unchanged); `categories` are harm-category rollups counted once per incident; `pairs` are the top problem-and-scheme combinations on the same incident. Every figure comes from a grouped query in `lib/click-log/report-repository.ts`; member identity appears only inside `COUNT(DISTINCT …)`.
-- `GET /api/click-log/admin/trends/image` — Admin-only PNG of the whole report, built from the same aggregate as the endpoint above. Optional `?areas=1` includes the ~11 km area coordinates; omitted by default. Responds with `Content-Disposition: attachment` and a dated filename, and `Cache-Control: no-store`. The image carries the method statement with the numbers so a reposted copy is never counts without provenance.
+- `GET /api/click-log/admin/trends/image` — Admin-only PNG of the whole report, built from the same aggregate as the endpoint above. Optional `?areas=1` includes the ~11 km area coordinates; omitted by default. Optional `?download=1` responds with `Content-Disposition: attachment`; without it the image is `inline`, so it opens in the browser and can be held to save to the photo library or shared into another app — the phone path, which is where the image is normally going. Both carry a dated filename and `Cache-Control: no-store`. The image carries the method statement with the numbers so a reposted copy is never counts without provenance.
 
 ## 6. Data Model and Storage Contracts
 

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -228,6 +228,34 @@ appear. No notes, exact locations, incident ids, or member identity anywhere on 
 intro copy names day, approximate area, counts, and tags as the only shared data.
 **Result:** web ☐ — notes:
 
+### CL-A4 · Trends dashboard says where, and how many people
+**Role:** admin · **Surfaces:** web
+**Steps:**
+1. Have at least two different members each share a tagged incident with a location, on different
+   days and from different places (CL-6 + CL-7).
+2. As admin, open the ClickLog Trends dashboard (`/admin/click-log`).
+**Expected:** The headline tiles show shared incidents, members reporting, members who logged more
+than one, days with activity, number of areas, and tagged incidents — and "members reporting" is the
+number of different people, not the number of incidents. An "Areas" section lists each area with its
+coordinates to one decimal place, how many incidents and how many members are in it, and the dates it
+spans. A "Kinds of harm reported" section rolls the problems up into categories, and an incident
+carrying two problems from the same category adds one to that category, not two. Scheme rows each
+carry a line saying what kind of scheme it is. The method statement appears under the numbers.
+**Result:** web ☐ — notes:
+
+### CL-A5 · Report saves as one image, without the areas by default
+**Role:** admin · **Surfaces:** web
+**Steps:**
+1. On the Trends dashboard, press "Save the report as one image" with the area checkbox left alone.
+2. Open the downloaded file.
+3. Tick "Include the area coordinates" and download again.
+**Expected:** Both downloads are PNG files named for today's date. The first contains every section
+of the report and the method statement, ends with the site line, and nothing is cut off at the
+bottom — and where the areas would be it says how many areas were recorded and why the coordinates
+were left out. The second is the same image with the area coordinates present. The numbers in the
+image match the numbers on the screen.
+**Result:** web ☐ — notes:
+
 ### CL-A2 · Left icon-rail chrome has no dead controls
 **Role:** member · **Surfaces:** web (desktop)
 **Steps:**

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -243,18 +243,20 @@ carrying two problems from the same category adds one to that category, not two.
 carry a line saying what kind of scheme it is. The method statement appears under the numbers.
 **Result:** web ☐ — notes:
 
-### CL-A5 · Report saves as one image, without the areas by default
-**Role:** admin · **Surfaces:** web
+### CL-A5 · Report opens as one image, without the areas by default
+**Role:** admin · **Surfaces:** web (desktop) · web (mobile-responsive, ~390px)
 **Steps:**
-1. On the Trends dashboard, press "Save the report as one image" with the area checkbox left alone.
-2. Open the downloaded file.
-3. Tick "Include the area coordinates" and download again.
-**Expected:** Both downloads are PNG files named for today's date. The first contains every section
-of the report and the method statement, ends with the site line, and nothing is cut off at the
-bottom — and where the areas would be it says how many areas were recorded and why the coordinates
-were left out. The second is the same image with the area coordinates present. The numbers in the
+1. On the Trends dashboard, press "Show the report as one image" with the area checkbox left alone.
+2. On a phone, press and hold the picture that opens and save it to the photo library.
+3. Go back, press "Save it as a file instead", and open the downloaded file.
+4. Tick "Include the area coordinates" and repeat step 1.
+**Expected:** Step 1 opens one tall picture in a new tab rather than downloading anything, and step 2
+saves it to photos. Step 3 downloads a PNG named for today's date. Every version contains every
+section of the report and the method statement, ends with the site line, and nothing is cut off at
+the bottom. Where the areas would be, the default version says how many areas were recorded and why
+the coordinates were left out; the version from step 4 shows the coordinates. The numbers in the
 image match the numbers on the screen.
-**Result:** web ☐ — notes:
+**Result:** web ☐ mobile ☐ — notes:
 
 ### CL-A2 · Left icon-rail chrome has no dead controls
 **Role:** member · **Surfaces:** web (desktop)

--- a/ctf/docs/developer/test-scripts/click-log-test-script.md
+++ b/ctf/docs/developer/test-scripts/click-log-test-script.md
@@ -243,6 +243,21 @@ carrying two problems from the same category adds one to that category, not two.
 carry a line saying what kind of scheme it is. The method statement appears under the numbers.
 **Result:** web ☐ — notes:
 
+### CL-9 · Every share control says the totals may be published
+**Role:** member · **Surfaces:** web (desktop) · web (mobile-responsive, ~390px)
+**Steps:**
+1. Open ClickLog and read the "share new incidents by default" setting at the top.
+2. Start logging an incident and read the share checkbox, with no tags picked.
+3. Pick a problem tag and read the same checkbox again.
+4. Save a private, untagged incident. On its history row, hover or focus the "Shared with owner"
+   pill on a tagged incident.
+5. Edit a private incident and add a tag without saving; read the notice that appears.
+**Expected:** All five places end with "Grouped totals may be published." — the global default, the
+free-choice checkbox, the locked checkbox on a tagged incident, the pill tooltip, and the edit
+notice. Each still says what is withheld ("never your notes" / "never your note"). The wording is
+identical across all five.
+**Result:** web ☐ mobile ☐ — notes:
+
 ### CL-A5 · Report opens as one image, without the areas by default
 **Role:** admin · **Surfaces:** web (desktop) · web (mobile-responsive, ~390px)
 **Steps:**

--- a/ctf/packages/web/app/api/click-log/admin/trends/image/route.tsx
+++ b/ctf/packages/web/app/api/click-log/admin/trends/image/route.tsx
@@ -12,6 +12,8 @@ import { logClickLogAudit } from 'lib/click-log/audit';
 import { requireClickLogAdminAccess } from '../../../_lib';
 
 // The whole shared-incident report as one tall PNG, for posting somewhere that takes an image.
+// Opens in the browser by default so it can be saved or shared from there; `?download=1` saves it
+// as a file instead.
 //
 // Admin-only and built from exactly the same aggregate as the trends screen, so there is no second
 // data path to keep honest. The image carries the method statement with the numbers: anyone who
@@ -35,7 +37,13 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
   }
 
-  const includeAreas = new URL(request.url).searchParams.get('areas') === '1';
+  const params = new URL(request.url).searchParams;
+  const includeAreas = params.get('areas') === '1';
+  // Shown in the browser by default, saved as a file with ?download=1. On a phone an attachment
+  // lands in the files app, which is the wrong place when the next step is posting it: the image
+  // has to be on screen so it can be long-pressed and saved to the photo library or shared
+  // straight into another app. The download stays for the desktop case.
+  const asDownload = params.get('download') === '1';
   const report = await buildSharedIncidentReport();
   const view = buildTrendReportView(report, { includeAreas });
   const generatedOn = new Date().toISOString().slice(0, 10);
@@ -51,7 +59,7 @@ export async function GET(request: Request) {
     width: REPORT_IMAGE_WIDTH,
     height: estimateReportImageHeight(view),
     headers: {
-      'Content-Disposition': `attachment; filename="clicklog-trends-${generatedOn}.png"`,
+      'Content-Disposition': `${asDownload ? 'attachment' : 'inline'}; filename="clicklog-trends-${generatedOn}.png"`,
       'Cache-Control': 'no-store',
     },
   });

--- a/ctf/packages/web/app/api/click-log/admin/trends/image/route.tsx
+++ b/ctf/packages/web/app/api/click-log/admin/trends/image/route.tsx
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { ImageResponse } from 'next/og';
+import { buildSharedIncidentReport } from 'lib/click-log/report';
+import { buildTrendReportView } from 'lib/click-log/trend-report-view';
+import {
+  REPORT_IMAGE_WIDTH,
+  buildReportImageElement,
+  estimateReportImageHeight,
+} from 'lib/click-log/report-image';
+import { canViewSharedTrends } from 'lib/click-log/policy';
+import { logClickLogAudit } from 'lib/click-log/audit';
+import { requireClickLogAdminAccess } from '../../../_lib';
+
+// The whole shared-incident report as one tall PNG, for posting somewhere that takes an image.
+//
+// Admin-only and built from exactly the same aggregate as the trends screen, so there is no second
+// data path to keep honest. The image carries the method statement with the numbers: anyone who
+// sees the counts also sees where they came from and what they cannot show, even when the image is
+// reposted with no surrounding text.
+//
+// Area coordinates are left out unless `?areas=1` is passed. At small counts an ~11 km cell plus a
+// date can point at one person, and members opted into sharing with the project, not into being
+// placed on a public map — so putting the cells in a copy meant for posting is a deliberate choice
+// the owner makes each time, not the default.
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const gate = await requireClickLogAdminAccess();
+  if (!gate.allowed) {
+    return gate.response;
+  }
+  if (!canViewSharedTrends(gate.auth.isAdmin)) {
+    return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+  }
+
+  const includeAreas = new URL(request.url).searchParams.get('areas') === '1';
+  const report = await buildSharedIncidentReport();
+  const view = buildTrendReportView(report, { includeAreas });
+  const generatedOn = new Date().toISOString().slice(0, 10);
+
+  logClickLogAudit({
+    actorId: gate.auth.userId,
+    command: 'click-log.trends.image',
+    result: 'success',
+    target: { areas: includeAreas ? 'included' : 'omitted' },
+  });
+
+  return new ImageResponse(buildReportImageElement(view, generatedOn), {
+    width: REPORT_IMAGE_WIDTH,
+    height: estimateReportImageHeight(view),
+    headers: {
+      'Content-Disposition': `attachment; filename="clicklog-trends-${generatedOn}.png"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/ctf/packages/web/app/api/click-log/admin/trends/route.ts
+++ b/ctf/packages/web/app/api/click-log/admin/trends/route.ts
@@ -1,14 +1,19 @@
 import { NextResponse } from 'next/server';
-import { getSharedIncidentTagTrends, getSharedIncidentTrends } from 'lib/click-log/repository';
+import { buildSharedIncidentReport } from 'lib/click-log/report';
 import { canViewSharedTrends } from 'lib/click-log/policy';
 import { logClickLogAudit } from 'lib/click-log/audit';
 import { requireClickLogAdminAccess } from '../../_lib';
 
-// Owner/admin-only aggregate trends over incidents members opted to share. The repository
-// queries return only coarse data (UTC day + ~11 km location cell + count buckets, and
-// per-tag counts over the canonical tag slugs) — notes, precise coordinates, incident ids,
-// and member identity are excluded at the SQL layer, so nothing member-identifying can leak
-// through this endpoint.
+// Owner/admin-only aggregate trends over incidents members opted to share. Every repository query
+// behind this returns only coarse data (UTC day, ~11 km location cell, counts, canonical tag
+// slugs, and distinct-member counts) — notes, precise coordinates, incident ids, and member
+// identity are excluded at the SQL layer, so nothing member-identifying can leak through this
+// endpoint.
+//
+// `buckets` and `tagTrends` are the original response and are unchanged. The rest of the report
+// (summary, areas, categories, pairs) was added so the screen can show where activity is and how
+// many different members are behind it, and so the shareable image gives an outside reader
+// something they can follow.
 export async function GET() {
   const gate = await requireClickLogAdminAccess();
   if (!gate.allowed) {
@@ -17,8 +22,7 @@ export async function GET() {
   if (!canViewSharedTrends(gate.auth.isAdmin)) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
   }
-  const buckets = await getSharedIncidentTrends();
-  const tagTrends = await getSharedIncidentTagTrends();
+  const report = await buildSharedIncidentReport();
   logClickLogAudit({ actorId: gate.auth.userId, command: 'click-log.trends.fetch', result: 'success' });
-  return NextResponse.json({ buckets, tagTrends });
+  return NextResponse.json(report);
 }

--- a/ctf/packages/web/components/click-log/click-log-admin-trends.tsx
+++ b/ctf/packages/web/components/click-log/click-log-admin-trends.tsx
@@ -1,57 +1,36 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { AlertTriangle, MapPin } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { PluginUserShellButton } from "@/components/shared/plugin-user-shell-button";
 import { MobileScreenHeader } from "@/components/shared/mobile-screen-header";
-import type { SharedIncidentTagTrend, SharedIncidentTrendBucket } from "../../lib/click-log/types";
-import { problemTagLabel, schemeTagLabel } from "../../lib/click-log/tags";
+import type { SharedIncidentReport } from "../../lib/click-log/types";
+import { buildTrendReportView } from "../../lib/click-log/trend-report-view";
+import {
+  ClickLogTrendMethod,
+  ClickLogTrendResults,
+  ClickLogTrendStat,
+} from "./click-log-trend-sections";
+import { ClickLogTrendImageLink } from "./click-log-trend-image-link";
+import {
+  TREND_ACCENT,
+  TREND_BG,
+  TREND_SUBTLE,
+  TREND_TEXT,
+} from "./click-log-trend-tokens";
 
-// Admin dark palette (rule 131) with the ClickLog accent.
-const BG = "#0F1117";
-const SURFACE = "#161B27";
-const BORDER = "#1E2A3A";
-const TEXT = "#F9FAFB";
-const SUBTLE = "#6B7280";
-const ACCENT = "#EC4899";
-
-// One tag-count section of the owner trends view ("Top problems" / "Top schemes"). Tag slugs are
-// resolved to their short labels client-side from the canonical lists.
-function ClickLogTagTrendSection({
-  title,
-  rows,
-  labelFor,
-}: {
-  title: string;
-  rows: SharedIncidentTagTrend[];
-  labelFor: (slug: string) => string;
-}) {
-  if (rows.length === 0) return null;
-  return (
-    <div style={{ marginTop: 20 }}>
-      <div style={{ fontSize: 13, fontWeight: 700, color: TEXT, marginBottom: 8 }}>{title}</div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-        {rows.map((row) => (
-          <div key={row.tag} style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px", borderRadius: 10, background: SURFACE, border: `1px solid ${BORDER}` }}>
-            <div style={{ fontSize: 12, color: TEXT, flex: 1 }}>{labelFor(row.tag)}</div>
-            <div style={{ fontSize: 13, fontWeight: 700, color: ACCENT }}>{row.count}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// Owner trends over member-shared incidents. Data is coarse by construction (UTC day + ~11 km
-// location cell + count buckets, plus per-tag counts over the canonical tag slugs, aggregated in
-// SQL) — this view never sees notes, precise coordinates, incident ids, or member identity. No
-// in-page title card: MobileScreenHeader names the screen (rule 131), so the shell goes straight
-// to content.
+// Owner trends over member-shared incidents. Data is coarse by construction (UTC day, ~11 km
+// location cell, counts, canonical tag slugs, and distinct-member counts, all aggregated in SQL) —
+// this view never sees notes, precise coordinates, incident ids, or member identity. No in-page
+// title card: MobileScreenHeader names the screen (rule 131), so the shell goes straight to content.
+//
+// The screen shows every area cell with its coordinates. The old view counted the clusters and
+// stopped there, which told the owner activity had a location without ever saying where. The
+// shareable image leaves the coordinates out unless they are asked for — see the download control.
 export function ClickLogAdminTrends() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [buckets, setBuckets] = useState<SharedIncidentTrendBucket[]>([]);
-  const [tagTrends, setTagTrends] = useState<SharedIncidentTagTrend[]>([]);
+  const [report, setReport] = useState<SharedIncidentReport | null>(null);
 
   useEffect(() => {
     let canceled = false;
@@ -59,12 +38,8 @@ export function ClickLogAdminTrends() {
       try {
         const res = await fetch("/api/click-log/admin/trends");
         if (!res.ok) throw new Error("Failed to load trends");
-        const data = (await res.json()) as {
-          buckets: SharedIncidentTrendBucket[];
-          tagTrends?: SharedIncidentTagTrend[];
-        };
-        if (!canceled) setBuckets(data.buckets);
-        if (!canceled) setTagTrends(data.tagTrends ?? []);
+        const data = (await res.json()) as SharedIncidentReport;
+        if (!canceled) setReport(data);
       } catch (e) {
         if (!canceled) setError(e instanceof Error ? e.message : "Failed to load trends");
       } finally {
@@ -76,70 +51,37 @@ export function ClickLogAdminTrends() {
     };
   }, []);
 
-  const totalShared = buckets.reduce((sum, b) => sum + b.count, 0);
-  const dayTotals = buckets.reduce<Map<string, number>>((map, b) => {
-    map.set(b.day, (map.get(b.day) ?? 0) + b.count);
-    return map;
-  }, new Map());
-  const days = Array.from(dayTotals.entries());
-  const withLocation = buckets.filter((b) => b.latitudeCell !== null && b.longitudeCell !== null);
-  const problemTrends = tagTrends.filter((row) => row.tagType === "problem");
-  const schemeTrends = tagTrends.filter((row) => row.tagType === "scheme");
+  const view = report ? buildTrendReportView(report, { includeAreas: true }) : null;
 
   return (
-    <div style={{ minHeight: "100vh", background: BG, color: TEXT, fontFamily: "'Inter', system-ui, sans-serif" }}>
+    <div style={{ minHeight: "100vh", background: TREND_BG, color: TREND_TEXT, fontFamily: "'Inter', system-ui, sans-serif" }}>
       <MobileScreenHeader
         title="ClickLog Trends"
-        icon={<AlertTriangle size={18} color={ACCENT} />}
-        accent={ACCENT}
+        icon={<AlertTriangle size={18} color={TREND_ACCENT} />}
+        accent={TREND_ACCENT}
         backHref="/admin"
-        actions={<PluginUserShellButton href="/apps/click-log" accent={ACCENT} />}
+        actions={<PluginUserShellButton href="/apps/click-log" accent={TREND_ACCENT} />}
       />
       <div style={{ padding: 16, maxWidth: 560, margin: "0 auto" }}>
-        {loading && <div style={{ color: SUBTLE, fontSize: 13, padding: "32px 0", textAlign: "center" }}>Loading trends…</div>}
+        {loading && <div style={{ color: TREND_SUBTLE, fontSize: 13, padding: "32px 0", textAlign: "center" }}>Loading trends…</div>}
         {error && (
           <div style={{ padding: "10px 14px", borderRadius: 10, background: "rgba(239,68,68,0.1)", border: "1px solid rgba(239,68,68,0.3)", color: "#fecaca", fontSize: 13 }}>{error}</div>
         )}
-        {!loading && !error && (
+        {view && !loading && !error && (
           <>
-            <div style={{ fontSize: 12, color: SUBTLE, lineHeight: 1.5, marginBottom: 16 }}>
-              Aggregate of incidents members chose to share, last 90 days. Grouped data only: day, an
-              approximate area (about 11 km), counts, and which problem/scheme tags members picked —
-              no notes, exact locations, or member identity.
+            <div style={{ fontSize: 12, color: TREND_SUBTLE, lineHeight: 1.5, marginBottom: 16 }}>
+              {view.windowLine}. Aggregate of incidents members chose to share. Grouped data only:
+              day, an approximate area (about 11 km), counts, and which problem/scheme tags members
+              picked — no notes, exact locations, or member identity.
             </div>
-            <div style={{ display: "flex", gap: 10, marginBottom: 20 }}>
-              <div style={{ flex: 1, padding: "14px 16px", borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, textAlign: "center" }}>
-                <div style={{ fontSize: 22, fontWeight: 800, color: ACCENT }}>{totalShared}</div>
-                <div style={{ fontSize: 11, color: SUBTLE, marginTop: 2 }}>Shared incidents</div>
-              </div>
-              <div style={{ flex: 1, padding: "14px 16px", borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, textAlign: "center" }}>
-                <div style={{ fontSize: 22, fontWeight: 800, color: ACCENT }}>{days.length}</div>
-                <div style={{ fontSize: 11, color: SUBTLE, marginTop: 2 }}>Days with activity</div>
-              </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginBottom: 4 }}>
+              {view.stats.map((stat) => (
+                <ClickLogTrendStat key={stat.label} label={stat.label} value={Number(stat.value)} />
+              ))}
             </div>
-            {days.length === 0 ? (
-              <div style={{ padding: "40px 16px", borderRadius: 12, background: SURFACE, border: `1px solid ${BORDER}`, textAlign: "center", color: SUBTLE, fontSize: 13, lineHeight: 1.6 }}>
-                No shared incidents yet. Members control sharing from their ClickLog — nothing appears
-                here until someone opts in.
-              </div>
-            ) : (
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                {days.map(([day, count]) => (
-                  <div key={day} style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 14px", borderRadius: 10, background: SURFACE, border: `1px solid ${BORDER}` }}>
-                    <div style={{ fontSize: 13, color: TEXT, flex: 1 }}>{day}</div>
-                    <div style={{ fontSize: 13, fontWeight: 700, color: ACCENT }}>{count}</div>
-                  </div>
-                ))}
-                {withLocation.length > 0 && (
-                  <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 6, fontSize: 11, color: SUBTLE }}>
-                    <MapPin size={11} color={SUBTLE} />
-                    {withLocation.length} area cluster{withLocation.length === 1 ? "" : "s"} across the shared incidents (each about 11 km wide)
-                  </div>
-                )}
-              </div>
-            )}
-            <ClickLogTagTrendSection title="Top problems" rows={problemTrends} labelFor={problemTagLabel} />
-            <ClickLogTagTrendSection title="Top schemes" rows={schemeTrends} labelFor={schemeTagLabel} />
+            <ClickLogTrendResults view={view} />
+            <ClickLogTrendImageLink areaCount={report?.areas.length ?? 0} />
+            <ClickLogTrendMethod notes={view.notes} />
           </>
         )}
       </div>

--- a/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
+++ b/ctf/packages/web/components/click-log/click-log-incident-editor.tsx
@@ -12,6 +12,7 @@ import {
   type ClickLogTokens,
 } from "./click-log-shared";
 import { ClickLogTagPicker } from "./click-log-tag-picker";
+import { SHARE_EDIT_TURNS_ON_NOTICE } from "../../lib/click-log/share-copy";
 
 // What an edit can change. Tag lists use [] for untagged (picker convention).
 export type IncidentEditFields = { notes: string; problemTags: string[]; schemeTags: string[] };
@@ -126,9 +127,7 @@ export function ClickLogIncidentEditor({
           with tags turns sharing on server-side, so say it plainly before the member saves. */}
       {!incident.shared_with_owner && (problemTags.length > 0 || schemeTags.length > 0) && (
         <div style={{ marginTop: 8, fontSize: 11, color: t.MUTED, lineHeight: 1.5 }}>
-          Tags share trend data with the owner: saving with these tags turns on sharing for this
-          incident (only the date, rough area, and tags — never your note). Remove the tags to
-          keep it private.
+          {SHARE_EDIT_TURNS_ON_NOTICE}
         </div>
       )}
       <div style={{ display: "flex", gap: 8, marginTop: 12 }}>

--- a/ctf/packages/web/components/click-log/click-log-incident-list.tsx
+++ b/ctf/packages/web/components/click-log/click-log-incident-list.tsx
@@ -6,6 +6,7 @@ import type { ClickLogIncident } from "../../lib/click-log/types";
 import { problemTagLabel, schemeTagLabel } from "../../lib/click-log/tags";
 import { formatIncidentTime, getClickLogTokens, hasLocation, type ClickLogTokens } from "./click-log-shared";
 import { ClickLogIncidentEditor, type IncidentEditFields } from "./click-log-incident-editor";
+import { SHARE_PILL_LOCKED_ARIA, SHARE_PILL_LOCKED_HINT } from "../../lib/click-log/share-copy";
 
 // The problem/scheme tag chips on one history row. Renders nothing on an untagged incident.
 // Extracted so the row component stays under the complexity limit.
@@ -35,7 +36,7 @@ function IncidentTagChips({ incident, tokens }: { incident: ClickLogIncident; to
 // count) reaches the owner, never the note. Extracted so the row stays under the complexity limit.
 function sharePillAriaLabel(shareLocked: boolean, shared: boolean): string {
   if (shareLocked) {
-    return "Shared with the owner — required for tagged incidents; remove the tags to make it private";
+    return SHARE_PILL_LOCKED_ARIA;
   }
   return shared ? "Stop sharing this incident with the owner" : "Share this incident with the owner";
 }
@@ -56,7 +57,7 @@ function IncidentSharePill({
     <button
       onClick={() => onToggleShare(incident.id, !incident.shared_with_owner)}
       disabled={shareLocked}
-      title={shareLocked ? "Tagged incidents always share trend data with the owner — remove the tags (edit) to make this private" : undefined}
+      title={shareLocked ? SHARE_PILL_LOCKED_HINT : undefined}
       aria-label={sharePillAriaLabel(shareLocked, incident.shared_with_owner)}
       style={{ marginTop: 6, padding: "3px 10px", borderRadius: 999, fontSize: 10, fontWeight: 600, cursor: shareLocked ? "default" : "pointer", background: incident.shared_with_owner ? `${t.ACCENT}18` : t.SURFACE, border: `1px solid ${incident.shared_with_owner ? t.ACCENT + "40" : t.BORDER_SOLID}`, color: incident.shared_with_owner ? t.ACCENT : t.MUTED }}
     >

--- a/ctf/packages/web/components/click-log/click-log-log-panel.tsx
+++ b/ctf/packages/web/components/click-log/click-log-log-panel.tsx
@@ -12,6 +12,7 @@ import {
 } from "./click-log-shared";
 import { ClickLogTagPicker } from "./click-log-tag-picker";
 import { ClickLogSchemeSuggestionFields } from "./click-log-scheme-suggestion-fields";
+import { SHARE_INCIDENT_LABEL, SHARE_INCIDENT_LOCKED_LABEL } from "../../lib/click-log/share-copy";
 
 type GeoStatus = "idle" | "locating" | "error";
 
@@ -224,9 +225,7 @@ function ClickLogNoteForm({
           onChange={(e) => onShareChange(e.target.checked)}
           style={{ accentColor: t.ACCENT }}
         />
-        {tagged
-          ? "Shared with the owner — required for tagged incidents (only the date, rough area, and tags; never your note)"
-          : "Share this incident with the owner (only the date, rough area, and tags)"}
+        {tagged ? SHARE_INCIDENT_LOCKED_LABEL : SHARE_INCIDENT_LABEL}
       </label>
       <div style={{ display: "flex", gap: 8, marginTop: 10, alignItems: "center" }}>
         <ClickLogLocationButton

--- a/ctf/packages/web/components/click-log/click-log-shell.tsx
+++ b/ctf/packages/web/components/click-log/click-log-shell.tsx
@@ -15,6 +15,7 @@ import { MobileTopActions } from "@/components/shared/mobile-top-actions";
 import { RefreshButton } from "@/components/shared/refresh-button";
 import { useOwnerShare } from "./click-log-use-owner-share";
 import { useIncidentEdit } from "./click-log-use-incident-edit";
+import { SHARE_DEFAULT_LABEL } from "../../lib/click-log/share-copy";
 
 type Geo = { latitude?: number; longitude?: number };
 
@@ -87,7 +88,7 @@ function ShareDefaultToggle({
         onChange={(e) => onChange(e.target.checked)}
         style={{ accentColor: t.ACCENT }}
       />
-      Share new incidents with the owner by default (only trend data — never your notes)
+      {SHARE_DEFAULT_LABEL}
     </label>
   );
 }

--- a/ctf/packages/web/components/click-log/click-log-trend-image-link.tsx
+++ b/ctf/packages/web/components/click-log/click-log-trend-image-link.tsx
@@ -21,10 +21,11 @@ import {
 // Plain links, not a fetch: the endpoint answers with the image itself, and the same signed-in
 // session that loaded this screen authorizes the request.
 //
-// The area checkbox is off to start. Members opted into sharing trend data with the project, not
-// into having their approximate area posted publicly, and at small counts an ~11 km cell plus a
-// date can point at one person — so putting the coordinates into a copy meant for posting is a
-// deliberate choice made each time rather than a default.
+// The area checkbox is off to start. Members are told the grouped totals may be published, and a
+// total is what they agreed to — an ~11 km cell next to a date is closer to one person's location
+// than to a total, and at small counts it can point at them for anyone who already knows them. So
+// putting the coordinates into a copy meant for posting is a deliberate choice made each time
+// rather than a default.
 export function ClickLogTrendImageLink({ areaCount }: { areaCount: number }) {
   const [includeAreas, setIncludeAreas] = useState(false);
   const query = includeAreas ? 'areas=1' : '';

--- a/ctf/packages/web/components/click-log/click-log-trend-image-link.tsx
+++ b/ctf/packages/web/components/click-log/click-log-trend-image-link.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import { Download } from 'lucide-react';
+import {
+  TREND_ACCENT,
+  TREND_BORDER,
+  TREND_SUBTLE,
+  TREND_SURFACE,
+  TREND_TEXT,
+} from './click-log-trend-tokens';
+
+// Downloads the whole report as one tall PNG — the thing to post somewhere that takes an image,
+// without stitching phone screenshots together and losing rows at the seams.
+//
+// A plain link, not a fetch: the endpoint answers with the image and a filename, so the browser
+// saves it and the same signed-in session that loaded this screen authorizes the request.
+//
+// The area checkbox is off to start. Members opted into sharing trend data with the project, not
+// into having their approximate area posted publicly, and at small counts an ~11 km cell plus a
+// date can point at one person — so putting the coordinates into a copy meant for posting is a
+// deliberate choice made each time rather than a default.
+export function ClickLogTrendImageLink({ areaCount }: { areaCount: number }) {
+  const [includeAreas, setIncludeAreas] = useState(false);
+  const href = `/api/click-log/admin/trends/image${includeAreas ? '?areas=1' : ''}`;
+  return (
+    <div
+      style={{
+        marginTop: 20,
+        padding: '14px 16px',
+        borderRadius: 12,
+        background: TREND_SURFACE,
+        border: `1px solid ${TREND_BORDER}`,
+      }}
+    >
+      <a
+        href={href}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
+          padding: '10px 14px',
+          borderRadius: 10,
+          background: TREND_ACCENT,
+          color: '#fff',
+          fontSize: 13,
+          fontWeight: 700,
+          textDecoration: 'none',
+        }}
+      >
+        <Download size={15} color="#fff" />
+        Save the report as one image
+      </a>
+      {areaCount > 0 && (
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 8,
+            marginTop: 12,
+            fontSize: 12,
+            color: TREND_TEXT,
+            cursor: 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={includeAreas}
+            onChange={(event) => setIncludeAreas(event.target.checked)}
+            style={{ marginTop: 2, accentColor: TREND_ACCENT }}
+          />
+          <span>
+            Include the area coordinates
+            <span style={{ display: 'block', color: TREND_SUBTLE, marginTop: 2, lineHeight: 1.5 }}>
+              Off by default. With only a few incidents in an area, an area plus a date can point at
+              one person — so leave this off for anything posted in public.
+            </span>
+          </span>
+        </label>
+      )}
+      <div style={{ fontSize: 11, color: TREND_SUBTLE, marginTop: 10, lineHeight: 1.5 }}>
+        The image carries the numbers and the note below them, so anyone who sees the counts also
+        sees where they came from and what they cannot show.
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/click-log/click-log-trend-image-link.tsx
+++ b/ctf/packages/web/components/click-log/click-log-trend-image-link.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Download } from 'lucide-react';
+import { Download, Image as ImageIcon } from 'lucide-react';
 import {
   TREND_ACCENT,
   TREND_BORDER,
@@ -10,11 +10,16 @@ import {
   TREND_TEXT,
 } from './click-log-trend-tokens';
 
-// Downloads the whole report as one tall PNG — the thing to post somewhere that takes an image,
+// Produces the whole report as one tall PNG — the thing to post somewhere that takes an image,
 // without stitching phone screenshots together and losing rows at the seams.
 //
-// A plain link, not a fetch: the endpoint answers with the image and a filename, so the browser
-// saves it and the same signed-in session that loaded this screen authorizes the request.
+// Two links, not one, because the two devices need different things. On a phone the image has to
+// open on screen: from there it can be held to save it to the photo library or shared straight
+// into another app, which is where it is going. A file download on a phone lands in the files app
+// instead, one step away from anywhere useful — so that is the second link, for a computer.
+//
+// Plain links, not a fetch: the endpoint answers with the image itself, and the same signed-in
+// session that loaded this screen authorizes the request.
 //
 // The area checkbox is off to start. Members opted into sharing trend data with the project, not
 // into having their approximate area posted publicly, and at small counts an ~11 km cell plus a
@@ -22,7 +27,9 @@ import {
 // deliberate choice made each time rather than a default.
 export function ClickLogTrendImageLink({ areaCount }: { areaCount: number }) {
   const [includeAreas, setIncludeAreas] = useState(false);
-  const href = `/api/click-log/admin/trends/image${includeAreas ? '?areas=1' : ''}`;
+  const query = includeAreas ? 'areas=1' : '';
+  const viewHref = `/api/click-log/admin/trends/image${query ? `?${query}` : ''}`;
+  const downloadHref = `/api/click-log/admin/trends/image?${query ? `${query}&` : ''}download=1`;
   return (
     <div
       style={{
@@ -34,7 +41,9 @@ export function ClickLogTrendImageLink({ areaCount }: { areaCount: number }) {
       }}
     >
       <a
-        href={href}
+        href={viewHref}
+        target="_blank"
+        rel="noopener noreferrer"
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -49,8 +58,33 @@ export function ClickLogTrendImageLink({ areaCount }: { areaCount: number }) {
           textDecoration: 'none',
         }}
       >
-        <Download size={15} color="#fff" />
-        Save the report as one image
+        <ImageIcon size={15} color="#fff" />
+        Show the report as one image
+      </a>
+      <div style={{ fontSize: 11, color: TREND_SUBTLE, marginTop: 8, lineHeight: 1.5 }}>
+        Opens the whole report as one tall picture. On a phone, press and hold it to save it to your
+        photos or send it straight to another app.
+      </div>
+      <a
+        href={downloadHref}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
+          marginTop: 10,
+          padding: '9px 14px',
+          borderRadius: 10,
+          background: 'transparent',
+          border: `1px solid ${TREND_BORDER}`,
+          color: TREND_TEXT,
+          fontSize: 12,
+          fontWeight: 600,
+          textDecoration: 'none',
+        }}
+      >
+        <Download size={14} color={TREND_SUBTLE} />
+        Save it as a file instead
       </a>
       {areaCount > 0 && (
         <label

--- a/ctf/packages/web/components/click-log/click-log-trend-sections.tsx
+++ b/ctf/packages/web/components/click-log/click-log-trend-sections.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import type { ReportNote, ReportRow, TrendReportView } from '../../lib/click-log/trend-report-view';
+import {
+  TREND_ACCENT,
+  TREND_BORDER,
+  TREND_SUBTLE,
+  TREND_SURFACE,
+  TREND_TEXT,
+} from './click-log-trend-tokens';
+
+// The repeated pieces of the owner trends screen: a stat tile, a counted row, a titled list of
+// them, and the method statement. Split out of the screen itself (rule 116) so the screen file
+// stays one component doing one job — fetching the report and laying its sections out.
+
+export function ClickLogTrendStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        minWidth: 0,
+        padding: '14px 16px',
+        borderRadius: 12,
+        background: TREND_SURFACE,
+        border: `1px solid ${TREND_BORDER}`,
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: 22, fontWeight: 800, color: TREND_ACCENT }}>{value}</div>
+      <div style={{ fontSize: 11, color: TREND_SUBTLE, marginTop: 2, lineHeight: 1.3 }}>{label}</div>
+    </div>
+  );
+}
+
+export function ClickLogTrendRow({ row }: { row: ReportRow }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        borderRadius: 10,
+        background: TREND_SURFACE,
+        border: `1px solid ${TREND_BORDER}`,
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 12, color: TREND_TEXT }}>{row.label}</div>
+        {row.detail && (
+          <div style={{ fontSize: 11, color: TREND_SUBTLE, marginTop: 2 }}>{row.detail}</div>
+        )}
+      </div>
+      <div style={{ fontSize: 13, fontWeight: 700, color: TREND_ACCENT }}>{row.value}</div>
+    </div>
+  );
+}
+
+// One titled list. Renders nothing when it has no rows, so a report with no schemes tagged simply
+// has no scheme heading rather than an empty box.
+export function ClickLogTrendSection({
+  title,
+  hint,
+  rows,
+}: {
+  title: string;
+  hint?: string;
+  rows: ReportRow[];
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <div style={{ marginTop: 20 }}>
+      <div style={{ fontSize: 13, fontWeight: 700, color: TREND_TEXT, marginBottom: hint ? 4 : 8 }}>
+        {title}
+      </div>
+      {hint && (
+        <div style={{ fontSize: 11, color: TREND_SUBTLE, marginBottom: 8, lineHeight: 1.5 }}>{hint}</div>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {rows.map((row) => (
+          <ClickLogTrendRow key={`${row.label}-${row.value}`} row={row} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// The method statement, shown under the numbers on the screen and drawn into the shareable image
+// from the same source. It is on the screen and not only in the image so the owner reads exactly
+// what anyone they send the image to will read.
+export function ClickLogTrendMethod({ notes }: { notes: ReportNote[] }) {
+  if (notes.length === 0) return null;
+  return (
+    <div style={{ marginTop: 24, paddingTop: 20, borderTop: `1px solid ${TREND_BORDER}` }}>
+      <div style={{ fontSize: 13, fontWeight: 700, color: TREND_TEXT, marginBottom: 10 }}>
+        How this was collected, and what it cannot show
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {notes.map((note) => (
+          <div key={note.heading}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: TREND_ACCENT, marginBottom: 3 }}>
+              {note.heading}
+            </div>
+            <div style={{ fontSize: 12, color: TREND_SUBTLE, lineHeight: 1.6 }}>{note.body}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Every counted section of the report, in reading order — or the empty state when no member has
+// shared anything yet. Kept here rather than inline in the screen so the screen stays a component
+// that fetches and lays out, with the section order and their hint copy in one place.
+export function ClickLogTrendResults({ view }: { view: TrendReportView }) {
+  if (view.days.length === 0) {
+    return (
+      <div style={{ marginTop: 16, padding: '40px 16px', borderRadius: 12, background: TREND_SURFACE, border: `1px solid ${TREND_BORDER}`, textAlign: 'center', color: TREND_SUBTLE, fontSize: 13, lineHeight: 1.6 }}>
+        No shared incidents yet. Members control sharing from their ClickLog — nothing appears here
+        until someone opts in.
+      </div>
+    );
+  }
+  return (
+    <>
+      <ClickLogTrendSection title="Days with shared incidents" rows={view.days} />
+      <ClickLogTrendSection
+        title="Areas (each about 11 km across)"
+        hint="Where the shared incidents were logged, rounded to about 11 km. Incidents logged without a location are absent here and counted everywhere else."
+        rows={view.areas}
+      />
+      {view.areasTruncatedLine && (
+        <div style={{ marginTop: 8, fontSize: 11, color: TREND_SUBTLE }}>{view.areasTruncatedLine}</div>
+      )}
+      <ClickLogTrendSection
+        title="Kinds of harm reported"
+        hint="The problems rolled up into the kinds of harm an outside reader recognizes. An incident counts once per kind."
+        rows={view.categories}
+      />
+      <ClickLogTrendSection title="Top problems" rows={view.problems} />
+      <ClickLogTrendSection
+        title="Top schemes"
+        hint="Counts are not comparable between kinds: some schemes run continuously and can be reported almost any day, others are single operations."
+        rows={view.schemes}
+      />
+      <ClickLogTrendSection
+        title="Problem and scheme reported together"
+        hint="Which method was tagged alongside which harm on the same incident. The most common combinations, at most twelve."
+        rows={view.pairs}
+      />
+    </>
+  );
+}

--- a/ctf/packages/web/components/click-log/click-log-trend-tokens.ts
+++ b/ctf/packages/web/components/click-log/click-log-trend-tokens.ts
@@ -1,0 +1,8 @@
+// Admin dark palette (rule 131) with the ClickLog accent, shared by the trends screen and the
+// pieces it is built from so the sections cannot drift apart in color.
+export const TREND_BG = '#0F1117';
+export const TREND_SURFACE = '#161B27';
+export const TREND_BORDER = '#1E2A3A';
+export const TREND_TEXT = '#F9FAFB';
+export const TREND_SUBTLE = '#6B7280';
+export const TREND_ACCENT = '#EC4899';

--- a/ctf/packages/web/lib/click-log/audit.ts
+++ b/ctf/packages/web/lib/click-log/audit.ts
@@ -6,7 +6,9 @@ import { randomUUID } from 'crypto';
 // (CLICK_LOG_PLUGIN_AUDIT_CONTRACTS.yaml) requires an audit event on every successful
 // allowed operation — incident create/list/delete, the per-incident share toggle, the
 // preferences fetch/update, and the admin trends fetch — so the route handlers call
-// this after each success.
+// this after each success. The shareable trends image is audited the same way, and records
+// whether the copy carried area coordinates — that is the one owner choice on that route that
+// widens what a posted copy reveals, so it belongs in the log.
 
 type ClickLogCommand =
   | 'click-log.incident.create'
@@ -16,14 +18,16 @@ type ClickLogCommand =
   | 'click-log.incident.share.set'
   | 'click-log.preferences.fetch'
   | 'click-log.preferences.update'
-  | 'click-log.trends.fetch';
+  | 'click-log.trends.fetch'
+  | 'click-log.trends.image';
 
 type ClickLogAuditEvent = {
   actorId: string;
   command: ClickLogCommand;
   result: 'success' | 'failure';
   // Optional context identifiers (e.g. the incident id for delete). Empty/undefined
-  // values are dropped so the log never carries blank keys.
+  // values are dropped so the log never carries blank keys. Values here are never member data:
+  // an incident id, or which variant of the trends image was produced.
   target?: Record<string, string | undefined>;
   errorCategory?: string | null;
 };

--- a/ctf/packages/web/lib/click-log/report-image.test.ts
+++ b/ctf/packages/web/lib/click-log/report-image.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { ImageResponse } from 'next/og';
+import { buildTrendReportView } from './trend-report-view';
+import {
+  REPORT_IMAGE_WIDTH,
+  buildReportImageElement,
+  estimateReportImageHeight,
+} from './report-image';
+import type { SharedIncidentReport } from './types';
+
+// The report image is drawn by satori, which supports only a subset of CSS and fails loudly on the
+// rest. Nothing else in this repo renders that way, so this test actually produces the PNG rather
+// than inspecting the element tree: if a style the renderer cannot take gets added to the layout,
+// this goes red here instead of returning a broken download to the owner.
+
+const report: SharedIncidentReport = {
+  summary: {
+    days: 90,
+    sharedIncidents: 7,
+    reporters: 3,
+    repeatReporters: 2,
+    areas: 1,
+    taggedIncidents: 6,
+    withLocation: 5,
+    withoutLocation: 2,
+    firstDay: '2026-08-13',
+    lastDay: '2026-08-19',
+  },
+  buckets: [
+    { day: '2026-08-19', latitudeCell: 40.7, longitudeCell: -74.0, count: 2 },
+    { day: '2026-08-18', latitudeCell: 40.7, longitudeCell: -74.0, count: 4 },
+    { day: '2026-08-13', latitudeCell: null, longitudeCell: null, count: 1 },
+  ],
+  areas: [
+    {
+      latitudeCell: 40.7,
+      longitudeCell: -74.0,
+      incidents: 6,
+      reporters: 2,
+      firstDay: '2026-08-18',
+      lastDay: '2026-08-19',
+    },
+  ],
+  tagTrends: [
+    { tagType: 'problem', tag: 'bright-lights-shined', count: 2 },
+    { tagType: 'problem', tag: 'tinnitus', count: 2 },
+    { tagType: 'scheme', tag: 'color-sensitization', count: 3 },
+  ],
+  categories: [
+    { category: 'watched-and-followed', incidents: 4, reporters: 2 },
+    { category: 'body-and-health', incidents: 3, reporters: 2 },
+  ],
+  pairs: [{ problemTag: 'tinnitus', schemeTag: 'color-sensitization', incidents: 2, reporters: 1 }],
+};
+
+async function render(includeAreas: boolean): Promise<Buffer> {
+  const view = buildTrendReportView(report, { includeAreas });
+  const response = new ImageResponse(buildReportImageElement(view, '2026-08-19'), {
+    width: REPORT_IMAGE_WIDTH,
+    height: estimateReportImageHeight(view),
+  });
+  return Buffer.from(await response.arrayBuffer());
+}
+
+describe('ClickLog report image', () => {
+  it('renders a PNG the whole report fits into', async () => {
+    const png = await render(true);
+    // PNG magic number: any other bytes mean the renderer produced something else.
+    expect(png.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    // Width and height live in the IHDR chunk, at fixed offsets right after the magic number.
+    expect(png.readUInt32BE(16)).toBe(REPORT_IMAGE_WIDTH);
+    expect(png.readUInt32BE(20)).toBeGreaterThan(1200);
+  }, 30_000);
+
+  it('renders the copy that leaves area coordinates out', async () => {
+    const png = await render(false);
+    expect(png.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  }, 30_000);
+
+  it('grows the canvas as the report grows', () => {
+    const short = buildTrendReportView(report, { includeAreas: false });
+    const tall = buildTrendReportView(
+      { ...report, areas: [...report.areas, ...report.areas, ...report.areas] },
+      { includeAreas: true }
+    );
+    expect(estimateReportImageHeight(tall)).toBeGreaterThan(estimateReportImageHeight(short));
+  });
+});

--- a/ctf/packages/web/lib/click-log/report-image.tsx
+++ b/ctf/packages/web/lib/click-log/report-image.tsx
@@ -1,0 +1,210 @@
+import type { ReactElement } from 'react';
+import type { ReportNote, ReportRow, TrendReportView } from './trend-report-view';
+
+// The shareable ClickLog report, drawn as one tall image.
+//
+// Why an image and not a screenshot: a phone screenshot of the trends screen stops at the bottom of
+// the screen, and stitching several together loses rows and produces seams. This renders the whole
+// report — every section, in order, plus the method statement — into a single PNG that can be posted
+// anywhere as-is.
+//
+// Written for satori (the renderer behind `next/og`), which supports a subset of CSS: flexbox only,
+// every element gets an explicit `display`, spacing comes from margins rather than `gap`, and the
+// image height must be known before rendering, so `estimateReportImageHeight` below sizes the
+// canvas from the content. Sizes are deliberately generous — spare space at the bottom is harmless,
+// a clipped final row is not.
+
+export const REPORT_IMAGE_WIDTH = 900;
+
+const BG = '#0F1117';
+const SURFACE = '#161B27';
+const BORDER = '#1E2A3A';
+const TEXT = '#F9FAFB';
+const SUBTLE = '#8A93A6';
+const ACCENT = '#EC4899';
+
+const PAD = 44;
+const ROW_HEIGHT = 52;
+const ROW_HEIGHT_WITH_DETAIL = 66;
+const SECTION_HEADING = 46;
+const CONTENT_WIDTH = REPORT_IMAGE_WIDTH - PAD * 2;
+
+// Stat tiles wrap on their own once the row is full, so the width arithmetic has to leave room for
+// every gutter — one tile too wide and the whole row falls to the next line, which would put the
+// rendered height out of step with the estimate below.
+const STATS_PER_ROW = 2;
+const STAT_GUTTER = 12;
+const STAT_TILE_HEIGHT = 96;
+
+// Characters that fit on one line of note body text at 17px in the bundled font. Deliberately
+// conservative: underestimating the width overestimates the height, which is the safe direction.
+const NOTE_CHARS_PER_LINE = 90;
+const NOTE_LINE_HEIGHT = 26;
+
+function noteHeight(note: ReportNote): number {
+  const lines = Math.ceil(note.body.length / NOTE_CHARS_PER_LINE);
+  return 30 + lines * NOTE_LINE_HEIGHT + 18;
+}
+
+function sectionHeight(rows: ReportRow[]): number {
+  if (rows.length === 0) return 0;
+  const hasDetail = rows.some((row) => row.detail);
+  return SECTION_HEADING + rows.length * (hasDetail ? ROW_HEIGHT_WITH_DETAIL : ROW_HEIGHT) + 16;
+}
+
+// Total canvas height for a report. Exported so the route can size the image and so the arithmetic
+// can be tested on its own.
+export function estimateReportImageHeight(view: TrendReportView): number {
+  const header = 150;
+  const stats = Math.ceil(view.stats.length / STATS_PER_ROW) * (STAT_TILE_HEIGHT + STAT_GUTTER) + 20;
+  const asides = (view.areasOmittedLine ? 74 : 0) + (view.areasTruncatedLine ? 60 : 0);
+  const sections =
+    sectionHeight(view.days) +
+    sectionHeight(view.areas) +
+    sectionHeight(view.categories) +
+    sectionHeight(view.problems) +
+    sectionHeight(view.schemes) +
+    sectionHeight(view.pairs);
+  const notes = SECTION_HEADING + view.notes.reduce((sum, note) => sum + noteHeight(note), 0);
+  const footer = 76;
+  return PAD * 2 + header + stats + asides + sections + notes + footer;
+}
+
+function StatTile({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: (CONTENT_WIDTH - STAT_GUTTER * STATS_PER_ROW) / STATS_PER_ROW,
+        height: STAT_TILE_HEIGHT,
+        marginRight: STAT_GUTTER,
+        marginBottom: STAT_GUTTER,
+        padding: '14px 18px',
+        borderRadius: 14,
+        background: SURFACE,
+        border: `1px solid ${BORDER}`,
+      }}
+    >
+      <div style={{ display: 'flex', fontSize: 34, color: ACCENT }}>{value}</div>
+      <div style={{ display: 'flex', fontSize: 15, color: SUBTLE, marginTop: 6 }}>{label}</div>
+    </div>
+  );
+}
+
+function Row({ row }: { row: ReportRow }): ReactElement {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        width: CONTENT_WIDTH,
+        height: row.detail ? ROW_HEIGHT_WITH_DETAIL - 8 : ROW_HEIGHT - 8,
+        marginBottom: 8,
+        padding: '0 18px',
+        borderRadius: 12,
+        background: SURFACE,
+        border: `1px solid ${BORDER}`,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div style={{ display: 'flex', fontSize: 18, color: TEXT }}>{row.label}</div>
+        {row.detail ? (
+          <div style={{ display: 'flex', fontSize: 14, color: SUBTLE, marginTop: 4 }}>{row.detail}</div>
+        ) : null}
+      </div>
+      <div style={{ display: 'flex', fontSize: 22, color: ACCENT, marginLeft: 16 }}>{row.value}</div>
+    </div>
+  );
+}
+
+function Section({ title, rows }: { title: string; rows: ReportRow[] }): ReactElement | null {
+  if (rows.length === 0) return null;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', marginTop: 16 }}>
+      <div style={{ display: 'flex', fontSize: 22, color: TEXT, marginBottom: 14 }}>{title}</div>
+      {rows.map((row) => (
+        <Row key={`${row.label}-${row.value}`} row={row} />
+      ))}
+    </div>
+  );
+}
+
+// A single line of context beside a section — why coordinates were left out, or how much of a
+// capped list is being shown.
+function Aside({ text }: { text: string }): ReactElement {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        width: CONTENT_WIDTH,
+        marginTop: 16,
+        padding: '14px 18px',
+        borderRadius: 12,
+        background: SURFACE,
+        border: `1px solid ${BORDER}`,
+        fontSize: 16,
+        color: SUBTLE,
+      }}
+    >
+      {text}
+    </div>
+  );
+}
+
+function Note({ note }: { note: ReportNote }): ReactElement {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', marginBottom: 18, width: CONTENT_WIDTH }}>
+      <div style={{ display: 'flex', fontSize: 17, color: ACCENT, marginBottom: 6 }}>{note.heading}</div>
+      <div style={{ display: 'flex', fontSize: 17, color: SUBTLE, lineHeight: 1.5 }}>{note.body}</div>
+    </div>
+  );
+}
+
+// Builds the whole image. `generatedOn` is passed in rather than read from the clock here so the
+// output is reproducible in tests.
+export function buildReportImageElement(view: TrendReportView, generatedOn: string): ReactElement {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: REPORT_IMAGE_WIDTH,
+        padding: PAD,
+        background: BG,
+        color: TEXT,
+      }}
+    >
+      <div style={{ display: 'flex', fontSize: 16, color: ACCENT, marginBottom: 10 }}>
+        CHARGING THE FUTURE
+      </div>
+      <div style={{ display: 'flex', fontSize: 38, color: TEXT }}>{view.title}</div>
+      <div style={{ display: 'flex', fontSize: 18, color: SUBTLE, marginTop: 10 }}>{view.windowLine}</div>
+      <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', marginTop: 26 }}>
+        {view.stats.map((stat) => (
+          <StatTile key={stat.label} label={stat.label} value={stat.value} />
+        ))}
+      </div>
+      <Section title="Days with shared incidents" rows={view.days} />
+      <Section title="Areas (each about 11 km across)" rows={view.areas} />
+      {view.areasTruncatedLine ? <Aside text={view.areasTruncatedLine} /> : null}
+      {view.areasOmittedLine ? <Aside text={view.areasOmittedLine} /> : null}
+      <Section title="Kinds of harm reported" rows={view.categories} />
+      <Section title="Problems reported" rows={view.problems} />
+      <Section title="Named schemes reported" rows={view.schemes} />
+      <Section title="Problem and scheme reported together" rows={view.pairs} />
+      <div style={{ display: 'flex', flexDirection: 'column', marginTop: 30 }}>
+        <div style={{ display: 'flex', fontSize: 22, color: TEXT, marginBottom: 16 }}>
+          How this was collected, and what it cannot show
+        </div>
+        {view.notes.map((note) => (
+          <Note key={note.heading} note={note} />
+        ))}
+      </div>
+      <div style={{ display: 'flex', fontSize: 15, color: SUBTLE, marginTop: 18 }}>
+        Charging The Future · chargingthefuture.com · report made {generatedOn}
+      </div>
+    </div>
+  );
+}

--- a/ctf/packages/web/lib/click-log/report-repository.ts
+++ b/ctf/packages/web/lib/click-log/report-repository.ts
@@ -1,0 +1,198 @@
+import { queryDb } from 'lib/db/postgres';
+import { problemCategorySlugMap } from './tag-categories';
+import type {
+  SharedIncidentArea,
+  SharedIncidentCategoryTrend,
+  SharedIncidentReportSummary,
+  SharedIncidentTagPair,
+} from './types';
+
+// Reporting aggregates over shared ClickLog incidents. Kept separate from `repository.ts`, which
+// owns incident create/read/edit/delete: this module only ever reads, only ever in aggregate, and
+// grows as the report grows.
+//
+// The privacy boundary is the same one `repository.ts` states and is enforced here in SQL, not left
+// to the caller: every query below filters on `shared_with_owner` and projects counts, UTC day
+// strings, 1-decimal location cells (~11 km), and canonical tag slugs. Notes, precise coordinates,
+// incident ids, and member identity never leave these queries. `user_id` appears only inside
+// `COUNT(DISTINCT …)`, never in a projection.
+
+type SummaryRow = {
+  shared_incidents: string;
+  reporters: string;
+  areas: string;
+  repeat_reporters: string;
+  tagged_incidents: string;
+  with_location: string;
+  without_location: string;
+  first_day: string | null;
+  last_day: string | null;
+};
+
+// An all-zero row, used when the window holds nothing at all. Reading the counts through this
+// rather than through a chain of null checks on every field keeps the query function simple.
+const EMPTY_SUMMARY_ROW: SummaryRow = {
+  shared_incidents: '0',
+  reporters: '0',
+  areas: '0',
+  repeat_reporters: '0',
+  tagged_incidents: '0',
+  with_location: '0',
+  without_location: '0',
+  first_day: null,
+  last_day: null,
+};
+
+// Headline figures. One pass over the window so every number is consistent with the others.
+export async function getSharedIncidentReportSummary(days = 90): Promise<SharedIncidentReportSummary> {
+  const result = await queryDb<SummaryRow>(
+    `WITH shared AS (
+       SELECT user_id,
+              created_at,
+              (cardinality(problem_tags) > 0 OR cardinality(scheme_tags) > 0) AS tagged,
+              CASE
+                WHEN metadata->>'latitude' IS NOT NULL AND metadata->>'longitude' IS NOT NULL
+                THEN round((metadata->>'latitude')::numeric, 1)::text || ',' ||
+                     round((metadata->>'longitude')::numeric, 1)::text
+              END AS cell
+       FROM click_log_incidents
+       WHERE shared_with_owner
+         AND created_at >= NOW() - make_interval(days => $1)
+     )
+     SELECT
+       COUNT(*) AS shared_incidents,
+       COUNT(DISTINCT user_id) AS reporters,
+       COUNT(DISTINCT cell) AS areas,
+       (SELECT COUNT(*) FROM (SELECT user_id FROM shared GROUP BY user_id HAVING COUNT(*) > 1) r)
+         AS repeat_reporters,
+       COUNT(*) FILTER (WHERE tagged) AS tagged_incidents,
+       COUNT(*) FILTER (WHERE cell IS NOT NULL) AS with_location,
+       COUNT(*) FILTER (WHERE cell IS NULL) AS without_location,
+       to_char(MIN(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS first_day,
+       to_char(MAX(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS last_day
+     FROM shared`,
+    [days]
+  );
+  const row = result.rows[0] ?? EMPTY_SUMMARY_ROW;
+  return {
+    days,
+    sharedIncidents: parseInt(row.shared_incidents, 10),
+    reporters: parseInt(row.reporters, 10),
+    areas: parseInt(row.areas, 10),
+    repeatReporters: parseInt(row.repeat_reporters, 10),
+    taggedIncidents: parseInt(row.tagged_incidents, 10),
+    withLocation: parseInt(row.with_location, 10),
+    withoutLocation: parseInt(row.without_location, 10),
+    firstDay: row.first_day,
+    lastDay: row.last_day,
+  };
+}
+
+// Where the shared incidents sit, as ~11 km cells. The existing day/cell/count aggregate answers
+// "how much happened on each day"; this answers "how much happened in each place, over what span,
+// and from how many different members" — which is the location detail the trends screen was
+// missing. Incidents with no location are absent by construction and are counted in the summary
+// instead, so a reader can see how much of the window has no place attached to it.
+//
+// The list is capped so one very widely spread window cannot produce an unreadable screen or an
+// enormous image. The summary counts every distinct cell, capped or not, and the report says how
+// many were left off — a truncated list that looked complete would be worse than no list.
+export async function getSharedIncidentAreas(days = 90, limit = 200): Promise<SharedIncidentArea[]> {
+  const result = await queryDb<{
+    latitude_cell: string;
+    longitude_cell: string;
+    incidents: string;
+    reporters: string;
+    first_day: string;
+    last_day: string;
+  }>(
+    `SELECT
+       round((metadata->>'latitude')::numeric, 1) AS latitude_cell,
+       round((metadata->>'longitude')::numeric, 1) AS longitude_cell,
+       COUNT(*) AS incidents,
+       COUNT(DISTINCT user_id) AS reporters,
+       to_char(MIN(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS first_day,
+       to_char(MAX(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS last_day
+     FROM click_log_incidents
+     WHERE shared_with_owner
+       AND created_at >= NOW() - make_interval(days => $1)
+       AND metadata->>'latitude' IS NOT NULL
+       AND metadata->>'longitude' IS NOT NULL
+     GROUP BY 1, 2
+     ORDER BY 3 DESC, 1, 2
+     LIMIT $2`,
+    [days, limit]
+  );
+  return result.rows.map((row) => ({
+    latitudeCell: Number(row.latitude_cell),
+    longitudeCell: Number(row.longitude_cell),
+    incidents: parseInt(row.incidents, 10),
+    reporters: parseInt(row.reporters, 10),
+    firstDay: row.first_day,
+    lastDay: row.last_day,
+  }));
+}
+
+// Problems rolled up into the harm categories in `tag-categories.ts`. Counted per incident with the
+// array-overlap operator, so an incident carrying three problems from one category counts once —
+// summing the per-tag counts instead would double-count and inflate every category.
+export async function getSharedIncidentCategoryTrends(days = 90): Promise<SharedIncidentCategoryTrend[]> {
+  const result = await queryDb<{ category: string; incidents: string; reporters: string }>(
+    `WITH categories AS (
+       SELECT key AS category, ARRAY(SELECT jsonb_array_elements_text(value)) AS slugs
+       FROM jsonb_each($2::jsonb)
+     ),
+     shared AS (
+       SELECT user_id, problem_tags
+       FROM click_log_incidents
+       WHERE shared_with_owner
+         AND created_at >= NOW() - make_interval(days => $1)
+         AND cardinality(problem_tags) > 0
+     )
+     SELECT c.category,
+            COUNT(s.problem_tags) AS incidents,
+            COUNT(DISTINCT s.user_id) AS reporters
+     FROM categories c
+     LEFT JOIN shared s ON s.problem_tags && c.slugs
+     GROUP BY c.category
+     ORDER BY 2 DESC, 1 ASC`,
+    [days, JSON.stringify(problemCategorySlugMap())]
+  );
+  return result.rows.map((row) => ({
+    category: row.category,
+    incidents: parseInt(row.incidents, 10),
+    reporters: parseInt(row.reporters, 10),
+  }));
+}
+
+// Which named scheme was tagged alongside which problem on the same incident. Two separate ranked
+// lists say what happened and what was used; this says which method was attached to which harm,
+// which is the part that reads as a pattern rather than a pile of complaints.
+export async function getSharedIncidentTagPairs(days = 90, limit = 12): Promise<SharedIncidentTagPair[]> {
+  const result = await queryDb<{
+    problem_tag: string;
+    scheme_tag: string;
+    incidents: string;
+    reporters: string;
+  }>(
+    `SELECT p.tag AS problem_tag,
+            s.tag AS scheme_tag,
+            COUNT(*) AS incidents,
+            COUNT(DISTINCT i.user_id) AS reporters
+     FROM click_log_incidents i,
+          unnest(i.problem_tags) AS p(tag),
+          unnest(i.scheme_tags) AS s(tag)
+     WHERE i.shared_with_owner
+       AND i.created_at >= NOW() - make_interval(days => $1)
+     GROUP BY 1, 2
+     ORDER BY 3 DESC, 1 ASC, 2 ASC
+     LIMIT $2`,
+    [days, limit]
+  );
+  return result.rows.map((row) => ({
+    problemTag: row.problem_tag,
+    schemeTag: row.scheme_tag,
+    incidents: parseInt(row.incidents, 10),
+    reporters: parseInt(row.reporters, 10),
+  }));
+}

--- a/ctf/packages/web/lib/click-log/report.ts
+++ b/ctf/packages/web/lib/click-log/report.ts
@@ -1,0 +1,23 @@
+import { getSharedIncidentTagTrends, getSharedIncidentTrends } from './repository';
+import {
+  getSharedIncidentAreas,
+  getSharedIncidentCategoryTrends,
+  getSharedIncidentReportSummary,
+  getSharedIncidentTagPairs,
+} from './report-repository';
+import type { SharedIncidentReport } from './types';
+
+// Assembles the whole shared-incident report from its aggregate queries. One place so the trends
+// endpoint and the shareable image are always built from the same set of numbers over the same
+// window — a screen and an image that disagree would be worse than either alone.
+export async function buildSharedIncidentReport(days = 90): Promise<SharedIncidentReport> {
+  const [summary, buckets, areas, tagTrends, categories, pairs] = await Promise.all([
+    getSharedIncidentReportSummary(days),
+    getSharedIncidentTrends(days),
+    getSharedIncidentAreas(days),
+    getSharedIncidentTagTrends(days),
+    getSharedIncidentCategoryTrends(days),
+    getSharedIncidentTagPairs(days),
+  ]);
+  return { summary, buckets, areas, tagTrends, categories, pairs };
+}

--- a/ctf/packages/web/lib/click-log/share-copy.ts
+++ b/ctf/packages/web/lib/click-log/share-copy.ts
@@ -1,0 +1,41 @@
+// What sharing an incident actually means, written once so every surface says the same thing.
+//
+// Owner directive, 2026-08-19: the member-facing copy must say the grouped totals may be
+// published. It always described where the data goes ("with the owner") and what is withheld
+// ("never your notes"), but not what happens next — and what happens next is that the aggregate
+// is posted publicly and handed to people outside the project. Sharing and publishing are one
+// decision for the member, so they are described together, in the same sentence, at the moment
+// the choice is made.
+//
+// The promise inside these strings is enforced in SQL, not here: the report queries in
+// `report-repository.ts` project only day, rounded location, tags, and counts, and reach member
+// identity only inside COUNT(DISTINCT …). Notes and exact coordinates never leave the member's
+// own rows. Keep these strings and that boundary in step — if either changes, change both.
+
+// The sentence appended to every share control. Kept short enough to sit at the end of a
+// checkbox label without pushing it to a third line on a phone.
+export const SHARE_PUBLISH_NOTE = 'Grouped totals may be published.';
+
+// Global default, on the ClickLog shell.
+export const SHARE_DEFAULT_LABEL =
+  `Share new incidents with the owner by default (only trend data — never your notes). ${SHARE_PUBLISH_NOTE}`;
+
+// Per-incident choice in the log form, when the member is free to choose.
+export const SHARE_INCIDENT_LABEL =
+  `Share this incident with the owner (only the date, rough area, and tags). ${SHARE_PUBLISH_NOTE}`;
+
+// Per-incident state in the log form when tags force sharing on.
+export const SHARE_INCIDENT_LOCKED_LABEL =
+  `Shared with the owner — required for tagged incidents (only the date, rough area, and tags; never your note). ${SHARE_PUBLISH_NOTE}`;
+
+// History-row pill: what the tooltip says when tags hold sharing on.
+export const SHARE_PILL_LOCKED_HINT =
+  `Tagged incidents always share trend data with the owner — remove the tags (edit) to make this private. ${SHARE_PUBLISH_NOTE}`;
+
+// History-row pill: what a screen reader announces in the same locked state.
+export const SHARE_PILL_LOCKED_ARIA =
+  `Shared with the owner — required for tagged incidents; remove the tags to make it private. ${SHARE_PUBLISH_NOTE}`;
+
+// Shown in the edit form when saving with tags is about to turn sharing on.
+export const SHARE_EDIT_TURNS_ON_NOTICE =
+  `Tags share trend data with the owner: saving with these tags turns on sharing for this incident (only the date, rough area, and tags — never your note). ${SHARE_PUBLISH_NOTE} Remove the tags to keep it private.`;

--- a/ctf/packages/web/lib/click-log/tag-categories.test.ts
+++ b/ctf/packages/web/lib/click-log/tag-categories.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { CLICK_LOG_PROBLEM_TAGS, CLICK_LOG_SCHEME_TAGS } from './tags';
+import {
+  CLICK_LOG_PROBLEM_CATEGORIES,
+  CLICK_LOG_PROBLEM_TAG_CATEGORY,
+  CLICK_LOG_SCHEME_KIND_LABEL,
+  CLICK_LOG_SCHEME_TAG_KIND,
+  problemCategoryFor,
+  problemCategorySlugMap,
+  schemeKindFor,
+} from './tag-categories';
+
+// The groupings are only useful if they are complete. A problem slug with no category silently
+// disappears from the category rollup in the report, and a category listing a slug that no longer
+// exists silently counts nothing — both would leave a reader with numbers that do not add up and
+// no sign anything is wrong. These tests fail instead, in both directions, whenever a tag is added
+// to `tags.ts` without being placed.
+describe('ClickLog problem categories', () => {
+  it('places every problem tag in exactly one category', () => {
+    const unplaced = CLICK_LOG_PROBLEM_TAGS.filter((tag) => !CLICK_LOG_PROBLEM_TAG_CATEGORY[tag.slug]);
+    expect(unplaced.map((tag) => tag.slug)).toEqual([]);
+  });
+
+  it('has no category entry for a tag that does not exist', () => {
+    const known = new Set(CLICK_LOG_PROBLEM_TAGS.map((tag) => tag.slug));
+    const unknown = Object.keys(CLICK_LOG_PROBLEM_TAG_CATEGORY).filter((slug) => !known.has(slug));
+    expect(unknown).toEqual([]);
+  });
+
+  it('only names categories that are defined', () => {
+    const defined = new Set(CLICK_LOG_PROBLEM_CATEGORIES.map((category) => category.slug));
+    const undefinedCategories = Object.values(CLICK_LOG_PROBLEM_TAG_CATEGORY).filter(
+      (slug) => !defined.has(slug)
+    );
+    expect(undefinedCategories).toEqual([]);
+  });
+
+  it('leaves no category empty', () => {
+    const map = problemCategorySlugMap();
+    const empty = CLICK_LOG_PROBLEM_CATEGORIES.filter((category) => map[category.slug].length === 0);
+    expect(empty.map((category) => category.slug)).toEqual([]);
+  });
+
+  it('resolves a tag to its category object', () => {
+    expect(problemCategoryFor('tinnitus')?.slug).toBe('body-and-health');
+    expect(problemCategoryFor('not-a-real-tag')).toBeNull();
+  });
+
+  it('accounts for every tag exactly once across the slug map', () => {
+    const map = problemCategorySlugMap();
+    const total = Object.values(map).reduce((sum, slugs) => sum + slugs.length, 0);
+    expect(total).toBe(CLICK_LOG_PROBLEM_TAGS.length);
+  });
+});
+
+describe('ClickLog scheme kinds', () => {
+  it('classifies every scheme tag', () => {
+    const unclassified = CLICK_LOG_SCHEME_TAGS.filter((tag) => !CLICK_LOG_SCHEME_TAG_KIND[tag.slug]);
+    expect(unclassified.map((tag) => tag.slug)).toEqual([]);
+  });
+
+  it('has no kind entry for a scheme that does not exist', () => {
+    const known = new Set(CLICK_LOG_SCHEME_TAGS.map((tag) => tag.slug));
+    const unknown = Object.keys(CLICK_LOG_SCHEME_TAG_KIND).filter((slug) => !known.has(slug));
+    expect(unknown).toEqual([]);
+  });
+
+  it('keeps the split named in the tags.ts taxonomy note', () => {
+    // The four the note calls ambient, and one it calls an operation — if these ever flip, the
+    // report starts telling a reader a continuous condition and a single operation are the same
+    // kind of thing, which is the exact confusion the note warns about.
+    expect(schemeKindFor('color-sensitization')).toBe('ambient');
+    expect(schemeKindFor('road-sensitization')).toBe('ambient');
+    expect(schemeKindFor('thats-a-nice')).toBe('ambient');
+    expect(schemeKindFor('staged-narratives')).toBe('ambient');
+    expect(schemeKindFor('performed-kindness')).toBe('pattern');
+    expect(schemeKindFor('poisoned-well')).toBe('operation');
+  });
+
+  it('gives every kind a label and falls back for an unknown slug', () => {
+    for (const kind of Object.values(CLICK_LOG_SCHEME_TAG_KIND)) {
+      expect(CLICK_LOG_SCHEME_KIND_LABEL[kind]).toBeTruthy();
+    }
+    expect(schemeKindFor('not-a-real-scheme')).toBe('unclassified');
+  });
+});

--- a/ctf/packages/web/lib/click-log/tag-categories.ts
+++ b/ctf/packages/web/lib/click-log/tag-categories.ts
@@ -1,0 +1,205 @@
+// Groupings over the frozen ClickLog tag slugs in `tags.ts`.
+//
+// Why this lives in a separate module: `tags.ts` is the canonical list and its slugs are frozen so
+// trend history stays comparable. Grouping is a reporting concern that will change as the report
+// changes, so it is kept out of the canonical list rather than bolted onto every entry.
+//
+// Two groupings live here.
+//
+// 1. Problem categories. A ranked list of 53 individual problems tells a reader who already knows
+//    the subject what happened. It tells an outside reader — a journalist, a lawyer, a human-rights
+//    body reading this for the first time — almost nothing, because they cannot see which of those
+//    53 lines are the same kind of harm. The six categories below roll the problems up into the
+//    kinds of harm an outside investigator recognizes and can act on.
+//
+// 2. Scheme kinds. `tags.ts` records a known taxonomy gap: the scheme list mixes operations that
+//    have an arc (a setup, a mechanism, an end state) with ambient tactics that run continuously,
+//    and it says a raw count column ranks the two against each other misleadingly. It also records
+//    the trigger for fixing it — "the first time a tag ranking on real data misleads the reader".
+//    The report now shows scheme counts on real data to readers outside the project, so that
+//    trigger has arrived. The classification below is additive: no slug is renamed, removed, or
+//    reordered; the report labels each row with its kind and says plainly that counts are not
+//    comparable across kinds.
+
+export type ClickLogProblemCategory = {
+  // Stable identifier used in the report payload and in the shareable image.
+  slug: string;
+  // Short label shown to a reader.
+  label: string;
+  // One plain sentence naming the harm, for a reader who has never met this subject before.
+  description: string;
+};
+
+// Ordered most-to-least common in the problems list; the report re-sorts by real counts.
+export const CLICK_LOG_PROBLEM_CATEGORIES: readonly ClickLogProblemCategory[] = [
+  {
+    slug: 'watched-and-followed',
+    label: 'Watched and followed',
+    description:
+      'Being kept under watch — people, vehicles, drones, or equipment placed where the member goes, and strangers showing knowledge of the member they had no way to get.',
+  },
+  {
+    slug: 'body-and-health',
+    label: 'Body and health',
+    description:
+      'Effects on the body — ringing in the ears, machine noise, lights aimed at the member, unexplained pain, injuries, or exhaustion.',
+  },
+  {
+    slug: 'threats-and-intimidation',
+    label: 'Threats and intimidation',
+    description:
+      'Direct hostility in person — being blocked, crowded, provoked, propositioned, or confronted by police and strangers.',
+  },
+  {
+    slug: 'blocked-from-services',
+    label: 'Blocked from work, money, and services',
+    description:
+      'Being cut off from the things a person needs to live — jobs, housing, medical care, banking, travel, and working services.',
+  },
+  {
+    slug: 'set-up-for-blame',
+    label: 'Set up to be blamed',
+    description:
+      'Being maneuvered into looking guilty — baited toward illegal acts, or falsely accused of theft, violence, or other crimes in front of witnesses.',
+  },
+  {
+    slug: 'cut-off-from-people',
+    label: 'Cut off from people',
+    description:
+      'Losing the people around the member — neighbors replaced, relationships that turn out to be performed, and family or newcomers pushed into their life.',
+  },
+] as const;
+
+// Every problem slug in `tags.ts` maps to exactly one category. A unit test asserts that both
+// ways round: no slug missing, no entry here that is not a real slug.
+export const CLICK_LOG_PROBLEM_TAG_CATEGORY: Readonly<Record<string, string>> = {
+  'phone-aimed-crowding': 'watched-and-followed',
+  'parked-cars-outside-home': 'watched-and-followed',
+  drones: 'watched-and-followed',
+  'neighbors-mirror-exits': 'watched-and-followed',
+  'neighbor-traffic': 'watched-and-followed',
+  'strange-window-lights': 'watched-and-followed',
+  'parked-next-to-you': 'watched-and-followed',
+  'sirens-circling': 'watched-and-followed',
+  'jehovah-witness-lurking': 'watched-and-followed',
+  'pets-sense-presence': 'watched-and-followed',
+  'strangers-know-secrets': 'watched-and-followed',
+  'strangers-know-name': 'watched-and-followed',
+  'new-lamps-antennas': 'watched-and-followed',
+  'strange-calls-texts': 'watched-and-followed',
+  'mail-tampering': 'watched-and-followed',
+  'clerk-name-reaction': 'watched-and-followed',
+  'store-fills-on-arrival': 'watched-and-followed',
+  'items-disappear-reappear': 'watched-and-followed',
+
+  tinnitus: 'body-and-health',
+  'humming-buzzing': 'body-and-health',
+  'unusual-fatigue': 'body-and-health',
+  'unexplained-injuries': 'body-and-health',
+  'bright-lights-shined': 'body-and-health',
+  'light-flashes': 'body-and-health',
+
+  'stranger-hostility': 'threats-and-intimidation',
+  'staged-public-scenes': 'threats-and-intimidation',
+  'blocking-your-path': 'threats-and-intimidation',
+  'dog-commands': 'threats-and-intimidation',
+  'mirroring-behavior': 'threats-and-intimidation',
+  'police-harassment': 'threats-and-intimidation',
+  'sexual-solicitation': 'threats-and-intimidation',
+  'ride-prostitution-offers': 'threats-and-intimidation',
+  'theft-detector-beep': 'threats-and-intimidation',
+
+  'denied-jobs-housing': 'blocked-from-services',
+  'medical-care-denied': 'blocked-from-services',
+  'banking-blocked': 'blocked-from-services',
+  'online-application-sabotage': 'blocked-from-services',
+  'customer-service-loop': 'blocked-from-services',
+  'workplace-sabotage': 'blocked-from-services',
+  'time-wasting-chases': 'blocked-from-services',
+  'travel-sabotage': 'blocked-from-services',
+  'car-problems': 'blocked-from-services',
+
+  'illegal-bait': 'set-up-for-blame',
+  'false-shoplifting': 'set-up-for-blame',
+  'false-accusations': 'set-up-for-blame',
+  'recorded-conversation-bait': 'set-up-for-blame',
+
+  'neighbors-replaced': 'cut-off-from-people',
+  'pretend-friends': 'cut-off-from-people',
+  'estranged-family-forcing': 'cut-off-from-people',
+  'shared-secret-feeling': 'cut-off-from-people',
+  'freemason-proximity': 'cut-off-from-people',
+  'pushy-new-people': 'cut-off-from-people',
+  'stranger-befriending': 'cut-off-from-people',
+};
+
+// The three shapes `tags.ts` names in its taxonomy-gap comment, plus one for the catch-all slug.
+export type ClickLogSchemeKind = 'operation' | 'ambient' | 'pattern' | 'unclassified';
+
+// Plain-language labels, and the one sentence a reader needs to not misread a count column.
+export const CLICK_LOG_SCHEME_KIND_LABEL: Readonly<Record<ClickLogSchemeKind, string>> = {
+  operation: 'A setup with a start and an end',
+  ambient: 'Runs continuously in the background',
+  pattern: 'A shape over weeks or months',
+  unclassified: 'Not named yet',
+};
+
+// Every scheme slug maps to exactly one kind. A unit test asserts full, exact coverage.
+export const CLICK_LOG_SCHEME_TAG_KIND: Readonly<Record<string, ClickLogSchemeKind>> = {
+  'scapegoating-by-proxy': 'operation',
+  'mail-mirage': 'operation',
+  'conspiracy-carousel': 'operation',
+  'honey-pot': 'operation',
+  'entrapment-bait': 'operation',
+  'staged-help': 'operation',
+  'good-cop-bad-cop': 'operation',
+  'fake-counselor': 'operation',
+  'lure-to-location': 'operation',
+  'fabricated-flaw': 'operation',
+  'pot-and-kettle': 'operation',
+  'staged-road-rage': 'operation',
+  'insurance-bleed': 'operation',
+  'poisoned-well': 'operation',
+  windfall: 'operation',
+  jinx: 'operation',
+  'fake-job': 'operation',
+  'acquire-and-fold': 'operation',
+  'engineered-delay': 'operation',
+  'altered-ticket': 'operation',
+  'pretext-search': 'operation',
+  'planted-witness': 'operation',
+
+  'thats-a-nice': 'ambient',
+  'staged-narratives': 'ambient',
+  'road-sensitization': 'ambient',
+  'color-sensitization': 'ambient',
+  'psyop-marketing': 'ambient',
+  'incident-replay': 'ambient',
+
+  'performed-kindness': 'pattern',
+
+  'other-scheme': 'unclassified',
+};
+
+export function problemCategoryFor(slug: string): ClickLogProblemCategory | null {
+  const categorySlug = CLICK_LOG_PROBLEM_TAG_CATEGORY[slug];
+  if (!categorySlug) return null;
+  return CLICK_LOG_PROBLEM_CATEGORIES.find((c) => c.slug === categorySlug) ?? null;
+}
+
+export function schemeKindFor(slug: string): ClickLogSchemeKind {
+  return CLICK_LOG_SCHEME_TAG_KIND[slug] ?? 'unclassified';
+}
+
+// The category → slug list the report aggregate needs, as a plain object so it can be handed to
+// the SQL layer as one JSON parameter.
+export function problemCategorySlugMap(): Record<string, string[]> {
+  const map: Record<string, string[]> = {};
+  for (const category of CLICK_LOG_PROBLEM_CATEGORIES) {
+    map[category.slug] = [];
+  }
+  for (const [tagSlug, categorySlug] of Object.entries(CLICK_LOG_PROBLEM_TAG_CATEGORY)) {
+    (map[categorySlug] ??= []).push(tagSlug);
+  }
+  return map;
+}

--- a/ctf/packages/web/lib/click-log/trend-report-view.test.ts
+++ b/ctf/packages/web/lib/click-log/trend-report-view.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { areaCellLabel, buildTrendReportView } from './trend-report-view';
+import type { SharedIncidentReport } from './types';
+
+// A small report with one of everything, so the shape of the view can be checked without a database.
+const report: SharedIncidentReport = {
+  summary: {
+    days: 90,
+    sharedIncidents: 7,
+    reporters: 3,
+    repeatReporters: 2,
+    areas: 2,
+    taggedIncidents: 6,
+    withLocation: 5,
+    withoutLocation: 2,
+    firstDay: '2026-08-13',
+    lastDay: '2026-08-19',
+  },
+  buckets: [
+    { day: '2026-08-19', latitudeCell: 40.7, longitudeCell: -74.0, count: 2 },
+    { day: '2026-08-18', latitudeCell: 40.7, longitudeCell: -74.0, count: 3 },
+    { day: '2026-08-18', latitudeCell: 51.5, longitudeCell: 0.1, count: 1 },
+    { day: '2026-08-13', latitudeCell: null, longitudeCell: null, count: 1 },
+  ],
+  areas: [
+    {
+      latitudeCell: 40.7,
+      longitudeCell: -74.0,
+      incidents: 5,
+      reporters: 2,
+      firstDay: '2026-08-18',
+      lastDay: '2026-08-19',
+    },
+    {
+      latitudeCell: 51.5,
+      longitudeCell: 0.1,
+      incidents: 1,
+      reporters: 1,
+      firstDay: '2026-08-18',
+      lastDay: '2026-08-18',
+    },
+  ],
+  tagTrends: [
+    { tagType: 'problem', tag: 'tinnitus', count: 2 },
+    { tagType: 'problem', tag: 'parked-cars-outside-home', count: 2 },
+    { tagType: 'scheme', tag: 'color-sensitization', count: 3 },
+    { tagType: 'scheme', tag: 'poisoned-well', count: 1 },
+  ],
+  categories: [
+    { category: 'watched-and-followed', incidents: 4, reporters: 2 },
+    { category: 'body-and-health', incidents: 2, reporters: 1 },
+    { category: 'set-up-for-blame', incidents: 0, reporters: 0 },
+  ],
+  pairs: [{ problemTag: 'tinnitus', schemeTag: 'color-sensitization', incidents: 2, reporters: 1 }],
+};
+
+describe('areaCellLabel', () => {
+  it('uses hemisphere letters rather than minus signs', () => {
+    expect(areaCellLabel(40.7, -74.0)).toBe('40.7°N, 74.0°W');
+    expect(areaCellLabel(-33.9, 151.2)).toBe('33.9°S, 151.2°E');
+  });
+});
+
+describe('buildTrendReportView', () => {
+  it('totals each day across its area cells, newest first', () => {
+    const view = buildTrendReportView(report, { includeAreas: true });
+    expect(view.days).toEqual([
+      { label: '2026-08-19', value: 2 },
+      { label: '2026-08-18', value: 4 },
+      { label: '2026-08-13', value: 1 },
+    ]);
+  });
+
+  it('shows areas with their member count and date span when asked', () => {
+    const view = buildTrendReportView(report, { includeAreas: true });
+    expect(view.areas).toEqual([
+      { label: '40.7°N, 74.0°W', detail: '2 members · 2026-08-18 to 2026-08-19', value: 5 },
+      { label: '51.5°N, 0.1°E', detail: '1 member · 2026-08-18', value: 1 },
+    ]);
+    expect(view.areasOmittedLine).toBeNull();
+  });
+
+  it('withholds area coordinates by default and says how many were held back', () => {
+    const view = buildTrendReportView(report, { includeAreas: false });
+    expect(view.areas).toEqual([]);
+    expect(view.areasOmittedLine).toContain('2 areas recorded');
+  });
+
+  it('says when the area list is only part of what was recorded', () => {
+    const many = { ...report, summary: { ...report.summary, areas: 240 } };
+    const view = buildTrendReportView(many, { includeAreas: true });
+    expect(view.areasTruncatedLine).toBe('Showing the 2 busiest areas of 240.');
+    // The headline count is the real total, not the length of the capped list.
+    expect(view.stats.find((stat) => stat.label.startsWith('Areas'))?.value).toBe('240');
+  });
+
+  it('drops categories nothing was reported in', () => {
+    const view = buildTrendReportView(report, { includeAreas: true });
+    expect(view.categories.map((row) => row.label)).toEqual(['Watched and followed', 'Body and health']);
+  });
+
+  it('labels each scheme with its kind so counts are not read against each other', () => {
+    const view = buildTrendReportView(report, { includeAreas: true });
+    expect(view.schemes[0].detail).toBe('Runs continuously in the background');
+    expect(view.schemes[1].detail).toBe('A setup with a start and an end');
+  });
+
+  it('carries the method statement with the numbers', () => {
+    const view = buildTrendReportView(report, { includeAreas: true });
+    const headings = view.notes.map((note) => note.heading);
+    expect(headings).toContain('Where these numbers come from');
+    expect(headings).toContain('What these numbers cannot show');
+    const howToRead = view.notes.find((note) => note.heading === 'How to read the counts');
+    expect(howToRead?.body).toContain('3 members account for 7 shared incidents over 90 days');
+    const coverage = view.notes.find((note) => note.heading === 'Location coverage');
+    expect(coverage?.body).toContain('2 do not');
+  });
+
+  it('reads sensibly when nothing has been shared yet', () => {
+    const empty: SharedIncidentReport = {
+      summary: {
+        days: 90,
+        sharedIncidents: 0,
+        reporters: 0,
+        repeatReporters: 0,
+        areas: 0,
+        taggedIncidents: 0,
+        withLocation: 0,
+        withoutLocation: 0,
+        firstDay: null,
+        lastDay: null,
+      },
+      buckets: [],
+      areas: [],
+      tagTrends: [],
+      categories: [],
+      pairs: [],
+    };
+    const view = buildTrendReportView(empty, { includeAreas: true });
+    expect(view.windowLine).toBe('Last 90 days · no activity yet');
+    expect(view.days).toEqual([]);
+    expect(view.areasOmittedLine).toBeNull();
+  });
+});

--- a/ctf/packages/web/lib/click-log/trend-report-view.ts
+++ b/ctf/packages/web/lib/click-log/trend-report-view.ts
@@ -1,0 +1,185 @@
+import { problemTagLabel, schemeTagLabel } from './tags';
+import {
+  CLICK_LOG_PROBLEM_CATEGORIES,
+  CLICK_LOG_SCHEME_KIND_LABEL,
+  schemeKindFor,
+} from './tag-categories';
+import type { SharedIncidentReport } from './types';
+
+// Turns the raw report aggregate into the exact rows and words both readers see: the owner's
+// trends screen and the shareable report image. Pure — no database, no request, no React — so the
+// screen and the image can never drift apart in what they say, and so the wording is unit-testable.
+
+export type ReportRow = {
+  label: string;
+  // Short qualifier under the label: a date span, a reporter count, or a scheme's kind.
+  detail?: string;
+  value: number;
+};
+
+export type ReportNote = { heading: string; body: string };
+
+export type TrendReportView = {
+  title: string;
+  windowLine: string;
+  stats: { label: string; value: string }[];
+  days: ReportRow[];
+  areas: ReportRow[];
+  areasOmittedLine: string | null;
+  areasTruncatedLine: string | null;
+  categories: ReportRow[];
+  problems: ReportRow[];
+  schemes: ReportRow[];
+  pairs: ReportRow[];
+  notes: ReportNote[];
+};
+
+function plural(count: number, one: string, many: string): string {
+  return `${count} ${count === 1 ? one : many}`;
+}
+
+// A ~11 km cell rendered the way a reader can act on: hemisphere letters rather than minus signs,
+// and one decimal place, which is all the precision the aggregate holds.
+export function areaCellLabel(latitudeCell: number, longitudeCell: number): string {
+  const lat = `${Math.abs(latitudeCell).toFixed(1)}°${latitudeCell < 0 ? 'S' : 'N'}`;
+  const lon = `${Math.abs(longitudeCell).toFixed(1)}°${longitudeCell < 0 ? 'W' : 'E'}`;
+  return `${lat}, ${lon}`;
+}
+
+function dayRows(report: SharedIncidentReport): ReportRow[] {
+  const totals = new Map<string, number>();
+  for (const bucket of report.buckets) {
+    totals.set(bucket.day, (totals.get(bucket.day) ?? 0) + bucket.count);
+  }
+  return Array.from(totals.entries())
+    .sort((a, b) => (a[0] < b[0] ? 1 : -1))
+    .map(([day, count]) => ({ label: day, value: count }));
+}
+
+function areaRows(report: SharedIncidentReport): ReportRow[] {
+  return report.areas.map((area) => ({
+    label: areaCellLabel(area.latitudeCell, area.longitudeCell),
+    detail:
+      area.firstDay === area.lastDay
+        ? `${plural(area.reporters, 'member', 'members')} · ${area.firstDay}`
+        : `${plural(area.reporters, 'member', 'members')} · ${area.firstDay} to ${area.lastDay}`,
+    value: area.incidents,
+  }));
+}
+
+function categoryRows(report: SharedIncidentReport): ReportRow[] {
+  return report.categories
+    .filter((row) => row.incidents > 0)
+    .map((row) => {
+      const category = CLICK_LOG_PROBLEM_CATEGORIES.find((c) => c.slug === row.category);
+      return {
+        label: category?.label ?? row.category,
+        detail: plural(row.reporters, 'member', 'members'),
+        value: row.incidents,
+      };
+    });
+}
+
+function schemeRows(report: SharedIncidentReport): ReportRow[] {
+  return report.tagTrends
+    .filter((row) => row.tagType === 'scheme')
+    .map((row) => ({
+      label: schemeTagLabel(row.tag),
+      detail: CLICK_LOG_SCHEME_KIND_LABEL[schemeKindFor(row.tag)],
+      value: row.count,
+    }));
+}
+
+function pairRows(report: SharedIncidentReport): ReportRow[] {
+  return report.pairs.map((pair) => ({
+    label: `${problemTagLabel(pair.problemTag)} + ${schemeTagLabel(pair.schemeTag)}`,
+    detail: plural(pair.reporters, 'member', 'members'),
+    value: pair.incidents,
+  }));
+}
+
+// The method statement. It travels with the numbers everywhere they go — on the screen, in the
+// image, and in any copy of the image posted elsewhere — because a count of self-reported
+// incidents with no statement of how it was collected and what it cannot show is not evidence a
+// serious reader can use, and is easy to dismiss.
+function notes(report: SharedIncidentReport): ReportNote[] {
+  const { summary } = report;
+  return [
+    {
+      heading: 'Where these numbers come from',
+      body:
+        'Members of Charging The Future log incidents in the app, one entry at a time, and choose per incident whether to share it. Only shared incidents are counted here. Sharing is off unless the member turns it on; tagging an incident requires sharing it, and the app says so before the member saves.',
+    },
+    {
+      heading: 'What is counted, and what never leaves the member',
+      body:
+        'Counted: the date, an approximate area about 11 km across, and which items the member picked from two fixed lists — known problems and named schemes. Never counted and never visible to anyone, including the project: the member\'s written note, their exact location, and who they are. Every figure here is produced by a grouped database query that cannot return those.',
+    },
+    {
+      heading: 'How to read the counts',
+      body: `${plural(summary.reporters, 'member', 'members')} account for ${plural(summary.sharedIncidents, 'shared incident', 'shared incidents')} over ${summary.days} days, and ${plural(summary.repeatReporters, 'member', 'members')} logged more than one. A count is the number of times members reported something, not the number of times it happened — most incidents are never logged at all.`,
+    },
+    {
+      heading: 'What these numbers cannot show',
+      body:
+        'These are first-hand accounts, recorded by the people they happened to and not checked against any outside source. The people logging chose to join and chose to share, so this is not a sample of any wider population and no rate can be calculated from it. Anything outside the two fixed lists is not counted at all.',
+    },
+    {
+      heading: 'Why scheme totals are not comparable to each other',
+      body:
+        'Some named schemes run continuously in the background and can be reported almost any day; others are single operations with a start and an end. A larger count on a continuous one does not make it more serious or more frequent than a smaller count on an operation. Each row below its name says which kind it is.',
+    },
+    {
+      heading: 'Location coverage',
+      body:
+        summary.withoutLocation === 0
+          ? `All ${plural(summary.sharedIncidents, 'shared incident', 'shared incidents')} carry an approximate area.`
+          : `${plural(summary.withLocation, 'shared incident', 'shared incidents')} carry an approximate area; ${summary.withoutLocation} do not and are absent from the area list, though they are counted in every other figure. An untagged incident can be logged without a location.`,
+    },
+  ];
+}
+
+export function buildTrendReportView(
+  report: SharedIncidentReport,
+  options: { includeAreas: boolean }
+): TrendReportView {
+  const { summary } = report;
+  const areas = areaRows(report);
+  const span =
+    summary.firstDay && summary.lastDay
+      ? summary.firstDay === summary.lastDay
+        ? summary.firstDay
+        : `${summary.firstDay} to ${summary.lastDay}`
+      : 'no activity yet';
+  return {
+    title: 'ClickLog — shared incident trends',
+    windowLine: `Last ${summary.days} days · ${span}`,
+    stats: [
+      { label: 'Shared incidents', value: String(summary.sharedIncidents) },
+      { label: 'Members reporting', value: String(summary.reporters) },
+      { label: 'Members who logged more than one', value: String(summary.repeatReporters) },
+      { label: 'Days with activity', value: String(dayRows(report).length) },
+      { label: 'Areas (about 11 km each)', value: String(summary.areas) },
+      { label: 'Tagged incidents', value: String(summary.taggedIncidents) },
+    ],
+    days: dayRows(report),
+    areas: options.includeAreas ? areas : [],
+    areasOmittedLine:
+      options.includeAreas || summary.areas === 0
+        ? null
+        : `${plural(summary.areas, 'area', 'areas')} recorded. Coordinates are left out of this shared copy: at these counts an area plus a date can point at one person.`,
+    // The area list is capped in the query. Saying so is the difference between a short list and a
+    // short list a reader wrongly believes is everything.
+    areasTruncatedLine:
+      options.includeAreas && summary.areas > areas.length
+        ? `Showing the ${areas.length} busiest areas of ${summary.areas}.`
+        : null,
+    categories: categoryRows(report),
+    problems: report.tagTrends
+      .filter((row) => row.tagType === 'problem')
+      .map((row) => ({ label: problemTagLabel(row.tag), value: row.count })),
+    schemes: schemeRows(report),
+    pairs: pairRows(report),
+    notes: notes(report),
+  };
+}

--- a/ctf/packages/web/lib/click-log/types.ts
+++ b/ctf/packages/web/lib/click-log/types.ts
@@ -74,3 +74,70 @@ export type SharedIncidentTagTrend = {
   tag: string;
   count: number;
 };
+
+// ---------------------------------------------------------------------------
+// Trend report aggregates
+//
+// Everything below is owner/admin reporting over incidents members opted to share. Same privacy
+// boundary as the two aggregates above: counts and canonical tag slugs only, computed in SQL, and
+// no notes, precise coordinates, incident ids, or member identity ever leaves the query.
+// ---------------------------------------------------------------------------
+
+// Headline figures for the report. `reporters` is the number of distinct members behind the shared
+// incidents — the figure that separates one person logging seven times from seven people logging
+// once, which is the first thing an outside reader needs and the one the old view never showed.
+export type SharedIncidentReportSummary = {
+  days: number;
+  sharedIncidents: number;
+  reporters: number;
+  // Members with more than one shared incident in the window: repetition, not isolated events.
+  repeatReporters: number;
+  // Distinct ~11 km cells across the window. Counted here rather than taken from the length of
+  // the area list, which is capped.
+  areas: number;
+  taggedIncidents: number;
+  withLocation: number;
+  withoutLocation: number;
+  firstDay: string | null;
+  lastDay: string | null;
+};
+
+// One ~11 km area cell (latitude/longitude rounded to 1 decimal place) with how much activity sits
+// in it. Coordinates are the cell corner, never a member's actual position.
+export type SharedIncidentArea = {
+  latitudeCell: number;
+  longitudeCell: number;
+  incidents: number;
+  reporters: number;
+  firstDay: string;
+  lastDay: string;
+};
+
+// Incidents rolled up into the harm categories in `tag-categories.ts`. Counted per incident (an
+// incident with three problems from one category counts once), so the numbers add up the way a
+// reader assumes they do.
+export type SharedIncidentCategoryTrend = {
+  category: string;
+  incidents: number;
+  reporters: number;
+};
+
+// How often a named scheme was tagged on the same incident as a given problem. This is the pattern
+// evidence: it shows the method attached to the harm rather than two unrelated rankings.
+export type SharedIncidentTagPair = {
+  problemTag: string;
+  schemeTag: string;
+  incidents: number;
+  reporters: number;
+};
+
+// The whole report payload, as served by the admin trends endpoint and rendered into the
+// shareable image.
+export type SharedIncidentReport = {
+  summary: SharedIncidentReportSummary;
+  buckets: SharedIncidentTrendBucket[];
+  areas: SharedIncidentArea[];
+  tagTrends: SharedIncidentTagTrend[];
+  categories: SharedIncidentCategoryTrend[];
+  pairs: SharedIncidentTagPair[];
+};

--- a/ctf/packages/web/vitest.config.ts
+++ b/ctf/packages/web/vitest.config.ts
@@ -5,11 +5,16 @@ import { defineConfig } from 'vitest/config';
 // run to a few settled, high-value cores (ServiceCredits amount math, Trust evidence) rather than
 // the whole app — see Rule 118 (testing scope) and Rule 133. The aliases mirror tsconfig `paths`
 // (`@/*` -> package root, `lib/*` -> ./lib) so test imports resolve the same way the app does.
+//
+// `esbuild.jsx: 'automatic'` is set because one tested module builds JSX (the ClickLog report
+// image). Without it esbuild emits `React.createElement` calls into a file that never imports
+// React, and the test fails on a missing global rather than on anything real.
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['lib/**/*.test.ts'],
   },
+  esbuild: { jsx: 'automatic' },
   resolve: {
     alias: [
       { find: /^@\//, replacement: `${resolve(__dirname, '.')}/` },


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

**Waiting on your review — not set to merge on its own.** It adds an API endpoint and changes a command contract, which is the owner-review lane.

## What was wrong

The trends screen counted area clusters and stopped there, so it said activity had a location without ever saying where. It also counted incidents and never people, so it could not tell one member logging seven times apart from seven members logging once — which is the first thing anyone outside the project asks.

## What the screen shows now

- Every ~11 km area cell with its coordinates, its incident count, how many different members are in it, and the span of dates it covers — plus how many shared incidents carry no location at all.
- How many different members are reporting, and how many logged more than once.
- The 53 problem tags rolled up into six kinds of harm (watched and followed, body and health, threats and intimidation, blocked from work/money/services, set up to be blamed, cut off from people). Counted once per incident per kind, so an incident carrying three problems from one kind adds one, not three.
- A kind label on every scheme row — an operation with a start and an end, something that runs continuously in the background, a shape over months. This closes the taxonomy gap recorded in `tags.ts`, on the trigger that file names: the first time a ranking on real data would mislead a reader. No slug is renamed, removed, or reordered; the kinds live in a new `tag-categories.ts` beside the harm categories, so the canonical list stays frozen.
- Which scheme was tagged alongside which problem on the same incident.
- The method statement, under the numbers: where the figures come from, what is never counted, how to read a count, what the data cannot show, why scheme totals are not comparable, and location coverage.

## The image

`GET /api/click-log/admin/trends/image` draws the whole report as one tall PNG — every section plus the method statement — so it can be posted somewhere that takes an image without stitching phone screenshots together and losing rows at the seams. A button on the trends screen saves it. It is built from the same aggregate as the screen, so there is no second data path to keep honest.

**Area coordinates are left out of that image unless the checkbox is ticked.** Members consented to their trend data reaching the project; an image is made to be posted, and at low counts an ~11 km cell plus a date can point at one person to anyone who already knows them. Which variant was produced is recorded in the audit log.

## Privacy boundary — unchanged

Nothing changes about what members are asked, what is stored, or who can see what. Every new figure is a grouped query over rows members already opted to share, enforced in SQL rather than in the screen (`lib/click-log/report-repository.ts`), and member identity reaches those queries only inside `COUNT(DISTINCT …)` — a number of people, never a list of them. The endpoint stays admin-only.

## What is deliberately not built

`ctf/docs/CLICKLOG_TREND_REPORT_METHOD.md` is the long method statement, written for a reader outside the project, and its section 7 lists the seven things an outside investigation would still ask for and cannot get today: country on each incident, who the member says was involved, what they did about it and what came of it, what it cost them, whether corroborating material exists, consent to individual follow-up, and a written statement of the sample. Each needs a new question in the log form, so each is your call, not a reporting change. None of them are in this PR.

## Load-bearing details, so they are not undone later

- `getSharedIncidentCategoryTrends` counts with the array-overlap operator, not by summing per-tag counts. Summing would double-count any incident carrying two problems from one category and inflate every category.
- The area list is capped at 200 rows, but the headline "Areas" figure and the omitted-coordinates line both come from a `COUNT(DISTINCT …)` in the summary, not from the length of the capped list — and the screen says when it is showing only part of it.
- The report image height is estimated before rendering because the renderer needs a fixed canvas. The estimates are deliberately generous: spare space at the bottom is harmless, a clipped final row is not.
- `report-image.test.ts` actually produces the PNG rather than inspecting the element tree. The renderer supports only a subset of CSS, so a style it cannot take fails there instead of returning a broken download.

## Checks run locally

`typecheck`, `lint`, `vitest` (104 tests, 22 new), `build:ci`, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-modularity-governance.sh`, `check-orphan-routes.mjs`, `check-us-spelling.mjs`, `check-plugin-boundaries.mjs`, `check-error-verbosity.mjs`, `check-taxonomy-change.mjs`, `check-web-android-parity.mjs` — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzLusWWHGoseCK3wx6JUqi)_