### PR TITLE
fix: drop the Quora export settings path that does not exist

### DIFF
--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-comic-feature-inventory.md
@@ -200,13 +200,14 @@ its plugin-routing role (today's hardcoded `getActionForText`) becomes Rasa-back
      URLs stripped from the corpus in the first place. Only quora.com links are accepted, duplicates
      within one submission are rejected, and a post under 120 characters is refused up front (not a
      quality judgment — a couple of lines cannot ground an answer, and saying so now saves the wait).
-   - **Whole export.** For the rarer member whose public writing is nearly all on-topic: they get the
-     Quora export (Settings → Privacy → Download your information) and upload the `.zip` exactly as
-     it arrived. A FAQ card on the same page — **Getting a copy of your Quora data** — carries
-     Quora's own help article quoted in full (request by email to `privacy@quora.com`, or
-     `quora.com/contact` → "I want a copy of my data"; the archive normally arrives within 72 hours
-     to the account's email address), plus the link to the original. It is quoted rather than only
-     linked so the page still works when the help article moves. On the same page they read and tick
+   - **Whole export.** For the rarer member whose public writing is nearly all on-topic: they ask
+     Quora for the export by hand — there is no settings screen that produces one (checked by the
+     owner, 2026-08-20) — and upload the `.zip` exactly as it arrived. A FAQ card on the same page —
+     **Getting a copy of your Quora data** — carries Quora's own help article quoted in full
+     (request by email to `privacy@quora.com`, or `quora.com/contact` → "I want a copy of my data";
+     the archive normally arrives within 72 hours to the account's email address), plus the link to
+     the original. It is quoted rather than only linked so the page still works when the help
+     article moves. On the same page they read and tick
    six consent statements — one checkbox each, no bundled "agree to all" — covering: it is their own
    public writing; the one use permitted; they keep every right; they can withdraw; a human reads it
    and not everything is used; parts naming other people may be cut. An optional box asks whether
@@ -723,7 +724,19 @@ buckets are not reproduced — only real provenance (engine / intent / safety ca
 
 ## Change Log
 
-- 2026-08-20 (latest): **The knowledge library now says how to get a Quora export, in Quora's own
+- 2026-08-20 (latest): **Removed the Quora settings path that does not exist.** The knowledge
+  library's export hint read "In Quora: Settings → Privacy → Download your information", and the
+  same route was repeated in this inventory and in the test script's precondition. The owner checked
+  Quora on 2026-08-20: there is no such screen. Its most likely origin is a bot that invented a
+  plausible-sounding settings path, which is exactly the failure the quoted help article now guards
+  against — an instruction nobody can follow, and no way for a member to tell that it is wrong. The
+  hint now says the archive is requested by hand and points at the FAQ card directly below it, where
+  Quora's own article gives the only route that works: email `privacy@quora.com`, or `quora.com/contact`
+  → "I want a copy of my data". The FAQ card also answers the question directly — "Where is the
+  download button in Quora's settings?" — so someone already hunting for one stops hunting.
+  **Do not reinstate a settings path unless Quora publishes one.** Copy only — no route, schema, or
+  contract change.
+- 2026-08-20: **The knowledge library now says how to get a Quora export, in Quora's own
   words.** `/knowledge` offered "Send my whole Quora export" and a one-line pointer at Quora's
   settings, but nothing told a member how the archive is actually requested or how long it takes —
   a step that happens entirely on Quora's side, where nothing in this app can help. Added a FAQ card
@@ -736,9 +749,6 @@ buckets are not reproduced — only real provenance (engine / intent / safety ca
   posts needs nothing from Quora), it usually takes up to 72 hours, and the `.zip` is sent exactly as
   it arrived. Placed under both options rather than only the export one, because the days of waiting
   are part of choosing between them. Copy and data only — no route, schema, or contract change.
-  **Open question for the owner:** the shipped mode hint says "In Quora: Settings → Privacy →
-  Download your information", which is not the route Quora's help article describes; that line was
-  left exactly as it ships and needs an owner decision.
 
 - 2026-07-29: **One canonical `content_hash` formula, so the importer and the contribution path agree.** `content_hash` is what stops the same writing being stored twice in `comic_knowledge_entries`, and the places that computed it had drifted: `importComicKnowledge.mjs` joined the fields with a **NUL** character while the member-contribution accept path (`app/api/comic/admin/contributions/[id]/review/route.ts`) joined them with a **space**, under a comment claiming it matched the importer. Effect: a member contributing a post whose text was already in the library hashed differently, hit no conflict, and was stored a second time. The formula now lives once as `contentHashOf` in `ctf/scripts/lib/comicDatasetShared.mjs`, imported by the importer; the web route is outside that package and cannot import it, so it keeps a deliberate second copy with a comment naming the canonical definition and requiring both to change together. NUL is kept because it produced every live row hash (no stored hash is invalidated) and because it cannot occur in the text — a space join collides `(question "a b", content "c")` with `(question "a", content "b c")`, which NUL keeps distinct. Verified: the canonical function reproduces the importer previous hash for every case, both sites now agree, and the old space formula does not. **Known data gap, not fixed here:** the one-time identifier scrub (`scrubComicKnowledgeIdentifiers.mjs`, removed in #1954 after its production run) used the same space formula and *rewrote* `content_hash` on every row it touched, so those production rows hold hashes the importer will not reproduce and will not dedupe against a re-import until recomputed. Tracked in the corpus-refresh issue.
 - 2026-07-29: **`importComicKnowledge.mjs` is plain text again, so its diffs are reviewable.** The NUL separator was stored as a literal NUL byte, which made git classify the source as binary and print "Binary files differ" instead of a diff — a loader script that writes to the knowledge base could be changed without the change being visible in review. Moving the formula into `comicDatasetShared.mjs` (written with the `\u0000` escape rather than a raw byte) removes the last raw NUL from the file. The runtime string, and therefore every hash, is unchanged. This commit's own diff still shows binary because the base version on `main` contains the raw bytes; every diff after it is text.

--- a/ctf/docs/developer/test-scripts/comic-test-script.md
+++ b/ctf/docs/developer/test-scripts/comic-test-script.md
@@ -103,8 +103,8 @@ the tests worth running slowly.
 **Precondition:** none — no export or upload is needed for this check.
 
 **Steps:**
-1. Open `/knowledge` and read the card **Getting a copy of your Quora data**, under the two sending
-   options.
+1. Open `/knowledge`, choose **Send my whole Quora export**, and read the line under the two
+   options and then the card **Getting a copy of your Quora data**.
 2. Switch between **Pick a few posts** and **Send my whole Quora export**.
 3. Tap the `privacy@quora.com` address, then **Open the original page**.
 
@@ -114,8 +114,11 @@ the tests worth running slowly.
   copy of my data", and the archive normally arrives within 72 hours to the account's email address.
   Under the quote is the byline, the date the page was read, and a link to the original.
 - The card stays visible for **both** options — the wait is part of choosing between them.
-- Three answers follow: the export is optional, it usually takes up to 72 hours, and the `.zip` is
-  sent exactly as it arrived.
+- **No Quora settings path is named anywhere on the page.** There is no screen in Quora that produces
+  an export (checked 2026-08-20); the line under the options says the archive is asked for by hand
+  and points at the card. A settings path reappearing here is a defect.
+- Four answers follow: the export is optional, there is no download button in Quora's settings, it
+  usually takes up to 72 hours, and the `.zip` is sent exactly as it arrived.
 - The address opens a mail draft; the link opens Quora's page in a new tab. **The quote must still
   read correctly with no network at all** — that is the point of quoting it.
 
@@ -125,7 +128,10 @@ the tests worth running slowly.
 
 ## CMC-C1c · Whole export (the secondary path)
 **Role:** signed-in member
-**Precondition:** a real Quora export `.zip` (Settings → Privacy → Download your information).
+**Precondition:** a real Quora export `.zip`. Ask Quora for it by hand — email `privacy@quora.com`,
+or use `quora.com/contact` and choose "I want a copy of my data" — and allow up to 72 hours. There is
+no settings screen that produces one; if you find this script telling you otherwise, the route is
+wrong, not Quora.
 
 **Steps:**
 1. On `/knowledge`, choose **Send my whole Quora export**.

--- a/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
+++ b/ctf/packages/web/components/comic/comic-knowledge-shell.tsx
@@ -369,11 +369,17 @@ function ModeSelector({ t, mode, onSelectMode }: { t: ComicTokens; mode: Mode; o
         ))}
       </div>
 
+      {/* No in-app settings path is named here. This line used to read "In Quora: Settings → Privacy
+          → Download your information"; the owner checked on 2026-08-20 and that screen does not
+          exist. Quora's own help article says the archive is requested by hand — by email or through
+          their contact form — and that article is quoted in full in the FAQ card directly below, so
+          the only instructions on this page are Quora's own. Do not reinstate a settings path unless
+          Quora publishes one. */}
       {mode === 'export' ? (
         <p style={{ ...bodyStyle(t), marginTop: 12, marginBottom: 0 }}>
-          In Quora: Settings → Privacy → Download your information. It arrives by email as a{' '}
-          <strong>.zip</strong>. Send it exactly as it arrived — do not unzip it, and do not try to
-          clean it out first. You do not have to.
+          You ask Quora for the archive by hand and they email it to you — how to ask is right below,
+          in Quora&apos;s own words. It arrives as a <strong>.zip</strong>. Send it exactly as it
+          arrived — do not unzip it, and do not try to clean it out first. You do not have to.
         </p>
       ) : (
         <p style={{ ...bodyStyle(t), marginTop: 12, marginBottom: 0 }}>

--- a/ctf/packages/web/components/comic/comic-quora-export-faq.tsx
+++ b/ctf/packages/web/components/comic/comic-quora-export-faq.tsx
@@ -33,6 +33,14 @@ const FAQ_ITEMS: { question: string; answer: string }[] = [
       'No. Picking a few posts is the recommended way and needs nothing from Quora — you open each post, copy the link, and paste the text. The export is for the rarer case where nearly everything you have written publicly belongs here.',
   },
   {
+    // The owner checked Quora on 2026-08-20: there is no such screen, and this page told members to
+    // look for one until then. Answering it head-on stops the next person hunting for a button that
+    // was never there.
+    question: 'Where is the download button in Quora’s settings?',
+    answer:
+      'There is not one. The archive is asked for by hand — by email, or through Quora’s contact form — and it is emailed back to you. If you are looking through Quora’s settings for an export screen, stop looking; use the two ways above.',
+  },
+  {
     question: 'How long does it take to arrive?',
     answer:
       'Quora says the archive usually reaches you within 72 hours of their team confirming they got the request. It comes to the email address on your Quora account.',


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What changed

`/knowledge` told members "In Quora: Settings → Privacy → Download your information", and the same route was repeated in the comic feature inventory and in the manual test script's precondition. You checked Quora on 2026-08-20: there is no such screen. The likely origin is a bot that invented a plausible-sounding settings path — an instruction nobody can follow, with no way for a member to tell that it is wrong.

- The export hint now says the archive is asked for by hand and points at the FAQ card directly below it, where Quora's own help article gives the route that works: email `privacy@quora.com`, or `quora.com/contact` and choose "I want a copy of my data".
- The FAQ card gained one more answer, aimed straight at the wrong instruction people may already be acting on: "Where is the download button in Quora's settings?" — there is not one, ask by hand instead.
- Comic feature inventory and manual test script updated to match. Both carry the note not to reinstate a settings path unless Quora publishes one, and the test case now fails if one reappears on the page.

Follow-up to #2271, which added the quoted help article but left this line as shipped pending your decision.

## Checks run locally

`typecheck`, `lint`, `lint:a11y`, `governance:check`, `format:check` (EOF), `check:us-spelling`, `check:inventory-drift`, `check:test-script-drift`, `check:notice-formatting`, and a full `@ctf/web` build — all pass.

Copy and docs only: no route, schema, or contract change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxEKTiSzpFoerdNp37N3Q9)_