### PR TITLE
feat: give members a way to find the account-removal survey

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
@@ -37,6 +37,21 @@ this inventory.
 
 ## User Features
 
+Members reach the form from two places inside the app (owner report, 2026-08-19 — until then the
+only link anywhere in the product was the admin screen's "Member view" button, so no member could
+find it):
+
+- The Unlock verification screens, beside the existing "can't find your Quora profile URL?" help.
+  That is where an unapproved member is held, and the survey is one of only three things they may
+  do before approval — so without a link there, the exception carved out for them was unreachable
+  by them. It also fits: the person who cannot produce a profile URL is usually the person whose
+  accounts were taken.
+- The Directory profile edit screen, under the member's own Quora URL field, whose help text
+  already covers an account that changed. A removal is the harder version of that case.
+
+Both render the one shared `SurveyInviteNote` (`components/shared/survey-invite-note.tsx`) so the
+wording cannot drift, and both are invitations — nothing in either flow depends on answering.
+
 Anyone can open `/survey/quora-account-deletions` and read the whole explanation — what the survey
 is for, what happens to answers, and what the results can and cannot show. A signed-out visitor
 sees that plus a sign-in link, and no questions. Any signed-in member, verified or not, can:
@@ -359,6 +374,10 @@ this is not a plugin. The steps that matter:
   to the public form. The signed-out landing keeps no header on purpose — there is no session
   behind it and nothing in-app to go back to — so the page title is now conditional and shows only
   there.
+- 2026-08-19: Added the two member-facing links to the form (Unlock screens, Directory profile
+  edit) through one shared note component. Before this the form had no in-app entry point at all —
+  the only link was the admin surface's "Member view" button, so the members most likely to have
+  something to report, the unapproved ones held in the Unlock flow, could not reach it.
 - 2026-08-19: The subject list moved to `lib/shared/quora-research-subjects.ts`, shared with the
   live census, which merged first. The two carried identical copies while this branch was open,
   and copies drift apart without anything failing to warn anyone.

--- a/ctf/packages/web/components/directory/directory-profile-edit.tsx
+++ b/ctf/packages/web/components/directory/directory-profile-edit.tsx
@@ -7,6 +7,7 @@ import { getDirectoryTokens, type DirectoryTokens } from "./shared";
 import { DirectorySkillsPicker } from "./directory-skills-picker";
 import { CountrySelect, StateField } from "@/components/shared/location-select";
 import { useTheme } from "@/hooks/useTheme";
+import { SurveyInviteNote } from "@/components/shared/survey-invite-note";
 import { DIRECTORY_MAX_PROPOSED_SKILL_LENGTH, DIRECTORY_MAX_PROPOSED_SKILLS } from "@/lib/directory/constants";
 import { failureText } from 'lib/errors/client-failure';
 
