### PR TITLE
docs: add Trust and Knowledge Library sections to the user guide

### DIFF
--- a/ctf/docs/USER_GUIDE.md
+++ b/ctf/docs/USER_GUIDE.md
@@ -1,6 +1,6 @@
 # How to use Charging the Future
 
-_Last updated: 2026-08-09_
+_Last updated: 2026-08-19_
 
 This guide explains what each part of the app does and how to use it, in plain words.
 The app is made of small apps, each doing one job. Open any of them from the main menu.
@@ -233,6 +233,25 @@ You can dismiss the fundraiser banner for two months if you want. It collapses t
 2. Pick a contribution type (gift card, Quora comment, or GitHub profile) and fill in the form with the required information.
 3. If you're submitting a gift card, send the code to the owner over Signal, not in the app.
 
+## Knowledge Library
+
+_Last updated: 2026-08-19_
+
+Knowledge Library is where you lend your own public Quora writing to the assistant, so it can answer from more than one person's experience.
+
+The page is at /knowledge and it is open to any signed-in member, whether or not you have finished Unlock. If you have not been approved yet, sending your writing is a way in rather than something you have to wait for: your Quora profile link goes into the same review queue at the same time. Open the page signed out and you get a public page instead, explaining what the library is, what happens to your writing, and that you can take it back.
+
+There are two ways to give. Picking a few posts is the one selected for you: for each post you paste its link on Quora and the post's text, up to twenty in one submission. Nothing ever opens the link — it is there so the person reading your writing can see the post is public and yours. Only quora.com links are accepted, the same link twice is refused, and a post of only a line or two is refused straight away, because a couple of lines is not enough for the assistant to answer from. The other way is a whole Quora export, for the rarer case where nearly all of your public writing fits. You ask Quora for that export yourself, and the page carries Quora's own instructions for doing it. The file is read as it arrives, only the public parts are kept, and the file itself is never stored.
+
+Before you can type anything you tick six separate lines of consent — one box each, with no single 'agree to all'. They cover that this is your own public writing, the one use it is for, that you keep every right to it, that you can take it back, that a person reads it and not everything gets used, and that parts naming other people may be cut. After you send, a receipt tells you how many pieces were kept. Your submission then sits under 'What you have sent' as waiting to be read, and you can withdraw it at any time from the same page — withdrawing really does stop the assistant using your writing.
+
+**How to use it**
+
+1. Open /knowledge. Signed out you get the public page; signed in you get the form.
+2. Tick all six consent lines. Until you do, the boxes for your posts stay switched off.
+3. Leave 'Pick a few posts' selected, paste one post's Quora link and its full text, and use 'Add another post' for each one after that. Send, then read the receipt saying how many pieces were kept.
+4. Come back to the same page whenever you want to see what you have sent, or to withdraw it.
+
 ## LevelUp
 
 _Last updated: 2026-08-05_
@@ -250,6 +269,25 @@ If a problem comes up with an enrollment, you can open a dispute and add comment
 1. Sign in and open the LevelUp app. You'll see cohort cards to browse.
 2. Go to the Wallet tab to see your ServiceCredits balance and escrow totals.
 3. Pick a cohort and follow the enrollment flow to sign up. If a deposit is required, you'll set that up as part of enrollment.
+
+## Trust
+
+_Last updated: 2026-08-14_
+
+Trust shows what you have actually done in the app, written as plain lines other members can read.
+
+Your trust card is a list of real things you have done here — how often you sign in, your ServiceCredits activity, your connections with other members, the cohorts you have finished. Each one is a plain sentence, not a number. There is no score, no badge, and no status. The app does not check anyone's identity, background, or work, so nothing on the card says a person has been checked out.
+
+Signing in shows up as two separate lines. 'Active on 162 days' counts every day you have ever signed in on, and it never goes down. 'Active 12 days in a row' counts the run you are on right now, and it only shows while that run reaches today or yesterday — miss a day and the line goes away. Nothing asks you to keep a run going, nothing reminds you about it, and losing it takes nothing else away.
+
+Your own card has two parts. 'Your trust' is everything you have. 'What members see' shows the exact lines any other member gets about you. You cannot change either part: what others see is set the same way for everyone, so trust cannot be hidden by the person it describes. The second part is there so you are never guessing what is on show about you.
+
+**How to use it**
+
+1. Sign in and open your account page. Your trust card is on it, with a line for each thing you have done.
+2. Open the app list and tap Trust to land on that same card.
+3. Read the 'What members see' part of the card to see exactly what other members are shown about you.
+4. Open Trust without signing in to read the public page, which lists the four kinds of signals: how often you sign in, ServiceCredits activity, community connections, and cohort completion record.
 
 ## TrustTransport
 
