### PR TITLE
docs: add Commons, Unlock, Mutual Time and Reporting a problem to the user guide

### DIFF
--- a/ctf/docs/USER_GUIDE.md
+++ b/ctf/docs/USER_GUIDE.md
@@ -6,6 +6,44 @@ This guide explains what each part of the app does and how to use it, in plain w
 The app is made of small apps, each doing one job. Open any of them from the main menu.
 Below, each app has a short summary, a few notes on what a member can do, and simple steps where they help.
 
+## Commons
+
+_Last updated: 2026-08-18_
+
+Commons is the home page: one shared channel to read and post in, and the list of every app.
+
+Commons is what you land on. It has two halves, switched with the two buttons in the top bar — a speech-bubbles button for the chat and a grid button for All Apps. The chat is a single shared channel. Everything comes through it: official notes from Farah, marked with a shield badge and signed with her name, answers from the assistant, and posts from other members.
+
+You can post to the channel, reply to a message so your own carries a short quote of it above the text, react with an emoji, and delete anything you wrote. There is no edit — to change a post you delete it and write it again, so a corrected message is a fresh one with its own replies and reactions. A 'New messages' line marks where you left off last time. A row of suggestion chips sits above the box you type in: some open an app straight away, others send a question to the assistant.
+
+The other half is a grid of every app, with a search box and a choice of order — most recent, alphabetical, or most used. You do not need an account to read: a visitor sees the posts and the live community figures at the top of the page. Signing in, which is free, is what lets you post and reach the rest of the apps.
+
+**How to use it**
+
+1. Open the app. You land on Commons with the chat showing.
+2. Read the channel. Official notes carry a shield badge and Farah's name; every other post shows the member who wrote it.
+3. Type in the box at the bottom to post. Use Reply on a message to quote it, or the small add-reaction control under a post to react.
+4. Tap the grid button in the top bar for All Apps, then search the grid or change its order to find the one you want.
+
+## Unlock
+
+_Last updated: 2026-08-19_
+
+Unlock is how a new account gets approved: you send the web address of your Quora profile, and a person reads it.
+
+Almost everything in the app waits on this one step. You paste the web address of your own Quora profile and send it. The screen shows what that address should look like, why it is asked for, and where your submission has got to. Sending a new one replaces the one before it.
+
+While you wait you can look but not take part. If nothing has been sent for a while, access narrows to support only. Once you are approved everything opens, and a one-time thank-you of 100 ServiceCredits is sent to you.
+
+If you cannot find the address of your own profile, the screen carries a note telling you what to do: go to skillseconomy.quora.com, comment on any post asking for help, and Farah will reply with your profile address. The same note sits beside the re-send box if a submission was turned down, so you are never left without a next step.
+
+**How to use it**
+
+1. Open the app on a new account. The Unlock screen asks for the web address of your Quora profile.
+2. Paste that address and send it. The screen changes to say it is under review.
+3. If you cannot find the address, use the note on the same screen: comment on any post at skillseconomy.quora.com asking for help, and you will be sent your profile address.
+4. Wait for the decision. If your submission is turned down, you can send another address from the same screen.
+
 ## Directory
 
 _Last updated: 2026-07-31_
@@ -68,9 +106,9 @@ Mutual Time finds an hour a group can meet, from one link everyone opens — no 
 
 You reach Mutual Time from a link that is shared with you, on Quora or Signal or anywhere else. There is no tile for it in your app list. Open the link and you see the event, and a line saying where the meeting will happen — for example 'We'll meet in Chyme' — with a button straight to it. That line is there from the moment you open the link, not only after a time is picked.
 
-While voting is open you pick up to three one-hour windows you are free. The times are shown in your own timezone, which is worked out for you and can be changed if you are travelling or on a VPN. Days come as chips, and each day's hours are grouped into morning, afternoon, and evening. You can change or clear your picks as often as you like while voting is open. The days on offer are always the next seven from the moment you open the link, so an event that has been open a while still shows days ahead of you. If a time you picked earlier has since gone by, the form says so and asks you to pick again rather than dropping your vote quietly.
+While voting is open you pick up to three one-hour windows you are free. The times are shown in your own timezone, which is worked out for you and can be changed if you are traveling or on a VPN. Days come as chips, and each day's hours are grouped into morning, afternoon, and evening. You can change or clear your picks as often as you like while voting is open. The days on offer are always the next seven from the moment you open the link, so an event that has been open a while still shows days ahead of you. If a time you picked earlier has since gone by, the form says so and asks you to pick again rather than dropping your vote quietly.
 
