### PR TITLE
fix: add the shared screen header to the Quora survey and census screens

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
@@ -351,6 +351,14 @@ this is not a plugin. The steps that matter:
 
 ## Change Log
 
+- 2026-08-19: Added the shared screen header (`MobileScreenHeader`) to the admin surface and to
+  the signed-in public form, both of which shipped without one — no back control and no
+  report-bug / settings / account cluster, which strands anyone reaching them on a phone. The form
+  matters most: it sits at a top-level path rather than under `/apps`, so a member opening it from
+  a link had no way into the rest of the app at all. The admin header carries a "Member view" link
+  to the public form. The signed-out landing keeps no header on purpose — there is no session
+  behind it and nothing in-app to go back to — so the page title is now conditional and shows only
+  there.
 - 2026-08-19: The subject list moved to `lib/shared/quora-research-subjects.ts`, shared with the
   live census, which merged first. The two carried identical copies while this branch was open,
   and copies drift apart without anything failing to warn anyone.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-live-census-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-live-census-feature-inventory.md
@@ -279,6 +279,12 @@ this is not a plugin. The steps that matter:
 
 ## Change Log
 
+- 2026-08-19: Added the shared screen header (`MobileScreenHeader`) to the admin surface, which
+  shipped without one. It had no back control and no report-bug / settings / account cluster, so an
+  admin reaching it on a phone — where the installed app has no browser back button — was stranded
+  (owner report). No "Member view" button: this surface has no member shell to link to. The
+  in-page "All runs" control is a list/detail toggle within the screen, not a route back, so it
+  stays.
 - 2026-08-19: Built, on the owner's instruction, as the survivor-side half the deletion survey
   could not cover. Runs, coded entries, stance tally, close and reopen, CSV export.
 - 2026-08-19: Removed the three wellbeing stance values on the owner's decision, after a review

