### PR TITLE
fix: make the ask-for-help button work for members waiting on review

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-unlock-feature-inventory.md
@@ -50,9 +50,11 @@ This plugin must:
 
 ### 1.4 Commons Access Before Verifying
 
-1. A member with no submission on file reaches the Commons (support-only) when either is true: they
-   pressed "ask for help", or they have been here on an earlier day (`login_events`). Anything else
-   about their access is unchanged — approved-only surfaces stay closed.
+1. A member who cannot reach the Commons on their stored tier reaches it (support-only) when either
+   is true: they pressed "ask for help", or they have been here on an earlier day (`login_events`).
+   That covers **both** a member with no submission and one whose submission is waiting in the review
+   queue (`pending_readonly`). Anything else about their access is unchanged — approved-only surfaces
+   stay closed.
 2. Coming back a second day counts on its own because returning is the member telling us the wall did
    not work for them. The Unlock screen still greets a genuinely first-time visitor.
 3. Wherever they land, the Commons shows the verification banner above the chat, so the Quora URL is
@@ -337,6 +339,28 @@ Seed script requirement: deterministic Unlock seed scenarios for pending, approv
    `Delete Account (manual)` Actions workflow, one account at a time.
 
 ## 9) Change Log
+
+- 2026-08-19: **Fix: the "ask for help" button did nothing for a member waiting on review, and showed
+  on the approved screen (owner report).** Three faults in the path shipped earlier the same day.
+  (1) `getUnlockAccessTier` only applied the Commons fallback when there was **no** stored tier, but a
+  member awaiting review has one — `pending_readonly` — which passes no gate. So pressing the button
+  recorded the request, navigated to `/`, and `/` bounced them straight back to the Unlock screen: a
+  flash and nothing else, for someone who had already done everything asked of them. The fallback now
+  applies to `pending_readonly` as well as to no submission at all; `approved_full` and
+  `locked_support_only` are returned untouched as before. (2) The help card rendered on the
+  **approved** status view, where it offered to open the Commons for a member who already has it and
+  would have recorded a help request nobody needs; it now renders nothing when verified. Mobile never
+  showed it when approved but also never showed it while pending, so the waiting member had the same
+  dead end there — the mobile status screen now shows it for pending too, matching web (the re-submit
+  card moved into its own `ResubmitCard` component to stay inside the rule-116 complexity limit).
+  (3) `router.refresh()` ran immediately before the full-page navigation, repainting the screen being
+  left — the visible "flash" — and buying nothing, since a full navigation re-runs the server anyway;
+  removed. The status payload's `commonsAccess` is now resolved through `getUnlockAccessTier` rather
+  than recomputed from `hasSubmission`, so the mobile wall and the web routing cannot disagree about
+  who may enter — reading it a second way is how a member ends up bounced by a button that said it
+  would let them in. A failed grant now also offers a plain link onward instead of leaving the member
+  on a screen whose only action did nothing. `hasUnlockCommonsAccessWithoutSubmission` renamed to
+  `hasUnlockCommonsFallback`, the old name having become untrue. No schema or contract change.
 
 - 2026-08-19: **New `duplicate` review decision, and a landing for a closed account (owner request).**
   One Quora profile signing up twice under different emails is common and ordinary, and neither existing

--- a/ctf/docs/developer/test-scripts/unlock-test-script.md
+++ b/ctf/docs/developer/test-scripts/unlock-test-script.md
@@ -373,6 +373,23 @@ because the member Unlock screen is on the keep-list. Nothing here grants any ap
 open a plugin and you still get its public landing page.
 **Result:** web ☐ · android ☐ — notes:
 
+### UNLOCK-A8a · Asking for help works while your submission is waiting on review
+**Role:** member with a **pending** submission · **Surfaces:** web + mobile-responsive, android
+**Precondition:** a test account that submitted a Quora URL and has not been reviewed yet. This is the
+case that was broken: a waiting member has a stored `pending_readonly` tier, which passes no gate.
+**Steps:**
+1. Sign in. You land on the Verification Status screen showing "Pending Review".
+2. Find "Can't find your Quora profile URL?" and press **Ask for help in the Commons**.
+3. Watch what happens on screen.
+4. Repeat on Android.
+**Expected:** Step 2: you land on the Commons. Step 3: **no flash and no bounce back to the Unlock
+screen** — that was the bug. The screen you are leaving is not repainted first, and you do not return
+to where you started. The verification banner sits above the chat, and your pending submission is
+untouched — asking for help never changes your place in the queue. Step 4: Android shows the same help
+card on a pending status screen and behaves the same. If the grant cannot be recorded, an error appears
+with a link onward rather than a button that silently did nothing.
+**Result:** web ☐ · android ☐ — notes:
+
 ### UNLOCK-A8b · Coming back a second day opens the Commons on its own
 **Role:** member (not yet verified, no submission) · **Surfaces:** web + mobile-responsive, android
 **Precondition:** a test account that signed in on an earlier calendar day (UTC) and never submitted a