-Anyone can open the link, whether or not they are signed in or approved. A visitor sees the event, the times on offer greyed out so they can see what would be on the table, and a note that they are welcome to come and listen in at whatever time is chosen. Signing in is only needed to have a say in the time. Once voting closes, the same link shows the winning hour in your own timezone and how many members can make it. Every version of the page has a copy-link button, so you can pass it on.
+Anyone can open the link, whether or not they are signed in or approved. A visitor sees the event, the times on offer grayed out so they can see what would be on the table, and a note that they are welcome to come and listen in at whatever time is chosen. Signing in is only needed to have a say in the time. Once voting closes, the same link shows the winning hour in your own timezone and how many members can make it. Every version of the page has a copy-link button, so you can pass it on.
 
 **How to use it**
 
@@ -393,5 +431,23 @@ The GDP dashboard loads when you sign in and visit the app. It displays data abo
 1. Sign in to your account.
 2. Go to the GDP dashboard. The page loads without errors.
 3. View the community metrics displayed on the dashboard.
+
+## Reporting a problem
+
+_Last updated: 2026-08-18_
+
+Reporting a problem sends a note about anything that went wrong, from wherever you are in the app.
+
+The control sits behind the Help '?' in the top bar: 'Report a problem'. It opens a small form on top of whatever you were doing, so you do not lose your place. There is no tile for it in the app list and no separate page to find.
+
+The form asks two things: what went wrong, which you have to fill in, and what you were trying to do, which is optional. Nothing technical is ever asked of you — the page you were on and the app you were in are attached for you. Send it and you get a short, plain confirmation.
+
+Your report is stored privately the moment you send it. What you wrote is not posted anywhere public, and a report holding an email address, a phone number, or strong language waits for a person to read it before it goes any further. Anyone signed in can report a problem, including a member still waiting on approval — the person most likely to hit a problem is the one stuck at the start.
+
+**How to use it**
+
+1. Tap the Help '?' control in the top bar, then 'Report a problem'.
+2. Write one line about what went wrong. Add what you were trying to do if it helps.
+3. Send it. You get a short confirmation, and the report is stored privately straight away.
 
 The code is open source at https://github.com/chargingthefuture/chargingthefuture.

--- a/ctf/docs/USER_GUIDE.md
+++ b/ctf/docs/USER_GUIDE.md
@@ -60,6 +60,25 @@ You can send ServiceCredits as a tip to another member in the room right now usi
 3. Type a message in the chat and send it. It will show up in the list right away and stay there when you come back.
 4. If you're not signed in, you can listen to the room but won't be able to speak or chat.
 
