### PR TITLE
docs: add the Quora research brief for the blog-writing agent

### DIFF
--- a/ctf/docs/QUORA_RESEARCH_BLOG_AGENT_BRIEF.md
+++ b/ctf/docs/QUORA_RESEARCH_BLOG_AGENT_BRIEF.md
@@ -1,0 +1,162 @@
+# Quora Research — Brief for the Blog-Writing Agent
+
+Feed this to the agent that writes the blog. It describes the two Quora datasets this project
+collects, where the survey lives so posts can link to it, and the rules for what may and may not be
+said about the numbers.
+
+Keep it in sync with the two feature inventories, which are the source of truth:
+`ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md`
+and `ctf-quora-live-census-feature-inventory.md`. If this file and an inventory disagree, the
+inventory wins.
+
+---
+
+## What you are working with
+
+Two separate datasets that answer different questions. Neither answers the other's question, and
+most wrong claims come from treating one as if it were the other.
+
+| | Account-removal survey | Live account census |
+|---|---|---|
+| What it records | Accounts **Quora closed**, reported by the person who lost them | Accounts **still standing** on a fixed date |
+| Where it comes from | Self-report, through a public form | Observation, by an admin reading Quora |
+| Answers | How often removals happen, to whom, writing about what | What remains, and what subject matter it covers |
+| Cannot answer | What survives | How much was removed (with one exception, below) |
+
+## Where the survey lives
+
+Public form, linkable from anywhere:
+
+```
+https://app.chargingthefuture.com/survey/quora-account-deletions
+```
+
+Reading it needs no account. Submitting needs a free sign-in — that keeps bulk junk out of a table
+meant to be citable, and is not a claim that the person is verified.
+
+Inside the app, members reach it from two places, both sitting where they have just been asked for
+a Quora profile URL: the Unlock verification screens, and the Directory profile edit screen. When a
+post tells readers how to take part, the public link above is the one to give — it works for people
+with no account, which is most of the audience.
+
+## What the survey collects
+
+Per person: whether they consider themselves a targeted individual (yes/no, required), whether at
+least one account was removed (yes/no, required), whether they still hold an account that was not
+removed (optional), free-text evidence, free-text notes, and three separate publication consents.
+
+Per closed account, one card each, up to 25:
+
+- The handle.
+- What happened: the whole account was deleted / banned or suspended / answers or posts removed with
+  the account kept / a Space they ran was removed / blocked from posting. Every option is something
+  Quora did — there is no self-closure option, so nothing self-initiated is in this data.
+- Month and year, either optional.
+- The reason Quora gave: no reason was given / spam / harassment or bullying / misinformation /
+  impersonation or a fake name / adult content / making a new account after a ban / something else /
+  I do not remember. "No reason was given" is expected to be the most common and is an answer in its
+  own right, not a blank.
+- Whether they appealed, and whether anything was restored.
+- What the account mostly wrote about (subject list below).
+- Rough post count and rough months active, both optional.
+
+**The removal count is the number of account cards, never a number anyone typed.** So every removal
+in a total carries a handle and a date behind it.
+
+## What the census collects
+
+Per run: the observation date, what was searched, how accounts were picked, and the **frame kind**.
+A run is closed when finished, and a closed run refuses new entries, so a number that has been
+quoted cannot change afterwards.
+
+Per account observed: handle, profile link, state when checked (still live / gone when checked /
+renamed or moved), subject matter, stance, rough answer count, last active year, archive link.
+
+Stance values are: practical help (what to do, what worked) / organizing (groups, meetups, building
+something) / personal account (their own experience) / cannot tell from the account / not about
+targeting at all.
+
+## The subject list, shared by both
+
+Both datasets code subject matter with the same list, so they can be compared:
+
+targeting and gang stalking · surveillance and harassment tactics · coping, support, encouragement ·
+legal steps and reporting · organizing, meetups, community building · subjects unrelated to targeting
+
+## Rules for publishing — these are hard
+
+### Never publish a handle or a quote without the matching consent
+
+Each survey response carries three separate yes/no consents, all defaulting to no:
+
+1. the handles may be published,
+2. the words may be quoted,
+3. the handle may be attached to that quote.
+
+A handle appears in a post only when 1 is yes. A quote appears only when 2 is yes. A quote appears
+**next to a handle** only when 2 and 3 are both yes. Consent 2 without 3 means the words may be
+used and the person may not be named.
+
+A response with all three off still counts in every total. Nothing is lost by someone declining.
+
+Census handles carry **no consent at all**. Every census row is an observation about a real person's
+public account, recorded without asking them. Publish counts from the census; do not publish the
+handles in it.
+
+### Never state a share of Quora, or of targeted individuals
+
+Report counts, and say what they are counts of. "Forty-one removals reported by twenty-three
+people" is publishable. "Forty percent of targeted individuals have lost accounts" is not, from
+either dataset.
+
+For a census run, a percentage is a share **of that run** and must be labeled that way: "of the 60
+accounts in the 3 March list, 22 were gone." Never "of Quora."
+
+### Say it is self-report
+
+Nothing in the survey is checked against Quora. It records what people say happened. Say so once
+in any post that uses the numbers.
+
+### Selection bias runs one way, from two causes
+
+Only someone who found their way to another platform can answer at all, and only someone willing to
+make an account can submit. So the survey counts people who kept going and were willing to sign up,
+and misses everyone else. Every survey total is a **floor**, never an estimate of the whole.
+
+### A removal rate is readable from only one kind of census run
+
+A run built by searching Quora during the run cannot show removals at all — a search today cannot
+return an account that no longer exists, so the accounts that were taken are missing from the
+results by construction. Only a run built from a list assembled **before** the removals supports
+"how many of a fixed set are gone," because its denominator was fixed in advance.
+
+Check the run's frame kind before writing any removal figure from the census. If it says the
+accounts came from searching during the run, that run can describe what remains and nothing else.
+
+### The census cannot speak to tone
+
+It records what accounts are **about** and whether they are still standing. It does not code how
+discouraging, hopeless, or defeatist an account is — those values were deliberately removed. So no
+claim of the form "what remains is mostly people telling each other to give up" can be supported by
+this data, however the numbers look. If a post wants to make a claim about tone, it needs evidence
+this project does not currently collect, and the post should say the claim is an impression rather
+than dress it in a number.
+
+### A run with a large "cannot tell" share is a thin reading, not an ambiguous population
+
+"Cannot tell from the account" is the stored default. A high share of it means the coder did not
+look closely enough, not that the accounts were genuinely unclear. Do not report it as a finding.
+
+## How to cite a number
+
+Give the reader enough to check it:
+
+- Survey: the count, how many people it came from, and the date range of the reports.
+- Census: the count, the observation date, what was searched, how accounts were picked, and the
+  frame kind. A census number without its date and method is not usable.
+
+## When the data does not support the point
+
+Say the point plainly as an impression, and say the data does not yet test it. That is honest and
+still worth reading. Do not stretch a number to cover it, and do not present a count from one
+dataset as evidence for the other's question.

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
@@ -366,6 +366,11 @@ this is not a plugin. The steps that matter:
 
 ## Change Log
 