@@ -384,6 +401,16 @@ Quora URL or pressed "ask for help". A row in `login_events` from a previous day
 us the wall did not work for them. Step 2: the banner is there, so the Quora URL is still asked for. If
 this account has no prior-day login row it will still see the Unlock screen once; that is the rule
 working, not a bug.
+**Result:** web ☐ · android ☐ — notes:
+
+### UNLOCK-A8d · An approved member is not offered help they do not need
+**Role:** member with an **approved** submission · **Surfaces:** web + mobile-responsive, android
+**Steps:**
+1. Sign in as an approved member and open the Verification Status screen.
+2. Look below the "Approved — full access unlocked" card.
+**Expected:** No "Can't find your Quora profile URL?" card and no "Ask for help in the Commons" button.
+An approved member already has the Commons, so the button would grant access they hold and record a
+help request nobody needs. Android has never shown it here; web used to and no longer does.
 **Result:** web ☐ · android ☐ — notes:
 
 ### UNLOCK-A8c · Spam is not listed as support-only access

--- a/ctf/packages/mobile/src/features/unlock/Unlock.tsx
+++ b/ctf/packages/mobile/src/features/unlock/Unlock.tsx
@@ -244,6 +244,54 @@ function SubmissionView({
 }
 
 // Status view (has submission — pending / approved / rejected)
+// The re-submit card shown after a rejection. Its own component so StatusView keeps one job and
+// stays inside the rule-116 complexity limit.
+function ResubmitCard({
+  s,
+  t,
+  url,
+  onUrlChange,
+  submitting,
+  error,
+  onSubmit,
+  accent,
+  onHelped,
+}: {
+  s: Styles;
+  t: ThemeTokens;
+  url: string;
+  onUrlChange: (_value: string) => void;
+  submitting: boolean;
+  error: string | null;
+  onSubmit: () => void;
+  accent: string;
+  onHelped: () => void;
+}) {
+  return (
+    <View style={s.resubCard}>
+      <Text style={s.cardHeading}>Re-submit with a new URL</Text>
+      <QuoraHelp s={s} accent={accent} onHelped={onHelped} />
+      <TextInput
+        value={url}
+        onChangeText={onUrlChange}
+        placeholder="https://quora.com/profile/…"
+        placeholderTextColor={t.textSecondary}
+        style={[s.input, { borderWidth: 1, borderColor: t.border, borderRadius: 10, padding: 10, marginBottom: 10, color: t.textPrimary }]}
+        autoCapitalize="none"
+        autoCorrect={false}
+      />
+      {error ? <Text style={s.errorText}>{error}</Text> : null}
+      <TouchableOpacity
+        onPress={onSubmit}
+        disabled={!url.trim() || submitting}
+        style={[s.primaryBtn, { backgroundColor: '#EF4444' }]}
+      >
+        <Text style={[s.primaryBtnText, { color: '#fff' }]}>{submitting ? 'Re-submitting…' : 'Re-submit'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
 function StatusView({
   status,
   onResubmitted,
@@ -322,29 +370,25 @@ function StatusView({
         )}
       </View>
 
-      {/* Re-submit form on rejection */}
+      {/* A member waiting on review gave a URL and did everything asked of them, but until they can
+          reach the Commons there is nobody to ask while they wait. Matches the web status screen; an
+          approved member sees nothing here, having no need of it. */}
+      {display === 'pending' && (
+        <QuoraHelp s={s} accent={accent} onHelped={onResubmitted} />
+      )}
+
       {display === 'rejected' && (
-        <View style={s.resubCard}>
-          <Text style={s.cardHeading}>Re-submit with a new URL</Text>
-          <QuoraHelp s={s} accent={accent} onHelped={onResubmitted} />
-          <TextInput
-            value={resubUrl}
-            onChangeText={setResubUrl}
-            placeholder="https://quora.com/profile/…"
-            placeholderTextColor={t.textSecondary}
-            style={[s.input, { borderWidth: 1, borderColor: t.border, borderRadius: 10, padding: 10, marginBottom: 10, color: t.textPrimary }]}
-            autoCapitalize="none"
-            autoCorrect={false}
-          />
-          {error ? <Text style={s.errorText}>{error}</Text> : null}
-          <TouchableOpacity
-            onPress={handleResubmit}
-            disabled={!resubUrl.trim() || submitting}
-            style={[s.primaryBtn, { backgroundColor: '#EF4444' }]}
-          >
-            <Text style={[s.primaryBtnText, { color: '#fff' }]}>{submitting ? 'Re-submitting…' : 'Re-submit'}</Text>
-          </TouchableOpacity>
-        </View>
+        <ResubmitCard
+          s={s}
+          t={t}
+          url={resubUrl}
+          onUrlChange={setResubUrl}
+          submitting={submitting}
+          error={error}
+          onSubmit={handleResubmit}
+          accent={accent}
+          onHelped={onResubmitted}
+        />
       )}
 
       {/* What gets unlocked */}

--- a/ctf/packages/web/app/api/unlock/status/route.ts
+++ b/ctf/packages/web/app/api/unlock/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireUnlockUserAccess, resolveUnlockRequestId } from 'lib/unlock/_lib';
 import { getUnlockStatusForUser, insertUnlockAudit } from 'lib/unlock/repository';
-import { hasUnlockCommonsAccessWithoutSubmission } from 'lib/unlock/help-requests';
+import { getUnlockAccessTier } from 'lib/unlock/access';
 import { reportError } from 'lib/observability/report';
 
 export async function GET(request: Request) {
@@ -14,12 +14,13 @@ export async function GET(request: Request) {
 
   try {
     const baseStatus = await getUnlockStatusForUser(gate.auth.userId);
-    // Whether this member may enter the Commons without a submission — they asked for help, or they
-    // have been here on an earlier day. Resolved here rather than in the repository so `accessTier`
-    // keeps meaning strictly "what the submission says". The mobile app gates its Unlock wall on it.
-    const commonsAccess = baseStatus.hasSubmission
-      ? false
-      : await hasUnlockCommonsAccessWithoutSubmission(gate.auth.userId);
+    // Whether this member may enter the Commons. Resolved through the same gate the server uses, so
+    // the mobile wall and the web routing can never disagree about it — reading it any other way is
+    // how a member ends up bounced back to the Unlock screen by a button that said it would let them
+    // in. `accessTier` above still means strictly "what the submission says"; this is the effective
+    // answer, which for a waiting or unsubmitted member who asked for help is more generous.
+    const effectiveTier = await getUnlockAccessTier(gate.auth.userId).catch(() => null);
+    const commonsAccess = effectiveTier === 'approved_full' || effectiveTier === 'locked_support_only';
     const status = { ...baseStatus, commonsAccess };
 
     await insertUnlockAudit({

--- a/ctf/packages/web/components/unlock/unlock-quora-help.tsx
+++ b/ctf/packages/web/components/unlock/unlock-quora-help.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { HelpCircle, Loader2 } from "lucide-react";
 import { failureText } from "lib/errors/client-failure";
 import { useTheme } from "@/hooks/useTheme";
@@ -17,12 +16,18 @@ import { getUnlockTokens } from "./unlock-shared";
 // Commons to a member with no submission — see lib/unlock/help-requests.ts) and takes them straight
 // there, where they can ask in the chat and get an answer. The verification prompt follows them, so
 // the Quora URL is still asked for; it is just no longer the only thing they can do.
-export function UnlockQuoraHelp() {
-  const router = useRouter();
+export function UnlockQuoraHelp({ alreadyVerified = false }: { alreadyVerified?: boolean }) {
   const { theme } = useTheme();
   const tok = getUnlockTokens(theme);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // An approved member already has the Commons and everything else. Offering to "open the Commons"
+  // for them is at best noise on a screen that just told them they are done, and the button would
+  // record a help request nobody needs.
+  if (alreadyVerified) {
+    return null;
+  }
 
   async function askForHelp() {
     if (busy) return;
@@ -38,10 +43,13 @@ export function UnlockQuoraHelp() {
         setError(data?.message ?? "Could not open the Commons just now. Try again.");
         return;
       }
-      // Full navigation, not a client push: the access tier is resolved on the server for the home
-      // route, so the request that lands there has to be a fresh one.
-      router.refresh();
+
+      // Full navigation, not a client push: the home route resolves access on the server, so the
+      // request that lands there has to be a fresh one. Deliberately no router.refresh() first — it
+      // repaints the screen we are leaving, which reads as a flash and buys nothing, since a full
+      // navigation re-runs the server anyway.
       window.location.assign("/");
+      return;
     } catch (caught) {
       setError(failureText(caught, { area: "unlock", op: "help_request", fallback: "Network error. Try again." }));
     } finally {
@@ -90,7 +98,16 @@ export function UnlockQuoraHelp() {
         {busy ? <Loader2 size={14} /> : <HelpCircle size={14} />}
         {busy ? "Opening the Commons…" : "Ask for help in the Commons"}
       </button>
-      {error ? <div style={{ fontSize: 12, color: "#F87171", marginTop: 8 }}>{error}</div> : null}
+      {error ? (
+        <div style={{ fontSize: 12, color: "#F87171", marginTop: 8, lineHeight: 1.6 }}>
+          {error}{" "}
+          {/* Never leave them on a screen whose only action did nothing. The Commons may still be
+              reachable — if it is not, they land back here rather than nowhere. */}
+          <a href="/" style={{ color: tok.ACCENT, fontWeight: 700, textDecoration: "underline" }}>
+            Try opening the Commons anyway
+          </a>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ctf/packages/web/components/unlock/unlock-status-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-status-view.tsx
@@ -41,7 +41,10 @@ export function UnlockStatusView({
         error={error}
       />
       <div style={{ display: "flex", justifyContent: "center" }}>
-        <UnlockQuoraHelp />
+        {/* An approved member is done — the help card renders nothing for them. A pending member
+            still sees it: they gave a URL and are waiting, and until this they had no way to ask
+            anything while they waited. */}
+        <UnlockQuoraHelp alreadyVerified={status === "approved"} />
       </div>
     </>
   );

--- a/ctf/packages/web/lib/unlock/access.ts
+++ b/ctf/packages/web/lib/unlock/access.ts
@@ -1,6 +1,6 @@
 import { UNLOCK_FLAGS } from '@ctf/shared';
 import { evaluateBooleanFlag } from 'lib/feature-flags';
-import { hasUnlockCommonsAccessWithoutSubmission } from './help-requests';
+import { hasUnlockCommonsFallback } from './help-requests';
 import { getEffectiveUnlockAccessTier } from './repository';
 import type { UnlockAccessTier } from './types';
 
@@ -28,15 +28,22 @@ export async function getUnlockAccessTier(userId: string): Promise<UnlockAccessT
 	// is unconfigured. The flag client returns the default (false) in both cases, so we
 	// consult the DB to avoid locking out previously approved users.
 	const storedTier = await getEffectiveUnlockAccessTier(userId);
-	if (storedTier) return storedTier;
+	if (storedTier === 'approved_full' || storedTier === 'locked_support_only') return storedTier;
 
-	// No submission on file. Before, that meant no tier and therefore no access to anything except
-	// the Unlock screen — including no access to the Commons, which is the only place to ask for help
-	// with the very step they are stuck on. A member who has asked for help, or who has been here on
-	// an earlier day, gets the support-only tier instead, which is what the Commons requires. They
-	// still cannot reach any approved-only surface, and the Commons shows them the verification
-	// banner, so the ask stays in front of them.
-	return (await hasUnlockCommonsAccessWithoutSubmission(userId)) ? 'locked_support_only' : null;
+	// Everything below is a member who cannot reach the Commons on their stored tier: either no
+	// submission at all (null) or one waiting in the review queue (`pending_readonly`). Both used to
+	// mean the Unlock screen was the only thing they could open — including no access to the Commons,
+	// which is the one place to ask for help with the step they are stuck on.
+	//
+	// The waiting case matters as much as the missing one. Someone who gave a URL and is waiting has
+	// done everything asked of them; leaving them with nobody to ask until the review window lapses is
+	// the same dead end, and it silently sent them back to the Unlock screen when they pressed the
+	// help button. Asking for help, or coming back on a later day, opens the Commons for either.
+	//
+	// They still reach no approved-only surface, and the Commons keeps the verification banner in
+	// front of them.
+	if (await hasUnlockCommonsFallback(userId)) return 'locked_support_only';
+	return storedTier;
 }
 
 // Returns true if the user has full (approved) access to the platform. Thin wrapper over

--- a/ctf/packages/web/lib/unlock/help-requests.ts
+++ b/ctf/packages/web/lib/unlock/help-requests.ts
@@ -30,11 +30,19 @@ export async function recordUnlockHelpRequest(userId: string): Promise<void> {
   );
 }
 
-// May this member reach the Commons even though they have no submission on file? One query for both
-// conditions, so the access gate pays a single round trip. Best-effort: this only ever widens access,
-// so a database failure must resolve to false (the member keeps the Unlock screen) rather than throw
-// on a request that would otherwise have worked.
-export async function hasUnlockCommonsAccessWithoutSubmission(userId: string): Promise<boolean> {
+// May the Commons open for this member before they are verified? One query for both conditions, so
+// the access gate pays a single round trip.
+//
+// This applies to a member with no submission AND to one whose submission is sitting in the review
+// queue. The waiting case was missed at first, and it was the worse of the two: someone who gave a
+// URL and is waiting has a stored `pending_readonly` tier, which passes no gate at all, so pressing
+// "ask for help" sent them to a Commons that bounced them straight back to the Unlock screen. They
+// had done everything asked of them and still had nobody to ask, for up to the length of the review
+// window.
+//
+// Best-effort: this only ever widens access, so a database failure resolves to false (the member
+// keeps the Unlock screen) rather than throwing on a request that would otherwise have worked.
+export async function hasUnlockCommonsFallback(userId: string): Promise<boolean> {
   try {
     const result = await queryDb<{ asked_for_help: boolean; returned_later: boolean }>(
       `SELECT


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

The Android side is in scope (the member Unlock screen is on the rule-105 keep-list) and is fixed here too.

## What you saw

You pressed **Ask for help in the Commons**, the page flashed, and nothing opened. Three faults, all in the path that shipped earlier today.

## The one that caused it

`getUnlockAccessTier` applied the Commons fallback **only when there was no stored tier**. A member awaiting review has one — `pending_readonly` — and it passes no gate at all.

So the sequence was: button pressed → help request recorded → navigate to `/` → `/` sees a tier that is neither `approved_full` nor `locked_support_only` → redirect back to `/plugin/unlock`. A flash and nothing else, for someone who had already given a URL and done everything asked of them. They stayed walled until the review window lapsed.

The fallback now covers `pending_readonly` as well as no submission at all. `approved_full` and `locked_support_only` are returned untouched, so nothing about an approved or support-only member changes.

## Two more, found while looking

**The card was rendering on the approved screen** — visible in your screenshot, above an "Approved — full access unlocked" card. It offered to open the Commons for someone who already has it, and the button would have recorded a help request nobody needs. It now renders nothing when verified.

Mobile never showed it when approved, but it also never showed it while **pending** — so the waiting member had the same dead end there with no way out at all. The mobile status screen now shows it for pending too, matching web. The re-submit card moved into its own `ResubmitCard` component to stay inside the rule-116 complexity limit.

**`router.refresh()` ran immediately before the full-page navigation.** That repaints the screen you are leaving — the visible flash — and buys nothing, because a full navigation re-runs the server anyway. Removed.

## Also

The status payload's `commonsAccess` is now resolved through `getUnlockAccessTier` instead of being recomputed from `hasSubmission`. Answering the same question a second way is exactly how the mobile wall and the web routing end up disagreeing about who may enter, which is what a bounced member experiences.

A failed grant now offers a plain link onward, so nobody is left on a screen whose only action did nothing.

`hasUnlockCommonsAccessWithoutSubmission` is renamed to `hasUnlockCommonsFallback` — the old name stopped being true once waiting members were covered.

## Scope

No schema change, no contract change, no new route. Behavior and rendering only.

## Checks run locally

typecheck · lint · a11y lint · modularity governance · web `build:ci` · unit tests · EOF/format · inventory drift · orphan routes · error verbosity · US spelling · notice formatting · test-script drift · deletion registry · web/android parity — all pass.

Two test-script steps added: `UNLOCK-A8a` covers the pending case that was broken, and `UNLOCK-A8d` covers the approved screen not offering help it does not need.

## Review lane

This changes an access gate, so it is owner-review lane and auto-merge is not enabled — though it is a bug fix on a live surface, so merge it as soon as you are satisfied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eeeus3t1nQs2Ld6ujxP4bB)_