+## Mutual Time
+
+_Last updated: 2026-08-13_
+
+Mutual Time finds an hour a group can meet, from one link everyone opens — no calendar is collected from anyone.
+
+You reach Mutual Time from a link that is shared with you, on Quora or Signal or anywhere else. There is no tile for it in your app list. Open the link and you see the event, and a line saying where the meeting will happen — for example 'We'll meet in Chyme' — with a button straight to it. That line is there from the moment you open the link, not only after a time is picked.
+
+While voting is open you pick up to three one-hour windows you are free. The times are shown in your own timezone, which is worked out for you and can be changed if you are travelling or on a VPN. Days come as chips, and each day's hours are grouped into morning, afternoon, and evening. You can change or clear your picks as often as you like while voting is open. The days on offer are always the next seven from the moment you open the link, so an event that has been open a while still shows days ahead of you. If a time you picked earlier has since gone by, the form says so and asks you to pick again rather than dropping your vote quietly.
+
+Anyone can open the link, whether or not they are signed in or approved. A visitor sees the event, the times on offer greyed out so they can see what would be on the table, and a note that they are welcome to come and listen in at whatever time is chosen. Signing in is only needed to have a say in the time. Once voting closes, the same link shows the winning hour in your own timezone and how many members can make it. Every version of the page has a copy-link button, so you can pass it on.
+
+**How to use it**
+
+1. Open the link someone shared with you. You do not need to find Mutual Time in your app list — the link is the way in.
+2. Sign in if you want a say in the time. Without signing in you can still read the event and come along to whatever hour is chosen.
+3. Pick up to three one-hour windows you are free, choosing from the day chips and the morning, afternoon, and evening groups. Check the timezone shown is yours, and change it if it is not. Save.
+4. Open the same link after voting closes to see the chosen hour, how many members can make it, and the button through to where the meeting happens.
+
 ## SocketRelay
 
 _Last updated: 2026-08-09_

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -300,6 +300,23 @@ An owner-curated list of real community comments, shown two ways on the public (
 
 ## 5) Change Log
 
+- 2026-08-20: **Commons, Unlock, Mutual Time, and Reporting a problem added to the user guide (owner
+  request); Weekly Performance stays out.** Four surfaces every member passes through had no section.
+  Commons was already in the reading order (added 2026-08-18) but the guide had not been regenerated
+  since, so no section existed for it. Unlock and Bug Reporting are `isVisible: false` — no launcher
+  tile — yet a member meets both: Unlock is the gate every account starts behind, and the Help control
+  is how anyone reports a problem. Mutual Time reaches members through a shared event link rather than
+  a tile. None of the three had been in the reading order at all. Weekly Performance stays out: its own
+  inventory says "Weekly Performance is admin-only; there is no general user-facing dashboard", so a
+  member-guide section would describe a screen no member can open (owner confirmed, 2026-08-20). The
+  missing-section notice deliberately stays scoped to launcher tiles rather than being widened to
+  cover hidden-but-member-facing plugins — widening it would report every operator surface as a gap.
+  Unlock's reading-order entry points at its test script's "Member walkthrough" instead of "Core
+  smoke", which is the admin review queue. The framing-block lookup now also matches an inventory
+  whose heading is plainly "Intent" (four of them, Bug Reporting among them) rather than "Intent and
+  Outcome". The new sections were written by hand for the same no-credits reason as the earlier ones,
+  dated to their source docs' last commit so the next scheduled run keeps them. Content and generator
+  only; no schema, route, or contract change.
 - 2026-08-20: **Mutual Time added to the user guide; the new missing-section notice was over-reporting
   (owner request).** The notice added earlier the same day counted a plugin as a gap on `isVisible`
   alone, and named Weekly Performance and Mutual Time. Both are in `ADMIN_ONLY_PLUGIN_SLUGS`, so

--- a/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
+++ b/ctf/docs/developer/ctf-plugin-feature-inventories/ctf-non-plugin-feature-inventory.md
@@ -300,6 +300,20 @@ An owner-curated list of real community comments, shown two ways on the public (
 
 ## 5) Change Log
 
+- 2026-08-20: **Mutual Time added to the user guide; the new missing-section notice was over-reporting
+  (owner request).** The notice added earlier the same day counted a plugin as a gap on `isVisible`
+  alone, and named Weekly Performance and Mutual Time. Both are in `ADMIN_ONLY_PLUGIN_SLUGS`, so
+  neither is a tile a member ever sees, and the notice now checks that set too — it reports nothing
+  today. The two are not the same case underneath, though. **Weekly Performance has no member side at
+  all** ("Weekly Performance is admin-only; there is no general user-facing dashboard" — its own
+  inventory), so it gets no guide section: describing an operator analytics screen on a public member
+  page would document something no member can open. **Mutual Time does have a member side, and every
+  member uses it** — the owner runs the polls, but members open the shared event link
+  (`/mutual-time/<slug>`), pick the hours they are free, and read the chosen time there. That half is
+  now a guide section, written by hand for the same no-credits reason as Trust and Knowledge Library,
+  with a scope note on its reading-order entry keeping the model off the owner's side of the plugin.
+  Its `updated` date is its source docs' last-commit date, so the next scheduled run keeps it. Content
+  and generator only; no schema, route, or contract change.
 - 2026-08-20: **Trust and Knowledge Library now have user-guide sections, and the generator can see
   when a plugin is missing one (owner report).** Both are member-facing plugins in the launcher, and
   neither appeared on `/guide`. The reading order in `ctf/scripts/generate-user-guide.mjs` is a

--- a/ctf/packages/web/app/guide/guide-content.json
+++ b/ctf/packages/web/app/guide/guide-content.json
@@ -55,6 +55,23 @@
    ]
   },
   {
+   "id": "mutual-time",
+   "title": "Mutual Time",
+   "updated": "2026-08-13",
+   "summary": "Mutual Time finds an hour a group can meet, from one link everyone opens — no calendar is collected from anyone.",
+   "body": [
+    "You reach Mutual Time from a link that is shared with you, on Quora or Signal or anywhere else. There is no tile for it in your app list. Open the link and you see the event, and a line saying where the meeting will happen — for example 'We'll meet in Chyme' — with a button straight to it. That line is there from the moment you open the link, not only after a time is picked.",
+    "While voting is open you pick up to three one-hour windows you are free. The times are shown in your own timezone, which is worked out for you and can be changed if you are travelling or on a VPN. Days come as chips, and each day's hours are grouped into morning, afternoon, and evening. You can change or clear your picks as often as you like while voting is open. The days on offer are always the next seven from the moment you open the link, so an event that has been open a while still shows days ahead of you. If a time you picked earlier has since gone by, the form says so and asks you to pick again rather than dropping your vote quietly.",
+    "Anyone can open the link, whether or not they are signed in or approved. A visitor sees the event, the times on offer greyed out so they can see what would be on the table, and a note that they are welcome to come and listen in at whatever time is chosen. Signing in is only needed to have a say in the time. Once voting closes, the same link shows the winning hour in your own timezone and how many members can make it. Every version of the page has a copy-link button, so you can pass it on."
+   ],
+   "howTo": [
+    "Open the link someone shared with you. You do not need to find Mutual Time in your app list — the link is the way in.",
+    "Sign in if you want a say in the time. Without signing in you can still read the event and come along to whatever hour is chosen.",
+    "Pick up to three one-hour windows you are free, choosing from the day chips and the morning, afternoon, and evening groups. Check the timezone shown is yours, and change it if it is not. Save.",
+    "Open the same link after voting closes to see the chosen hour, how many members can make it, and the button through to where the meeting happens."
+   ]
+  },
+  {
    "id": "socket-relay",
    "title": "SocketRelay",
    "updated": "2026-08-09",

--- a/ctf/packages/web/app/guide/guide-content.json
+++ b/ctf/packages/web/app/guide/guide-content.json
@@ -7,6 +7,40 @@
  ],
  "sections": [
   {
+   "id": "commons",
+   "title": "Commons",
+   "updated": "2026-08-18",
+   "summary": "Commons is the home page: one shared channel to read and post in, and the list of every app.",
+   "body": [
+    "Commons is what you land on. It has two halves, switched with the two buttons in the top bar — a speech-bubbles button for the chat and a grid button for All Apps. The chat is a single shared channel. Everything comes through it: official notes from Farah, marked with a shield badge and signed with her name, answers from the assistant, and posts from other members.",
+    "You can post to the channel, reply to a message so your own carries a short quote of it above the text, react with an emoji, and delete anything you wrote. There is no edit — to change a post you delete it and write it again, so a corrected message is a fresh one with its own replies and reactions. A 'New messages' line marks where you left off last time. A row of suggestion chips sits above the box you type in: some open an app straight away, others send a question to the assistant.",
+    "The other half is a grid of every app, with a search box and a choice of order — most recent, alphabetical, or most used. You do not need an account to read: a visitor sees the posts and the live community figures at the top of the page. Signing in, which is free, is what lets you post and reach the rest of the apps."
+   ],
+   "howTo": [
+    "Open the app. You land on Commons with the chat showing.",
+    "Read the channel. Official notes carry a shield badge and Farah's name; every other post shows the member who wrote it.",
+    "Type in the box at the bottom to post. Use Reply on a message to quote it, or the small add-reaction control under a post to react.",
+    "Tap the grid button in the top bar for All Apps, then search the grid or change its order to find the one you want."
+   ]
+  },
+  {
+   "id": "unlock",
+   "title": "Unlock",
+   "updated": "2026-08-19",
+   "summary": "Unlock is how a new account gets approved: you send the web address of your Quora profile, and a person reads it.",
+   "body": [
+    "Almost everything in the app waits on this one step. You paste the web address of your own Quora profile and send it. The screen shows what that address should look like, why it is asked for, and where your submission has got to. Sending a new one replaces the one before it.",
+    "While you wait you can look but not take part. If nothing has been sent for a while, access narrows to support only. Once you are approved everything opens, and a one-time thank-you of 100 ServiceCredits is sent to you.",
+    "If you cannot find the address of your own profile, the screen carries a note telling you what to do: go to skillseconomy.quora.com, comment on any post asking for help, and Farah will reply with your profile address. The same note sits beside the re-send box if a submission was turned down, so you are never left without a next step."
+   ],
+   "howTo": [
+    "Open the app on a new account. The Unlock screen asks for the web address of your Quora profile.",
+    "Paste that address and send it. The screen changes to say it is under review.",
+    "If you cannot find the address, use the note on the same screen: comment on any post at skillseconomy.quora.com asking for help, and you will be sent your profile address.",
+    "Wait for the decision. If your submission is turned down, you can send another address from the same screen."
+   ]
+  },
+  {
    "id": "directory",
    "title": "Directory",
    "updated": "2026-07-31",
@@ -61,8 +95,8 @@
    "summary": "Mutual Time finds an hour a group can meet, from one link everyone opens — no calendar is collected from anyone.",
    "body": [
     "You reach Mutual Time from a link that is shared with you, on Quora or Signal or anywhere else. There is no tile for it in your app list. Open the link and you see the event, and a line saying where the meeting will happen — for example 'We'll meet in Chyme' — with a button straight to it. That line is there from the moment you open the link, not only after a time is picked.",
-    "While voting is open you pick up to three one-hour windows you are free. The times are shown in your own timezone, which is worked out for you and can be changed if you are travelling or on a VPN. Days come as chips, and each day's hours are grouped into morning, afternoon, and evening. You can change or clear your picks as often as you like while voting is open. The days on offer are always the next seven from the moment you open the link, so an event that has been open a while still shows days ahead of you. If a time you picked earlier has since gone by, the form says so and asks you to pick again rather than dropping your vote quietly.",
-    "Anyone can open the link, whether or not they are signed in or approved. A visitor sees the event, the times on offer greyed out so they can see what would be on the table, and a note that they are welcome to come and listen in at whatever time is chosen. Signing in is only needed to have a say in the time. Once voting closes, the same link shows the winning hour in your own timezone and how many members can make it. Every version of the page has a copy-link button, so you can pass it on."
+    "While voting is open you pick up to three one-hour windows you are free. The times are shown in your own timezone, which is worked out for you and can be changed if you are traveling or on a VPN. Days come as chips, and each day's hours are grouped into morning, afternoon, and evening. You can change or clear your picks as often as you like while voting is open. The days on offer are always the next seven from the moment you open the link, so an event that has been open a while still shows days ahead of you. If a time you picked earlier has since gone by, the form says so and asks you to pick again rather than dropping your vote quietly.",
+    "Anyone can open the link, whether or not they are signed in or approved. A visitor sees the event, the times on offer grayed out so they can see what would be on the table, and a note that they are welcome to come and listen in at whatever time is chosen. Signing in is only needed to have a say in the time. Once voting closes, the same link shows the winning hour in your own timezone and how many members can make it. Every version of the page has a copy-link button, so you can pass it on."
    ],
    "howTo": [
     "Open the link someone shared with you. You do not need to find Mutual Time in your app list — the link is the way in.",
@@ -353,6 +387,22 @@
     "Sign in to your account.",
     "Go to the GDP dashboard. The page loads without errors.",
     "View the community metrics displayed on the dashboard."
+   ]
+  },
+  {
+   "id": "bug-reporting",
+   "title": "Reporting a problem",
+   "updated": "2026-08-18",
+   "summary": "Reporting a problem sends a note about anything that went wrong, from wherever you are in the app.",
+   "body": [
+    "The control sits behind the Help '?' in the top bar: 'Report a problem'. It opens a small form on top of whatever you were doing, so you do not lose your place. There is no tile for it in the app list and no separate page to find.",
+    "The form asks two things: what went wrong, which you have to fill in, and what you were trying to do, which is optional. Nothing technical is ever asked of you — the page you were on and the app you were in are attached for you. Send it and you get a short, plain confirmation.",
+    "Your report is stored privately the moment you send it. What you wrote is not posted anywhere public, and a report holding an email address, a phone number, or strong language waits for a person to read it before it goes any further. Anyone signed in can report a problem, including a member still waiting on approval — the person most likely to hit a problem is the one stuck at the start."
+   ],
+   "howTo": [
+    "Tap the Help '?' control in the top bar, then 'Report a problem'.",
+    "Write one line about what went wrong. Add what you were trying to do if it helps.",
+    "Send it. You get a short confirmation, and the report is stored privately straight away."
    ]
   }
  ]