+- 2026-08-19: Added `ctf/docs/QUORA_RESEARCH_BLOG_AGENT_BRIEF.md`, the brief fed to the agent that
+  writes the blog: what both datasets record, the public survey link, and the rules for what may be
+  published (consent per handle and per quote, counts never shares, self-report stated, removal
+  rates readable only from a run whose list predates the removals, and no tone claim from the
+  census). This file and that brief must move together.
 - 2026-08-19: Added the shared screen header (`MobileScreenHeader`) to the admin surface and to
   the signed-in public form, both of which shipped without one — no back control and no
   report-bug / settings / account cluster, which strands anyone reaching them on a phone. The form

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-live-census-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-live-census-feature-inventory.md
@@ -279,6 +279,10 @@ this is not a plugin. The steps that matter:
 
 ## Change Log
 
+- 2026-08-19: Added `ctf/docs/QUORA_RESEARCH_BLOG_AGENT_BRIEF.md`, the brief fed to the blog-writing
+  agent. The two limits it must carry from here: a removal rate is readable only from a run whose
+  frame is a list assembled before the removals, and the census cannot speak to tone since those
+  stance values were removed. Keep the brief and this inventory in step.
 - 2026-08-19: Added the shared screen header (`MobileScreenHeader`) to the admin surface, which
   shipped without one. It had no back control and no report-bug / settings / account cluster, so an
   admin reaching it on a phone — where the installed app has no browser back button — was stranded


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What this is

`ctf/docs/QUORA_RESEARCH_BLOG_AGENT_BRIEF.md` — one file to feed the agent that writes the blog, so it knows what the two Quora datasets record, where to send readers who want to take part, and what the numbers cannot be made to say.

Docs only. No code, no schema, no routes.

## What it carries

- What the survey and the census each record, and which question each one **cannot** answer. Most wrong claims come from treating one as the other: the survey records what was removed and can never establish what remains; the census is the reverse.
- The public survey link, plus the two in-app paths (Unlock screens, Directory profile edit) added in #2269. Posts should give the public link — it works for readers with no account, which is most of the audience.
- The exact option lists both use, so the agent never invents a category: what Quora did, the reason Quora gave, account state, stance, and the subject list the two datasets share.

## The publishing rules, which are the point of the file

Four things a writer holding research data would otherwise get wrong:

**Consent is per handle and per quote.** Three separate flags, all defaulting to no. A quote can be usable while the name is not — consent to quote does not carry consent to attribute. Census handles carry **no consent at all**: every row is an observation about a real person's public account, recorded without asking them. Counts from the census are publishable; the handles in it are not.

**Counts, never shares.** "Forty-one removals reported by twenty-three people" is publishable. "Forty percent of targeted individuals" is not, from either dataset. Every survey total is a floor, since only someone who reached another platform and was willing to sign up can answer at all. Census percentages are a share of that run, labeled as such, never of Quora.

**A removal rate is readable from one kind of census run only.** A run built by searching Quora during the run cannot see removed accounts — they are gone, so they never appear in the results, and the denominator is missing by construction. Only a run whose list was assembled before the removals supports "how many of a fixed set are gone." The brief tells the agent to check a run's frame kind before writing any removal figure.

**The census cannot speak to tone.** Those stance values were removed on your decision, so no claim about what remains being discouraging can be drawn from this data however the numbers look. The brief says plainly that such a claim needs evidence this project does not collect, and that a post wanting to make it should present it as an impression rather than dress it in a number.

## Keeping it true

Both feature inventories record the file and remain its source of truth; the brief says so and says the inventory wins on any disagreement. Change-log entries added to both.

## Checks run locally

`check-eof-format.sh`, `check-us-spelling.mjs`, `check-notice-formatting.mjs`, `check-inventory-drift.mjs`, `check-credits-money-language.mjs`, and the workspace typecheck via the pre-commit gate. All passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkBsytc3EoVM4q1M1uGeCL)_