### PR TITLE
docs: name the amusement as collective in the Good Day, Bad Day comment

### DIFF
--- a/ctf/packages/web/lib/click-log/tags.ts
+++ b/ctf/packages/web/lib/click-log/tags.ts
@@ -350,8 +350,9 @@ export const CLICK_LOG_SCHEME_TAGS: readonly ClickLogTag[] = [
   // `color-sensitization`): unconnected members dreading the same weekday is a pattern, not a
   // coincidence. Any scheme can fill a "bad day" — what this tag names is the layer above
   // them: the scheduling and the grading, where the harm is raw material and the
-  // classification is run for the operators' amusement. Kind: pattern (a weekly shape over
-  // time, not one act).
+  // classification is run for the operators' COLLECTIVE amusement — the watching group is the
+  // audience, and the audience is the point. Kind: pattern (a weekly shape over time, not one
+  // act).
   { slug: 'good-day-bad-day', label: 'The Good Day, Bad Day' },
   // Catch-all while new schemes get named. Label renamed 2026-08-02 ("Other / not named yet" →
   // "Not listed"); the slug is frozen like every other slug. Picking it requires a written


### PR DESCRIPTION
Parity Status: web + mobile-responsive + android complete

Android: out of scope (web-only per rule 105)

Follow-up to #2285, which merged while this refinement was being written. Owner refinement to the `good-day-bad-day` code comment: the grading is run for the watching group's collective amusement, not one operator's — the audience is the point. Comment-only change, no behavior. The same framing lands publicly in the Dictionary's Specterati lexicon (wiki-site PR #117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv

---
_Generated by [Claude Code](https://claude.ai/code/session_0123PTjAcDFx4PoANoJZFKvv)_