--- a/ctf/packages/web/components/quora-deletion-survey/survey-admin-shell.tsx
+++ b/ctf/packages/web/components/quora-deletion-survey/survey-admin-shell.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Download, RefreshCw } from 'lucide-react';
+import { ClipboardList, Download, RefreshCw } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
+import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
+import { PluginUserShellButton } from '@/components/shared/plugin-user-shell-button';
 import { failureText, responseFailureText } from '@/lib/errors/client-failure';
 import {
   QUORA_SURVEY_ACTION_LABEL,
@@ -58,10 +60,17 @@ export function QuoraSurveyAdminShell() {
 
   return (
     <main style={{ minHeight: '100dvh', background: t.BG, color: t.TITLE, fontFamily: "'Inter',system-ui,sans-serif" }}>
+      {/* The shared header is the only sanctioned back control (rule 134). It carries the back
+          chevron and the report-bug / settings / account cluster, so an admin on a phone — where
+          the installed app has no browser back button — is never stranded here. The title is not
+          repeated in the page body below: the header already names the screen. */}
+      <MobileScreenHeader
+        title="Quora Account Deletion Survey"
+        accent={t.ACCENT}
+        icon={<ClipboardList size={18} color={t.ACCENT} />}
+        actions={<PluginUserShellButton href={QUORA_SURVEY_PUBLIC_PATH} accent={t.ACCENT} />}
+      />
       <div style={{ maxWidth: 900, margin: '0 auto', padding: '28px 16px 56px' }}>
-        <h1 style={{ fontSize: 22, fontWeight: 800, margin: '0 0 6px' }}>
-          Quora account deletion survey
-        </h1>
         <p style={{ fontSize: 13, color: t.MUTED, margin: '0 0 16px' }}>
           Self-reports from the public form at {QUORA_SURVEY_PUBLIC_PATH}. Nothing here is verified
           against Quora, and only people who reached another platform could answer — report counts

--- a/ctf/packages/web/components/quora-deletion-survey/survey-intro.tsx
+++ b/ctf/packages/web/components/quora-deletion-survey/survey-intro.tsx
@@ -17,15 +17,21 @@ import { hintStyle } from './survey-fields';
 // The answer is saved with the account that sent it, and the copy now says so. What the consent
 // boxes control — whether any of it is published — is unchanged and is the promise that matters.
 
-export function SurveyIntro({ tokens }: { tokens: SurveyTokens }) {
+// `showTitle` is false on the signed-in form, where the shared screen header already names the
+// screen and carries its icon — repeating it costs most of a phone screen for no new information.
+// The signed-out landing has no header (no session behind it, nothing in-app to go back to), so it
+// keeps the title and is the default.
+export function SurveyIntro({ tokens, showTitle = true }: { tokens: SurveyTokens; showTitle?: boolean }) {
   return (
     <>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
-        <ClipboardList size={22} color={tokens.ACCENT} aria-hidden="true" />
-        <h1 style={{ fontSize: 23, fontWeight: 800, margin: 0, color: tokens.TITLE }}>
-          Quora account removals
-        </h1>
-      </div>
+      {showTitle ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+          <ClipboardList size={22} color={tokens.ACCENT} aria-hidden="true" />
+          <h1 style={{ fontSize: 23, fontWeight: 800, margin: 0, color: tokens.TITLE }}>
+            Quora account removals
+          </h1>
+        </div>
+      ) : null}
 
       <p style={{ fontSize: 15, lineHeight: 1.65, color: tokens.TEXT }}>
         People writing about being targeted keep losing their Quora accounts. That gets said a lot

--- a/ctf/packages/web/components/quora-deletion-survey/survey-public-shell.tsx
+++ b/ctf/packages/web/components/quora-deletion-survey/survey-public-shell.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { Plus } from 'lucide-react';
+import { ClipboardList, Plus } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
+import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import {
   QUORA_SURVEY_MAX_ACCOUNTS,
   QUORA_SURVEY_TARGETED_INDIVIDUAL,
@@ -255,8 +256,18 @@ export function QuoraSurveyPublicShell({ needsUnlock }: { needsUnlock: boolean }
 
   return (
     <main style={pageStyle(t)}>
+      {/* Rule 134: every screen carries the one shared back control. This form sits at a
+          top-level path rather than under /apps, so a signed-in member who opens it from a link
+          has no other way into the app — and in the installed web app there is no browser back
+          button to fall back on. The signed-out landing deliberately has no header: there is no
+          session behind it and nothing in-app to go back to. */}
+      <MobileScreenHeader
+        title="Quora account removals"
+        accent={t.ACCENT}
+        icon={<ClipboardList size={18} color={t.ACCENT} />}
+      />
       <div style={columnStyle}>
-        <SurveyIntro tokens={t} />
+        <SurveyIntro tokens={t} showTitle={false} />
 
         <TargetedIndividualQuestion
           value={targetedIndividual}

--- a/ctf/packages/web/components/quora-live-census/census-admin-shell.tsx
+++ b/ctf/packages/web/components/quora-live-census/census-admin-shell.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { ArrowLeft, RefreshCw } from 'lucide-react';
+import { ArrowLeft, ClipboardCheck, RefreshCw } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
+import { MobileScreenHeader } from '@/components/shared/mobile-screen-header';
 import type { CensusRunSummary } from 'lib/quora-live-census/repository';
 import {
   QUORA_CENSUS_FRAME_KIND_LABEL,
@@ -108,8 +109,18 @@ export function CensusAdminShell() {
 
   return (
     <main style={pageStyle(t)}>
+      {/* The shared header is the only sanctioned back control (rule 134). It carries the back
+          chevron and the report-bug / settings / account cluster, so an admin on a phone — where
+          there is no browser back button in the installed app — is never stranded here.
+          No `actions` Member view button: this surface has no member shell to link to. The census
+          is admin-only observation, and the survey's public form is a different feature, not this
+          one's member side. */}
+      <MobileScreenHeader
+        title="Quora Live Account Census"
+        accent={t.ACCENT}
+        icon={<ClipboardCheck size={18} color={t.ACCENT} />}
+      />
       <div style={columnStyle}>
-        <h1 style={{ fontSize: 22, fontWeight: 800, margin: '0 0 6px' }}>Quora live account census</h1>
         <p style={{ fontSize: 13, color: t.MUTED, margin: '0 0 4px' }}>
           The other half of the deletion survey. That one records what was removed, which cannot
           show what remains; this records what is still standing on a stated date, by a stated


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

Three screens shipped with no way back. Reported on the census admin screen; the other two have the same defect and are fixed in the same pass.

Rule 134 requires the one shared control (`MobileScreenHeader`) on every screen. These had none — no back chevron, and no report-bug / settings / account cluster. On a phone, where the installed web app has no browser back button, that strands whoever reaches them.

**The public survey form is the worst of the three.** It sits at a top-level path rather than under `/apps`, precisely so the link reads well outside the app — which means a member opening it from Quora or a blog post had no route into the rest of the app at all.

## What changed

| Screen | Change |
|---|---|
| `/admin/quora-live-census` | Header added. No "Member view" button — this surface has no member shell to link to. |
| `/admin/quora-deletion-survey` | Header added, with a "Member view" link to the public form. |
| `/survey/quora-account-deletions` | Header added for the signed-in form only. |

Two judgment calls worth checking:

**The signed-out landing keeps no header, on purpose.** There is no session behind it — the header's settings and account cluster would be wrong — and there is nothing in-app to go back to, since most people opening that link have no account. So the page title is now conditional (`showTitle`) and renders only there. That also stops it repeating the header title on the signed-in form, which would have cost most of a phone screen for no new information.

**The census's in-page "All runs" control stays.** It looks like a back affordance but is a list/detail toggle inside one screen, not a route back, so rule 134's ban on hand-rolled back controls does not apply to it.

## Checks run locally

typecheck (all workspaces), lint, `lint:a11y`, the web production build, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-us-spelling.mjs`, `check-error-verbosity.mjs`, `check-plugin-boundaries.mjs`, `check-orphan-routes.mjs`, `check-notice-formatting.mjs`, `check-modularity-governance.sh`. All passing.

Both feature inventories record the change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkBsytc3EoVM4q1M1uGeCL)_