@@ -289,15 +327,15 @@ If a host makes you uncomfortable, you can block them from any listing. When you
 
 ## ClickLog
 
-_Last updated: 2026-08-07_
+_Last updated: 2026-08-18_
 
-ClickLog is a private place to record incidents and track patterns over time.
+ClickLog records incidents — privately for your own pattern-spotting, and, if you choose, as shared trend data.
 
-Open ClickLog and press Log Incident to add a new entry. You can add a location and notes. Only you see your incident list.
+Three rules cover all of it. One: your notes are always private — nobody but you ever sees them. Two: an incident can be private only when it has no tags, and a private, untagged incident does not need a location. Three: tagging an incident with problems or schemes requires a location and trend sharing, because tags exist to feed the global map — a tagged incident is always a shared one.
 
-When you log an incident, you can tag it with a problem type from the 50+ published problems list, or a scheme name from the canonical list. If you know of a scheme that is not listed, you can suggest a new one with a description (up to 200 characters) — this option is only available if you hold the Weavers of the Commons badge. Tagging requires a location so trend data stays useful.
+What sharing sends is grouped trend data only — the date, a rough area, and the tags. Never your notes, never your exact location. An incident you keep untagged shares nothing unless you choose otherwise: for untagged incidents, sharing is off until you turn it on, per incident or as a default.
 