@@ -421,6 +422,7 @@ function ProfileFormFields({
           account changed, just paste your new profile link here — the previous one is kept until you replace
           it with a valid Quora URL.
         </div>
+        <SurveyInviteNote variant="inline" accent={t.ACCENT} muted={t.SUBTLE} />
         {saveNotice ? (
           <div style={{ fontSize: 12, color: t.ACCENT, marginTop: 6, lineHeight: 1.5 }}>{saveNotice}</div>
         ) : null}

--- a/ctf/packages/web/components/shared/survey-invite-note.tsx
+++ b/ctf/packages/web/components/shared/survey-invite-note.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Link from 'next/link';
+import { ArchiveX } from 'lucide-react';
+import { QUORA_SURVEY_PUBLIC_PATH } from 'lib/quora-deletion-survey/constants';
+
+// The member-facing way into the Quora account-removal survey.
+//
+// The survey lives at a top-level path rather than under /apps, so the link reads well when it is
+// posted on Quora or in a blog post. That is right for the audience outside the app and left the
+// audience inside it with nothing: until this component, the only link anywhere in the product was
+// the admin screen's "Member view" button (owner report, 2026-08-19).
+//
+// One component for both placements so the wording cannot drift between them. Both sit where a
+// member has just been asked for a Quora profile URL, because the person who cannot produce one is
+// usually the person whose accounts were taken:
+//
+//   - Unlock ('card'), beside the existing "can't find your profile URL?" help. That screen is
+//     where an unapproved member is held, and the survey is one of only three things they are
+//     allowed to do before approval — so with no link here, the exception carved out for them was
+//     unreachable by them.
+//   - Directory profile edit ('inline'), under the member's own Quora URL field, whose help text
+//     already covers the case where their account changed. A removal is the harder version of that.
+//
+// Deliberately an invitation, not a requirement: nothing in either flow depends on answering, and
+// the copy must not imply that verification or a profile is blocked on it.
+
+const HEADING = 'Have your Quora accounts been removed?';
+const BODY =
+  'People writing about being targeted keep losing their accounts. If that happened to you, the survey records which ones and when — one place where the removals are written down instead of forgotten.';
+
+export function SurveyInviteNote({
+  variant = 'card',
+  accent = '#C8A84B',
+  muted = '#9CA3AF',
+  title = '#F3F4F6',
+}: {
+  variant?: 'card' | 'inline';
+  accent?: string;
+  muted?: string;
+  title?: string;
+}) {
+  if (variant === 'inline') {
+    return (
+      <div style={{ fontSize: 12, color: muted, marginTop: 6, lineHeight: 1.5 }}>
+        Had an account removed rather than changed?{' '}
+        <Link
+          href={QUORA_SURVEY_PUBLIC_PATH}
+          style={{ color: accent, fontWeight: 700, textDecoration: 'underline' }}
+        >
+          Record it in the account-removal survey
+        </Link>{' '}
+        — it is optional, and it does not affect your profile here.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="note"
+      style={{
+        marginTop: 16,
+        padding: '14px 16px',
+        borderRadius: 12,
+        background: `${accent}0D`,
+        border: `1px solid ${accent}33`,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <ArchiveX size={16} color={accent} style={{ flexShrink: 0 }} />
+        <span style={{ fontSize: 14, fontWeight: 800, color: title }}>{HEADING}</span>
+      </div>
+      <div style={{ fontSize: 13, color: muted, lineHeight: 1.6, marginBottom: 10 }}>{BODY}</div>
+      <Link
+        href={QUORA_SURVEY_PUBLIC_PATH}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '9px 14px',
+          borderRadius: 10,
+          border: `1px solid ${accent}55`,
+          background: 'transparent',
+          color: accent,
+          fontSize: 13,
+          fontWeight: 700,
+          textDecoration: 'none',
+        }}
+      >
+        Tell us which accounts
+      </Link>
+    </div>
+  );
+}

--- a/ctf/packages/web/components/unlock/unlock-status-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-status-view.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { STATUS_CONFIG, getUnlockTokens, type DisplayStatus } from "./unlock-shared";
 import { UnlockStatusCard } from "./unlock-status-card";
 import { UnlockQuoraHelp } from "./unlock-quora-help";
+import { SurveyInviteNote } from "@/components/shared/survey-invite-note";
 
 export function UnlockStatusView({
   status,
@@ -45,6 +46,9 @@ export function UnlockStatusView({
             still sees it: they gave a URL and are waiting, and until this they had no way to ask
             anything while they waited. */}
         <UnlockQuoraHelp alreadyVerified={status === "approved"} />
+        {/* Shown whatever the verification status is: having accounts taken is independent of
+            being approved, and an approved member is just as likely to have lost some. */}
+        <SurveyInviteNote accent={t.ACCENT} muted={t.MUTED} title={t.TITLE} />
       </div>
     </>
   );

--- a/ctf/packages/web/components/unlock/unlock-submission-view.tsx
+++ b/ctf/packages/web/components/unlock/unlock-submission-view.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { PluginAdminButton } from "@/components/shared/plugin-admin-button";
 import { getUnlockTokens, UNLOCK_BENEFITS } from "./unlock-shared";
 import { UnlockQuoraHelp } from "./unlock-quora-help";
+import { SurveyInviteNote } from "@/components/shared/survey-invite-note";
 
 const WHY = [
   { icon: "🔗", t: "Real-person proof", d: "Quora activity proves you're a real person with history online." },
@@ -84,6 +85,7 @@ export function UnlockSubmissionView({
             </button>
 
             <UnlockQuoraHelp />
+            <SurveyInviteNote accent={tok.ACCENT} muted={tok.MUTED} title={tok.TITLE} />
           </div>
         </div>
 


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

The survey had no in-app entry point. Verified by searching every reference to the path: the only link anywhere in the product was the admin screen's "Member view" button. The only person who could find the form was an admin who already knew it existed (owner report).

The survey deliberately sits at a top-level path rather than under `/apps`, so the link reads well when posted on Quora or in a blog post. That was right for the audience outside the app, and it left the audience inside it with nothing — no registry entry, no nav rank, no tile.

**The sharper half.** An unapproved member is redirected from `/` straight into the Unlock flow and never reaches the apps grid. The survey is one of only three things they are permitted to do before approval — so the exception carved out for them was unreachable by them. Someone who signs up specifically to answer landed on a screen with no link to the form.

## What changed

Two links, both placed where a member has just been asked for a Quora profile URL, because the person who cannot produce one is usually the person whose accounts were taken.

| Placement | Why there |
|---|---|
| Unlock screens (`unlock-submission-view`, `unlock-status-view`) | Beside the existing "can't find your Quora profile URL?" help — the screen where an unapproved member is held. Shown whatever the verification status is, since having accounts removed is independent of being approved. |
| Directory profile edit | Under the member's own Quora URL field, whose help text already covers the case where their account changed. A removal is the harder version of that case. |

Both render one shared component, `components/shared/survey-invite-note.tsx`, in a card variant and an inline variant, so the wording cannot drift between the two places.

## Judgment calls worth checking

**Both are invitations, not requirements.** Nothing in either flow depends on answering, and the copy avoids implying that verification or a profile is blocked on it. The Unlock screen is where roughly half of sign-ups already stop; it must not gain something that reads as another hurdle.

**No apps-grid tile.** The grid is built purely from the plugin registry, and the survey is documented as deliberately not a plugin. `PluginRegistryItem` has no `href` field, so a tile would mean either making it a plugin — pulling in the whole plugin lifecycle — or adding an href concept to the registry. Both are larger changes than this problem needs, and neither reaches the unapproved members who need it most, since the grid sits behind approval.

## Checks run locally

typecheck (all workspaces), lint, `lint:a11y`, the web production build, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-us-spelling.mjs`, `check-error-verbosity.mjs`, `check-plugin-boundaries.mjs`, `check-orphan-routes.mjs`, `check-notice-formatting.mjs`, `check-unlock-tier-exceptions.mjs`, `check-modularity-governance.sh`. All passing.

The survey inventory records both placements and the reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkBsytc3EoVM4q1M1uGeCL)_