### PR TITLE
fix: stop the survey silently dropping reported accounts

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-quora-deletion-survey-feature-inventory.md
@@ -61,7 +61,7 @@ sees that plus a sign-in link, and no questions. Any signed-in member, verified 
 - Say whether they consider themselves a targeted individual — yes or no. Required; the form will
   not send without it.
 - Say yes or no to whether at least one of their Quora accounts was removed.
-- Describe each removed account on its own card, adding as many cards as they lost (up to 25): the
+- Describe each removed account on its own card, adding as many cards as they lost: the
   handle, what happened (deleted, banned or suspended, answers removed but account kept, a Space
   removed, blocked from posting), the month and year, the reason Quora gave (including "no reason
   was given" and "I do not remember"), whether they appealed, whether anything was put back, what
@@ -366,6 +366,17 @@ this is not a plugin. The steps that matter:
 
 ## Change Log
 
+
+- 2026-08-20: The per-response account limit went from 25 to 500, and an over-limit response is now
+  refused rather than trimmed. The old number was arbitrary and could have cut off a real
+  respondent — someone cycled through ban-evasion accounts over years might pass 25, and that is
+  the most-targeted person in the study. Worse, it failed silently: extra rows were dropped with
+  nothing on screen and nothing in the audit row. The limit is a spam bound only, and it stays
+  rather than going away entirely for two reasons: the survey is the one write path reachable
+  without a Quora URL, since it runs before the Unlock gate that stops roughly half of sign-ups;
+  and a response plus its account rows are written in one transaction with one INSERT per account,
+  so an unbounded body would hold a transaction open across arbitrarily many round trips. The form
+  also now explains the limit instead of quietly removing the "add another account" button.
 - 2026-08-19: Added `ctf/docs/QUORA_RESEARCH_BLOG_AGENT_BRIEF.md`, the brief fed to the agent that
   writes the blog: what both datasets record, the public survey link, and the rules for what may be
   published (consent per handle and per quote, counts never shares, self-report stated, removal

--- a/ctf/packages/web/components/quora-deletion-survey/survey-public-shell.tsx
+++ b/ctf/packages/web/components/quora-deletion-survey/survey-public-shell.tsx
@@ -95,7 +95,15 @@ function AccountsSection({
           <Plus size={15} aria-hidden="true" />
           Add another account
         </button>
-      ) : null}
+      ) : (
+        // Say why rather than just removing the button. The limit sits far past any realistic
+        // answer, so nobody should see this — but a control that disappears without explanation is
+        // how the old cap failed people, and the fix is worth having in both places.
+        <p style={hintStyle(tokens)}>
+          That is {QUORA_SURVEY_MAX_ACCOUNTS} accounts, which is as many as one response holds. Send
+          this one, then start another for the rest.
+        </p>
+      )}
     </div>
   );
 }

