### PR TITLE
docs: quote Quora's data-export instructions in the knowledge library

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -202,7 +202,11 @@ its plugin-routing role (today's hardcoded `getActionForText`) becomes Rasa-back
      quality judgment — a couple of lines cannot ground an answer, and saying so now saves the wait).
    - **Whole export.** For the rarer member whose public writing is nearly all on-topic: they get the
      Quora export (Settings → Privacy → Download your information) and upload the `.zip` exactly as
-     it arrived. On the same page they read and tick
+     it arrived. A FAQ card on the same page — **Getting a copy of your Quora data** — carries
+     Quora's own help article quoted in full (request by email to `privacy@quora.com`, or
+     `quora.com/contact` → "I want a copy of my data"; the archive normally arrives within 72 hours
+     to the account's email address), plus the link to the original. It is quoted rather than only
+     linked so the page still works when the help article moves. On the same page they read and tick
    six consent statements — one checkbox each, no bundled "agree to all" — covering: it is their own
    public writing; the one use permitted; they keep every right; they can withdraw; a human reads it
    and not everything is used; parts naming other people may be cut. An optional box asks whether
@@ -719,10 +723,27 @@ buckets are not reproduced — only real provenance (engine / intent / safety ca
 
 ## Change Log
 
+- 2026-08-20 (latest): **The knowledge library now says how to get a Quora export, in Quora's own
+  words.** `/knowledge` offered "Send my whole Quora export" and a one-line pointer at Quora's
+  settings, but nothing told a member how the archive is actually requested or how long it takes —
+  a step that happens entirely on Quora's side, where nothing in this app can help. Added a FAQ card
+  (`components/comic/comic-quora-export-faq.tsx`) under the two sending options, showing Quora's help
+  article "Can I get a copy of my data?" quoted in full, with the byline, the date it was read, and a
+  link to the original. The quote lives in `lib/comic/quora-export-help.ts` so the displayed text has
+  one source and can be re-checked as a unit. Quoted rather than only linked because help-center
+  article ids get renumbered, and a contributor who lands on a 404 cannot tell whether the process
+  changed or the page merely moved. Three short answers sit under it: the export is optional (picking
+  posts needs nothing from Quora), it usually takes up to 72 hours, and the `.zip` is sent exactly as
+  it arrived. Placed under both options rather than only the export one, because the days of waiting
+  are part of choosing between them. Copy and data only — no route, schema, or contract change.
+  **Open question for the owner:** the shipped mode hint says "In Quora: Settings → Privacy →
+  Download your information", which is not the route Quora's help article describes; that line was
+  left exactly as it ships and needs an owner decision.
+
 - 2026-07-29: **One canonical `content_hash` formula, so the importer and the contribution path agree.** `content_hash` is what stops the same writing being stored twice in `comic_knowledge_entries`, and the places that computed it had drifted: `importComicKnowledge.mjs` joined the fields with a **NUL** character while the member-contribution accept path (`app/api/comic/admin/contributions/[id]/review/route.ts`) joined them with a **space**, under a comment claiming it matched the importer. Effect: a member contributing a post whose text was already in the library hashed differently, hit no conflict, and was stored a second time. The formula now lives once as `contentHashOf` in `ctf/scripts/lib/comicDatasetShared.mjs`, imported by the importer; the web route is outside that package and cannot import it, so it keeps a deliberate second copy with a comment naming the canonical definition and requiring both to change together. NUL is kept because it produced every live row hash (no stored hash is invalidated) and because it cannot occur in the text — a space join collides `(question "a b", content "c")` with `(question "a", content "b c")`, which NUL keeps distinct. Verified: the canonical function reproduces the importer previous hash for every case, both sites now agree, and the old space formula does not. **Known data gap, not fixed here:** the one-time identifier scrub (`scrubComicKnowledgeIdentifiers.mjs`, removed in #1954 after its production run) used the same space formula and *rewrote* `content_hash` on every row it touched, so those production rows hold hashes the importer will not reproduce and will not dedupe against a re-import until recomputed. Tracked in the corpus-refresh issue.
 - 2026-07-29: **`importComicKnowledge.mjs` is plain text again, so its diffs are reviewable.** The NUL separator was stored as a literal NUL byte, which made git classify the source as binary and print "Binary files differ" instead of a diff — a loader script that writes to the knowledge base could be changed without the change being visible in review. Moving the formula into `comicDatasetShared.mjs` (written with the `\u0000` escape rather than a raw byte) removes the last raw NUL from the file. The runtime string, and therefore every hash, is unchanged. This commit's own diff still shows binary because the base version on `main` contains the raw bytes; every diff after it is text.
 - 2026-07-29: **Reconciled the `source_ref` knowledge-import change with the merged member-contribution feature (schema-compatible).** After the member Quora-contribution feature (`comic_contributions`, `comic_contribution_entries`, `comic_knowledge_entries.contribution_id`) and the Quora space rename merged to `main`, this branch was rebased on top. The contribution accept path (`acceptContribution` in `lib/comic/contribution-repository.ts`) promoted rows with a bare `ON CONFLICT (content_hash) DO NOTHING`, which no longer matches the schema once the global `UNIQUE(content_hash)` is replaced by the partial index `uq_comic_knowledge_entries_content_hash` (`WHERE source_ref IS NULL`). Updated that insert and its already-present backfill lookup to key on `... WHERE source_ref IS NULL`: contributed rows carry a null `source_ref`, so they still dedupe against legacy and contribution rows exactly as before, while Markdown-repo rows (`source_ref` set) form a separate identity space and never collide with them. Confirmed the two partial indexes coexist with `contribution_id` and its `ON DELETE CASCADE`. Re-verified end to end on an embedded Postgres including the contribution insert path. **Owner note:** the pedigree101 content now has two ingestion routes — the already-imported legacy seed rows and the Markdown-repo `source_ref` path — so before importing the Markdown, decide which is authoritative for that account and retire the other's rows (`active = FALSE`) so the bot is not grounded on two copies.
-- 2026-08-09 (latest): **The signed-out Knowledge library page had no way back (owner report).**
+- 2026-08-09: **The signed-out Knowledge library page had no way back (owner report).**
   `comic-knowledge-public-shell.tsx` builds its own header — the BookOpen mark and the title — and
   carried no back control at all, so a visitor who reached `/knowledge` from inside the app was
   stranded there at phone width, where there is no browser back button in the installed web app.

--- a/ctf/docs/developer/test-scripts/comic-test-script.md
+++ b/ctf/docs/developer/test-scripts/comic-test-script.md
@@ -98,6 +98,31 @@ the tests worth running slowly.
 
 ---
 
+## CMC-C1b2 · The Quora export FAQ
+**Role:** any signed-in member
+**Precondition:** none — no export or upload is needed for this check.
+
+**Steps:**
+1. Open `/knowledge` and read the card **Getting a copy of your Quora data**, under the two sending
+   options.
+2. Switch between **Pick a few posts** and **Send my whole Quora export**.
+3. Tap the `privacy@quora.com` address, then **Open the original page**.
+
+**Expected:**
+- The card shows Quora's help article "Can I get a copy of my data?" quoted word for word — the
+  request goes by email to `privacy@quora.com` or through `quora.com/contact` by choosing "I want a
+  copy of my data", and the archive normally arrives within 72 hours to the account's email address.
+  Under the quote is the byline, the date the page was read, and a link to the original.
+- The card stays visible for **both** options — the wait is part of choosing between them.
+- Three answers follow: the export is optional, it usually takes up to 72 hours, and the `.zip` is
+  sent exactly as it arrived.
+- The address opens a mail draft; the link opens Quora's page in a new tab. **The quote must still
+  read correctly with no network at all** — that is the point of quoting it.
+
+**Result:** web ☐
+
+---
+
 ## CMC-C1c · Whole export (the secondary path)
 **Role:** signed-in member
 **Precondition:** a real Quora export `.zip` (Settings → Privacy → Download your information).

--- a/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
+++ b/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../lib/comic/contribution-consent';
 import { MAX_LINKED_POSTS } from '../../lib/comic/contribution-links';
 import { failureText } from 'lib/errors/client-failure';
+import { QuoraExportFaqSection } from './comic-quora-export-faq';
 
 // The knowledge page (`/knowledge`): where a member lends their own public Quora writing to the
 // assistant's reference library, and where the consent that permits it is given.
@@ -282,6 +283,10 @@ export function ComicKnowledgeShell({ askForQuoraUrl = false }: { askForQuoraUrl
         </p>
 
         <ModeSelector t={t} mode={c.mode} onSelectMode={c.selectMode} />
+        {/* Sits under the two options, for both of them: the export route depends on a request made
+            on Quora's side that takes days, and someone choosing between the options needs to know
+            that before they pick. */}
+        <QuoraExportFaqSection t={t} />
         <WhatHappensSection t={t} />
         <WhatIsUsedSection t={t} />
         <ConsentSection

--- a/ctf/packages/web/components/comic/comic-quora-export-faq.tsx
+++ b/ctf/packages/web/components/comic/comic-quora-export-faq.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { HelpCircle } from 'lucide-react';
+import { getComicTokens } from './comic-shared';
+import {
+  QUORA_CONTACT_URL,
+  QUORA_DATA_EXPORT_HELP_ATTRIBUTION,
+  QUORA_DATA_EXPORT_HELP_PARAGRAPHS,
+  QUORA_DATA_EXPORT_HELP_READ_ON,
+  QUORA_DATA_EXPORT_HELP_TITLE,
+  QUORA_DATA_EXPORT_HELP_URL,
+  QUORA_PRIVACY_EMAIL,
+} from '../../lib/comic/quora-export-help';
+
+// The questions a member asks before they can send a whole Quora export: how do I get one, how long
+// does it take, what do I send.
+//
+// Getting the archive happens entirely on Quora's side, so the answer is Quora's own instructions
+// rather than ours. They are quoted in full — not linked and summarized — because help-center
+// articles get renumbered, and someone who follows a dead link has no way to tell whether the
+// process changed or the page simply moved. The link is still there for anyone who wants to check
+// the source; the quote is what keeps this page usable when it breaks.
+//
+// It sits on `/knowledge` for both sending options, not only the export one: someone weighing the
+// two needs to know what the export actually costs them in time before they can choose.
+
+type ComicTokens = ReturnType<typeof getComicTokens>;
+
+const FAQ_ITEMS: { question: string; answer: string }[] = [
+  {
+    question: 'Do I need an export at all?',
+    answer:
+      'No. Picking a few posts is the recommended way and needs nothing from Quora — you open each post, copy the link, and paste the text. The export is for the rarer case where nearly everything you have written publicly belongs here.',
+  },
+  {
+    question: 'How long does it take to arrive?',
+    answer:
+      'Quora says the archive usually reaches you within 72 hours of their team confirming they got the request. It comes to the email address on your Quora account.',
+  },
+  {
+    question: 'What do I send once it arrives?',
+    answer:
+      'The file exactly as Quora sent it — the .zip, unopened. Do not unzip it and do not try to clean it out first. Your inbox messages, drafts, and profile data are stripped out on arrival here, before any person reads a word of it.',
+  },
+];
+
+// The tokens come from the parent because the whole page shares one theme read.
+export function QuoraExportFaqSection({ t }: { t: ComicTokens }) {
+  return (
+    <section style={cardStyle(t)}>
+      <h2 style={cardTitleStyle}>
+        <HelpCircle size={16} color={t.ACCENT} style={{ verticalAlign: '-2px', marginRight: 6 }} />
+        Getting a copy of your Quora data
+      </h2>
+      <p style={bodyStyle(t)}>
+        Only Quora can produce your archive, and you ask them for it by hand — there is no button
+        here that fetches it. Their instructions are quoted in full below, so this page still works if
+        their help page moves.
+      </p>
+
+      <QuotedHelpArticle t={t} />
+
+      <p style={{ ...bodyStyle(t), marginTop: 14 }}>
+        In plain words: email{' '}
+        <a href={`mailto:${QUORA_PRIVACY_EMAIL}`} style={linkStyle(t)}>
+          {QUORA_PRIVACY_EMAIL}
+        </a>{' '}
+        and ask for a copy of your data, or open{' '}
+        <a href={QUORA_CONTACT_URL} target="_blank" rel="noopener noreferrer" style={linkStyle(t)}>
+          quora.com/contact
+        </a>{' '}
+        and choose <strong>I want a copy of my data</strong>. Ask from the account the writing is on,
+        because the archive is sent to that account&apos;s email address.
+      </p>
+
+      {FAQ_ITEMS.map((item) => (
+        <div key={item.question} style={{ borderTop: `1px solid ${t.BORDER}`, paddingTop: 12, marginTop: 12 }}>
+          <h3 style={{ fontSize: 14, fontWeight: 700, margin: '0 0 4px', color: t.TITLE }}>{item.question}</h3>
+          <p style={{ ...bodyStyle(t), marginBottom: 0 }}>{item.answer}</p>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+// The quote itself, marked up as a quotation with its source so it is never mistaken for our own
+// wording — these are Quora's terms, not ours, and we cannot change what they will do.
+function QuotedHelpArticle({ t }: { t: ComicTokens }) {
+  return (
+    <blockquote
+      cite={QUORA_DATA_EXPORT_HELP_URL}
+      style={{
+        margin: 0,
+        padding: '12px 14px',
+        borderRadius: 10,
+        background: `${t.ACCENT}10`,
+        borderLeft: `3px solid ${t.ACCENT}`,
+      }}
+    >
+      <p style={{ fontSize: 13, fontWeight: 700, color: t.TITLE, margin: '0 0 8px' }}>
+        {QUORA_DATA_EXPORT_HELP_TITLE}
+      </p>
+      {QUORA_DATA_EXPORT_HELP_PARAGRAPHS.map((paragraph) => (
+        <p key={paragraph} style={{ ...bodyStyle(t), fontStyle: 'italic' }}>
+          {paragraph}
+        </p>
+      ))}
+      <footer style={{ fontSize: 12, lineHeight: 1.55, color: t.MUTED }}>
+        {QUORA_DATA_EXPORT_HELP_ATTRIBUTION} — Quora Help Center, read {QUORA_DATA_EXPORT_HELP_READ_ON}.{' '}
+        <a href={QUORA_DATA_EXPORT_HELP_URL} target="_blank" rel="noopener noreferrer" style={linkStyle(t)}>
+          Open the original page
+        </a>
+      </footer>
+    </blockquote>
+  );
+}
+
+const cardStyle = (t: ComicTokens): React.CSSProperties => ({
+  marginTop: 18,
+  borderRadius: 14,
+  background: t.HEADER,
+  border: `1px solid ${t.BORDER_SOLID}`,
+  padding: 18,
+});
+const cardTitleStyle: React.CSSProperties = { fontSize: 16, fontWeight: 700, margin: '0 0 10px' };
+const bodyStyle = (t: ComicTokens): React.CSSProperties => ({
+  fontSize: 14,
+  lineHeight: 1.65,
+  color: t.TEXT,
+  marginTop: 0,
+  marginBottom: 10,
+});
+const linkStyle = (t: ComicTokens): React.CSSProperties => ({ color: t.ACCENT, fontWeight: 600 });

--- a/ctf/packages/web/lib/comic/quora-export-help.ts
+++ b/ctf/packages/web/lib/comic/quora-export-help.ts
@@ -1,0 +1,36 @@
+// Quora's own instructions for requesting a copy of your data, kept in the repo so the knowledge
+// library can show them even if Quora's help page moves or disappears.
+//
+// The whole-export path on `/knowledge` depends on a member being able to get the archive out of
+// Quora first, and that step happens entirely on Quora's side where nothing here can help. A link
+// alone is not enough: help-center articles get renumbered, and a contributor who lands on a 404 has
+// no way to tell whether the process changed or the page merely moved. So the page text is quoted
+// verbatim below, with the date it was read, and the link is offered alongside it rather than
+// instead of it.
+//
+// This is a quotation of Quora's published help article, reproduced so members can follow the
+// process. Keep it exact — if the article changes, update the text and the `readOn` date together
+// rather than paraphrasing.
+
+export const QUORA_DATA_EXPORT_HELP_URL =
+  'https://help.quora.com/hc/en-us/articles/360000839503-Can-I-get-a-copy-of-my-data';
+
+export const QUORA_DATA_EXPORT_HELP_TITLE = 'Can I get a copy of my data?';
+
+// The date this repo last read the article, shown next to the quote so a member can judge how old
+// it is. Update it whenever the quoted text is checked or changed.
+export const QUORA_DATA_EXPORT_HELP_READ_ON = '20 August 2026';
+
+// The article's byline, kept because it is what tells a reader the words are Quora's own.
+export const QUORA_DATA_EXPORT_HELP_ATTRIBUTION = 'Official Quora Account';
+
+// The article body, verbatim, one string per paragraph.
+export const QUORA_DATA_EXPORT_HELP_PARAGRAPHS: readonly string[] = [
+  'Yes. Quora will send an archive of your content and personal data to your account’s primary email address on request. If you would like to request a copy of your data, you may do so by submitting a request via email to privacy@quora.com or by visiting quora.com/contact and selecting "I want a copy of my data"',
+  'Please note that you will typically receive the archive within 72 hours of our team confirming that we have received your data request.',
+];
+
+// The two addresses named in the quote, pulled out so the FAQ can make them usable without altering
+// the quoted text.
+export const QUORA_PRIVACY_EMAIL = 'privacy@quora.com';
+export const QUORA_CONTACT_URL = 'https://www.quora.com/contact';


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

`/knowledge` offers "Send my whole Quora export", but nothing on the page said how a member actually gets that archive or how long it takes. That step happens entirely on Quora's side, so the answer has to be Quora's own instructions.

- New FAQ card, **Getting a copy of your Quora data**, under the two sending options (`ctf/packages/web/components/comic/comic-quora-export-faq.tsx`). It shows Quora's help article "Can I get a copy of my data?" quoted word for word, with the byline, the date the page was read, and a link to the original.
- The quoted text lives in `ctf/packages/web/lib/comic/quora-export-help.ts` so the displayed wording has one source and can be re-checked as a unit when the article changes.
- Three short answers follow the quote: the export is optional (picking a few posts needs nothing from Quora), the archive normally takes up to 72 hours, and the `.zip` is sent exactly as it arrived.
- Comic feature inventory and the manual test script updated to match (new case CMC-C1b2).

## Why quote instead of just linking

Help-center article ids get renumbered. Someone who follows a dead link cannot tell whether the process changed or the page merely moved, and the whole-export route stops there. Quoting the page keeps this usable when the link breaks — the card reads correctly with no network at all.

## One thing that needs your decision

The shipped mode hint right above the new card says "In Quora: Settings → Privacy → Download your information". Quora's own help article does not describe that route — it says to email `privacy@quora.com` or use `quora.com/contact` and choose "I want a copy of my data". I left that shipped line exactly as it is rather than rewriting approved copy. Say the word and I will change it in a follow-up; the same sentence is repeated in the inventory and the test script precondition.

## Checks run locally

`typecheck`, `lint`, `lint:a11y`, `governance:check`, `format:check` (EOF), `check:us-spelling`, `check:inventory-drift`, `check:test-script-drift`, `check:error-verbosity`, `check:notice-formatting`, and a full `@ctf/web` build — all pass.

No route, schema, or contract change: copy and a data module only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxEKTiSzpFoerdNp37N3Q9)_