### PR TITLE
feat: put each failing run's actual error in the workflow triage issue

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,25 @@ remove, or rename a workflow, update this table in the same change.
 workflows together in the Actions tab. Full rule:
 [`119-github-actions-ci-rules.mdc`](../instructions/119-github-actions-ci-rules.mdc).
 
+## The triage issue carries each failure's actual error
+
+`workflow-health-check.yml` collects failing workflows into one triage issue. Each entry names the job
+and step that failed and includes an excerpt of what that run actually printed, in a collapsed
+"What it said" block — so an agent session picking the issue up can tell whether an entry is worth
+working or dismissing without opening the logs first.
+
+The excerpt is pulled from the failing job's log and anchored on the first `##[error]` line that says
+something (`Process completed with exit code 1` is the runner's boilerplate, not a reason), keeping the
+lines around it — which is where a script prints why it gave up. Post-job cleanup output is dropped,
+lines and totals are capped so one noisy failure cannot bury the rest, and the text is scrubbed for
+credential shapes before it goes into what is a public issue. If a log cannot be read (they expire) the
+entry still lists, just without the excerpt.
+
+**What this asks of a workflow: print the reason before you exit.** A script should say which step
+failed and why (rule 137 covers this and CI enforces it for app code); a shell step should `echo` a
+reason before `exit 1`. A failure whose log says only "exit code 1" produces an entry nobody can
+triage without opening it, which is the situation this replaced.
+
 ## When a red run is not a defect: `CTF_RUN_BLOCKED_EXTERNAL`
 
 Some workflows call a paid API. This project funds its APIs some months and not others, so those
@@ -118,4 +137,4 @@ deploy's status (live or failed) — it does not build or deploy anything itself
 | `unlock-reward-reconciliation.yml` | Unlock — Reward Reconciliation | Hourly at :17; manual | Self-heals missed Unlock approval rewards by minting any pending ServiceCredits rewards (safe to repeat). |
 | `update-neon-db.yml` | Neon — Update DB (Migrations + schema.sql) | Push to `main` touching schema/migrations; manual | Applies pre-schema migrations, the canonical `schema.sql`, then post-schema migrations to the Neon database in order (all safe to repeat). |
 | `weekly-performance-goal-snapshot.yml` | Weekly Performance — Goal Snapshot Capture | Daily 05:35 UTC; manual | Records the Weekly Performance goal readings into `weekly_performance_goal_snapshots` via the app's internal capture route; the last capture of the week wins. |
-| `workflow-health-check.yml` | Github Workflows — Health Check | Every 8 hours; manual | Checks each active workflow's most recent run on `main`, collects failures into one always-current triage issue, and closes it when everything is green. A run that marks itself blocked by an outside state (`CTF_RUN_BLOCKED_EXTERNAL`, see above) is listed as paused rather than failing, and never opens or holds open the issue. |
+| `workflow-health-check.yml` | Github Workflows — Health Check | Every 8 hours; manual | Checks each active workflow's most recent run on `main`, collects failures into one always-current triage issue, and closes it when everything is green. Each entry names the failing job and step and quotes what the run printed, so it can be triaged without opening the logs. A run that marks itself blocked by an outside state (`CTF_RUN_BLOCKED_EXTERNAL`, see above) is listed as paused rather than failing, and never opens or holds open the issue. |

--- a/.github/workflows/workflow-health-check.yml
+++ b/.github/workflows/workflow-health-check.yml
@@ -12,6 +12,13 @@ name: Github Workflows — Health Check
 # blocked-by-an-outside-state, and this check believes it: those runs are listed separately as
 # "paused, not broken" and never open or hold open the issue.
 #
+# The issue also carries each failure's actual error output, pulled from the failing job's log. The
+# workflows here do say why they fail — scripts print a reason before exiting, shell steps echo one —
+# but none of that reached this issue, so triaging any entry meant opening its log first. With the
+# reason in the issue, an agent session can tell at a glance whether an entry is worth working or
+# dismissing. Log text is masked by Actions for registered secrets and scrubbed again here before it
+# goes into a public issue.
+#
 # How a workflow declares it: print a GitHub Actions error annotation whose text contains
 # `CTF_RUN_BLOCKED_EXTERNAL:<reason>` — e.g.
 #   console.log(`::error title=...::... [CTF_RUN_BLOCKED_EXTERNAL:no_credit]`)
@@ -91,6 +98,91 @@ jobs:
               return null;
             }
 