--- a/ctf/packages/web/lib/quora-deletion-survey/constants.ts
+++ b/ctf/packages/web/lib/quora-deletion-survey/constants.ts
@@ -103,7 +103,27 @@ export const QUORA_SURVEY_AUDIT_COMMAND = {
 
 export const QUORA_SURVEY_HANDLE_MAX_LENGTH = 200;
 export const QUORA_SURVEY_TEXT_MAX_LENGTH = 5000;
-export const QUORA_SURVEY_MAX_ACCOUNTS = 25;
+// How many closed accounts one response may list.
+//
+// Not a research limit — a spam bound, and it is set where only a script reaches it (owner,
+// 2026-08-20). The earlier figure of 25 was arbitrary and could plausibly have cut off a real
+// person: someone cycled through ban-evasion accounts over a decade might pass it, and that person
+// is the most-targeted respondent in the study. A limit that bites hardest on the strongest case
+// is the wrong limit.
+//
+// Nobody hand-documents hundreds of handles — most people struggle to find even one, which is why
+// half of sign-ups stop at the Quora URL question. So 500 is roughly twenty times any realistic
+// answer, and anything above it came from automation rather than a person.
+//
+// It matters that the bound exists at all, because the survey is the one write path a spammer can
+// reach without ever producing a Quora URL: it runs at the `any_authenticated` tier, before the
+// Unlock gate that filters everyone else. And a response and its account rows are written in one
+// transaction, one INSERT per account — so an unbounded body is a single request holding a
+// transaction open across arbitrarily many round trips, which is a cheap way to hurt the database.
+//
+// Over the limit the response is REJECTED, never trimmed. Silently dropping the extra rows was the
+// real defect in the old cap: a person who reported more than 25 lost the rest with nothing said.
+export const QUORA_SURVEY_MAX_ACCOUNTS = 500;
 
 // The earliest year worth offering: Quora opened to the public in 2010, and a report of a
 // removal before that is a typing mistake rather than an event.
@@ -132,9 +152,10 @@ export const QUORA_SURVEY_REMOVED_ACCOUNT_PREFIX = 'removed-quora-account:';
 // verification form.
 export const QUORA_SURVEY_UNLOCK_SOURCE = 'quora_deletion_survey';
 
-// How many removed handles one verification request may carry onto an account. The survey itself
-// allows more accounts than this; the cap is on what gets written to the identified side.
-export const QUORA_SURVEY_MAX_LINKED_HANDLES = 25;
+// Closures written to a member's account history are bounded by the same number as the response
+// that produced them — they come from an already-validated response, so a second, smaller limit
+// here would silently drop handles the survey accepted.
+export const QUORA_SURVEY_MAX_LINKED_HANDLES = QUORA_SURVEY_MAX_ACCOUNTS;
 
 export function removedQuoraAccountMarker(handle: string): string {
   return `${QUORA_SURVEY_REMOVED_ACCOUNT_PREFIX}${handle.trim()}`;

--- a/ctf/packages/web/lib/quora-deletion-survey/parse.ts
+++ b/ctf/packages/web/lib/quora-deletion-survey/parse.ts
@@ -121,12 +121,29 @@ function parseAccount(raw: unknown): SurveyAccountInput | null {
   };
 }
 
-function parseAccounts(raw: unknown): SurveyAccountInput[] {
-  if (!Array.isArray(raw)) return [];
-  return raw
-    .slice(0, QUORA_SURVEY_MAX_ACCOUNTS)
-    .map(parseAccount)
-    .filter((account): account is SurveyAccountInput => account !== null);
+type AccountsResult =
+  | { ok: true; accounts: SurveyAccountInput[] }
+  | { ok: false; message: string };
+
+// Over the limit the whole response is refused, never trimmed to fit. Trimming was the old
+// behavior and it was wrong in the one direction that matters here: a person reporting more
+// accounts than the cap lost the rest with nothing on screen and nothing in the audit row saying
+// anything had been dropped. A refusal at least tells them, and the limit sits far enough out
+// (see QUORA_SURVEY_MAX_ACCOUNTS) that only automation should ever meet it.
+function parseAccounts(raw: unknown): AccountsResult {
+  if (!Array.isArray(raw)) return { ok: true, accounts: [] };
+  if (raw.length > QUORA_SURVEY_MAX_ACCOUNTS) {
+    return {
+      ok: false,
+      message: `That is more than ${QUORA_SURVEY_MAX_ACCOUNTS} accounts in one response. Nothing was recorded — send them in more than one response, or get in touch if you really did lose that many.`,
+    };
+  }
+  return {
+    ok: true,
+    accounts: raw
+      .map(parseAccount)
+      .filter((account): account is SurveyAccountInput => account !== null),
+  };
 }
 
 // A response is worth storing when it says something. Answering "yes, accounts of mine were
@@ -140,7 +157,11 @@ export function parseSurveySubmission(raw: unknown): ParseResult {
 
   const body = raw as Record<string, unknown>;
   const anyAccountRemoved = asBoolean(body.anyAccountRemoved);
-  const accounts = parseAccounts(body.accounts);
+  const parsedAccounts = parseAccounts(body.accounts);
+  if (!parsedAccounts.ok) {
+    return { ok: false, message: parsedAccounts.message };
+  }
+  const accounts = parsedAccounts.accounts;
 
   // Q1 has no third option and therefore no safe default: storing an unanswered response as
   // either 'yes' or 'no' would count the person as having said something they did not say.


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

The per-response account limit was 25, and the number was arbitrary — I picked it as a paste bound without checking it against any realistic answer.

**It failed silently.** Anything past 25 was trimmed by `.slice(0, 25)` with nothing on screen and nothing in the audit row saying rows had been discarded. On the form, the "add another account" button simply vanished at 25, giving no reason why a 26th account could not be added.

**And the number could have cut off a real person.** Someone cycled through ban-evasion accounts over years might pass 25 — and that person is the most-targeted respondent in the study. A limit that bites hardest on the strongest case is the same shape of error as the census frame that could not see removed accounts, and the verification offer that excluded people whose accounts were all gone.

## What changed

- The limit is now 500, and an over-limit response is **refused with a reason** rather than trimmed to fit.
- The form explains the limit instead of quietly removing the button.
- `QUORA_SURVEY_MAX_LINKED_HANDLES` now derives from the same constant. It was separately 25, so a response the survey accepted could have had handles silently dropped on the way to the member's account history.

## Why keep a bound at all

The owner's read is right that no honest respondent will hit it — most people struggle to find even one handle, which is why roughly half of sign-ups stop at the Quora URL question. 500 is about twenty times any realistic answer. Two reasons it is not removed entirely:

**The survey is the one write path reachable without a Quora URL.** It runs at the `any_authenticated` tier, before the Unlock gate — so the drop-off that filters spam elsewhere in the app, including perps who cannot produce a handle, does not protect this route.

**A response and its account rows go in as one transaction, one INSERT per account.** An unbounded body would be a single request holding a transaction open across arbitrarily many sequential round trips. That is a cheap way to hurt the database, and exactly the spam the bound exists for.

Once truncation became rejection, the number stopped costing an honest respondent anything wherever it sits — so it can be set purely where automation lands.

## Checks run locally

typecheck (all workspaces), lint, `lint:a11y`, the web production build, `check-eof-format.sh`, `check-inventory-drift.mjs`, `check-us-spelling.mjs`, `check-error-verbosity.mjs`, `check-plugin-boundaries.mjs`, `check-orphan-routes.mjs`, `check-notice-formatting.mjs`, `check-unlock-tier-exceptions.mjs`, `check-deletion-registry.mjs`, `check-modularity-governance.sh`. All passing.

The survey inventory records the change and the reasoning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkBsytc3EoVM4q1M1uGeCL)_