--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -60,6 +60,17 @@ const ORDER = [
   ['directory', 'Directory'],
   ['foundation', 'Foundation'],
   ['chyme', 'Chyme'],
+  [
+    'mutual-time',
+    'Mutual Time',
+    {
+      // Mutual Time is in ADMIN_ONLY_PLUGIN_SLUGS, so it is not a tile in the member launcher — the
+      // owner runs the polls. Members still use it, every time: they open the shared event link and
+      // pick their times. That member half is what this section covers.
+      focus:
+        'This section is ONLY about what a member does with a shared Mutual Time link at /mutual-time/<slug> — seeing the event, picking the hours they are free, and reading the chosen time afterwards. Creating, opening, and closing an event is the owner\'s side; write nothing about it.',
+    },
+  ],
   ['socket-relay', 'SocketRelay'],
   ['beacon', 'Beacon'],
   ['peer-programming', 'PeerProgramming'],
@@ -92,24 +103,36 @@ const ORDER = [
 
 // Trust and Knowledge Library were both missing from the guide for months because ORDER is a
 // hand-kept list and nothing compared it to the plugins members can actually see. This prints the
-// difference on every run: any plugin the registry shows in the launcher but the guide never
-// mentions. It is a notice, not a failure — some launcher entries genuinely do not belong in a
-// member guide — but the omission is now visible in the run log instead of waiting to be noticed.
+// difference on every run: any plugin a member finds in their launcher that the guide never
+// mentions. It is a notice, not a failure, but the omission is now visible in the run log instead of
+// waiting to be noticed.
+//
+// A plugin is only counted when a member can see its tile: `isVisible: true` in the registry AND not
+// in `ADMIN_ONLY_PLUGIN_SLUGS`, which is the set the launcher filters out for everyone but the owner.
+// Reading `isVisible` alone reported Weekly Performance (an operator analytics screen with no member
+// side at all) and Mutual Time as gaps, which they are not.
 function noticeMissingFromGuide() {
   const registryFile = join(ctfRoot, 'packages/web/lib/plugins/repository.ts');
   if (!existsSync(registryFile)) return;
   const src = readFileSync(registryFile, 'utf-8');
+  const adminOnly = new Set(
+    (/ADMIN_ONLY_PLUGIN_SLUGS = new Set<string>\(\[([^\]]*)\]/.exec(src)?.[1] ?? '')
+      .split(',')
+      .map((s) => s.trim().replace(/^'|'$/g, ''))
+      .filter(Boolean),
+  );
   const covered = new Set(ORDER.map(([slug]) => slug));
   const missing = [];
   const entry = /slug: '([^']+)',[\s\S]{0,600}?isVisible: (true|false),/g;
   let m = entry.exec(src);
   while (m) {
-    if (m[2] === 'true' && !covered.has(m[1])) missing.push(m[1]);
+    const slug = m[1];
+    if (m[2] === 'true' && !adminOnly.has(slug) && !covered.has(slug)) missing.push(slug);
     m = entry.exec(src);
   }
   if (missing.length) {
     console.error(
-      `notice: these plugins appear in the launcher but have no guide section: ${missing.join(', ')}. ` +
+      `notice: these plugins appear in the member launcher but have no guide section: ${missing.join(', ')}. ` +
         'Add each one to ORDER, or decide it is not something a member needs explained.',
     );
   }

--- a/ctf/scripts/generate-user-guide.mjs
+++ b/ctf/scripts/generate-user-guide.mjs
@@ -57,6 +57,16 @@ const ORDER = [
   // members still need it explained (owner decision, 2026-08-18) — it leads the reading order as
   // the surface everyone lands on first.
   ['commons', 'Commons'],
+  [
+    'unlock',
+    'Unlock',
+    {
+      // Unlock's "Core smoke" is the admin review queue; the member half is the walkthrough below it.
+      smokeHeading: /Member walkthrough/i,
+      focus:
+        'This section is ONLY about what a member does to get approved: sending their Quora profile link, what they can reach while they wait, and where to get help finding that link. The review queue and every approve/reject/spam decision is the owner\'s side; write nothing about it.',
+    },
+  ],
   ['directory', 'Directory'],
   ['foundation', 'Foundation'],
   ['chyme', 'Chyme'],
@@ -99,6 +109,14 @@ const ORDER = [
   ['click-log', 'ClickLog'],
   ['recurring-activity', 'Recurring Activity'],
   ['gdp', 'GDP'],
+  [
+    'bug-reporting',
+    'Reporting a problem',
+    {
+      focus:
+        'This section is ONLY about a member reporting a problem: where the control is, what the form asks, and what happens to the report afterwards. The triage queue and everything downstream of it is the owner\'s side; write nothing about it.',
+    },
+  ],
 ];
 
 // Trust and Knowledge Library were both missing from the guide for months because ORDER is a
@@ -331,7 +349,7 @@ for (const [slug, title, sources] of ORDER) {
   // falls back to the other two blocks. Capped because these sections carry developer planning notes
   // the model does not need — only the longest (PeerProgramming) is near the cap today — and the cap
   // lands on a paragraph break so the block never ends mid-sentence and reads as a truncated claim.
-  const whatItIs = capAtParagraph(extractSection(inv, /Intent (and|&) Outcome/i), 2500);
+  const whatItIs = capAtParagraph(extractSection(inv, /Intent( (and|&) Outcome)?/i), 2500);
   const features = extractSection(inv, /User Features/i);
   const coreSmoke = extractSection(ts, sources?.smokeHeading ?? /Core smoke/i);
   const updated = lastUpdated([invPath, tsPath]);


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Follow-up to #2274. Adds the four sections you asked for, and leaves Weekly Performance out as you directed.

## The four sections

All four are surfaces a member passes through, and none of them had a guide section.

- **Commons** — the home page: the shared channel (posting, quoted replies, emoji reactions, delete-not-edit, the "New messages" line, the suggestion chips) and the All Apps grid with its search and ordering. It was already in the reading order, added on 2026-08-18, but the guide has not been regenerated since, so no section existed for it.
- **Unlock** — the gate every new account starts behind: sending the web address of your Quora profile, what you can do while you wait, the one-time 100 ServiceCredits thank-you on approval, and the note pointing you at skillseconomy.quora.com when you cannot find your own profile address.
- **Mutual Time** — the member half. You run the polls; members open the shared event link, pick up to three one-hour windows in their own timezone, and read the chosen hour there. A signed-out or not-yet-approved visitor can open the link, see the times on offer grayed out, and come and listen in. The section says up front that the link is the way in and there is no tile to look for.
- **Reporting a problem** — where the control lives (behind the Help "?"), what the form asks, and what happens to the report: stored privately on send, never posted anywhere public, held for a person to read if it contains contact details or strong language, and open to a member still waiting on approval.

Unlock and Bug Reporting are `isVisible: false`, so neither has a launcher tile — which is exactly why they had been missed.

## Weekly Performance stays out

Its own inventory says "Weekly Performance is admin-only; there is no general user-facing dashboard," and every feature it lists is under Admin Feature Scope. A member-guide section would describe a screen no member can open.

## Generator changes

- Reading order gains Unlock (after Commons), Mutual Time (after Chyme), and Reporting a problem (last). Each carries a scope note keeping the model on the member's half of a plugin whose docs also cover the owner's side.
- Unlock's entry points at its test script's "Member walkthrough" instead of "Core smoke", which is the admin review queue.
- The framing-block lookup now also matches an inventory whose heading is plainly "Intent" rather than "Intent and Outcome" — four of them, Bug Reporting among them, and they were silently getting no framing block.
- The missing-section notice from #2274 was counting a plugin as a gap on `isVisible` alone, which is how Weekly Performance and Mutual Time came to be flagged together. It now also skips `ADMIN_ONLY_PLUGIN_SLUGS`. It stays scoped to launcher tiles rather than being widened to catch hidden-but-member-facing plugins, since that would report every operator surface as a gap.

All sections written by hand — no API credits used. Each is dated to its source docs' last commit, so the next scheduled run keeps this wording; `GUIDE_FORCE=1` will rewrite them when credits are available. Verified against a stubbed model call: every new entry resolves real source blocks, the scope notes are passed through, and the notice now prints nothing.

## Checks run locally

`typecheck`, `lint`, `build`, `check-eof-format.sh`, `check-us-spelling.mjs`, `check-notice-formatting.mjs`, `check-error-verbosity.mjs`, `check:inventory-drift`, `check:test-script-drift` — all pass. The US Spelling Gate caught two British spellings in the first Mutual Time draft ("travelling", "greyed"); both are fixed here and that check now runs before every push.

Content and generator only. No schema, route, or contract change. Change log entry added to `ctf-non-plugin-feature-inventory.md`.