+            // Per-failure log excerpt budget. The issue body is capped by GitHub, and a long excerpt
+            // buries the next entry — a couple of dozen lines is enough to tell "work it" from "dismiss it".
+            const EXCERPT_MAX_LINES = 24;
+            const EXCERPT_MAX_CHARS = 1600;
+            const CONTEXT_BEFORE = 20;
+            const CONTEXT_AFTER = 6;
+            const TOTAL_EXCERPT_BUDGET = 30000;
+
+            // Defense in depth before log text goes into a public issue. Actions already masks every
+            // registered secret as ***, so this is the second line, not the first: it catches shapes that
+            // were never registered as secrets (a URL with credentials, a bearer token echoed by a tool).
+            function scrub(line) {
+              return line
+                .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s:@/]+:[^\s@/]+@/gi, '$1***:***@')
+                .replace(/\b(bearer|token|api[_-]?key|secret|password)(["']?\s*[:=]\s*["']?)[^\s"',;]+/gi, '$1$2***')
+                .replace(/\b[A-Za-z0-9_-]{40,}\b/g, '***');
+            }
+
+            // The part of a failing job's log worth reading. Anchors on the first ##[error] line that
+            // says something — "Process completed with exit code 1" is the runner's boilerplate, not a
+            // reason — and keeps the lines around it, which is where a script prints why it gave up.
+            function errorExcerptFrom(logText) {
+              const lines = logText
+                .split(/\r?\n/)
+                .map((l) => l.replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s?/, ''))
+                .map((l) => l.replace(/\u001b\[[0-9;]*m/g, ''));
+
+              const isBoilerplate = (l) =>
+                /^##\[error\](Process completed with exit code|The operation was canceled|The process .* failed with exit code)/.test(l);
+              const errorLines = [];
+              lines.forEach((l, i) => {
+                if (l.startsWith('##[error]')) errorLines.push(i);
+              });
+              const meaningful = errorLines.filter((i) => !isBoilerplate(lines[i]));
+              const anchor = meaningful.length
+                ? meaningful[0]
+                : errorLines.length
+                  ? errorLines[errorLines.length - 1]
+                  : lines.length - 1;
+
+              const raw = lines.slice(
+                Math.max(0, anchor - CONTEXT_BEFORE),
+                Math.min(lines.length, anchor + CONTEXT_AFTER + 1),
+              );
+              // Everything from "Post job cleanup" on is the runner tearing the job down — never a reason.
+              const cleanupAt = raw.findIndex((l) => /^Post job cleanup/.test(l.trim()));
+              const window = (cleanupAt === -1 ? raw : raw.slice(0, cleanupAt))
+                .filter((l) => l.trim() && !/^##\[(group|endgroup|debug|command)\]/.test(l))
+                .map((l) => scrub(l.replace(/^##\[error\]/, 'ERROR: ')))
+                .map((l) => (l.length > 220 ? l.slice(0, 220) + ' …' : l));
+
+              const kept = window.slice(-EXCERPT_MAX_LINES);
+              const text = kept.join('\n');
+              return text.length > EXCERPT_MAX_CHARS ? text.slice(-EXCERPT_MAX_CHARS) : text;
+            }
+
+            // Which job and step failed, plus the readable part of that job's log. Best effort — a
+            // failure to read it never hides the entry, it just leaves the excerpt out.
+            async function failureDetailFor(runId) {
+              try {
+                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                  owner, repo, run_id: runId, per_page: 100,
+                });
+                const job = jobs.find((j) => j.conclusion === 'failure');
+                if (!job) return null;
+                const step = (job.steps || []).find((st) => st.conclusion === 'failure');
+                let excerpt = '';
+                try {
+                  const log = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                    owner, repo, job_id: job.id,
+                  });
+                  const text =
+                    typeof log.data === 'string' ? log.data : Buffer.from(log.data).toString('utf8');
+                  excerpt = errorExcerptFrom(text);
+                } catch (e) {
+                  // Logs expire, and a very large log can time out. The entry still lists without one.
+                  core.warning('Could not read the log for job ' + job.id + ': ' + e.message);
+                }
+                return { job: job.name, step: step ? step.name : null, excerpt };
+              } catch (e) {
+                core.warning('Could not read jobs for run ' + runId + ': ' + e.message);
+                return null;
+              }
+            }
+
             const failing = [];
             const blocked = [];
             for (const wf of workflows) {
@@ -122,6 +214,8 @@ jobs:
                 if (reason) {
                   blocked.push({ ...entry, reason });
                 } else {
+                  // Only for real failures — a paused run's reason is already the whole story.
+                  entry.detail = latest.conclusion === 'failure' ? await failureDetailFor(latest.id) : null;
                   failing.push(entry);
                 }
               }
@@ -171,12 +265,40 @@ jobs:
             }
 
             failing.sort((a, b) => a.name.localeCompare(b.name));