-By default, new incidents are not shared. You can turn on sharing per incident or set a global default. When sharing is on, only grouped trend data (date, rough area, and tags) goes to the owner — never your notes or exact location. You can delete any of your own incidents, and you can turn off sharing for any incident at any time.
+You can edit or delete your own incidents at any time. An untagged incident's sharing can be turned off again whenever you like; a tagged incident becomes private by removing its tags first. If you know a scheme that is not on the list, you can suggest one while logging (Weavers of the Commons badge required).
 
 **How to use it**
 

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -300,6 +300,25 @@ An owner-curated list of real community comments, shown two ways on the public (
 
 ## 5) Change Log
 
+- 2026-08-20: **Trust and Knowledge Library now have user-guide sections, and the generator can see
+  when a plugin is missing one (owner report).** Both are member-facing plugins in the launcher, and
+  neither appeared on `/guide`. The reading order in `ctf/scripts/generate-user-guide.mjs` is a
+  hand-kept list and nothing ever compared it to the plugins members can actually open, so an
+  omission stayed invisible. Trust was simply absent from that list. Knowledge Library was absent for
+  a second reason: it is its own registry entry (`knowledge`, the `/knowledge` page) but its
+  documentation lives inside the AI assistant's (`comic`) inventory and test script, so the
+  generator's `ctf-<slug>-feature-inventory.md` / `<slug>-test-script.md` lookup found nothing for it.
+  A reading-order entry can now name its source files, the test-script heading that holds the member
+  walkthrough (the assistant's script has no "Core smoke" heading), and a one-line scope note telling
+  the model which part of a shared document the section covers — without that note the assistant's own
+  features would have been written up as Knowledge Library. Every run now also prints any launcher
+  plugin with no guide section; today that is Weekly Performance and Mutual Time, left for the owner
+  to decide on. The two new sections were written by hand rather than generated, because there were no
+  API credits to run the workflow; their `updated` dates are the last-commit dates of their source
+  docs, so the next scheduled run keeps them instead of paying to regenerate. `docs/USER_GUIDE.md` was
+  rebuilt from `guide-content.json` in the same pass, which also picked up the ClickLog section that
+  had been corrected in the JSON on 2026-08-18 without the markdown copy being rebuilt. Content and
+  generator only; no schema, route, or contract change.
 - 2026-08-19: **Deleting your account now removes your sign-in, not just your data (owner report).**
   `DELETE /api/account/full-account` deleted every plugin's rows and queued the ServiceCredits reclaim
   but left the member's auth-provider identity in place, so someone who asked to be forgotten was still

--- a/ctf/packages/web/app/guide/guide-content.json
+++ b/ctf/packages/web/app/guide/guide-content.json
@@ -1,5 +1,5 @@
 {
- "updated": "2026-08-09",
+ "updated": "2026-08-19",
  "intro": [
   "This guide explains what each part of the app does and how to use it, in plain words.",
   "The app is made of small apps, each doing one job. Open any of them from the main menu.",
@@ -211,6 +211,23 @@
    ]
   },
   {
+   "id": "knowledge",
+   "title": "Knowledge Library",
+   "updated": "2026-08-19",
+   "summary": "Knowledge Library is where you lend your own public Quora writing to the assistant, so it can answer from more than one person's experience.",
+   "body": [
+    "The page is at /knowledge and it is open to any signed-in member, whether or not you have finished Unlock. If you have not been approved yet, sending your writing is a way in rather than something you have to wait for: your Quora profile link goes into the same review queue at the same time. Open the page signed out and you get a public page instead, explaining what the library is, what happens to your writing, and that you can take it back.",
+    "There are two ways to give. Picking a few posts is the one selected for you: for each post you paste its link on Quora and the post's text, up to twenty in one submission. Nothing ever opens the link — it is there so the person reading your writing can see the post is public and yours. Only quora.com links are accepted, the same link twice is refused, and a post of only a line or two is refused straight away, because a couple of lines is not enough for the assistant to answer from. The other way is a whole Quora export, for the rarer case where nearly all of your public writing fits. You ask Quora for that export yourself, and the page carries Quora's own instructions for doing it. The file is read as it arrives, only the public parts are kept, and the file itself is never stored.",
+    "Before you can type anything you tick six separate lines of consent — one box each, with no single 'agree to all'. They cover that this is your own public writing, the one use it is for, that you keep every right to it, that you can take it back, that a person reads it and not everything gets used, and that parts naming other people may be cut. After you send, a receipt tells you how many pieces were kept. Your submission then sits under 'What you have sent' as waiting to be read, and you can withdraw it at any time from the same page — withdrawing really does stop the assistant using your writing."
+   ],
+   "howTo": [
+    "Open /knowledge. Signed out you get the public page; signed in you get the form.",
+    "Tick all six consent lines. Until you do, the boxes for your posts stay switched off.",
+    "Leave 'Pick a few posts' selected, paste one post's Quora link and its full text, and use 'Add another post' for each one after that. Send, then read the receipt saying how many pieces were kept.",
+    "Come back to the same page whenever you want to see what you have sent, or to withdraw it."
+   ]
+  },
+  {
    "id": "level-up",
    "title": "LevelUp",
    "updated": "2026-08-05",
@@ -224,6 +241,23 @@
     "Sign in and open the LevelUp app. You'll see cohort cards to browse.",
     "Go to the Wallet tab to see your ServiceCredits balance and escrow totals.",
     "Pick a cohort and follow the enrollment flow to sign up. If a deposit is required, you'll set that up as part of enrollment."
+   ]
+  },
+  {
+   "id": "trust",
+   "title": "Trust",
+   "updated": "2026-08-14",
+   "summary": "Trust shows what you have actually done in the app, written as plain lines other members can read.",
+   "body": [
+    "Your trust card is a list of real things you have done here — how often you sign in, your ServiceCredits activity, your connections with other members, the cohorts you have finished. Each one is a plain sentence, not a number. There is no score, no badge, and no status. The app does not check anyone's identity, background, or work, so nothing on the card says a person has been checked out.",
+    "Signing in shows up as two separate lines. 'Active on 162 days' counts every day you have ever signed in on, and it never goes down. 'Active 12 days in a row' counts the run you are on right now, and it only shows while that run reaches today or yesterday — miss a day and the line goes away. Nothing asks you to keep a run going, nothing reminds you about it, and losing it takes nothing else away.",
+    "Your own card has two parts. 'Your trust' is everything you have. 'What members see' shows the exact lines any other member gets about you. You cannot change either part: what others see is set the same way for everyone, so trust cannot be hidden by the person it describes. The second part is there so you are never guessing what is on show about you."
+   ],
+   "howTo": [
+    "Sign in and open your account page. Your trust card is on it, with a line for each thing you have done.",
+    "Open the app list and tap Trust to land on that same card.",
+    "Read the 'What members see' part of the card to see exactly what other members are shown about you.",
+    "Open Trust without signing in to read the public page, which lists the four kinds of signals: how often you sign in, ServiceCredits activity, community connections, and cohort completion record."
    ]
   },
   {

--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -42,7 +42,16 @@ const OUT_JSON = join(ctfRoot, 'packages/web/app/guide/guide-content.json');
 const OUT_MD = join(ctfRoot, 'docs/USER_GUIDE.md');
 
 // Reading order for the guide — people/connection first, then the ways to contribute, then the
-// quieter tools and stats. Each entry: [slug, display name]. Only member-facing plugins appear.
+// quieter tools and stats. Only member-facing plugins appear.
+//
+// Each entry is [slug, display name] plus, when that plugin's docs do not follow the usual
+// `ctf-<slug>-feature-inventory.md` / `<slug>-test-script.md` naming, a third entry naming the
+// source files. Knowledge Library is the one that needs it today: it is a member-facing plugin of
+// its own in the registry, but its documentation lives inside the AI assistant's (`comic`) docs,
+// which is exactly why earlier passes silently left it out of the guide. That third entry can also
+// carry `smokeHeading` (the test-script heading holding the member walkthrough, when the script does
+// not use "Core smoke") and `focus` (one line telling the model which part of a shared document this
+// section covers, so it does not write about the rest of the file).
 const ORDER = [
   // Commons is the home page and the app list itself, so earlier passes left it out of the guide;
   // members still need it explained (owner decision, 2026-08-18) — it leads the reading order as
@@ -61,13 +70,50 @@ const ORDER = [
   ['skills-taxonomy', 'Skills Taxonomy'],
   ['service-credits', 'ServiceCredits'],
   ['contributions', 'Contributions'],
+  [
+    'knowledge',
+    'Knowledge Library',
+    {
+      inventory: 'ctf-comic-feature-inventory.md',
+      testScript: 'comic-test-script.md',
+      smokeHeading: /Pick a few posts/i,
+      focus:
+        'This section is ONLY about the Knowledge Library at /knowledge — lending your own public Quora writing to the assistant, and taking it back. The source documents also describe the AI assistant itself (asking it questions, rating its answers); ignore all of that and write nothing about it.',
+    },
+  ],
   ['level-up', 'LevelUp'],
+  ['trust', 'Trust'],
   ['trust-transport', 'TrustTransport'],
   ['lighthouse', 'LightHouse'],
   ['click-log', 'ClickLog'],
   ['recurring-activity', 'Recurring Activity'],
   ['gdp', 'GDP'],
 ];
+
+// Trust and Knowledge Library were both missing from the guide for months because ORDER is a
+// hand-kept list and nothing compared it to the plugins members can actually see. This prints the
+// difference on every run: any plugin the registry shows in the launcher but the guide never
+// mentions. It is a notice, not a failure — some launcher entries genuinely do not belong in a
+// member guide — but the omission is now visible in the run log instead of waiting to be noticed.
+function noticeMissingFromGuide() {
+  const registryFile = join(ctfRoot, 'packages/web/lib/plugins/repository.ts');
+  if (!existsSync(registryFile)) return;
+  const src = readFileSync(registryFile, 'utf-8');
+  const covered = new Set(ORDER.map(([slug]) => slug));
+  const missing = [];
+  const entry = /slug: '([^']+)',[\s\S]{0,600}?isVisible: (true|false),/g;
+  let m = entry.exec(src);
+  while (m) {
+    if (m[2] === 'true' && !covered.has(m[1])) missing.push(m[1]);
+    m = entry.exec(src);
+  }
+  if (missing.length) {
+    console.error(
+      `notice: these plugins appear in the launcher but have no guide section: ${missing.join(', ')}. ` +
+        'Add each one to ORDER, or decide it is not something a member needs explained.',
+    );
+  }
+}
 
 const repoUrl = 'https://github.com/chargingthefuture/chargingthefuture';
 
@@ -77,7 +123,11 @@ const brandVoice = existsSync(join(ctfRoot, 'docs/BRAND_VOICE_LEXICON.md'))
 
 // ── Source resolution ──────────────────────────────────────────────────────────
 
-function inventoryPath(slug) {
+function inventoryPath(slug, override) {
+  if (override) {
+    const named = join(INVENTORY_DIR, override);
+    return existsSync(named) ? named : null;
+  }
   const direct = join(INVENTORY_DIR, `ctf-${slug}-feature-inventory.md`);
   if (existsSync(direct)) return direct;
   // A few slugs map to a differently-named inventory file (e.g. gdp → gross-domestic-product).
@@ -92,8 +142,8 @@ function inventoryPath(slug) {
   return null;
 }
 
-function testScriptPath(slug) {
-  const p = join(TEST_SCRIPT_DIR, `${slug}-test-script.md`);
+function testScriptPath(slug, override) {
+  const p = join(TEST_SCRIPT_DIR, override ?? `${slug}-test-script.md`);
   return existsSync(p) ? p : null;
 }
 
@@ -183,7 +233,7 @@ function extractJson(text) {
   return t;
 }
 
-async function rewrite(slug, title, whatItIs, features, coreSmoke) {
+async function rewrite(slug, title, whatItIs, features, coreSmoke, focus) {
   if (!process.env.ANTHROPIC_API_KEY) return null;
   const res = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
@@ -199,7 +249,7 @@ async function rewrite(slug, title, whatItIs, features, coreSmoke) {
       messages: [
         {
           role: 'user',
-          content: `Write the "${title}" section of the user guide, grounded ONLY in the three source blocks below.\n\n=== ${title} — What it is (developer notes on the point of this plugin) ===\n${whatItIs || '(none documented)'}\n\nUse that first block only to get the framing right — what this plugin is and is not. It is written for developers, so never copy its wording, its rule numbers, its file paths, or its planning notes into the guide. Everything a member can DO comes from the two blocks below.\n\n=== ${title} — User Features (what a member can do) ===\n${features || '(none documented)'}\n\n=== ${title} — Core smoke (plain member steps) ===\n${coreSmoke || '(none documented)'}\n\nReturn ONLY a JSON object with these exact keys:\n- summary: one plain sentence saying what ${title} is for.\n- body: an array of 1 to 3 short plain paragraphs on what a member can do here (strings).\n- howTo: an array of 2 to 4 plain steps for using it, drawn from the Core smoke block (strings). Use an empty array if there is no meaningful walkthrough.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
+          content: `Write the "${title}" section of the user guide, grounded ONLY in the three source blocks below.\n${focus ? `\nSCOPE: ${focus}\n` : ''}\n=== ${title} — What it is (developer notes on the point of this plugin) ===\n${whatItIs || '(none documented)'}\n\nUse that first block only to get the framing right — what this plugin is and is not. It is written for developers, so never copy its wording, its rule numbers, its file paths, or its planning notes into the guide. Everything a member can DO comes from the two blocks below.\n\n=== ${title} — User Features (what a member can do) ===\n${features || '(none documented)'}\n\n=== ${title} — Core smoke (plain member steps) ===\n${coreSmoke || '(none documented)'}\n\nReturn ONLY a JSON object with these exact keys:\n- summary: one plain sentence saying what ${title} is for.\n- body: an array of 1 to 3 short plain paragraphs on what a member can do here (strings).\n- howTo: an array of 2 to 4 plain steps for using it, drawn from the Core smoke block (strings). Use an empty array if there is no meaningful walkthrough.\n\nReturn ONLY valid JSON. No markdown fences. No preamble.`,
         },
       ],
     }),
@@ -244,10 +294,12 @@ const prev = new Map(
 );
 const prevIntro = existsSync(OUT_JSON) ? JSON.parse(readFileSync(OUT_JSON, 'utf-8')).intro : null;
 
+noticeMissingFromGuide();
+
 const sections = [];
-for (const [slug, title] of ORDER) {
-  const invPath = inventoryPath(slug);
-  const tsPath = testScriptPath(slug);
+for (const [slug, title, sources] of ORDER) {
+  const invPath = inventoryPath(slug, sources?.inventory);
+  const tsPath = testScriptPath(slug, sources?.testScript);
   const inv = invPath ? readFileSync(invPath, 'utf-8') : '';
   const ts = tsPath ? readFileSync(tsPath, 'utf-8') : '';
   // "Intent and Outcome" states what the plugin IS. Without it the model has only feature bullets
@@ -258,7 +310,7 @@ for (const [slug, title] of ORDER) {
   // lands on a paragraph break so the block never ends mid-sentence and reads as a truncated claim.
   const whatItIs = capAtParagraph(extractSection(inv, /Intent (and|&) Outcome/i), 2500);
   const features = extractSection(inv, /User Features/i);
-  const coreSmoke = extractSection(ts, /Core smoke/i);
+  const coreSmoke = extractSection(ts, sources?.smokeHeading ?? /Core smoke/i);
   const updated = lastUpdated([invPath, tsPath]);
 
   // Cost control: the guide is regenerated on a schedule (see the workflow), so most runs happen
@@ -273,7 +325,7 @@ for (const [slug, title] of ORDER) {
   }
 
   console.error(`generating ${slug}…`);
-  const written = await rewrite(slug, title, whatItIs, features, coreSmoke);
+  const written = await rewrite(slug, title, whatItIs, features, coreSmoke, sources?.focus);
   if (!written || !written.summary || !written.body.length) {
     // Model call failed or returned nothing usable. Keep the reviewed section as-is (only bumping
     // its date); fail only if there is no prior section to preserve.


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## What was wrong

Trust and Knowledge Library are both member-facing plugins in the launcher, and neither had a section on `/guide`. The reading order in `ctf/scripts/generate-user-guide.mjs` is a hand-kept list, and nothing ever compared it against the plugins members can actually open, so the omission stayed invisible.

- **Trust** was simply absent from that list.
- **Knowledge Library** was absent for a second reason: it is its own registry entry (`knowledge`, the `/knowledge` page), but its documentation lives inside the AI assistant's (`comic`) inventory and test script. The generator's `ctf-<slug>-feature-inventory.md` / `<slug>-test-script.md` lookup found nothing for it, so even adding it to the list would have produced an empty section.

## Generator changes (`ctf/scripts/generate-user-guide.mjs`)

- A reading-order entry can now carry a third element naming its source files, the test-script heading that holds the member walkthrough (the assistant's script has no "Core smoke" heading), and a one-line scope note telling the model which part of a shared document the section covers. Without that scope note the assistant's own features would have been written up as Knowledge Library.
- Both plugins added to the reading order: Knowledge Library after Contributions, Trust before TrustTransport.
- Every run now prints any launcher plugin that has no guide section. Today that is **Weekly Performance** and **Mutual Time** — left alone here, since the report named two plugins and whether those two belong in a member guide is a call for you to make.

Verified without spending API credits by running the generator against a stubbed model call: both new entries resolve real source blocks (Trust 1073/1560/3867 characters; Knowledge Library 807/4707/1134 plus the scope line), and the section order comes out as intended.

## The two sections

Written by hand rather than generated, since there were no API credits to run the workflow. Each is grounded only in the same source blocks the generator would have fed the model — the inventory's "Intent and Outcome" and "User Features", plus the test-script walkthrough — and follows the same voice rules: no score, no badge, and no claim that the app checks anyone out.

Their `updated` dates are the last-commit dates of their source docs (Trust 2026-08-14, Knowledge Library 2026-08-19), so the next scheduled run keeps this wording instead of paying to regenerate it. A `GUIDE_FORCE=1` run will rewrite them when credits are available.

`ctf/docs/USER_GUIDE.md` was rebuilt from `guide-content.json` by the generator's own markdown builder. That also picked up the ClickLog section, which was corrected in the JSON on 2026-08-18 without the markdown copy being rebuilt — so the two files agree again.

## Checks run locally

`pnpm --filter @ctf/web run typecheck`, `run lint`, `run build`, `check-eof-format.sh`, `check:inventory-drift`, `check:test-script-drift` — all pass.

Content and generator only. No schema, route, or contract change. Change log entry added to `ctf-non-plugin-feature-inventory.md`, where the `/guide` page is documented.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQtSoACPP8Tj19kMtrAvfp)_