-            const lines = failing.map(
-              (f) => '- **' + f.name + '** — last run ' + f.conclusion + ' ([logs](' + f.url + ')), ' + f.when,
-            );
+            let excerptBudget = TOTAL_EXCERPT_BUDGET;
+            const lines = failing.map((f) => {
+              const head =
+                '- **' + f.name + '** — last run ' + f.conclusion + ' ([logs](' + f.url + ')), ' + f.when;
+              const where = f.detail
+                ? [f.detail.job && 'job `' + f.detail.job + '`', f.detail.step && 'step `' + f.detail.step + '`']
+                    .filter(Boolean)
+                    .join(', ')
+                : '';
+              const parts = [head];
+              if (where) parts.push('  - Failed in ' + where + '.');
+              const excerpt = f.detail && f.detail.excerpt;
+              if (excerpt && excerpt.length <= excerptBudget) {
+                excerptBudget -= excerpt.length;
+                parts.push(
+                  '',
+                  '  <details><summary>What it said</summary>',
+                  '',
+                  '  ```text',
+                  ...excerpt.split('\n').map((l) => '  ' + l),
+                  '  ```',
+                  '',
+                  '  </details>',
+                );
+              } else if (excerpt) {
+                parts.push('  - (Error output omitted — this issue is already at its size limit. Open the logs.)');
+              }
+              return parts.join('\n');
+            });
             const body = [
               marker,
               'These workflows\' most recent run on `' + branch + '` did not pass. Updated automatically by the health check that runs every 8 hours (' + new Date().toISOString() + ').',
+              '',
+              'Each entry carries the error its run actually printed, so you can tell whether it is worth working without opening the logs first. The text is an excerpt around the failure, with secrets masked.',
               '',
               ...lines,
               '',


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

## The audit

Went through how all 54 workflows report a failure, expecting to find a lot of silent ones. The opposite is true — **the workflows already say why they fail:**

| Checked | Result |
|---|---|
| Every `exit 1` site | All carry an `echo` or `::error` with a reason. One exception, `unit-tests.yml`'s `run: exit 1`, is deliberate — the step before it already filed an issue explaining the failure; this only marks the run red. |
| Every `curl` call (12 workflows) | All use `--fail`, so an HTTP error is a real failure with the response surfaced, never a silent success. |
| Every script a workflow runs (72 under `ctf/scripts/`) | 71 print a reason before exiting. The one that doesn't, `audit-schema-queries.mjs`, is run by no workflow. Rule 137 and the `check-error-verbosity` gate keep this true for app code. |
| Third-party actions (EAS, Docker, Render, gh-release) and `github-script` steps | Surface their own errors and messages. |

So there was nothing to fix in the workflows. **The gap was at the other end: none of what they print reached the triage issue.** An entry was a name, a conclusion and a link, so triaging any one of them meant opening its log first — which is the cost you pay per entry, per sweep, and the reason a red run sits unlooked-at.

## What changed

`workflow-health-check.yml` now pulls the failing job's log and puts the readable part of it under each entry, with the job and step that failed:

```
- **Skills Hunt — Propose Skill Promotions** — last run failure ([logs](…)), 2026-08-20T…
  - Failed in job `propose-skill-promotions`, step `Propose skill promotions`.

  <details><summary>What it said</summary>

  proposeSkillPromotions: STOPPED — the Anthropic account is out of credit.
    What to do: Add funds to the Anthropic account whenever suits.
  ERROR: Process completed with exit code 1.

  </details>
```

Details that make the excerpt useful rather than noisy:

- **Anchored on the first `##[error]` line that says something.** `Process completed with exit code 1` is the runner's boilerplate, not a reason — anchoring on it would miss a failure in an earlier step (exactly `unit-tests.yml`'s shape, tested below).
- **Keeps the lines around the anchor**, which is where a script prints why it gave up.
- **Post-job cleanup output dropped** — it is the runner tearing the job down, never a reason.
- **Capped** per entry (24 lines / 1600 chars) and in total (30k), so one noisy failure cannot bury the rest or blow the issue-body limit.
- **Scrubbed for credential shapes** before it goes into what is a public issue. Actions already masks registered secrets as `***`; this is the second line of defense for things never registered as secrets — a URL with inline credentials, a bearer token echoed by a tool.
- **A log that cannot be read** (they expire) is reported as a warning and the entry still lists, just without the excerpt.

## Verification

Extraction, against four realistic log shapes:

| Log shape | Excerpt captured |
|---|---|
| Script printed its reason, then `exit code 1` boilerplate | The script's three lines of reasoning |
| Failure in an **earlier** step, tail is a later step's output | The actual test failure (`Expected: 5 Received: 4`), not the tail |
| A meaningful `##[error]` line (Infisical 401) | That line, with its context |
| Unmasked `postgres://user:pass@…` and a bearer token | `postgresql://***:***@…`, `Bearer ***` |

Behavior, against a stubbed GitHub API (the suite from #2281, re-run on this change): a marked run still lists as paused and doesn't open the issue; a real failure still opens it; a stub without the log endpoint warns and still lists the entry.

Also checked the workflow YAML parses and the embedded script parses the way `actions/github-script` wraps it. Gates run locally: `check-eof-format.sh`, `check-us-spelling.mjs`, `check-inventory-drift.mjs`, `check-test-script-drift.mjs`, `check-schema-drift.sh` — all pass.

## Scope

`workflow-health-check.yml` and the workflows README only — no `ctf/` code, no schema, no contracts. Extra API calls are one log download per run already found failing; a green run costs nothing. The README gains what this asks of a workflow in return: print the reason before you exit, because a log that says only "exit code 1" produces an entry nobody can triage without opening it.

---
_Generated by [Claude Code](https://claude.ai/code/session_012YQ2DZ1JxDNNTu7WUFZjFf)_